### PR TITLE
Add borrowed and fixed eth tvl

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@project-serum/anchor": "^0.18.2",
     "@project-serum/serum": "^0.13.38",
     "@solana/web3.js": "^1.30.2",
+    "@solendprotocol/solend-sdk": "^0.1.64",
     "@vechain/connex-driver": "^2.0.7",
     "@vechain/connex-framework": "^2.0.7",
     "async-retry": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@project-serum/anchor": "^0.18.2",
     "@project-serum/serum": "^0.13.38",
     "@solana/web3.js": "^1.30.2",
-    "@solendprotocol/solend-sdk": "^0.1.64",
     "@vechain/connex-driver": "^2.0.7",
     "@vechain/connex-framework": "^2.0.7",
     "async-retry": "^1.3.1",

--- a/projects/solend/index.js
+++ b/projects/solend/index.js
@@ -1,6 +1,6 @@
 const BigNumber = require("bignumber.js");
 const { PublicKey, Connection } = require("@solana/web3.js");
-const { parseReserve } = require("@solendprotocol/solend-sdk");
+const { parseReserve } = require("./utils");
 const { getTokenBalance } = require("../helper/solana");
 
 async function borrowed() {

--- a/projects/solend/index.js
+++ b/projects/solend/index.js
@@ -1,53 +1,159 @@
-const {getTokenBalance} = require('../helper/solana')
+const BigNumber = require("bignumber.js");
+const { PublicKey, Connection } = require("@solana/web3.js");
+const { parseReserve } = require("@solendprotocol/solend-sdk");
+const { getTokenBalance } = require("../helper/solana");
+
+async function borrowed() {
+  const connection = new Connection("https://solana-api.projectserum.com/");
+
+  const parsedAccounts = await connection
+    .getMultipleAccountsInfo(
+      [
+        new PublicKey("BgxfHJDzm44T7XG68MYKx7YisTjZu73tVovyZSjJMpmw"),
+        new PublicKey("GYzjMCXTDue12eUGKKWAqtF5jcBYNmewr6Db6LaguEaX"),
+        new PublicKey("3PArRsZQ6SLkr1WERZWyC6AqsajtALMq4C66ZMYz4dKQ"),
+        new PublicKey("5suXmvdbKQ98VonxGCXqViuWRu8k4zgZRxndYKsH2fJg"),
+        new PublicKey("8K9WC8xoh2rtQNY7iEGXtPvfbDCi563SdWhCAhuMP2xE"),
+        new PublicKey("2dC4V23zJxuv521iYQj8c471jrxYLNQFaGS6YPwtTHMd"),
+        new PublicKey("9n2exoMQwMTzfw6NFoFFujxYPndWVLtKREJePssrKb36"),
+        new PublicKey("Hthrt4Lab21Yz1Dx9Q4sFW4WVihdBUTtWRQBjPsYHCor"),
+        new PublicKey("5Sb6wDpweg6mtYksPJ2pfGbSyikrhR8Ut8GszcULQ83A"),
+        new PublicKey("8PbodeaosQP19SjYFx855UMqWxH2HynZLdBXmsrbac36"),
+        new PublicKey("CCpirWrgNuBVLdkP2haxLTbD6XqEgaYuVXixbbpxUB6"),
+        new PublicKey("CPDiKagfozERtJ33p7HHhEfJERjvfk1VAjMXAFLrvrKP"),
+      ],
+      "processed"
+    )
+    .then((unparsedReserves) => {
+      return unparsedReserves.map((unparsedReserve) =>
+        parseReserve(PublicKey.default, unparsedReserve)
+      );
+    });
+
+  const [
+    usdcAmount,
+    btcAmount,
+    ethAmount,
+    srmAmount,
+    usdtAmount,
+    fttAmount,
+    rayAmount,
+    sbrAmount,
+    merAmount,
+    solAmount,
+    msolAmount,
+    wewethAmount,
+  ] = parsedAccounts.map((acc) => {
+    return new BigNumber(
+      acc.info.liquidity.borrowedAmountWads.toString()
+    ).dividedBy(
+      new BigNumber(
+        `1${Array(acc.info.liquidity.mintDecimals + 19)
+          .fill("")
+          .join("0")}`
+      )
+    );
+  });
+
+  return {
+    bitcoin: btcAmount,
+    "usd-coin": usdcAmount,
+    ethereum: ethAmount.plus(wewethAmount),
+    serum: srmAmount,
+    tether: usdtAmount,
+    "ftx-token": fttAmount,
+    raydium: rayAmount,
+    saber: sbrAmount,
+    mercurial: merAmount,
+    solana: solAmount,
+    msol: msolAmount,
+  };
+}
 
 async function tvl() {
-    const [usdcAmount,
-          btcAmount,
-          ethAmount,
-          srmAmount,
-          usdtAmount,
-          fttAmount,
-          rayAmount,
-          sbrAmount,
-          merAmount,
-          solAmount,
-          msolAmount,
-          wewethAmount, ] = await Promise.all([
-
-        getTokenBalance("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", "DdZR6zRFiUt4S5mg7AV1uKB2z1f1WzcNYCaTEEWPAuby"),
-        getTokenBalance("9n4nbM75f5Ui33ZbPYXn59EwSgE8CGsHtAeTH5YFeJ9E", "DdZR6zRFiUt4S5mg7AV1uKB2z1f1WzcNYCaTEEWPAuby"),
-        getTokenBalance("2FPyTwcZLUg1MDrwsyoP4D6s1tM7hAkHYRjkNb5w6Pxk", "DdZR6zRFiUt4S5mg7AV1uKB2z1f1WzcNYCaTEEWPAuby"),
-        getTokenBalance("SRMuApVNdxXokk5GT7XD5cUUgXMBCoAz2LHeuAoKWRt", "DdZR6zRFiUt4S5mg7AV1uKB2z1f1WzcNYCaTEEWPAuby"),
-        getTokenBalance("Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB", "DdZR6zRFiUt4S5mg7AV1uKB2z1f1WzcNYCaTEEWPAuby"),
-        getTokenBalance("AGFEad2et2ZJif9jaGpdMixQqvW5i81aBdvKe7PHNfz3", "DdZR6zRFiUt4S5mg7AV1uKB2z1f1WzcNYCaTEEWPAuby"),
-        getTokenBalance("4k3Dyjzvzp8eMZWUXbBCjEvwSkkk59S5iCNLY3QrkX6R", "DdZR6zRFiUt4S5mg7AV1uKB2z1f1WzcNYCaTEEWPAuby"),
-        getTokenBalance("Saber2gLauYim4Mvftnrasomsv6NvAuncvMEZwcLpD1", "DdZR6zRFiUt4S5mg7AV1uKB2z1f1WzcNYCaTEEWPAuby"),
-        getTokenBalance("MERt85fc5boKw3BW1eYdxonEuJNvXbiMbs6hvheau5K", "DdZR6zRFiUt4S5mg7AV1uKB2z1f1WzcNYCaTEEWPAuby"),
-        getTokenBalance("So11111111111111111111111111111111111111112", "DdZR6zRFiUt4S5mg7AV1uKB2z1f1WzcNYCaTEEWPAuby"),
-        getTokenBalance("mSoLzYCxHdYgdzU16g5QSh3i5K3z3KZK7ytfqcJm7So", "DdZR6zRFiUt4S5mg7AV1uKB2z1f1WzcNYCaTEEWPAuby"),
-        getTokenBalance("7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs", "DdZR6zRFiUt4S5mg7AV1uKB2z1f1WzcNYCaTEEWPAuby"),
-    ])
-    return {
-        'bitcoin': btcAmount,
-        'usd-coin': usdcAmount,
-        'ethereum': ethAmount,
-        'serum': srmAmount,
-        'tether': usdtAmount,
-        'ftx-token': fttAmount,
-        'raydium': rayAmount,
-        'saber': sbrAmount,
-        'mercurial': merAmount,
-        'solana': solAmount,
-        'msol': msolAmount,
-        'weweth': wewethAmount,
-    }
+  const [
+    usdcAmount,
+    btcAmount,
+    ethAmount,
+    srmAmount,
+    usdtAmount,
+    fttAmount,
+    rayAmount,
+    sbrAmount,
+    merAmount,
+    solAmount,
+    msolAmount,
+    wewethAmount,
+  ] = await Promise.all([
+    getTokenBalance(
+      "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      "DdZR6zRFiUt4S5mg7AV1uKB2z1f1WzcNYCaTEEWPAuby"
+    ),
+    getTokenBalance(
+      "9n4nbM75f5Ui33ZbPYXn59EwSgE8CGsHtAeTH5YFeJ9E",
+      "DdZR6zRFiUt4S5mg7AV1uKB2z1f1WzcNYCaTEEWPAuby"
+    ),
+    getTokenBalance(
+      "2FPyTwcZLUg1MDrwsyoP4D6s1tM7hAkHYRjkNb5w6Pxk",
+      "DdZR6zRFiUt4S5mg7AV1uKB2z1f1WzcNYCaTEEWPAuby"
+    ),
+    getTokenBalance(
+      "SRMuApVNdxXokk5GT7XD5cUUgXMBCoAz2LHeuAoKWRt",
+      "DdZR6zRFiUt4S5mg7AV1uKB2z1f1WzcNYCaTEEWPAuby"
+    ),
+    getTokenBalance(
+      "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
+      "DdZR6zRFiUt4S5mg7AV1uKB2z1f1WzcNYCaTEEWPAuby"
+    ),
+    getTokenBalance(
+      "AGFEad2et2ZJif9jaGpdMixQqvW5i81aBdvKe7PHNfz3",
+      "DdZR6zRFiUt4S5mg7AV1uKB2z1f1WzcNYCaTEEWPAuby"
+    ),
+    getTokenBalance(
+      "4k3Dyjzvzp8eMZWUXbBCjEvwSkkk59S5iCNLY3QrkX6R",
+      "DdZR6zRFiUt4S5mg7AV1uKB2z1f1WzcNYCaTEEWPAuby"
+    ),
+    getTokenBalance(
+      "Saber2gLauYim4Mvftnrasomsv6NvAuncvMEZwcLpD1",
+      "DdZR6zRFiUt4S5mg7AV1uKB2z1f1WzcNYCaTEEWPAuby"
+    ),
+    getTokenBalance(
+      "MERt85fc5boKw3BW1eYdxonEuJNvXbiMbs6hvheau5K",
+      "DdZR6zRFiUt4S5mg7AV1uKB2z1f1WzcNYCaTEEWPAuby"
+    ),
+    getTokenBalance(
+      "So11111111111111111111111111111111111111112",
+      "DdZR6zRFiUt4S5mg7AV1uKB2z1f1WzcNYCaTEEWPAuby"
+    ),
+    getTokenBalance(
+      "mSoLzYCxHdYgdzU16g5QSh3i5K3z3KZK7ytfqcJm7So",
+      "DdZR6zRFiUt4S5mg7AV1uKB2z1f1WzcNYCaTEEWPAuby"
+    ),
+    getTokenBalance(
+      "7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs",
+      "DdZR6zRFiUt4S5mg7AV1uKB2z1f1WzcNYCaTEEWPAuby"
+    ),
+  ]);
+  return {
+    bitcoin: btcAmount,
+    "usd-coin": usdcAmount,
+    ethereum: ethAmount + wewethAmount,
+    serum: srmAmount,
+    tether: usdtAmount,
+    "ftx-token": fttAmount,
+    raydium: rayAmount,
+    saber: sbrAmount,
+    mercurial: merAmount,
+    solana: solAmount,
+    msol: msolAmount,
+  };
 }
 
 module.exports = {
-    timetravel: false,
-    tvl,
-    methodology: 'TVL consists of deposits made to the protocol and like other lending protocols, borrowed tokens are not counted. Coingecko is used to price tokens.',
-    hallmarks: [
-        [1635940800, "SLND launch"]
-    ]
-}
+  timetravel: false,
+  tvl,
+  borrowed,
+  methodology:
+    "TVL consists of deposits made to the protocol and like other lending protocols, borrowed tokens are not counted. Coingecko is used to price tokens.",
+  hallmarks: [[1635940800, "SLND launch"]],
+};

