### PR TITLE
Add LP token price calculation on folks-finance

### DIFF
--- a/projects/folks-finance/constants.js
+++ b/projects/folks-finance/constants.js
@@ -35,14 +35,33 @@ const pools = [
     assetId: 694432641,
     assetDecimals: 6,
   },
+  {
+    appId: 743679535,
+    assetId: 694683000,
+    assetDecimals: 6,
+    poolAppAddress:
+      "WNA4H7Y3UGEVNEVVFU2TUDLMOMLWSV72UF6SYYRBOQ7IGDW4ZIOKYWNIWU",
+  },
+  {
+    appId: 743685742,
+    assetId: 701364134,
+    assetDecimals: 6,
+    poolAppId: 701363946,
+  },
 ];
 
 const liquidGovernanceAppId = 694427622;
 
 const oracleAppId = 735190677;
+const oracleAdapterAppId = 743660117;
 const oracleDecimals = 14;
+const tinymanValidatorAppId = 552635992;
 
-exports.pools = pools;
-exports.liquidGovernanceAppId = liquidGovernanceAppId;
-exports.oracleAppId = oracleAppId;
-exports.oracleDecimals = oracleDecimals;
+module.exports = {
+  pools,
+  liquidGovernanceAppId,
+  oracleAppId,
+  oracleAdapterAppId,
+  oracleDecimals,
+  tinymanValidatorAppId,
+};

--- a/projects/folks-finance/prices.js
+++ b/projects/folks-finance/prices.js
@@ -1,0 +1,111 @@
+const { lookupAccountByID, lookupApplications } = require("../helper/algorand");
+const {
+  oracleAppId,
+  oracleAdapterAppId,
+  pools,
+  tinymanValidatorAppId,
+  oracleDecimals,
+} = require("./constants");
+const {
+  getAppState,
+  getParsedValueFromState,
+  fromIntToBytes8Hex,
+  parseOracleValue,
+  parseOracleAdapterValue,
+  calcLPPrice,
+} = require("./utils");
+
+async function getTinymanLPPrice(validatorAppId, poolAddress, p0, p1) {
+  const res = await lookupAccountByID(poolAddress);
+  const { account } = res;
+
+  const state = account["apps-local-state"]?.find(
+    (app) => app.id === validatorAppId
+  )?.["key-value"];
+  if (state === undefined)
+    throw new Error(
+      `Unable to find Tinyman Pool: ${poolAddress} for validator app ${validatorAppId}.`
+    );
+  const r0 = BigInt(getParsedValueFromState(state, "s1") || 0);
+  const r1 = BigInt(getParsedValueFromState(state, "s2") || 0);
+  const lts = BigInt(getParsedValueFromState(state, "ilt") || 0);
+
+  return calcLPPrice(r0, r1, p0, p1, lts);
+}
+
+async function getPactLPPrice(poolAppId, p0, p1) {
+  const res = await lookupApplications(poolAppId);
+  const state = res.application.params["global-state"];
+
+  const r0 = BigInt(getParsedValueFromState(state, "A") || 0);
+  const r1 = BigInt(getParsedValueFromState(state, "B") || 0);
+  const lts = BigInt(getParsedValueFromState(state, "L") || 0);
+
+  return calcLPPrice(r0, r1, p0, p1, lts);
+}
+
+/* Get prices from oracle */
+async function getPrices() {
+  const oracleState = await getAppState(oracleAppId);
+  const oracleAdapterState = await getAppState(oracleAdapterAppId);
+  const prices = {};
+
+  let price;
+  for (const pool of pools) {
+    const base64Value = getParsedValueFromState(
+      oracleAdapterState,
+      fromIntToBytes8Hex(pool.assetId),
+      "hex"
+    );
+
+    // check if liquidity token
+    if (base64Value !== undefined) {
+      const oracleAdapterValue = parseOracleAdapterValue(base64Value);
+
+      const price0 = parseOracleValue(
+        String(
+          getParsedValueFromState(
+            oracleState,
+            fromIntToBytes8Hex(oracleAdapterValue.asset0Id),
+            "hex"
+          )
+        )
+      );
+      const price1 = parseOracleValue(
+        String(
+          getParsedValueFromState(
+            oracleState,
+            fromIntToBytes8Hex(oracleAdapterValue.asset1Id),
+            "hex"
+          )
+        )
+      );
+
+      price =
+        oracleAdapterValue.provider === "Tinyman"
+          ? await getTinymanLPPrice(
+              tinymanValidatorAppId,
+              oracleAdapterValue.poolAddress,
+              price0,
+              price1
+            )
+          : await getPactLPPrice(oracleAdapterValue.poolAppId, price0, price1);
+    } else {
+      price = parseOracleValue(
+        String(
+          getParsedValueFromState(
+            oracleState,
+            fromIntToBytes8Hex(pool.assetId),
+            "hex"
+          )
+        )
+      );
+    }
+
+    prices[pool.assetId] = Number(price) / 10 ** oracleDecimals;
+  }
+
+  return prices;
+}
+
+module.exports = { getPrices };

