### PR TITLE
Sperax: adding USDT and USDC in strategy contracts on TVL

### DIFF
--- a/projects/sperax/abi.json
+++ b/projects/sperax/abi.json
@@ -1,0 +1,21 @@
+{
+  "checkBalance": {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_asset",
+        "type": "address"
+      }
+    ],
+    "name": "checkBalance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "balance",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+}

--- a/projects/sperax/index.js
+++ b/projects/sperax/index.js
@@ -1,28 +1,54 @@
 const sdk = require("@defillama/sdk");
+const abi = require("./abis/abi.json");
+const BigNumber = require("bignumber.js");
 
 const vaultcore = '0xF783DD830A4650D2A8594423F123250652340E3f'
 const collateralTokens = [
   '0xff970a61a04b1ca14834a43f5de4533ebddb5cc8', // USDC
   '0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9', // USDT 
 ]
-const SPA = '0x5575552988a3a80504bbaeb1311674fcfd40ad4b' 
+const strategyArr = [
+  '0xbF82a3212e13b2d407D10f5107b5C8404dE7F403', // Strategy （TwoPoolStrategy） for USDC
+  '0xdc118F2F00812326Fe0De5c9c74c1c0c609d1eB4', // Strategy （TwoPoolStrategy） for USDT
+]
+
+const SPA = '0x5575552988a3a80504bbaeb1311674fcfd40ad4b'
 
 async function tvl (timestamp, ethBlock, chainBlocks) {
   const chain = 'arbitrum'
   const block = chainBlocks[chain]
 
-  const collateralBalances = await sdk.api.abi.multiCall({
-    abi: "erc20:balanceOf",
-    calls: collateralTokens.map((t) => ({
+  const allstrategyBalance = (
+    await sdk.api.abi.multiCall({
+      abi: abi.checkBalance,
+      calls: strategyArr.map((item, index) => ({
+        target: item,
+        params: [collateralTokens[index]],
+      })),
+      chain,
+      block,
+    })
+  ).output.map((o) => o.output);
+
+  const collateralBalances = (await sdk.api.abi.multiCall({
+      abi: "erc20:balanceOf",
+      calls: collateralTokens.map((t) => ({
         target: t,
         params: [vaultcore],
       })),
-    chain,
-    block,
-  });
+      chain,
+      block,
+    })
+  ).output.map((o) => o.output);
 
   const balances = {};
-  sdk.util.sumMultiBalanceOf(balances, collateralBalances, true, t=>`arbitrum:${t}`);
+  function getBalance (balances) {
+    for(let i =0; i < collateralTokens.length; i++) {
+      sdk.util.sumSingleBalance(balances, `arbitrum:${collateralTokens[i]}`, (BigNumber(collateralBalances[i]).plus(BigNumber(allstrategyBalance[i]))).toFixed(0))
+    }
+  }
+  getBalance(balances)
+  console.log(balances)
   return balances
 }
 


### PR DESCRIPTION
The TVL of Sperax's USDs protocol is consist of two components: 1. USDC and USDT locked in the VaultCore contract 2. USDC and USDT deposited into Curve USDC-USDT pool. The previous TVL was only considering the first component.

##### Twitter Link:


##### List of audit links if any:


##### Website Link:


##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):


##### Current TVL:


##### Chain:


##### Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description (to be shown on DefiLlama):


##### Token address and ticker if any:


##### Category (Yield/Dexes/Lending/Minting/Assets/Insurance/Options/Indexes/Staking) *Please choose only one:


##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):


##### forkedFrom (Does your project originate from another project):


##### methodology (what is being counted as tvl, how is tvl being calculated): The TVL of Sperax's USDs protocol is consist of two components: 1. USDC and USDT locked in the VaultCore contract 2. USDC and USDT deposited into Curve USDC-USDT pool. The previous TVL was only considering the first component. The USDC and USDT deposited into Curve are calculated based on how many USDC and USDT can be redeemed when we withdraw all the lp tokens hold on the contract (and the curve gauge) (via calc_withdraw_one_coin() function of the curve pool).


