### PR TITLE
Fixed: SSL error for MochiSwap Harmony Graph

### DIFF
--- a/projects/mochiswap/index.js
+++ b/projects/mochiswap/index.js
@@ -38,11 +38,8 @@ module.exports = {
   bsc: {
     tvl: bsc
   },
-  /*
   harmony: {
     tvl: harmony
   },
   tvl: sdk.util.sumChainTvls([harmony, bsc])
-  */
- tvl: bsc
 }


### PR DESCRIPTION
SSL is now fixed! The Harmony graph URL should no longer return ssl error. This push re-adds harmony TVL. 

Thanks!
