### PR TITLE
add Tempus Fantom pools

### DIFF
--- a/projects/tempus.js
+++ b/projects/tempus.js
@@ -1,31 +1,69 @@
 const sdk = require("@defillama/sdk");
 
-const pools = [
-  {
-    address: "0x6320E6844EEEa57343d5Ca47D3166822Ec78b116",
-    token: "0xae7ab96520de3a18e5e111b5eaab095312d7fe84",
-  },
-  {
-    address: "0x0697B0a2cBb1F947f51a9845b715E9eAb3f89B4F",
-    token: "0xae7ab96520de3a18e5e111b5eaab095312d7fe84",
-  },
-  {
-    address: "0xc58b8DD0075f7ae7B1CF54a56F899D8b25a7712E",
-    token: "0x6b175474e89094c44da98b954eedeac495271d0f", /// DAI
-    tokenBalanceRegistry: "0xC6BF8C8A55f77686720E0a88e2Fd1fEEF58ddf4a" /// RariFundManager.balnceOf returns the USD balance of a given holder
-  }
-];
+const USDT = "0xdac17f958d2ee523a2206206994597c13d831ec7";
+const USDC = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+const DAI = "0x6b175474e89094c44da98b954eedeac495271d0f";
+const YFI = "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e";
+const WETH = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2";
 
-async function tvl(timestamp, block) {
+const CHAIN_DATA = {
+  ethereum: {
+    stats: "0xe552369a1b109b1eeebf060fcb6618f70f9131f7",
+    pools: [
+      {
+        address: "0x6320E6844EEEa57343d5Ca47D3166822Ec78b116",
+        token: WETH
+      },
+      {
+        address: "0x0697B0a2cBb1F947f51a9845b715E9eAb3f89B4F",
+        token: WETH
+      },
+      {
+        address: "0xc58b8DD0075f7ae7B1CF54a56F899D8b25a7712E",
+        token: USDC
+      }
+    ]
+  },
+  fantom: {
+    stats: "0x7008d1f94088c8AA012B4F370A4fe672ad592Ee3",
+    pools: [
+      {
+        address: "0x9c0273E4abB665ce156422a75F5a81db3c264A23",
+        token: DAI
+      },
+      {
+        address: "0x943B73d3B7373de3e5Dd68f64dbf85E6F4f56c9E",
+        token: USDC
+      },
+      {
+        address: "0xE9b557f9766Fb20651E3685374cd1DF6f977d36B",
+        token: USDT
+      },
+      {
+        address: "0xA9C549aeFa21ee6e79bEFCe91fa0E16a9C7d585a",
+        token: WETH
+      },
+      {
+        address: "0xAE7E5242eb52e8a592605eE408268091cC8794b8",
+        token: YFI
+      }
+    ]
+  }
+}
+
+
+async function tvl(chain, timestamp, block) {
+  const { stats, pools } = CHAIN_DATA[chain];
   let balances = {};
   const lockedBalances = (
     await sdk.api.abi.multiCall({
-      abi: "erc20:balanceOf",
+      abi: { "inputs": [ { "internalType": "contract ITempusPool", "name": "pool", "type": "address" } ], "name": "totalValueLockedInBackingTokens", "outputs": [ { "internalType": "uint256", "name": "", "type": "uint256" } ], "stateMutability": "view", "type": "function" },
       calls: pools.map((p) => ({
-        target: p.tokenBalanceRegistry ? p.tokenBalanceRegistry : p.token,
+        target: stats,
         params: [p.address],
       })),
       block,
+      chain
     })
   ).output;
 
@@ -43,7 +81,9 @@ async function tvl(timestamp, block) {
 module.exports = {
   methodology: `All assets that were deposited into our active pools.`,
   ethereum: {
-    tvl,
+    tvl: tvl.bind(null, "ethereum"),
   },
-  tvl
+  fantom: {
+    tvl: tvl.bind(null, "fantom")
+  }
 };


### PR DESCRIPTION
2 changes in this PR:
* Added newly deployed Tempus Fantom pools
* Switched TVL calculation methodology from a simple balance check on each of the pools to using our `Stats` contract to calculate the TVL. The reason why just checking token balances is problematic is that our pools hold different types of Yield Bearing Tokens and some of them are not listed on CoinGecko so there's no pricing data for some of the tokens (such as yvDAI).