### PR TITLE
CAUTION - Add UNI-v3 staking (harvest position)

### DIFF
--- a/projects/babylon-finance/index.js
+++ b/projects/babylon-finance/index.js
@@ -1,6 +1,7 @@
 const sdk = require("@defillama/sdk")
 const BigNumber = require("bignumber.js")
 const abi = require('./abi.json');
+const { unwrapUniswapV3LPs } = require("../helper/unwrapLPs");
 
 const babController = '0xd4a5b5fcb561daf3adf86f8477555b92fba43b5f'
 const babylonViewer = '0x740913FEF40720E82498D5b73A4E8C3a5D9b9d79'
@@ -58,11 +59,25 @@ async function tvl(timestamp, ethBlock, chainBlocks) {
     return balances
 }
 
+const harvest_vault = '0xadB16dF01b9474347E8fffD6032360D3B54627fB'
+const harvest_pool = '0x3e6397E309f68805FA8Ef66A6216bD2010DdAF19'
+// const harvest_position_id = 158516
+async function staking(timestamp, ethBlock, chainBlocks) { 
+    const balances = {}
+    const univ3_Positions = [{
+        vault: harvest_vault,
+        pool: harvest_pool
+    }]
+    await unwrapUniswapV3LPs(balances, univ3_Positions, ethBlock, chain='ethereum')
+    console.log('balances:', balances)
+    return balances
+}
+
 module.exports = {
   methodology: "TVL of Babylon corresponds to capital locked into each garden (idle capital waiting to be deployed) as well as capital deployed to each strategy of these gardens",
   ethereum: {
-    staking: () => ({}),
-    tvl,
+    staking, // : () => ({})
+    tvl // : () => ({}),
   }
 }
 

--- a/projects/helper/unwrapLPs.js
+++ b/projects/helper/unwrapLPs.js
@@ -5,6 +5,7 @@ const {getPoolTokens, getPoolId} = require('./abis/balancer.json')
 const getPricePerShare = require('./abis/getPricePerShare.json')
 const {requery} = require('./requery')
 const creamAbi = require('./abis/cream.json')
+const { request, gql } = require("graphql-request");
 
 const crvPools = {
     '0x6c3f90f043a72fa612cbac8115ee7e52bde6e490': {
@@ -438,6 +439,162 @@ async function unwrapUniswapLPs(balances, lpPositions, block, chain='ethereum', 
       }))
 }
 
