### PR TITLE
add renbtc and staked spell to KogeFarm tvl

### DIFF
--- a/projects/kogefarm/helper.js
+++ b/projects/kogefarm/helper.js
@@ -22,6 +22,22 @@ function transformAddressKF(chain = 'polygon') {
       return `ethereum:0xdac17f958d2ee523a2206206994597c13d831ec7`
     }
     if (
+      // renbtc on Fantom
+      (chain === 'fantom' &&
+        addr.toLowerCase() === '0xdbf31df14b66535af65aac99c32e9ea844e14501')
+    ) {
+      // renbtc on Polygon
+      return `polygon:0xDBf31dF14B66535aF65AaC99C32e9eA844e14501`
+    }
+    if (
+      // staked spell on Fantom
+      (chain === 'fantom' &&
+        addr.toLowerCase() === '0xbb29d2a58d880af8aa5859e30470134deaf84f2b')
+    ) {
+      // spell on Fantom
+      return `fantom:0x468003B688943977e6130F4F68F23aad939a1040`
+    }
+    if (
       // Dai on Fantom
       (chain === 'fantom' &&
         addr.toLowerCase() === '0x8d11ec38a3eb5e956b052f67da8bdc9bef8abf3e')

--- a/projects/kogefarm/index.js
+++ b/projects/kogefarm/index.js
@@ -349,6 +349,34 @@ const fantomTvl = async (timestamp, block, chainBlocks) => {
     // Then, multiply the wMEMO balance by memo per wMemo ratio, use price of Time as price of Memo since they are 1:1
     balances[TIME] = Math.floor(balances[TIME] * memoPerWMemo / 10 ** 9);
   }
+
+  // Convert sSpell into Spell by multiplying by the appropriate ratio
+  const sSpell = 'fantom:0xbb29d2a58d880af8aa5859e30470134deaf84f2b';
+  if (sSpell in balances){
+    // First, find the spell to staked spell ratio by looking at the total supply of staked spell divided by the spell locked
+    const sSpellSupply = (
+      await sdk.api.abi.call({
+        chain: 'ethereum',
+        block: chainBlocks['ethereum'],
+        target: "0x26FA3fFFB6EfE8c1E69103aCb4044C26B9A106a9",
+        abi: abi.totalSupply,
+      })
+    ).output
+    const spellLocked = (
+      await sdk.api.abi.call({
+        chain: 'ethereum',
+        block: chainBlocks['ethereum'],
+        target: "0x090185f2135308BaD17527004364eBcC2D37e5F6",
+        params: ["0x26FA3fFFB6EfE8c1E69103aCb4044C26B9A106a9"],
+        abi: abi.balanceOf,
+      })
+    ).output
+    const spellPersSpell = spellLocked / sSpellSupply
+
+    // Then, multiply the staked spell balance by spell to staked spell ratio
+    balances[sSpell] = Math.floor(balances[sSpell] * spellPersSpell);
+  }
+
   return balances
 }
 


### PR DESCRIPTION
This adds renBTC and staked spell to KogeFarm TVL.

- the address for renBTC in Fantom is converted to renBTC in Polygon so it can be found on Coingecko.
- staked spell is converted into spell using the spellPersSpell ratio computed from the Ethereum blockchain data, then added to the spell balance.

##### Twitter Link:


##### List of audit links if any:


##### Website Link:


##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):


##### Current TVL:


##### Chain:


##### Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description (to be shown on DefiLlama):


##### Token address and ticker if any:


##### Category (Yield/Dexes/Lending/Minting/Assets/Insurance/Options/Indexes/Staking) *Please choose only one:


##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):


##### forkedFrom (Does your project originate from another project):


##### methodology (what is being counted as tvl, how is tvl being calculated):


