### PR TITLE
Update endpoint to take data from the staked API

### DIFF
--- a/projects/alchemist/index.js
+++ b/projects/alchemist/index.js
@@ -4,7 +4,9 @@ const pool2s = [
     "0xf0D415189949d913264A454F57f4279ad66cB24d", // Aludel v1
     "0x93c31fc68E613f9A89114f10B38F9fd2EA5de6BC" // Aludel v1.5
 ]
-const endpoint = "https://crucible.alchemist.wtf/api/get-program-rewards-usd?network=1"
+
+// Retrieve Staked Token Values from API
+const endpoint = "https://crucible.alchemist.wtf/api/get-program-staked-usd?network=1"
 
 function get(includePool2){
 return async function() {


### PR DESCRIPTION
Currently the endpoint used is for the value of rewards in reward programs

The API in this proposal contains the value of tokens locked/staked to those reward programs.