### PR TITLE
Add TVL adapter for Lido's bLuna

### DIFF
--- a/projects/bluna.js
+++ b/projects/bluna.js
@@ -1,0 +1,24 @@
+const utils = require('./helper/utils');
+
+async function fetch() {
+  let tvl = 0;
+
+  let { total_bond_amount } = (
+      await utils.fetchURL("https://lcd.terra.dev/wasm/contracts/terra1mtwph2juhj0rvjz7dy92gvl6xvukaxu8rfv8ts/store?query_msg=%7B%22state%22%3A%20%7B%7D%7D")
+    ).data.result;
+
+  let { amount } = (
+    await utils.fetchURL("https://lcd.terra.dev/market/swap?offer_coin=1000000uluna&ask_denom=uusd")
+  ).data.result;
+
+  tvl = Math.floor(
+    (amount*1.0/1000000)*(total_bond_amount/1000000)
+  );
+
+  return tvl;
+}
+
+
+module.exports = {
+  fetch
+}


### PR DESCRIPTION
##### Twitter Link:

www.twitter.com/lidofinance

##### List of audit links if any: 

https://github.com/lidofinance/audits

##### Website Link: 

www.lido.fi

##### Contact Email: 

info@lido.fi

##### Current TVL: 

$765.6m 

##### Chain: 

Ethereum, Terra

##### Coingecko ID (so your TVL can appear on Coingecko): 

lido-dao

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): 

8000

##### Description/bio (to be shown on DefiLlama): 

Stake your ETH with Lido and receive liquid stETH with daily rewards.

##### Token address and ticker if any: 

* LDO;  https://etherscan.io/token/0x5a98fcbea516cf06857215779fd812ca3bef1b32
* stETH; https://etherscan.io/token/0xae7ab96520de3a18e5e111b5eaab095312d7fe84 
* bLUNA; https://finder.terra.money/columbus-4/address/terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp


##### Category (Yield/Dexes/Lending/Minting): 

Yield, Staking