### PR TITLE
Add Phoenix DEX (Terra2)

### DIFF
--- a/projects/phoenix-dex/index.js
+++ b/projects/phoenix-dex/index.js
@@ -1,0 +1,12 @@
+const { getFactoryTvl } = require("../terraswap/factoryTvl");
+
+module.exports = {
+  timetravel: true,
+  misrepresentedTokens: true,
+  methodology: "Liquidity on the DEX",
+  terra2: {
+    tvl: getFactoryTvl(
+      "terra1pewdsxywmwurekjwrgvjvxvv0dv2pf8xtdl9ykfce2z0q3gf0k3qr8nezy"
+    ),
+  },
+};


### PR DESCRIPTION
##### Twitter Link:
https://twitter.com/PhoenixFinan

##### Website Link:
https://phoenixfi.so

##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):
https://app.phoenixfi.so/logo.svg

##### Current TVL:
```
--- terra2 ---
terra-luna-2              567.84 k
Total: 567.84 k 

--- tvl ---
terra-luna-2              567.84 k
Total: 567.84 k 

------ TVL ------
terra2                    567.84 k

total                    567.84 k 
```

##### Chain:
Terra2

##### Short Description (to be shown on DefiLlama):
The flagship community-owned DEX on Terra 2.0

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Dexes

##### methodology (what is being counted as tvl, how is tvl being calculated):
Same as Terraswap (Calculate token price per Luna based on pool balance, sum total Luna)