### PR TITLE
feat(): add 0xlend tvl

### DIFF
--- a/projects/0xLend/CompoundLens.json
+++ b/projects/0xLend/CompoundLens.json
@@ -1,0 +1,1226 @@
+[
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "contract CToken",
+        "name": "cToken",
+        "type": "address"
+      },
+      {
+        "internalType": "address payable",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "cTokenBalances",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "cToken",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "balanceOf",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "borrowBalanceCurrent",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "balanceOfUnderlying",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "tokenBalance",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "tokenAllowance",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct CompoundLens.CTokenBalances",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "contract CToken[]",
+        "name": "cTokens",
+        "type": "address[]"
+      },
+      {
+        "internalType": "address payable",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "cTokenBalancesAll",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "cToken",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "balanceOf",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "borrowBalanceCurrent",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "balanceOfUnderlying",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "tokenBalance",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "tokenAllowance",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct CompoundLens.CTokenBalances[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "contract CToken",
+        "name": "cToken",
+        "type": "address"
+      }
+    ],
+    "name": "cTokenMetadata",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "cToken",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "cTokenDecimals",
+            "type": "uint256"
+          },
+          {
+            "internalType": "string",
+            "name": "cTokenSymbol",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "cTokenName",
+            "type": "string"
+          },
+          {
+            "internalType": "address",
+            "name": "underlyingAssetAddress",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "underlyingDecimals",
+            "type": "uint256"
+          },
+          {
+            "internalType": "string",
+            "name": "underlyingSymbol",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "underlyingName",
+            "type": "string"
+          },
+          {
+            "internalType": "uint256",
+            "name": "exchangeRateCurrent",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "supplyRatePerBlock",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "borrowRatePerBlock",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "reserveFactorMantissa",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "collateralFactorMantissa",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "totalBorrows",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "totalReserves",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "totalSupply",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "totalCash",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bool",
+            "name": "isListed",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint256",
+            "name": "borrowCap",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct CompoundLens.CTokenMetadata",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "contract CToken[]",
+        "name": "cTokens",
+        "type": "address[]"
+      }
+    ],
+    "name": "cTokenMetadataAll",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "cToken",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "cTokenDecimals",
+            "type": "uint256"
+          },
+          {
+            "internalType": "string",
+            "name": "cTokenSymbol",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "cTokenName",
+            "type": "string"
+          },
+          {
+            "internalType": "address",
+            "name": "underlyingAssetAddress",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "underlyingDecimals",
+            "type": "uint256"
+          },
+          {
+            "internalType": "string",
+            "name": "underlyingSymbol",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "underlyingName",
+            "type": "string"
+          },
+          {
+            "internalType": "uint256",
+            "name": "exchangeRateCurrent",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "supplyRatePerBlock",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "borrowRatePerBlock",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "reserveFactorMantissa",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "collateralFactorMantissa",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "totalBorrows",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "totalReserves",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "totalSupply",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "totalCash",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bool",
+            "name": "isListed",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint256",
+            "name": "borrowCap",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct CompoundLens.CTokenMetadata[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "contract CToken",
+        "name": "cToken",
+        "type": "address"
+      }
+    ],
+    "name": "cTokenUnderlyingPrice",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "cToken",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "underlyingPrice",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct CompoundLens.CTokenUnderlyingPrice",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "contract CToken[]",
+        "name": "cTokens",
+        "type": "address[]"
+      }
+    ],
+    "name": "cTokenUnderlyingPriceAll",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "cToken",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "underlyingPrice",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct CompoundLens.CTokenUnderlyingPrice[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "contract ComptrollerLensInterface",
+        "name": "comptroller",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "getAccountLimits",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "contract CToken[]",
+            "name": "markets",
+            "type": "address[]"
+          },
+          {
+            "internalType": "uint256",
+            "name": "liquidity",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "shortfall",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct CompoundLens.AccountLimits",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "contract ComptrollerLensInterface",
+        "name": "comptroller",
+        "type": "address"
+      }
+    ],
+    "name": "getAllMarkets",
+    "outputs": [
+      {
+        "internalType": "contract CToken[]",
+        "name": "",
+        "type": "address[]"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "contract ComptrollerLensInterface",
+        "name": "comptroller",
+        "type": "address"
+      },
+      {
+        "internalType": "address payable",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "getAllMarketsBalances",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "cToken",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "balanceOf",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "borrowBalanceCurrent",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "balanceOfUnderlying",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "tokenBalance",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "tokenAllowance",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct CompoundLens.CTokenBalances[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "contract ComptrollerLensInterface",
+        "name": "comptroller",
+        "type": "address"
+      }
+    ],
+    "name": "getAllMarketsData",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "cToken",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "cTokenDecimals",
+            "type": "uint256"
+          },
+          {
+            "internalType": "string",
+            "name": "cTokenSymbol",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "cTokenName",
+            "type": "string"
+          },
+          {
+            "internalType": "address",
+            "name": "underlyingAssetAddress",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "underlyingDecimals",
+            "type": "uint256"
+          },
+          {
+            "internalType": "string",
+            "name": "underlyingSymbol",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "underlyingName",
+            "type": "string"
+          },
+          {
+            "internalType": "uint256",
+            "name": "exchangeRateCurrent",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "supplyRatePerBlock",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "borrowRatePerBlock",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "reserveFactorMantissa",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "collateralFactorMantissa",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "totalBorrows",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "totalReserves",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "totalSupply",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "totalCash",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bool",
+            "name": "isListed",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint256",
+            "name": "borrowCap",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct CompoundLens.CTokenMetadata[]",
+        "name": "",
+        "type": "tuple[]"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "cToken",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "compSupplySpeed",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "compBorrowSpeed",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct CompoundLens.CompSpeeds[]",
+        "name": "",
+        "type": "tuple[]"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "cToken",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "underlyingPrice",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct CompoundLens.CTokenUnderlyingPrice[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "contract Comp",
+        "name": "comp",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "getCompBalanceMetadata",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "balance",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "votes",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "delegate",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct CompoundLens.CompBalanceMetadata",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "contract Comp",
+        "name": "comp",
+        "type": "address"
+      },
+      {
+        "internalType": "contract ComptrollerLensInterface",
+        "name": "comptroller",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "getCompBalanceMetadataExt",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "balance",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "votes",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "delegate",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "allocated",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct CompoundLens.CompBalanceMetadataExt",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "contract ComptrollerLensInterface",
+        "name": "comptroller",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "getCompBalanceMetadataExtV2",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "balance",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "votes",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "delegate",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "allocated",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct CompoundLens.CompBalanceMetadataExt",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "contract ComptrollerLensInterface",
+        "name": "comptroller",
+        "type": "address"
+      },
+      {
+        "internalType": "contract CToken[]",
+        "name": "cTokens",
+        "type": "address[]"
+      }
+    ],
+    "name": "getCompSpeedsAll",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "cToken",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "compSupplySpeed",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "compBorrowSpeed",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct CompoundLens.CompSpeeds[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "contract Comp",
+        "name": "comp",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint32[]",
+        "name": "blockNumbers",
+        "type": "uint32[]"
+      }
+    ],
+    "name": "getCompVotes",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "blockNumber",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "votes",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct CompoundLens.CompVotes[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "contract GovernorBravoInterface",
+        "name": "governor",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "proposalIds",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "getGovBravoProposals",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "proposalId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "proposer",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "eta",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address[]",
+            "name": "targets",
+            "type": "address[]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "values",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "string[]",
+            "name": "signatures",
+            "type": "string[]"
+          },
+          {
+            "internalType": "bytes[]",
+            "name": "calldatas",
+            "type": "bytes[]"
+          },
+          {
+            "internalType": "uint256",
+            "name": "startBlock",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "endBlock",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "forVotes",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "againstVotes",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "abstainVotes",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bool",
+            "name": "canceled",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "executed",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct CompoundLens.GovBravoProposal[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "contract GovernorBravoInterface",
+        "name": "governor",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "voter",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "proposalIds",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "getGovBravoReceipts",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "proposalId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bool",
+            "name": "hasVoted",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint8",
+            "name": "support",
+            "type": "uint8"
+          },
+          {
+            "internalType": "uint96",
+            "name": "votes",
+            "type": "uint96"
+          }
+        ],
+        "internalType": "struct CompoundLens.GovBravoReceipt[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "contract GovernorAlpha",
+        "name": "governor",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "proposalIds",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "getGovProposals",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "proposalId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "proposer",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "eta",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address[]",
+            "name": "targets",
+            "type": "address[]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "values",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "string[]",
+            "name": "signatures",
+            "type": "string[]"
+          },
+          {
+            "internalType": "bytes[]",
+            "name": "calldatas",
+            "type": "bytes[]"
+          },
+          {
+            "internalType": "uint256",
+            "name": "startBlock",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "endBlock",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "forVotes",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "againstVotes",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bool",
+            "name": "canceled",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "executed",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct CompoundLens.GovProposal[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "contract GovernorAlpha",
+        "name": "governor",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "voter",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "proposalIds",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "getGovReceipts",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "proposalId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bool",
+            "name": "hasVoted",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "support",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint96",
+            "name": "votes",
+            "type": "uint96"
+          }
+        ],
+        "internalType": "struct CompoundLens.GovReceipt[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/projects/0xLend/index.js
+++ b/projects/0xLend/index.js
@@ -1,0 +1,232 @@
+const { default: BigNumber } = require("bignumber.js");
+const sdk = require("@defillama/sdk");
+const { toUSDTBalances } = require("../helper/balances");
+
+async function data(timestamp, block, chainBlocks) {
+  const [markets, , prices] = (
+    await sdk.api.abi.call({
+      abi: {
+        constant: false,
+        inputs: [
+          {
+            internalType: "contract ComptrollerLensInterface",
+            name: "comptroller",
+            type: "address",
+          },
+        ],
+        name: "getAllMarketsData",
+        outputs: [
+          {
+            components: [
+              {
+                internalType: "address",
+                name: "cToken",
+                type: "address",
+              },
+              {
+                internalType: "uint256",
+                name: "cTokenDecimals",
+                type: "uint256",
+              },
+              {
+                internalType: "string",
+                name: "cTokenSymbol",
+                type: "string",
+              },
+              {
+                internalType: "string",
+                name: "cTokenName",
+                type: "string",
+              },
+              {
+                internalType: "address",
+                name: "underlyingAssetAddress",
+                type: "address",
+              },
+              {
+                internalType: "uint256",
+                name: "underlyingDecimals",
+                type: "uint256",
+              },
+              {
+                internalType: "string",
+                name: "underlyingSymbol",
+                type: "string",
+              },
+              {
+                internalType: "string",
+                name: "underlyingName",
+                type: "string",
+              },
+              {
+                internalType: "uint256",
+                name: "exchangeRateCurrent",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "supplyRatePerBlock",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "borrowRatePerBlock",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "reserveFactorMantissa",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "collateralFactorMantissa",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "totalBorrows",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "totalReserves",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "totalSupply",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "totalCash",
+                type: "uint256",
+              },
+              {
+                internalType: "bool",
+                name: "isListed",
+                type: "bool",
+              },
+              {
+                internalType: "uint256",
+                name: "borrowCap",
+                type: "uint256",
+              },
+            ],
+            internalType: "struct CompoundLens.CTokenMetadata[]",
+            name: "",
+            type: "tuple[]",
+          },
+          {
+            components: [
+              {
+                internalType: "address",
+                name: "cToken",
+                type: "address",
+              },
+              {
+                internalType: "uint256",
+                name: "compSupplySpeed",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "compBorrowSpeed",
+                type: "uint256",
+              },
+            ],
+            internalType: "struct CompoundLens.CompSpeeds[]",
+            name: "",
+            type: "tuple[]",
+          },
+          {
+            components: [
+              {
+                internalType: "address",
+                name: "cToken",
+                type: "address",
+              },
+              {
+                internalType: "uint256",
+                name: "underlyingPrice",
+                type: "uint256",
+              },
+            ],
+            internalType: "struct CompoundLens.CTokenUnderlyingPrice[]",
+            name: "",
+            type: "tuple[]",
+          },
+        ],
+        payable: false,
+        stateMutability: "nonpayable",
+        type: "function",
+      },
+      chain: "kcc",
+      target: "0xCA4D163Eeb21eeF70bF8Cbeb34E1e20D4C65d528",
+      params: ["0x337d8719f70D514367aBe780F7c1eAd1c0113Bc7"],
+      block: chainBlocks["kcc"],
+    })
+  ).output;
+
+  return { markets, prices };
+}
+
+async function tvl(timestamp, block, chainBlocks) {
+  const { markets, prices } = await data(timestamp, block, chainBlocks);
+
+  let totalCash = new BigNumber(0);
+
+  markets.forEach((market) => {
+    const underlyingPrice = prices.find(
+      (p) => p.cToken === market.cToken
+    ).underlyingPrice;
+
+    const price = new BigNumber(underlyingPrice).div(
+      new BigNumber(10).pow(new BigNumber(18))
+    );
+
+    totalCash = totalCash.plus(
+      new BigNumber(market.totalCash)
+        .div(new BigNumber(10).pow(new BigNumber(market.underlyingDecimals)))
+        .times(price)
+    );
+  });
+
+  return toUSDTBalances(totalCash.toNumber());
+}
+
+async function borrowed(timestamp, block, chainBlocks) {
+  const { markets, prices } = await data(timestamp, block, chainBlocks);
+
+  let borrowed = new BigNumber(0);
+
+  markets.forEach((market) => {
+    const underlyingPrice = prices.find(
+      (p) => p.cToken === market.cToken
+    ).underlyingPrice;
+
+    const price = new BigNumber(underlyingPrice).div(
+      new BigNumber(10).pow(new BigNumber(18))
+    );
+
+    borrowed = borrowed.plus(
+      new BigNumber(market.totalBorrows)
+        .div(new BigNumber(10).pow(new BigNumber(market.underlyingDecimals)))
+        .times(price)
+    );
+  });
+
+  return toUSDTBalances(borrowed.toNumber());
+}
+
+module.exports = {
+  timetravel: true,
+  misrepresentedTokens: false,
+  methodology: "counts the number in the KCC contract.",
+  start: 9161067,
+  kcc: {
+    tvl,
+    borrowed,
+  },
+};


