### PR TITLE
fix missing chess staking data

### DIFF
--- a/projects/tranchess/index.js
+++ b/projects/tranchess/index.js
@@ -13,7 +13,7 @@ function getBSCAddress(address) {
   return `bsc:${address}`
 }
 
-async function tvl(timestamp, blockETH, chainBlocks){
+async function bsc(timestamp, blockETH, chainBlocks){
   let balances = {};
   const block = chainBlocks["bsc"];
   
@@ -78,12 +78,12 @@ async function staking(timestamp, block, chainBlocks) {
 
 module.exports = {
   methodology: `Counts the underlying assets in each fund.`,
-  tvl: tvl,
+  tvl: sdk.util.sumChainTvls([bsc]),
   staking:{
     tvl: staking
   },
   bsc:{
     staking,
-    tvl: tvl
+    tvl: bsc
   }
 }

--- a/projects/tranchess/index.js
+++ b/projects/tranchess/index.js
@@ -77,6 +77,13 @@ async function staking(timestamp, block, chainBlocks) {
 }
 
 module.exports = {
+  methodology: `Counts the underlying assets in each fund.`,
   tvl: tvl,
-  staking: staking
+  staking:{
+    tvl: staking
+  },
+  bsc:{
+    staking,
+    tvl: tvl
+  }
 }


### PR DESCRIPTION
Seems that CHESS staking data were still missing from the frontend [defillama.com/protocol/tranchess](https://defillama.com/protocol/tranchess). I made the following change to fix it, could admins please help to review the fix? Thanks for your time