### PR TITLE
add simple tvl for spore

### DIFF
--- a/projects/spore-finance.js
+++ b/projects/spore-finance.js
@@ -1,0 +1,10 @@
+const utils = require('./helper/utils');
+
+async function fetch() {
+  var totalTvl = await utils.fetchURL('https://x-api.snowball.network/spore/tvl')
+  return totalTvl.data;
+}
+
+module.exports = {
+  fetch
+}


### PR DESCRIPTION
##### Twitter Link:

https://twitter.com/SporeFinance

##### List of audit links if any:
Unaudited Token Contracts
https://cchain.explorer.avax.network/address/0x6e7f5C0b9f4432716bDd0a77a3601291b9D9e985
https://bscscan.com/token/0x33a3d962955a3862c8093d1273344719f03ca17c

##### Website Link:

https://sporefinance.co/ - 

##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):

https://x-api.snowball.network/assets/avalanche-tokens/0x6e7f5c0b9f4432716bdd0a77a3601291b9d9e985/logo.png

##### Current TVL:

362625.76 as represented on the AVAX side.

##### Chain:

BSC 
AVAX

##### Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)

https://www.coingecko.com/en/coins/spore-finance

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

https://coinmarketcap.com/currencies/spore-finance/

##### Description/bio (to be shown on DefiLlama):

Spore Finance aims at creating an ecosystem combining reflect tokens, algorithmically generated NFTs and the first NFT prediction market.

##### Token address and ticker if any:

https://cchain.explorer.avax.network/address/0x6e7f5C0b9f4432716bDd0a77a3601291b9D9e985/transactions

https://x-api.snowball.network/spore/price

##### Category (Yield/Dexes/Lending/Minting):

Reflective / Community / MultiChain

##### [Optional] ETH addresss (to receive a LlamaPunk):

0x52E49872153fb72F96a0E4a04356d06d5b4AaCd8 
