### PR TITLE
Update buni subgraph url

### DIFF
--- a/projects/bunicorn/index.js
+++ b/projects/bunicorn/index.js
@@ -4,11 +4,11 @@ const sdk = require("@defillama/sdk");
 const { request, gql } = require("graphql-request");
 
 const tokenSubgraphUrl =
-  "https://graph.bunicorn.exchange/subgraphs/name/bunicorndefi/buni-token";
+  "https://api.thegraph.com/subgraphs/name/bunicorndefi/buni-token";
 const stableSubgraphUrl =
   "https://api.thegraph.com/subgraphs/name/bunicorndefi/buni-stablecoins";
 const BUNI_CONTRACT_ADDRESS = "0x0e7beec376099429b85639eb3abe7cf22694ed49";
-const MASTERCHET_CONTRACT_ADDRESS =
+const MASTERCHEF_CONTRACT_ADDRESS =
   "0xA12c974fE40ea825E66615bA0Dc4Fd19be4D7d24";
 
 const graphTotalTokenTVLQuery = gql`
@@ -36,7 +36,7 @@ async function getTotalFarmTVL(timestamp, ethBlock, chainBlocks) {
     const balances = {};
     const stakedBuni = sdk.api.erc20.balanceOf({
       target: BUNI_CONTRACT_ADDRESS,
-      owner: MASTERCHET_CONTRACT_ADDRESS,
+      owner: MASTERCHEF_CONTRACT_ADDRESS,
       chain: "bsc",
       block: chainBlocks.bsc,
     });
@@ -94,6 +94,6 @@ module.exports = {
   misrepresentedTokens: true,
   bsc: {
     tvl: getTotalTVL,
-    staking: getTotalFarmTVL
+    staking: getTotalFarmTVL,
   },
 };


### PR DESCRIPTION
References [Bunicorn in broken column](https://github.com/DefiLlama/DefiLlama-Adapters/projects/2#card-73985232)

Subgraph url for Buni token seemed to be outdated and returning 502s. Additionally, subgraph sometimes has not indexed up to the requested block to calculate TVL for and could throw an error.

TVL calculations appear to be correct:

**getTotalFarmTVL** - Returns single sided stake TVL for BUNI governance token. The platform has an additional rewards token which can be single sided (BUR), though it is unclear if that should be included in the calculation, and the staking contract currently has 0 balance of BUR.

**getTotalTokenTVL** - Returns total liquidity in non-stable pools. Appears to be higher than on the buni app because this value includes non-finalized pools which are not visible on the app.

**getTotalStableTVL** - Returns total liquidity in stable pools. Looks good.

Fixed the URL for subgraph as it was the only glaring problem.