### PR TITLE
Add Minimax in DefiLama

### DIFF
--- a/projects/minimax/index.js
+++ b/projects/minimax/index.js
@@ -1,0 +1,14 @@
+const retry = require('async-retry')
+const axios = require("axios");
+const CAKE_PRICE_URL = "https://api.coingecko.com/api/v3/simple/price?ids=pancakeswap-token&vs_currencies=usd&include_market_cap=true&include_24hr_vol=true&include_24hr_change=true"
+
+async function fetch() {
+    var cake_tvl = await retry(async bail => axios.get("https://api.minimax.finance/tvl/cake"));
+    var price_feed = await retry(async bail => await axios.get(CAKE_PRICE_URL));
+    var tvl = parseFloat(cake_tvl.data.TotalTvl) * price_feed.data['pancakeswap-token'].usd;
+    return tvl;
+}
+
+module.exports = {
+    fetch
+}


### PR DESCRIPTION
##### Twitter Link:

https://twitter.com/MinimaxFinance

##### List of audit links if any:

Will be added in 1-2 weeks

##### Website Link:
https://www.minimax.finance/

##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):

![logo](https://user-images.githubusercontent.com/97958812/153209439-b3f51dd5-9fe5-43a1-92b7-1b13a59c1143.svg)


##### Current TVL:
6.09k$

##### Chain:

Binance Smart Chain

##### Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)
N/A

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

N/A


##### Short Description (to be shown on DefiLlama):

Minimax.finance is an aggregator of staking and yield farming opportunities with stop loss and take profit.

##### Token address and ticker if any:

N/A

##### Category (Yield/Dexes/Lending/Minting/Assets/Insurance/Options/Indexes/Staking) *Please choose only one:
Staking

##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):

https://data.chain.link/bsc/mainnet/crypto-usd/cake-usd

##### forkedFrom (Does your project originate from another project):

N/A

##### methodology (what is being counted as tvl, how is tvl being calculated):

We store all user positions in our database, which is built using the blockchain data (it helps us fetch read data fast for our website). TVL equals to the total amount of staked CAKE multiplied by the current CAKE price.

P.S. 
We are running on BSC, but did fetch-adapter, as our smart contracts don't hold tokens on their addresses, but instead we use multiple addresses - one address for each position. So, with SDK adapter calculation of TVL would be complicated and a lot of requests to a BSC node would be done.
