### PR TITLE
The Idols TVL

### DIFF
--- a/projects/the-idols/index.js
+++ b/projects/the-idols/index.js
@@ -1,0 +1,9 @@
+const { ohmTvl } = require('../helper/ohm')
+
+const treasury = "0x439cac149b935ae1d726569800972e1669d17094" 
+const virtue_token = "0x9416ba76e88d873050a06e5956a3ebf10386b863"
+const stakingAddress = "0x0dd5a35fe4cd65fe7928c7b923902b43d6ea29e7" 
+const treasuryTokens = [
+    ["0xae7ab96520de3a18e5e111b5eaab095312d7fe84", false], //stETH
+   ]
+module.exports = ohmTvl(treasury, treasuryTokens, "ethereum", stakingAddress, virtue_token, undefined, undefined, true)


### PR DESCRIPTION
stETH in treasury backing VIRTUE price, and VIRTUE and NFT stakers accrue protocol fees

##### Twitter Link:
https://twitter.com/TheIdolsNFT

##### List of audit links if any:
Certik and WhiteHatDAO https://docs.theidols.io/resources/audit

##### Website Link:
https://www.theidols.io/

##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):
https://pbs.twimg.com/profile_images/1499050047224393733/wtADmgzl_400x400.jpg

##### Current TVL:
9M core on ethereum (treasury backing VIRUE token price) + 1.7M in staked VIRUE, but no coingecko price feed at the moment

##### Chain:
ethereum mainnet


##### Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description (to be shown on DefiLlama):
The first staked ETH NFT. A 100% community aligned project which rewards NFT holders and protocol token stakers.


##### Token address and ticker if any:
VIRTUE 0x9416ba76e88d873050a06e5956a3ebf10386b863

##### Category (full list at https://defillama.com/categories) *Please choose only one:
[Reserve Currency](https://defillama.com/protocols/Reserve%20Currency)

##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):


##### forkedFrom (Does your project originate from another project):
not an ohm fork, code written from scratch

##### methodology (what is being counted as tvl, how is tvl being calculated):
similar to OHM, treasury holds stETH which backs VIRTUE price. VIRUE price feed not yet on coingecko, so staked VIRTUE is not accounted for at the moment, but will be as soon as coingecko lists it
