### PR TITLE
deduplicate Koyo pool token addresses

### DIFF
--- a/projects/koyo/index.js
+++ b/projects/koyo/index.js
@@ -53,7 +53,7 @@ const chainTVL = (chain) => {
 
     await sumTokensAndLPsSharedOwners(
       balances,
-      data.swaps.flatMap((swap) => swap.tokens).map((token) => [token, false]),
+      [...new Set(data.swaps.flatMap((swap) => swap.tokens)).values()].map((token) => [token, false]),
       data.swaps.map((swap) => swap.address),
       block,
       chain,


### PR DESCRIPTION
The currently tracked TVL is invalid as when I created the adapter I didn't account for duplicate entries thus this was produced
```
--- boba ---
USDT                      1.87 k
FRAX                      1.79 k
USDC                      1.78 k
DAI                       882.527304341257
Total: 6.32 k 

--- boba-treasury ---
BOBA                      4.38 k
Total: 4.38 k 

--- tvl ---
USDT                      1.87 k
FRAX                      1.79 k
USDC                      1.78 k
DAI                       882.527304341257
Total: 6.32 k 

--- treasury ---
BOBA                      4.38 k
Total: 4.38 k 

------ TVL ------
boba                      6.32 k
boba-treasury             4.38 k
treasury                  4.38 k

total                    6.32 k
```
This PR deduplicates returned addresses to produce a valid TVL count
```
--- boba ---
USDT                      934.8514875699999
FRAX                      892.6435361550559
USDC                      890.7464555989999
DAI                       882.527304341257
Total: 3.60 k 

--- boba-treasury ---
BOBA                      4.38 k
Total: 4.38 k 

--- tvl ---
USDT                      934.8514875699999
FRAX                      892.6435361550559
USDC                      890.7464555989999
DAI                       882.527304341257
Total: 3.60 k 

--- treasury ---
BOBA                      4.38 k
Total: 4.38 k 

------ TVL ------
boba                      3.60 k
boba-treasury             4.38 k
treasury                  4.38 k

total                    3.60 k
```