### PR TITLE
Added Gaj Finance

### DIFF
--- a/projects/GajFinance/index.js
+++ b/projects/GajFinance/index.js
@@ -2,20 +2,10 @@ const sdk = require("@defillama/sdk");
 const {calculateUniTvl} = require('../helper/calculateUniTvl.js')
 
 const GAJ_TOKEN = '0xf4b0903774532aee5ee567c02aab681a81539e92'
-const MASTER_GAJ = '0xb03f95e649724df6ba575c2c6ef062766a7fdb51'
+const GAJ_AVAX_TOKEN = '0x595c8481c48894771CE8FaDE54ac6Bf59093F9E8'
 const NFTFARM_GAJ = '0xce52df6E9ca6db41DC4776B1735fdE60f5aD5012'
-
-async function masterChefTvl(timestamp, ethBlock, chainBlocks) {
-    const balances = {};
-    const stakedGaj = sdk.api.erc20.balanceOf({
-      target: GAJ_TOKEN,
-      owner: MASTER_GAJ,
-      chain: 'polygon',
-      block: chainBlocks.polygon
-    })
-    sdk.util.sumSingleBalance(balances, 'polygon:' + GAJ_TOKEN, (await stakedGaj).output)
-    return balances
-}
+const NFTFARM_GAJ_AVAX = '0x65096f7dB56fC27C7646f0aBb6F9bC0CEA2d8765'
+const JUNGLEPOOL = '0xD45AB9b5655D1A3d58162ed1a311df178C04ddDe'
 
 async function nftFarmTvl(timestamp, ethBlock, chainBlocks) {
     const balances = {};
@@ -29,14 +19,41 @@ async function nftFarmTvl(timestamp, ethBlock, chainBlocks) {
     return balances
 }
 
+async function nftFarmAvaxTvl(timestamp, ethBlock, chainBlocks) {
+    const balances = {};
+    const stakedGaj = sdk.api.erc20.balanceOf({
+      target: GAJ_AVAX_TOKEN,
+      owner: NFTFARM_GAJ_AVAX,
+      chain: 'avax',
+      block: chainBlocks.avax
+    })
+    sdk.util.sumSingleBalance(balances, 'avax:' + GAJ_AVAX_TOKEN, (await stakedGaj).output)
+    return balances
+}
+
+async function JunglePoolTvl(timestamp, ethBlock, chainBlocks) {
+    const balances = {};
+    const stakedGaj = sdk.api.erc20.balanceOf({
+      target: GAJ_TOKEN,
+      owner: JUNGLEPOOL,
+      chain: 'polygon',
+      block: chainBlocks.polygon
+    })
+    sdk.util.sumSingleBalance(balances, 'polygon:' + GAJ_TOKEN, (await stakedGaj).output)
+    return balances
+}
+
 module.exports = {
   misrepresentedTokens: true,
-  masterchef:{
-    tvl: masterChefTvl,
+  junglepool:{
+    tvl: JunglePoolTvl,
   },
   nftfarm:{
     tvl: nftFarmTvl,
   },
-  methodology: "TVL comes from NFT Farming and Masterchef",
-  tvl: sdk.util.sumChainTvls([masterChefTvl, nftFarmTvl])
+  avax_nftfarm:{
+    tvl: nftFarmAvaxTvl,
+  },
+  methodology: "TVL comes from NFT Farming and Jungle Pools",
+  tvl: sdk.util.sumChainTvls([JunglePoolTvl, nftFarmTvl, nftFarmAvaxTvl])
 }

--- a/projects/GajFinance/index.js
+++ b/projects/GajFinance/index.js
@@ -1,0 +1,42 @@
+const sdk = require("@defillama/sdk");
+const {calculateUniTvl} = require('../helper/calculateUniTvl.js')
+
+const GAJ_TOKEN = '0xf4b0903774532aee5ee567c02aab681a81539e92'
+const MASTER_GAJ = '0xb03f95e649724df6ba575c2c6ef062766a7fdb51'
+const NFTFARM_GAJ = '0xce52df6E9ca6db41DC4776B1735fdE60f5aD5012'
+
+async function masterChefTvl(timestamp, ethBlock, chainBlocks) {
+    const balances = {};
+    const stakedGaj = sdk.api.erc20.balanceOf({
+      target: GAJ_TOKEN,
+      owner: MASTER_GAJ,
+      chain: 'polygon',
+      block: chainBlocks.polygon
+    })
+    sdk.util.sumSingleBalance(balances, 'polygon:' + GAJ_TOKEN, (await stakedGaj).output)
+    return balances
+}
+
+async function nftFarmTvl(timestamp, ethBlock, chainBlocks) {
+    const balances = {};
+    const stakedGaj = sdk.api.erc20.balanceOf({
+      target: GAJ_TOKEN,
+      owner: NFTFARM_GAJ,
+      chain: 'polygon',
+      block: chainBlocks.polygon
+    })
+    sdk.util.sumSingleBalance(balances, 'polygon:' + GAJ_TOKEN, (await stakedGaj).output)
+    return balances
+}
+
+module.exports = {
+  misrepresentedTokens: true,
+  masterchef:{
+    tvl: masterChefTvl,
+  },
+  nftfarm:{
+    tvl: nftFarmTvl,
+  },
+  methodology: "TVL comes from NFT Farming and Masterchef",
+  tvl: sdk.util.sumChainTvls([masterChefTvl, nftFarmTvl])
+}


### PR DESCRIPTION
##### Twitter Link:
https://twitter.com/GajFinance

##### List of audit links if any:
https://solidity.finance/audits/Gaj-NFT-Farming/

##### Website Link:
https://gaj.finance

##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):
https://raw.githubusercontent.com/PolyGaj/assets/main/logo200x200.png

##### Current TVL:


##### Chain:
Polygon

##### Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)
gaj

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
gaj-finance

##### Description/bio (to be shown on DefiLlama):
Gaj, previously known as PolyGaj, is a multichain platform covering the two most promising subsects of cryptocurrency namely DeFi and NFT. With a vision to be a one-stop solution for users who want to experience both DeFi and NFT and with humble beginnings, Gaj picked up steam due to its unique offerings, especially focused on users who now had a variety of options to earn 

The team behind Gaj wanted the platform to be robust and quick so that the user experience could be enriched and hence the natively picked up Polygon protocol to built its platform as the protocol promised low transaction fees, extremely fast transactions, staking reward offerings, and enough headroom to scale. 
With the rise in demand for Gaj and with a mission to expand its users base. Gaj slowly decided to expand to a multichain level, a giant step of the Gaj in the true sense. With the first bridge deployed already, Gaj opened its door to the Binance Smart Chain users with many more bridges to come. 

To be a one-stop solution, Gaj launched a variety of products at the intersection of DeFi and NFT. These products were designed in a manner that the user can experience the power of both DeFi and the potential of  NFT’s along with great opportunities to earn additional income by staking hodling, and bidding. The range of products that Gaj is providing are all powered by its native token - $GAJ 

##### Token address and ticker if any:
0xf4b0903774532aee5ee567c02aab681a81539e92
GAJ

##### Category (Yield/Dexes/Lending/Minting):
Yield

##### [Optional] ETH addresss (to receive a LlamaPunk):
