### PR TITLE
Fetch adapter for StreamFlow

### DIFF
--- a/projects/streamflow/index.js
+++ b/projects/streamflow/index.js
@@ -1,0 +1,22 @@
+/**
+ * Streamflow token distribution platform: https://streamflow.finance/.
+ * Endpoint for fetching TVL is open sourced at: https://github.com/streamflow-finance/analytics/
+ * 1. It uses CoinGecko to fetch token prices
+ * 2. Fetches data from Solana for 2 streamflow programs
+ * 3. The server multiplies the token price by the amount of tokens in the program and sums them up
+ */
+
+const axios = require("axios");
+const retry = require('../helper/retry');
+
+const url = "https://maximus.internal-streamflow.com/api/contracts/summary";
+
+async function fetch() {
+  var response = await retry(async () => await axios.get(url))
+
+  return response.data.total_value_locked;
+}
+
+module.exports = {
+  fetch,
+};


### PR DESCRIPTION
Hello DefiLlama Reviewers! Here's the info for StreamFlow:

##### Twitter Link:
https://twitter.com/streamflow_fi

##### List of audit links if any:
https://github.com/streamflow-finance/rust-sdk/blob/main/protocol_audit.pdf

##### Website Link:
https://streamflow.finance/

##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):
- https://static-content-23313.s3.amazonaws.com/logo.c4294b7c.png

##### Current TVL:
$112M

##### Chain:
Solana

##### Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)
- N/A

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
- N/A

##### Short Description (to be shown on DefiLlama):
Streamflow brings streamed token vesting and batch payments to Solana. Making token streams the ultimate way to distribute value.

##### Token address and ticker if any:
- N/A

##### Category (full list at https://defillama.com/categories) *Please choose only one:
[Services](https://defillama.com/protocols/Services)

##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):
- N/A

##### forkedFrom (Does your project originate from another project):
No

##### methodology (what is being counted as tvl, how is tvl being calculated):
 Endpoint for fetching TVL is open sourced at: https://github.com/streamflow-finance/analytics/
 1. It uses CoinGecko to fetch token prices
 2. Fetches data from Solana for 2 streamflow programs
 3. The server multiplies the token price by the amount of tokens in the program and sums them up