### PR TITLE
Add all IndexCoop Products

### DIFF
--- a/projects/dpi.js
+++ b/projects/dpi.js
@@ -1,8 +1,18 @@
 const utils = require('./helper/utils')
 
 async function fetch() {
-    let dpiAddress = "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b"
-    return (await utils.getTokenPricesFromString(dpiAddress)).data[dpiAddress].usd_market_cap
+    const dpiAddress = "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b";
+    const fliAddress = "0xaa6e8127831c9de45ae56bb1b0d4d4da6e5665bd";
+    const mviAddress = "0x72e364f2abdc788b7e918bc238b21f109cd634d7";
+    const cgiAddress = "0xada0a1202462085999652dc5310a7a9e2bf3ed42";
+    
+    const addresses = [ dpiAddress, fliAddress, mviAddress, cgiAddress ];
+    
+    return addresses.reduce(async (sum, address) => await sum + await getCaps(address), 0);
+}
+
+async function getCaps(address) {
+    return (await utils.getTokenPricesFromString(address)).data[address].usd_market_cap;
 }
 
 module.exports = {


### PR DESCRIPTION
Update the IndexCoop space to include our newest products. Right now this adapter is called dpi.js, should we rename it to indexcoop.js?