### PR TITLE
Update Maximizer: Fix balance calculation inconsistency by using synchronous loop

### DIFF
--- a/projects/maximizer/index.js
+++ b/projects/maximizer/index.js
@@ -190,12 +190,12 @@ async function tvl(timestamp, block, chainBlocks) {
     ...config,
   })).output.map(result => result.output);
 
-  Allocators.forEach((allocator, index) => {
+  for (const [index, allocator] of Allocators.entries()) {
     sdk.util.sumSingleBalance(balances, config.transformAddress(allocator.stakeToken), stakedYieldTokens[index]);
     sdk.util.sumSingleBalance(balances, config.transformAddress(allocator.yieldToken), pendingYieldTokens[index]);
-  });
+  };
 
-  BenqiMarkets.forEach(async market => {
+  for (const market of BenqiMarkets) {
     const [balance, exchangeRate] = await Promise.all([
       sdk.
       api.abi.call({ target: market.qiToken, abi: qiTokenAbi.balanceOf, params: [BenqiAllocator], ...config }),
@@ -203,7 +203,7 @@ async function tvl(timestamp, block, chainBlocks) {
     ]);
     const underlyingTokenBalance = new BigNumber(balance.output).times(new BigNumber(exchangeRate.output)).div(new BigNumber(1e18));
     sdk.util.sumSingleBalance(balances, config.transformAddress(market.underlyingToken), underlyingTokenBalance.toFixed(0));
-  });
+  }
 
   const stakedPtp = (await sdk.api.abi.call({
     target: VEPTP,

--- a/projects/maximizer/index.js
+++ b/projects/maximizer/index.js
@@ -96,23 +96,24 @@ function compareToIgnoreCase(a, b) {
 };
 
 const transformAddress = (addr) => {
+  let resultantAddress = addr;
   // sMAXI -> MAXI
   if (compareToIgnoreCase(addr, SMAXI)) {
-    return `avax:${MAXI}`;
+    resultantAddress = MAXI;
   }
   // USDC -> USDC.e
   if (compareToIgnoreCase(addr, USDC)) {
-    return `avax:${USDCe}`;
+    resultantAddress = USDCe;
   }
   // MONEY -> DAI
   if (compareToIgnoreCase(addr, MONEY)) {
-    return `avax:${DAI}`;
+    resultantAddress = DAI;
   }
   // xJOE -> JOE
   if (compareToIgnoreCase(addr, XJOE)) {
-    return `avax:${JOE}`;
+    resultantAddress = JOE;
   }
-  return `avax:${addr}`;
+  return `avax:${resultantAddress.toLowerCase()}`;
 };
 
 const chainConfig = (chainBlocks) => ({


### PR DESCRIPTION
`sdk.util.sumSingleBalance` does not produce consistent result when using async loops. It seems like `balances[token]` would be occasionally be `undefined`. This is reproducible if you run it a few times. 

Async foreach of concern:
https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/maximizer/index.js#L197

If we run `node test.js projects/maximizer/index.js` a few times, we can obvious this:

**Sometimes incorrect result**
```
--- tvl ---
DAI                       1.14 M
```

**Sometimes incorrect result**
```
--- tvl ---
DAI                       6.28 M
```

I'm unsure if `sdk.util.sumSingleBalance` is meant to be only used in a synchronous way. Either way, using a synchronous for-loop certainly mitigates this.

##### Twitter Link: https://twitter.com/maximizer_xyz


##### List of audit links if any: None


##### Website Link: https://maxi.xyz , https://maxixyz.com


##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders): https://i.ibb.co/mNYCM9S/maxi-logo-white-black.png


##### Current TVL: 11.54 M


##### Chain: Avalanche


##### Coingecko ID (so your TVL can appear on Coingecko): maximizer


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): 15243


##### Short Description (to be shown on DefiLlama): Maximizer is a decentralized reserve currency for Avalanche that remains unbound by a peg.


##### Token address and ticker if any:
Token Address: 0x7C08413cbf02202a1c13643dB173f2694e0F73f0 
Ticker: MAXI


##### Category (Yield/Dexes/Lending/Minting/Assets/Insurance/Options/Indexes/Staking) *Please choose only one: Assets


##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using): None


##### forkedFrom (Does your project originate from another project): OlympusDAO


##### methodology (what is being counted as tvl, how is tvl being calculated):
Counts MAXI, MAXI LP (MAXI-DAI.e JLP, MAXI-WAVAX PGL), DAI.e, USDC, WAVAX, liquidity tokens (PGL, JLP), single partner tokens on the treasury and allocators
