### PR TITLE
added fuse markets for TVL

### DIFF
--- a/projects/fujidao/index.js
+++ b/projects/fujidao/index.js
@@ -3,26 +3,61 @@ const abi = require('./abi.json')
 const sdk = require('@defillama/sdk')
 const { default: BigNumber } = require('bignumber.js')
 
-const contract = "0x1Cf24e4eC41DA581bEe223E1affEBB62a5A95484"
-const ids = [0,2,4]
-const weth = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+const contracts = [
+    {
+        name: "F1155 Core",
+        address: "0x1Cf24e4eC41DA581bEe223E1affEBB62a5A95484",
+        ids: [0, 2, 4]
+    },
+    {
+        name: "F1155 Fuse",
+        address: "0xa2d62f8b02225fbFA1cf8bF206C8106bDF4c692b",
+        ids: [0, 2]
+    },
+];
+
+const weth = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2";
+const wbtc = "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599";
+const ftm = "0x4E15361FD6b4BB609Fa63C81A2be19d873717870";
 
 async function tvl(_timestamp, block){
-    const supplies = await sdk.api.abi.multiCall({
-        abi: abi.totalSupply,
-        calls: ids.map(id=>({
-            target:contract,
-            params: [id]
-        })),
-        block
-    })
+
+    const marketsupply = async (contract) => {
+        return await sdk.api.abi.multiCall(
+            {
+                abi: abi.totalSupply,
+                calls: (contract.ids).map( id => ({
+                    target:(contract.address),
+                    params: [id]
+                })),
+                block
+            }
+        );
+    }
+
+    const allMarketSupplies = async () => {
+        let allMarkets;
+        for (let index = 0; index < contracts.length; index++) {
+            if (!allMarkets) {
+                allMarkets = await marketsupply(contracts[index]);
+            } else {
+                let temp = allMarkets.output;
+                let response = await marketsupply(contracts[index]);
+                response = response.output;
+                allMarkets.output = temp.concat(response);
+            } 
+        }
+        return allMarkets;
+    }
+
+    const supplies = await allMarketSupplies();
 
     return {
-        [weth]: supplies.output.reduce((t,v)=>t.plus(v.output), BigNumber(0)).toFixed(0)
+        [weth]: supplies.output.reduce((t,v) => t.plus(v.output), BigNumber(0)).toFixed(0)
     }
 }
 
 module.exports = {
     tvl,
-    methodology: "Counts the c-tokens on all vaults, "
+    methodology: "Counts balance of receipt tokens in F1155 Contract on all vaults."
 }


### PR DESCRIPTION
##### Twitter Link:
https://twitter.com/FujiFinance
https://twitter.com/DaigaroC

##### List of audit links if any:
In process

##### Website Link:
https://www.fujidao.org/#/
https://fuse.fujidao.org/#/dashboard

##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):


##### Current TVL:
2.37 M

##### Chain:
Ethereum Mainnet

##### Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description (to be shown on DefiLlama):
Fuji is a protocol that aggregates borrowing crypto markets. It optimizes borrowing costs to its users by pooling funds and automatically refinancing across lending-borrowing protocols in search of minimum borrowing APR.

##### Token address and ticker if any:
N/A

##### Category (Yield/Dexes/Lending/Minting/Assets/Insurance/Options/Indexes/Staking) *Please choose only one:
Lending

##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):
Chainlink

##### forkedFrom (Does your project originate from another project):
no

##### methodology (what is being counted as tvl, how is tvl being calculated):
Counts balance of receipt tokens in F1155 Contract on all vaults.