--- a/projects/folks-finance/utils.js
+++ b/projects/folks-finance/utils.js
@@ -1,0 +1,106 @@
+const { lookupApplications } = require("../helper/algorand");
+const { encodeAddress } = require("../helper/algorandUtils/address");
+
+function fromIntToBytes8Hex(num) {
+  return num.toString(16).padStart(16, "0");
+}
+
+function encodeToBase64(str, encoding = "utf8") {
+  return Buffer.from(str, encoding).toString("base64");
+}
+
+function parseOracleValue(base64Value) {
+  const value = Buffer.from(base64Value, "base64").toString("hex");
+  // first 8 bytes are the price
+  const price = BigInt("0x" + value.slice(0, 16));
+
+  return price;
+}
+
+function parseOracleAdapterValue(base64Value) {
+  const value = Buffer.from(base64Value, "base64").toString("hex");
+  // first 8 bytes are if Tinyman
+  const isTinyman = Number(`0x${value.slice(0, 16)}`);
+  // next 16 bytes are asset ids
+  const asset0Id = Number(`0x${value.slice(16, 32)}`);
+  const asset1Id = Number(`0x${value.slice(32, 48)}`);
+
+  // check if LP token is Tinyman or Pact
+  if (isTinyman) {
+    // next 32 bytes are tinyman pool address
+    const poolAddress = encodeAddress(Buffer.from(value.slice(48, 112), "hex"));
+    return { provider: "Tinyman", asset0Id, asset1Id, poolAddress };
+  } else {
+    // next 8 bytes are pact pool app id
+    const poolAppId = Number(`0x${value.slice(48, 64)}`);
+    return { provider: "Pact", asset0Id, asset1Id, poolAppId };
+  }
+}
+
+function getParsedValueFromState(state, key, encoding = "utf8") {
+  const encodedKey = encoding ? encodeToBase64(key, encoding) : key;
+  const keyValue = state.find((entry) => entry.key === encodedKey);
+  if (keyValue === undefined) return;
+  const { value } = keyValue;
+  if (value.type === 1) return value.bytes;
+  if (value.type === 2) return BigInt(value.uint);
+  return;
+}
+
+async function getAppState(appId) {
+  const res = await lookupApplications(appId);
+  return res.application.params["global-state"];
+}
+
+/**
+ * Calculate the sqrt of a bigint (rounded down to nearest integer)
+ * @param value value to be square-rooted
+ * @return bigint sqrt
+ */
+function sqrt(value) {
+  if (value < BigInt(0))
+    throw Error("square root of negative numbers is not supported");
+
+  if (value < BigInt(2)) return value;
+
+  function newtonIteration(n, x0) {
+    const x1 = (n / x0 + x0) >> BigInt(1);
+    if (x0 === x1 || x0 === x1 - BigInt(1)) return x0;
+    return newtonIteration(n, x1);
+  }
+
+  return newtonIteration(value, BigInt(1));
+}
+
+/**
+ * Calculates the LP price
+ * @param r0 pool supply of asset 0
+ * @param r1 pool supply of asset 1
+ * @param p0 price of asset 0
+ * @param p1 price of asset 1
+ * @param lts circulating supply of liquidity token
+ * @return bigint LP price
+ */
+function calcLPPrice(r0, r1, p0, p1, lts) {
+  return BigInt(2) * (sqrt(r0 * p0 * r1 * p1) / lts);
+}
+
+function isTinymanLPTokenPool(pool) {
+  return "poolAppAddress" in pool;
+}
+
+function isPactLPTokenPool(pool) {
+  return "poolAppId" in pool;
+}
+
+module.exports = {
+  fromIntToBytes8Hex,
+  encodeToBase64,
+  parseOracleValue,
+  parseOracleAdapterValue,
+  getParsedValueFromState,
+  getAppState,
+  isTinymanLPTokenPool,
+  isPactLPTokenPool,
+  calcLPPrice,
+};

--- a/projects/helper/algorandUtils/address.js
+++ b/projects/helper/algorandUtils/address.js
@@ -67,5 +67,6 @@ function genericHash(arr) {
 }
 
 module.exports = {
+  encodeAddress,
   getApplicationAddress,
 }


### PR DESCRIPTION
Given the upcoming introduction of LP tokens as collateral on folks-finance, modifications were made to obtain their price from the oracle smart contract.

In addition, the `encodeAddress` function was exported from the file [`projects/helper/algorandUtils/address.js`](https://github.com/DefiLlama/DefiLlama-Adapters/commit/bfab1ac4e0096b1991acc128bb4827d2c34d7f2d#diff-8f01f0b7533d6d24af2bc8ef9282e3d01e29cf4a6bd521944007eb608cee4277).