### PR TITLE
Add Darkness TVL to DarkCrypto

### DIFF
--- a/projects/darkcrypto/index.js
+++ b/projects/darkcrypto/index.js
@@ -1,64 +1,12 @@
-const { addFundsInMasterChef } = require("../helper/masterchef");
 const { stakingUnknownPricedLP } = require("../helper/staking");
-const { pool2BalanceFromMasterChef } = require("../helper/pool2");
 const farmUtils = require("./farm-utils");
-const vaultUtils = require("./vault-utils")
+const vaultUtils = require("./vault-utils");
+const darkness = require('../darkness');
 
 const sdk = require("@defillama/sdk");
-const dark = "0x83b2AC8642aE46FC2823Bc959fFEB3c1742c48B5";
 const sky = "0x9D3BBb0e988D9Fb2d55d07Fe471Be2266AD9c81c";
-const krx = "0xf0681bb7088ac68a62909929554aa22ad89a21fb";
-const krx_usdc = "0x9504a7cEd300B2C79e64FC63f368fC27011Fe916";
-const masterchefDark = "0x28d81863438F25b6EC4c9DA28348445FC5E44196";
 const boardroom = "0x2e7d17ABCb9a2a40ec482B2ac9a9F811c12Bf630";
 
-async function tvl(timestamp, block, chainBlocks) {
-  let balances = await vaultUtils.vaultLocked(block, "cronos");
-
-  //DARK POOL
-  await addFundsInMasterChef(
-    balances,
-    masterchefDark,
-    chainBlocks.cronos,
-    "cronos",
-    (addr) => `cronos:${addr}`,
-    undefined,
-    [dark, krx],
-    true,
-    true,
-    dark,
-  );
-/*
-  //get staking KRX token
-  let krxBalance = await stakingUnknownPricedLP(
-    masterchefDark,
-    krx,
-    "cronos",
-    krx_usdc
-  )(timestamp, block, chainBlocks);
-  sdk.util.sumSingleBalance(
-    balances,
-    "cronos:0xc21223249CA28397B4B6541dfFaEcC539BfF0c59",
-    krxBalance["cronos:0xc21223249CA28397B4B6541dfFaEcC539BfF0c59"]
-  );
-
-  
-
-  //BoardRoom
-  let boardroomBalance = await stakingUnknownPricedLP(
-    boardroom,
-    sky,
-    "cronos",
-    "0xaA0845EE17e4f1D4F3A8c22cB1e8102baCf56a77"
-  )(timestamp, block, chainBlocks);
-  sdk.util.sumSingleBalance(
-    balances,
-    "cronos:0x5C7F8A570d578ED84E63fdFA7b1eE72dEae1AE23",
-    boardroomBalance["cronos:0x5C7F8A570d578ED84E63fdFA7b1eE72dEae1AE23"]
-  );*/
-
-  return balances;
-}
 async function pool2(timestamp, block, chainBlocks) {
   // SKY POOL
   const farmTvl = await farmUtils.farmLocked(chainBlocks["cronos"]);
@@ -87,14 +35,14 @@ async function vault(timestamp, block, chainBlocks){
 
 module.exports = {
   cronos: {
-    tvl:vault,
-    pool2: pool2,
+    tvl: sdk.util.sumChainTvls([vault, darkness.cronos.tvl]),
+    pool2: sdk.util.sumChainTvls([pool2, darkness.cronos.pool2]),
     staking: stakingUnknownPricedLP(
       boardroom,
       sky,
       "cronos",
       "0xaA0845EE17e4f1D4F3A8c22cB1e8102baCf56a77"
     ),
-    
+
   },
 };

--- a/projects/darkcrypto/index.js
+++ b/projects/darkcrypto/index.js
@@ -43,6 +43,6 @@ module.exports = {
       "cronos",
       "0xaA0845EE17e4f1D4F3A8c22cB1e8102baCf56a77"
     ),
-
+    methodology: `DarkCrypto TVL is amount staked on the platform (Farm, Vault, Boardroom) and TVL of ecosystem products (DarkNess,...)`
   },
 };


### PR DESCRIPTION
Twitter Link:
https://twitter.com/DarkCryptoFi

List of audit links if any:
Website Link:
https://www.darkcrypto.finance/

Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):
https://www.darkcrypto.finance/images/dark.svg

Current TVL:
$80,482,697

Chain:
Cronos

Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)
darkcrypto

Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
17118

Short Description (to be shown on DefiLlama):
DarkCrypto Finance is the first ecosystem running around an algorithmic token pegged to CRO on Cronos chain. DarkVerse will be our ecosystem using DARK as the main token. It contains: DeFi App (Vaults, Stablecoin swap, lending), GameFi, NFT Apps, Betting DApps, MetaVerse applications

Token address and ticker if any:
0x83b2AC8642aE46FC2823Bc959fFEB3c1742c48B5
$DARK

Category (Yield/Dexes/Lending/Minting/Assets/Insurance/Options/Indexes/Staking) *Please choose only one:
Algo-Stables

Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):
forkedFrom (Does your project originate from another project):
Tomb Finance

methodology (what is being counted as tvl, how is tvl being calculated):
DarkCrypto TVL is amount staked on the platform (Farm, Vault, Boardroom) and TVL of ecosystem products (DarkNess,...)