### PR TITLE
Updating Index Coop Adapter

### DIFF
--- a/projects/indexcoop/index.js
+++ b/projects/indexcoop/index.js
@@ -1,29 +1,28 @@
-const sdk = require('@defillama/sdk');
+const sdk = require("@defillama/sdk");
 
 const dpiAddress = "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b";
-const fliAddress = "0xaa6e8127831c9de45ae56bb1b0d4d4da6e5665bd";
+const ethFliAddress = "0xaa6e8127831c9de45ae56bb1b0d4d4da6e5665bd";
 const mviAddress = "0x72e364f2abdc788b7e918bc238b21f109cd634d7";
-const cgiAddress = "0xada0a1202462085999652dc5310a7a9e2bf3ed42";
-const btcFli = "0x0b498ff89709d3838a063f1dfa463091f9801c2b";
-const tokens = [dpiAddress, fliAddress, mviAddress, cgiAddress, btcFli];
+const btcFliAddress = "0x0b498ff89709d3838a063f1dfa463091f9801c2b";
+const tokens = [dpiAddress, ethFliAddress, mviAddress, btcFliAddress];
 
 async function tvl(timestamp, block) {
-    const calls = tokens.map(token=>({
-        target: token
-    }))
-    const totalSupplies = await sdk.api.abi.multiCall({
-        block,
-        calls,
-        abi: 'erc20:totalSupply'
-    })
-    const balances = {}
-    sdk.util.sumMultiBalanceOf(balances, totalSupplies)
-    return balances
+  const calls = tokens.map((token) => ({
+    target: token,
+  }));
+  const totalSupplies = await sdk.api.abi.multiCall({
+    block,
+    calls,
+    abi: "erc20:totalSupply",
+  });
+  const balances = {};
+  sdk.util.sumMultiBalanceOf(balances, totalSupplies);
+  return balances;
 }
 
 module.exports = {
-    ethereum: {
-        tvl
-    },
-    tvl
-}
+  ethereum: {
+    tvl,
+  },
+  tvl,
+};


### PR DESCRIPTION
The Index Coop adapter needed updating to account for the deprecation of the CGI token. While in the adapter, I also renamed the FLI product line addresses to be more future proof/readable