### PR TITLE
Add celo for Gamma Strategies adapter

### DIFF
--- a/projects/visor/index.js
+++ b/projects/visor/index.js
@@ -11,7 +11,8 @@ const getTotalAmounts = require("./abis/getTotalAmounts.json");
 const GRAPH_URL = {
   ethereum: "https://api.thegraph.com/subgraphs/name/gammastrategies/gamma",
   polygon: "https://api.thegraph.com/subgraphs/name/gammastrategies/polygon",
-  optimism: "https://api.thegraph.com/subgraphs/name/gammastrategies/optimism"
+  optimism: "https://api.thegraph.com/subgraphs/name/gammastrategies/optimism",
+  celo: "https://api.thegraph.com/subgraphs/name/gammastrategies/celo",
 };
 
 const liquidityMiningQuery = gql`
@@ -67,6 +68,10 @@ async function tvlPolygon(timestamp, block, chainBlocks) {
 
 async function tvlOptimism(timestamp, block, chainBlocks) {
   return await tvlUniV3(timestamp, chainBlocks, "optimism");
+}
+
+async function tvlCelo(timestamp, block, chainBlocks) {
+  return await tvlUniV3(timestamp, chainBlocks, "celo");
 }
 
 /*Tokens staked in Visors*/
@@ -188,5 +193,8 @@ module.exports = {
   },
   optimism: {
     tvl: tvlOptimism,
-  }
+  },
+  celo: {
+    tvl: tvlCelo,
+  },
 };


### PR DESCRIPTION
Gamma Strategies just launched on celo (https://twitter.com/GammaStrategies/status/1555194679721082881).

Adding support for celo.