### PR TITLE
added support to calculate TVL for non-native assets locked in Oswap

### DIFF
--- a/projects/helper/obyte.js
+++ b/projects/helper/obyte.js
@@ -1,29 +1,118 @@
 const utils = require('./utils')
 
 /**
- * @param {number} timestamp - unix timestamp in seconds from epoch of the moment in time for which the TVL is calculated
- * @param {string} address - the Obyte address of the base AA for which the total TVL is calculated
+ * @param {number} timestamp - unix timestamp in seconds from epoch of the moment in time for which the balances are requested
+ * @param {string} address - the Obyte address of the base AA for which the balances are fetched
  *
- * @return the total TVL of all AAs that are based on the base AA identified by address
+ * @return {Promise<object>} the balances of all assets of all AAs that are based on the base AA identified by address
  */
-async function fetchBaseAATvl(timestamp, address) {
+async function fetchBaseAABalances(timestamp, address) {
   /*
-   * Example result:
    * {
-   *   "type": "spot",
-   *   "series": "tvl",
    *   "subject": "GS23D3GQNNMNJ5TL4Z5PINZ5626WASMA",
-   *   "unit": "USD_MA",
-   *   "data": {
-   *     "2022-05-20T06:16:18.169Z": 8419.285627948508
+   *   "addresses": {
+   *     "67XYBBBME57DZMJPLOYNXSIMAIDHGUDW": {
+   *       "assets": {
+   *         "3XF+1slNoFxIVPvRupR5uf9AXluOm92nobzKyCCSE3c=": {
+   *           "balance": 829,
+   *           "burned": false,
+   *           "selfIssued": false,
+   *           "selfIssuedUncapped": false
+   *         },
+   *         "base": {
+   *           "balance": 36262,
+   *           "burned": false,
+   *           "selfIssued": false,
+   *           "selfIssuedUncapped": false
+   *         }
+   *       }
+   *     },
+   *     "TBLLH5DGDX6KU5UGHG4WDH4N7IC5FPKP": {
+   *        ...
+   *     },
    *   }
    * }
    */
-  const fetched = await utils.fetchURL(` https://api.charts.obyte.app/baseagents/${address}/tvl?ts=${timestamp}`)
-  const totalTvlResponse = fetched.data
-  return Object.values(totalTvlResponse.data)[0]
+  const fetched = await utils.fetchURL(` https://api.charts.obyte.app/baseagents/${address}/balances?ts=${timestamp}`)
+  return fetched.data
+}
+
+/**
+ * @return {Promise<object>} fetches all exchange rates traded on Oswap v1 and v2 plus a few externally defined tokens such as GBYTE-USD or BTC-USD
+ */
+async function fetchOswapExchangeRates() {
+  /*
+   * {
+   *   "BTC_USD": 29832,
+   *   "GBYTE_BTC": 0.0004509,
+   *   "GBYTE_USD": 13.4512488,
+   *   "+X9n1ni9OpH/0PFXdmeB4f16wSxSivW4/qcyOt1UEDI=_USD": 88.2777158012621,
+   *   "/1ReF/OW7wud1rqomgWMSeaetx8WjyD6eSTnGurTftU=_USD": 0.22874160911121644
+   * }
+   */
+  const fetched = await utils.fetchURL("https://v2-data.oswap.io/api/v1/exchangeRates")
+  return fetched.data
+}
+
+/**
+ * @return {Promise<object>} fetches assets traded on Oswap v1
+ */
+async function fetchOswapV1Assets() {
+  /*
+   * {
+   *  "O2-GBYTE-USDC": {
+   *    "asset_id": "cQZVAFFh0Aaj5kMMydWoTqcMDxpfzGzEZhhEaQSVbHA=",
+   *    "decimals": 0,
+   *    "description": "Oswap v2 LP shares GBYTE-USDC",
+   *    "symbol": "O2-GBYTE-USDC",
+   *    "supply": 5026551
+   *  }
+   * }
+   */
+  const fetched = await utils.fetchURL("https://v1-data.oswap.io/api/v1/assets")
+  const assets = fetched.data
+  return Object.values(assets).reduce((map, asset) => {
+    map[asset.asset_id] = asset
+    return map
+  }, {})
+}
+
+/**
+ * @return {Promise<object>} fetches assets traded on Oswap v2
+ */
+async function fetchOswapV2Assets() {
+  /*
+   * {
+   *  "O2-GBYTE-USDC": {
+   *    "asset_id": "cQZVAFFh0Aaj5kMMydWoTqcMDxpfzGzEZhhEaQSVbHA=",
+   *    "decimals": 0,
+   *    "description": "Oswap v2 LP shares GBYTE-USDC",
+   *    "symbol": "O2-GBYTE-USDC",
+   *    "supply": 5026551
+   *  }
+   * }
+   */
+  const fetched = await utils.fetchURL("https://v2-data.oswap.io/api/v1/assets")
+  const assets = fetched.data
+  return Object.values(assets).reduce((map, asset) => {
+    map[asset.asset_id] = asset
+    return map
+  }, {})
+}
+
+async function fetchOswapAssets() {
+  const [assets1, assets2] = await Promise.all([
+      fetchOswapV1Assets(),
+      fetchOswapV2Assets()
+  ])
+  return {
+    ...assets1,
+    ...assets2
+  }
 }
 
 module.exports = {
-  fetchBaseAATvl
+  fetchBaseAABalances,
+  fetchOswapExchangeRates,
+  fetchOswapAssets
 }

--- a/projects/oswap/index.js
+++ b/projects/oswap/index.js
@@ -2,28 +2,59 @@
  * Oswap is a decentralized token swap protocol on the Obyte ledger.
  *
  * @see https://oswap.io/
+ * @see https://v2-stats.oswap.io/
+ *
+ * @see https://v1.oswap.io/
+ * @see https://v1-stats.oswap.io/
  */
-const { fetchBaseAATvl } = require('../helper/obyte')
+const {fetchBaseAABalances, fetchOswapExchangeRates, fetchOswapAssets} = require('../helper/obyte')
 
-async function totalTvl(timestamp) {
-  return Promise.all([
-      fetchBaseAATvl(timestamp, "GS23D3GQNNMNJ5TL4Z5PINZ5626WASMA"), // Oswap v1
-      fetchBaseAATvl(timestamp, "2JYYNOSRFGLI3TBI4FVSE6GFBUAZTTI3"), // Oswap v2
-      fetchBaseAATvl(timestamp, "DYZOJKX4MJOQRAUPX7K6WCEV5STMKOHI")  // Oswap v3
-    ]).then( values => {
-      return values.reduce( (total, tvl) => total + tvl, 0)
-  })
+// TODO support time travel for the exchange rate, currently it always returns the latest rates
+async function tvl(timestamp) {
+    const [exchangeRates, assetMetadata] = await Promise.all([
+        fetchOswapExchangeRates(),
+        fetchOswapAssets()
+    ])
+
+    return Promise.all([
+        fetchBaseAABalances(timestamp, "GS23D3GQNNMNJ5TL4Z5PINZ5626WASMA"), // Oswap v1
+        fetchBaseAABalances(timestamp, "2JYYNOSRFGLI3TBI4FVSE6GFBUAZTTI3"), // Oswap v2
+        fetchBaseAABalances(timestamp, "DYZOJKX4MJOQRAUPX7K6WCEV5STMKOHI")  // Oswap v2.1
+    ]).then(baseAABalances => {
+
+        const summingAssetTvl = (total, [asset, assetDetails]) => {
+            if (!assetMetadata?.hasOwnProperty(asset)) return total
+
+            const decimals = assetMetadata[asset].decimals ?? 0
+            const baseCurrency = (asset === "base") ? "GBYTE" : asset
+            const usdRate = exchangeRates[`${baseCurrency}_USD`] ?? 0
+            const usdValue = assetDetails.balance / Math.pow(10, decimals) * usdRate
+            // console.log(`  ${assetMetadata[asset]?.symbol ?? asset} = ${usdValue.toFixed(2)}`)
+            return total + usdValue
+        }
+
+        const summingAddressTvl = (total, [address, addressDetails]) => {
+            // console.log(`${address}:`)
+            return total + Object.entries(addressDetails.assets)
+                .filter(([asset, assetDetails]) => !assetDetails.selfIssued)
+                .reduce(summingAssetTvl, 0)
+        }
+
+        const summingBaseAATvl = (total, balances) => {
+            return total + Object.entries(balances.addresses).reduce(summingAddressTvl, 0)
+        }
+
+        return baseAABalances.reduce(summingBaseAATvl, 0)
+    })
 }
 
 module.exports = {
-  timetravel: true,
-  doublecounted: false,
-  methodology:
-    "The TVL is the USD value of the total native asset (bytes) locked into the autonomous agents extending the Oswap protocol (v1, v2 and v3). " +
-    "The value of other assets listed in Oswap are not part of this TVL because they are either assets without established value " +
-    "other protocol tokens such as algorithmic stable coins (Ostable) or imported tokens from other chains (CounterStake bridge).",
-  obyte: {
-    fetch: totalTvl
-  },
-  fetch: totalTvl
+    timetravel: false,
+    doublecounted: false,
+    methodology:
+        "The TVL is the USD value of the all non-self issued assets locked into the autonomous agents extending the Oswap protocol.",
+    obyte: {
+        fetch: tvl
+    },
+    fetch: tvl
 }


### PR DESCRIPTION
Currently, the live Oswap adapter version only counts TVL of the native asset (bytes) locked in, basically only one side of each liquidity pool. This pull request calculates TVL for all non-native assets as well that are locked in on Oswap, but only those not issued by the pool itself.  These non-native assets can either be outputs of other protocols or user issued custom assets. 

This pull request will basically double the calculated TVL of Oswap compared to what is live right now.

Also, updated methodology to reflect the new calculation method.