### PR TITLE
Add BENQI Staked AVAX (SAVAX)

### DIFF
--- a/projects/benqi-staked-avax/index.js
+++ b/projects/benqi-staked-avax/index.js
@@ -1,0 +1,27 @@
+const sdk = require("@defillama/sdk");
+const savaxAbi = require("./savax.json");
+
+const SAVAX = "0x2b2C81e08f1Af8835a78Bb2A90AE924ACE0eA4bE";
+const WAVAX = "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7";
+
+const transformAddress = (addr) => `avax:${addr}`;
+
+async function tvl(timestamp, block, chainBlocks) {
+    const pooledAvax = await sdk.api.abi.call({
+        target: SAVAX,
+        abi: savaxAbi.totalPooledAvax,
+        chain: "avax",
+        block: chainBlocks.avax,
+    });
+    
+    return {
+        [transformAddress(WAVAX)]: pooledAvax.output
+    };
+}
+
+module.exports={
+    avalanche: {
+        tvl,
+    },
+    methodology: "Counts staked AVAX tokens.",
+}

--- a/projects/benqi-staked-avax/savax.json
+++ b/projects/benqi-staked-avax/savax.json
@@ -1,0 +1,34 @@
+{
+  "totalPooledAvax": {
+    "inputs": [],
+    "name": "totalPooledAvax",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  "getSharesByPooledAvax": {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "avaxAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "getSharesByPooledAvax",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+}


### PR DESCRIPTION
We're hoping that our page title can be `BENQI Staked AVAX $SAVAX` 

No price feeds available yet on Coingecko or Coinmarketcap

##### Twitter Link: https://twitter.com/BenqiFinance


##### List of audit links if any:


##### Website Link: https://staking.benqi.fi/


##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders): https://staking.benqi.fi/images/assets/savax.png


##### Current TVL: 30.33M


##### Chain: Avalanche


##### Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)
benqi-liquid-staked-avax

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
Not available at the moment

##### Short Description (to be shown on DefiLlama):
Stake AVAX on BENQI's Liquid Staking Protocol and freely utilize it within powerful Decentralized Financial applications.

##### Token address and ticker if any:
0x2b2C81e08f1Af8835a78Bb2A90AE924ACE0eA4bE

##### Category (Yield/Dexes/Lending/Minting/Assets/Insurance/Options/Indexes/Staking) *Please choose only one:
Liquid Staking

##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using): None


##### forkedFrom (Does your project originate from another project):


##### methodology (what is being counted as tvl, how is tvl being calculated):
Counts staked AVAX tokens.

