### PR TITLE
Add Dogechain to Atlantis Loans

### DIFF
--- a/projects/atlantisloans/index.js
+++ b/projects/atlantisloans/index.js
@@ -5,21 +5,21 @@ const { compoundExports } = require("../helper/compound");
 const comptroller = "0xE7E304F136c054Ee71199Efa6E26E8b0DAe242F3";
 const polygonComptroller = "0x8f85ee1c0a96734cb76870106dd9c016db6de09a"
 const avaxComptroller = "0x8f85ee1c0a96734cb76870106dd9c016db6de09a"
-const dcComptroller = "0xcd590a530f98730d7188e332dea83412fa3e4bf8"
+const dcComptroller = "0xA65722af4957CeF481Edb4cB255f804DD36E8aDc"
 
-const vaultStakingContract = "0x9aFc9877b1621e414E907F13A8d3ED9511bE03de";
+const vaultStakingContract_BNB = "0x9aFc9877b1621e414E907F13A8d3ED9511bE03de";
 const ATL = "0x1fD991fb6c3102873ba68a4e6e6a87B3a5c10271";
 
-const lpVaultStakingContract = "0xC7A5Bb6FCd603309D7a010de44dcBDe26fD45B58";
-const ALT_BUSD_CakeLP = "0xaa40dc3ec6ad76db3254b54443c4531e3dfe6bdb";
+const lpVaultStakingContract_BNB = "0xC7A5Bb6FCd603309D7a010de44dcBDe26fD45B58";
+const ALT_BUSD_CakeLP_BNB = "0xaa40dc3ec6ad76db3254b54443c4531e3dfe6bdb";
 
 module.exports = {
   misrepresentedTokens: true,
   timetravel: true,
   doublecounted: false,
   bsc: {
-    pool2: pool2(lpVaultStakingContract, ALT_BUSD_CakeLP, "bsc"),
-    staking: staking(vaultStakingContract, ATL, "bsc"),
+    pool2: pool2(lpVaultStakingContract_BNB, ALT_BUSD_CakeLP_BNB, "bsc"),
+    staking: staking(vaultStakingContract_BNB, ATL, "bsc"),
     ...compoundExports( comptroller,
       "bsc",
       "0x5A9A90983A369b6bB8F062f0AFe6219Ac01caF63",
@@ -40,13 +40,13 @@ module.exports = {
       "0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7"
     ),
   },
-  /*dogechain: {
+  dogechain: {
     ...compoundExports( dcComptroller,
       "dogechain",
       "0xbc46Dc817ce983CfD1B36cBc599031aCBEc2FDfe",
       "0xb7ddc6414bf4f5515b52d8bdd69973ae205ff101"
     ),
-  },*/
+  },
   methodology:
-    "Same as compound, we just get all the collateral (not borrowed money) on the lending markets",
+    "TVL is comprised of tokens deposited to the protocol as collateral, similar to Compound Finance and other lending protocols the borrowed tokens are not counted as TVL.",
 };


### PR DESCRIPTION
We have changed the comptroller address of Atlantis Loans on Dogechain.