### PR TITLE
Remove Moonriver from Hundred temporarily

### DIFF
--- a/projects/hundredfinance/index.js
+++ b/projects/hundredfinance/index.js
@@ -64,6 +64,6 @@ module.exports={
     arbitrum:tvlWithBamm(comptroller, "arbitrum", "0x8e15a22853A0A60a0FBB0d875055A8E66cff0235", "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1", transformArbitrumAddress),
     fantom:tvlWithBamm(comptroller, "fantom", "0xfCD8570AD81e6c77b8D252bEbEBA62ed980BD64D", "0x21be370d5312f44cb42ce377bc9b8a0cef1a4c83", transformFantomAddress),
     harmony:compoundExportsWithAsyncTransform(comptroller, "harmony", "0xbb93C7F378B9b531216f9aD7b5748be189A55807", "0xcf664087a5bb0237a0bad6742852ec6c8d69a27a", transformHarmonyAddress),
-    moonriver:compoundExportsWithAsyncTransform("0x7d166777bd19a916c2edf5f1fc1ec138b37e7391", "moonriver", "0x42B458056f887Fd665ed6f160A59Afe932e1F559", "0x98878b06940ae243284ca214f92bb71a2b032b8a", transformMoonriverAddress),
+    // moonriver:compoundExportsWithAsyncTransform("0x7d166777bd19a916c2edf5f1fc1ec138b37e7391", "moonriver", "0x42B458056f887Fd665ed6f160A59Afe932e1F559", "0x98878b06940ae243284ca214f92bb71a2b032b8a", transformMoonriverAddress),
     xdai:compoundExportsWithAsyncTransform(comptroller, "xdai", "0x090a00A2De0EA83DEf700B5e216f87a5D4F394FE", "0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d", transformXdaiAddress),
 }


### PR DESCRIPTION
Moonriver does not work currently due to some RPC issue, causing Hundred's TVL not to update. 

Also xdai does not work currently but I don't know how to debug it:
`Error on token [object Promise], we'll just assume it's price is 0... TypeError: Cannot read properties of undefined (reading '[object promise]')`