### PR TITLE
Reverting the changes made to Blindex

### DIFF
--- a/projects/blindex/index.js
+++ b/projects/blindex/index.js
@@ -288,5 +288,4 @@ module.exports = {
   rsk: {
     tvl: rsk,
   },
-  tvl: sdk.util.sumChainTvls([rsk]),
 };

--- a/projects/blindex/index.js
+++ b/projects/blindex/index.js
@@ -1,9 +1,19 @@
 const sdk = require("@defillama/sdk");
 const abi = require("../helper/abis/blindex.json");
+const { getBlock } = require("../helper/getBlock");
 const { calculateUniTvl } = require("../helper/calculateUniTvl.js");
 const { formatAddressChecksum } = require("../helper/formatAddressChecksum.js");
-const { getBlock } = require('../helper/getBlock');
-const { sumTokensAndLPsSharedOwners } = require('../helper/unwrapLPs');
+
+//-------------------------------------------------------------------------------------------------------------
+// How to add a new chain?
+// 1. Add it to the chains global array
+// 2. create a function to calculate the TVL of the chain (similar to what we did with the 'rskTvl' function)
+// 3. Add your new chain to the export module
+// 4. Add your new chain to the 'sumChainTvls' function in the export module
+//-------------------------------------------------------------------------------------------------------------
+
+// Test on the RSK network:
+// Go to @defilama/sdk/build/computetvl/blocks.js and add 'rsk' to the chainsForBlocks array
 
 const chains = {
   rsk: {
@@ -37,51 +47,120 @@ function mapCoingeckoAddress(chainName, address) {
   return mappedName;
 }
 
-const transforms = {
-  "0x542fda317318ebf1d3deaf76e0b632741a7e677d": "0x8daebade922df735c38c80c7ebd708af50815faa", // RSK's WRBTC
-  "0x1d931bf8656d795e50ef6d639562c5bd8ac2b78f": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", // RSK's ETHs
-}
+async function getBDStableCollateralBalances(block, chainName, bdstable) {
+  const collateralPoolsLength = (
+    await sdk.api.abi.call({
+      target: formatAddressChecksum(bdstable.address, chainName),
+      abi: abi["getBdStablesPoolsLength"],
+      chain: chainName,
+      block,
+    })
+  ).output;
 
-const collatVaults = [
-  "0xb40ba8b40cab1c1b502071e53ce476ed488a94a8",
-  "0x638b112b09dd60bddbb94a3a7b5e64e15ef91b2e",
-  "0x49dc93f18e47981abce48e721f8ff6d0be922fa9",
-  "0x5c122f0e5cc38a92548c9632bbddb336ec019a63"
-  ];
-  
-  const tokenOfVaults = [
-    ["0x542fda317318ebf1d3deaf76e0b632741a7e677d", false],
-    ["0x1d931bf8656d795e50ef6d639562c5bd8ac2b78f", false]
-  ]
+  const bdstableCollateralPools = [];
+  for (let index = 0; index < collateralPoolsLength; index++) {
+    const poolAddress = (
+      await sdk.api.abi.call({
+        target: formatAddressChecksum(bdstable.address, chainName),
+        abi: abi["bdstable_pools_array"],
+        params: index,
+        chain: chainName,
+        block,
+      })
+    ).output;
 
-async function collaterlTvl(timestamp, ethblock, chainBlocks) {
-  const block = await getBlock(timestamp, "rsk", chainBlocks);
-  let balances = {};
+    bdstableCollateralPools.push(poolAddress);
+  }
 
-  await sumTokensAndLPsSharedOwners(
-    balances, 
-    tokenOfVaults, 
-    collatVaults, 
-    block, 
-    "rsk",
-    (addr) => {return transforms[addr.toLowerCase()] ?? `rsk:${addr}`}
+  const balances = {};
+
+  for (let index = 0; index < bdstableCollateralPools.length; index++) {
+    const collateralAddress = await (
+      await sdk.api.abi.call({
+        target: formatAddressChecksum(
+          bdstableCollateralPools[index],
+          chainName
+        ),
+        abi: abi["getBDStablePoolCollateral"],
+        chain: chainName,
+        block,
+      })
+    ).output;
+
+    const coingeckoMappedName = mapCoingeckoAddress(
+      chainName,
+      collateralAddress
     );
-    
-  return balances;
+    const collateralBalance = await getBalanceOfWithPercision(
+      block,
+      chainName,
+      formatAddressChecksum(bdstableCollateralPools[index], chainName),
+      collateralAddress
+    );
 
+    balances[coingeckoMappedName] = balances.hasOwnProperty(coingeckoMappedName)
+      ? balances[coingeckoMappedName] + collateralBalance
+      : collateralBalance;
+  }
+
+  const bdxTokenAddress = chains[chainName].bdxTokenAddress;
+  const coingeckoMapBdxAddress = mapCoingeckoAddress(
+    chainName,
+    bdxTokenAddress
+  );
+
+  balances[coingeckoMapBdxAddress] = await getBalanceOfWithPercision(
+    block,
+    chainName,
+    formatAddressChecksum(bdstable.address, chainName),
+    formatAddressChecksum(bdxTokenAddress, chainName)
+  );
+
+  return balances;
 }
 
-const uniswapFactoryAddress = "0x5Af7cba7CDfE30664ab6E06D8D2210915Ef73c2E";
-const chainName = "rsk";
-async function uniswapV2Tvl(timestamp, ethblock, chainBlocks) {
-  const block = await getBlock(timestamp, "rsk", chainBlocks);
+async function getBalanceOfWithPercision(block, chainName, owner, target) {
+  let balance = (
+    await sdk.api.erc20.balanceOf({
+      target: formatAddressChecksum(target, chainName),
+      owner: formatAddressChecksum(owner, chainName),
+      chain: chainName,
+      block,
+    })
+  ).output;
+
+  const decimals = (
+    await sdk.api.erc20.decimals(
+      formatAddressChecksum(target, chainName),
+      chainName
+    )
+  ).output;
+
+  return balance / 10 ** decimals;
+}
+
+function sumBalances(balancesArray) {
+  return balancesArray.reduce((balances, singleBalance) => {
+    for (const [coingeckoTokenId, amount] of Object.entries(singleBalance)) {
+      if (!balances[coingeckoTokenId]) {
+        balances[coingeckoTokenId] = 0;
+      }
+
+      balances[coingeckoTokenId] += amount;
+    }
+
+    return balances;
+  }, {});
+}
+
+async function uniswapV2Tvl(block, chainName) {
   const rawBalances = await calculateUniTvl(
     (address) => formatAddressChecksum(address, chainName),
     block,
     chainName,
-    uniswapFactoryAddress,
-    undefined,
-    true,
+    formatAddressChecksum(chains[chainName].uniswapFactoryAddress, chainName),
+    0,
+    true
   );
 
   const tokensAddresses = Object.keys(rawBalances);
@@ -107,15 +186,107 @@ async function uniswapV2Tvl(timestamp, ethblock, chainBlocks) {
   return balances;
 }
 
+async function getAllBDStables(block, bdxTokenAddress, chainName) {
+  const bdStables = [];
+  const bdstablesLength = (
+    await sdk.api.abi.call({
+      target: formatAddressChecksum(bdxTokenAddress, chainName),
+      abi: abi["getBdStablesLength"],
+      chain: chainName,
+      block,
+    })
+  ).output;
 
+  for (let index = 0; index < bdstablesLength; index++) {
+    bdStables.push({
+      address: (
+        await sdk.api.abi.call({
+          target: formatAddressChecksum(bdxTokenAddress, chainName),
+          abi: abi["getBDStable"],
+          chain: chainName,
+          block,
+          params: index,
+        })
+      ).output,
+    });
+  }
 
+  return bdStables;
+}
+
+async function getBdxPriceInUSD(block, chainName) {
+  const bdusAddress = formatAddressChecksum(
+    "0xb450ff06d950efa9a9c0ad63790c51971c1be885",
+    chainName
+  );
+
+  const bdxPriceInUsd_d12 = (
+    await sdk.api.abi.call({
+      target: bdusAddress,
+      abi: abi["getBDXPriceUsdD12"],
+      chain: chainName,
+      block,
+    })
+  ).output;
+
+  return bdxPriceInUsd_d12 / 10 ** 12;
+}
+
+// TODO: This is needed until BDX will be avilable on Coingecko
+async function convertBdxToUsdc(block, chainName, balances) {
+  const bdxTokenAddress = chains[chainName].bdxTokenAddress;
+  const coingeckoMapBdxAddress = mapCoingeckoAddress(
+    chainName,
+    bdxTokenAddress
+  );
+
+  balances["usd-coin"] +=
+    balances[coingeckoMapBdxAddress] *
+    (await getBdxPriceInUSD(block, chainName));
+  balances[coingeckoMapBdxAddress] = 0;
+
+  return balances;
+}
+
+async function tvl(chainName, block) {
+  const balancesArray = [];
+
+  //=======
+  // AMM
+  //=======
+  balancesArray.push(await uniswapV2Tvl(block, chainName));
+
+  //===================
+  // Collateral
+  //===================
+  const bdstables = await getAllBDStables(
+    block,
+    chains[chainName].bdxTokenAddress,
+    chainName
+  );
+  for (let index = 0; index < bdstables.length; index++) {
+    balancesArray.push(
+      await getBDStableCollateralBalances(block, chainName, bdstables[index])
+    );
+  }
+
+  const balances = sumBalances(balancesArray);
+
+  // TODO: This should be removed when BDX will be listed on Coingecko
+  return await convertBdxToUsdc(block, chainName, balances);
+}
+
+const rsk = async function rskTvl(timestamp, ethBlock, chainblocks) {
+  const block = await getBlock(timestamp, "rsk", chainblocks);
+  return tvl("rsk", block);
+};
 
 module.exports = {
   misrepresentedTokens: true,
   methodology:
     "(1) AMM LP pairs - All the liquidity pools from the Factory address are used to find the LP pairs. (2) Collateral - All the collateral being used to support the stable coins - Bitcoin, Ethereum & BDX",
   rsk: {
-    tvl: sdk.util.sumChainTvls([uniswapV2Tvl,collaterlTvl]),
+    tvl: rsk,
   },
-  
+  tvl: sdk.util.sumChainTvls([rsk]),
 };

--- a/projects/blindex/index.js
+++ b/projects/blindex/index.js
@@ -159,7 +159,7 @@ async function uniswapV2Tvl(block, chainName) {
     block,
     chainName,
     formatAddressChecksum(chains[chainName].uniswapFactoryAddress, chainName),
-    0,
+    undefined,
     true
   );
 


### PR DESCRIPTION
* Based on the [feedback in Discord](https://discord.com/channels/823822164956151810/823822533974425621/953953087142395925) - 
Reverting the changes made to Blindex adapter to have new stablecoins be loaded automatically instead of a need for another PR and backfilling of the data.
* Also adds back the BDX value
* Added the use of the `getBlock` function

Clarification - no need to backfill any data after the PR will be merged.