### PR TITLE
add Sunny mai-usdc

### DIFF
--- a/projects/sunny.js
+++ b/projects/sunny.js
@@ -244,7 +244,20 @@ async function tvl() {
             tokenB: "tether",
             decimals: 6,
             tvlReader: sunnySaberPoolReader
-        }
+        },
+        {
+            poolName: "Saber_MAI-USDC",
+            relevantAccounts: {
+              sunnyPool: "6UQSBG9p7Z9Tu9CTnQaYTyjP4r7CdV9yHDj8UojguNvA",
+              tokenAReserve: "DhgiEgiNdqZdRdo195UUHnoEJUtefK8buko8nU97XJUZ",
+              tokenBReserve: "2K2kkXsouBHtWVjtcgkyiXd8eP3oVBvq1bTJzcVdLLr2",
+              lpTokenSPL: "MAiP3Zmjhc6NYiCb2xK2893ifvTTDHciCS57Kga39pC"
+            },
+            tokenA: "dai", // MAI
+            tokenB: "usd-coin",
+            decimals: 9,
+            tvlReader: sunnySaberPoolReader
+        },
     ]
 
     // a mapping of coin name to coin amount


### PR DESCRIPTION
This is a new pool.

```
npx @defillama/sdk projects/sunny.js
Saber_USDT-USDC { 'usd-coin': 61729047.44790579, tether: 56195597.94500224 }
Saber_mSOL-SOL { solana: 456918.18413866556 }
Saber_PAI-USDC { dai: 0, 'usd-coin': 0 }
Saber_BTC-renBTC { renbtc: 287.6088632731339, bitcoin: 361.2421362507761 }
Saber_pBTC-renBTC { renbtc: 0, bitcoin: 0 }
Saber_UST-USDC { 'usd-coin': 0.0024936167733572855, terrausd: 0.0023129341514467753 }
Saber_wDAI-USDC { dai: 0, 'usd-coin': 0 }
Saber_wBUSD-USDC { busd: 0, 'usd-coin': 0 }
Saber_wLUNA-renLUNA { 'terra-luna': 0 }
Saber_wFRAX-USDC { frax: 0, 'usd-coin': 0 }
Saber_HBTC-renBTC { bitcoin: 0 }
Saber_HUSD-USDC { husd: 0, 'usd-coin': 0 }
Saber_USDK-USDC { usdk: 0, 'usd-coin': 0 }
Saber_wFTT-FTT { 'ftx-token': 290728.06031072873 }
Saber_wSRM-SRM { serum: 50.5025640674843 }
Saber_ibBTC-renBTC { bitcoin: 0 }
Saber_apUSDT-USDT { tether: 0 }
Saber_MAI-USDC { dai: 2290607.3784159035, 'usd-coin': 2347145.097178926 }
usd-coin                  64.05 M
solana                    56.38 M
tether                    56.17 M
ftx-token                 19.72 M
bitcoin                   17.90 M
renbtc                    14.24 M
dai                       2.29 M
serum                     449.9778458412851
terrausd                  0.002309561893453966
busd                      0
terra-luna                0
frax                      0
husd                      0
usdk                      0
Total: 230.76 M
```

![image](https://user-images.githubusercontent.com/88907597/131887472-8242675a-4887-4790-9de0-e39ff6143d00.png)
