### PR TITLE
Added GotchiVault index

### DIFF
--- a/projects/GotchiVault/abi.json
+++ b/projects/GotchiVault/abi.json
@@ -18,6 +18,8 @@
       ],
       "stateMutability": "view",
       "type": "function"
-    }
+    },
+    "tokenIdsOfOwner":
+    {"inputs":[{"internalType":"address","name":"_owner","type":"address"}],"name":"tokenIdsOfOwner","outputs":[{"internalType":"uint32[]","name":"tokenIds_","type":"uint32[]"}],"stateMutability":"view","type":"function"}
 
   }

--- a/projects/GotchiVault/abi.json
+++ b/projects/GotchiVault/abi.json
@@ -1,0 +1,23 @@
+{
+  "totalGHST":
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_user",
+          "type": "address"
+        }
+      ],
+      "name": "totalGHST",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "_totalGHST",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    }
+
+  }

--- a/projects/GotchiVault/index.js
+++ b/projects/GotchiVault/index.js
@@ -1,10 +1,61 @@
 const sdk = require('@defillama/sdk');
 const { transformPolygonAddress } = require('../helper/portedTokens');
 const abi = require("./abi.json");
+const { request, gql } = require("graphql-request");
+
 
 
 const VGHST_CONTRACT = "0x51195e21BDaE8722B29919db56d95Ef51FaecA6C";
 const GHST_CONTRACT = "0x385Eeac5cB85A38A9a07A70c73e0a3271CfB54A7";
+const VAULT_CONTRACT = "0xDd564df884Fd4e217c9ee6F65B4BA6e5641eAC63";
+
+const graphUrl = 'https://api.thegraph.com/subgraphs/name/aavegotchi/aavegotchi-core-matic'
+const graphQuery = gql`
+query GET_SUMMONED_GOTCHIS ($skip: Int, $block: Int) {
+  aavegotchis(
+    first: 1000
+    skip: $skip
+    block: { number: $block }
+    where: {
+      status: "3" # summoned gotchis
+      gotchiId_gt: $minGotchiId
+    }
+    orderBy: gotchiId
+    orderDirection: asc
+  ) {
+    gotchiId
+    collateral
+    stakedAmount
+  }
+}`
+async function getGotchisCollateral(timestamp, block) {
+  const allGotchis = [];
+  let minGotchiId = 0;
+  while (minGotchiId !== -1) {
+    const { aavegotchis } = await request(
+      graphUrl,
+      graphQuery, 
+      {minGotchiId, block}
+    );
+    if (aavegotchis && aavegotchis.length > 0) {
+      minGotchiId = parseInt(aavegotchis[aavegotchis.length - 1].gotchiId);
+      allGotchis.push(...aavegotchis);
+    } else {
+      minGotchiId = -1;
+    }
+  }
+  const gotchisBalances = {
+    output: allGotchis.map(g => ({
+      input: {target: g.collateral},
+      success: true,
+      output: g.stakedAmount
+    }))
+  };
+
+  const balances = {};
+  sdk.util.sumMultiBalanceOf(balances, gotchisBalances, true, x => 'polygon:' + x);
+  return gotchisBalances;
+}
 
 async function tvl(timestamp, block, chainBlocks) {
   const balances = {};
@@ -19,6 +70,10 @@ async function tvl(timestamp, block, chainBlocks) {
   })).output;
 
   await sdk.util.sumSingleBalance(balances, transform(GHST_CONTRACT), collateralBalance)
+
+  //const gotchisBalances = await getGotchisCollateral(timestamp, chainBlocks["polygon"]);
+  //await sdk.util.sumMultiBalanceOf(balances, gotchisBalances, true, x => 'polygon:' + x);
+
 
   return balances;
 }

--- a/projects/GotchiVault/index.js
+++ b/projects/GotchiVault/index.js
@@ -1,0 +1,32 @@
+const sdk = require('@defillama/sdk');
+const { transformPolygonAddress } = require('../helper/portedTokens');
+const abi = require("./abi.json");
+
+
+const VGHST_CONTRACT = "0x51195e21BDaE8722B29919db56d95Ef51FaecA6C";
+const GHST_CONTRACT = "0x385Eeac5cB85A38A9a07A70c73e0a3271CfB54A7";
+
+async function tvl(timestamp, block, chainBlocks) {
+  const balances = {};
+  const transform = await transformPolygonAddress();
+
+  const collateralBalance = (await sdk.api.abi.call({
+    abi: abi.totalGHST,
+    chain: 'polygon',
+    target: VGHST_CONTRACT,
+    params: [VGHST_CONTRACT],
+    block: chainBlocks['polygon'],
+  })).output;
+
+  await sdk.util.sumSingleBalance(balances, transform(GHST_CONTRACT), collateralBalance)
+
+  return balances;
+}
+
+module.exports = {
+  methodology:
+    "TVL counts the total GHST tokens that are staked by the Gotchi Vault contracts",
+    polygon: {
+    tvl,
+  }
+};


### PR DESCRIPTION
##### Twitter Link: @GotchiVault


##### List of audit links if any:


##### Website Link: GotchiVault.com


##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders): 
![treasury](https://user-images.githubusercontent.com/81598239/153673322-d8277494-fe08-4772-82fb-cb093f997f23.png)


##### Current TVL: 4.39m


##### Chain: Polygon


##### Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list) N/A


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000) N/A


##### Short Description (to be shown on DefiLlama):  Gotchi Vault allows users to deposit their GHST and Aavegotchis into the Vault smart contracts to be collectively managed.


##### Token address and ticker if any:  VGHST, polygon:0x51195e21BDaE8722B29919db56d95Ef51FaecA6C


##### Category (Yield/Dexes/Lending/Minting/Assets/Insurance/Options/Indexes/Staking) *Please choose only one: Staking


##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):


##### forkedFrom (Does your project originate from another project): QiDao


##### methodology (what is being counted as tvl, how is tvl being calculated):  TVL counts all the GHST tokens that are maintained by the Gotchi Vault contracts, and staked for yield.


