### PR TITLE
Update jumboexchange calculation

### DIFF
--- a/projects/jumboexchange/index.js
+++ b/projects/jumboexchange/index.js
@@ -10,12 +10,11 @@ async function tvl() {
   const numberOfPools = await call(PROJECT_CONTRACT, 'get_number_of_pools', {})
 
   do {
-    const pools = await call(PROJECT_CONTRACT, 'get_pools', { from_index: 0, limit: 100 })
+    const pools = await call(PROJECT_CONTRACT, 'get_pools', { from_index: poolIndex, limit: 100 })
 
     pools
       .filter(({ shares_total_supply }) => +shares_total_supply > 0) // Token pair must have some liquidity
       .map(({ token_account_ids, pool_kind, amounts }) => {
-        if (pool_kind !== 'SIMPLE_POOL') throw new Error('Unknown pool kind, add handler')
         token_account_ids.forEach((token, index) => {
           sumSingleBalance(balances, token, amounts[index])
         })


### PR DESCRIPTION
Loop iterator was not used in a loop so the same first 100 elements were counted in every loop iteration.
Also pool_kind verification is not needed because all pools has same structure.

##### Twitter Link: https://twitter.com/jumbo_exchange


##### List of audit links if any:


##### Website Link: https://jumbo.exchange/swap


##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):
https://jumbo.exchange/logo.svg

##### Current TVL: 660 K

##### Chain: Near


##### Coingecko ID (so your TVL can appear on Coingecko): jumbo


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): 1652


##### Short Description (to be shown on DefiLlama):
Jumbo provides Ecosystem-Wide Liquidity for users and projects


##### Token address and ticker if any: [token.jumbo_exchange.near](https://explorer.near.org/accounts/token.jumbo_exchange.near)


##### Category (full list at https://defillama.com/categories) *Please choose only one: DEX


##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):


##### forkedFrom (Does your project originate from another project):


##### methodology (what is being counted as tvl, how is tvl being calculated): Summed up all the tokens deposited in their pool

