### PR TITLE
Add Depth TVL info on BSC chain

### DIFF
--- a/projects/depth/index.js
+++ b/projects/depth/index.js
@@ -456,7 +456,7 @@ async function getVaultTotalDepositBsc(){
     return totalSelfUnderlying
 }
 
-
+//heco tvl
 async function fetchHeco() {
 
     let balances = {};
@@ -491,7 +491,7 @@ async function fetchHeco() {
     return total+dao+vault
 }
 
-
+//bsc tvl
 async function fetchBsc() {
     const swapTvl=await swapV2PoolUnderlyingCoinBalanceBsc("0xc57220b65dd9200562aa73b850c06be7bd632b57")
     const vaultTvl=await getVaultTotalDepositBsc()
@@ -503,6 +503,6 @@ module.exports = {
     name: 'Depth',
     website: 'https://depth.fi/',
     token: 'DEP',
-    fetchHeco,//hecoTvl
-    fetchBsc//bsctvl
+    fetchHeco,
+    fetchBsc
 }


### PR DESCRIPTION
Name: Depth

Twitter Link:https://twitter.com/DepthFi

List of audit links if any:https://docs.depth.fi/audit

Website Link: https://www.depth.fi/

Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):
https://drive.google.com/drive/folders/1rhsaMEbeByC55MalaFFR2QFnagRcfTTw?usp=sharing

Current TVL: $189,581,749.50

Chain: HECO, BSC
Coingecko ID (so your TVL can appear on Coingecko): 
HECO：depth-token
BSC: N/A (yet)

Coinmarketcap ID (so your TVL can appear on Coinmarketcap): 
HECO: 9164
BSC: N/A (yet)

Short Description (to be shown on DefiLlama):
Depth is a secure and efficient stable assets management protocol. Depth allows stablecoins to swap in a safe and secure environment with good depth, low slippage, and low transaction fees. Depth has delicately selected multiple yield aggregators for users. Besides the transaction fees, Depth also integrated other DeFi yield protocols, providing users long-term extra rewards in a safe condition.


Token address and ticker if any:
DEP- HECO：0x48C859531254F25e57D1C1A8E030Ef0B1c895c27
BDEP- BSC：0x16f99577b259B069a2d1D166e70d349b11b1D325

Category (Yield/Dexes/Lending/Minting/Assets/Insurance/Options/Indexes/Staking)
 *Please choose only one: 
Dexes

Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):
N/A

forkedFrom (Does your project originate from another project):
N/A

methodology (what is being counted as tvl, how is tvl being calculated):
Our TVL includes asset that is held in the protocol's contracts
Except: pool2 LPs like: BDEP/BNB LP on Pancakeswap, and DEP/USDT LP on Hswap