### PR TITLE
mistswap: add xmist staking

### DIFF
--- a/projects/mistswap/index.js
+++ b/projects/mistswap/index.js
@@ -1,16 +1,28 @@
-const {calculateUsdUniTvl} = require('../helper/getUsdUniTvl')
-const { staking } = require("../helper/staking");
+const { calculateUsdUniTvl } = require("../helper/getUsdUniTvl");
+const { stakingPricedLP } = require("../helper/staking");
 
-const mistToken = "0x5fA664f69c2A4A3ec94FaC3cBf7049BD9CA73129"
-const masterChef = "0x3A7B9D0ed49a90712da4E087b17eE4Ac1375a5D4"
+const xMIST = "0xC41C680c60309d4646379eD62020c534eB67b6f4";
+const MIST = "0x5fA664f69c2A4A3ec94FaC3cBf7049BD9CA73129";
+const xMIST_WBCH_PAIR = "0xa331430473aba2337698fd95a7c2fcf376debfb1";
 
-
-
-module.exports={
-    misrepresentedTokens: true,
-    methodology: "Factory address (0x6008247F53395E7be698249770aa1D2bfE265Ca0) is used to find the LP pairs. TVL is equal to the liquidity on the AMM.",
-    smartbch: {
-        tvl:calculateUsdUniTvl("0x6008247F53395E7be698249770aa1D2bfE265Ca0", "smartbch", "0x3743eC0673453E5009310C727Ba4eaF7b3a1cc04", ["0x5fA664f69c2A4A3ec94FaC3cBf7049BD9CA73129"], "bitcoin-cash"),
-        //staking: staking(masterChef, mistToken, "smartbch", "", 18), MIST token still not on coingecko
-    }
-}
+module.exports = {
+  misrepresentedTokens: true,
+  methodology:
+    "Factory address (0x6008247F53395E7be698249770aa1D2bfE265Ca0) is used to find the LP pairs. TVL is equal to the liquidity on the AMM.",
+  smartbch: {
+    tvl: calculateUsdUniTvl(
+      "0x6008247F53395E7be698249770aa1D2bfE265Ca0",
+      "smartbch",
+      "0x3743eC0673453E5009310C727Ba4eaF7b3a1cc04",
+      ["0x5fA664f69c2A4A3ec94FaC3cBf7049BD9CA73129"],
+      "bitcoin-cash"
+    ),
+    staking: stakingPricedLP(
+      xMIST,
+      MIST,
+      "smartbch",
+      xMIST_WBCH_PAIR,
+      "bitcoin-cash"
+    ),
+  },
+};


### PR DESCRIPTION
##### Chain:

SmartBCH

##### Token address and ticker if any:

MIST `0x5fA664f69c2A4A3ec94FaC3cBf7049BD9CA73129`
xMIST `0xC41C680c60309d4646379eD62020c534eB67b6f4`

##### Category (Yield/Dexes/Lending/Minting/Assets/Insurance/Options/Indexes/Staking) *Please choose only one:

Dexes

##### methodology (what is being counted as tvl, how is tvl being calculated):

add staking info via `stakingPricedLP` using MIST/WBCH pair
