### PR TITLE
Include staked BAI in AstridDAO TVL

### DIFF
--- a/projects/astriddao/index.js
+++ b/projects/astriddao/index.js
@@ -86,7 +86,7 @@ async function tvl(ts, _block, chainBlocks ) {
 module.exports = {
   timetravel: true,
   start: 915830,
-  methodology: "Total locked collateral assets (in ERC-20 form) in ActivePool and DefaultPool",
+  methodology: "Total locked collateral assets (in ERC-20 form) in ActivePool and DefaultPool, plus total staked BAI in StabilityPool",
   astar: {
     tvl,
   },

--- a/projects/astriddao/index.js
+++ b/projects/astriddao/index.js
@@ -29,6 +29,25 @@ const COLLATERALS = {
   }
 }
 
+const BAI_TOKEN_ADDRESS = "0x733ebcC6DF85f8266349DEFD0980f8Ced9B45f35"
+const STAKES = {
+  WASTAR: {
+    contracts: {
+      stabilityPool: "0x7e3D1e75C8deef26d659B2fb7b7E436ab8Ea35d9"
+    }
+  },
+  BUSD: {
+    contracts: {
+      stabilityPool: "0x2D95D9191F12a17D61B3a1904581DceFd2C6e3eD"
+    }
+  },
+  DAI: {
+    contracts: {
+      stabilityPool: "0xA5Bb226e06732005Cf6053429B8F6d607A8A530a"
+    }
+  }
+}
+
 const BRIDGE_TOKEN_MAPPINGS = {}
 for (const collateralInfo of Object.values(COLLATERALS)) {
   if (collateralInfo.bridgeTokenMapping) {
@@ -53,6 +72,10 @@ async function tvl(ts, _block, chainBlocks ) {
   let balances = {}
   for (const collateralInfo of Object.values(COLLATERALS)) {
     const tokensAndOwners = Object.values(collateralInfo.contracts).map(owner => [collateralInfo.tokenAddress, owner])
+    await sumTokens(balances, tokensAndOwners, block, chain)
+  }
+  for (const stakeInfo of Object.values(STAKES)) {
+    const tokensAndOwners = Object.values(stakeInfo.contracts).map(owner => [BAI_TOKEN_ADDRESS, owner])
     await sumTokens(balances, tokensAndOwners, block, chain)
   }
   balances = translateBalancesForBridgeToken(balances)

--- a/projects/helper/portedTokens.js
+++ b/projects/helper/portedTokens.js
@@ -760,9 +760,8 @@ function fixAstarBalances(balances) {
     '0x4Bf769b05E832FCdc9053fFFBC78Ca889aCb5E1E': { coingeckoId: 'binance-usd', decimals: 18, },
     '0xb7aB962c42A8Bb443e0362f58a5A43814c573FFb': { coingeckoId: 'binance-usd', decimals: 18, },
     '0x29F6e49c6E3397C3A84F715885F9F233A441165C': { coingeckoId: 'dai', decimals: 18, },
-    '0x733ebcC6DF85f8266349DEFD0980f8Ced9B45f35': { coingeckoId: 'dai', decimals: 18, },
+    '0x733ebcC6DF85f8266349DEFD0980f8Ced9B45f35': { coingeckoId: 'bai-stablecoin', decimals: 18, },
     // '0x29F6e49c6E3397C3A84F715885F9F233A441165C': { coingeckoId: 'orcus-ousd', decimals: 18, }, // todo: fix this, use correct coingecko id
-    // '0x733ebcC6DF85f8266349DEFD0980f8Ced9B45f35': { coingeckoId: 'bai-stablecoin', decimals: 18, }, // todo: fix this, use correct coingecko id
   }
 
   return fixBalances(balances, mapping)


### PR DESCRIPTION
`bai-stablecoin` has become available on CoinGecko. Correct the price listing of BAI (which was temporarily set to DAI as a hack), and include staked BAI into AstridDAO's TVL.
