### PR TITLE
PositionExchange: Add Sum Casted NFT to TVL

### DIFF
--- a/projects/positionexchange/index.js
+++ b/projects/positionexchange/index.js
@@ -59,7 +59,7 @@ async function treasury(timestamp, chain, chainBlocks) {
 
 module.exports = {
   methodolgy:
-    "TVL is calculated by value locked in MasterChef contract and treasury value is the POSI in the treasury contract.",
+    "TVL is calculated by value locked in MasterChef contract, casted NFT and treasury value is the POSI in the treasury contract.",
   bsc: {
     tvl,
     staking,

--- a/projects/positionexchange/index.js
+++ b/projects/positionexchange/index.js
@@ -1,44 +1,69 @@
 const sdk = require("@defillama/sdk");
-const {addFundsInMasterChef} = require("../helper/masterchef");
+const { addFundsInMasterChef } = require("../helper/masterchef");
 const token = "0x5CA42204cDaa70d5c773946e69dE942b85CA6706";
 const masterchef = "0x0C54B0b7d61De871dB47c3aD3F69FEB0F2C8db0B";
 const treasuryAddress = "0xF7224c91BaF653ef46F498a92E2FFF35Ad0588a2";
+const nftMiningProxy = "0x0Fb07a8527f45d7625Ab6486718910ce44a608b5";
 async function tvl(timestamp, chain, chainBlocks) {
-    let balances = {};
-    await addFundsInMasterChef(balances, masterchef, chainBlocks.bsc, "bsc", addr=>`bsc:${addr}`);
-    return balances;
+  let balances = {};
+  await addFundsInMasterChef(
+    balances,
+    masterchef,
+    chainBlocks.bsc,
+    "bsc",
+    (addr) => `bsc:${addr}`
+  );
+  await sumCastedNft(balances, chainBlocks);
+  return balances;
+}
+
+async function sumCastedNft(balances, chainBlocks) {
+  let stakingBalance = (
+    await sdk.api.erc20.balanceOf({
+      target: token,
+      owner: nftMiningProxy,
+      block: chainBlocks.bsc,
+      chain: "bsc",
+    })
+  ).output;
+  sdk.util.sumSingleBalance(balances, `bsc:${token}`, stakingBalance);
 }
 
 async function staking(timestamp, chain, chainBlocks) {
-    let balances = {};
-    let stakingBalance = (await sdk.api.erc20.balanceOf({
-        target: token,
-        owner: masterchef,
-        block: chainBlocks.bsc,
-        chain: "bsc"
-    })).output;
-    sdk.util.sumSingleBalance(balances, `bsc:${token}`, stakingBalance);
-    return balances;
+  let balances = {};
+  let stakingBalance = (
+    await sdk.api.erc20.balanceOf({
+      target: token,
+      owner: masterchef,
+      block: chainBlocks.bsc,
+      chain: "bsc",
+    })
+  ).output;
+  sdk.util.sumSingleBalance(balances, `bsc:${token}`, stakingBalance);
+  return balances;
 }
 
 async function treasury(timestamp, chain, chainBlocks) {
-    let balances = {};
-    let posiBalance = (await sdk.api.erc20.balanceOf({
-        target: token,
-        owner: treasuryAddress,
-        block: chainBlocks.bsc,
-        chain: "bsc"
-    })).output
-    sdk.util.sumSingleBalance(balances, `bsc:${token}`, posiBalance);
-    return balances;
+  let balances = {};
+  let posiBalance = (
+    await sdk.api.erc20.balanceOf({
+      target: token,
+      owner: treasuryAddress,
+      block: chainBlocks.bsc,
+      chain: "bsc",
+    })
+  ).output;
+  sdk.util.sumSingleBalance(balances, `bsc:${token}`, posiBalance);
+  return balances;
 }
 
 module.exports = {
-    methodolgy: "TVL is calculated by value locked in MasterChef contract and treasury value is the POSI in the treasury contract.",
-    bsc: {
-        tvl,
-        staking,
-        treasury
-    },
-    tvl
-}
+  methodolgy:
+    "TVL is calculated by value locked in MasterChef contract and treasury value is the POSI in the treasury contract.",
+  bsc: {
+    tvl,
+    staking,
+    treasury,
+  },
+  tvl,
+};


### PR DESCRIPTION
Hi DefiLlama Team,

I create this PR to update the adapter calculating Position Exchange's TVL.

Our project allows users casting the NFT by locking POSI token then users are able to stake the NFT or sell it on NFT Marketplace. Hence we'd like to add the volume of total casted POSI to TVL. This implement simply count the balance of this NFTMintingProxy contract: 0x0Fb07a8527f45d7625Ab6486718910ce44a608b5 then add to TVL

The new code has been run by this test:

`node test.js projects/positionexchange/index.js `

And the result

`--- bsc-treasury ---
POSI                      292.23 k
Total: 292.23 k 

--- bsc-staking ---
POSI                      2.19 M
Total: 2.19 M 

--- bsc ---
POSI                      47.03 M
BUSD                      12.27 M
WBNB                      6.02 M
Total: 65.32 M 

--- tvl ---
POSI                      47.03 M
BUSD                      12.27 M
WBNB                      6.02 M
Total: 65.33 M 

--- treasury ---
POSI                      292.23 k
Total: 292.23 k 

--- staking ---
POSI                      2.19 M
Total: 2.19 M 

------ TVL ------
bsc-treasury              292.23 k
bsc-staking               2.19 M
bsc                       65.32 M
treasury                  292.23 k
staking                   2.19 M

total                    65.33 M `