### PR TITLE
Updating Tranquil Finance TVL with stONE

### DIFF
--- a/projects/helper/compound.js
+++ b/projects/helper/compound.js
@@ -3,6 +3,7 @@ const sdk = require('@defillama/sdk');
 const abi = require('./abis/compound.json');
 const {getBlock} = require('./getBlock');
 const { unwrapUniswapLPs } = require('./unwrapLPs');
+const { fixHarmonyBalances } = require('../helper/portedTokens');
 
 // ask comptroller for all markets array
 async function getAllCTokens(comptroller, block, chain) {
@@ -94,6 +95,9 @@ function getCompoundV2Tvl(comptroller, chain="ethereum", transformAdress = addr=
                 sdk.util.sumSingleBalance(balances, transformAdress(market.underlying), getCash.output)
             }
         });
+        if(chain == "harmony") {
+            fixHarmonyBalances(balances);
+        }
         if(lpPositions.length > 0){
             await unwrapUniswapLPs(balances, lpPositions, block, chain, transformAdress)
         }

--- a/projects/tranquil/index.js
+++ b/projects/tranquil/index.js
@@ -1,26 +1,26 @@
 const sdk = require("@defillama/sdk");
 const { BigNumber } = require("bignumber.js");
-const {staking} = require('../helper/staking')
-const {compoundExports} = require('../helper/compound')
+const {compoundExports, getCompoundV2Tvl} = require('../helper/compound')
 
 const tqOne = "0x34B9aa82D89AE04f0f546Ca5eC9C93eFE1288940"; // tqONE
-
-const sushiLP = "0x643f94fc0a804ea13adb88b9e17244bf94022a25";
-const tranqToken = "0xcf1709ad76a79d5a60210f23e81ce2460542a836";
 const wOne = "0xcf664087a5bb0237a0bad6742852ec6c8d69a27a";
+const stONEAddr = "0x22D62b19b7039333ad773b7185BB61294F3AdC19"; // stONE ERC20 contract
+const tranqToken = "0xcf1709ad76a79d5a60210f23e81ce2460542a836";
 
-async function pool2(timestamp, chain, chainBlocks) {
-  let balances = {};
 
+const tranqWONESushiLP = "0x643f94fc0a804ea13adb88b9e17244bf94022a25";
+const stoneWONESushiLP = "0x6b53ca1ed597ed7ccd5664ec9e03329992c2ba87";
+
+async function tranqWONE_pool2(balances, timestamp, chain, chainBlocks) {
   let { output: balance } = await sdk.api.abi.multiCall({
     calls: [
       {
         target: tranqToken,
-        params: sushiLP,
+        params: tranqWONESushiLP,
       },
       {
         target: wOne,
-        params: sushiLP,
+        params: tranqWONESushiLP,
       },
     ],
     abi: "erc20:balanceOf",
@@ -38,18 +38,95 @@ async function pool2(timestamp, chain, chainBlocks) {
     balance[0].output
   );
   sdk.util.sumSingleBalance(balances, ["wrapped-one"], oneBalance);
+}
+
+async function stoneWONE_pool2(balances, timestamp, chain, chainBlocks) {
+  let { output: balance } = await sdk.api.abi.multiCall({
+    calls: [
+      {
+        target: stONEAddr,
+        params: stoneWONESushiLP,
+      },
+      {
+        target: wOne,
+        params: stoneWONESushiLP,
+      },
+    ],
+    abi: "erc20:balanceOf",
+    block: chainBlocks.harmony,
+    chain: "harmony",
+  });
+
+  let oneBalance = BigNumber(balance[1].output)
+    .div(10 ** 18)
+    .toFixed(0);
+
+  sdk.util.sumSingleBalance(
+    balances,
+    `harmony:${stONEAddr}`,
+    balance[0].output
+  );
+  sdk.util.sumSingleBalance(balances, ["wrapped-one"], oneBalance);
+}
+
+async function pool2(timestamp, chain, chainBlocks) {
+  let balances = {};
+  await tranqWONE_pool2(balances, timestamp, chain, chainBlocks);
+  await stoneWONE_pool2(balances, timestamp, chain, chainBlocks);
+
 
   return balances;
 }
 
+async function tvl(timestamp, chain, chainBlocks) {
+    const transformAddress = addr=>`harmony:${addr}`;
+    const lendingMarketTvlFn = getCompoundV2Tvl("0x6a82A17B48EF6be278BBC56138F35d04594587E3", "harmony", transformAddress, tqOne, wOne, false);
+    let balances = await lendingMarketTvlFn(timestamp, chain, chainBlocks);
+
+    // Add ONE amount locked in Liquid Staking
+    // https://docs.tranquil.finance/liquid-staking-stone/tranquil-stone
+    const stoneBalance = (await sdk.api.abi.call({
+      block: chainBlocks.harmony,
+      target: stONEAddr,
+      abi: 'erc20:totalSupply',
+      chain: 'harmony'
+    })).output;
+    sdk.util.sumSingleBalance(balances, `harmony:${stONEAddr}`, stoneBalance);
+
+    return balances;
+}
+
+async function borrowed(timestamp, chain, chainBlocks) {
+    const transformAddress = addr=>`harmony:${addr}`;
+    const lendingMarketTvlFn = getCompoundV2Tvl("0x6a82A17B48EF6be278BBC56138F35d04594587E3", "harmony", transformAddress, tqOne, wOne, true);
+    return await lendingMarketTvlFn(timestamp, chain, chainBlocks);
+}
+
+
 const xtranqToken = "0xb4aa8c8e555b3a2f1bfd04234ff803c011760e59";
 const stakingContract = "0x59a4d6b2a944e8acabbd5d2571e731388918669f";
+
+async function staking(timestamp, chain, chainBlocks) {
+  let balances = {};
+
+  let { output: balance } = await sdk.api.erc20.balanceOf({
+    target: xtranqToken,
+    owner: stakingContract,
+    block: chainBlocks.harmony,
+    chain: "harmony",
+  });
+
+  sdk.util.sumSingleBalance(balances, `harmony:${tranqToken}`, balance);
+
+  return balances;
+}
 
 module.exports = {
   methodology: "TVL includes values locked into TqTokens. Pool2 are the liquidity in the TRANQ-WONE SUSHI LPs. Staking TVL are the xTRANQ tokens locked into the staking contract.",
   harmony: {
-    ...compoundExports("0x6a82A17B48EF6be278BBC56138F35d04594587E3", "harmony", tqOne, wOne),
+    tvl,
+    borrowed,
     pool2,
-    staking: staking(stakingContract, xtranqToken, "harmony"),
+    staking: staking,
   },
 };


### PR DESCRIPTION
##### Short Description (to be shown on DefiLlama):

Tranquil Finance has already been onboarded to DefiLlama.

We have launched "**Tranquil stONE**", a new staking derivative (like stETH or mSOL) for the Harmony ONE blockchain.

This PR is to update the TVL calculation to also include stONE:

1. Add ONEs being delegated via. stONE for liquid staking. This is equivalent to the stONE in circulation.
2. Add stONE used in the Tranquil lending market
3. Add pool2 for stONE-WONE on sushi


##### Token address and ticker if any:
https://explorer.harmony.one/address/0x22d62b19b7039333ad773b7185bb61294f3adc19?activeTab=7

$STONE on coingecko:
* https://www.coingecko.com/en/coins/tranquil-staked-one

---

Old PR: https://github.com/DefiLlama/DefiLlama-Adapters/pull/1218
Test output: https://gist.github.com/0xKrillin/3777ff38ac2dffe69affe42e5cafbd0b