### PR TITLE
Add Pools v2 to DeFiLlama TVL

### DIFF
--- a/projects/tracerdao/index.js
+++ b/projects/tracerdao/index.js
@@ -1,85 +1,54 @@
 const sdk = require("@defillama/sdk");
 const abi = require("./abi.json");
+const { sumTokens2 } = require('../helper/unwrapLPs')
+
+const USDC = "0xff970a61a04b1ca14834a43f5de4533ebddb5cc8";
+const chain = 'arbitrum'
 
 // Both v1 and v2 factories
-const factoryPoolContracts = ["0x98C58c1cEb01E198F8356763d5CbA8EB7b11e4E2", "0x3Feafee6b12C8d2E58c5B118e54C09F9273c6124"];
-const USDC = "0xff970a61a04b1ca14834a43f5de4533ebddb5cc8";
+const factoryPoolContractsConfig = [
+  {
+    fromBlock: 1009749,
+    contract: '0x98C58c1cEb01E198F8356763d5CbA8EB7b11e4E2',
+  },
+  {
+    fromBlock: 13387522,
+    contract: '0x3Feafee6b12C8d2E58c5B118e54C09F9273c6124',
+  },
+]
 
-const arbiTvl = async (chainBlocks) => {
-  const balances = {};
-  const numOfPoolsFirstFactory = (
-    await sdk.api.abi.call({
-      abi: abi.numPools,
-      target: factoryPoolContracts[0],
-      chain: "arbitrum",
-      block: chainBlocks["arbitrum"],
-    })
-  ).output;
-
-  for (let index = 0; index < numOfPoolsFirstFactory; index++) {
-    const pool = (
-      await sdk.api.abi.call({
-        abi: abi.pools,
-        target: factoryPoolContracts[0],
-        params: index,
-        chain: "arbitrum",
-        block: chainBlocks["arbitrum"],
-      })
-    ).output;
-
-    const poolBalance = (
-      await sdk.api.abi.call({
-        abi: 'erc20:balanceOf',
-        target: USDC,
-        params: pool,
-        chain: "arbitrum",
-        block: chainBlocks["arbitrum"],
-      })
-    ).output;
-
-    sdk.util.sumSingleBalance(balances, `arbitrum:${USDC}`, poolBalance);
+async function tvl(_, _b, { arbitrum: block }) {
+  let factories = []
+  if (!block) factories = factoryPoolContractsConfig.map(i => i.contract)
+  else {
+    factoryPoolContractsConfig.filter(i => block > i.fromBlock).forEach(i => factories.push(i.contract))
   }
+  const { output: numPools } = await sdk.api.abi.multiCall({
+    calls: factories.map(i => ({ target: i })),
+    abi: abi.numPools,
+    chain, block,
+  })
 
-  const numOfPoolsSecondFactory = (
-    await sdk.api.abi.call({
-      abi: abi.numPools,
-      target: factoryPoolContracts[1],
-      chain: "arbitrum",
-      block: chainBlocks["arbitrum"],
-    })
-  ).output;
+  const calls = []
+  numPools.forEach(i => {
+    for (let j = 0; j < +i.output; j++)
+      calls.push({ target: i.input.target, params: j })
+  })
 
-  for (let index = 0; index < numOfPoolsSecondFactory; index++) {
-    const pool = (
-      await sdk.api.abi.call({
-        abi: abi.pools,
-        target: factoryPoolContracts[1],
-        params: index,
-        chain: "arbitrum",
-        block: chainBlocks["arbitrum"],
-      })
-    ).output;
+  const { output: pools } = await sdk.api.abi.multiCall({
+    abi: abi.pools,
+    calls,
+    chain, block,
+  })
 
-    const poolBalance = (
-      await sdk.api.abi.call({
-        abi: 'erc20:balanceOf',
-        target: USDC,
-        params: pool,
-        chain: "arbitrum",
-        block: chainBlocks["arbitrum"],
-      })
-    ).output;
-
-    sdk.util.sumSingleBalance(balances, `arbitrum:${USDC}`, poolBalance);
-  }
-
-  return balances;
-};
+  const owners = pools.map(i => i.output)
+  return sumTokens2({ owners, chain, block, tokens: [USDC] })
+}
 
 module.exports = {
   misrepresentedTokens: true,
   arbitrum: {
-    tvl: arbiTvl,
+    tvl,
   },
   methodology:
     "We count liquidity on the Leveraged Pools through PoolFactory contract",

--- a/projects/tracerdao/index.js
+++ b/projects/tracerdao/index.js
@@ -1,26 +1,59 @@
 const sdk = require("@defillama/sdk");
 const abi = require("./abi.json");
 
-const factoryPoolContract = "0x98C58c1cEb01E198F8356763d5CbA8EB7b11e4E2";
+// Both v1 and v2 factories
+const factoryPoolContracts = ["0x98C58c1cEb01E198F8356763d5CbA8EB7b11e4E2", "0x3Feafee6b12C8d2E58c5B118e54C09F9273c6124"];
 const USDC = "0xff970a61a04b1ca14834a43f5de4533ebddb5cc8";
 
 const arbiTvl = async (chainBlocks) => {
   const balances = {};
-
-  const numOfPools = (
+  const numOfPoolsFirstFactory = (
     await sdk.api.abi.call({
       abi: abi.numPools,
-      target: factoryPoolContract,
+      target: factoryPoolContracts[0],
       chain: "arbitrum",
       block: chainBlocks["arbitrum"],
     })
   ).output;
 
-  for (let index = 0; index < numOfPools; index++) {
+  for (let index = 0; index < numOfPoolsFirstFactory; index++) {
     const pool = (
       await sdk.api.abi.call({
         abi: abi.pools,
-        target: factoryPoolContract,
+        target: factoryPoolContracts[0],
+        params: index,
+        chain: "arbitrum",
+        block: chainBlocks["arbitrum"],
+      })
+    ).output;
+
+    const poolBalance = (
+      await sdk.api.abi.call({
+        abi: 'erc20:balanceOf',
+        target: USDC,
+        params: pool,
+        chain: "arbitrum",
+        block: chainBlocks["arbitrum"],
+      })
+    ).output;
+
+    sdk.util.sumSingleBalance(balances, `arbitrum:${USDC}`, poolBalance);
+  }
+
+  const numOfPoolsSecondFactory = (
+    await sdk.api.abi.call({
+      abi: abi.numPools,
+      target: factoryPoolContracts[1],
+      chain: "arbitrum",
+      block: chainBlocks["arbitrum"],
+    })
+  ).output;
+
+  for (let index = 0; index < numOfPoolsSecondFactory; index++) {
+    const pool = (
+      await sdk.api.abi.call({
+        abi: abi.pools,
+        target: factoryPoolContracts[1],
         params: index,
         chain: "arbitrum",
         block: chainBlocks["arbitrum"],


### PR DESCRIPTION
**NOTE**

1. The protocol is usually listed within 24 hours of merging the PR
2. Please fill the form below  **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
3. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can  edit it there and put up a PR
4. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
5. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap

---
**This is an edit of the already-existing Tracer DAO TVL calculation on DeFiLlama**
---

### Justification/Reasons/Details

A couple of months ago, Tracer launched Perpetual Pools V2
- Details: https://www.tracer.finance/radar/v2-mechanism/
This update comes with the addition of a new factory. The current DeFiLlama TVL calculations only use the V1 factory.

This PR adds the calculation of the TVL (using the exact same methodology) for the V2 factory as well as the V1 factory.

- [x] Run `node test.js projects/tracerdao/index.js` successfully, with correct output.

Please let me know if there are any questions :)