### PR TITLE
Include all known tokens of MuesliSwap DEX on DefiLlama

### DIFF
--- a/projects/muesliswap/index.js
+++ b/projects/muesliswap/index.js
@@ -2,10 +2,12 @@ const {calculateUsdUniTvl} = require('../helper/getUsdUniTvl')
 const { fetchURL } = require('../helper/utils')
 
 async function adaTvl(){
-    const tokens = (await fetchURL("https://orders.muesliswap.com/tokens-info")).data
+    const tokens = (await fetchURL("https://orders.muesliswap.com/known-tokens")).data
     let totalAda = 0
     await Promise.all(tokens.map(async t=>{
-        const orders = (await fetchURL(`https://orders.muesliswap.com/orderbook/?policy-id=${t.policyId}&tokenname=${t.name}`)).data
+        const policyId = t.address.split(".")[0];
+        const tokenname = t.address.split(".")[1];
+        const orders = (await fetchURL(`https://orders.muesliswap.com/orderbook/?policy-id=${policyId}&tokenname=${tokenname}`)).data
         if(orders.fromToken !== "."){
             throw new Error("Tokens paired against something other than ADA")
         }


### PR DESCRIPTION
With the upgrade to the "Trade Anything/Community Trading" feature on MuesliSwap, not only featured tokens but all tokens on the network may be traded via MuesliSwap DEX. The information on currently traded tokens (rather than only featured) moves from tokens -> known_tokens and has a slightly more efficient format.

