### PR TITLE
added Bitgert Brise staking pseudo code

### DIFF
--- a/projects/bitgert/index.js
+++ b/projects/bitgert/index.js
@@ -1,9 +1,17 @@
 const { staking } = require('../helper/staking')
+const { sumTokens2, nullAddress } = require('../helper/unwrapLPs')
 
 module.exports = {
   bsc: {
-  tvl: () =>  ({}),
-    staking: staking('0xD578BF8Cc81A89619681c5969D99ea18A609C0C3', '0x8FFf93E810a2eDaaFc326eDEE51071DA9d398E83', 'bsc') + 
-    staking('0x8Ed91b2f3d9f6a5Ee426B4705F981090a7403795', '0x0000000000000000000000000000000000000000', 'bitgert')
+    tvl: () => ({}),
+    staking: staking('0xd578bf8cc81a89619681c5969d99ea18a609c0c3', '0x8FFf93E810a2eDaaFc326eDEE51071DA9d398E83', 'bsc'),
   },
+  bitgert: {
+    staking: async (_, _b, { bitgert: block }) => sumTokens2({
+      chain: 'bitgert',
+      block,
+      owner: '0x8Ed91b2f3d9f6a5Ee426B4705F981090a7403795',
+      tokens: [nullAddress],
+    })
+  }
 };

--- a/projects/bitgert/index.js
+++ b/projects/bitgert/index.js
@@ -3,6 +3,7 @@ const { staking } = require('../helper/staking')
 module.exports = {
   bsc: {
   tvl: () =>  ({}),
-    staking: staking('0xD578BF8Cc81A89619681c5969D99ea18A609C0C3', '0x8FFf93E810a2eDaaFc326eDEE51071DA9d398E83', 'bsc')
+    staking: staking('0xD578BF8Cc81A89619681c5969D99ea18A609C0C3', '0x8FFf93E810a2eDaaFc326eDEE51071DA9d398E83', 'bsc') + 
+    staking('0x8Ed91b2f3d9f6a5Ee426B4705F981090a7403795', '0x0000000000000000000000000000000000000000', 'bitgert')
   },
 };


### PR DESCRIPTION
Hello, Bitgert now has Brise staking directly on the Bitgert blockchain.
That staking is in the chains native currency, so no ERC20 tokens.
I don't know your prefered way of handling that, that's why I added a tiny pseudo code where the staking contract is in, but was not sure how to implement it in a clean way, also since staking is now available on BSC and Bitgert for the same token (Brise) I don't know how combining block numbers would look like.
Sorry for leaving the work to you, but i really don't know how a clean solution would be implemented here.
Thx a lot for your help, you have a great project!