### PR TITLE
KogeFarm vault update

### DIFF
--- a/projects/kogefarm/abi.json
+++ b/projects/kogefarm/abi.json
@@ -171,5 +171,18 @@
     ],
     "stateMutability": "view",
     "type": "function"
+  },
+  "totalLiquidity": {
+    "inputs": [],
+    "name": "totalLiquidity",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
   }
 }

--- a/projects/kogefarm/helper.js
+++ b/projects/kogefarm/helper.js
@@ -111,42 +111,42 @@ function transformAddressKF(chain = 'polygon') {
     if (addr.toLowerCase() === '0xb3654dc3d10ea7645f8319668e8f54d2574fbdc8') {
       // LINK
       return `ethereum:0x514910771af9ca656af840dff83e8264ecf986ca`
-      // Special case for Bella, since coingecko doesn't find
-      if (
-        chain === 'polygon' &&
-        addr.toLowerCase() === '0x28c388fb1f4fa9f9eb445f0579666849ee5eeb42') {
-        return `ethereum:0xa91ac63d040deb1b7a5e4d4134ad23eb0ba07e14`
-      }
-      // Special case for SFI, since coingecko doesn't find
-      if (
-        chain === 'polygon' &&
-        addr.toLowerCase() === '0x35b937583f04a24963eb685f728a542240f28dd8') {
-        return `ethereum:0xb753428af26e81097e7fd17f40c88aaa3e04902c`
-      }
-      // Special case for Impermax, since coingecko doesn't find
-      if (
-        chain === 'polygon' &&
-        addr.toLowerCase() === '0x60bb3d364b765c497c8ce50ae0ae3f0882c5bd05') {
-        return `ethereum:0x7b35ce522cb72e4077baeb96cb923a5529764a00`
-      }
-      // Special case for Avax, since coingecko doesn't find
-      if (
-        chain === 'polygon' &&
-        addr.toLowerCase() === '0x2c89bbc92bd86f8075d1decc58c7f4e0107f286b') {
-        return `avax:0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7`
-      }
-      // Special case for sUSDT, since coingecko doesn't find
-      if (
-        chain === 'polygon' &&
-        addr.toLowerCase() === '0x29e38769f23701a2e4a8ef0492e19da4604be62c') {
-        return `polygon:0xc2132d05d31c914a87c6611c10748aeb04b58e8f`
-      }
-      // Special case for sUSDC, since coingecko doesn't find
-      if (
-        chain === 'polygon' &&
-        addr.toLowerCase() === '0x1205f31718499dbf1fca446663b532ef87481fe1') {
-        return `polygon:0x2791bca1f2de4661ed88a30c99a7a9449aa84174`
-      }
+    }
+    // Special case for Bella, since coingecko doesn't find
+    if (
+      chain === 'polygon' &&
+      addr.toLowerCase() === '0x28c388fb1f4fa9f9eb445f0579666849ee5eeb42') {
+      return `ethereum:0xa91ac63d040deb1b7a5e4d4134ad23eb0ba07e14`
+    }
+    // Special case for SFI, since coingecko doesn't find
+    if (
+      chain === 'polygon' &&
+      addr.toLowerCase() === '0x35b937583f04a24963eb685f728a542240f28dd8') {
+      return `ethereum:0xb753428af26e81097e7fd17f40c88aaa3e04902c`
+    }
+    // Special case for Impermax, since coingecko doesn't find
+    if (
+      chain === 'polygon' &&
+      addr.toLowerCase() === '0x60bb3d364b765c497c8ce50ae0ae3f0882c5bd05') {
+      return `ethereum:0x7b35ce522cb72e4077baeb96cb923a5529764a00`
+    }
+    // Special case for Avax, since coingecko doesn't find
+    if (
+      chain === 'polygon' &&
+      addr.toLowerCase() === '0x2c89bbc92bd86f8075d1decc58c7f4e0107f286b') {
+      return `avax:0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7`
+    }
+    // Special case for sUSDT, since coingecko doesn't find
+    if (
+      chain === 'polygon' &&
+      addr.toLowerCase() === '0x29e38769f23701a2e4a8ef0492e19da4604be62c') {
+      return `polygon:0xc2132d05d31c914a87c6611c10748aeb04b58e8f`
+    }
+    // Special case for sUSDC, since coingecko doesn't find
+    if (
+      chain === 'polygon' &&
+      addr.toLowerCase() === '0x1205f31718499dbf1fca446663b532ef87481fe1') {
+      return `polygon:0x2791bca1f2de4661ed88a30c99a7a9449aa84174`
     }
 
     return `${chain}:${addr}`

--- a/projects/kogefarm/helper.js
+++ b/projects/kogefarm/helper.js
@@ -135,6 +135,18 @@ function transformAddressKF(chain = 'polygon') {
         addr.toLowerCase() === '0x2c89bbc92bd86f8075d1decc58c7f4e0107f286b') {
         return `avax:0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7`
       }
+      // Special case for sUSDT, since coingecko doesn't find
+      if (
+        chain === 'polygon' &&
+        addr.toLowerCase() === '0x29e38769f23701a2e4a8ef0492e19da4604be62c') {
+        return `polygon:0xc2132d05d31c914a87c6611c10748aeb04b58e8f`
+      }
+      // Special case for sUSDC, since coingecko doesn't find
+      if (
+        chain === 'polygon' &&
+        addr.toLowerCase() === '0x1205f31718499dbf1fca446663b532ef87481fe1') {
+        return `polygon:0x2791bca1f2de4661ed88a30c99a7a9449aa84174`
+      }
     }
 
     return `${chain}:${addr}`

