### PR TITLE
Fixed msol pricing.

### DIFF
--- a/projects/portfinance/index.js
+++ b/projects/portfinance/index.js
@@ -15,12 +15,11 @@ async function tvl() {
     return {
         'usd-coin': usdcAmount,
         'tether': usdtAmount,
-        'solana': solAmount + pSolAmount,
+        'solana': solAmount + pSolAmount + mSolAmount,
         'usdp': paiAmount,
         'mercurial': merAmount,
         'bitcoin': btcAmount,
         'serum': srmAmount,
-        'marinade-staked-sol': mSolAmount,
     }
 }
 


### PR DESCRIPTION
Fixed #582 
I suspect it is caused by Coingecko doesn't show the correct mSOL price, so in this PR I change to use the Solana price (which is a slight under estimate since mSOL is accuring value over time) instead.