### PR TITLE
iZUMi TVL update: separate TVL on Ethereum, Polygon, and Arbitrum

### DIFF
--- a/projects/izumi/index.js
+++ b/projects/izumi/index.js
@@ -42,6 +42,8 @@ module.exports = {
     arbitrum: {
         fetch: fetchArbitrum,
     },
-    pool2,
+    pool2: {
+        fetch: pool2
+    },
     fetch,
 }

--- a/projects/izumi/index.js
+++ b/projects/izumi/index.js
@@ -2,6 +2,24 @@ const retry = require('async-retry')
 const axios = require("axios");
 const BigNumber = require("bignumber.js");
 
+async function fetchPolygon() {
+  let response = await retry(async bail => await axios.get('https://izumi.finance/api/v1/farm/stat/chaintvl/?chainId=137'))
+  let tvl = new BigNumber(response.data.data.tvl).toFixed(2);
+  return tvl;
+}
+
+async function fetchArbitrum() {
+  let response = await retry(async bail => await axios.get('https://izumi.finance/api/v1/farm/stat/chaintvl/?chainId=42161'))
+  let tvl = new BigNumber(response.data.data.tvl).toFixed(2);
+  return tvl;
+}
+
+async function fetchEthereum() {
+  let response = await retry(async bail => await axios.get('https://izumi.finance/api/v1/farm/stat/chaintvl/?chainId=1'))
+  let tvl = new BigNumber(response.data.data.tvl).toFixed(2);
+  return tvl;
+}
+
 async function fetch() {
   let response = await retry(async bail => await axios.get('https://izumi.finance/api/v1/farm/stat/tvl'))
   let tvl = new BigNumber(response.data.data.tvl).toFixed(2);
@@ -15,6 +33,15 @@ async function pool2() {
 }
 
 module.exports = {
-  fetch,
-  pool2
+    ethereum: {
+        fetch: fetchEthereum,
+    },
+    polygon: {
+        fetch: fetchPolygon,
+    },
+    arbitrum: {
+        fetch: fetchArbitrum,
+    },
+    pool2,
+    fetch,
 }


### PR DESCRIPTION
We count the TVL on Polygon and Arbitrum besides the assets on Ethereum.  We separate the TVL on Ethereum, Polygon, and Arbitrum.  Thanks !