### PR TITLE
Update WardenSwap Adapter

### DIFF
--- a/projects/wardenswap/index.js
+++ b/projects/wardenswap/index.js
@@ -1,19 +1,75 @@
 const sdk = require("@defillama/sdk");
-const tvlOnPairs = require("../helper/processPairs.js");
-
-const factory = "0x3657952d7bA5A0A4799809b5B6fdfF9ec5B46293";
-// Masterchef has not been included since they're staking their own LP token from the pools
+const token0 = require("../helper/abis/token0.json");
+const token1 = require("../helper/abis/token1.json");
+const getReserves = require("../helper/abis/getReserves.json");
 
 const bscTvl = async (timestamp, ethBlock, chainBlocks) => {
   const balances = {};
 
-  await tvlOnPairs("bsc", chainBlocks, factory, balances);
+  const trackedPairAddresses = [
+    "0xdc683adb914edf91df4a36c33ee4f59ca41bc263", // WAD/BNB
+    "0xc95b1750043fce5dfcc8539835ea3830ec002a89", // WAD/BUSD
+    "0xcf643c4b9dbf42239aa00e23a0570c90d517e6dc", // BUSD/BNB
+    "0xfd468f81f4a6d859a0eb3667c65f7bea9dc69028", // USDT/BNB
+    "0x1b1675a97b2f62b568569ebd349e88a04dde8586", // BTCB/BNB
+    "0x8485c5f255ff30aafab0030329e508bd8dde11c5", // ETH/BNB
+    "0x087d69b97a6df4fb37e4e93a31752008223a6c19", // USDT/BUSD
+  ];
+
+  const chain = "bsc";
+  const multiCallProperties = {
+    chain,
+    calls: trackedPairAddresses.map((pairAddress) => ({
+      target: pairAddress,
+    })),
+    block: chainBlocks[chain],
+  };
+
+  const [token0Addresses, token1Addresses, reserves] = await Promise.all([
+    sdk.api.abi
+      .multiCall({
+        abi: token0,
+        ...multiCallProperties,
+      })
+      .then(({ output }) => output),
+    sdk.api.abi
+      .multiCall({
+        abi: token1,
+        ...multiCallProperties,
+      })
+      .then(({ output }) => output),
+    sdk.api.abi
+      .multiCall({
+        abi: getReserves,
+        ...multiCallProperties,
+      })
+      .then(({ output }) => output),
+  ]);
+
+  trackedPairAddresses.forEach((_addr, n) => {
+    sdk.util.sumSingleBalance(
+      balances,
+      `${chain}:${token1Addresses[n].output}`,
+      reserves[n].output[1]
+    );
+    sdk.util.sumSingleBalance(
+      balances,
+      `${chain}:${token0Addresses[n].output}`,
+      reserves[n].output[0]
+    );
+  });
 
   return balances;
 };
 
 module.exports = {
-  
+  name: 'WardenSwap',
+  website: 'https://www.wardenswap.finance/',
+  token: 'WAD',
+  category: 'dexes',
+  methodology: "TVL of WardenSwap is calculated by querying total liquidity of WardenSwap's active pools listed on our farm page https://farm.wardenswap.finance/?t=1&s=1/#/farm. However, pools at PancakeSwap and inactive pools are not included",
+  bsc:{
     tvl: bscTvl,
-  
+  },
+  tvl: sdk.util.sumChainTvls([bscTvl]),
 };


### PR DESCRIPTION
Hi. We are from WardenSwap team and we would like to update the TVL calculation of WardenSwap with some more info.

##### Twitter Link: https://twitter.com/WardenSwap

##### Website Link: https://www.wardenswap.finance/

##### Logo: (already exists on Defillama)

##### Current TVL: ~7.8 Million USD

##### Chain: BSC, Arbitrum, Polygon (Note that we only provide TVL on BSC chain as our farming pools are lived on BSC only).

##### Coingecko ID: `warden`
##### Coinmarketcap ID: `8981`

##### Short Description (to be shown on DefiLlama): WardenSwap is the AI-powered DEX that provide "Best Rate" of token pairs available on the market. The platform helps finding the best route of token trading based on multiple pools from multiple DEXes.

##### Token address and ticker if any: `0x0fEAdcC3824E7F3c12f40E324a60c23cA51627fc`.

##### Category (Yield/Dexes/Lending/Minting/Assets/Insurance/Options/Indexes/Staking) *Please choose only one: `Dexes`

##### methodology (what is being counted as tvl, how is tvl being calculated): TVL is calculated from total liquidity of WardenSwap's active pools listed on our farm page https://farm.wardenswap.finance/?t=1&s=1/#/farm, excluding pools at PancakeSwap and inactive pools are not included, plus total warden staked in Warden pool.