### PR TITLE
Update API for fetching HumbleSwap TVL

### DIFF
--- a/projects/humble/index.js
+++ b/projects/humble/index.js
@@ -13,7 +13,7 @@ async function tvl(){
 
     const data = response.data.find(p => p.id === 'H2')
 
-    return toUSDTBalances(data?.tvl);
+    return toUSDTBalances(data.tvl);
 }
 
 module.exports={

--- a/projects/humble/index.js
+++ b/projects/humble/index.js
@@ -6,14 +6,14 @@ async function tvl(){
     const response = (
         await retry(
             async () => await axios.get(
-                'https://yhnyufyj90.execute-api.us-east-1.amazonaws.com/prod/humble-tvl'
+                'https://free-api.vestige.fi/providers?currency=USD'
             )
         )
     )
 
-    const data = response.data
+    const data = response.data.find(p => p.id === 'H2')
 
-    return toUSDTBalances(data.tvl);
+    return toUSDTBalances(data?.tvl);
 }
 
 module.exports={

--- a/projects/humble/index.js
+++ b/projects/humble/index.js
@@ -17,6 +17,7 @@ async function tvl(){
 }
 
 module.exports={
+    timetravel: false,
     misrepresentedTokens:true,
     algorand:{
         tvl


### PR DESCRIPTION
Sorry this still isn't talking to the algorand chain directly; in a future update we may be able to do that for a part of the tvl.

This updates the api we previously used for tvl to one maintained by a group (Vestige) within the Algorand community; this will allow us to reduce our dependence on AWS.