### PR TITLE
Adding Hallmarks on Mean Finance

### DIFF
--- a/projects/meanfinance/index.js
+++ b/projects/meanfinance/index.js
@@ -106,4 +106,12 @@ module.exports = {
   optimism: getV2TvlObject('optimism'),
   polygon: getV2TvlObject('polygon'),
   arbitrum: getV2TvlObject('arbitrum'),
+   hallmarks: [
+    [1638850958, "V2 Beta launch on Optimism"],
+    [1643602958, "V2 full launch"],
+    [1646367758, "Deployment on Polygon"],
+    [1650082958, "Protocol is paused because a non-critical vulnerability"],
+    [1653366158, "V2 Relaunch"]
+    [1654057358, "OP launch bring more users into Optimism and benefit Mean"]
+  ]
 };

--- a/projects/meanfinance/index.js
+++ b/projects/meanfinance/index.js
@@ -111,7 +111,7 @@ module.exports = {
     [1643602958, "V2 full launch"],
     [1646367758, "Deployment on Polygon"],
     [1650082958, "Protocol is paused because a non-critical vulnerability"],
-    [1653366158, "V2 Relaunch"]
+    [1653366158, "V2 Relaunch"],
     [1654057358, "OP launch bring more users into Optimism and benefit Mean"]
   ]
 };


### PR DESCRIPTION
7/12/2021 "V2 Beta launch on Optimism"; https://twitter.com/mean_fi/status/1468245192260083716 
31/01/2022 "V2 full launch"; https://twitter.com/mean_fi/status/1488248678209007618 
04/03/2022 "Deployment on Polygon"; https://twitter.com/mean_fi/status/1499725947100143618 
16/04/2022 "Protocol is paused because a non-critical vulnerability"; https://mean-finance.medium.com/mean-vulnerability-disclosure-poisonous-decimals-40bc1f45b5ea 
24/05/2022 "V2 Relaunch" https://mean-finance.medium.com/mean-is-back-8a79de480314 
01/06/2022 "OP first drop bring more users into Optimism and benefit Mean" https://twitter.com/optimismFND/status/1531714854901391360