### PR TITLE
Exclude TETU swap vaults

### DIFF
--- a/projects/tetu/abi.json
+++ b/projects/tetu/abi.json
@@ -51,5 +51,31 @@
     ],
     "stateMutability": "view",
     "type": "function"
+  },
+  "strategy": {
+    "inputs": [],
+    "name": "strategy",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  "platform": {
+    "inputs": [],
+    "name": "platform",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
   }
 }

--- a/projects/tetu/index.js
+++ b/projects/tetu/index.js
@@ -6,6 +6,10 @@ const POLY_BOOKKEEPER = "0x0A0846c978a56D6ea9D2602eeb8f977B21F3207F";
 const POLY_CONTRACT_READER = "0xCa9C8Fba773caafe19E6140eC0A7a54d996030Da";
 const POLY_USDC = "polygon:0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174";
 
+const EXCLUDED_PLATFORMS = {
+  "12": true
+}
+
 const polygonTvl = async (timestamp, ethBlock, chainBlocks) => {
   const block = chainBlocks["polygon"];
   let balances = {};
@@ -30,9 +34,31 @@ const polygonTvl = async (timestamp, ethBlock, chainBlocks) => {
         })
     ).output;
 
+    const strategy = (
+        await sdk.api.abi.call({
+          block,
+          target: vaultAddress,
+          abi: abi.strategy,
+          chain: "polygon",
+        })
+    ).output;
+
+    const platform = (
+        await sdk.api.abi.call({
+          block,
+          target: strategy,
+          abi: abi.platform,
+          chain: "polygon",
+        })
+    ).output;
+
+    if (EXCLUDED_PLATFORMS[platform] === true) {
+      continue;
+    }
+
     // Tetu is using our own PriceCalculator for determination prices of each assets
     // ContractReader uses this solution for calculation vault TVL with USDC price
-     const usdcBal = (
+    const usdcBal = (
         await sdk.api.abi.call({
           block,
           target: POLY_CONTRACT_READER,
@@ -41,8 +67,9 @@ const polygonTvl = async (timestamp, ethBlock, chainBlocks) => {
           chain: "polygon",
         })
     ).output;
-     // vaultTvlUsdc returns 18 decimals but USDC has 6
-    sdk.util.sumSingleBalance(balances, POLY_USDC, BigNumber(usdcBal).div(1e12).toFixed(0));
+    // vaultTvlUsdc returns 18 decimals but USDC has 6
+    sdk.util.sumSingleBalance(balances, POLY_USDC,
+        BigNumber(usdcBal).div(1e12).toFixed(0));
   }
 
   return balances;


### PR DESCRIPTION
We are starting new sub-platforms. Need to exclude these vaults to avoid double calculation