### PR TITLE
DappRadar RADAR staking on sushi masterchef

### DIFF
--- a/projects/dappradar.js
+++ b/projects/dappradar.js
@@ -1,0 +1,13 @@
+const {pool2} = require('./helper/pool2')
+
+const RADAR = '0x44709a920fccf795fbc57baa433cc3dd53c44dbe'
+const RADAR_WETH_sushi = '0x559ebe4e206e6b4d50e9bd3008cda7ce640c52cb'
+const sushiMasterchef = '0xef0881ec094552b2e128cf945ef17a6752b4ec5d'
+
+module.exports={
+    methodology: 'RADAR token can be LP\'ed on Sushi and LP can be staked on Sushiswap Masterchef - more TVL soon',
+    ethereum:{
+        tvl: () => ({}),
+        pool2: pool2(sushiMasterchef, RADAR_WETH_sushi, 'ethereum'),
+    }
+}


### PR DESCRIPTION
DapRadar RADAR staking on sushi masterchef

##### Twitter Link:
https://twitter.com/dappradar

##### List of audit links if any:


##### Website Link:
https://dappradar.com

##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):
white bg: https://avatars.githubusercontent.com/u/48711064?s=280&v=4

##### Current TVL:
500k staked on sushi masterchef (RADAR/WETH LP)

##### Chain:
Eth mainnet

##### Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)
dappradar

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
15188

##### Short Description (to be shown on DefiLlama):
Discover, Track & Trade Everything DeFi, NFT and Gaming

##### Token address and ticker if any:
RADAR 0x44709a920fccf795fbc57baa433cc3dd53c44dbe

##### Category (Yield/Dexes/Lending/Minting/Assets/Insurance/Options/Indexes/Staking) *Please choose only one:
Assets

##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):


##### forkedFrom (Does your project originate from another project):


##### methodology (what is being counted as tvl, how is tvl being calculated):
RADAR token can be LP'ed on Sushi and LP can be staked on Sushiswap Masterchef - more TVL soon

