### PR TITLE
Amun's DFI and DMX tokens

### DIFF
--- a/projects/dfi/abi.json
+++ b/projects/dfi/abi.json
@@ -1,0 +1,17 @@
+{
+    "getTokens": {
+        "name": "getTokens",
+        "type": "function",
+        "inputs": [
+          
+        ],
+        "outputs": [
+          {
+            "name": "",
+            "type": "address[]",
+            "internalType": "address[]"
+          }
+        ],
+        "stateMutability": "view"
+      }
+}

--- a/projects/dfi/index.js
+++ b/projects/dfi/index.js
@@ -1,0 +1,30 @@
+const sdk = require('@defillama/sdk');
+const abi = require('./abi.json')
+
+const DFI_ADDRESS = '0xA9536B9c75A9E0faE3B56a96AC8EdF76AbC91978';
+
+async function tvl(timestamp, block) {
+    let balances = {};
+    const underlyings = await sdk.api.abi.call({
+        block,
+        target: DFI_ADDRESS,
+        abi: abi.getTokens
+    });
+    for (const token of underlyings.output) {
+        const held = await sdk.api.erc20.balanceOf({
+            block,
+            target: token,
+            owner: DFI_ADDRESS
+        });
+        balances[token] = held.output
+    };
+
+    return balances;
+}
+
+module.exports = {
+    ethereum:{
+      tvl
+    },
+    tvl,
+  };

--- a/projects/dmx/abi.json
+++ b/projects/dmx/abi.json
@@ -1,0 +1,17 @@
+{
+    "getTokens": {
+        "name": "getTokens",
+        "type": "function",
+        "inputs": [
+          
+        ],
+        "outputs": [
+          {
+            "name": "",
+            "type": "address[]",
+            "internalType": "address[]"
+          }
+        ],
+        "stateMutability": "view"
+      }
+}

--- a/projects/dmx/index.js
+++ b/projects/dmx/index.js
@@ -1,0 +1,30 @@
+const sdk = require('@defillama/sdk');
+const abi = require('./abi.json')
+
+const DMX_ADDRESS = '0x1660F10B4D610cF482194356eCe8eFD65B15bA83';
+
+async function tvl(timestamp, block) {
+    let balances = {};
+    const underlyings = await sdk.api.abi.call({
+        block,
+        target: DMX_ADDRESS,
+        abi: abi.getTokens
+    });
+    for (const token of underlyings.output) {
+        const held = await sdk.api.erc20.balanceOf({
+            block,
+            target: token,
+            owner: DMX_ADDRESS
+        });
+        balances[token] = held.output
+    };
+
+    return balances;
+}
+
+module.exports = {
+    ethereum:{
+      tvl
+    },
+    tvl,
+  };

--- a/projects/olympus/index.js
+++ b/projects/olympus/index.js
@@ -7,6 +7,7 @@ const ohm = "0x383518188c0c6d7730d91b2c03a03c837814a899";
 const slp = "0x34d7d7aaf50ad4944b70b320acb24c95fa2def7c";
 const frax = "0x853d955acef822db058eb8505911ed77f175b99e";
 const fraxLP = "0x2dce0dda1c2f98e0f171de8333c3c6fe1bbf4877";
+const slpOhm = "0x34d7d7aaf50ad4944b70b320acb24c95fa2def7c";
 
 // Treasury TVL consists of DAI balance + Sushi SLP balance
 async function tvl(timestamp, block) {
@@ -15,7 +16,8 @@ async function tvl(timestamp, block) {
     [dai, false],
     [frax, false],
     [slp, true],
-    [fraxLP, true]
+    [fraxLP, true],
+    [slpOhm, true]
   ], treasuryAddresses, block)
 
   return balances


### PR DESCRIPTION
### This PR includes 2 tokens, DFI and DMX. Info on them below:

- DFI:
##### Twitter Link: https://twitter.com/amuntokens


##### List of audit links if any:


##### Website Link: https://tokens.amun.com/


##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders): https://tokens.amun.com/images/logos/amun-dfi.png


##### Current TVL: $277.5k


##### Chain: ETH


##### Coingecko ID (so your TVL can appear on Coingecko): {“id”:“amun-defi-index”,“symbol”:“dfi”,“name”:“Amun DeFi Index”}

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): N/A


##### Description/bio (to be shown on DefiLlama): Amun’s DeFi Index Token (DFI) is composed of the top eight DeFi tokens in the Ethereum ecosystem by market capitalization. DFI provides investors with exposure to protocols that provide trading, lending and borrowing, yield farming, data oracles, insurance, prediction markets, and synthetic assets. The index’s components are equally weighted and rebalances monthly. Holders of DFI own fractions of the underlying tokens, which can be redeemed by burning the index token.


##### Token address and ticker if any: DFI (0xA9536B9c75A9E0faE3B56a96AC8EdF76AbC91978)


##### Category (Yield/Dexes/Lending/Minting): DeFi


##### [Optional] ETH addresss (to receive a LlamaPunk): 0xE33f67b82ddF3cABb4af48dd5b447872dc9f2cDe


$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$


- DMX:
##### Twitter Link: https://twitter.com/amuntokens


##### List of audit links if any:


##### Website Link: https://tokens.amun.com/


##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders): https://tokens.amun.com/images/logos/amun-dmx.png


##### Current TVL: $219.5k


##### Chain: ETH


##### Coingecko ID (so your TVL can appear on Coingecko): {“id”:“amun-defi-momentum-index”,“symbol”:“dmx”,“name”:“Amun DeFi Momentum Index”}


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): N/A


##### Description/bio (to be shown on DefiLlama): Amun’s DeFi Momentum Token (DMX) is composed of the top eight DeFi tokens in the Ethereum ecosystem based on price momentum. DMX holdings operate in areas such as trading, lending and borrowing, yield farming, data oracles, insurance, prediction markets, synthetic assets, and stable coins. The index’s components are equally weighted. Holding constituents are rebalanced daily as necessary and holding weights are rebalanced monthly. Holders of DMX own fractions of the underlying tokens, which can be redeemed by burning the index token.


##### Token address and ticker if any: DMX (0x1660F10B4D610cF482194356eCe8eFD65B15bA83)


##### Category (Yield/Dexes/Lending/Minting): DeFi


##### [Optional] ETH addresss (to receive a LlamaPunk): 0xE33f67b82ddF3cABb4af48dd5b447872dc9f2cDe

