### PR TITLE
Add RIC to Superfluid balance

### DIFF
--- a/projects/superfluid.js
+++ b/projects/superfluid.js
@@ -82,7 +82,8 @@ async function getChainBalances(allTokens, chain, block, transform = a => a) {
 
 const tokensNativeToSidechain = [
   '0x2bf2ba13735160624a0feae98f6ac8f70885ea61', // xdai FRACTION
-  '0x63e62989d9eb2d37dfdb1f93a22f063635b07d51'  // xdai MIVA 
+  '0x63e62989d9eb2d37dfdb1f93a22f063635b07d51', // xdai MIVA 
+  '0x263026e7e53dbfdce5ae55ade22493f828922965', // polygon RIC
 ]
 
 async function retrieveSupertokensBalances(chain, timestamp, ethBlock, chainBlocks) {
@@ -105,7 +106,7 @@ async function retrieveSupertokensBalances(chain, timestamp, ethBlock, chainBloc
     {block}
   )
 
-  const allTokens = tokens.filter(t => t.symbol.length > 0)
+  const allTokens = tokens // .filter(t => t.symbol.length > 0)
 
   return getChainBalances(allTokens, chain, block, transform)
 }

--- a/projects/superfluid.js
+++ b/projects/superfluid.js
@@ -5,8 +5,12 @@ const { transformPolygonAddress, transformXdaiAddress } = require("./helper/port
 // const abi = require('./erc20-abi.json')
 
 // Superfluid Supertokens can be retrieved using GraphQl API - cannot use block number to retrieve historical data at the moment though
-const polygonGraphUrl = 'https://api.thegraph.com/subgraphs/name/superfluid-finance/superfluid-matic'
-const xdaiGraphUrl = 'https://api.thegraph.com/subgraphs/name/superfluid-finance/superfluid-xdai'
+// TheGraph URL before being deprecated, before 2021-12-23
+// const polygonGraphUrl = 'https://api.thegraph.com/subgraphs/name/superfluid-finance/superfluid-matic'
+// const xdaiGraphUrl = 'https://api.thegraph.com/subgraphs/name/superfluid-finance/superfluid-xdai'
+const polygonGraphUrl = 'https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-matic'
+const xdaiGraphUrl = 'https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-xdai'
+
 const supertokensQuery = gql`
 query get_supertokens($block: Int) {
   tokens(


### PR DESCRIPTION
Superfluid graphql endpoint returns empty name and symbol for RIC. Since RIC is now listed on coingecko, we can return its balance in the adapter to add the 20M RIC TVL (by not filtering on symbol string length.

##### Twitter Link:


##### List of audit links if any:


##### Website Link:


##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):


##### Current TVL:


##### Chain:


##### Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description (to be shown on DefiLlama):


##### Token address and ticker if any:


##### Category (Yield/Dexes/Lending/Minting/Assets/Insurance/Options/Indexes/Staking) *Please choose only one:


##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):


##### forkedFrom (Does your project originate from another project):


##### methodology (what is being counted as tvl, how is tvl being calculated):


