### PR TITLE
Adding ViveLaBouje

### DIFF
--- a/projects/vivelabouje/index.js
+++ b/projects/vivelabouje/index.js
@@ -1,0 +1,28 @@
+const abi = require("../helper/abis/masterchef.json")
+const { transformFantomAddress } = require("../helper/portedTokens");
+const { addFundsInMasterChef } = require("../helper/masterchef");
+const { staking, stakingPricedLP } = require("../helper/staking");
+const { pool2Exports } = require('../helper/pool2')
+
+
+const chef = "0x1277dd1dCbe60d597aAcA80738e1dE6cB95dCB54"
+const vive = "0xE509Db88B3c26D45f1fFf45b48E7c36A8399B45A"
+const viveFtmLP = "0xf561C4dA5c86F5B35E761E637aA6387219780bfA"
+const viveUsdcLP = "0x2D2Ce3AD0Bf68624c8C80F26e0863214af284218";
+
+async function tvl(timestamp, block, chainBlocks) {
+  const balances = {}
+  const transformAddress = await transformFantomAddress();
+  await addFundsInMasterChef(balances, chef, chainBlocks.fantom, "fantom", transformAddress, abi.poolInfo, [vive, viveFtmLP, viveUsdcLP]);
+  return balances;
+}
+
+module.exports = {
+  methodology: "TVL includes all farms in MasterChef contract",
+  fantom: {
+      tvl,
+      staking: stakingPricedLP(chef, vive, "fantom","0xf561C4dA5c86F5B35E761E637aA6387219780bfA", "fantom"),
+      pool2: pool2Exports(chef, [viveFtmLP, viveUsdcLP], "fantom"),
+  },
+  
+} 


### PR DESCRIPTION
##### Twitter Link: https://twitter.com/BoujeFinance


##### List of audit links if any: https://paladinsec.co/projects/bouje-finance/


##### Website Link: https://vive.bouje.finance/


##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders): https://vive.bouje.finance/logo.png


##### Current TVL: $3000


##### Chain: Fantom


##### Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list) NIL


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000) NIL


##### Short Description (to be shown on DefiLlama):
Building upon the success of Bouje Finance, Vive La Bouje is a second-generation yield farming platform made on the Fantom Blockchain, aiming to have positive and steady price action. Utilizing a new-age system called APR reset (inspired by Swift Finance). For APR reset, the concept is to retire non-native pools weekly and replace them with new pools that the community has power in deciding. This would help reset the APR and raise it to attractive levels for new people to deposit. Furthermore, this would help the farm gain a new round of deposit fees to continue functioning. This latest round of deposit fees would be re-invested into the native token, Vive, driving the support for the token price. 


##### Token address and ticker if any:

VIVE
0xe509db88b3c26d45f1fff45b48e7c36a8399b45a
https://ftmscan.com/address/0xe509db88b3c26d45f1fff45b48e7c36a8399b45a

##### Category (Yield/Dexes/Lending/Minting/Assets/Insurance/Options/Indexes/Staking) *Please choose only one:
Yield

##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):


##### forkedFrom (Does your project originate from another project):


##### methodology (what is being counted as tvl, how is tvl being calculated):


