### PR TITLE
Improve `borrowed()` definition for Goldfinch

### DIFF
--- a/projects/goldfinch/index.js
+++ b/projects/goldfinch/index.js
@@ -6,7 +6,7 @@ const BigNumber = require("bignumber.js");
 const seniorPoolAddress = "0x8481a6EbAf5c7DABc3F7e09e44A89531fd31F822";
 const gfFactoryAddress = "0xd20508E1E971b80EE172c73517905bfFfcBD87f9";
 const poolTokensAddress = "0x57686612C601Cb5213b01AA8e80AfEb24BBd01df";
-const V2_START = 13097274
+const V2_START = 13097274;
 const USDC = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
 
 const getTranchedPoolAddresses = async (ethBlock) => {
@@ -15,64 +15,112 @@ const getTranchedPoolAddresses = async (ethBlock) => {
     keys: [],
     fromBlock: V2_START,
     toBlock: ethBlock,
-    topic: "PoolCreated(address,address)"
-  })
-  return logs.output.map(l=>"0x"+l.topics[1].substr(26))
-}
+    topic: "PoolCreated(address,address)",
+  });
+  return logs.output.map((l) => "0x" + l.topics[1].substr(26));
+};
 
-const ethTvl = async (timestamp, ethBlock) => {
+/**
+ * This metric represents DeFiLlama's "base" definition of Total Value Locked. It includes
+ * only USDC balances in the protocol (that is, in the `SeniorPool` and in all `TranchedPool`s).
+ */
+const tvl = async (timestamp, ethBlock) => {
   const balances = {};
 
-  const tranchedPoolAddresses = await getTranchedPoolAddresses(ethBlock)
+  const tranchedPoolAddresses = await getTranchedPoolAddresses(ethBlock);
 
-  await sumTokens(balances, [seniorPoolAddress, ...tranchedPoolAddresses].map(pool=>[USDC, pool]), ethBlock)
+  await sumTokens(
+    balances,
+    [seniorPoolAddress, ...tranchedPoolAddresses].map((pool) => [USDC, pool]),
+    ethBlock
+  );
 
   return balances;
 };
 
+/**
+ * This metric supplements the "base" `tvl()` metric, by additionally counting value that has
+ * been borrowed through the protocol.
+ *
+ * Goldfinch considers the protocol's Total Value Locked to be the sum of `tvl()` and `borrowed()`.
+ *
+ * This metric does not include the interest gains of Backers of `TranchedPool`s (though those
+ * interest gains are reflected in the USDC balance of `TranchedPool`s in `tvl()`, before
+ * that balance is withdrawn). This metric also does not reflect "writedowns" in the value of 
+ * the principal of Backers of `TranchedPool`s, as there is no such writedown mechanic for Backers. 
+ * Only the `SeniorPool` has a writedown mechanic -- which is reflected in this metric (via 
+ * `SeniorPool.assets()`).
+ */
 const borrowed = async (_, ethBlock) => {
+  const _seniorPoolUsdcBalances = {};
+  await sumTokens(
+    _seniorPoolUsdcBalances,
+    [seniorPoolAddress].map((pool) => [USDC, pool]),
+    ethBlock
+  );
+  const seniorPoolUsdcBalance = new BigNumber(_seniorPoolUsdcBalances[USDC]);
+
   const balances = {};
 
-  const tranchedPoolAddresses = await getTranchedPoolAddresses(ethBlock)
+  const tranchedPoolAddresses = await getTranchedPoolAddresses(ethBlock);
 
-  const poolStats = (await sdk.api.abi.multiCall({
-    calls: tranchedPoolAddresses.map((tranchedPoolAddress) => ({
-      target: poolTokensAddress,
-      params: tranchedPoolAddress,
-    })),
-    abi: abi.pools,
-    ethBlock
-  })).output
+  const poolStats = (
+    await sdk.api.abi.multiCall({
+      calls: tranchedPoolAddresses.map((tranchedPoolAddress) => ({
+        target: poolTokensAddress,
+        params: tranchedPoolAddress,
+      })),
+      abi: abi.pools,
+      ethBlock,
+    })
+  ).output;
 
   const totalInvested = await poolStats.reduce((sum, thisPoolStats) => {
     return sum
       .plus(new BigNumber(thisPoolStats.output.totalMinted))
-      .minus(new BigNumber(thisPoolStats.output.totalPrincipalRedeemed))
-  }, new BigNumber(0))
+      .minus(new BigNumber(thisPoolStats.output.totalPrincipalRedeemed));
+  }, new BigNumber(0));
 
