### PR TITLE
Add Blizz Finance

### DIFF
--- a/projects/blizzfinance/index.js
+++ b/projects/blizzfinance/index.js
@@ -1,0 +1,12 @@
+const { aaveChainTvl} = require('../helper/aave')
+const { transformAvaxAddress } = require('../helper/portedTokens')
+
+async function tvl(timestamp, ethBlock, chainBlocks) {
+    const transform = await transformAvaxAddress()
+    return  aaveChainTvl("avalanche", "0xfF50b540c9152F1841edF47b49dA69696Be59783", transform)(timestamp, ethBlock, chainBlocks)
+}
+
+module.exports={
+    methodology: "Counts the tokens locked in the contracts to be used as collateral to borrow or to earn yield. Borrowed coins are not counted towards the TVL, so only the coins actually locked in the contracts are counted. There's multiple reasons behind this but one of the main ones is to avoid inflating the TVL through cycled lending",
+    tvl
+}


### PR DESCRIPTION
##### Twitter Link:

https://twitter.com/BlizzFinance

##### List of audit links if any:

N/A

##### Website Link:

https://blizz.finance/

##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):

https://docs.blizz.finance/useful-info/brand-assets

##### Current TVL:

~$600m

##### Chain:

Avalanche

##### Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)

blizz-finance

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

N/A

##### Short Description (to be shown on DefiLlama):

Blizz Finance is a decentralized, non-custodial liquidity market protocol operating on Avalanche.

##### Token address and ticker if any:

https://snowtrace.io/token/0x0f34919404a290e71fc6a510cb4a6acb8d764b24

$BLZZ

##### Category (Yield/Dexes/Lending/Minting/Assets/Insurance/Options/Indexes/Staking) *Please choose only one:

Lending

##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):

Chainlink

##### forkedFrom (Does your project originate from another project):

AAVE/GEIST

##### methodology (what is being counted as tvl, how is tvl being calculated):

Counts the tokens locked in the contracts to be used as collateral to borrow or to earn yield. Borrowed coins are not counted towards the TVL, so only the coins actually locked in the contracts are counted. There's multiple reasons behind this but one of the main ones is to avoid inflating the TVL through cycled lending.
