### PR TITLE
add Guard(helmet.insure)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 run.js
 blocks.js
 historical-data.js
+/.idea

--- a/projects/helmetinsure/index.js
+++ b/projects/helmetinsure/index.js
@@ -1,0 +1,75 @@
+const retry = require('../helper/retry')
+const { GraphQLClient, gql } = require('graphql-request')
+const BigNumber = require("bignumber.js");
+const CHAIN_POLYGON = 'polygon'
+const CHAIN_BSC = 'bsc'
+
+
+BigNumber.config({ EXPONENTIAL_AT: 50 })
+
+const THEGARPH_API = {
+  [CHAIN_POLYGON]: "https://api.thegraph.com/subgraphs/name/app-helmet-insure/guard",
+  [CHAIN_BSC]: "https://api.thegraph.com/subgraphs/name/app-helmet-insure/helmet-insure"
+}
+
+
+function transform(str){
+  switch (str){
+    case "bsc:0xaf90e457f4359adcc8b37e8df8a27a1ff4c3f561": // SHIB
+      return "0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE"
+    case "bsc:0xf218184af829cf2b0019f8e6f0b2423498a36983": // MATH
+      return "0x08d967bb0134f2d07f7cfb6e246680c53927dd30"
+    case "bsc:0xbd2949f67dcdc549c6ebe98696449fa79d988a9f":
+      return "0xBd2949F67DcdC549c6Ebe98696449Fa79D988A9F"
+    default:
+      return str
+  }
+}
+
+async function fetch(chain) {
+  var endpoint = THEGARPH_API[chain]
+  var graphQLClient = new GraphQLClient(endpoint)
+  var query = gql`
+    {
+      options(first: 1000) {
+        collateral
+        asks {
+          volume
+          settleToken
+        }
+      }
+    }
+    `;
+  const results = await retry(async bail => await graphQLClient.request(query))
+  const {options} = results
+
+  const data = options.flatMap(o => {
+    return o.asks.map(ask => {
+      return Object.assign(ask, {
+        collateral: o.collateral
+      })
+    })
+  }).reduce((_data, ask) => {
+    const key = transform(`${chain}:${ask.collateral}`)
+    if(typeof _data[key] === 'undefined'){
+      _data[key] = ask.volume
+    }else {
+      _data[key] = new BigNumber(_data[key]).plus(new BigNumber(ask.volume)).toString()
+    }
+    return _data
+  }, {})
+  return data
+}
+
+async function tvl(timestamp, block) {
+  const bsc = await fetch(CHAIN_BSC)
+  const polygon = await fetch(CHAIN_POLYGON)
+  const balances = Object.assign({}, bsc, polygon)
+  console.log(balances)
+  return balances;
+}
+
+
+module.exports = {
+  tvl
+}


### PR DESCRIPTION
##### Twitter Link:
https://twitter.com/Helmet_insure

##### List of audit links if any:
https://www.certik.org/projects/helmet

##### Website Link:
https://www.guard.insure/
https://www.helmet.insure/

##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):
https://drive.google.com/file/d/1X7DwsFxwlV4RvQwg68LxU95GPpUsIRBH/view?usp=sharing

##### Current TVL:
Total: 16.74 M

##### Chain:
BSC & MATIC

##### Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)
helmet-insure

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
8265

##### Description/bio (to be shown on DefiLlama):
Total supply of GUARD+HELMET = 100 million

Guard.insure is a peer-to-peer (P2P) price-shield insurance protocol launched on Binance Smart Chain (BSC) fistly  with the form of helmet.insure and now multi-chained to support Polygon net with the aim to redefine option trading with user-friendly insurance policy wrapping.

Guard allows users to create an insurance policy for any crypto asset in the market, protecting DeFi users against the risk of price fluctuations. Policy trading on Guard is market-oriented without complex mathematics. There are two kinds of policy which could be involved in mining: SHORT Tokens and LONG tokens.

##### Token address and ticker if any:
0x948d2a81086A075b3130BAc19e4c6DEe1D2E3fE8

##### Category (Yield/Dexes/Lending/Minting):
Insurance

##### [Optional] ETH addresss (to receive a LlamaPunk):
0x23FCB0E1DDbC821Bd26D5429BA13B7D5c96C0DE0