### PR TITLE
Count Locked XTZ in Kolibri TVL

### DIFF
--- a/projects/kolibri/index.js
+++ b/projects/kolibri/index.js
@@ -1,16 +1,27 @@
 const axios = require("axios");
 const {toUSDTBalances} = require('../helper/balances')
 
+const priceUrl = 'https://oracle-data.kolibri.finance/data.json';
 const tvlUrl = 'https://kolibri-data.s3.amazonaws.com/mainnet/totals.json';
 
 async function tvl() {
-    return toUSDTBalances((await axios.get(tvlUrl)).data.liquidityPoolBalance);
+    const response = await axios.get(tvlUrl)
+
+    // Balance of Liquidity Pool
+    const liquidityPoolBalance = new BigNumber(response.data.liquidityPoolBalance)
+
+    // Balance of locked XTZ, in terms of USD
+    const price = new BigNumber((await axios.get(priceUrl)).data.prices.XTZ);
+    const xtzInOvens = new BigNumber(response.data.totalBalance);
+    const usdInOvens = xtzInOvens.multipliedBy(price).dividedBy(1000000).toFixed(0);
+    
+    return toUSDTBalances(usdInOvens.plus(liquidityPoolBalance))
 }
 async function pool2() {
     return toUSDTBalances((await axios.get(tvlUrl)).data.quipuswapFarmBalanceUSD);
 }
 module.exports = {
-    methodology: 'TVL counts the XTZ tokens that are deposited to mint kUSD, kUSD in the liquidity pool, and value locked in Kolibri Protocol\'s farms. Borrowed tokens are not counted.',
+    methodology: 'TVL counts the XTZ tokens that are deposited to mint kUSD, and kUSD in the liquidity pool. Borrowed tokens are not counted.',
     tezos:{
         tvl,
         pool2


### PR DESCRIPTION
We recently merged https://github.com/DefiLlama/DefiLlama-Adapters/pull/467/files (apologies for letting this go stale). A follow up change modified the merged PR:
https://github.com/DefiLlama/DefiLlama-Adapters/commit/631ed6f03c0661992d185ee5105e15e837aec299

The change caused us to miscount Kolibri's TVL (dropping from ~$28M to ~$1M) because we omit counting the value of XTZ in locked in CDPs to mint kUSD. 
<img width="1435" alt="Screen Shot 2021-10-19 at 11 49 07 AM" src="https://user-images.githubusercontent.com/18271723/137946417-b137c94e-2a78-4be4-a4b8-7d54ed43d015.png">

This PR restores counting of the locked XTZ. The new code is almost completely identical to the original code (https://github.com/DefiLlama/DefiLlama-Adapters/commit/4fd73ac684a404d1e94e721957eda57092de47b7#diff-2ab47883a02786ff2d1adeb2de334d0a9d0772d38bb166857a1cbfbcfcfd3722) from the DefiLlama team. 

Lastly, update the `methodology` field to say that farms are not counted in TVL.
