### PR TITLE
Add fetch adapter for Vee finance

### DIFF
--- a/projects/vee-finance/index.js
+++ b/projects/vee-finance/index.js
@@ -1,21 +1,12 @@
-const axios = require('axios');
-const BN = require('bignumber.js');
+const {getCompoundV2Tvl} = require('../helper/compound')
+const sdk = require('@defillama/sdk')
 
-async function fetch() {   
-    var tvl = 0;
-    try {
-        var responseV1   = await axios.get('https://api-prod.vee.finance/getv1tvl');
-        var responseV2   = await axios.get('https://api-prod.vee.finance/getv2tvl');
-        
-        if(responseV1.status == 200 && responseV2.status == 200){            
-            tvl = new BN(responseV1.data.data['tvl']).plus(responseV2.data.data['tvl']).toFixed(2);           
-        }
-    } catch (error) {
-       //console.error("tvl()-error: ===> " + error);
-  }
-  return tvl;    
-}
-
-module.exports = {
-    fetch
+module.exports={
+    methodology: 'As in Compound Finance, TVL counts the tokens locked in the contracts to be used as collateral to borrow or to earn yield. Borrowed coins are not counted towards the TVL, so only the coins actually locked in the contracts are counted.',
+    tvl: sdk.util.sumChainTvls([
+        getCompoundV2Tvl("0xA67DFeD73025b0d61F2515c531dd8D25D4Cfd0Db", "avax", addr=>`avax:${addr}`),
+        getCompoundV2Tvl("0x43AAd7d8Bc661dfA70120865239529ED92Faa054", "avax", addr=>`avax:${addr}`, "0x6481490DBb6Bd0e8b7CB7E1317470f6d08aDa5A2", "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7"),
+        getCompoundV2Tvl("0xAF7f6F7a1295dEDF52a01F5c3f04Ad1b502CdA6a", "avax", addr=>`avax:${addr}`),
+        getCompoundV2Tvl("0xeEf69Cab52480D2BD2D4A3f3E8F5CcfF2923f6eF", "avax", addr=>`avax:${addr}`, "0x125605c515e3f75CAd62d3613c97A76F13d73A64", "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7"),
+    ])
 }


### PR DESCRIPTION
##### Add adapter for Vee finance

##### Twitter Link:
https://twitter.com/VeeFinance

##### List of audit links if any:
audit by SlowMist and Certik
https://github.com/VeeFinance/audit

##### Website Link:
https://vee.finance/home

##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):
https://rs.vee.finance/image/logo-white.png
https://rs.vee.finance/image/logo-black.png

##### Current TVL:
$6,090,006.60

##### Chain:
Avalanche

##### Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)
vee-finance

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
11961
https://coinmarketcap.com/currencies/vee-finance/

##### Short Description (to be shown on DefiLlama):
Vee.Finance is a DeFi lending platform for both traditional finance and crypto users, and dedicates itself to bridging the gap between traditional finance and DeFi by providing users with better digital asset management services.

##### Token address and ticker if any:
0x3709E8615E02C15B096f8a9B460ccb8cA8194e86

##### Category (Yield/Dexes/Lending/Minting/Assets/Insurance/Options/Indexes/Staking) *Please choose only one:
Lending

##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):
Chainlink

##### forkedFrom (Does your project originate from another project):
Compound

##### methodology (what is being counted as tvl, how is tvl being calculated):
Total TVL = Sum amount of tokens from our contracts including both V1 and V2.
