### PR TITLE
Add Inuswap TVL adapter

### DIFF
--- a/projects/inuswap/index.js
+++ b/projects/inuswap/index.js
@@ -1,0 +1,15 @@
+const {
+    getUniTVL
+} = require('../helper/unknownTokens')
+
+const chain = 'dogechain'
+
+module.exports = {
+    dogechain: {
+        tvl: getUniTVL({
+            chain,
+            useDefaultCoreAssets: true,
+            factory: '0xbDe460e12B5dcD955e70da8889754958113E988a',
+        }),
+    },
+}


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
Inuswap

##### Twitter Link:
https://twitter.com/inuswapfi

##### Website Link:
https://inuswap.fi/

##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):
https://inuswap.fi/logo.png

##### Current TVL:
6.48596586

##### Chain:
Dogechain

##### Short Description (to be shown on DefiLlama):
Inuswap aims to be the one-stop shop for decentralized trading on Dogechain.

##### Token address and ticker if any:
0x3D84ce3Da6Ca29f8a1e87fAe44e2840F2C3cBE85
INU

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Dexes

##### forkedFrom (Does your project originate from another project):
Uniswap

##### methodology (what is being counted as tvl, how is tvl being calculated):
Factory address (0xbDe460e12B5dcD955e70da8889754958113E988a) is used to find the LP pairs. TVL is equal to the liquidity on the AMM.
