### PR TITLE
Add Llama Airforce cvxFXS pounder

### DIFF
--- a/projects/llama-airforce/index.js
+++ b/projects/llama-airforce/index.js
@@ -6,6 +6,11 @@ async function tvl(time, block){
             target: "0x83507cc8c8b67ed48badd1f59f684d5d02884c81",
             abi: {"inputs":[],"name":"totalUnderlying","outputs":[{"internalType":"uint256","name":"total","type":"uint256"}],"stateMutability":"view","type":"function"},
             block
+        })).output,
+        "0xFEEf77d3f69374f66429C91d732A244f074bdf74": (await sdk.api.abi.call({
+            target: "0xf964b0e3ffdea659c44a5a52bc0b82a24b89ce0e",
+            abi: {"inputs":[],"name":"totalUnderlying","outputs":[{"internalType":"uint256","name":"total","type":"uint256"}],"stateMutability":"view","type":"function"},
+            block
         })).output
     }
 }


### PR DESCRIPTION
I'm not sure if DefiLlama has a properly working cvxFXS oracle yet, but this PR adds the cvxFXS pounder TVL to the Llama Airforce project.

I've made this PR in hackerman style directly through Github, so naturally it's untested.

##### Twitter Link:
https://twitter.com/0xAlunara

##### Website Link:
https://llama.airforce/#/union/pounders

##### Current TVL:
$961.0k (the cvxFXS pounder)

##### Chain:
Ethereum
