### PR TITLE
Update bifi ( included staking service )

### DIFF
--- a/projects/bifi/index.js
+++ b/projects/bifi/index.js
@@ -1,5 +1,8 @@
 const sdk = require("@defillama/sdk");
 
+const stakingPool = '0x488933457E89656D7eF7E69C10F2f80C7acA19b5';
+const bfcAddr = '0x0c7D5ae016f806603CB1782bEa29AC69471CAb9c';
+
 const ethPool = '0x13000c4a215efe7e414bb329b2f11c39bcf92d78';
 const ethTokenPools = {
     'usdt': {
@@ -66,6 +69,14 @@ async function tvl(timestamp, block) {
         target: ethPool,
         ethBlock
     })).output
+
+    // staking pool
+    let tokenStaked = await sdk.api.erc20.balanceOf({
+        owner: stakingPool,
+        target: bfcAddr,
+        ethBlock
+      });
+      sdk.util.sumSingleBalance(balances, bfcAddr, tokenStaked.output);
 
     // eth tokens
     for (token in ethTokenPools) {


### PR DESCRIPTION
##### Twitter Link: https://twitter.com/BiFi_lending

##### List of audit links if any:
1. BiFi Lending Audits from Theori: https://github.com/bifrost-platform/BIFI/blob/master/docs/bifrost_bifi_audit.pdf
2. BiFi Staking & Pooling Audit by Theori: https://github.com/bifrost-platform/BiFi-staking-protocol/blob/main/docs/theori-audit-rev-2.0.pdf

##### Website Link: https://bifi.finance/

##### Contact Email: hello@pi-lab.io 

##### Current TVL:
Ethereum : 7800000 $
BSC : 6900000 $

##### Chain: Ethereum, and BSC (Binance Smart Chain)

##### Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)
- bifi

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
- bifi

##### Description/bio (to be shown on DefiLlama):
BiFi (abbreviation of Bifrost Finance) is the decentralized finance platform built on Bifrost, the universal multichain middleware. BiFi aims to create a multichain DeFi ecosystem for cryptocurrencies with financial products and services that interoperate across multiple blockchains with scalable efficiency. In its first iteration, BiFi offers lending and staking protocols. The lending protocol implements depositing and borrowing, and the staking protocol implements liquidity pools, which will serve as the foundation for the upcoming decentralized exchange (DEX). The interest rates on BiFi Lending is algorithmically derived from the supply and demand in the market. This decentralized lending enables investors to take leveraged long positions, short a token, and earn interest on idle assets. BiFi is available on the Binance Smart Chain (BSC) and Ethereum Mainnet. Unlike other DeFi projects, BiFi on BSC and Ethereum are not separate instances, living on separate islands. BiFi’s smart contracts based on Bifrost transfers real-time market data on both chains to distribute BiFi tokens to users of both blockchains.

##### Token address and ticker if any: https://etherscan.io/token/0x2791bfd60d232150bff86b39b7146c0eaaa2ba81 

##### Category (Yield/Dexes/Lending/Minting): Lending 

##### [Optional] ETH addresss (to receive a LlamaPunk): 0xEC6876784A5Af73b657c5f9769a1CcCD00000000
