### PR TITLE
Add Agave TVL

### DIFF
--- a/projects/agave.js
+++ b/projects/agave.js
@@ -39,15 +39,13 @@ async function getV2Reserves(block, addressesProviderRegistry, chain, v2Atokens,
   // v2Atokens = atokens.map(atoken => atoken.id)
   v2ReserveTokens = []
   v2Atokens = atokens.map(atoken => {
-    underlyingAssetAddress = atoken.underlyingAssetAddress
+    const underlyingAssetAddress = atoken.underlyingAssetAddress
     v2ReserveTokens.push(underlyingAssetAddress)
     const reserve = reserves.find(r => r.underlyingAsset === underlyingAssetAddress)
-    reserveSymbol = reserve.symbol
-    decimals = reserve.decimals
 
     addressSymbolMapping[underlyingAssetAddress] = {
-      symbol: reserveSymbol,
-      decimals: decimals
+      symbol: reserve.symbol,
+      decimals: reserve.decimals
     }
     return atoken.id
   })
@@ -61,12 +59,11 @@ const {getV2Tvl} = require('./helper/aave.js');
 function aaveChainTvl(chain, addressesProviderRegistry, transformAddress){
   return async (timestamp, ethBlock, chainBlocks)=>{
     const balances = {}
-    const block = chainBlocks[chain]
     let v2Atokens = [];
     let v2ReserveTokens = [];
     let addressSymbolMapping = {};
-    [v2Atokens, v2ReserveTokens, addressSymbolMapping] = await getV2Reserves(block, addressesProviderRegistry, chain, v2Atokens, v2ReserveTokens, addressSymbolMapping)
-    const v2Tvl = await getV2Tvl(block, chain, v2Atokens, v2ReserveTokens, addressSymbolMapping);
+    [v2Atokens, v2ReserveTokens, addressSymbolMapping] = await getV2Reserves(chainBlocks[chain], addressesProviderRegistry, chain, v2Atokens, v2ReserveTokens, addressSymbolMapping)
+    const v2Tvl = await getV2Tvl(chainBlocks[chain], chain, v2Atokens, v2ReserveTokens, addressSymbolMapping);
     v2Tvl.map(data => {
       sdk.util.sumSingleBalance(balances, transformAddress?transformAddress(data.underlying):`${chain}:${data.underlying}`, data.balance);
     })


### PR DESCRIPTION
Add Agave TVL - deposited tokens exchanged for aTokens as well as staked Agve

##### Twitter Link:
https://twitter.com/Agave_lending

##### List of audit links if any:


##### Website Link:
https://agave.finance/

##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):
https://agave.finance/images/logo.svg

##### Current TVL:


##### Chain:
xdai

##### Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)
https://www.coingecko.com/en/coins/agave-token

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
https://coinmarketcap.com/fr/currencies/agave/

##### Short Description (to be shown on DefiLlama):
Agave rewards depositors with passive income and lets them use their deposits as collateral to borrow and lend digital assets. Forked from Aave.

##### Token address and ticker if any:
AGVE

##### Category (Yield/Dexes/Lending/Minting/Assets/Insurance/Options/Indexes/Staking) *Please choose only one:
Lending

##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):


##### forkedFrom (Does your project originate from another project):
Uniswap

##### methodology (what is being counted as tvl, how is tvl being calculated):
This PR is inspired by Aave adapter. Counts the tokens locked in the contracts to be used as collateral to borrow or to earn yield. Borrowed coins are not counted towards the TVL, so only the coins actually locked in the contracts are counted. There's multiple reasons behind this but one of the main ones is to avoid inflating the TVL through cycled lending