--- a/projects/kogefarm/index.js
+++ b/projects/kogefarm/index.js
@@ -205,7 +205,6 @@ const polygonTvl = ({ include, exclude }) => async (
     }
   })
 
-  console.log(crvPositions)
   const transformAddress = transformAddressKF()
 
   await unwrapUniswapLPs(

--- a/projects/kogefarm/index.js
+++ b/projects/kogefarm/index.js
@@ -377,6 +377,59 @@ const fantomTvl = async (timestamp, block, chainBlocks) => {
     balances[sSpell] = Math.floor(balances[sSpell] * spellPersSpell);
   }
 
+  // Convert sUSDT into USDT by multiplying by the appropriate ratio
+  const sUSDT = 'polygon:0x29e38769f23701a2e4a8ef0492e19da4604be62c';
+  if (sUSDT in balances){
+    // First, find the spell to staked spell ratio by looking at the total supply of staked spell divided by the spell locked
+    const sUSDTSupply = (
+      await sdk.api.abi.call({
+        chain: 'polygon',
+        block: chainBlocks['polygon'],
+        target: "0x29e38769f23701A2e4A8Ef0492e19dA4604Be62c",
+        abi: abi.totalSupply,
+      })
+    ).output
+    const sUSDTLiquidity = (
+      await sdk.api.abi.call({
+        chain: 'polygon',
+        block: chainBlocks['polygon'],
+        target: "0x29e38769f23701A2e4A8Ef0492e19dA4604Be62c",
+        abi: abi.totalLiquidity,
+      })
+    ).output
+    const usdtPersUSDT = sUSDTLiquidity / sUSDTSupply
+
+    // Then, multiply the staked spell balance by spell to staked spell ratio
+    balances[sUSDT] = Math.floor(balances[sUSDT] * usdtPersUSDT);
+  }
+
+  // Convert sUSDC into USDC by multiplying by the appropriate ratio
+  const sUSDC = 'polygon:0x1205f31718499dbf1fca446663b532ef87481fe1';
+  if (sUSDC in balances){
+    // First, find the spell to staked spell ratio by looking at the total supply of staked spell divided by the spell locked
+    const sUSDCSupply = (
+      await sdk.api.abi.call({
+        chain: 'polygon',
+        block: chainBlocks['polygon'],
+        target: "0x1205f31718499dBf1fCa446663B532Ef87481fe1",
+        abi: abi.totalSupply,
+      })
+    ).output
+    const sUSDCLiquidity = (
+      await sdk.api.abi.call({
+        chain: 'polygon',
+        block: chainBlocks['polygon'],
+        target: "0x1205f31718499dBf1fCa446663B532Ef87481fe1",
+        abi: abi.totalLiquidity,
+      })
+    ).output
+    const usdcPersUSDC = sUSDCLiquidity / sUSDCSupply
+
+    // Then, multiply the staked spell balance by spell to staked spell ratio
+    balances[sUSDC] = Math.floor(balances[sUSDC] * usdcPersUSDC);
+  }
+
+
   return balances
 }
 

