### PR TITLE
Newdex & DFS - single alt tokens are falsely increasing the TVL

### DIFF
--- a/projects/dfs/index.js
+++ b/projects/dfs/index.js
@@ -4,9 +4,8 @@ const EOSFLARE_ENDPOINT = "https://api.eosflare.io";
 
 async function get_account_tvl(account) {
   const response = await axios.default.post(EOSFLARE_ENDPOINT + "/v1/eosflare/get_account", {account});
-  const { token_value, balance_total, eos_price } = response.data.account;
-  return token_value + // sum of all alt tokens
-         balance_total * eos_price; // sum of EOS balance * price
+  const { balance_total, eos_price } = response.data.account;
+  return balance_total * eos_price; // sum of EOS balance * price
 }
 
 // https://apps.defis.network/
@@ -21,9 +20,6 @@ async function fetch() {
 
 module.exports = {
   methodology: `DFS TVL is achieved by querying token balances from DFS's AMM swap liquidity smart contract via https://eosflare.io/api.`,
-  name: 'DFS',
-  token: 'DEX',
-  category: 'dexes',
   eos: {
     fetch: eos
   },

--- a/projects/dfs/index.js
+++ b/projects/dfs/index.js
@@ -1,11 +1,33 @@
 const axios = require("axios");
+const retry = require('../helper/retry')
+const { get_currency_balance } = require("../helper/eos");
 
-const EOSFLARE_ENDPOINT = "https://api.eosflare.io";
+async function simple_price(ids) {
+  const response = await retry(async () => await axios.get(`https://api.coingecko.com/api/v3/simple/price?ids=${ids}&vs_currencies=usd`));
+  return response.data;
+}
+
+const tokens = [
+  ["eosio.token", "EOS", "eos"],
+  ["minedfstoken", "DFS", "defis-network"],
+  ["btc.ptokens", "PBTC", "ptokens-btc"],
+  ["tethertether", "USDT", "tether"],
+  ["token.defi", "BOX", "defibox"],
+  ["token.newdex", "DEX", "newdex-token"],
+  ["chexchexchex", "CHEX", "chex-token"],
+  ["everipediaiq", "IQ", "everipedia"],
+  ["eosiotptoken", "TPT", "token-pocket"],
+  ["core.ogx", "OGX", "organix"],
+]
 
 async function get_account_tvl(account) {
-  const response = await axios.default.post(EOSFLARE_ENDPOINT + "/v1/eosflare/get_account", {account});
-  const { balance_total, eos_price } = response.data.account;
-  return balance_total * eos_price; // sum of EOS balance * price
+  let tvl = 0;
+  const price_feed = await simple_price(tokens.map(row => row[2]).join(","));
+  for ( const [ code, symbol, id ] of tokens ) {
+    const balance = await get_currency_balance(code, account, symbol);
+    tvl += balance * price_feed[id].usd;
+  }
+  return tvl;
 }
 
 // https://apps.defis.network/
@@ -19,7 +41,7 @@ async function fetch() {
 }
 
 module.exports = {
-  methodology: `DFS TVL is achieved by querying token balances from DFS's AMM swap liquidity smart contract via https://eosflare.io/api.`,
+  methodology: `DFS TVL is achieved by querying token balances from DFS's AMM swap liquidity smart contract.`,
   eos: {
     fetch: eos
   },

--- a/projects/dfs/index.js
+++ b/projects/dfs/index.js
@@ -9,10 +9,11 @@ async function simple_price(ids) {
 
 const tokens = [
   ["eosio.token", "EOS", "eos"],
-  ["minedfstoken", "DFS", "defis-network"],
-  ["btc.ptokens", "PBTC", "ptokens-btc"],
   ["tethertether", "USDT", "tether"],
+  ["btc.ptokens", "PBTC", "ptokens-btc"],
   ["token.defi", "BOX", "defibox"],
+  ["minedfstoken", "DFS", "defis-network"],
+  ["emanateoneos", "EMT", "emanate"],
   ["token.newdex", "DEX", "newdex-token"],
   ["chexchexchex", "CHEX", "chex-token"],
   ["everipediaiq", "IQ", "everipedia"],

--- a/projects/helper/eos.js
+++ b/projects/helper/eos.js
@@ -1,0 +1,17 @@
+const axios = require('axios')
+const retry = require('../helper/retry')
+
+const RPC_ENDPOINT = 'https://eos.greymass.com'
+
+async function get_currency_balance(code, account, symbol) {
+    const response = await retry(async () => await axios.default.post(`${RPC_ENDPOINT}/v1/chain/get_currency_balance`, {code, account, symbol}));
+    try {
+        return Number(response.data[0].split(" ")[0]);
+    } catch (e) {
+        return 0;
+    }
+}
+
+module.exports = {
+    get_currency_balance,
+}

--- a/projects/newdex/index.js
+++ b/projects/newdex/index.js
@@ -4,9 +4,8 @@ const EOSFLARE_ENDPOINT = "https://api.eosflare.io";
 
 async function get_account_tvl(account) {
   const response = await axios.default.post(EOSFLARE_ENDPOINT + "/v1/eosflare/get_account", {account});
-  const { token_value, balance_total, eos_price } = response.data.account;
-  return token_value + // sum of all alt tokens
-         balance_total * eos_price; // sum of EOS balance * price
+  const { balance_total, eos_price } = response.data.account;
+  return balance_total * eos_price; // sum of EOS balance * price
 }
 
 // https://newdex.io
@@ -15,14 +14,8 @@ async function eos() {
   return await get_account_tvl("newdexpublic");
 }
 
-// https://bsc.newdex.io
-// project active on BSC, however no TVL
-async function bsc() {
-  return 0; // TODO FIX
-}
-
 async function fetch() {
-  return await eos() + await bsc();
+  return await eos();
 }
 
 module.exports = {

--- a/projects/newdex/index.js
+++ b/projects/newdex/index.js
@@ -1,11 +1,34 @@
 const axios = require("axios");
+const retry = require('../helper/retry')
+const { get_currency_balance } = require("../helper/eos");
 
-const EOSFLARE_ENDPOINT = "https://api.eosflare.io";
+async function simple_price(ids) {
+  const response = await retry(async () => await axios.get(`https://api.coingecko.com/api/v3/simple/price?ids=${ids}&vs_currencies=usd`));
+  return response.data;
+}
+
+const tokens = [
+  ["eosio.token", "EOS", "eos"],
+  ["tethertether", "USDT", "tether"],
+  ["btc.ptokens", "PBTC", "ptokens-btc"],
+  ["token.defi", "BOX", "defibox"],
+  ["minedfstoken", "DFS", "defis-network"],
+  ["emanateoneos", "EMT", "emanate"],
+  ["token.newdex", "DEX", "newdex-token"],
+  ["chexchexchex", "CHEX", "chex-token"],
+  ["everipediaiq", "IQ", "everipedia"],
+  ["eosiotptoken", "TPT", "token-pocket"],
+  ["core.ogx", "OGX", "organix"],
+]
 
 async function get_account_tvl(account) {
-  const response = await axios.default.post(EOSFLARE_ENDPOINT + "/v1/eosflare/get_account", {account});
-  const { balance_total, eos_price } = response.data.account;
-  return balance_total * eos_price; // sum of EOS balance * price
+  let tvl = 0;
+  const price_feed = await simple_price(tokens.map(row => row[2]).join(","));
+  for ( const [ code, symbol, id ] of tokens ) {
+    const balance = await get_currency_balance(code, account, symbol);
+    tvl += balance * price_feed[id].usd;
+  }
+  return tvl;
 }
 
 // https://newdex.io
@@ -19,7 +42,7 @@ async function fetch() {
 }
 
 module.exports = {
-  methodology: `NewDex TVL is achieved by querying token balances from NewDex's limit orderbook smart contract via https://eosflare.io/api.`,
+  methodology: `NewDex TVL is achieved by querying token balances from NewDex's limit orderbook smart contract.`,
   eos: {
     fetch: eos
   },


### PR DESCRIPTION
### ❗**ISSUE**

Single alt tokens are falsely increasing the TVL:
  - BEAN: +$74MM USD in NewDex
  - MASK +$31MM USD in DFS

### 🔨 **FIX**

- [x] remove alt tokens from being calculated in TVL
- [x] get currency balance directly from chain
- [x] remove EOS Flare API
- [x] only calculate tokens which are listed on CoinGecko

##### Current TVL

- NewDex: ~$921,979 USD
- DFS: ~$10,622,269 USD