### PR TITLE
Updating Tranquil Finance TVL with stONE

### DIFF
--- a/projects/tranquil/index.js
+++ b/projects/tranquil/index.js
@@ -7,7 +7,10 @@ const markets = [
   "0xc63AB8c72e636C9961c5e9288b697eC5F0B8E1F7", // tq1ETH
   "0xCa3e902eFdb2a410C952Fd3e4ac38d7DBDCB8E96", // tq1USDC
   "0x7af2430eFa179dB0e76257E5208bCAf2407B2468", // tq1USDT
+  "0x973f22036A0fF3A93654e7829444ec64CB37BD78", // tqstONE
 ];
+
+const stONEAddr = "0x22D62b19b7039333ad773b7185BB61294F3AdC19"; // stONE ERC20 contract
 
 const underlyingAbi = {
   stateMutability: "view",
@@ -60,6 +63,7 @@ async function tvl(timestamp, chain, chainBlocks) {
     chain: "harmony",
   });
 
+
   for (let result in marketBalances) {
     sdk.util.sumSingleBalance(
       balances,
@@ -68,25 +72,35 @@ async function tvl(timestamp, chain, chainBlocks) {
     );
   }
 
+  // Add ONE amount locked in Liquid Staking
+  // https://docs.tranquil.finance/liquid-staking-stone/tranquil-stone
+  const stoneBalance = (await sdk.api.abi.call({
+    block: chainBlocks.harmony,
+    target: stONEAddr,
+    abi: 'erc20:totalSupply',
+    chain: 'harmony'
+  })).output;
+
+  sdk.util.sumSingleBalance(balances, `harmony:${stONEAddr}`, stoneBalance);
+
   return balances;
 }
 
-const sushiLP = "0x643f94fc0a804ea13adb88b9e17244bf94022a25";
+const tranqWONESushiLP = "0x643f94fc0a804ea13adb88b9e17244bf94022a25";
+const stoneWONESushiLP = "0x6b53ca1ed597ed7ccd5664ec9e03329992c2ba87";
 const tranqToken = "0xcf1709ad76a79d5a60210f23e81ce2460542a836";
 const wOne = "0xcf664087a5bb0237a0bad6742852ec6c8d69a27a";
 
-async function pool2(timestamp, chain, chainBlocks) {
-  let balances = {};
-
+async function tranqWONE_pool2(balances, timestamp, chain, chainBlocks) {
   let { output: balance } = await sdk.api.abi.multiCall({
     calls: [
       {
         target: tranqToken,
-        params: sushiLP,
+        params: tranqWONESushiLP,
       },
       {
         target: wOne,
-        params: sushiLP,
+        params: tranqWONESushiLP,
       },
     ],
     abi: "erc20:balanceOf",
@@ -104,6 +118,42 @@ async function pool2(timestamp, chain, chainBlocks) {
     balance[0].output
   );
   sdk.util.sumSingleBalance(balances, ["wrapped-one"], oneBalance);
+}
+
+async function stoneWONE_pool2(balances, timestamp, chain, chainBlocks) {
+  let { output: balance } = await sdk.api.abi.multiCall({
+    calls: [
+      {
+        target: stONEAddr,
+        params: stoneWONESushiLP,
+      },
+      {
+        target: wOne,
+        params: stoneWONESushiLP,
+      },
+    ],
+    abi: "erc20:balanceOf",
+    block: chainBlocks.harmony,
+    chain: "harmony",
+  });
+
+  let oneBalance = BigNumber(balance[1].output)
+    .div(10 ** 18)
+    .toFixed(0);
+
+  sdk.util.sumSingleBalance(
+    balances,
+    `harmony:${stONEAddr}`,
+    balance[0].output
+  );
+  sdk.util.sumSingleBalance(balances, ["wrapped-one"], oneBalance);
+}
+
+async function pool2(timestamp, chain, chainBlocks) {
+  let balances = {};
+  await tranqWONE_pool2(balances, timestamp, chain, chainBlocks);
+  await stoneWONE_pool2(balances, timestamp, chain, chainBlocks);
+
 
   return balances;
 }
@@ -127,7 +177,7 @@ async function staking(timestamp, chain, chainBlocks) {
 }
 
 module.exports = {
-  methodology: "TVL includes values locked into TqTokens. Pool2 are the liquidity in the TRANQ-WONE SUSHI LPs. Staking TVL are the xTRANQ tokens locked into the staking contract.",
+  methodology: "TVL includes values locked into TqTokens and stONE liquid staking. Pool2 are the liquidity in the TRANQ-WONE and stONE-ONE SUSHI LPs. Staking TVL are the xTRANQ tokens locked into the staking contract.",
   harmony: {
     tvl,
     pool2,


### PR DESCRIPTION
##### Short Description (to be shown on DefiLlama):

Tranquil Finance has already been onboarded to DefiLlama.

We have launched "**Tranquil stONE**", a new staking derivative (like stETH or mSOL) for the Harmony ONE blockchain.

This PR is to update the TVL calculation to also include stONE:

1. Add ONEs being delegated via. stONE for liquid staking. This is equivalent to the stONE in circulation.
2. Add stONE used in the Tranquil lending market
3. Add pool2 for stONE-WONE on sushi


##### Token address and ticker if any:
https://explorer.harmony.one/address/0x22d62b19b7039333ad773b7185bb61294f3adc19?activeTab=7

$STONE on coingecko:
* https://www.coingecko.com/en/coins/tranquil-staked-one
