### PR TITLE
Added SSOV to Dopex TVL

### DIFF
--- a/projects/dopex/abi.json
+++ b/projects/dopex/abi.json
@@ -1,0 +1,33 @@
+{
+  "balanceOf": {
+    "constant": true,
+    "inputs": [
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "payable": false,
+    "name": "balanceOf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  "earned": {
+    "inputs": [
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "earned",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "DPXtokensEarned",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "RDPXtokensEarned",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+}

--- a/projects/dopex/index.js
+++ b/projects/dopex/index.js
@@ -1,23 +1,77 @@
-const { pool2 } = require('../helper/pool2')
-const {staking}= require('../helper/staking')
+const sdk = require("@defillama/sdk");
+const BigNumber = require("bignumber.js");
+const abi = require("./abi");
+const { pool2 } = require("../helper/pool2");
+const { staking } = require("../helper/staking");
 
-const DPX = "0xeec2be5c91ae7f8a338e1e5f3b5de49d07afdc81"
-function transformArbitrum(addr){
-    if(addr.toLowerCase() === "0x6c2c06790b3e3e3c38e12ee22f8183b37a13ee55"){
-        return DPX
-    }
-    return `arbitrum:${addr}`
+const DPX = "0xeec2be5c91ae7f8a338e1e5f3b5de49d07afdc81";
+const RDPX = "0x0ff5A8451A839f5F0BB3562689D9A44089738D11";
+const stakingRewardsDPX = "0xc6D714170fE766691670f12c2b45C1f34405AAb6";
+const SSOVDpx = "0x818ceD3D446292061913f1f74B2EAeE6341a76Ec";
+
+function transformArbitrum(addr) {
+  if (addr.toLowerCase() === "0x6c2c06790b3e3e3c38e12ee22f8183b37a13ee55") {
+    return DPX;
+  } else if (
+    addr.toLowerCase() === "0x32eb7902d4134bf98a28b963d26de779af92a212"
+  ) {
+    return RDPX;
+  }
+  return `arbitrum:${addr}`;
 }
 
-module.exports={
-    ethereum:{
-        staking:staking('0xce4d3e893f060cb14b550b3e6b0ad512bef30995', DPX, 'ethereum'),
-        pool2: pool2("0x2a52330be21d311a7a3f40dacbfee8978541b74a", "0xf64af01a14c31164ff7381cf966df6f2b4cb349f", "ethereum"),
-        tvl: async()=>({})
-    },
-    arbitrum:{
-        staking:staking('0xc6D714170fE766691670f12c2b45C1f34405AAb6', '0x6c2c06790b3e3e3c38e12ee22f8183b37a13ee55', 'arbitrum', DPX),
-        pool2: pool2("0x96B0d9c85415C69F4b2FAC6ee9e9CE37717335B4", "0x0C1Cf6883efA1B496B01f654E247B9b419873054", "arbitrum", transformArbitrum),
-        tvl: async()=>({})
-    }
+async function arbitrumTvl(timestamp, block) {
+  let balances = {};
+  const ssovBalance = await sdk.api.abi.call({
+    target: stakingRewardsDPX,
+    abi: abi["balanceOf"],
+    params: [SSOVDpx],
+    block: block,
+    chain: "arbitrum",
+  });
+  const ssovEarntRewards = await sdk.api.abi.call({
+    target: stakingRewardsDPX,
+    abi: abi["earned"],
+    params: [SSOVDpx],
+    block: block,
+    chain: "arbitrum",
+  });
+
+  balances[DPX] = new BigNumber(ssovBalance.output)
+    .plus(new BigNumber(ssovEarntRewards.output.DPXtokensEarned))
+    .toFixed();
+  balances[RDPX] = ssovEarntRewards.output.RDPXtokensEarned;
+
+  return balances;
 }
+
+module.exports = {
+  ethereum: {
+    staking: staking(
+      "0xce4d3e893f060cb14b550b3e6b0ad512bef30995",
+      DPX,
+      "ethereum"
+    ),
+    pool2: pool2(
+      "0x2a52330be21d311a7a3f40dacbfee8978541b74a",
+      "0xf64af01a14c31164ff7381cf966df6f2b4cb349f",
+      "ethereum"
+    ),
+    tvl: async () => ({}),
+  },
+  arbitrum: {
+    staking: staking(
+      "0xc6D714170fE766691670f12c2b45C1f34405AAb6",
+      "0x6c2c06790b3e3e3c38e12ee22f8183b37a13ee55",
+      "arbitrum",
+      DPX
+    ),
+    pool2: pool2(
+      "0x96B0d9c85415C69F4b2FAC6ee9e9CE37717335B4",
+      "0x0C1Cf6883efA1B496B01f654E247B9b419873054",
+      "arbitrum",
+      transformArbitrum
+    ),
+    tvl: arbitrumTvl,
+  },
+};


### PR DESCRIPTION
##### Twitter Link: https://twitter.com/dopex_io


##### List of audit links if any: 
- https://github.com/solidified-platform/audits/blob/2b18110d0989aa083ce3869915de83037f5291b9/Audit%20Report%20-%20Dopex%20%5B21.06.2021%5D.pdf


##### Website Link: https://www.dopex.io/


##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):
- https://app.dopex.io/static/media/logo.8217a4fd.svg
- https://icons.llama.fi/dopex.png


##### Current TVL: $1.18M


##### Chain: Arbitrum


##### Coingecko ID (so your TVL can appear on Coingecko): dopex


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): 11188


##### Short Description (to be shown on DefiLlama): Dopex is a maximum liquidity and minimal exposure options protocol


##### Token address and ticker if any: 
- 0xeec2be5c91ae7f8a338e1e5f3b5de49d07afdc81 (DPX)
- 0x0ff5A8451A839f5F0BB3562689D9A44089738D11 (RDPX)


##### Category (Yield/Dexes/Lending/Minting/Assets/Insurance/Options/Indexes/Staking) *Please choose only one: Options


##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using): Chainlink/TWAP


##### forkedFrom (Does your project originate from another project): No


##### methodology (what is being counted as tvl, how is tvl being calculated): The deposits in the [DPX Single Staking Option Vaults (SSOV)](https://blog.dopex.io/dpx-single-staking-option-vaults-2b2dbda540f9) is counted as TVL. The SSOV sells covered calls of the deposited token at fixed strikes. In the DPX SSOV, deposited DPX earns additional yield by staking it into the DPX StakingRewards to earn DPX and RDPX rewards. Hence the TVL is the tokens deposited in the SSOV (includes yield from call buyers) and the DPX and RDPX yield the deposited tokens have earned so far from the StakingRewards single sided staking.