### PR TITLE
Add pStake TVL

### DIFF
--- a/projects/pstake.js
+++ b/projects/pstake.js
@@ -1,0 +1,34 @@
+const sdk = require("@defillama/sdk")
+const BigNumber = require('bignumber.js')
+
+const pATOM = '0x446E028F972306B5a2C36E81D3d088Af260132B3',
+stkATOM = '0x44017598f2AF1bD733F9D87b5017b4E7c1B28DDE',
+pXPRT = '0x8793cD84c22B94B1fDD3800f02C4B1dcCa40D50b',
+stkXPRT = '0x45e007750Cc74B1D2b4DD7072230278d9602C499'
+
+async function tvl(timestamp, block, chainBlocks) {
+  const totalSupplies = await sdk.api.abi.multiCall({
+    abi: 'erc20:totalSupply',
+    calls: [pATOM, stkATOM, pXPRT, stkXPRT].map(t => ({target:t})),
+    block
+  })
+  console.log(totalSupplies.output.map(call => call.input.target + ', ' + BigNumber(call.output).div(1e6).toFixed(2)).join('\n'))
+
+  // Dont know why sumMultiBalanceOf do not list pTokens but do list stkTokens, so grouping them manually
+  // const balances = {};
+  // sdk.util.sumMultiBalanceOf(balances, totalSupplies);
+  // Grouping the pToken and stkToken balances manually into stkToken, recognized by defillama
+  const totalSuppliesOut = totalSupplies.output
+  totalAtom = BigNumber(totalSuppliesOut[0].output).plus(BigNumber(totalSuppliesOut[1].output))
+  totalXPRT = BigNumber(totalSuppliesOut[2].output).plus(BigNumber(totalSuppliesOut[3].output))
+  balances = {
+    '0x44017598f2AF1bD733F9D87b5017b4E7c1B28DDE': totalAtom, // pATOM + stkATOM
+    '0x45e007750Cc74B1D2b4DD7072230278d9602C499': totalXPRT  // pXPRT + stkXPRT
+  }
+  return balances;
+}
+
+module.exports = {
+  tvl: tvl,
+  methodology: `TVL is totalSupply of pATOM + stkATOM wrapped and staked from COSMOS to Eth mainnet, as well as totalSupply of XPRT (p and stk)`
+}


### PR DESCRIPTION
Add pStake TVL = pATOM + stkATOM + pXPRT + stkXPRT
Dont know why sumMultiBalanceOf do not list pTokens but do list stkTokens, so grouping them manually

##### Twitter Link:
https://twitter.com/PersistenceOne

##### List of audit links if any:


##### Website Link:
https://pstake.finance/

##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):
both logos in a single SVG: https://app.pstake.finance/static/media/dark-light-logo.962eeeb6.svg
raster on dark bg: https://pbs.twimg.com/profile_images/1350490180399071232/oW3AGQyU_400x400.jpg

##### Current TVL:
20M 

##### Chain:
Ethereum mainnet

##### Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)
https://www.coingecko.com/fr/pi%C3%A8ces/persistence

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
https://coinmarketcap.com/fr/currencies/persistence/

##### Short Description (to be shown on DefiLlama):
Stakers today need to lock up their PoS assets (such as ATOM, XPRT, ETH, SOL, etc.) on the network to earn staking rewards. Staked assets are usually illiquid and cannot be put to any further use.
pSTAKE is a liquid staking protocol unlocking the liquidity of staked assets. Stakers of PoS tokens can now stake their assets while maintaining the liquidity of these assets. On staking with pSTAKE, users earn staking rewards and also receive 1:1 pegged staked representative tokens (stkTOKENs) which can be used in DeFi to generate additional yield (yield on top of staking rewards).


##### Token address and ticker if any:
XPRT

##### Category (Yield/Dexes/Lending/Minting/Assets/Insurance/Options/Indexes/Staking) *Please choose only one:
Staking

##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):


##### forkedFrom (Does your project originate from another project):


##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL is totalSupply of pATOM + stkATOM wrapped and staked from COSMOS to Eth mainnet, as well as totalSupply of XPRT (p and stk)

