### PR TITLE
Add Linear Finance adapter

### DIFF
--- a/projects/linear/abis.json
+++ b/projects/linear/abis.json
@@ -1,0 +1,41 @@
+{
+  "totalLockedAmount": {
+    "inputs": [],
+    "name": "totalLockedAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  "totalStakeAmount": {
+    "inputs": [],
+    "name": "totalStakeAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  "totalSubscribedAmount": {
+    "inputs": [],
+    "name": "totalSubscribedAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+}

--- a/projects/linear/index.js
+++ b/projects/linear/index.js
@@ -1,0 +1,102 @@
+const sdk = require("@defillama/sdk");
+const BigNumber = require("bignumber.js");
+
+const abis = require("./abis.json");
+const { unwrapUniswapLPs } = require("../helper/unwrapLPs");
+
+const LnCollateralSystemAddress = "0xcE2c94d40e289915d4401c3802D75f6cA5FEf57E";
+const LnRewardLockerAddress = "0x66D60EDc3876b8aFefD324d4edf105fd5c4aBeDc";
+
+const tokens = {
+  lUSD: "0x23e8a70534308a4aaf76fb8c32ec13d17a3bd89e",
+  LINA: "0x762539b45A1dCcE3D36d080F74d1AED37844b878",
+  bUSD: "0xe9e7cea3dedca5984780bafc599bd69add087d56",
+  LPTOKEN: "0x392f351fc02a3b74f7900de81a9aaac13ec28e95",
+};
+
+const vaultpools = {
+  bUSD: "0x072F11c46146Ce636691d387BFbF8fD28e818EE8",
+  lUSD: "0xD36b669491ADFB5cDE87C281dF417148674f88B4",
+  LP: "0x12efdFF85f717ac1738CF50Be5f4Cdc916b0B8B1",
+};
+
+function getBSCAddress(address) {
+  return `bsc:${address}`;
+}
+
+async function tvl(timestamp, blockETH, chainBlocks) {
+  const block = chainBlocks["bsc"];
+  const balances = {};
+
+  const stakedLina = await sdk.api.abi.call({
+    block,
+    chain: "bsc",
+    target: tokens["LINA"],
+    params: LnCollateralSystemAddress,
+    abi: "erc20:balanceOf",
+  });
+
+  const lockedLina = await sdk.api.abi.call({
+    block,
+    chain: "bsc",
+    target: LnRewardLockerAddress,
+    abi: abis["totalLockedAmount"],
+  });
+
+  const bUSDPoolLockedlUSD = await sdk.api.abi.call({
+    block,
+    chain: "bsc",
+    target: tokens["lUSD"],
+    params: vaultpools["lUSD"],
+    abi: "erc20:balanceOf",
+  });
+
+  const lUSDPoolLockedlUSD = await sdk.api.abi.call({
+    block,
+    chain: "bsc",
+    target: tokens["lUSD"],
+    params: vaultpools["bUSD"],
+    abi: "erc20:balanceOf",
+  });
+
+  const vaultsLockedLpToken = await sdk.api.abi.call({
+    block,
+    chain: "bsc",
+    target: vaultpools["LP"],
+    abi: abis["totalStakeAmount"],
+  });
+
+  balances[getBSCAddress(tokens["LINA"])] = BigNumber(stakedLina.output)
+    .plus(lockedLina.output)
+    .toFixed(0);
+
+  await unwrapUniswapLPs(
+    balances,
+    [
+      {
+        balance: vaultsLockedLpToken.output,
+        token: tokens["LPTOKEN"],
+      },
+    ],
+    chainBlocks.bsc,
+    "bsc",
+    getBSCAddress
+  );
+
+  // use bUSD to represent lUSD as it is not listed on coingecko
+  delete balances[getBSCAddress(tokens["lUSD"])];
+
+  balances[getBSCAddress(tokens["bUSD"])] = BigNumber(
+    balances[getBSCAddress(tokens["bUSD"])] * 2
+  )
+    .plus(bUSDPoolLockedlUSD.output)
+    .plus(lUSDPoolLockedlUSD.output);
+
+  return balances;
+}
+
+module.exports = {
+  bsc: {
+    tvl,
+  },
+};


### PR DESCRIPTION
##### Twitter Link

https://twitter.com/linearfinance

##### List of audit links if any

https://www.certik.com/projects/linearfinance

##### Website Link

https://linear.finance/

##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders)

https://logo.linear.finance/

##### Current TVL

\$66.35M

##### Chain

Ethereum, BSC

##### Coingecko ID (so your TVL can appear on Coingecko)

linear

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap)

linear

##### Short Description (to be shown on DefiLlama)

The first cross-chain compatible, delta-one asset protocol.

##### Token address and ticker if any

- Ethereum: 0x3E9BC21C9b189C09dF3eF1B824798658d5011937 (LINA)
- BSC: 0x762539b45A1dCcE3D36d080F74d1AED37844b878 (LINA)

##### Category (Yield/Dexes/Lending/Minting/Assets/Insurance/Options/Indexes/Staking) \*Please choose only one:

Derivatives

##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):

Chainlink

##### forkedFrom (Does your project originate from another project):

No

##### methodology (what is being counted as tvl, how is tvl being calculated):

- Staked LINA tokens in Linear Buildr
- Locked LINA rewards from staking
- Staked lUSD tokens in Linear Vault
- Staked lUSD-BUSD PancakeSwap LP tokens lin Linear Vault
