### PR TITLE
Update Defibox lend methodology

### DIFF
--- a/projects/defibox/index.js
+++ b/projects/defibox/index.js
@@ -1,5 +1,6 @@
 const axios = require("axios");
 const utils = require("../helper/utils");
+const {lendingMarket} = require("../helper/methodologies")
 
 const eosEndpoint = "https://dapp.defibox.io/api/"
 const bscEndpoint = "https://bsc.defibox.io/api/"
@@ -9,16 +10,16 @@ async function eos() {
   const swap = await utils.fetchURL(eosEndpoint + "swap/get24HInfo")
   const lend = await utils.fetchURL(eosEndpoint + "lend/getGlobalOpenPositionStat")
   const usn = await utils.fetchURL(eosEndpoint + "st/open/getGlobalOpenStat")
-  const tvl = Number(swap.data.data.eosBalance) * eosPrice * 2 +
-              lend.data.data.practicalBalance +
-              usn.data.globalOpenStat.totalMortgage
+  const tvl = Number(swap.data.data.eosBalance) * eosPrice * 2 + // swap TVL
+              lend.data.data.practicalBalance - lend.data.data.totalBorrowsVariable + // lend TVL
+              usn.data.globalOpenStat.totalMortgage // usn (stable token) TVL
   return tvl
 }
 
 async function bsc() {
   const bnbPrice = (await utils.getPricesfromString("binancecoin")).data.binancecoin.usd;
   const swap = await axios.default.post(bscEndpoint + "swap/get24HInfo", {}, { headers: { chainid: 56 }})
-  const tvl = swap.data.data.usd_balance + swap.data.data.wbnb_balance * bnbPrice
+  const tvl = swap.data.data.usd_balance + swap.data.data.wbnb_balance * bnbPrice // swap TVL
   return tvl
 }
 
@@ -27,7 +28,7 @@ async function fetch() {
 }
 
 module.exports = {
-  methodology: 'Defibox TVL is achieved by making a call to its API: https://dapp.defibox.io/api/.',
+  methodology: `${lendingMarket}. Defibox TVL is achieved by making a call to its API: https://dapp.defibox.io/api/.`,
   name: 'Defibox',
   token: 'BOX',
   category: 'dexes',


### PR DESCRIPTION
Update Defibox lend methodology

CC: @0xngmi

> Counts the tokens locked in the contracts to be used as collateral to borrow or to earn yield. Borrowed coins are not counted towards the TVL, so only the coins actually locked in the contracts are counted. There's multiple reasons behind this but one of the main ones is to avoid inflating the TVL through cycled lending.

Reference discussion: https://github.com/DefiLlama/DefiLlama-Adapters/pull/427#pullrequestreview-744536131

Now deducts borrowed assets from TVL

https://defibox.io/lend

```
Lend Total deposit
39,299,866 USD

Lend Total borrow
4,601,793 USD

Lend Total TVL
34,698,073 USD
```

Defibox DefiLlama TVL:

```
--- eos ---
Total: 137.88 M
--- bsc ---
Total: 6.74 M
--- fetch ---
Total: 144.62 M
```