### PR TITLE
Add Optimism as a Supported Network on InsureDAO

### DIFF
--- a/projects/insuredao/abi.json
+++ b/projects/insuredao/abi.json
@@ -100,5 +100,18 @@
     ],
     "stateMutability": "view",
     "type": "function"
+  },
+  "getPendingProtocolReward": {
+    "inputs": [],
+    "name": "getPendingProtocolReward",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
   }
 }

--- a/projects/insuredao/abi.json
+++ b/projects/insuredao/abi.json
@@ -100,18 +100,5 @@
     ],
     "stateMutability": "view",
     "type": "function"
-  },
-  "getPendingProtocolReward": {
-    "inputs": [],
-    "name": "getPendingProtocolReward",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
   }
 }

--- a/projects/insuredao/index.js
+++ b/projects/insuredao/index.js
@@ -10,7 +10,7 @@ const usdc = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
 const insure = "0xd83AE04c9eD29d6D3E6Bf720C71bc7BeB424393E";
 
 const Vault = "0x131fb74c6fede6d6710ff224e07ce0ed8123f144";
-const optimismVault = "0x2FaE8C7Edd26213cA1A88fC57B65352dbe353698"; //test by pika 
+const optimismVault = "0xCa1FeE73b00c221966E5f25226402146BdffE259";
 
 const VotingEscrow = "0x3dc07E60ecB3d064d20c386217ceeF8e3905916b";
 const vlINSURE = "0xA12ab76a82D118e33682AcB242180B4cc0d19E29";
@@ -18,11 +18,10 @@ const vlINSURE = "0xA12ab76a82D118e33682AcB242180B4cc0d19E29";
 const uni = "0x1b459aec393d604ae6468ae3f7d7422efa2af1ca";
 const uniStaking = "0xf57882cf186db61691873d33e3511a40c3c7e4da";
 
-
+// =================== GET ETH usdc BALANCES =================== //
 async function tvl(timestamp, block) {
   let balances = {};
 
-  // =================== GET usdc BALANCES =================== //
   const vusdcBalances = (
     await sdk.api.abi.call({
       target: Vault,
@@ -36,14 +35,14 @@ async function tvl(timestamp, block) {
   return balances;
 }
 
-// =================== GET 'optimism' usdc BALANCES =================== //
+// =================== GET Optimism usdc BALANCES =================== //
 async function optimismtvl(timestamp, block) {
   let balances = {};
 
   const vusdcBalances = (
     await sdk.api.abi.call({
       target: optimismVault,
-      abi: abi["getPendingProtocolReward"], //test 
+      abi: abi["valueAll"],
       chain: "optimism",
       block: block,
     })

--- a/projects/insuredao/index.js
+++ b/projects/insuredao/index.js
@@ -10,6 +10,8 @@ const usdc = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
 const insure = "0xd83AE04c9eD29d6D3E6Bf720C71bc7BeB424393E";
 
 const Vault = "0x131fb74c6fede6d6710ff224e07ce0ed8123f144";
+const optimismVault = "0x2FaE8C7Edd26213cA1A88fC57B65352dbe353698"; //test by pika 
+
 const VotingEscrow = "0x3dc07E60ecB3d064d20c386217ceeF8e3905916b";
 const vlINSURE = "0xA12ab76a82D118e33682AcB242180B4cc0d19E29";
 
@@ -26,6 +28,23 @@ async function tvl(timestamp, block) {
       target: Vault,
       abi: abi["valueAll"],
       chain: chain,
+      block: block,
+    })
+  ).output;
+  sdk.util.sumSingleBalance(balances, usdc, vusdcBalances);
+
+  return balances;
+}
+
+// =================== GET 'optimism' usdc BALANCES =================== //
+async function optimismtvl(timestamp, block) {
+  let balances = {};
+
+  const vusdcBalances = (
+    await sdk.api.abi.call({
+      target: optimismVault,
+      abi: abi["getPendingProtocolReward"], //test 
+      chain: "optimism",
       block: block,
     })
   ).output;
@@ -78,5 +97,8 @@ module.exports = {
     tvl: tvl,
     staking: staking,
     pool2: pool2,
+  },
+  optimism: {
+    tvl: optimismtvl,
   },
 };


### PR DESCRIPTION
This is an update to include TVL from InsureDAO's deployment on the Optimism
Previously InsureDAO was only deployed on the ETH Mainnet

====

Twitter Link:
Already be configured - this is an update

List of audit links if any:
Already be configured - this is an update

Website Link:
Already be configured - this is an update

Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):
Already be configured - this is an update

Current TVL:
$135.08k on ETH Mainnet
$200k      on Optimism

Chain:
Optimism - New
ETH Mainnet - Existing

Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)
Already be configured

Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
Already be configured

Short Description (to be shown on DefiLlama):
Already be configured

Token address and ticker if any:
Already be configured

Category (full list at https://defillama.com/categories) *Please choose only one:
Already be configured

Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):
Already be configured

forkedFrom (Does your project originate from another project):
Already be configured
