### PR TITLE
Add Optimism to PoolTogether TVL

### DIFF
--- a/projects/pooltogether/index.js
+++ b/projects/pooltogether/index.js
@@ -143,5 +143,5 @@ module.exports = {
   bsc: {
     tvl: bsc
   },
-  methodology: `TVL is the total quantity of tokens locked in poolTogether pools, on Ethereum, Polygon, Avalance, Optimism, Celo, and BSC`
+  methodology: `TVL is the total quantity of tokens locked in poolTogether pools, on Ethereum, Polygon, Avalanche, Optimism, Celo, and BSC`
 }

--- a/projects/pooltogether/index.js
+++ b/projects/pooltogether/index.js
@@ -34,6 +34,9 @@ const v4pools={
   ],
   avax:[
     ['0x46a51127c3ce23fb7ab1de06226147f446e4a857', '0x7437db21A0dEB844Fa64223e2d6Db569De9648Ff']
+  ],
+  optimism:[
+    ['0x625E7708f30cA75bfd92586e17077590C60eb4cD', '0x4ecB5300D9ec6BCA09d66bfd8Dcb532e3192dDA1']
   ]
 }
 
@@ -97,6 +100,10 @@ async function avax(timestamp, block, chainBlocks) {
   return getChainBalances([], 'avax', chainBlocks.avax, ()=>`avax:0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664`)
 }
 
+async function optimism(timestamp, block, chainBlocks) {
+  return getChainBalances([], 'optimism', chainBlocks.optimism, ()=>`optimism:0x7F5c764cBc14f9669B88837ca1490cCa17c31607`)
+}
+
 async function celo(timestamp, block, chainBlocks) {
   const transform = await transformCeloAddress()
   let allPrizePools = []
@@ -124,14 +131,17 @@ module.exports = {
   polygon: {
     tvl: polygon
   },
+  avalanche:{
+    tvl: avax
+  },
+  optimism:{
+    tvl: optimism
+  },
   celo: {
     tvl: celo
   },
   bsc: {
     tvl: bsc
   },
-  avalanche:{
-    tvl: avax
-  },
-  methodology: `TVL is the total quantity of tokens locked in poolTogether pools, on Ethereum, Polygon, Celo, and BSC`
+  methodology: `TVL is the total quantity of tokens locked in poolTogether pools, on Ethereum, Polygon, Avalance, Optimism, Celo, and BSC`
 }

--- a/projects/pooltogether/index.js
+++ b/projects/pooltogether/index.js
@@ -143,5 +143,5 @@ module.exports = {
   bsc: {
     tvl: bsc
   },
-  methodology: `TVL is the total quantity of tokens locked in poolTogether pools, on Ethereum, Polygon, Avalanche, Optimism, Celo, and BSC`
+  methodology: `TVL is the total quantity of tokens locked in PoolTogether pools on Ethereum, Polygon, Avalanche, Optimism, Celo, and BSC`
 }


### PR DESCRIPTION
##### Reasoning:
PoolTogether v4 was recently deployed on Optimism, this change is to add this data to the PoolTogether TVL. 
