### PR TITLE
Quickswap hallmarks

### DIFF
--- a/projects/quickswap/index.js
+++ b/projects/quickswap/index.js
@@ -7,4 +7,12 @@ module.exports = {
       polygon: 'https://polygon.furadao.org/subgraphs/name/quickswap'
     })('polygon')
   },
+    hallmarks:[
+    [1611917218, "Aavegotchi LM"],
+    [1619095618, "QUICK staking - Dragon's Liar launch"],
+    [1619611200, "DeFi season on Polygon PoS begun"],
+    [1623851400, "Iron Finance V1 collapse"],
+    [1651668418, "QUICK split by 1:1000"],
+    [1652481840, "QuickSwap’s GoDaddy Domain Hijack"]
+   ]
 }


### PR DESCRIPTION
- 29/01/2021 "Aavegotchi LM" 
https://aavegotchi.medium.com/ghst-token-live-on-matic-100k-usd-liquidity-migration-incentives-announced-faq-2590daa25d73

- 22/04/2021 "QUICK staking - Dragon's Liar launch"
https://twitter.com/QuickswapDEX/status/1385321673088376835?s=20

- 28/04/2021 "DeFi season on Polygon PoS begun"
https://blog.polygon.technology/the-defiforall-fund-a-150m-defi-fund-db34f66be3ec/

- 16/06/2021 "Iron Finance V1 collapse"
https://ironfinance.medium.com/iron-finance-post-mortem-17-june-2021-6a4e9ccf23f5

- 4/05/2022 "QUICK split by 1:1000"
https://twitter.com/QuickswapDEX/status/1521609968612487171

- 13/05/2022 "QuickSwap’s GoDaddy Domain Hijack"
https://twitter.com/QuickswapDEX/status/1525306033400188928