### PR TITLE
Add Polynomial BTC vaults

### DIFF
--- a/projects/polynomial/index.js
+++ b/projects/polynomial/index.js
@@ -8,7 +8,9 @@ const transform = t => `${chain}:${t}`
 // Polynomial contract addresses
 const polynomial_contracts = [
   '0xfa923aa6b4df5bea456df37fa044b37f0fddcdb4', 
-  '0x331cf6e3e59b18a8bc776a0f652af9e2b42781c5'
+  '0x331cf6e3e59b18a8bc776a0f652af9e2b42781c5',
+  '0xea48dD74BA1Ff41B705ba5Cf993B2D558e12D860',
+  '0x23CB080dd0ECCdacbEB0BEb2a769215280B5087D'
 ]
 
 async function tvl (timestamp, ethBlock, chainBlocks) {


### PR DESCRIPTION
Add Polynomial BTC covered call and put selling vaults to the existing dashboard. 

existing dashboard: https://defillama.com/protocol/polynomial-protocol

reference contract addresses: https://github.com/Polynomial-Protocol/polynomial-earn-contracts/blob/master/deployments.json#L15
