### PR TITLE
Adding algorand-governance

### DIFF
--- a/projects/algorand-governance/index.js
+++ b/projects/algorand-governance/index.js
@@ -1,0 +1,20 @@
+const retry = require('async-retry')
+const axios = require("axios");
+const BigNumber = require("bignumber.js");
+
+async function fetch() {
+  let price_endpoint = 'https://api.coingecko.com/api/v3/simple/price?ids=algorand&vs_currencies=usd'
+  let governance_endpoint ='https://governance.algorand.foundation/api/periods/active/';
+
+  let price_feed = await retry(async bail => await axios.get(price_endpoint))
+  let response = await retry(async bail => await axios.get(governance_endpoint))
+
+  let tvl = new BigNumber(response.data.total_committed_stake).div(10 ** 6).toFixed(2);
+
+  return (tvl * price_feed.data.algorand.usd);
+}
+
+
+module.exports = {
+  fetch
+}


### PR DESCRIPTION
##### Twitter Link:
https://twitter.com/AlgoFoundation

##### Website Link:
https://algorand.foundation/governance
https://governance.algorand.foundation/
https://governance.algorand.foundation/api/documentation/#section/Welcome!


##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):
![algorand-foundation-logo-mark_white_100px](https://user-images.githubusercontent.com/520236/156051532-60f784ad-e518-4930-9ada-0ffc27888172.png)
![algorand-foundation-logo-mark_black_100px](https://user-images.githubusercontent.com/520236/156051550-d731b5d8-eb3b-4346-aaf0-2d718b9fdf31.png)

##### Current TVL:
~2.7B

##### Chain:
Algorand

##### Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)
algorand

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
4030

##### Short Description (to be shown on DefiLlama):
Algorand Governance program committed Algos. 

##### Token address and ticker if any:
algo

##### Category (Yield/Dexes/Lending/Minting/Assets/Insurance/Options/Indexes/Staking) *Please choose only one:
Staking

##### methodology (what is being counted as tvl, how is tvl being calculated):
A number of Algos is committed by each governor account. Over the governance period this balance must be maintained and the governor must cast a vote or any potential rewards are abandoned.


# Note

I'm not sure if this is a valid addition here. The algos committed are not locked with a contract but their commitment is an agreement to participate and keep their balance above the amount committed. 

The number of algos committed dwarfs what is currently locked in our defi protocols.  Maybe it needs a new type of flag to prevent it from being included in those? 

Also the governance period is quarterly so every 3 months or so there might be some weird wiggles in the chart while folks commit to the new governance period.