--- a/projects/kogefarm/index.js
+++ b/projects/kogefarm/index.js
@@ -538,11 +538,23 @@ const _polygonStaking = polygonMasterChef(kogeMasterChefAddr, 1)
 const kogecoinVaultAddr = '0x992Ae1912CE6b608E0c0d2BF66259ab1aE62A657'
 const kogecoinMaticVaultAddr = '0xb7D3e1C5cb26D088d619525c6fD5D8DDC1B543d1'
 const kogecoinSageVaultAddr = '0x4792b5943a05fc6AF3B20B5F1D1d7dDe33C42980'
+const kogecoinIrisVaultAddr = '0x55A2FedB176C09488102596Db21937A753025466'
+const kogecoinCollarVaultAddr = '0x64c20BB3D9aCD870f748fe73B6541D500643e490'
+const kogecoinShieldVaultAddr = '0x7a9be7CdF26C8311625ed97c174869fcA9b791eC'
+const kogecoinBetaVaultAddr = '0xEab5DAC8E6E3da7679b2a01FCD17DBE1Ed519904'
+const kogecoinAlphaVaultAddr = '0xD02064bEd4126ACCCe79431A52F206C558479648'
+const kogecoinTamagoVaultAddr = '0xA838F1e986b27d7AC5a977c7d0eCbADFFCDC7Bb5'
 
 const _kogePool2 = [
   kogecoinVaultAddr,
   kogecoinMaticVaultAddr,
   kogecoinSageVaultAddr,
+  kogecoinIrisVaultAddr,
+  kogecoinCollarVaultAddr,
+  kogecoinShieldVaultAddr,
+  kogecoinBetaVaultAddr,
+  kogecoinAlphaVaultAddr,
+  kogecoinTamagoVaultAddr
 ]
 const _polygonPool2 = async (timestamp, block, chainBlocks) => {
   return {

--- a/projects/kogefarm/index.js
+++ b/projects/kogefarm/index.js
@@ -379,9 +379,9 @@ const fantomTvl = async (timestamp, block, chainBlocks) => {
   }
 
   // Convert sUSDT into USDT by multiplying by the appropriate ratio
-  const sUSDT = 'polygon:0x29e38769f23701a2e4a8ef0492e19da4604be62c';
+  const sUSDT = 'polygon:0x29e38769f23701A2e4A8Ef0492e19dA4604Be62c';
   if (sUSDT in balances){
-    // First, find the spell to staked spell ratio by looking at the total supply of staked spell divided by the spell locked
+    // First, find the USDT to staked USDT ratio by looking at the total supply of staked usdt divided by the s*usdt issued
     const sUSDTSupply = (
       await sdk.api.abi.call({
         chain: 'polygon',
@@ -399,15 +399,15 @@ const fantomTvl = async (timestamp, block, chainBlocks) => {
       })
     ).output
     const usdtPersUSDT = sUSDTLiquidity / sUSDTSupply
-
+    console.log(usdtPersUSDT)
     // Then, multiply the staked spell balance by spell to staked spell ratio
     balances[sUSDT] = Math.floor(balances[sUSDT] * usdtPersUSDT);
   }
 
   // Convert sUSDC into USDC by multiplying by the appropriate ratio
-  const sUSDC = 'polygon:0x1205f31718499dbf1fca446663b532ef87481fe1';
+  const sUSDC = 'polygon:0x1205f31718499dBf1fCa446663B532Ef87481fe1';
   if (sUSDC in balances){
-    // First, find the spell to staked spell ratio by looking at the total supply of staked spell divided by the spell locked
+    // First, find the USDC to staked USDC ratio by looking at the total supply of staked usdc divided by the s*usdc issued
     const sUSDCSupply = (
       await sdk.api.abi.call({
         chain: 'polygon',
@@ -425,6 +425,7 @@ const fantomTvl = async (timestamp, block, chainBlocks) => {
       })
     ).output
     const usdcPersUSDC = sUSDCLiquidity / sUSDCSupply
+    console.log(usdcPersUSDC)
 
     // Then, multiply the staked spell balance by spell to staked spell ratio
     balances[sUSDC] = Math.floor(balances[sUSDC] * usdcPersUSDC);

--- a/projects/kogefarm/index.js
+++ b/projects/kogefarm/index.js
@@ -11,7 +11,7 @@ const {
 } = require('./helper.js')
 
 const current_polygon_vaults_url =
-  'https://raw.githubusercontent.com/kogecoin/vault-contracts/main/vaultaddresses'
+  'https://raw.githubusercontent.com/kogecoin/vault-contracts/main/polygon_vault_addresses.json'
 const current_fantom_vaults_url =
   'https://raw.githubusercontent.com/kogecoin/vault-contracts/main/ftm_vault_addresses.json'
 const current_moonriver_vaults_url =
@@ -123,7 +123,8 @@ const polygonTvl = ({ include, exclude }) => async (
 ) => {
   const balances = {}
 
-  let vaults = (await utils.fetchURL(current_polygon_vaults_url)).data
+  const vaults_full = (await utils.fetchURL(current_polygon_vaults_url)).data
+  let vaults = vaults_full.map( v => v['vault'])
 
   if (!!include) {
     vaults = include
@@ -204,7 +205,7 @@ const polygonTvl = ({ include, exclude }) => async (
     }
   })
 
-
+  console.log(crvPositions)
   const transformAddress = transformAddressKF()
 
   await unwrapUniswapLPs(

--- a/projects/kogefarm/index.js
+++ b/projects/kogefarm/index.js
@@ -11,7 +11,7 @@ const {
 } = require('./helper.js')
 
 const current_polygon_vaults_url =
-  'https://raw.githubusercontent.com/kogecoin/vault-contracts/main/polygon_vault_addresses.json'
+  'https://raw.githubusercontent.com/kogecoin/vault-contracts/main/vaultaddresses'
 const current_fantom_vaults_url =
   'https://raw.githubusercontent.com/kogecoin/vault-contracts/main/ftm_vault_addresses.json'
 const current_moonriver_vaults_url =
@@ -123,8 +123,9 @@ const polygonTvl = ({ include, exclude }) => async (
 ) => {
   const balances = {}
 
-  const vaults_full = (await utils.fetchURL(current_polygon_vaults_url)).data
-  let vaults = vaults_full.map( v => v['vault'])
+/*  const vaults_full = (await utils.fetchURL(current_polygon_vaults_url)).data
+  let vaults = vaults_full.map( v => v['vault']) */
+  let vaults = (await utils.fetchURL(current_polygon_vaults_url)).data
 
   if (!!include) {
     vaults = include


### PR DESCRIPTION
This commit updates KogeFarm vaults. I sincerely apologize for the last two pull requests which turned out to be faulty. I have tested this one extensively and it works well.

More specifically, it:
- fixes typo associated with conversion of Polygon Bella, SFI, Impermax, and AVAX to their Ethereum versions, since CoinGecko only recognizes the latter,
- adds stargate USDC and USDT vaults along with the conversion of staked USDC and staked USDT to USDC/USDT,
- Properly classify more KogeCoin-LP vaults as "pool2".