### PR TITLE
Update padswap subgraph to self-hosted node

### DIFF
--- a/projects/padswap/index.js
+++ b/projects/padswap/index.js
@@ -15,9 +15,10 @@ const PADSWAP_MOONRIVER_FACTORY_ADDRESS =
   "0x760d2Bdb232027aB3b1594405077F9a1b91C04c1";
 
 const subgraphTvls = getChainTvl({
-  bsc: "https://api.thegraph.com/subgraphs/name/toadguy/padswap",
-  moonriver: "https://api.thegraph.com/subgraphs/name/toadguy/padswap-subgraph-moonriver"
-})
+  bsc: "https://subgraph.toadlytics.com:8080/subgraphs/name/padswap-subgraph",
+  moonriver:
+    "https://api.thegraph.com/subgraphs/name/toadguy/padswap-subgraph-moonriver",
+});
 
 module.exports = {
   methodology: `TVL accounts for the liquidity on all AMM pools (see https://info.padswap.exchange/ and https://movr-info.padswap.exchange/). Staking includes all TOAD staked in TOAD farms.`,
@@ -29,14 +30,22 @@ module.exports = {
       "0xc0888d80ee0abf84563168b3182650c0addeb6d5", //pad
     ], "wbnb"),
     */
-    staking: stakings([TOAD_FARM_ADDRESS, TOAD_PADSWAP_FARM_V1_ADDRESS, TOAD_PADSWAP_FARM_V2_ADDRESS], TOAD_ADDRESS, "bsc"),
+    staking: stakings(
+      [
+        TOAD_FARM_ADDRESS,
+        TOAD_PADSWAP_FARM_V1_ADDRESS,
+        TOAD_PADSWAP_FARM_V2_ADDRESS,
+      ],
+      TOAD_ADDRESS,
+      "bsc"
+    ),
   },
-  moonriver:{
-    tvl: subgraphTvls("moonriver")
+  moonriver: {
+    tvl: subgraphTvls("moonriver"),
     /*calculateUsdUniTvl(PADSWAP_MOONRIVER_FACTORY_ADDRESS, "moonriver", "0x663a07a2648296f1a3c02ee86a126fe1407888e5", [
       "0xe3f5a90f9cb311505cd691a46596599aa1a0ad7d", //usdc
       "0x45488c50184ce2092756ba7cdf85731fd17e6f3d", //pad
     ], "moonriver"),
     */
-  }
+  },
 };


### PR DESCRIPTION
The BSC subgraph was having trouble keeping up. We now have a self-hosted GRT node that syncs much faster.