### PR TITLE
Add hallmasks from milestone

### DIFF
--- a/projects/alpha-homora/index.js
+++ b/projects/alpha-homora/index.js
@@ -47,4 +47,11 @@ module.exports = {
     tvl: opTvl
   },
   start: 1602054167, // unix timestamp (utc 0) specifying when the project began, or where live data begins
+  hallmarks: [
+    [1621382400, "DeFi summer, Homora V1 TVL at its peak"], // May 19, 2021 00:00 UTC
+    [1626220800, "Upgrade to V2 on ETH"], // July 14, 2021 00:00 UTC
+    [1634774400, "Homora V2 on Avalanche"], // Oct 21, 2021 00:00 UTC
+    [1648080000, "Homora V2 on Fantom"], // Mar 24, 2022 00:00 UTC
+    [1660780800, "Homora V2 on Optimism"], // Aug 18, 2022 00:00 UTC
+  ]
 };


### PR DESCRIPTION
### Add hallmasks
- May 19, 2021: DeFi summer, Homora V1 TVL at its peak 

- July 14, 2021: Upgrade to V2 on ETH

- Oct 21, 2021: Homora V2 on Avalanche

- Mar 24, 2022: Homora V2 on Fantom

- Aug 18, 2022: Homora V2 on Optimism