### PR TITLE
feat: support mean v2

### DIFF
--- a/projects/meanfinance/index.js
+++ b/projects/meanfinance/index.js
@@ -1,5 +1,56 @@
 const sdk = require("@defillama/sdk");
 const abi = require("./abi.json");
+const { request, gql } = require("graphql-request");
+
+const GRAPH_URLS = {
+  polygon: 'https://api.thegraph.com/subgraphs/name/mean-finance/dca-v2-polygon',
+  optimism: 'https://api.thegraph.com/subgraphs/name/mean-finance/dca-v2-optimism'
+}
+
+const DCA_HUB_ADDRESSES = {
+  polygon: '0x230C63702D1B5034461ab2ca889a30E343D81349',
+  optimism: '0x230C63702D1B5034461ab2ca889a30E343D81349'
+}
+
+const query = gql`
+  query tokens {
+    tokens {
+      id
+    }
+  }`
+;
+
+const getTokensInChain = async (chain) => {
+  try {
+    const result = await request(GRAPH_URLS[chain], query);
+    return result.tokens.map(({ id }) => id)
+  } catch (e) {
+    console.error(e);
+  }
+  return [];
+};
+
+function getV2TvlObject(chain) {
+  return {
+    tvl: (_, __, chainBlocks) => getV2TVL(chain, chainBlocks[chain])
+  }
+}
+
+async function getV2TVL(chain, block) {
+  const balances = {};
+  const tokens = await getTokensInChain(chain)
+  const hubAddress = DCA_HUB_ADDRESSES[chain]
+  for (const token of tokens) {
+    const balance = await sdk.api.erc20.balanceOf({
+      target: token,
+      owner: hubAddress,
+      block,
+      chain
+    })
+    sdk.util.sumSingleBalance(balances, `${chain}:${token}`, balance.output);
+  }
+  return balances
+}
 
 //DCA Factory
 const factoryAddress = "0xaC4a40a995f236E081424D966F1dFE014Fe0e98A";
@@ -40,4 +91,6 @@ module.exports = {
   ethereum: {
     tvl: ethTvl
   },
+  optimism: getV2TvlObject('optimism'),
+  polygon: getV2TvlObject('polygon')
 };


### PR DESCRIPTION
Hey Llamas!

We recently launched v2 at [Mean Finance](https://defillama.com/protocol/mean-finance). It's currently live on Polygon and Optimism, and we would love for v2 to be tracked on Defi Llama. This PR _should_ contain all necessary changes.

Also, if possible, we'd like to make a few changes to the displayed information:
- New description: "Mean Finance is the state-of-the-art DCA protocol. Our protocol enables users to Dollar Cost Average (DCA) any ERC20 into any ERC20 with their preferred period frequency by leveraging both Chainlink and Uniswap V3 TWAP oracles."
- Category: "Services" (we never did yield to begin with 😅 )
- Audits: We have [two](https://github.com/Mean-Finance/dca-v2-core/tree/main/audits) now! 
- Oracle used: Chainlink & TWAP