### PR TITLE
remove null filter used in KogeFarm adapter

### DIFF
--- a/projects/kogefarm/index.js
+++ b/projects/kogefarm/index.js
@@ -197,7 +197,7 @@ const polygonTvl = ({ include, exclude }) => async (
         balance: vault_balances[idx],
         token: lp_addresses[idx],
       })
-    } else if ((vaults[idx] !== '') & (lp_addresses[idx] !== null)) {
+    } else if (vaults[idx] !== '') {
       singlePositions.push({
         vaultAddr: vaults[idx],
         balance: vault_balances[idx],
@@ -252,7 +252,6 @@ const fantomTvl = async (timestamp, block, chainBlocks) => {
   ).output.map((val) => val.output)
 
   vaults = vaults.map((e, idx) => ({ ...e, lp_address: lp_addresses[idx] }))
-  vaults = vaults.filter(item => item.lp_address !== null)
 
   const vault_balances = (
     await sdk.api.abi.multiCall({
@@ -452,7 +451,6 @@ const moonriverTvl = async (timestamp, block, chainBlocks) => {
   ).output.map((val) => val.output)
 
   vaults = vaults.map((e, idx) => ({ ...e, lp_address: lp_addresses[idx] }))
-  vaults = vaults.filter(item => item.lp_address !== null)
 
   const vault_balances = (
     await sdk.api.abi.multiCall({


### PR DESCRIPTION
This pull request removes the null filter in the KogeFarm adapter so in the event of a RPC glitch the adapter returns an error rather than a small (incorrect) value. I hope this resolves the random low TVL issue that affects our adapter.