### PR TITLE
BenSwap: add FlexUSD denominated pairs to tracking

### DIFF
--- a/projects/benswap/index.js
+++ b/projects/benswap/index.js
@@ -5,6 +5,7 @@ const { stakingPricedLP } = require('../helper/staking')
 
 const WBCH = "0x3743eC0673453E5009310C727Ba4eaF7b3a1cc04";
 const EBEN = "0x77CB87b57F54667978Eb1B199b28a0db8C8E1c0B";
+const FLEXUSD = "0x7b2B3C5308ab5b2a1d9a94d20D35CCDf61e05b72";
 const FACTORY = "0x8d973bAD782c1FFfd8FcC9d7579542BA7Dd0998D";
 const MASTERBREEDER = "0xDEa721EFe7cBC0fCAb7C8d65c598b21B6373A2b6";
 const EBEN_WBCH_LP = "0x0D4372aCc0503Fbcc7EB129e0De3283c348B82c3";
@@ -27,7 +28,7 @@ async function bchMasterChef(timestamp, ethBlock, chainBlocks) {
     }
 }
 
-const bchDexTvl = calculateUsdUniTvl(FACTORY, CHAIN, WBCH, [EBEN], COREASSETNAME)
+const bchDexTvl = calculateUsdUniTvl(FACTORY, CHAIN, WBCH, [EBEN, FLEXUSD], COREASSETNAME)
 
 module.exports = {
     misrepresentedTokens: true,


### PR DESCRIPTION
Update benswap on smartbch

add FlexUSD denominated pairs to tracking to be consistent with mainnet-pat's PR: https://github.com/DefiLlama/DefiLlama-Adapters/pull/2539