### PR TITLE
Add Sunny Aggregator on Solana

### DIFF
--- a/projects/helper/solana.js
+++ b/projects/helper/solana.js
@@ -15,10 +15,10 @@ async function getTokenBalance(token, account) {
             }
         ]
     })
-    return tokenBalance.data.result.value.reduce((total, account)=>total+account.account.data.parsed.info.tokenAmount.uiAmount, 0)
+    return tokenBalance.data.result.value.reduce((total, account) => total + account.account.data.parsed.info.tokenAmount.uiAmount, 0)
 }
 
-async function getTokenAccountBalance(account){
+async function getTokenAccountBalance(account) {
     const tokenBalance = await axios.post('https://solana-api.projectserum.com/', {
         "jsonrpc": "2.0",
         "id": 1,
@@ -31,20 +31,58 @@ async function getTokenAccountBalance(account){
 }
 
 // Example: [[token1, account1], [token2, account2], ...]
-async function sumTokens(tokensAndAccounts){
-    const tokenlist = axios.get("https://cdn.jsdelivr.net/gh/solana-labs/token-list@main/src/tokens/solana.tokenlist.json").then(r=>r.data.tokens)
+async function sumTokens(tokensAndAccounts) {
+    const tokenlist = axios.get("https://cdn.jsdelivr.net/gh/solana-labs/token-list@main/src/tokens/solana.tokenlist.json").then(r => r.data.tokens)
     const tokenBalances = await Promise.all(tokensAndAccounts.map(getTokenBalance))
     const balances = {}
-    for(let i=0; i<tokensAndAccounts.length; i++){
+    for (let i = 0; i < tokensAndAccounts.length; i++) {
         const token = tokensAndAccounts[i][0]
-        const coingeckoId = tokenlist.find(t=>t.address === token)?.extensions?.coingeckoId
+        const coingeckoId = tokenlist.find(t => t.address === token)?.extensions?.coingeckoId
         balances[coingeckoId] = tokenBalances[i]
     }
     return balances
 }
 
+// accountsArray is an array of base58 address strings
+async function getMultipleAccountsRaw(accountsArray) {
+    if (!Array.isArray(accountsArray) || accountsArray.length === 0 || typeof accountsArray[0] !== "string") {
+        throw new Error("Expected accountsArray to be an array of strings")
+    }
+    const accountsInfo = await axios.post('https://api.mainnet-beta.solana.com', {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "getMultipleAccounts",
+        "params": [accountsArray]
+    })
+    return accountsInfo.data.result.value
+}
+
+// Gets data in Buffers of all addresses, while preserving labels
+// Example: labeledAddresses = { descriptiveLabel: "9xDUcgo8S6DdRjvrR6ULQ2zpgqota8ym1a4tvxiv2dH8", ... }
+async function getMultipleAccountBuffers(labeledAddresses) {
+    let labels = []
+    let addresses = []
+
+    for (const [label, address] of Object.entries(labeledAddresses)) {
+        labels.push(label)
+        addresses.push(address)
+    }
+    const accountsData = await getMultipleAccountsRaw(addresses)
+
+    const results = {}
+    accountsData.forEach((account, index) => {
+        results[labels[index]] = Buffer.from(account.data[0], account.data[1])
+
+        // Uncomment and paste into a hex editor to do some reverse engineering
+        // console.log(`${labels[index]}: ${results[labels[index]].toString("hex")}`);
+    });
+
+    return results;
+}
+
 module.exports = {
     getTokenBalance,
     getTokenAccountBalance,
-    sumTokens
+    sumTokens,
+    getMultipleAccountBuffers
 }

--- a/projects/sunny.js
+++ b/projects/sunny.js
@@ -1,0 +1,56 @@
+const { getMultipleAccountBuffers } = require('./helper/solana')
+
+async function sunnySaberPoolTVL(pool) {
+    const accountData = await getMultipleAccountBuffers(pool.relevantAccounts)
+
+    const lpTokensInSunnyPool = Number(accountData.sunnyPool.readBigInt64LE(209)) / 1000000
+    const reserveAAmount = Number(accountData.tokenAReserve.readBigInt64LE(64)) / 1000000
+    const reserveBAmount = Number(accountData.tokenBReserve.readBigInt64LE(64)) / 1000000
+    const poolTokenSPL = Number(accountData.poolTokenSPL.readBigInt64LE(36)) / 1000000
+
+    const sunnysShareOfSaber = lpTokensInSunnyPool / poolTokenSPL
+
+    const poolTvlCoins = {}
+    poolTvlCoins[pool.tokenA] = sunnysShareOfSaber * reserveAAmount
+    poolTvlCoins[pool.tokenB] = sunnysShareOfSaber * reserveBAmount
+
+    return poolTvlCoins
+}
+
+async function tvl() {
+    const pools = [{
+        poolName: "saber_usdc_usdt",
+        relevantAccounts: {
+            sunnyPool: "DgCMFSzZzZBnyFTmEiX1zfsugckBLyyX79YUgZr9XCf7",
+            tokenAReserve: "CfWX7o2TswwbxusJ4hCaPobu2jLCb1hfXuXJQjVq3jQF",
+            tokenBReserve: "EnTrdMMpdhugeH6Ban6gYZWXughWxKtVGfCwFn78ZmY3",
+            poolTokenSPL: "2poo1w1DL6yd2WNTCnNTzDqkC6MBXq7axo77P16yrBuf",
+        },
+        tokenA: "usd-coin",
+        tokenB: "tether",
+        tvlParser: sunnySaberPoolTVL,
+    }]
+
+    // a mapping of coin name to coin amount
+    const tvlResult = {}
+
+    // Run these serially to avoid rate limiting issues
+    for (const pool of pools) {
+        const poolTVL = await pool.tvlParser(pool)
+        console.log(pool.poolName, poolTVL)
+
+        for (const [tokenId, amount] of Object.entries(poolTVL)) {
+            if (!tvlResult[tokenId]) {
+                tvlResult[tokenId] = amount
+            } else {
+                tvlResult[tokenId] += amount
+            }
+        }
+    }
+
+    return tvlResult
+}
+
+module.exports = {
+    tvl,
+}


### PR DESCRIPTION
Sunny Aggregator just launched in Mainnet yesterday. I think my solution is elegant since it only relies on the Solana blockchain and returns granular information. Also, other Solana projects can use my helper function `getMultipleAccountBuffers()` which uses Solana RPC to fetch raw account data on chain. Please let me know what else is needed. When other pools are live, I will create another PR.

```
npx @defillama/sdk projects/sunny.js
saber_usdc_usdt { 'usd-coin': 792591.7934064921, tether: 659944.4208034169 }
usd-coin                  792.59 k
tether                    659.94 k
Total: 1.45 M
```

To verify the data via the web app, go to https://app.sunny.ag/

To contact us, message `sunnyag#1971` on Discord.

##### Twitter Link:
https://twitter.com/SunnyAggregator

##### List of audit links if any:
none

##### Website Link:
https://sunny.ag/

##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):
https://gist.github.com/sunnymicrosystems/21ed21908c57835d2b22cabe6dca0290

##### Current TVL:
$1.45m

##### Chain:
Solana

##### Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)
Not yet listed

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
Not yet listed

##### Description/bio (to be shown on DefiLlama):
Sunny is a composable DeFi yield aggregator powered by Solana, one of the fastest growing blockchain ecosystems. The Sunny Protocol is designed with composability as a core feature, enabling other applications and protocols to easily build on top of it.

##### Token address and ticker if any:
SPL Address: SUNNYWgPQmFxe9wTZzNK7iPnJ3vYDrkgnxJRJm1s3ag
Ticker: SUNNY

##### Category (Yield/Dexes/Lending/Minting):
Yield

##### [Optional] ETH addresss (to receive a LlamaPunk):
0xeFFb9aA17A597A2848295a9E83389eA740345aCd