### PR TITLE
Added 1bch.com DEX

### DIFF
--- a/projects/1bch/index.js
+++ b/projects/1bch/index.js
@@ -1,0 +1,40 @@
+const sdk = require('@defillama/sdk');
+const { getBlock } = require('../helper/getBlock');
+const { calculateUsdUniTvl } = require('../helper/getUsdUniTvl')
+const { stakingPricedLP } = require('../helper/staking')
+
+const WBCH = "0x3743eC0673453E5009310C727Ba4eaF7b3a1cc04";
+const rBCH = "0xb4602588E5F1F9653B6F234206c91552E457fAcB";
+const FACTORY = "0x3dC4e6aC26df957a908cfE1C0E6019545D08319b";
+const MASTERBREEDER = "0xeC0A7496e66a206181034F86B261DDDC1A2c406E";
+const rBCH_WBCH_LP = "0xb9659B524447F53FF1019952A6eeDBb99776Ab4A";
+const COREASSETNAME = "bitcoin-cash";
+const CHAIN = "smartbch";
+
+async function bchMasterChef(timestamp, ethBlock, chainBlocks) {
+    const block = await getBlock(timestamp, CHAIN, chainBlocks, true);
+
+    const stakedBCH = (await sdk.api.erc20.balanceOf({
+        target: WBCH,
+        owner: MASTERBREEDER,
+        chain: CHAIN,
+        block: block,
+        decimals: 18
+    })).output;
+
+    return {
+        [COREASSETNAME]: Number(stakedBCH)
+    }
+}
+
+const bchDexTvl = calculateUsdUniTvl(FACTORY, CHAIN, WBCH, [rBCH], COREASSETNAME)
+
+module.exports = {
+    misrepresentedTokens: true,
+    methodology: "Factory address (" + FACTORY + ") is used to find the LP pairs on smartBCH. TVL is equal to AMMs liquidity plus the extra staking balance and masterchef pools.",
+    smartbch: {
+        tvl: sdk.util.sumChainTvls([bchDexTvl, bchMasterChef]),
+        masterchef: bchMasterChef,
+        staking: stakingPricedLP(MASTERBREEDER, rBCH, "smartbch", rBCH_WBCH_LP, COREASSETNAME),
+    },
+}


### PR DESCRIPTION
##### Twitter Link:
https://twitter.com/1BCHOfficial


##### List of audit links if any:
will be done by Certik in December 2021


##### Website Link:
https://1bch.com/

##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):
https://1bch.com/images/home/lunar-bunny/bunny.svg

##### Current TVL:
smartbch-staking          41.11 k

smartbch                  538.57 k

staking                   41.11 k

total                    538.57 k


##### Chain:

smartbch


##### Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)
none yet

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
none yet

##### Short Description (to be shown on DefiLlama):
1BCH as the DEX on SmartBCH made by Kitties from Mars.
It is backed by long-term dedicated supporters of the BitcoinCash ecosystem.
We offer farms, statistics, srpinklers (stake 1 coin to receive another as Airdrop) NFTs and more.

##### Token address and ticker if any:
1BCH 0x77d4b6e44a53bbda9a1d156b32bb53a2d099e53d

##### Category (Yield/Dexes/Lending/Minting/Assets/Insurance/Options/Indexes/Staking) *Please choose only one:
Dexes

##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):
ChainLink

##### forkedFrom (Does your project originate from another project):
Pancake Swap v2

##### methodology (what is being counted as tvl, how is tvl being calculated):
We count TVL as all pool pairs that have been created (from user or admin).
Our 1-pair staking farms (Sprinklers) don't count into TVL.

