### PR TITLE
Fix totalReserve in Paladin Finance adapter

### DIFF
--- a/projects/paladinfinance/index.js
+++ b/projects/paladinfinance/index.js
@@ -39,7 +39,7 @@ async function ethTvl(timestamp, block) {
 
   let totalReserve = await sdk.api.abi.multiCall({
     calls,
-    abi: abi["totalBorrowed"],
+    abi: abi["totalReserve"],
     block: block
   })
 


### PR DESCRIPTION
Simple fix to Wrong ABI call in totalReserve computation : `abi["totalBorrowed"] => abi["totalReserve"]`

`tvl = underlyingBalances + totalBorrowed - totalReserve // totalBorrowed - totalReserve was always equal to zero`
