### PR TITLE
JPEG'd staking and pool2 TVL

### DIFF
--- a/projects/jpeg-d/index.js
+++ b/projects/jpeg-d/index.js
@@ -1,0 +1,15 @@
+const { staking } = require("../helper/staking")
+const { pool2 } = require("../helper/pool2")
+
+const JPEG = "0xe80c0cd204d654cebe8dd64a4857cab6be8345a3"
+const JPEG_WETH_SLP = "0xdb06a76733528761eda47d356647297bc35a98bd"
+const staking_contract = "0x3eed641562ac83526d7941e4326559e7b607556b"
+
+module.exports = {
+  methodology: `TVL for JPEG'd consists of the staking of JPEG and pool2 of the sushi JPEG/WETH LP`, 
+  ethereum:{
+    tvl: () => ({}),
+    staking: staking(staking_contract, JPEG, "ethereum"), 
+    pool2: pool2(staking_contract, JPEG_WETH_SLP, "ethereum"), 
+  }
+}


### PR DESCRIPTION
JPEG'd staking and pool2 TVL

##### Twitter Link:
https://twitter.com/JPEGd_69

##### List of audit links if any:
Quantstamp audit: https://jpeg-d.gitbook.io/jpegd/other-links/audits

##### Website Link:
https://jpegd.io/

##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):
SVG: https://1113203255-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FELc5L3ZX4GTNqYCERKF5%2Fuploads%2FM0zQsHDz1JwX26OZMdsh%2FCoins_JPEG.svg?alt=media&token=7950cad5-0f91-4a8b-b8e2-fe293cec69c6

##### Current TVL:
15M pool2 and 53M staking

##### Chain:
ethereum mainnet

##### Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)
jpeg-d

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
18439

##### Short Description (to be shown on DefiLlama):
JPEG'd is a decentralized lending protocol on the Ethereum blockchain that enables non-fungible token (NFT) holders to open collateralized debt positions (CDPs) using their NFTs as collateral. Users mint PUSD - the native stablecoin of the protocol - enabling them to effectively obtain leverage on their NFTs.

##### Token address and ticker if any:
JPEG 0xe80c0cd204d654cebe8dd64a4857cab6be8345a3

##### Category (full list at https://defillama.com/categories) *Please choose only one:
NFT Lending

##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):


##### forkedFrom (Does your project originate from another project):


##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL for JPEG'd consists of the staking of JPEG and pool2 of the sushi JPEG/WETH LP
