### PR TITLE
Fix Burrow.cash TVL

### DIFF
--- a/projects/helper/near.js
+++ b/projects/helper/near.js
@@ -10,21 +10,26 @@ const endpoint = "https://rpc.mainnet.near.org"
 const tokenMapping = {
   'wrap.near': { name: 'near', decimals: 24, },
   'meta-pool.near': { name: 'staked-near', decimals: 24, },
+  'linear-protocol.near': { name: 'linear-protocol', decimals: 24, },
   'usn': { name: 'usn', decimals: 18, },
   'aurora': { name: 'ethereum', decimals: 18, },
   'token.skyward.near': { name: 'skyward-finance', decimals: 18, },
   'dbio.near': { name: 'debio-network', decimals: 18, },
   // 'hak.tkn.near': { name: '', }, // Hakuna matata
-  // 'meta-token.near': { name: '', }, // $Meta
+  'meta-token.near': { name: 'meta-near', decimals: 24 },
   'v3.oin_finance.near': { name: 'oin-finance', decimals: 8, },
   // 'gems.l2e.near': { name: '', }, // https://www.landtoempire.com/
   // 'nd.tkn.near': { name: '', },   // nearDog
   // 'gold.l2e.near': { name: '', }, // https://www.landtoempire.com/
   'token.v2.ref-finance.near': { name: 'ref-finance', decimals: 18, },
   // 'myriadcore.near': { name: '', },  // Myria
-  'a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.factory.bridge.near': { name: 'usd-coin', decimals: 18 },
-  'dac17f958d2ee523a2206206994597c13d831ec7.factory.bridge.near': { name: 'tether', decimals: 18 },
-  '2260fac5e5542a773aa44fbcfedf7c193bc2c599.factory.bridge.near': { name: 'wrapped-bitcoin', decimals: 18 }
+  '6b175474e89094c44da98b954eedeac495271d0f.factory.bridge.near': { name: 'dai', decimals: 18 },
+  'a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.factory.bridge.near': { name: 'usd-coin', decimals: 6 },
+  'dac17f958d2ee523a2206206994597c13d831ec7.factory.bridge.near': { name: 'tether', decimals: 6 },
+  '2260fac5e5542a773aa44fbcfedf7c193bc2c599.factory.bridge.near': { name: 'wrapped-bitcoin', decimals: 8 },
+  'aaaaaa20d9e0e2461697782ef11675f668207961.factory.bridge.near': { name: 'aurora-near', decimals: 18 },
+  'token.burrow.near': { name: 'burrow', decimals: 18 },
+  'token.paras.near': { name: 'paras', decimals: 18 },
 }
 
 async function view_account(account_id) {

--- a/projects/spin/index.js
+++ b/projects/spin/index.js
@@ -17,10 +17,6 @@ async function tvl() {
     delete ftCurrencies[FT_AURORA];
 
     let balances = await addTokenBalances(ftCurrencies, SPOT_PROJECT_CONTRACT);
-    
-    // NOTE: usd-coin's decimals set to 18 because previously this is the right way 
-    //       to adjust the decimals for coingecko
-    balances['usd-coin'] = balances['usd-coin'].shiftedBy(12);
 
     const spot_contract_state = await view_account(SPOT_PROJECT_CONTRACT);
     sumSingleBalance(balances, FT_NEAR, spot_contract_state['amount']);


### PR DESCRIPTION
- Fixing burrow.cash project by including `reserved` and adjusting for internal decimal computation
- Remove the temp-hack from spin project that was affected by extra decimals
- Include all missing token mapping into near library