### PR TITLE
[StakeDAO] - added all mainnet and polygon vaults

### DIFF
--- a/projects/helper/unwrapLPs.js
+++ b/projects/helper/unwrapLPs.js
@@ -23,9 +23,9 @@ const crvPools = {
     "0xe7a24ef0c5e95ffb0f6684b813a78f2a3ad7d171": {
       swapContract: "0x445FE580eF8d70FF569aB36e80c647af338db351",
       underlyingTokens: [
-        "0x8f3cf7ad23cd3cadbd9735aff958023239c6a063",
-        "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
-        "0xc2132d05d31c914a87c6611c10748aeb04b58e8f"
+        "0x27F8D03b3a2196956ED754baDc28D73be8830A6e",
+        "0x1a13F4Ca1d028320A707D99520AbFefca3998b7F",
+        "0x60D55F02A771d515e077c9C2403a1ef324885CeC"
       ]
     },
     // sCRV Eth
@@ -66,7 +66,20 @@ const crvPools = {
         "0x853d955acef822db058eb8505911ed77f175b99e",
         "0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490"
       ]
-    }
+    },
+    // seCRV Eth
+    "0xa3d87fffce63b53e0d54faa1cc983b7eb0b74a9c": {
+        swapContract: "0xc5424B857f758E906013F3555Dad202e4bdB4567",
+        underlyingTokens: ["0x5e74C9036fb86BD7eCdcb084a0673EFc32eA31cb"]
+    },
+    // btcCRV Polygon
+    "0xf8a57c1d3b9629b77b6726a042ca48990a84fb49": {
+        swapContract: "0xC2d95EEF97Ec6C17551d45e77B590dc1F9117C67",
+        underlyingTokens: [
+          "0x5c2ed810328349100A66B82b78a1791B101C9D61",
+          "0xDBf31dF14B66535aF65AaC99C32e9eA844e14501"
+        ]
+      },
 }
 
 async function unwrapCrv(balances, crvToken, balance3Crv, block, chain = "ethereum", transformAddress=(addr)=>addr) {
@@ -87,15 +100,18 @@ async function unwrapCrv(balances, crvToken, balance3Crv, block, chain = "ethere
         abi: 'erc20:balanceOf'
     })).output
 
