### PR TITLE
Add bitcoin.com's Verse dex

### DIFF
--- a/projects/versedex/index.js
+++ b/projects/versedex/index.js
@@ -1,0 +1,20 @@
+const { calculateUsdUniTvl } = require("../helper/getUsdUniTvl");
+
+const FLEXUSD = "0x7b2B3C5308ab5b2a1d9a94d20D35CCDf61e05b72";
+const WBCH = "0x3743eC0673453E5009310C727Ba4eaF7b3a1cc04";
+const FACTORY = "0x16bc2B187D7C7255b647830C05a6283f2B9A3AF8";
+
+module.exports = {
+  misrepresentedTokens: true,
+  methodology:
+    "Factory address (0x16bc2B187D7C7255b647830C05a6283f2B9A3AF8) is used to find the LP pairs. TVL is equal to the liquidity on the AMM.",
+  smartbch: {
+    tvl: calculateUsdUniTvl(
+      FACTORY,
+      "smartbch",
+      WBCH,
+      [FLEXUSD],
+      "bitcoin-cash"
+    ),
+  },
+};


### PR DESCRIPTION
##### Twitter Link: https://twitter.com/BitcoinCom

##### List of audit links if any: 0xguard https://github.com/bitcoin-portal/bitcoincom-solidity-swap/blob/trunk/audits/Bitcoin.com_final-audit-report.pdf

##### Website Link: https://verse.bitcoin.com

##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders): https://analytics.verse.bitcoin.com/logo.png
![logo](https://user-images.githubusercontent.com/74184164/166914410-ca481440-65ee-4b39-9517-cf544cbe9b4c.png)


##### Current TVL: 1.16 M

##### Chain: SmartBch, Ethereum (TBD)

##### Coingecko ID (so your TVL can appear on Coingecko): N/A

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): N/A

##### Short Description (to be shown on DefiLlama):
Verse DEX by Bitcoin.com enables permissionless trading via your Web3 wallet. Currently this is only available on smartBCH, but more networks are coming soon and support for Ethereum will launch following completion of the Verse token sale. Sign up to get notified at [getverse.com](http://getverse.com/)!

##### Token address and ticker if any: N/A, TBD

##### Category (full list at https://defillama.com/categories) *Please choose only one: Dexes

##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using): TWAP

##### forkedFrom (Does your project originate from another project): Uniswap v2

##### methodology (what is being counted as tvl, how is tvl being calculated):
Factory address (0x16bc2B187D7C7255b647830C05a6283f2B9A3AF8) is used to find the LP pairs. TVL is equal to the liquidity on the AMM.
