### PR TITLE
Thetanuts: Update Bit Put/Call vault addresses

### DIFF
--- a/projects/thetanuts/index.js
+++ b/projects/thetanuts/index.js
@@ -9,8 +9,8 @@ const wbtcPutVault = '0xDCaA803Cd23cfb988DA3794B46aEDBE968ecE17a'
 const lunaPutVault = '0x49d8cde90cefdd4f8568f7d895e686fdb76b146e'
 const algoPutVault = '0xC2DD9C7F526C7465D14bbBb25991DaB35f8Ea2B4'
 const algoCallVault = '0xb8b5A6E1F300b023e9CdCa31AA94B0D66badd982'
-const bitPutVault = '0xfBeAcC9Ea393e0abd1F5cd90E8B9fFFBf0188799'
-const bitCallVault = '0xAC332bA8b1B75a7aC04964aB5fA26AE2ddCB7c38'
+const bitPutVault = '0x4Ca3e8bD2F471415b9131E35bdcEC0819a4E7a83'
+const bitCallVault = '0x9F639524db6DfD57613895b0abb49A53c11B3f0e'
 
 // Avalanche Vaults
 const avaxCallVault = '0x35e26F12a212b3a7eec8Dd215B8705Ed1AF4f39E'


### PR DESCRIPTION
Apologies, previous BITDAO put/call addresses were not the final addresses.

I overwrote them / no versioning for neatness, as there is no historic assets in the vaults to consider for historical queries.

Tested with >>> node test.js projects/thetanuts/index.js

--- polygon ---
WMATIC                    729.32 k
USDC                      598.04 k
Total: 1.33 M

--- aurora ---
WNEAR                     260.61 k
Total: 260.61 k

--- fantom ---
WFTM                      1.80 M
USDC                      55.19 k
Total: 1.86 M

--- avalanche ---
WAVAX                     2.33 M
USDC                      489.38 k
Total: 2.82 M

--- bsc ---
WOO                       577.58 k
BUSD                      146.19 k
WBNB                      100.41 k
ADA                       20.85 k
BCH                       1.39 k
Total: 846.43 k

--- ethereum ---
USDC                      9.58 M
WETH                      6.88 M
BIT                       3.30 M
UST                       2.11 M
WBTC                      1.76 M
UNKNOWN (0x0354762a3c01730d07d2f7098365d64dc81b565d) 0
UNKNOWN (0x9f238fae3d1f1982716f136836fc2c0d1c2928ab) 0
Total: 23.63 M

--- boba ---
BOBA                      522.13 k
USDC                      4.52 k
Total: 526.65 k

--- tvl ---
USDC                      10.72 M
WETH                      6.88 M
BIT                       3.30 M
WAVAX                     2.33 M
UST                       2.11 M
WFTM                      1.80 M
WBTC                      1.76 M
WMATIC                    729.32 k
WOO                       577.58 k
BOBA                      522.13 k
WNEAR                     260.61 k
BUSD                      146.19 k
WBNB                      100.41 k
ADA                       20.85 k
BCH                       1.39 k
UNKNOWN (0x0354762a3c01730d07d2f7098365d64dc81b565d) 0
UNKNOWN (0x9f238fae3d1f1982716f136836fc2c0d1c2928ab) 0
Total: 31.26 M

------ TVL ------
polygon                   1.33 M
aurora                    260.61 k
fantom                    1.86 M
avalanche                 2.82 M
bsc                       846.43 k
ethereum                  23.63 M
boba                      526.65 k

total                    31.26 M