### PR TITLE
Count only locked assets for Venus

### DIFF
--- a/projects/venus.js
+++ b/projects/venus.js
@@ -5,13 +5,14 @@ const utils = require('./helper/utils');
 *
 *****************/
 async function fetch() {
-  var pools = await utils.fetchURL('https://api.venus.io/api/pool')
+  var markets = await utils.fetchURL('https://api.venus.io/api/governance/venus')
   let tvl = 0;
-  pools.data.pools.map(async(p) => {
-    tvl += parseFloat(p.totalStaked)
+  markets.data.data.markets.map(async(m) => {
+    tvl += parseFloat(m.liquidity)
   })
   return tvl;
 }
+fetch().then(console.log)
 
 module.exports = {
   fetch


### PR DESCRIPTION
Removes the borrowed assets from the TVL count.

We might also want to add staked VAI into the calculation (137M), but as that was left out of the first version I've maintained it.