### PR TITLE
new adapter request for agora-plus

### DIFF
--- a/projects/agora-plus.js
+++ b/projects/agora-plus.js
@@ -1,0 +1,19 @@
+const { compoundExports } = require("./helper/compound");
+const { transformMetisAddress } = require("./helper/portedTokens");
+const comptroller = "0x92DcecEaF4c0fDA373899FEea00032E8E8Da58Da";
+
+module.exports = {
+  timeTravel: true,
+  incentivized: true,
+  misrepresentedTokens: true,
+  methodology: `As in Compound Finance, TVL counts the tokens locked in the contracts to be used as collateral to borrow or to earn yield. Borrowed coins are counted as "Borrowed" TVL and can be toggled towards the regular TVL.`,
+  metis: {
+    ...compoundExports(
+      comptroller,
+      "metis",
+      "0xE85A1ae1A2A21135c49ADEd398D3FD5Ed032B28e",
+      "0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000",
+      transformMetisAddress()
+    ),
+  },
+};


### PR DESCRIPTION
##### Twitter Link:
https://twitter.com/AgoraDefi

##### List of audit links if any:
https://github.com/Tech-Audit/Smart-Contract-Audits/blob/main/TECHAUDIT_AGORADEFI.pdf


##### Website Link:
https://agoradefi.io/
https://plus.agoradefi.io/#/

##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):
![Agora Plus logo](https://user-images.githubusercontent.com/97014053/152092135-6073ad20-82ce-4277-b39f-d8f063bc9067.png)


##### Current TVL:
$8,861,892

##### Chain: metis


##### Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description (to be shown on DefiLlama):
Borrow against your autocompounded LPs. Supply to LP. Autocompound. Stake to Borrow.

##### Token address and ticker if any:
0x0Ed0Ca6872073E02cd3aE005BaF04bA43BE947fA
SYMBOL: AGORA

##### Category (Yield/Dexes/Lending/Minting/Assets/Insurance/Options/Indexes/Staking) *Please choose only one:
Lending

##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):
TWAP

##### forkedFrom (Does your project originate from another project):
Compound

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL counts the tokens locked in the contracts to be used as collateral to borrow or to earn yield. Borrowed coins are counted as "Borrowed" TVL and can be toggled towards the regular TVL.


