### PR TITLE
Add ARCx staking

### DIFF
--- a/projects/arcx.js
+++ b/projects/arcx.js
@@ -1,0 +1,28 @@
+const sdk = require("@defillama/sdk")
+const BigNumber = require("bignumber.js")
+
+const stARCx = '0x9bffad7a6d5f52dbc51cae33e419793c72fd7d9d'
+const stakingContract = '0x9bffad7a6d5f52dbc51cae33e419793c72fd7d9d'
+const ARCx = '0x1321f1f1aa541a56c31682c57b80ecfccd9bb288'
+
+async function staking(timestamp, ethBlock, chainBlocks) {  
+  const stakedARCx = (await sdk.api.abi.call({
+      target: ARCx, 
+      params: stakingContract,
+      abi: 'erc20:balanceOf',
+      block: ethBlock,
+      chain: 'ethereum'
+    })).output
+  const balances = {
+    [ARCx]: stakedARCx
+  }
+  return balances
+}
+
+module.exports = {
+  methodology: "ARCx can be staked in the protocol",
+  ethereum: {
+    staking,
+    tvl: () => ({})
+  },
+}


### PR DESCRIPTION
Add ARCx staking

##### Twitter Link:
https://twitter.com/arcxmoney

##### List of audit links if any:


##### Website Link:
https://arcx.money

##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):
dark-bg svg: https://arcx.money/static/media/arcx-circle-white.d39a7294.svg

##### Current TVL:
3M staking

##### Chain:
Ethereum Mainnet

##### Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)
arc-governance

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
10515

##### Short Description (to be shown on DefiLlama):
ARCx is a decentralized scoring protocol that powers on-chain identity through the issuance of a DeFi Passport. The first element in the DeFi Passport is an on-chain credit score, which is issued to an identity based on an assessment of the address’ on-chain activity

##### Token address and ticker if any:
ARCx

##### Category (Yield/Dexes/Lending/Minting/Assets/Insurance/Options/Indexes/Staking) *Please choose only one:
Insurance

##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):


##### forkedFrom (Does your project originate from another project):


##### methodology (what is being counted as tvl, how is tvl being calculated):
ARCx can be staked in the ARCx staking contract. 

