### PR TITLE
Add Pangolin DEX

### DIFF
--- a/projects/pangolin.js
+++ b/projects/pangolin.js
@@ -1,0 +1,10 @@
+const utils = require('./helper/utils');
+
+async function fetch() {
+  var totalTvl = await utils.fetchURL('https://api.pangolin.exchange/png/tvl')
+  return totalTvl.data;
+}
+
+module.exports = {
+  fetch
+}


### PR DESCRIPTION
#### Why are you creating this pull request?
We'd like to list Pangolin on DeFi Llama.

##### Twitter Link:
https://twitter.com/pangolindex

##### List of audit if any:
Same security profile as Uniswap. Uniswap's V2 audits apply.

##### Website Link:
https://pangolin.exchange

##### Contact Email:
pangolindex@protonmail.com

##### Expected TVL:
About 218 million

##### Chain:
Avalanche

##### Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)
pangolin

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
8422 (token not exchange, no exchange listing at the moment)

##### Description/bio (to be shown on DefiLlama):
Pangolin is a community-driven DEX that runs on Avalanche. Using the same automated market-making (AMM) model as Uniswap, Pangolin is capable of trading all tokens issued on Ethereum and Avalanche.

##### Token address and ticker if any:
PNG 0x60781C2586D68229fde47564546784ab3fACA982 (on Avalanche)

##### Category (Yield/Dexes/Lending/Minting):
DEX