### PR TITLE
fix pangolin data query

### DIFF
--- a/projects/pangolin/index.js
+++ b/projects/pangolin/index.js
@@ -12,7 +12,7 @@ query get_tvl($block: Int) {
         totalLiquidityETH
         totalLiquidityUSD
   },
-  tokens(where: { symbol: "USDT" }, first:1) {
+  tokens(where: { symbol: "USDT" }, first:1, orderBy: totalLiquidity, orderDirection: desc) {
     derivedETH
   }
 }

--- a/projects/pangolin/index.js
+++ b/projects/pangolin/index.js
@@ -12,7 +12,7 @@ query get_tvl($block: Int) {
         totalLiquidityETH
         totalLiquidityUSD
   },
-  tokens(where: { symbol: "USDT" }, first:1, orderBy: totalLiquidity, orderDirection: desc) {
+  tokens(where: { id: "0xde3a24028580884448a5397872046a019649b084" }) {
     derivedETH
   }
 }


### PR DESCRIPTION
Currently, it's fetching this USDT token: https://info.pangolin.exchange/#/token/0x13d0d85fe3534e02c30ad87bc55a3f361e358c09

To not hardcode the correct USDT token, I changed the query to fetch the highest liquidity token with the symbol `USDT`.