### PR TITLE
Add HomeCoin sdk adapter

### DIFF
--- a/projects/homecoin/abi.json
+++ b/projects/homecoin/abi.json
@@ -1,0 +1,40 @@
+{
+  "getContractData": {
+      "inputs": [],
+      "name": "getContractData",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    }
+}

--- a/projects/homecoin/index.js
+++ b/projects/homecoin/index.js
@@ -1,0 +1,62 @@
+const sdk = require("@defillama/sdk");
+const { sumTokens } = require("../helper/unwrapLPs");
+const abi = require("./abi.json");
+const BigNumber = require("bignumber.js");
+
+const HOME = "0xb8919522331C59f5C16bDfAA6A121a6E03A91F62";
+const USDC = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
+const HOME_START = 13313474
+
+/**
+ * This metric represents DeFiLlama's "base" definition of Total Value Locked. It includes
+ * only USDC balances in the protocol.
+ */
+const tvl = async (timestamp, ethBlock) => {
+  const balances = {};
+
+  await sumTokens(
+    balances,
+    [HOME].map((pool) => [USDC, pool]),
+    ethBlock
+  );
+
+  return balances;
+};
+
+/**
+ * This metric supplements the "base" `tvl()` metric, by additionally counting value that has
+ * been borrowed through the protocol.
+ *
+ * Homecoin considers the protocol's Total Value Locked to be the sum of `tvl()` and `borrowed()`.
+ *
+ */
+const borrowed = async (_, ethBlock) => {
+  const balances = {};
+
+  const totalBorrowed = new BigNumber(
+    (
+      await sdk.api.abi.call({
+        abi: abi.getContractData,
+        target: HOME,
+        ethBlock,
+      })
+    ).output[4]
+  );
+
+  sdk.util.sumSingleBalance(balances, USDC, String(totalBorrowed));
+
+  return balances;
+};
+
+module.exports = {
+  timetravel: true,
+  misrepresentedTokens: true,
+  start: HOME_START,
+  ethereum: {
+    tvl,
+    borrowed,
+  },
+  methodology:
+    "The base TVL metric counts only USDC liquidity in the protocol." +
+    "The Borrowed TVL component also counts home loans made by the protocol.",
+};


### PR DESCRIPTION
Add HomeCoin to the TVL listing by creating a new adaptor for the protocol.


##### Twitter Link:

https://twitter.com/homecoinfinance

##### List of audit links if any:

https://files.baconcoin.finance/bacon-protocol-full-audit.pdf

##### Website Link:

https://www.homecoin.finance

##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):

https://files.baconcoin.com/homecoin-icon-500.png

##### Current TVL:

6,747,567

##### Chain:

Ethereum

##### Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)

bacon-protocol-home

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

20520

##### Short Description (to be shown on DefiLlama):

A StableCoin backed by U.S. Homes

##### Token address and ticker if any:

HOME
0xb8919522331C59f5C16bDfAA6A121a6E03A91F62


##### Category (full list at https://defillama.com/categories) *Please choose only one:

CDP

##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):

N/A

##### forkedFrom (Does your project originate from another project):

N/A

##### methodology (what is being counted as tvl, how is tvl being calculated):

TVL is counted as the USDC in the protocol for lending plus the value of the home loans currently active on the protocol.

The base TVL metric counts only USDC liquidity in the protocol available for lending. The Borrowed TVL component  counts only the value of the home loans made by the protocol.

