### PR TITLE
Include Polkadot (DOT) token value for Astar EVM

### DIFF
--- a/projects/helper/portedTokens.js
+++ b/projects/helper/portedTokens.js
@@ -751,6 +751,7 @@ function fixAstarBalances(balances) {
     '0xb7aB962c42A8Bb443e0362f58a5A43814c573FFb': { coingeckoId: 'binance-usd', decimals: 18, },
     '0x29F6e49c6E3397C3A84F715885F9F233A441165C': { coingeckoId: 'dai', decimals: 18, },
     '0x733ebcC6DF85f8266349DEFD0980f8Ced9B45f35': { coingeckoId: 'bai-stablecoin', decimals: 18, },
+    '0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF': { coingeckoId: 'polkadot', decimals: 10, },
     // '0x29F6e49c6E3397C3A84F715885F9F233A441165C': { coingeckoId: 'orcus-ousd', decimals: 18, }, // todo: fix this, use correct coingecko id
   }
 


### PR DESCRIPTION
`DOT` token on Astar EVM is using the special address `0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF` (see https://blockscout.com/astar/address/0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF/transactions). This PR ensures that its value will be correctly attributed for DOT assets (e.g. for AstridDAO).

Example:

Before this change:
```
$ node test.js projects/astriddao/index.js
--- astar ---
binance-usd               4.24 M
astar                     3.28 M
bai-stablecoin            3.24 M
dai                       784.25 k
UNKNOWN (0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF) 0
Total: 11.55 M

--- tvl ---
binance-usd               4.24 M
astar                     3.28 M
bai-stablecoin            3.24 M
dai                       784.25 k
UNKNOWN (0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF) 0
Total: 11.55 M

------ TVL ------
astar                     11.55 M

total                    11.55 M
```

After this change:
```
$ node test.js projects/astriddao/index.js
--- astar ---
binance-usd               4.24 M
astar                     3.28 M
bai-stablecoin            3.24 M
polkadot                  1.72 M
dai                       784.25 k
Total: 13.27 M

--- tvl ---
binance-usd               4.24 M
astar                     3.28 M
bai-stablecoin            3.24 M
polkadot                  1.72 M
dai                       784.25 k
Total: 13.27 M

------ TVL ------
astar                     13.27 M

total                    13.27 M
```