### PR TITLE
Support new version of mean finance

### DIFF
--- a/projects/meanfinance/index.js
+++ b/projects/meanfinance/index.js
@@ -11,7 +11,7 @@ const VERSIONS = {
   optimism: [
     { contract: STABLE_VERSION, subgraph: 'https://api.thegraph.com/subgraphs/name/mean-finance/dca-v2-optimism' },
     { contract: VULN_VERSION, subgraph: 'https://api.thegraph.com/subgraphs/name/mean-finance/dca-v2-vulnerable-optimism' },
-    { contract: BETA_VERSION, subgraph: 'https://api.thegraph.com/subgraphs/name/mean-finance/dca-v2-optimism-beta', ignore: ['0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'] },
+    { contract: BETA_VERSION, subgraph: 'https://api.thegraph.com/subgraphs/name/mean-finance/dca-v2-optimism-beta' },
   ],
   polygon: [ 
     { contract: STABLE_VERSION, subgraph: 'https://api.thegraph.com/subgraphs/name/mean-finance/dca-v2-polygon' },
@@ -24,16 +24,15 @@ const VERSIONS = {
 
 const query = gql`
   query tokens {
-    tokens {
+    tokens (where: { id_not: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" }) {
       id
     }
   }`
 ;
 
-const getTokensInChain = async (subgraph, ignore) => {
+const getTokensInChain = async (subgraph) => {
   const result = await request(subgraph, query);
   return result.tokens.map(({ id }) => id)
-    .filter(address => !ignore || !ignore.includes(address))
 };
 
 function getV2TvlObject(chain) {
@@ -51,8 +50,8 @@ async function getV2TVL(chain, block) {
 }
 
 async function getV2TVLForVersion(balances, chain, version, block) {
-  const { contract, subgraph, ignore } = version
-  const tokens = await getTokensInChain(subgraph, ignore)
+  const { contract, subgraph } = version
+  const tokens = await getTokensInChain(subgraph)
   const chainTransform = await getChainTransform(chain)
   for (const token of tokens) {
     const balance = await sdk.api.erc20.balanceOf({

--- a/projects/meanfinance/index.js
+++ b/projects/meanfinance/index.js
@@ -3,14 +3,23 @@ const abi = require("./abi.json");
 const { getChainTransform } = require("../helper/portedTokens")
 const { request, gql } = require("graphql-request");
 
-const GRAPH_URLS = {
-  polygon: 'https://api.thegraph.com/subgraphs/name/mean-finance/dca-v2-polygon',
-  optimism: 'https://api.thegraph.com/subgraphs/name/mean-finance/dca-v2-optimism'
-}
+const STABLE_VERSION = '0x059d306A25c4cE8D7437D25743a8B94520536BD5'
+const VULN_VERSION = '0x230C63702D1B5034461ab2ca889a30E343D81349'
+const BETA_VERSION = '0x24F85583FAa9F8BD0B8Aa7B1D1f4f53F0F450038'
 
-const DCA_HUB_ADDRESSES = {
-  polygon: '0x230C63702D1B5034461ab2ca889a30E343D81349',
-  optimism: '0x230C63702D1B5034461ab2ca889a30E343D81349'
+const VERSIONS = {
+  optimism: [
+    { contract: STABLE_VERSION, subgraph: 'https://api.thegraph.com/subgraphs/name/mean-finance/dca-v2-optimism' },
+    { contract: VULN_VERSION, subgraph: 'https://api.thegraph.com/subgraphs/name/mean-finance/dca-v2-vulnerable-optimism' },
+    { contract: BETA_VERSION, subgraph: 'https://api.thegraph.com/subgraphs/name/mean-finance/dca-v2-optimism-beta', ignore: ['0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'] },
+  ],
+  polygon: [ 
+    { contract: STABLE_VERSION, subgraph: 'https://api.thegraph.com/subgraphs/name/mean-finance/dca-v2-polygon' },
+    { contract: VULN_VERSION, subgraph: 'https://api.thegraph.com/subgraphs/name/mean-finance/dca-v2-vulnerable-polygon' },
+  ],
+  arbitrum: [
+    { contract: STABLE_VERSION, subgraph: 'https://api.thegraph.com/subgraphs/name/mean-finance/dca-v2-arbitrum' },
+  ]
 }
 
 const query = gql`
@@ -21,9 +30,10 @@ const query = gql`
   }`
 ;
 
-const getTokensInChain = async (chain) => {
-  const result = await request(GRAPH_URLS[chain], query);
+const getTokensInChain = async (subgraph, ignore) => {
+  const result = await request(subgraph, query);
   return result.tokens.map(({ id }) => id)
+    .filter(address => !ignore || !ignore.includes(address))
 };
 
 function getV2TvlObject(chain) {
@@ -34,19 +44,25 @@ function getV2TvlObject(chain) {
 
 async function getV2TVL(chain, block) {
   const balances = {};
-  const tokens = await getTokensInChain(chain)
+  for (const version of VERSIONS[chain]) {
+    await getV2TVLForVersion(balances, chain, version, block)
+  }
+  return balances
+}
+
+async function getV2TVLForVersion(balances, chain, version, block) {
+  const { contract, subgraph, ignore } = version
+  const tokens = await getTokensInChain(subgraph, ignore)
   const chainTransform = await getChainTransform(chain)
-  const hubAddress = DCA_HUB_ADDRESSES[chain]
   for (const token of tokens) {
     const balance = await sdk.api.erc20.balanceOf({
       target: token,
-      owner: hubAddress,
+      owner: contract,
       block,
       chain
     })
     sdk.util.sumSingleBalance(balances, chainTransform(token), balance.output);
   }
-  return balances
 }
 
 //DCA Factory
@@ -89,5 +105,6 @@ module.exports = {
     tvl: ethTvl
   },
   optimism: getV2TvlObject('optimism'),
-  polygon: getV2TvlObject('polygon')
+  polygon: getV2TvlObject('polygon'),
+  arbitrum: getV2TvlObject('arbitrum'),
 };


### PR DESCRIPTION
Hey Llamas!

About a month ago, we had a vulnerability report in [Mean Finance](https://defillama.com/protocol/mean-finance). Because of that, we had to redeploy our contracts (with the fix of course 😆 ). Right now, the adapter is only reporting the funds of the vulnerable version.

While the users migrate their positions, we thought it made sense to count the funds in both versions. Once all users have migrated, we can remove the old version. 

Also, we added support for Arbitrum, which has no funds yet (we haven't announced it). But if we add it now, we can avoid a future pull request

That's it from us, keep up the amazing work!