### PR TITLE
add WAX chain to Defibox adapter

### DIFF
--- a/projects/defibox/index.js
+++ b/projects/defibox/index.js
@@ -1,5 +1,6 @@
 const axios = require("axios");
 const utils = require("../helper/utils");
+const {get_account_tvl} = require('../helper/eos')
 const {lendingMarket} = require("../helper/methodologies")
 
 const eosEndpoint = "https://dapp.defibox.io/api/"
@@ -16,6 +17,26 @@ async function eos() {
   return tvl
 }
 
+async function wax() {
+  const tokens = [
+    ["eosio.token", "WAX", "wax"],
+    ["alien.worlds", "TLM", "alien-worlds"],
+    // ["e.rplanet", "AETHER", null], // no CoinGecko price support
+    // ["e.rplanet", "RDAO", null], // no CoinGecko price support
+    // ["prospectorsw", "PGL", null], // no CoinGecko price support
+  ];
+  return await get_account_tvl("cpu.box", tokens, "wax");
+}
+
+async function balancesToTvl( balances ) {
+  let tvl = 0;
+  for ( const [ key, balance ] of Object.entries(balances)) {
+    const price = (await utils.getPricesfromString(key)).data[key].usd;
+    tvl += price * balance;
+  }
+  return tvl;
+}
+
 async function bsc() {
   const bnbPrice = (await utils.getPricesfromString("binancecoin")).data.binancecoin.usd;
   const swap = await axios.default.post(bscEndpoint + "swap/get24HInfo", {}, { headers: { chainid: 56 }})
@@ -24,7 +45,7 @@ async function bsc() {
 }
 
 async function fetch() {
-  return await eos() + await bsc()
+  return await eos() + await bsc() + await balancesToTvl(await wax());
 }
 
 module.exports = {
@@ -37,6 +58,9 @@ module.exports = {
   },
   bsc: {
     fetch: bsc
+  },
+  wax: {
+    tvl: wax
   },
   fetch
 }

--- a/projects/defibox/index.js
+++ b/projects/defibox/index.js
@@ -25,7 +25,7 @@ async function wax() {
     // ["e.rplanet", "RDAO", null], // no CoinGecko price support
     // ["prospectorsw", "PGL", null], // no CoinGecko price support
   ];
-  return await get_account_tvl("cpu.box", tokens, "wax");
+  return await get_account_tvl("swap.box", tokens, "wax");
 }
 
 async function balancesToTvl( balances ) {

--- a/projects/helper/eos.js
+++ b/projects/helper/eos.js
@@ -1,10 +1,14 @@
 const axios = require('axios')
 const retry = require('../helper/retry')
 
-const RPC_ENDPOINT = 'https://eos.greymass.com'
+const RPC_ENDPOINTS = {
+    'eos': 'https://eos.greymass.com',
+    'wax': 'https://wax.greymass.com',
+    'telos': 'https://telos.greymass.com',
+}
 
-async function get_currency_balance(code, account, symbol) {
-    const response = await retry(async () => await axios.default.post(`${RPC_ENDPOINT}/v1/chain/get_currency_balance`, {code, account, symbol}));
+async function get_currency_balance(code, account, symbol, chain = "eos") {
+    const response = await retry(async () => await axios.default.post(`${RPC_ENDPOINTS[chain]}/v1/chain/get_currency_balance`, {code, account, symbol}));
     try {
         return Number(response.data[0].split(" ")[0]);
     } catch (e) {
@@ -12,26 +16,47 @@ async function get_currency_balance(code, account, symbol) {
     }
 }
 
+/**
+ * Get symbol precision
+ *
+ * @example
+ *
+ * get_precision("EOS");
+ * // => 4
+ * get_precision("4,EOS");
+ * // => 4
+ * get_precision("8,WAX");
+ * // => 8
+ */
+function get_precision( symbol )
+{
+    if ( symbol.includes(",") ) return symbol.split(",")[0];
+    if ( symbol == "EOS") return 4;
+    if ( symbol == "TLOS") return 4;
+    if ( symbol == "WAX") return 8;
+    return 4;
+}
+
 // native staked CPU/Net & REX should be counted as liquid balance
-async function get_staked( account_name, precision = 4 ) {
-    const response = await retry(async () => await axios.default.post(`${RPC_ENDPOINT}/v1/chain/get_account`, { account_name }));
+async function get_staked(account_name, symbol, chain = "eos") {
+    const response = await retry(async () => await axios.default.post(`${RPC_ENDPOINTS[chain]}/v1/chain/get_account`, { account_name }));
     try {
-        return response.data.voter_info.staked / (10 ** precision)
+        return response.data.voter_info.staked / (10 ** get_precision( symbol ))
     } catch (e) {
         return 0;
     }
 }
 
-async function get_account_tvl(accounts, tokens) {
+async function get_account_tvl(accounts, tokens, chain = "eos") {
     const balances = {}
 
     // support single or multiple accounts
     for ( const account of Array.isArray(accounts) ? accounts : [ accounts ] ) {
         for ( const [ code, symbol, id ] of tokens ) {
-            const balance = await get_currency_balance(code, account, symbol);
+            const balance = await get_currency_balance(code, account, symbol, chain);
 
             // support native staking as balance
-            const staked = code == "eosio.token" ? await get_staked( account ) : 0;
+            const staked = code == "eosio.token" ? await get_staked(account, symbol, chain) : 0;
 
             // support adding same balance from multiple accounts
             if ( balances[id] ) balances[id] += balance + staked;


### PR DESCRIPTION
** In case WAX chain is ever supported on DefiLlama

Updated on existing adapter Defibox https://github.com/DefiLlama/DefiLlama-Adapters/pull/427

- [x] Add WAX chain TVL (currently WAX chain is not supported on DefiLlama)
- [x] Update eos tooling to support WAX token (uses precision 8 instead of 4)
- [x] Add multiple EOSIO RPC endpoints (EOS/Telos/Wax)


##### Current TVL:

- Total: $54,596,433 (EOS/BSC/WAX)
- WAX: $362,637