### PR TITLE
added suport for the new version of Prophet

### DIFF
--- a/projects/prophet/index.js
+++ b/projects/prophet/index.js
@@ -14,7 +14,8 @@ async function totalTvl(timestamp) {
     const [assetMetadata, exchangeRates, ...baseAABalances] = await Promise.all([
         fetchOswapAssets(),
         fetchOswapExchangeRates(),
-        fetchBaseAABalances(timestamp, "AXG7G57VBLAHF3WRN5WMQ53KQEQDRONC")
+        fetchBaseAABalances(timestamp, "AXG7G57VBLAHF3WRN5WMQ53KQEQDRONC"),
+        fetchBaseAABalances(timestamp, "A4EH5ZF5L4KEAHQIUSDEQGILHPEFJFPW")
     ])
 
     return {


### PR DESCRIPTION
A new version of Prophet Prediction Markets was rolled out this week, to support the new prediction markets based on the new version I added support to pull TVL from this new version. 