### PR TITLE
Add TVL for Makiswap in HECO network

### DIFF
--- a/projects/makiswap/abi.json
+++ b/projects/makiswap/abi.json
@@ -1,0 +1,38 @@
+{
+  "allPairs": {
+      "constant": true,
+      "inputs": [
+          {
+              "internalType": "uint256",
+              "name": "",
+              "type": "uint256"
+          }
+      ],
+      "name": "allPairs",
+      "outputs": [
+          {
+              "internalType": "address",
+              "name": "",
+              "type": "address"
+          }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+  },
+  "allPairsLength": {
+      "constant": true,
+      "inputs": [],
+      "name": "allPairsLength",
+      "outputs": [
+          {
+              "internalType": "uint256",
+              "name": "",
+              "type": "uint256"
+          }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+  }
+}

--- a/projects/makiswap/index.js
+++ b/projects/makiswap/index.js
@@ -1,0 +1,41 @@
+const { request, gql } = require("graphql-request");
+const sdk = require("@defillama/sdk");
+const BigNumber = require("bignumber.js");
+
+const abi = require("./abi.json");
+
+// We use USDT for TVL for all farm pairs
+const usdtToken = "0xdac17f958d2ee523a2206206994597c13d831ec7";
+
+const tvl = async (timestamp, ethBlock, chainBlocks) => {
+  let block = chainBlocks["heco"];
+
+  if (block === undefined) {
+    block = (await sdk.api.util.lookupBlock(timestamp, { chain: "heco" }))
+      .block;
+  }
+
+  const gqlEndpoint = 'https://q.hg.network/subgraphs/name/maki-exchanges/heco';
+  const gqlQuery = `
+    query tvl($block: Int){
+      uniswapFactories (
+        block:{ number: $block }
+      ) {
+        totalLiquidityUSD
+      }
+    }
+  `;
+  const result = await request(gqlEndpoint, gqlQuery, { block })
+    .then((data) => data.uniswapFactories[0].totalLiquidityUSD);
+
+  return {
+    // --- Arrange to account the decimals as it was usdt (decimals = 6) ---
+    [usdtToken]: BigNumber(result)
+      .multipliedBy(10 ** 6)
+      .toFixed(0),
+  };
+};
+
+module.exports = {
+  tvl
+};


### PR DESCRIPTION
##### Twitter Link:
https://twitter.com/makiswap

##### List of audit links if any:
https://www.certik.org/projects/makiswap

##### Website Link:
https://makiswap.com

##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):
![twitterlogo](https://user-images.githubusercontent.com/4900126/123197882-32e68980-d47a-11eb-941b-4d6486121661.jpg)

##### Current TVL:
$31,872,685

##### Chain:
HECO

##### Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)
makiswap

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
10232

##### Description/bio (to be shown on DefiLlama):
Makiswap is an automated market maker (AMM). You can think of an AMM as a primitive robotic market maker that is always willing to quote prices between two assets according to a simple pricing algorithm. Makiswap can be farmed that can be found on the "rewards" section on this page.

##### Token address and ticker if any:
Token Address: 0x5fad6fbba4bba686ba9b8052cf0bd51699f38b93
Ticker: `MAKI`

##### Category (Yield/Dexes/Lending/Minting):
DEX/Yield Farming

##### [Optional] ETH addresss (to receive a LlamaPunk):
0xa6A7cFCFEFe8F1531Fc4176703A81F570d50D6B5