### PR TITLE
[update] flabble - Update groprotocol to use PWRD and Vault tokens directly

### DIFF
--- a/projects/groprotocol/abi.json
+++ b/projects/groprotocol/abi.json
@@ -1,86 +1,15 @@
 {
-    "deadCoin": {
-        "inputs": [],
-        "name": "deadCoin",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    "underlyingVaults": {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "name": "underlyingVaults",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    "curveVault": {
-        "inputs": [],
-        "name": "curveVault",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    "token": {
-        "inputs": [],
-        "name": "token",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    "totalAssets": {
-        "inputs": [],
-        "name": "totalAssets",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    "vault": {
-        "inputs": [],
-        "name": "vault",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    }
+   "totalAssets": {
+       "inputs": [],
+       "name": "totalAssets",
+       "outputs": [
+           {
+               "internalType": "uint256",
+               "name": "",
+               "type": "uint256"
+           }
+       ],
+       "stateMutability": "view",
+       "type": "function"
+   }
 }


### PR DESCRIPTION
I'm part of the gro protcol team and have updated the adpter as follows:

Update groprotocol to use PWRD and Vault tokens to calc TVL, using DAI as a representation of 1USD (until coins on coingecko). This method works back to protocol start date which is included.




##### Twitter Link:
https://twitter.com/groprotocol

##### List of audit links if any:
https://docs.gro.xyz/gro-docs/how-it-works/security-and-audits


##### Website Link:
https://www.gro.xyz

##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):
![android-chrome-512x512](https://user-images.githubusercontent.com/75323828/129794091-f9f51f97-efbc-4539-a9f9-dc7a95a49680.png)


##### Current TVL:
Current TVL as of "Tue 17 Aug 20:08:24 UTC 2021" which matches our other internal counts:
DAI                       6.98 M
Total: 6.98 M


##### Chain:
Ethereum

##### Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)
Not yet

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
Not yet

##### Description/bio (to be shown on DefiLlama):
Gro protocol is a stablecoin yield aggregator that tranches risk and yield. The first two products built on it are the PWRD stablecoin with deposit protection and yield, and Vault with leveraged stablecoin yields.

##### Token address and ticker if any:
Not yet

##### Category (Yield/Dexes/Lending/Minting):
Yield

##### [Optional] ETH addresss (to receive a LlamaPunk):

