### PR TITLE
Update DomFi token addresses with XYZDOM-JUN40 series on Boba

### DIFF
--- a/projects/domfi/registry.js
+++ b/projects/domfi/registry.js
@@ -49,20 +49,19 @@ const lsps = {
   ],
   
   [Chain.BOBA]: [
-    // BTCDOM
-    {
-      address: "0x3C77d0130Eb6AfF1DED8C72fb7a5F383B7961c03",
-    },
+    // BTCDOM-JUN20
+    { address: "0x3C77d0130Eb6AfF1DED8C72fb7a5F383B7961c03" },
+    // ETHDOM-JUN20
+    { address: "0xCAB14a130cDB3143aD81657D552a7Cee1917a18e" },
+    // USDTDOM-JUN20
+    { address: "0x5B9f3B4648b1C7573d9c2A068020Bb34AEC67589" },
 
-    // ETHDOM
-    {
-      address: "0xCAB14a130cDB3143aD81657D552a7Cee1917a18e",
-    },
-
-    // USDTDOM
-    {
-      address: "0x5B9f3B4648b1C7573d9c2A068020Bb34AEC67589",
-    },
+    // BTCDOM-JUN40
+    { address: "0x156a4595b87cc204dc96d05f366ac3fcdff30bec" },
+    // ETHDOM-JUN40
+    { address: "0xF123b661d80e755ec26BC0C0CCaAFDD258a102d6" },
+    // USDTDOM-JUN40
+    { address: "0x6cafFBf5697c8744713956fdAf84d6a0613Ce20f" },
   ]
 }
 


### PR DESCRIPTION
This updates the Domination Finance adapter to include newly deployed addresses on Boba.
The methodology and protocol information is the same as originally submitted.
