### PR TITLE
Add Spice Farm SPI child project

### DIFF
--- a/projects/spice-farm-spi/index.js
+++ b/projects/spice-farm-spi/index.js
@@ -1,0 +1,39 @@
+const axios = require('axios');
+const SPICY_URL = 'https://spicya.sdaotools.xyz/api/rest';
+
+let _spicePools;
+
+const fetchPoolsAndReduce = async (timeAgg) => {
+  if (!_spicePools) _spicePools = axios(`${SPICY_URL}/PoolListAll?day_agg_start=${timeAgg.day_start}&hour_agg_start=${timeAgg.hour_start}`);
+  const spicyPools = (await _spicePools).data.pair_info;
+
+  return spicyPools.map(pool => pool.totalstakedfarmxtzspi).reduce((previous, current) => previous + current);
+}
+
+const calculateAgg = () => {
+  let day_start = new Date();
+  day_start.setDate(day_start.getDate() - 7);
+
+  let hour_start = new Date();
+  hour_start.setDate(hour_start.getDate() - 1);
+  
+  return { day_start: Math.floor(day_start.getTime() / 1000), hour_start: Math.floor(hour_start.getTime() / 1000) };
+}
+
+async function tvl() {
+  const timeAgg = calculateAgg();
+  const spicySpiFarmTvl = await fetchPoolsAndReduce(timeAgg);
+  
+  return {
+    tezos: spicySpiFarmTvl
+  };
+}
+
+module.exports = {
+    misrepresentedTokens: true,
+    timetravel: false,
+    methodology: `TVL counts the value of $SPI tokens staked in each pool's single-sided Spice Farm. Data is aggregated from: ${SPICY_URL}.`,
+    tezos: {
+      tvl,
+    }
+}


### PR DESCRIPTION
##### Twitter Link:
N/A

##### List of audit links if any:
N/A

##### Website Link:
https://docs.spicyswap.xyz/tutorial-basics/spice-farms/

##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):
![sfarms](https://user-images.githubusercontent.com/24196928/183315633-e0a237b5-265d-4061-bcca-9ee741639763.png)

##### Current TVL:
$23.63 k (total TVL of all Spice Farms ~$57,000

##### Chain:
Tezos

##### Short Description (to be shown on DefiLlama):
Single-sided SPI tokens can be staked to reward you with a split of the 0.1% trade fee applied on SpicySwap. 1/3 of this fee will be allocated towards single-sided Spice Farms. The difference in rewards is due to lower risks associated with single-sided Spice Farms.

##### Token address and ticker if any:
KT1CS2xKGHNPTauSh5Re4qE3N9PCfG5u4dPx, SPI

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Liquid Staking

