### PR TITLE
Add bsc quartz-defi

### DIFF
--- a/projects/quartzdefi_bsc/index.js
+++ b/projects/quartzdefi_bsc/index.js
@@ -1,0 +1,97 @@
+const sdk = require("@defillama/sdk");
+const { transformBscAddress } = require("../helper/portedTokens");
+const { unwrapUniswapLPs } = require("../helper/unwrapLPs");
+const { pool2Exports } = require("../helper/pool2");
+const { staking } = require("../helper/staking");
+
+const ashareTokenAddress = "0xFa4b16b0f63F5A6D0651592620D585D308F749A4";
+
+const LPTokens = [
+    "0x6f78a0d31adc7c9fb848850f9d2a40da5858ad03",
+    "0x39846550Ef3Cb8d06E3CFF52845dF42F71Ac3851",
+    "0x61503f74189074e8e793cc0827eae37798c2b8f7"
+]
+
+const aShareBoardroomAddress = "0xC183b26Ad8C660AFa7B388067Fd18c1Fb28f1bB4";
+
+const ashareRewardPool = "0x1da194F8baf85175519D92322a06b46A2638A530";
+
+
+async function tvl(timestamp, block, chainBlocks) {
+    const balances = {};
+    let lpPositions = [];
+    let transformAddress = await transformBscAddress();
+
+    // Quartz.defi Boardroom TVL
+    const boardroomBalance = sdk.api.erc20
+        .balanceOf({
+            target: ashareTokenAddress,
+            owner: aShareBoardroomAddress,
+            block: chainBlocks["bsc"],
+            chain: "bsc",
+        });
+    sdk.util.sumSingleBalance(
+        balances,
+        transformAddress(ashareTokenAddress),
+        (await boardroomBalance).output
+    );
+
+    // // Farms
+    const amesUSTFarmBalance = sdk.api.erc20
+        .balanceOf({
+            target: LPTokens[0],
+            owner: ashareRewardPool,
+            block: chainBlocks["bsc"],
+            chain: "bsc",
+        });
+
+    lpPositions.push({
+        token: LPTokens[0],
+        balance: (await amesUSTFarmBalance).output,
+    });
+
+    const ashareUSTBalance = sdk.api.erc20
+        .balanceOf({
+            target: LPTokens[1],
+            owner: ashareRewardPool,
+            block: chainBlocks["bsc"],
+            chain: "bsc",
+        });
+
+    lpPositions.push({
+        token: LPTokens[1],
+        balance: (await ashareUSTBalance).output,
+    });
+
+    const qshareUSTBalance = sdk.api.erc20
+        .balanceOf({
+            target: LPTokens[2],
+            owner: ashareRewardPool,
+            block: chainBlocks["bsc"],
+            chain: "bsc",
+        });
+
+    lpPositions.push({
+        token: LPTokens[2],
+        balance: (await qshareUSTBalance).output,
+    });
+
+    await unwrapUniswapLPs(
+        balances,
+        lpPositions,
+        chainBlocks["bsc"],
+        "bsc",
+        transformAddress
+    );
+
+    return balances;
+}
+
+module.exports = {
+    methodology: 'The TVL of Quartz.Defi is calculated using the Pancake LP token deposits (AMES/UST, ASHARE/UST, 1QSHARE/UST) in the farms, and the ASHARE deposits found in the Boardroom.',
+    bsc: {
+        tvl,
+        pool2: pool2Exports(ashareRewardPool, LPTokens, "bsc"),
+        staking: staking(aShareBoardroomAddress, ashareTokenAddress, "bsc"),
+    },
+};


### PR DESCRIPTION
##### Twitter Link: 
https://twitter.com/quartz_defi


##### List of audit links if any:


##### Website Link: 
https://bsc-quartz-defi.app/


##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):
https://raw.githubusercontent.com/quartz-defi/brand-assets/main/tokens%20ames/brand/token/ames-token-1600-round.png

##### Current TVL:
$312,000

##### Chain:
BSC

##### Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)
[AMES - amethyst](https://www.coingecko.com/en/coins/amethyst)
[ASHARE - quartz-defi-ashare](https://www.coingecko.com/en/coins/amethyst)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description (to be shown on DefiLlama):
AMES is an UST pegged algorithmic stablecoin ecosystem running on BNB blockchain.

The protocol's underlying mechanisms are designed in a way to ensure a peg of AMES:UST is achieved, and once achieved, it is maintained to establish $AMES as a mirrored, liquid asset to $UST. Protocol accomplishes this by introducing unique economic and game-theory centric dynamics into the market through its three tokens.


##### Token address and ticker if any:
AMES - 0xb9e05b4c168b56f73940980ae6ef366354357009
ASHARE - 0xfa4b16b0f63f5a6d0651592620d585d308f749a4

##### Category (Yield/Dexes/Lending/Minting/Assets/Insurance/Options/Indexes/Staking) *Please choose only one:
Yield

##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):


##### forkedFrom (Does your project originate from another project):
Unite.finance

##### methodology (what is being counted as tvl, how is tvl being calculated):
The TVL of Quartz.Defi is calculated using the Pancake LP token deposits (AMES/UST, ASHARE/UST, 1QSHARE/UST) in the farms, and the ASHARE deposits found in the Boardroom.