### PR DESCRIPTION
Twitter Link: [https://twitter.com/0xlendProtocol](url)
List of audit links if any: [https://docs.google.com/document/d/1d7v3F9r5-9moxStBaI7UiRxRQfMM8fTv_Njtc--do2g/edit](url)
Website Link: [https://www.0xlend.io](url)
Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders): [https://0xlend.oss-cn-beijing.aliyuncs.com/favicon.ico](url)
Current TVL: $425k
Chain: KuCoin Community Chain (KCC)
Coingecko ID (so your TVL can appear on Coingecko):  No Coingecko ID yet
Coinmarketcap ID (so your TVL can appear on Coinmarketcap):  No Coinmarketcap ID yet
Short Description (to be shown on DefiLlama): 0xLend is a Lending Protocol deployed on the KuCoin Community Chain (KCC) that supports the deposit and lending of mainstream crypto assets. Users can deposit assets to earn interest and borrow assets by collateralizing their assets.
Token address and ticker if any: 0x3505d1AA1162e5Ea1dcb6Ab34Fbe17b3f0eFbFf2 
Category (full list at https://defillama.com/categories) *Please choose only one: Lending
Oracle used (Chainlink/Band/API3/TWAP or any other that you are using): Witnet
forkedFrom (Does your project originate from another project): No
methodology (what is being counted as tvl, how is tvl being calculated): Counts the tokens locked in the contracts to be used as collateral to borrow or to earn yield. Borrowed coins are not counted towards the TVL, so only the coins actually locked in the contracts are counted. There's multiple reasons behind this but one of the main ones is to avoid inflating the TVL through cycled lending.