### PR TITLE
add optifi adapter

### DIFF
--- a/projects/optifi/index.js
+++ b/projects/optifi/index.js
@@ -1,0 +1,58 @@
+const { getTokenAccountBalance } = require("../helper/solana");
+const retry = require("../helper/retry");
+const { toUSDTBalances } = require('../helper/balances');
+const axios = require("axios");
+async function tvl() {
+    let url = "https://lambda.optifi.app/get_tvl?optifi_program_id="
+    let optifi_program_id = "optFiKjQpoQ3PvacwnFWaPUAqXCETMJSz2sz8HwPe9B"
+
+    const response = (
+        await retry(async () => await axios.get(url + optifi_program_id))
+    ).data;
+    let data = Object.values(response)
+    let userMarginAccountUsdcPubkey = []
+    userMarginAccountUsdcPubkey = data[0].userMarginAccountUsdcPubkey
+    let quoteTokenVault = []
+    quoteTokenVault = data[0].quoteTokenVault
+    let pcVault = []
+    pcVault = data[0].pcVault
+
+    let totalTvl = 0;
+
+    //1. user usdc balance in options dex margin account 
+    let usersMarginAccountUsdcBalance = 0;
+    for (let e of userMarginAccountUsdcPubkey) {
+        let balance = await getTokenAccountBalance(e)
+        usersMarginAccountUsdcBalance += balance
+    }
+    // console.log("usersMarginAccountUsdcBalance: " + usersMarginAccountUsdcBalance)
+
+    //2. user amm usdc balance
+    let userAmmUsdcBalance = 0;
+    for (let e of quoteTokenVault) {
+        let balance = await getTokenAccountBalance(e)
+        userAmmUsdcBalance += balance
+    }
+    // console.log("userAmmUsdcBalance: " + userAmmUsdcBalance)
+
+    //3.OptiFi serum market pcVault
+    let serumMarketPcVaultBalance = 0;
+    for (let e of pcVault) {
+        let balance = await getTokenAccountBalance(e)
+        serumMarketPcVaultBalance += balance
+    }
+    // console.log("serumMarketPcVaultBalance: " + serumMarketPcVaultBalance)
+
+    //totalTvl
+    totalTvl = usersMarginAccountUsdcBalance + userAmmUsdcBalance + serumMarketPcVaultBalance
+
+    return toUSDTBalances(totalTvl)
+}
+
+module.exports = {
+    timetravel: false,
+    methodology: "OptiFi uses the total of amm usdc balance, user usdc balance in the options margin account, and serum market pcVault to calculate TVL. The data doesn’t include Mango positions so there’s a difference from what is displayed on our app.",
+    solana: {
+        tvl: tvl,
+    }
+}


### PR DESCRIPTION
Twitter Link:
https://twitter.com/OptifiLabs

List of audit links if any:
 https://optifi.gitbook.io/optifi/security/audit-report

Website Link:
https://www.optifi.app/

Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders): https://drive.google.com/file/d/16m0gIp-HTlPOKSnkm1gS024uaUDP2U72/view?usp=sharing
Current TVL: 411.24 k
Chain: Solana
Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)
N/A

Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
N/A

Short Description (to be shown on DefiLlama):
OptiFi is an option DEX with portfolio margining and delta-neutral options market making vaults on Solana. The automatic options market maker (OMM) with a delta-neutral strategy allows all users to deposit USDC to generate yield while limiting delta risk by providing liquidity on OptiFi.

Token address and ticker if any:
N/A

Category (full list at https://defillama.com/categories) *Please choose only one:
Options

Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):
Pyth and Switchboard

forkedFrom (Does your project originate from another project):
N/A

methodology (what is being counted as tvl, how is tvl being calculated):
OptiFi uses the total of amm usdc balance, user usdc balance in the options margin account, and serum market pcVault to calculate TVL. The data doesn’t include Mango positions so there’s a difference from what is displayed on our app.