### PR TITLE
add metis nusd pool synapse

### DIFF
--- a/projects/synapse/index.js
+++ b/projects/synapse/index.js
@@ -222,6 +222,11 @@ const DATA = {
     ],
   },
   metis: {
+    stables: [
+      "0xea32a96608495e54156ae48931a7c20f0dcc1a21", // USDC
+    ],
+    nusd: "0x961318fc85475e125b99cc9215f62679ae5200ab",
+    pool: "0x555982d2e211745b96736665e19d9308b615f78e",
     tokens: [
       "0xfb21b70922b9f6e3c6274bcd6cb1aa8a0fe20b80", // gOHM
       "0x0b5740c6b4a97f90eF2F0220651Cca420B868FfB", // UST


### PR DESCRIPTION
```
------ TVL ------
optimism                  32.13 M
moonbeam                  215.23 k
ethereum                  47.45 M
cronos                    23.45896
polygon                   50.58 M
fantom                    92.11 M
ethereum-pool2            28.32 M
avalanche                 151.25 M
bsc                       81.63 M
aurora                    31.22 M
moonriver                 4.74 M
arbitrum                  144.17 M
metis                     3.29 M
boba                      14.99 M
harmony                   27.88 M
pool2                     28.32 M

total                    681.65 M 
```