### PR TITLE
Update Poof TVL metrics by including new pools

### DIFF
--- a/projects/poofcash/index.js
+++ b/projects/poofcash/index.js
@@ -8,12 +8,27 @@ const tokens = [
     tokenAddress: "0x918146359264C492BD6934071c6Bd31C854EDBc3", // mcUSD
   },
   {
+    holder: "0xD96A74081440C28E9a3c09a3256D6e0454c52E41", // wmcUSD 2
+    currency: "celo-dollar",
+    tokenAddress: "0x918146359264C492BD6934071c6Bd31C854EDBc3", // mcUSD
+  },
+  {
     holder: "0xd3D7831D502Ab85319E1F0A18109aa9aBEBC2603", // wmCELO
     currency: "celo",
     tokenAddress: "0x7D00cd74FF385c955EA3d79e47BF06bD7386387D", // mCELO
   },
   {
+    holder: "0x337ddAD7Fcb34E93a54a7B6df7C8Bae00fA91D09", // wmCELO 2
+    currency: "celo",
+    tokenAddress: "0x7D00cd74FF385c955EA3d79e47BF06bD7386387D", // mCELO
+  },
+  {
     holder: "0xb7e4e9329DA677969376cc76e87938563B07Ac6A", // wmcEUR
+    currency: "celo-euro",
+    tokenAddress: "0xE273Ad7ee11dCfAA87383aD5977EE1504aC07568", // mcEUR
+  },
+  {
+    holder: "0xAb32a0b6d427ce11a4cEf7Be174A3F291a2753E6", // wmcEUR 2
     currency: "celo-euro",
     tokenAddress: "0xE273Ad7ee11dCfAA87383aD5977EE1504aC07568", // mcEUR
   },


### PR DESCRIPTION
This diff just updates the existing adapter to include TVL from the newly launched v2 pools

##### Twitter Link:


##### List of audit links if any:


##### Website Link:


##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):


##### Current TVL:


##### Chain:


##### Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description (to be shown on DefiLlama):


##### Token address and ticker if any:


##### Category (Yield/Dexes/Lending/Minting/Assets/Insurance/Options/Indexes/Staking) *Please choose only one:


##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):


##### forkedFrom (Does your project originate from another project):


##### methodology (what is being counted as tvl, how is tvl being calculated):


