### PR TITLE
Add Moonbeam as a Supported Network on Moonwell

### DIFF
--- a/projects/moonwell/index.js
+++ b/projects/moonwell/index.js
@@ -11,12 +11,12 @@ const moonriverConfig = {
 }
 
 const moonbeamConfig = {
-  comptroller: "",
+  comptroller: "0x8E00D5e02E65A19337Cdba98bbA9F84d4186a180",
   chain: "moonbeam",
-  nativeTokenMarket: "",
+  nativeTokenMarket: "0x091608f4e4a15335145be0A279483C0f8E4c7955",
 
-  stakingContract: "0xCd76e63f3AbFA864c53b4B98F57c1aA6539FDa3a",
-  stakingTokenAddress: "0xBb8d88bcD9749636BC4D2bE22aaC4Bb3B01A58F1"  
+  stakingContract: "0x8568A675384d761f36eC269D695d6Ce4423cfaB1",
+  stakingTokenAddress: "0x511aB53F793683763E5a8829738301368a2411E3"  
 }
 
 // Moonriver

--- a/projects/moonwell/index.js
+++ b/projects/moonwell/index.js
@@ -40,5 +40,5 @@ const moonbeamStaking = staking(moonbeamConfig.stakingContract, moonbeamConfig.s
 
 module.exports = {
   moonriver: { ...moonriverTVL, ...moonriverStaking},
-  moonbeam: {...moonriverTVL, ...moonbeamStaking},
+  moonbeam: {...moonbeamTVL, ...moonbeamStaking},
 }

--- a/projects/moonwell/index.js
+++ b/projects/moonwell/index.js
@@ -1,17 +1,44 @@
 const { usdCompoundExports } = require('../helper/compound')
 const { staking } = require('../helper/staking');
 
-const comptroller = "0x0b7a0EAA884849c6Af7a129e899536dDDcA4905E"
-const chain = "moonriver"
-const mMOVR = "0x6a1A771C7826596652daDC9145fEAaE62b1cd07f"
-const moonwellStakingContract = "0xCd76e63f3AbFA864c53b4B98F57c1aA6539FDa3a";
-const moonwellTokenAddress = "0xBb8d88bcD9749636BC4D2bE22aaC4Bb3B01A58F1";
+const moonriverConfig = {
+  comptroller: "0x0b7a0EAA884849c6Af7a129e899536dDDcA4905E",
+  chain: "moonriver",
+  nativeTokenMarket: "0x6a1A771C7826596652daDC9145fEAaE62b1cd07f",
+
+  stakingContract: "0xCd76e63f3AbFA864c53b4B98F57c1aA6539FDa3a",
+  stakingTokenAddress: "0xBb8d88bcD9749636BC4D2bE22aaC4Bb3B01A58F1"
+}
+
+const moonbeamConfig = {
+  comptroller: "",
+  chain: "moonbeam",
+  nativeTokenMarket: "",
+
+  stakingContract: "0xCd76e63f3AbFA864c53b4B98F57c1aA6539FDa3a",
+  stakingTokenAddress: "0xBb8d88bcD9749636BC4D2bE22aaC4Bb3B01A58F1"  
+}
+
+// Moonriver
+const moonriverTVL =  usdCompoundExports(
+  moonriverConfig.comptroller,
+  moonriverConfig.chain,
+  moonriverConfig.nativeTokenMarket,
+)
+
+const moonriverStaking = staking(moonriverConfig.stakingContract, moonriverConfig.stakingTokenAddress)
+
+// Moonbeam 
+const moonbeamTVL = usdCompoundExports(
+  moonbeamConfig.comptroller,
+  moonbeamConfig.chain,
+  moonbeamConfig.nativeTokenMarket,
+)
+
+const moonbeamStaking = staking(moonbeamConfig.stakingContract, moonbeamConfig.stakingTokenAddress)
+
 
 module.exports = {
-  moonriver: usdCompoundExports(
-    comptroller,
-    chain,
-    mMOVR,
-  ),
-  staking: staking(moonwellStakingContract, moonwellTokenAddress),  
+  moonriver: { ...moonriverTVL, ...moonriverStaking},
+  moonbeam: {...moonriverTVL, ...moonbeamStaking},
 }


### PR DESCRIPTION
This is an update to include TVL from Moonwell's deployment on the Moonbeam Parachain (Polkadot). Previously Moonwell was only deployed on the Moonriver Parachain (Kusama).

====

##### Twitter Link:
https://twitter.com/MoonwellDeFi

##### List of audit links if any:
https://docs.moonwell.fi/moonwell-finance/protocol-info/audits

##### Website Link:
https://moonwell.fi/

##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):
Should already be configured - this is an update

##### Current TVL:
36.872M on Moonbeam
80.467 on Moonriver

##### Chain:
Moonbeam - New
Moonriver - Existing

##### Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)
WELL (Moonbeam): Not listed yet, in progress
MFAM (Moonriver): `moonwell` / https://www.coingecko.com/en/coins/moonwell-apollo


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

WELL (Moonbeam): Not listed yet, in progress
MFAM (Moonriver): `18698 ` / https://coinmarketcap.com/currencies/moonwell/

##### Short Description (to be shown on DefiLlama):
Moonwell is an open lending and borrowing DeFi protocol on Moonbeam & Moonriver.

##### Token address and ticker if any:
WELL (Moonbeam): 0x511aB53F793683763E5a8829738301368a2411E3
MFAM (Moonriver): 0xBb8d88bcD9749636BC4D2bE22aaC4Bb3B01A58F1

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Lending

##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):
Chainlink

##### forkedFrom (Does your project originate from another project):
Compound

##### methodology (what is being counted as tvl, how is tvl being calculated):
Supplies only for TVL. For staking, amount of WELL/MFAM that is staked in the protocol's safety module as reserves.