### PR TITLE
PaintSwap - Include Staking TVL 

### DIFF
--- a/projects/paintswap/abis/getReserves.json
+++ b/projects/paintswap/abis/getReserves.json
@@ -1,0 +1,25 @@
+[
+    {
+      "inputs": [],
+      "name": "getReserves",
+      "outputs": [
+        {
+          "internalType": "uint112",
+          "name": "reserve0",
+          "type": "uint112"
+        },
+        {
+          "internalType": "uint112",
+          "name": "reserve1",
+          "type": "uint112"
+        },
+        {
+          "internalType": "uint32",
+          "name": "blockTimestampLast",
+          "type": "uint32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ]

--- a/projects/paintswap/index.js
+++ b/projects/paintswap/index.js
@@ -1,7 +1,8 @@
-const web3 = require("../config/web3.js");
 const { calculateUsdUniTvl } = require('../helper/getUsdUniTvl.js')
 const sdk = require('@defillama/sdk');
 const BigNumber = require('bignumber.js');
+const Web3 = require('web3');
+const web3ftm = new Web3(new Web3.providers.HttpProvider(`https://rpc.ftm.tools/`));
 
 const factory = '0x733A9D1585f2d14c77b49d39BC7d7dd14CdA4aa5'
 const masterchef = '0xCb80F529724B9620145230A0C866AC2FACBE4e3D'
@@ -16,7 +17,7 @@ const whitelist = [
 ]
 
 const abi = require('./abis/getReserves.json');
-const ftmBrushPairContract = new web3.eth.Contract(abi, ftmBrushLP);
+const ftmBrushPairContract = new web3ftm.eth.Contract(abi, ftmBrushLP);
 
 const getBrushPriceInFtm = async (ftmBlock) => {
   const getReserves = async (pairContract) => {

--- a/projects/paintswap/index.js
+++ b/projects/paintswap/index.js
@@ -1,11 +1,61 @@
-const axios = require('axios');
-const retry = require('../helper/retry')
+const web3 = require("../config/web3.js");
+const { calculateUsdUniTvl } = require('../helper/getUsdUniTvl.js')
+const sdk = require('@defillama/sdk');
+const BigNumber = require('bignumber.js');
 
-async function fetch() {
-  const totalSupplyResponse = await retry(async bail => await axios.get("https://api.paintswap.finance/tvl"));
-  return totalSupplyResponse.data.tvl_usd;
+const factory = '0x733A9D1585f2d14c77b49d39BC7d7dd14CdA4aa5'
+const masterchef = '0xCb80F529724B9620145230A0C866AC2FACBE4e3D'
+const ftm = '0x21be370d5312f44cb42ce377bc9b8a0cef1a4c83'
+const brush = '0x85dec8c4b2680793661bca91a8f129607571863d'
+const ftmBrushLP = '0x452590b8Aa292b963a9d0f2B5E71bC7c927859b3'
+const whitelist = [
+  brush,
+  '0x04068da6c83afcfa0e13ba15a6696662335d5b75',
+  '0x49ac072c793fb9523f0688a0d863aadfbfb5d475',
+  '0x321162cd933e2be498cd2267a90534a804051b11'
+]
+
+const abi = require('./abis/getReserves.json');
+const ftmBrushPairContract = new web3.eth.Contract(abi, ftmBrushLP);
+
+const getBrushPriceInFtm = async (ftmBlock) => {
+  const getReserves = async (pairContract) => {
+    try {
+      return await pairContract.methods.getReserves().call();
+    } catch {
+      return { reserve0: '0', reserve1: '0' };
+    }
+  }; 
+  const { reserve0, reserve1 } = await getReserves(ftmBrushPairContract);
+  return new BigNumber(reserve1).div(new BigNumber(reserve0))
+}
+
+async function stakingtvl(timestamp, ftmBlock, chainBlocks) {
+  const balances = {}
+  // Get the brush staked in the masterchef
+  const brushBalance = await sdk.api.erc20.balanceOf({
+    block: chainBlocks['fantom'],
+    target: brush,
+    owner: masterchef,
+    chain: 'fantom'
+  })
+  sdk.util.sumSingleBalance(balances, brush, brushBalance.output)
+
+  // Convert to fantom amount as CoinGecko does not currently have our price
+  return new Promise(async (resolve, reject) => {
+    try {
+      const newBalances = {}
+      newBalances["fantom"] = BigNumber(balances[brush]).div(await getBrushPriceInFtm (ftmBlock)).div(BigNumber(10).pow(18));
+      resolve(newBalances);
+    } catch(error) {
+      reject(error);
+    }
+  })
 }
 
 module.exports = {
-  fetch
+  tvl: calculateUsdUniTvl(factory, 'fantom', ftm, whitelist, 'fantom'),
+  staking:{
+    tvl: stakingtvl
+  }
 }

--- a/projects/paintswap/index.js
+++ b/projects/paintswap/index.js
@@ -1,14 +1,11 @@
-const {calculateUsdUniTvl} = require('../helper/getUsdUniTvl.js')
+const axios = require('axios');
+const retry = require('../helper/retry')
 
-const factory = '0x733A9D1585f2d14c77b49d39BC7d7dd14CdA4aa5'
-const ftm = '0x21be370d5312f44cb42ce377bc9b8a0cef1a4c83'
-const whitelist = [
-  '0x04068da6c83afcfa0e13ba15a6696662335d5b75',
-  '0x85dec8c4b2680793661bca91a8f129607571863d',
-  '0x49ac072c793fb9523f0688a0d863aadfbfb5d475',
-  '0x321162cd933e2be498cd2267a90534a804051b11'
-]
+async function fetch() {
+  const totalSupplyResponse = await retry(async bail => await axios.get("https://api.paintswap.finance/tvl"));
+  return totalSupplyResponse.data.tvl_usd;
+}
 
 module.exports = {
-  tvl: calculateUsdUniTvl(factory, 'fantom', ftm, whitelist, 'fantom')
+  fetch
 }


### PR DESCRIPTION
Firstly, thanks for updating to whitelist RNDM & BRUSH!

I wanted to add our BRUSH single sided staking in our masterchef contract, as we have 1/3 of our liquidity there. Unfortunately we aren't on CoinGecko yet so it can't get the price when I tried using the `staking { }` field. We have an endpoint which returns, total tvl (incl staking), just LP and just staked tvl:

https://api.paintswap.finance/tvl
`{"updated_at":1632053590,"tvl_usd":5054841.330025606,"exchange_tvl":"3391837.895034088144048127148651982","staked_brush_usd":1663003.434991517}`

But I couldn't find a way to just add the staking part. `tvl_usd` includes everything, so seemed easier to just use that!

As an aside can we also be moved to DEX category instead of yield?