### PR TITLE
update Single Finance tvl calculation after adding MMF support

### DIFF
--- a/projects/single/cronos/farms.js
+++ b/projects/single/cronos/farms.js
@@ -1,6 +1,9 @@
 
-const WMASTERCHEF_ADDR = '0x05e0A288441dd6Ae69e412e4EB16f812498a4e32';
+const VVS_WMASTERCHEF_ADDR = '0x05e0A288441dd6Ae69e412e4EB16f812498a4e32';
 const VVS_MASTERCHEF = '0xDccd6455AE04b03d785F12196B492b18129564bc';
+
+const MMF_MASTERCHEF = '0x6bE34986Fdd1A91e4634eb6b9F8017439b7b5EDc';
+const MMF_WMASTERCHEF_ADDR = '0x539E14063fd3B5fC0C0ccf1E965397a284bC48cf';
 
 const LPS = {
   'USDC-SINGLE-LP': '0x0fbab8a90cac61b481530aad3a64fe17b322c25d',
@@ -20,6 +23,36 @@ const LPS = {
   "CRO-TONIC-LP": '0x4B377121d968Bf7a62D51B96523d59506e7c2BF0', 
   "USDC-USDT-LP": '0x39cC0E14795A8e6e9D02A21091b81FE0d61D82f9', 
   "CRO-ETH-LP": '0xA111C17f8B8303280d3EB01BBcd61000AA7F39F9',
+
+  //MMF
+  "MM-WCRO-MMF-LP": "0xbA452A1c0875D33a440259B1ea4DcA8f5d86D9Ae",
+  "MM-MMO-WCRO-LP": "0xf0b5074DBf73c96d766C9A48726CEe7a6074D436",
+  "MM-USDC-DAI-LP": "0x787A47b0596fa8F7D6666F3C59696b3c57bB612b",
+  "MM-WCRO-LIQ-LP": "0x081FbAE367269725af7a21479eddA39f62f4BAda",
+  "MM-MIMAS-WCRO-LP": "0xf56FDfeeF0Ba3de23DaB13a85602bd7BF135E80f",
+  "MM-BISON-WCRO-LP": "0xd3FD1eA9f86c6C6Bbdc6536a2247392D764543fD",
+  "MM-MMF-CROISSANT-LP": "0xDE991150329dbe53389dB41DB459cAe3fF220bac",
+  "MM-CRK-WCRO-LP": "0xc2f62bD1416845f606C5E48181743F7128a30Ee3",
+  "MM-CRP-MMF-LP": "0x1338D3C3Cc56f71B45f95F9988e762e4a1EF228D",
+  "MM-USDC-DNA-LP": "0x853067186eeB57241d8D460bD8c3aA92CBF6f60e",
+  "MM-WCRO-MOON-LP": "0xAeFd1c8B1acC0ECCba26d5c6c712dDf4741E24C7",
+  "MM-WCRO-WETH-LP": "0x019d9479606FBDd4aCB16488e0aAE49E4684322b",
+  "MM-WCRO-ANN-LP": "0x3DD1617e3E8ACf086efb41f2E3b3732A381DB140",
+  "MM-MMF-SPHERE-LP": "0x8ec4F97DE93B4B7BeA29EE5a1E452d1481D62BfC",
+  "MM-SINGLE-USDC-LP": "0x2d485E96e02dcF502B1F8C367523B29d4139d596",
+  "MM-MMF-BETIFY-LP": "0xe2c5275d86D2fB860F19a2CbBED9967d39AA73e8",
+  "MM-CGS-WCRO-LP": "0x0DD34d4Ff37D045074b6A077A289eD3163372D47",
+  "MM-AGO-MMF-LP": "0x90f27486424e0cC1d98e0144576637673570C903",
+  "MM-MMF-GRVE-LP": "0x16B7F0Bc8332EDBa5a1B91Ac867c3E5EfD3827e6",
+  "MM-MMF-METF-LP": "0xd7385f46FFb877d8c8Fe78E5f5a7c6b2F18C05A7",
+  "MM-GOAL-MMF-LP": "0xd36c36dE5D1F328BBCb9d74c55EcDa5A2Fb94e23",
+  "MM-WBTC-WCRO-LP": "0x5383202D48C24aAA19873366168f2Ed558a00ff0",
+  "MM-WCRO-USDC-LP": "0xa68466208F1A3Eb21650320D2520ee8eBA5ba623",
+  "MM-WCRO-USDT-LP": "0xEB28c926A7Afc75fcC8d6671Acd4c4A298b38419",
+  "MM-USDT-USDC-LP": "0x6F186E4BEd830D13DcE638e40bA27Fd6d91BAd0B",
+  "MM-MMF-USDC-LP": "0x722f19bd9A1E5bA97b3020c6028c279d27E4293C",
+  "MM-WBTC-WETH-LP": "0x0101112C7aDdb2E8197922e9cFa17cbAA935ECCc",
+  "MM-USDT-MMF-LP": "0x5801d37E04ab1f266c35A277E06C9D3afA1c9cA2"
 }
 
 const farms = [
@@ -27,6 +60,7 @@ const farms = [
     name: 'CRO-ETH',
     lpToken: LPS['CRO-ETH-LP'],
     masterChef: VVS_MASTERCHEF,
+    wmasterchef: VVS_WMASTERCHEF_ADDR,
     masterchefPoolId: 1,
     sinceBlock: 1273155
   },
@@ -34,6 +68,7 @@ const farms = [
     name: 'CRO-WBTC',
     lpToken: LPS['CRO-BTC-LP'],
     masterChef: VVS_MASTERCHEF,
+    wmasterchef: VVS_WMASTERCHEF_ADDR,
     masterchefPoolId: 2,
     sinceBlock: 1273155
   },
@@ -41,6 +76,7 @@ const farms = [
     name: 'CRO-USDC',
     lpToken: LPS['USDC-CRO-LP'],
     masterChef: VVS_MASTERCHEF,
+    wmasterchef: VVS_WMASTERCHEF_ADDR,
     masterchefPoolId: 3,
     sinceBlock: 1273155
   },
@@ -48,6 +84,7 @@ const farms = [
     name: 'CRO-VVS',
     lpToken: LPS['CRO-VVS-LP'],
     masterChef: VVS_MASTERCHEF,
+    wmasterchef: VVS_WMASTERCHEF_ADDR,
     masterchefPoolId: 4,
     sinceBlock: 1273155
   },
@@ -55,6 +92,7 @@ const farms = [
     name: 'VVS-USDC',
     lpToken: LPS['USDC-VVS-LP'],
     masterChef: VVS_MASTERCHEF,
+    wmasterchef: VVS_WMASTERCHEF_ADDR,
     masterchefPoolId: 5,
     sinceBlock: 1273155
   },
@@ -62,6 +100,7 @@ const farms = [
     name: 'USDC-USDT',
     lpToken: LPS['USDC-USDT-LP'],
     masterChef: VVS_MASTERCHEF,
+    wmasterchef: VVS_WMASTERCHEF_ADDR,
     masterchefPoolId: 6,
     sinceBlock: 1273155
   },
@@ -69,6 +108,7 @@ const farms = [
     name: 'VVS-USDT',
     lpToken: LPS['USDT-VVS-LP'],
     masterChef: VVS_MASTERCHEF,
+    wmasterchef: VVS_WMASTERCHEF_ADDR,
     masterchefPoolId: 7,
     sinceBlock: 1273155
   },
@@ -76,6 +116,7 @@ const farms = [
     name: 'CRO-SHIB',
     lpToken: LPS['CRO-SHIB-LP'],
     masterChef: VVS_MASTERCHEF,
+    wmasterchef: VVS_WMASTERCHEF_ADDR,
     masterchefPoolId: 8,
     sinceBlock: 1273155
   },
@@ -83,6 +124,7 @@ const farms = [
     name: 'CRO-USDT',
     lpToken: LPS['USDT-CRO-LP'],
     masterChef: VVS_MASTERCHEF,
+    wmasterchef: VVS_WMASTERCHEF_ADDR,
     masterchefPoolId: 9,
     sinceBlock: 1273155
   },
@@ -90,6 +132,7 @@ const farms = [
     name: 'CRO-DAI',
     lpToken: LPS['CRO-DAI-LP'],
     masterChef: VVS_MASTERCHEF,
+    wmasterchef: VVS_WMASTERCHEF_ADDR,
     masterchefPoolId: 10,
     sinceBlock: 1273155
   },
@@ -97,6 +140,7 @@ const farms = [
     name: 'CRO-DOGE',
     lpToken: LPS['CRO-DOGE-LP'],
     masterChef: VVS_MASTERCHEF,
+    wmasterchef: VVS_WMASTERCHEF_ADDR,
     masterchefPoolId: 12,
     sinceBlock: 1273155
   },
@@ -104,6 +148,7 @@ const farms = [
     name: 'CRO-ATOM',
     lpToken: LPS['CRO-ATOM-LP'],
     masterChef: VVS_MASTERCHEF,
+    wmasterchef: VVS_WMASTERCHEF_ADDR,
     masterchefPoolId: 13,
     sinceBlock: 1273155
   },
@@ -111,6 +156,7 @@ const farms = [
     name: 'CRO-ELON',
     lpToken: LPS['CRO-ELON-LP'],
     masterChef: VVS_MASTERCHEF,
+    wmasterchef: VVS_WMASTERCHEF_ADDR,
     masterchefPoolId: 15,
     sinceBlock: 1273155
   },
@@ -118,6 +164,7 @@ const farms = [
     name: 'CRO-TONIC',
     lpToken: LPS['CRO-TONIC-LP'],
     masterChef: VVS_MASTERCHEF,
+    wmasterchef: VVS_WMASTERCHEF_ADDR,
     masterchefPoolId: 16,
     sinceBlock: 1273155
   },
@@ -125,6 +172,7 @@ const farms = [
     name: 'SINGLE-VVS',
     lpToken: LPS['VVS-SINGLE-LP'],
     masterChef: VVS_MASTERCHEF,
+    wmasterchef: VVS_WMASTERCHEF_ADDR,
     masterchefPoolId: 17,
     sinceBlock: 1273155,
     isPool2: true,
@@ -133,15 +181,229 @@ const farms = [
     name: 'SINGLE-USDC',
     lpToken: LPS['USDC-SINGLE-LP'],
     masterChef: VVS_MASTERCHEF,
+    wmasterchef: VVS_WMASTERCHEF_ADDR,
     masterchefPoolId: 18,
     sinceBlock: 1273155,
     isPool2: true,
+  },
+
+
+  // MMF
+  {
+    name: 'CRO-MMF',
+    lpToken: LPS['MM-WCRO-MMF-LP'],
+    masterChef: MMF_MASTERCHEF,
+    wmasterchef: MMF_WMASTERCHEF_ADDR,
+    masterchefPoolId: 1,
+    sinceBlock: 2058468,
+  },
+
+  {
+    name: 'SINGLE-USDC',
+    lpToken: LPS['MM-SINGLE-USDC-LP'],
+    masterChef: MMF_MASTERCHEF,
+    wmasterchef: MMF_WMASTERCHEF_ADDR,
+    masterchefPoolId: 22,
+    sinceBlock: 2058468,
+    isPool2: true,
+  },
+
+  {
+    name: 'MM-USDC-DAI',
+    lpToken: LPS['MM-USDC-DAI-LP'],
+    masterChef: MMF_MASTERCHEF,
+    wmasterchef: MMF_WMASTERCHEF_ADDR,
+    masterchefPoolId: 11,
+    sinceBlock: 2058468,
+  },
+
+  {
+    name: 'MMF-USDC',
+    lpToken: LPS['MM-MMF-USDC-LP'],
+    masterChef: MMF_MASTERCHEF,
+    wmasterchef: MMF_WMASTERCHEF_ADDR,
+    masterchefPoolId: 7,
+    sinceBlock: 2058468,
+  },
+
+  {
+    name: 'WCRO-USDC',
+    lpToken: LPS['MM-WCRO-USDC-LP'],
+    masterChef: MMF_MASTERCHEF,
+    wmasterchef: MMF_WMASTERCHEF_ADDR,
+    masterchefPoolId: 4,
+    sinceBlock: 2058468,
+  },
+  {
+    name: 'USDT-MMF',
+    lpToken: LPS['MM-USDT-MMF-LP'],
+    masterChef: MMF_MASTERCHEF,
+    wmasterchef: MMF_WMASTERCHEF_ADDR,
+    masterchefPoolId: 9,
+    sinceBlock: 2058468,
+  },
+
+  {
+    name: 'WCRO-USDT',
+    lpToken: LPS['MM-WCRO-USDT-LP'],
+    masterChef: MMF_MASTERCHEF,
+    wmasterchef: MMF_WMASTERCHEF_ADDR,
+    masterchefPoolId: 5,
+    sinceBlock: 2058468,
+  },
+
+  {
+    name: 'MMO-WCRO',
+    lpToken: LPS['MM-MMO-WCRO-LP'],
+    masterChef: MMF_MASTERCHEF,
+    wmasterchef: MMF_WMASTERCHEF_ADDR,
+    masterchefPoolId: 10,
+    sinceBlock: 2058468,
+  },
+
+  {
+    name: 'WBTC-WCRO',
+    lpToken: LPS['MM-WBTC-WCRO-LP'],
+    masterChef: MMF_MASTERCHEF,
+    wmasterchef: MMF_WMASTERCHEF_ADDR,
+    masterchefPoolId: 3,
+    sinceBlock: 2058468,
+  },
+
+  {
+    name: 'WCRO-WETH',
+    lpToken: LPS['MM-WCRO-WETH-LP'],
+    masterChef: MMF_MASTERCHEF,
+    wmasterchef: MMF_WMASTERCHEF_ADDR,
+    masterchefPoolId: 2,
+    sinceBlock: 2058468,
+  },
+
+  {
+    name: 'MIMAS-WCRO',
+    lpToken: LPS['MM-MIMAS-WCRO-LP'],
+    masterChef: MMF_MASTERCHEF,
+    wmasterchef: MMF_WMASTERCHEF_ADDR,
+    masterchefPoolId: 13,
+    sinceBlock: 2058468,
+  },
+
+  {
+    name: 'CRK-WCRO',
+    lpToken: LPS['MM-CRK-WCRO-LP'],
+    masterChef: MMF_MASTERCHEF,
+    wmasterchef: MMF_WMASTERCHEF_ADDR,
+    masterchefPoolId: 16,
+    sinceBlock: 2058468,
+  },
+
+  {
+    name: 'CGS-WCRO',
+    lpToken: LPS['MM-CGS-WCRO-LP'],
+    masterChef: MMF_MASTERCHEF,
+    wmasterchef: MMF_WMASTERCHEF_ADDR,
+    masterchefPoolId: 24,
+    sinceBlock: 2058468,
+  },
+
+  {
+    name: 'WCRO-LIQ',
+    lpToken: LPS['MM-WCRO-LIQ-LP'],
+    masterChef: MMF_MASTERCHEF,
+    wmasterchef: MMF_WMASTERCHEF_ADDR,
+    masterchefPoolId: 12,
+    sinceBlock: 2058468,
+  },
+
+
+  {
+    name: 'BISON-WCRO',
+    lpToken: LPS['MM-BISON-WCRO-LP'],
+    masterChef: MMF_MASTERCHEF,
+    wmasterchef: MMF_WMASTERCHEF_ADDR,
+    masterchefPoolId: 14,
+    sinceBlock: 2058468,
+  },
+  {
+    name: 'MMF-CROISSANT',
+    lpToken: LPS['MM-MMF-CROISSANT-LP'],
+    masterChef: MMF_MASTERCHEF,
+    wmasterchef: MMF_WMASTERCHEF_ADDR,
+    masterchefPoolId: 15,
+    sinceBlock: 2058468,
+  },
+  
+  {
+    name: 'CRP-MMF',
+    lpToken: LPS['MM-CRP-MMF-LP'],
+    masterChef: MMF_MASTERCHEF,
+    wmasterchef: MMF_WMASTERCHEF_ADDR,
+    masterchefPoolId: 17,
+    sinceBlock: 2058468,
+  },
+  {
+    name: 'USDC-DNA',
+    lpToken: LPS['MM-USDC-DNA-LP'],
+    masterChef: MMF_MASTERCHEF,
+    wmasterchef: MMF_WMASTERCHEF_ADDR,
+    masterchefPoolId: 18,
+    sinceBlock: 2058468,
+  },
+  
+  {
+    name: 'WCRO-ANN',
+    lpToken: LPS['MM-WCRO-ANN-LP'],
+    masterChef: MMF_MASTERCHEF,
+    wmasterchef: MMF_WMASTERCHEF_ADDR,
+    masterchefPoolId: 20,
+    sinceBlock: 2058468,
+  },
+  
+  {
+    name: 'MMF-BETIFY',
+    lpToken: LPS['MM-MMF-BETIFY-LP'],
+    masterChef: MMF_MASTERCHEF,
+    wmasterchef: MMF_WMASTERCHEF_ADDR,
+    masterchefPoolId: 23,
+    sinceBlock: 2058468,
+  },
+  
+  {
+    name: 'AGO-MMF',
+    lpToken: LPS['MM-AGO-MMF-LP'],
+    masterChef: MMF_MASTERCHEF,
+    wmasterchef: MMF_WMASTERCHEF_ADDR,
+    masterchefPoolId: 25,
+    sinceBlock: 2058468,
+  },
+  {
+    name: 'MMF-GRVE',
+    lpToken: LPS['MM-MMF-GRVE-LP'],
+    masterChef: MMF_MASTERCHEF,
+    wmasterchef: MMF_WMASTERCHEF_ADDR,
+    masterchefPoolId: 26,
+    sinceBlock: 2058468,
+  },
+  {
+    name: 'MMF-METF',
+    lpToken: LPS['MM-MMF-METF-LP'],
+    masterChef: MMF_MASTERCHEF,
+    wmasterchef: MMF_WMASTERCHEF_ADDR,
+    masterchefPoolId: 27,
+    sinceBlock: 2058468,
+  },
+  {
+    name: 'GOAL-MMF',
+    lpToken: LPS['MM-GOAL-MMF-LP'],
+    masterChef: MMF_MASTERCHEF,
+    wmasterchef: MMF_WMASTERCHEF_ADDR,
+    masterchefPoolId: 28,
+    sinceBlock: 2058468,
   },
 
 ];
 
 
 module.exports = {
-  WMASTERCHEF_ADDR,
   farms,
 }

--- a/projects/single/cronos/vaults.js
+++ b/projects/single/cronos/vaults.js
@@ -28,6 +28,22 @@ const vaults = [
     token: '0x2D03bECE6747ADC00E1a131BBA1469C15fD11e03',
     sinceBlock: 1273023,
   },
+
+  {
+    name: 'ibUSDT',
+    decimals: 6,
+    address: '0x467dFF5B14B4DD40a52bE338B75C9B58EaD4Add0',
+    token: '0x66e428c3f67a68878562e79a0234c1f83c208770',
+    sinceBlock: 2134954,
+  },
+
+  {
+    name: 'ibMMF',
+    decimals: 18,
+    address: '0x14aE2E848B2cfac47a5E0c63FFd74fD671A5c3Db',
+    token: '0x97749c9B61F878a880DfE312d2594AE07AEd7656',
+    sinceBlock: 2135105,
+  },
     
 ];
   


### PR DESCRIPTION
We have just added MM Finance support, so here is the updated logic
- added MMF and USDT vaults
- added MMF farming pairs
- fixed ATOM token tvl always zero problem