### PR TITLE
add SherlockV2 TVL

### DIFF
--- a/projects/sherlock/index.js
+++ b/projects/sherlock/index.js
@@ -1,30 +1,32 @@
 const sdk = require('@defillama/sdk');
 const abi = require('./abi.json');
 const usdcabi = require('./usdcabi.json');
+const sherlockV2abi = require('./sherlockV2abi.json');
+const BigNumber = require("bignumber.js");
 
-
-const AaveContract = '0xEECee260A402FE3c20e5B8301382005124bef121';
 const USDC = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
-const aUSDC = '0xBcca60bB61934080951369a648Fb03DF4F96263C';
 const SherlockContract = '0xacbBe1d537BDa855797776F969612df7bBb98215';
+const SherlockV2Contract = '0x0865a889183039689034dA55c1Fd12aF5083eabF';
 
 async function tvl(timestamp, block) {
     let balances = {};
 
-    const AaveTVL = await sdk.api.abi.call({
-      target: AaveContract,
-      abi: abi['balanceOf'],
-      block: block
-    });
     const SherlockTVL = await sdk.api.abi.call({
       target: USDC,
       abi: usdcabi['balanceOf'],
       params: SherlockContract,
       block: block
     });
+    const SherlockV2TVL = await sdk.api.abi.call({
+      target: SherlockV2Contract,
+      abi: sherlockV2abi['totalTokenBalanceStakers'],
+      block: block
+    });
 
-    balances[aUSDC] = AaveTVL.output;
-    balances[USDC] = SherlockTVL.output;
+    const sherlockBalance = new BigNumber(SherlockTVL.output);
+    const sherlockV2Balance = new BigNumber(SherlockV2TVL.output);
+
+    balances[USDC] = sherlockV2Balance.plus(sherlockBalance).toString();
 
     return balances;
 }

--- a/projects/sherlock/sherlockV2abi.json
+++ b/projects/sherlock/sherlockV2abi.json
@@ -1,0 +1,15 @@
+{
+  "totalTokenBalanceStakers": {
+    "inputs": [],
+    "name": "totalTokenBalanceStakers",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+}


### PR DESCRIPTION
##### Twitter Link:
https://twitter.com/sherlockdefi


##### List of audit links if any:


##### Website Link:
https://sherlock.xyz


##### Logo:
![sherlock](https://user-images.githubusercontent.com/1225563/158428546-a03ee0ed-b0a3-4cf4-a7e2-d94377213ca9.png)




##### Current TVL: 
22.14 M


##### Chain: 
Ethereum Mainnet


##### Short Description: 
Sherlock is a protocol-to-protocol smart contract coverage provider, bug bounty coverage provider, and security review platform built on Ethereum L1.


##### Token address and ticker if any: 
0x46D2A90153cd8F09464CA3a5605B6BBeC9C2fF01 (SHER)


##### Category: 
Insurance



##### methodology (what is being counted as tvl, how is tvl being calculated):
Right now, it’s USDC held in Sherlock V1 and V2. The USDC is deployed to yield strategies in other protocols but we still count it as TVL since it is controlled by the protocol.


