### PR TITLE
Add support for yearn vaults

### DIFF
--- a/projects/helper/abis/token.json
+++ b/projects/helper/abis/token.json
@@ -1,0 +1,14 @@
+{
+  "inputs": [],
+  "name": "token",
+  "outputs": [
+    {
+      "internalType": "address",
+      "name": "",
+      "type": "address"
+    }
+  ],
+  "payable": false,
+  "stateMutability": "view",
+  "type": "function"
+}

--- a/projects/helper/masterchef.js
+++ b/projects/helper/masterchef.js
@@ -1,6 +1,7 @@
 const sdk = require('@defillama/sdk');
 const abi = require('./abis/masterchef.json')
 const { unwrapUniswapLPs } = require('./unwrapLPs')
+const tokenAbi = require("./abis/token.json");
 const token0Abi = require("./abis/token0.json");
 const token1Abi = require("./abis/token1.json");
 const getReservesAbi = require("./abis/getReserves.json");
@@ -57,6 +58,10 @@ async function getSymbolsAndBalances(masterChef, block, chain, poolInfo) {
 
 function isLP(symbol) {
     return symbol.includes('LP') || symbol.includes('PGL') || symbol.includes('UNI-V2') ||  symbol === "PNDA-V2"
+}
+
+function isYV(symbol) {
+    return symbol.includes('yv')
 }
 
 async function addFundsInMasterChef(balances, masterChef, block, chain = 'ethereum', transformAddress = id => id, poolInfoAbi = abi.poolInfo, ignoreAddresses = [], includeLPs = true, excludePool2 = false, stakingToken = undefined) {
@@ -162,7 +167,7 @@ function masterChefExports(masterChef, chain, stakingTokenRaw, tokenIsOnCoingeck
 
         const lpPositions = [];
 
-        symbols.output.forEach((symbol, idx) => {
+        await Promise.all(symbols.output.map(async (symbol, idx) => {
             const balance = tokenBalances.output[idx].output;
             const token = symbol.input.target.toLowerCase();
             if (token === stakingToken) {
@@ -172,10 +177,18 @@ function masterChefExports(masterChef, chain, stakingTokenRaw, tokenIsOnCoingeck
                     balance,
                     token
                 });
+            } else if (isYV(symbol.output)) {
+                let underlyingToken = (await sdk.api.abi.call({
+                    target: token,
+                    abi: tokenAbi,
+                    block,
+                    chain,
+                })).output;
+                sdk.util.sumSingleBalance(balances.tvl, transformAddress(underlyingToken), balance)
             } else {
                 sdk.util.sumSingleBalance(balances.tvl, transformAddress(token), balance)
             }
-        })
+        }));
 
         const [token0, token1] = await Promise.all([
             sdk.api.abi.multiCall({

--- a/projects/helper/masterchef.js
+++ b/projects/helper/masterchef.js
@@ -147,7 +147,7 @@ function awaitBalanceUpdate(balancePromise, section) {
     return async ()=>balancePromise.then(b => b[section])
 }
 
-function masterChefExports(masterChef, chain, stakingTokenRaw, tokenIsOnCoingecko = true, poolInfoAbi=abi.poolInfo) {
+function masterChefExports(masterChef, chain, stakingTokenRaw, tokenIsOnCoingecko = true, poolInfoAbi=abi.poolInfo, includeYVTokens = false) {
     const stakingToken = stakingTokenRaw.toLowerCase();
     let balanceResolve;
     const balancePromise = new Promise((resolve) => { balanceResolve = resolve })
@@ -177,7 +177,7 @@ function masterChefExports(masterChef, chain, stakingTokenRaw, tokenIsOnCoingeck
                     balance,
                     token
                 });
-            } else if (isYV(symbol.output)) {
+            } else if (includeYVTokens && isYV(symbol.output)) {
                 let underlyingToken = (await sdk.api.abi.call({
                     target: token,
                     abi: tokenAbi,

--- a/projects/radial/index.js
+++ b/projects/radial/index.js
@@ -1,5 +1,6 @@
 const {masterChefExports, standardPoolInfoAbi} = require('../helper/masterchef')
 
-module.exports=masterChefExports("0x6f536B36d02F362CfF4278190f922582d59E7e08", "fantom", "0xf04d7f53933becbf51ddf1f637fe7ecaf3d4ff94", true, 
-    standardPoolInfoAbi
+module.exports=masterChefExports("0x6f536B36d02F362CfF4278190f922582d59E7e08", "fantom", "0xf04d7f53933becbf51ddf1f637fe7ecaf3d4ff94", true,
+    standardPoolInfoAbi, true
 )
+


### PR DESCRIPTION
Follow up to #1445 

The code is behind a flag that's only enabled for Radial. Can potentially be enabled for other projects as well.

Tested using `node test.js projects/radial/index.js` that it returns the current TVL (without YVs) when the flag is not set, and includes YVs in the TVL when the flag is set to true.