-  const seniorAssets = new BigNumber((
-    await sdk.api.abi.call({
-      abi: abi.assets,
-      target: seniorPoolAddress,
-      ethBlock,
-    })
-  ).output);
+  const seniorAssets = new BigNumber(
+    (
+      await sdk.api.abi.call({
+        abi: abi.assets,
+        target: seniorPoolAddress,
+        ethBlock,
+      })
+    ).output
+  );
 
-  const seniorLoansOutstanding = new BigNumber((
-    await sdk.api.abi.call({
-      abi: abi.totalLoansOutstanding,
-      target: seniorPoolAddress,
-      ethBlock,
-    })
-  ).output);
+  const seniorLoansOutstanding = new BigNumber(
+    (
+      await sdk.api.abi.call({
+        abi: abi.totalLoansOutstanding,
+        target: seniorPoolAddress,
+        ethBlock,
+      })
+    ).output
+  );
 
   // `totalInvested` reflects the senior pool's investments. So we subtract out
   // `seniorLoansOutstanding`, to avoid double-counting given the inclusion of
-  // `totalLoansOutstanding` in the definition of `assets`. Thus we arrive at
-  // net invested + additional assets, giving us total TVL.
-  const totalTvl = totalInvested.plus(seniorAssets).minus(seniorLoansOutstanding)
+  // `SeniorPool.totalLoansOutstanding()` in the definition of `SeniorPool.assets()`.
+  //
+  // We also subtract out `seniorPoolUsdcBalance`, which is included in `SeniorPool.assets()`,
+  // and which we do not want to count in this metric so that this metric is properly
+  // supplementary to, and not double-counting vis-a-vis, `tvl()`.
+  //
+  // Note that for (a) a tranched pool that is open and whose principal hasn't been drawndown
+  // yet, and for (b) a tranched pool that has had principal repaid but not yet withdrawn, there 
+  // is a double-counting phenomenon for such a pool: the pool's USDC balance counted by 
+  // `tvl()`, and its principal counted by `totalInvested`. We do not worry about preventing 
+  // that double-counting, because it is transient; it disappears once the pool is drawndown 
+  // (in the case of (a)) or withdrawn from (in the case of (b)). 
+  const borrowed = totalInvested
+    .plus(seniorAssets)
+    .minus(seniorLoansOutstanding)
+    .minus(seniorPoolUsdcBalance);
 
-  sdk.util.sumSingleBalance(balances, USDC, String(totalTvl));
+  sdk.util.sumSingleBalance(balances, USDC, String(borrowed));
 
   return balances;
 };
@@ -81,9 +129,10 @@ module.exports = {
   timetravel: true,
   misrepresentedTokens: true,
   ethereum: {
-    tvl: ethTvl,
+    tvl,
     borrowed,
   },
   methodology:
-    "We count liquidity that is in both the Senior Pool as well as that from Backers in all the Borrower Pools.",
+    "The base TVL metric counts only excess USDC liquidity in the Senior Pool, and USDC in all the Borrower Pools. " +
+    "The Borrowed TVL component additionally counts loans made by the Senior Pool and the Backers of all Borrower Pools.",
 };


### PR DESCRIPTION
This PR improves the definition of the `borrowed()` TVL metric for Goldfinch, by avoiding double-counting of USDC in the SeniorPool, relative to the "base" `tvl()` metric. It also adds comments for clarity.

Thanks!

**NOTE**

1. The protocol is usually listed within 24 hours of merging the PR
2. Please fill the form below if the PR is for listing a new protocol
3. If you want to update the protocol info you entered in the form below, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can  edit it there and put up a PR
4. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI

---

##### Twitter Link:


##### List of audit links if any:


##### Website Link:


##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):


##### Current TVL:

##### Chain:


##### Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description (to be shown on DefiLlama):


##### Token address and ticker if any:


##### Category (full list at https://defillama.com/categories) *Please choose only one:


##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):


##### forkedFrom (Does your project originate from another project):


##### methodology (what is being counted as tvl, how is tvl being calculated):