-    // steth case where balanceOf not applicable on ETH balance
-    if (crvToken === "0x06325440d014e39736583c165c2963ba99faf14e") {
+    // steth and seth case where balanceOf not applicable on ETH balance
+    if (crvToken.toLowerCase() === "0x06325440d014e39736583c165c2963ba99faf14e" || crvToken.toLowerCase() === "0xa3d87fffce63b53e0d54faa1cc983b7eb0b74a9c") {
         underlyingSwapTokens[0].output = underlyingSwapTokens[0].output * 2;
     }
-
     const resolvedCrvTotalSupply = (await crvTotalSupply).output
     underlyingSwapTokens.forEach(call => {
         const underlyingBalance = BigNumber(call.output).times(balance3Crv).div(resolvedCrvTotalSupply);
-        sdk.util.sumSingleBalance(balances, transformAddress(call.input.target), underlyingBalance.toFixed(0))
+        if (chain == 'polygon') {
+            sdk.util.sumSingleBalance(balances, transformAddress(`polygon:${call.input.target}`), underlyingBalance.toFixed(0))
+        } else {
+            sdk.util.sumSingleBalance(balances, transformAddress(call.input.target), underlyingBalance.toFixed(0))
+        }
     })
 }
 /* lpPositions:{

--- a/projects/stakedao/index.js
+++ b/projects/stakedao/index.js
@@ -2,12 +2,8 @@ const sdk = require("@defillama/sdk");
 const abi = require('./abi.json')
 const {unwrapCrv} = require('../helper/unwrapLPs')
 
-const crv_3crv_vault1 = {
-  contract: '0x478bBC744811eE8310B461514BDc29D03739084D',
-  crvToken: '0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490',
-  abi: 'bal'
-}
-const crv_3crv_vault2 = {
+// Mainnet
+const crv_3crv_vault = {
   contract: '0xB17640796e4c27a39AF51887aff3F8DC0daF9567',
   crvToken: '0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490',
   abi: 'balance'
@@ -22,22 +18,56 @@ const crv_btc_vault = {
   crvToken: '0x075b1bb99792c9E1041bA13afEf80C91a1e70fB3',
   abi: 'balance'
 }
-const vaults = [crv_3crv_vault1, crv_3crv_vault2, crv_eurs_vault, crv_btc_vault]
+const crv_frax_vault = {
+  contract: '0x5af15DA84A4a6EDf2d9FA6720De921E1026E37b7',
+  crvToken: '0xd632f22692FaC7611d2AA1C0D552930D43CAEd3B',
+  abi: 'balance'
+}
+const crv_frax_vault2 = {
+  contract: '0x99780beAdd209cc3c7282536883Ef58f4ff4E52F',
+  crvToken: '0xd632f22692FaC7611d2AA1C0D552930D43CAEd3B',
+  abi: 'balance'
+}
+const crv_eth_vault = {
+  contract: '0xa2761B0539374EB7AF2155f76eb09864af075250',
+  crvToken: '0xA3D87FffcE63B53E0d54fAa1cc983B7eB0b74A9c',
+  abi: 'balance'
+}
+
+// Polygon
+const crv_3crv_vault_polygon = {
+  contract: '0x7d60F21072b585351dFd5E8b17109458D97ec120',
+  crvToken: '0xE7a24EF0C5e95Ffb0f6684b813A78F2a3AD7D171',
+  abi: 'balance'
+}
+const crv_btc_vault_polygon = {
+  contract: '0x953Cf8f1f097c222015FFa32C7B9e3E96993b8c1',
+  crvToken: '0xf8a57c1d3b9629b77b6726a042ca48990A84Fb49',
+  abi: 'balance'
+}
+
+const vaults = [
+  crv_3crv_vault, 
+  crv_eurs_vault, 
+  crv_btc_vault, 
+  crv_frax_vault,
+  crv_frax_vault2,
+  crv_eth_vault
+]
+
+const vaultsPolygon = [
+  crv_3crv_vault_polygon,
+  crv_btc_vault_polygon
+]
 
 const sanctuary = '0xaC14864ce5A98aF3248Ffbf549441b04421247D3'
 const sdtToken = '0x73968b9a57c6E53d41345FD57a6E6ae27d6CDB2F'
-const sdveCRV = '0x478bBC744811eE8310B461514BDc29D03739084D'
-const crvToken = '0xd533a949740bb3306d119cc777fa900ba034cd52'
 
-async function tvl(timestamp, block) {
+async function ethereum(timestamp, block) {
   let balances = {};
   const sdtInSactuary = sdk.api.erc20.balanceOf({
     target: sdtToken,
     owner: sanctuary,
-    block
-  })
-  const sdveCRVSupply = sdk.api.erc20.totalSupply({
-    target: sdveCRV,
     block
   })
   await Promise.all(vaults.map(async vault=>{
@@ -49,10 +79,31 @@ async function tvl(timestamp, block) {
     await unwrapCrv(balances, vault.crvToken, crvBalance.output, block)
   }))
   sdk.util.sumSingleBalance(balances, sdtToken, (await sdtInSactuary).output)
-  sdk.util.sumSingleBalance(balances, crvToken, (await sdveCRVSupply).output)
+  return balances
+}
+
+async function polygon(timestamp, ethBlock, chainBlocks) {
+  let balances = {};
+  const block = chainBlocks.polygon
+  await Promise.all(vaultsPolygon.map(async vault=>{
+    const crvBalance = await sdk.api.abi.call({
+      target: vault.contract,
+      block,
+      abi: abi[vault.abi], 
+      chain: 'polygon'
+    })  
+    await unwrapCrv(balances, vault.crvToken, crvBalance.output, block, chain='polygon')
+  }))
+
   return balances
 }
 
 module.exports = {
-  tvl
+  ethereum:{
+    tvl: ethereum
+  },
+  polygon:{
+    tvl: polygon
+  },
+  tvl: sdk.util.sumChainTvls([ethereum, polygon])
 }

--- a/projects/stakedao/index.js
+++ b/projects/stakedao/index.js
@@ -33,6 +33,11 @@ const crv_eth_vault = {
   crvToken: '0xA3D87FffcE63B53E0d54fAa1cc983B7eB0b74A9c',
   abi: 'balance'
 }
+const crv_perpetual_vault = {
+  contract: '0x52f541764E6e90eeBc5c21Ff570De0e2D63766B6',
+  crvToken: '0x5f3b5DfEb7B28CDbD7FAba78963EE202a494e2A2',
+  abi: 'balance'
+}
 
 // Polygon
 const crv_3crv_vault_polygon = {
@@ -62,12 +67,18 @@ const vaultsPolygon = [
 
 const sanctuary = '0xaC14864ce5A98aF3248Ffbf549441b04421247D3'
 const sdtToken = '0x73968b9a57c6E53d41345FD57a6E6ae27d6CDB2F'
+const crvToken = '0xD533a949740bb3306d119CC777fa900bA034cd52'
 
 async function ethereum(timestamp, block) {
   let balances = {};
   const sdtInSactuary = sdk.api.erc20.balanceOf({
     target: sdtToken,
     owner: sanctuary,
+    block
+  })
+  const crvInPerpetual = sdk.api.erc20.balanceOf({
+    target: crv_perpetual_vault.crvToken,
+    owner: crv_perpetual_vault.contract,
     block
   })
   await Promise.all(vaults.map(async vault=>{
@@ -79,6 +90,7 @@ async function ethereum(timestamp, block) {
     await unwrapCrv(balances, vault.crvToken, crvBalance.output, block)
   }))
   sdk.util.sumSingleBalance(balances, sdtToken, (await sdtInSactuary).output)
+  sdk.util.sumSingleBalance(balances, crvToken, (await crvInPerpetual).output)
   return balances
 }
 


### PR DESCRIPTION
This PR adds all stakeDAO vaults actually used on mainnet and polygon networks.

In `stakedao/index.js`:
- [X] All vaults added (mainnet, polygon)

In `helpers/unwrapLPs`:
- [X] Fixed the underlying token addresses for `am3CRV Polygon` (It was DAI/USDC/USDT (pos) but it should be amDAI/..)
- [X] Within the `unwrapCRV` function , i have added a check for recognize the correct chain and included even the sETH token in the check where the balance is not applicable to ETH.
