### PR TITLE
change in tvl calculation method.  Keeping only governance token in s…

### DIFF
--- a/projects/planet-finance/index.js
+++ b/projects/planet-finance/index.js
@@ -2,22 +2,10 @@ const sdk = require("@defillama/sdk");
 const abi = require("./abi.json");
 const { unwrapUniswapLPs } = require("../helper/unwrapLPs");
 const axios = require('axios')
+const { compoundExports } = require("../helper/compound");
 
 const aquaFarmAddress = "0x0ac58Fd25f334975b1B61732CF79564b6200A933";
 const newFarmAddress = "0xB87F7016585510505478D1d160BDf76c1f41b53d";
-
-// const abis = {
-//   oracle: {"constant":true,"inputs":[],"name":"getRegistry","outputs":[{"internalType":"address","name":"","type":"address"}],"payable":false,"stateMutability":"view","type":"function"},
-//   underlyingPrice: {
-//     "constant": true,
-//     "inputs": [{ "internalType": 'contract CToken', "name": 'gToken', "type": 'address' }],
-//     "name": 'getUnderlyingPrice',
-//     "outputs": [{ "internalType": 'uint256', "name": '', "type": 'uint256' }],
-//     "payable": false,
-//     "stateMutability": 'view',
-//     "type": 'function',
-//   },
-// }
 
 const replacements = {
   "0xa8Bb71facdd46445644C277F9499Dd22f6F0A30C":
@@ -352,6 +340,12 @@ async function tvl(timestamp, ethBlock, chainBlocks) {
 module.exports = {
   bsc: {
     tvl,
-    staking
+    staking,
+    borrowed: compoundExports(
+      '0xF54f9e7070A1584532572A6F640F09c606bb9A83',
+      'bsc',
+      '0x24664791B015659fcb71aB2c9C0d56996462082F',
+      '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c'
+    ).borrowed
   },
 };


### PR DESCRIPTION
Updated Tvl and kept only governance token in staking.
Added new Lending Markets.

Twitter Link:
https://twitter.com/planet_finance

List of audit links if any:
https://github.com/HalbornSecurity/PublicReports/blob/master/Solidity%20Smart%20Contract%20Audits/Planet_Finance_Green_Smart_Contract_Security_Audit_Report_Halborn_Final.pdf

Website Link:
https://app.planet.finance/

Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):
Current TVL:
Chain:
Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)
Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
Short Description (to be shown on DefiLlama):
Token address and ticker if any:
https://bscscan.com/address/0x72B7D61E8fC8cF971960DD9cfA59B8C829D91991#code

Category (full list at https://defillama.com/categories) *Please choose only one:
Dexes

Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):
forkedFrom (Does your project originate from another project):

methodology (what is being counted as tvl, how is tvl being calculated):
Our Tvl comprises of following -
Tvl locked in all pairs liquidity pool + Tvl locked in all markets supplied in lending + staking of aqua 