+// pool will give you the amount of fUniV3_WETH_ABC held by the pool of the position token against that token total supply
+const uniV3_nft_contract = '0xc36442b4a4522e871399cd717abdd847ab11fe88'
+const abi_staking = {
+    'univ3_positions': {"inputs":[{"internalType":"uint256","name":"tokenId","type":"uint256"}],"name":"positions","outputs":[{"internalType":"uint96","name":"nonce","type":"uint96"},{"internalType":"address","name":"operator","type":"address"},{"internalType":"address","name":"token0","type":"address"},{"internalType":"address","name":"token1","type":"address"},{"internalType":"uint24","name":"fee","type":"uint24"},{"internalType":"int24","name":"tickLower","type":"int24"},{"internalType":"int24","name":"tickUpper","type":"int24"},{"internalType":"uint128","name":"liquidity","type":"uint128"},{"internalType":"uint256","name":"feeGrowthInside0LastX128","type":"uint256"},{"internalType":"uint256","name":"feeGrowthInside1LastX128","type":"uint256"},{"internalType":"uint128","name":"tokensOwed0","type":"uint128"},{"internalType":"uint128","name":"tokensOwed1","type":"uint128"}],"stateMutability":"view","type":"function"}, 
+
+    'erc721_tokenOfOwnerByIndex': {"inputs":[{"internalType":"address","name":"owner","type":"address"},{"internalType":"uint256","name":"index","type":"uint256"}],"name":"tokenOfOwnerByIndex","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"}, 
+
+    'token0': {"inputs":[],"name":"token0","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"}, 
+    'token1': {"inputs":[],"name":"token1","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},
+}
+// Convert Uniswap v3 tick to a price (i.e. the ratio between the amounts of tokens: token1/token0)
+const tickBase = 1.0001
+function tick_to_price(tick) {
+    return tickBase ** tick
+}
+// GraphQL query to get the pool information
+const univ3_graph_url = "https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v3"
+const univ3_graph_query = gql`
+query position($block: Int, $position_id: ID!) {
+    position (
+        id: $position_id
+        block: { number: $block }
+    ) {
+        id
+        owner
+        tickLower {tickIdx}
+        tickUpper {tickIdx}
+        liquidity
+        pool {
+            tick
+            liquidity
+            feeTier
+            token0 { symbol decimals id }
+            token1 { symbol  decimals id }
+        }
+    }
+}`
+
+async function getUniv3PositionBalances(position_id, block) {
+    // Retrieve aTokens and reserves from graphql API endpoint
+    const { position } = await request(
+        univ3_graph_url,
+        univ3_graph_query, {
+            block: block,
+            position_id: position_id 
+        })
+    
+    // Extract pool parameters
+    const pool = position['pool']
+    const tick = pool['tick']
+    const token0 = pool['token0']['id']
+    const token1 = pool['token1']['id']
+    // Retrieve these from the graphql query instead of onchain call
+    const bottom_tick = position['tickLower']['tickIdx']
+    const top_tick = position['tickUpper']['tickIdx']
+    const liquidity = position['liquidity']
+    
+    // Compute square roots of prices corresponding to the bottom and top ticks
+    const sa = tick_to_price(Math.floor(bottom_tick / 2))
+    const sb = tick_to_price(Math.floor(top_tick / 2))
+    const price = tick_to_price(tick)
+    const sp = price ** 0.5
+    // const decimals0 = pool['token0']['decimals']
+    // const decimals1 = pool['token1']['decimals']
+    // const adjusted_price = price / (10 ** (decimals1 - decimals0))
+
+    // Compute real amounts of the two assets
+    const amount0 = liquidity * (sb - sp) / (sp * sb)
+    const amount1 = liquidity * (sp - sa)
+
+    console.log(`Whole pool: amount0: ${(amount0 / 1e18).toFixed(1)} / amount1: ${(amount1 / 1e18).toFixed(1)}`)
+    return {
+        [token0]: amount0, 
+        [token1]: amount1, 
+    }
+}
+/*
+// Could get some props of the position itself onchain rather than using uni-v3 graphql endpoint, but some information needed is missing like whole pool liq/tick etc
+const {output: position_props} = await sdk.api.abi.call({
+    block,
+    abi: abi_staking['univ3_positions'],
+    target: uniV3_nft_contract,
+    params: position_id, // get the last one for demonstration
+    chain: 'ethereum'
+})
+const bottom_tick = position_props['tickLower']
+const top_tick = position_props['tickUpper']
+const L = position_props['liquidity']
+const token0 = position_props['token0']
+const token1 = position_props['token1']
+*/
+
+/*
+univ3_Positions:{
+    vault,
+    pool
+}[]
+*/
+async function unwrapUniswapV3LPs(balances, univ3_Positions, block, chain='ethereum', transformAddress=(addr)=>addr, excludeTokensRaw = [], retry = false) {
+    const excludeTokens = excludeTokensRaw.map(addr=>addr.toLowerCase())
+    await Promise.all(univ3_Positions.map(async univ3_Position => {
+        try{ 
+            // Get share of that LP NFT inside the vault as balanceOf / totalSupply
+            const {output: totalSupply} = await sdk.api.abi.call({
+                block,
+                abi: 'erc20:totalSupply',
+                target: univ3_Position.vault,
+                chain: 'ethereum'
+            })
+            const {output: heldLPshares} = await sdk.api.abi.call({
+                block,
+                abi: 'erc20:balanceOf',
+                target: univ3_Position.vault,
+                params: univ3_Position.pool,
+                chain: 'ethereum'
+            })
+            const sharesRatio = heldLPshares / totalSupply
+
+            /*
+            const {output: uniV3_nft_count} = await sdk.api.abi.call({
+                block,
+                abi: 'erc20:balanceOf',
+                target: uniV3_nft_contract,
+                params: univ3_Position.vault,
+                chain: 'ethereum'
+            })
+            */
+           // Here we assume only the first nft position is retrieved
+           // could look for more using uniV3_nft_count 
+            const {output: position_id} = await sdk.api.abi.call({
+                block,
+                abi: abi_staking['erc721_tokenOfOwnerByIndex'],
+                target: uniV3_nft_contract,
+                params: [univ3_Position.vault, 0], 
+                chain: 'ethereum'
+            })
+
+            const positionBalances = await getUniv3PositionBalances(position_id, block)
+
+            // Add balances while multiplying amount by ratio of shares
+            Object.entries(positionBalances).forEach(async entry => {
+                const [key, value] = entry;
+                if(!excludeTokens.includes(key)){
+                    // balances[key] = BigNumber( balances[key] || 0 ).plus(sharesRatio * value);
+                    sdk.util.sumSingleBalance(balances, await transformAddress(key), sharesRatio * value) 
+                }
+            });
+            console.log(`ratio of the pool: ${(100 * sharesRatio).toFixed(1)}% of position_id ${position_id}`)
+            
+        } catch(e) {
+            console.log(`Failed to get data for LP token vault at ${univ3_Position.vault} on chain ${chain}`)
+            throw e
+        }
+    }))
+}
+
 async function addBalanceOfTokensAndLPs(balances, balanceResult, block){
     await addTokensAndLPs(balances, {
         output: balanceResult.output.map(t=>({output:t.input.target}))
@@ -704,6 +861,7 @@ module.exports = {
     unwrapYearn,
     unwrapCrv,
     unwrapUniswapLPs,
+    unwrapUniswapV3LPs,
     addTokensAndLPs,
     sumTokensAndLPsSharedOwners,
     addBalanceOfTokensAndLPs,


### PR DESCRIPTION
BABL_WETH can be LP'ed on harvest finance and the LP can be staked on harvest. A wrapper has been added to retrieve the amount of uni_v3 LP staked in the vault.

##### Twitter Link:


##### List of audit links if any:


##### Website Link:


##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):


##### Current TVL:


##### Chain:


##### Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description (to be shown on DefiLlama):


##### Token address and ticker if any:


##### Category (Yield/Dexes/Lending/Minting/Assets/Insurance/Options/Indexes/Staking) *Please choose only one:


##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):


##### forkedFrom (Does your project originate from another project):


##### methodology (what is being counted as tvl, how is tvl being calculated):


