### PR TITLE
Add support for DotOracle

### DIFF
--- a/projects/dotoracle.js
+++ b/projects/dotoracle.js
@@ -1,0 +1,18 @@
+const retry = require('./helper/retry');
+const axios = require('axios');
+
+async function fetch() {
+  const response = (
+    await retry(
+      async (bail) => await axios.get('https://bridge-mainnet.dotoracle.network/tvl')
+    )
+  ).data;
+
+  return response.tvl.tvl;
+}
+
+module.exports = {
+  timetravel: false,
+  methodology: "The DotOracle API endpoint fetches on-chain data listed at https://github.com/dotoracle/casper-contract-hash/blob/master/config.json from the supported EVM chains (Ethereum, BSC...) and Casper, then uses prices from Coingecko to aggregate total TVL.",
+  fetch,
+};


### PR DESCRIPTION
Twitter Link: 
https://twitter.com/DoTOracle

List of audit links if any: N/A

Website Link:
https://dotoracle.network/

Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):
https://drive.google.com/file/d/1vhtVrLm4TL7JT4sm4Up-8ldN-oocxQ6s/view?usp=sharing

Current TVL: 
641,644 $

Chain: Multichain

Coingecko ID (so your TVL can appear on Coingecko): 
dotoracle

Coinmarketcap ID (so your TVL can appear on Coinmarketcap): 
13014

Short Description (to be shown on DefiLlama): 
DotOracle is a real-time decentralized Oracle and Cross-chain bridge supported by multi-chains such as Polkadot, Ethereum, Binance Smart Chain, Fantom, Polygon, Avalanche, Tomochain, and Casper Network. It is currently the first cross-chain bridge on Casper Network and aims to support the Avalanche subnet

Token address and ticker if any: 
Address: 0xb57420fad6731b004309d5a0ec7c6c906adb8df7
Ticker: DTO

Category (full list at https://defillama.com/categories) *Please choose only one:
Bridge & Oracle

Oracle used (Chainlink/Band/API3/TWAP or any other that you are using): 
N/A


forkedFrom (Does your project originate from another project): 
N/A


methodology (what is being counted as tvl, how is tvl being calculated): 
The DotOracle API endpoint fetches on-chain data listed at https://github.com/dotoracle/casper-contract-hash/blob/master/config.json from the supported EVM chains (Ethereum, BSC...) and Casper, then uses prices from Coingecko to aggregate total TVL