### PR TITLE
Update near.js

### DIFF
--- a/projects/helper/near.js
+++ b/projects/helper/near.js
@@ -22,9 +22,9 @@ const tokenMapping = {
   // 'gold.l2e.near': { name: '', }, // https://www.landtoempire.com/
   'token.v2.ref-finance.near': { name: 'ref-finance', decimals: 18, },
   // 'myriadcore.near': { name: '', },  // Myria
-  'a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.factory.bridge.near': { name: 'usd-coin', decimals: 18 },
-  'dac17f958d2ee523a2206206994597c13d831ec7.factory.bridge.near': { name: 'tether', decimals: 18 },
-  '2260fac5e5542a773aa44fbcfedf7c193bc2c599.factory.bridge.near': { name: 'wrapped-bitcoin', decimals: 18 }
+  'a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.factory.bridge.near': { name: 'usd-coin', decimals: 6 },
+  'dac17f958d2ee523a2206206994597c13d831ec7.factory.bridge.near': { name: 'tether', decimals: 6 },
+  '2260fac5e5542a773aa44fbcfedf7c193bc2c599.factory.bridge.near': { name: 'wrapped-bitcoin', decimals: 8 }
 }
 
 async function view_account(account_id) {


### PR DESCRIPTION
Wrong decimals for USDT, USDC, WBTC.
Contract ft_metadata() returns 6, 6 and 8 accordingly:
[nearblocks.io](https://nearblocks.io/address/2260fac5e5542a773aa44fbcfedf7c193bc2c599.factory.bridge.near#contract
)