### PR TITLE
Use locked method for StakeDAO veCRV

### DIFF
--- a/projects/stakedao/abi.json
+++ b/projects/stakedao/abi.json
@@ -26,5 +26,27 @@
         ],
         "stateMutability": "view",
         "type": "function"
+    },
+    "locked": {
+        "name": "locked",
+        "outputs": [
+            {
+                "type": "int128",
+                "name": "amount"
+            },
+            {
+                "type": "uint256",
+                "name": "end"
+            }
+        ],
+        "inputs": [
+            {
+                "type": "address",
+                "name": "arg0"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "gas": 3359
     }
 }

--- a/projects/stakedao/index.js
+++ b/projects/stakedao/index.js
@@ -36,7 +36,7 @@ const crv_eth_vault = {
 const crv_perpetual_vault = {
   contract: '0x52f541764E6e90eeBc5c21Ff570De0e2D63766B6',
   crvToken: '0x5f3b5DfEb7B28CDbD7FAba78963EE202a494e2A2',
-  abi: 'balance'
+  abi: 'locked'
 }
 
 // Polygon
@@ -71,10 +71,11 @@ const crvToken = '0xD533a949740bb3306d119CC777fa900bA034cd52'
 
 async function ethereum(timestamp, block) {
   let balances = {};
-  const crvInPerpetual = sdk.api.erc20.balanceOf({
+  const crvInPerpetual = sdk.api.abi.call({
     target: crv_perpetual_vault.crvToken,
-    owner: crv_perpetual_vault.contract,
-    block
+    block,
+    abi: abi[crv_perpetual_vault.abi],
+    params: crv_perpetual_vault.contract
   })
   await Promise.all(vaults.map(async vault=>{
     const crvBalance = await sdk.api.abi.call({
@@ -84,7 +85,7 @@ async function ethereum(timestamp, block) {
     })
     await unwrapCrv(balances, vault.crvToken, crvBalance.output, block)
   }))
-  sdk.util.sumSingleBalance(balances, crvToken, (await crvInPerpetual).output)
+  sdk.util.sumSingleBalance(balances, crvToken, (await crvInPerpetual).output.amount)
   return balances
 }
 


### PR DESCRIPTION
Signed-off-by: Reinis Martinsons <reinis@umaproject.org>

This PR fixes the reported TVL for StakeDAO. It was incorrectly using the `balanceOf` method on Curve voting escrow contract that represents the voting weight. Instead the `locked` method should be used that represents actual CRV locked in the voting escrow contract.