### PR TITLE
Add more tokens to KogeFarm TVL - wMEMO balance need to be divided by 10**9

### DIFF
--- a/projects/kogefarm/helper.js
+++ b/projects/kogefarm/helper.js
@@ -22,6 +22,22 @@ function transformAddressKF(chain = 'polygon') {
       return `ethereum:0xdac17f958d2ee523a2206206994597c13d831ec7`
     }
     if (
+      // Dai on Fantom
+      (chain === 'fantom' &&
+        addr.toLowerCase() === '0x8d11ec38a3eb5e956b052f67da8bdc9bef8abf3e')
+    ) {
+      // Dai on Eth
+      return `ethereum:0x6b175474e89094c44da98b954eedeac495271d0f`
+    }
+    if (
+      // wMemo on Fantom
+      (chain === 'fantom' &&
+        addr.toLowerCase() === '0xddc0385169797937066bbd8ef409b5b3c0dfeb52')
+    ) {
+      // Time on avax (per Wonderland docs, staked time = Memo at a 1:1 ratio)
+      return `avax:0xb54f16fb19478766a268f172c9480f8da1a7c9c3`
+    }
+    if (
       chain === 'moonriver' &&
       addr.toLowerCase() === '0x748134b5f553f2bcbd78c6826de99a70274bdeb3' // USDC.m
     ) {

--- a/projects/kogefarm/helper.js
+++ b/projects/kogefarm/helper.js
@@ -96,6 +96,30 @@ function transformAddressKF(chain = 'polygon') {
       // LINK
       return `ethereum:0x514910771af9ca656af840dff83e8264ecf986ca`
     }
+    // Special case for Bella, since coingecko doesn't find
+    if (
+      chain === 'polygon' &&
+      addr.toLowerCase() === '0x28c388fb1f4fa9f9eb445f0579666849ee5eeb42') {
+      return `ethereum:0xa91ac63d040deb1b7a5e4d4134ad23eb0ba07e14`
+    }
+    // Special case for SFI, since coingecko doesn't find
+    if (
+      chain === 'polygon' &&
+      addr.toLowerCase() === '0x35b937583f04a24963eb685f728a542240f28dd8') {
+      return `ethereum:0xb753428af26e81097e7fd17f40c88aaa3e04902c`
+    }
+    // Special case for Impermax, since coingecko doesn't find
+    if (
+      chain === 'polygon' &&
+      addr.toLowerCase() === '0x60bb3d364b765c497c8ce50ae0ae3f0882c5bd05') {
+      return `ethereum:0x7b35ce522cb72e4077baeb96cb923a5529764a00`
+    }
+    // Special case for Avax, since coingecko doesn't find
+    if (
+      chain === 'polygon' &&
+      addr.toLowerCase() === '0x2c89bbc92bd86f8075d1decc58c7f4e0107f286b') {
+      return `avax:FvwEAhmxKfeiG8SnEvq42hc6whRyY3EFYAvebMqDNDGCgxN5Z`
+    }
 
     return `${chain}:${addr}`
   }

--- a/projects/kogefarm/helper.js
+++ b/projects/kogefarm/helper.js
@@ -118,7 +118,7 @@ function transformAddressKF(chain = 'polygon') {
     if (
       chain === 'polygon' &&
       addr.toLowerCase() === '0x2c89bbc92bd86f8075d1decc58c7f4e0107f286b') {
-      return `avax:FvwEAhmxKfeiG8SnEvq42hc6whRyY3EFYAvebMqDNDGCgxN5Z`
+      return `avax:0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7`
     }
 
     return `${chain}:${addr}`


### PR DESCRIPTION
Hi! This commit is to more accurately count our TVL by including tokens that are previously valued at $0. We do so by updating token addresses not found on CoinGecko into the corresponding addresses on other chains that are found on CoinGecko before fetching the balance. 

There is one problem with the commit, which as I have discussed in Discord is that $wMEMO on Fantom is 18 decimals while the token it corresponds to 1:1, $Time on AVAX, is 9 decimal places. This causes our $wMEMO balance to be multiplied by 10**9. We would like to divide by it but are not sure how to cleanly do so, and have been asked to commit anyways.