--- a/projects/solend/utils.js
+++ b/projects/solend/utils.js
@@ -1,0 +1,174 @@
+const BufferLayout = require("buffer-layout");
+const { PublicKey } = require("@solana/web3.js");
+const BN = require("bn.js");
+
+const publicKey = (property = "publicKey") => {
+  const publicKeyLayout = BufferLayout.blob(32, property);
+
+  const _decode = publicKeyLayout.decode.bind(publicKeyLayout);
+  const _encode = publicKeyLayout.encode.bind(publicKeyLayout);
+
+  publicKeyLayout.decode = (buffer, offset) => {
+    const data = _decode(buffer, offset);
+    return new PublicKey(data);
+  };
+
+  publicKeyLayout.encode = (key, buffer, offset) =>
+    _encode(key.toBuffer(), buffer, offset);
+
+  return publicKeyLayout;
+};
+
+/**
+ * Layout for a 64bit unsigned value
+ */
+const uint64 = (property = "uint64") => {
+  const layout = BufferLayout.blob(8, property);
+
+  const _decode = layout.decode.bind(layout);
+  const _encode = layout.encode.bind(layout);
+
+  layout.decode = (buffer, offset) => {
+    const data = _decode(buffer, offset);
+    return new BN(
+      [...data]
+        .reverse()
+        .map((i) => `00${i.toString(16)}`.slice(-2))
+        .join(""),
+      16
+    );
+  };
+
+  layout.encode = (num, buffer, offset) => {
+    const a = num.toArray().reverse();
+    let b = Buffer.from(a);
+    if (b.length !== 8) {
+      const zeroPad = Buffer.alloc(8);
+      b.copy(zeroPad);
+      b = zeroPad;
+    }
+    return _encode(b, buffer, offset);
+  };
+
+  return layout;
+};
+
+const uint128 = (property = "uint128") => {
+  const layout = BufferLayout.blob(16, property);
+
+  const _decode = layout.decode.bind(layout);
+  const _encode = layout.encode.bind(layout);
+
+  layout.decode = (buffer, offset) => {
+    const data = _decode(buffer, offset);
+    return new BN(
+      [...data]
+        .reverse()
+        .map((i) => `00${i.toString(16)}`.slice(-2))
+        .join(""),
+      16
+    );
+  };
+
+  layout.encode = (num, buffer, offset) => {
+    const a = num.toArray().reverse();
+    let b = Buffer.from(a);
+    if (b.length !== 16) {
+      const zeroPad = Buffer.alloc(16);
+      b.copy(zeroPad);
+      b = zeroPad;
+    }
+
+    return _encode(b, buffer, offset);
+  };
+
+  return layout;
+};
+const LastUpdateLayout = BufferLayout.struct(
+  [uint64("slot"), BufferLayout.u8("stale")],
+  "lastUpdate"
+);
+
+const ReserveLayout = BufferLayout.struct([
+  BufferLayout.u8("version"),
+
+  LastUpdateLayout,
+
+  publicKey("lendingMarket"),
+
+  BufferLayout.struct(
+    [
+      publicKey("mintPubkey"),
+      BufferLayout.u8("mintDecimals"),
+      publicKey("supplyPubkey"),
+      // @FIXME: oracle option
+      // TODO: replace u32 option with generic equivalent
+      // BufferLayout.u32('oracleOption'),
+      publicKey("pythOracle"),
+      publicKey("switchboardOracle"),
+      uint64("availableAmount"),
+      uint128("borrowedAmountWads"),
+      uint128("cumulativeBorrowRateWads"),
+      uint128("marketPrice"),
+    ],
+    "liquidity"
+  ),
+
+  BufferLayout.struct(
+    [
+      publicKey("mintPubkey"),
+      uint64("mintTotalSupply"),
+      publicKey("supplyPubkey"),
+    ],
+    "collateral"
+  ),
+
+  BufferLayout.struct(
+    [
+      BufferLayout.u8("optimalUtilizationRate"),
+      BufferLayout.u8("loanToValueRatio"),
+      BufferLayout.u8("liquidationBonus"),
+      BufferLayout.u8("liquidationThreshold"),
+      BufferLayout.u8("minBorrowRate"),
+      BufferLayout.u8("optimalBorrowRate"),
+      BufferLayout.u8("maxBorrowRate"),
+      BufferLayout.struct(
+        [
+          uint64("borrowFeeWad"),
+          uint64("flashLoanFeeWad"),
+          BufferLayout.u8("hostFeePercentage"),
+        ],
+        "fees"
+      ),
+      uint64("depositLimit"),
+      uint64("borrowLimit"),
+      publicKey("feeReceiver"),
+    ],
+    "config"
+  ),
+
+  BufferLayout.blob(256, "padding"),
+]);
+
+const parseReserve = (pubkey, info) => {
+  const { data } = info;
+  const buffer = Buffer.from(data);
+  const reserve = ReserveLayout.decode(buffer);
+
+  if (reserve.lastUpdate.slot.isZero()) {
+    return null;
+  }
+
+  const details = {
+    pubkey,
+    account: {
+      ...info,
+    },
+    info: reserve,
+  };
+
+  return details;
+};
+module.exports = {
+  parseReserve,
+};


### PR DESCRIPTION
There is a fix for wewETH TVL that I snuck in here as it wasn't being included. If this PR is going to take a while to merge, let me know and I'll put up a separate one for that.

### Description
Adds a borrowed method for Solend to pick up borrowed value.

TVL + borrowed will get you a view of what's deposited as requested @0xngmi .

Did this based on my understanding in tg. Feel free to takeover and fix if not fully to specs.

### Testing
Ran test script to see that it calculates correct borrowed amount

