### PR TITLE
Update Kashi-TVL adaptor

### DIFF
--- a/projects/sushiswap-kashi/index.js
+++ b/projects/sushiswap-kashi/index.js
@@ -1,20 +1,16 @@
-const {kashiLending, kashiLendingFantom} = require('./kashi-lending.js')
+const { kashiLending } = require("./kashi-lending.js");
 
-const modulesToExport = {}
-const kashi_chains = ['ethereum', //'polygon', 
-    'bsc', 'fantom', //'xdai', 
-    'arbitrum']
-    
-kashi_chains.forEach(chain => {
-    modulesToExport[chain]={
-        tvl: kashiLending(chain, false),
-        borrowed: kashiLending(chain, true),
-    }
-})
-// Fantom: use a more precise method correctly unwrapping wrapped assets
-modulesToExport['fantom'].tvl = kashiLendingFantom
+const modulesToExport = {};
+const kashi_chains = ["ethereum", "polygon", "bsc", "avax", "arbitrum"];
+
+kashi_chains.forEach((chain) => {
+  modulesToExport[chain] = {
+    tvl: kashiLending(chain, false),
+    borrowed: kashiLending(chain, true),
+  };
+});
 
 module.exports = {
-    misrepresentedTokens: true,
-    ...modulesToExport,
-}
+  misrepresentedTokens: true,
+  ...modulesToExport,
+};

--- a/projects/sushiswap-kashi/kashi-lending.js
+++ b/projects/sushiswap-kashi/kashi-lending.js
@@ -138,5 +138,5 @@ function kashiLending(chain, borrowed) {
 
 module.exports = {
   kashiLending,
-  methodology: `TVL of Sushiswap Kashi lending consists of the tokens available to lend and the ones used as collateral, tokens borrowed are not counted to avoid inflating TVL through cycled lending.`,
+  methodology: `TVL of Sushiswap Kashi lending consists of the tokens available to borrow and the ones used as collateral, tokens borrowed are not counted to avoid inflating TVL through cycled lending.`,
 };

--- a/projects/sushiswap-kashi/kashi-lending.js
+++ b/projects/sushiswap-kashi/kashi-lending.js
@@ -1,166 +1,142 @@
 const sdk = require("@defillama/sdk");
 const { request, gql } = require("graphql-request");
-const { sumTokens, sumTokens2 } = require('../helper/unwrapLPs')
-const { getChainTransform } = require('../helper/portedTokens')
+const { getChainTransform } = require("../helper/portedTokens");
+const { BigNumber } = require("ethers");
 
-const { getBlock } = require('../helper/getBlock')
-
-const mimAddress = {
-  ethereum: "0x99d8a9c45b2eca8864373a26d1459e3dff1e17f3",
-  bsc: "0xfe19f0b51438fd612f6fd59c1dbb3ea319f433ba",
-  fantom: "0x82f0b8b456c1a451378467398982d4834b6829c1",
-  arbitrum: "0xfea7a6a0b346362bf88a9e4a88416b77a57d6c2a",
-} // MIM uses kashi for unissued tokens, so these must be removed
-
-// https://thegraph.com/hosted-service/subgraph/sushiswap/bentobox
 const graphUrls = {
-  'ethereum': 'https://api.thegraph.com/subgraphs/name/sushiswap/bentobox',
-  'polygon': 'https://api.thegraph.com/subgraphs/name/sushiswap/matic-bentobox',
-  'fantom': 'https://api.thegraph.com/subgraphs/name/sushiswap/fantom-bentobox',
-  'bsc': 'https://api.thegraph.com/subgraphs/name/sushiswap/bsc-bentobox',
-  'xdai': 'https://api.thegraph.com/subgraphs/name/sushiswap/xdai-bentobox',
-  'arbitrum': 'https://api.thegraph.com/subgraphs/name/sushiswap/arbitrum-bentobox'
-}
+  ethereum: "https://api.thegraph.com/subgraphs/name/sushi-labs/kashi-ethereum",
+  polygon: "https://api.thegraph.com/subgraphs/name/sushi-labs/kashi-polygon",
+  arbitrum: "https://api.thegraph.com/subgraphs/name/sushi-labs/kashi-arbitrum",
+  bsc: "https://api.thegraph.com/subgraphs/name/sushi-labs/kashi-bsc",
+  avax: "https://api.thegraph.com/subgraphs/name/sushiswap/kashi-avalanche",
+};
 
-const bentoboxQuery = gql`
-query get_bentoboxes($block: Int, $tokensSkip: Int) {
-   bentoBoxes(
-     first: 100, 
-      # block: { number: $block } 
-    ) {
-     id
-     tokens (
-         skip: $tokensSkip
-         first: 1000
-         orderBy: totalSupplyBase
-         orderDirection: desc
-     ) {
-       id
-       symbol
-       name
-       decimals
-       totalSupplyBase 
-       totalSupplyElastic
-     }
-     kashiPairs(first:1000) {
-       id
-       bentoBox {
-         id
-       }
-       asset {
-         id
-       }
-       symbol
-       collateral {
-         id
-       }
-       totalAssetBase
-       totalBorrowBase
-       totalBorrowElastic
-       totalCollateralShare
-     }
-     totalKashiPairs
-     totalTokens
-   }
- } 
-`
+const bentoboxes = {
+  ethereum: "0xF5BCE5077908a1b7370B9ae04AdC565EBd643966",
+  polygon: "0x0319000133d3AdA02600f0875d2cf03D442C3367",
+  arbitrum: "0x74c764D41B77DBbb4fe771daB1939B00b146894A",
+  bsc: "0xF5BCE5077908a1b7370B9ae04AdC565EBd643966",
+  avax: "0x0711b6026068f736bae6b213031fce978d48e026",
+};
+
+const toAmountAbi = {
+  inputs: [
+    { internalType: "contract IERC20", name: "token", type: "address" },
+    { internalType: "uint256", name: "share", type: "uint256" },
+    { internalType: "bool", name: "roundUp", type: "bool" },
+  ],
+  name: "toAmount",
+  outputs: [{ internalType: "uint256", name: "amount", type: "uint256" }],
+  stateMutability: "view",
+  type: "function",
+};
+
+const kashiQuery = gql`
+  query get_pairs($block: Int) {
+    kashiPairs(block: { number: $block }, first: 1000) {
+      id
+      asset {
+        id
+      }
+      collateral {
+        id
+      }
+      totalAsset {
+        elastic
+      }
+      totalBorrow {
+        elastic
+      }
+      totalCollateralShare
+    }
+  }
+`;
 
 function kashiLending(chain, borrowed) {
   return async (timestamp, ethBlock, chainBlocks) => {
-    // Retrieve bento boxes tokens held in contract
-    const boxTokens = []
-    const graphUrl = graphUrls[chain]
-    const block = chainBlocks[chain]
-    const transform = await getChainTransform(chain)
+    const balances = {};
+    const graphUrl = graphUrls[chain];
+    const block = chainBlocks[chain] - 100; //subgraphs can be late by few seconds/minutes
+    const transform = await getChainTransform(chain);
 
-    // Query graphql endpoint and add tokenAndOwner to list
-    const { bentoBoxes } = await request(
-      graphUrl,
-      bentoboxQuery,
-      { block, tokensSkip: 0 }
-    )
+    // Query graphql endpoint
+    const { kashiPairs } = await request(graphUrl, kashiQuery, {
+      block,
+    });
 
-    // Sum all tokens
-    const balances = {}
-    // Filtering out causing null issues on bsc
-    const filteredOutTokens = ['0x87b008e57f640d94ee44fd893f0323af933f9195']
-    // MIM uses kashi for unissued tokens, so these must be removed
-    if (mimAddress[chain]) filteredOutTokens.push(mimAddress[chain].toLowerCase())
-    const tokensAndOwners = []
-
-    bentoBoxes.forEach(async box => {
-      if (box.totalTokens > box.tokens.length) {
-        throw (`More tokens (${box.totalTokens}) in bento box than returned by graphql api, probably over the 1000 tokens limit`)
-      }
-      if (box.totalKashiPairs > box.kashiPairs.length) {
-        throw (`More kashi pairs (${box.totalKashiPairs}) in bento box than returned by graphql api, probably over the 1000 limit`)
-      }
-      box.tokens.forEach(token => {
-        if (filteredOutTokens.includes(token.id)) return;
-        tokensAndOwners.push([token.id, box.id])
+    await Promise.all(
+      kashiPairs.map(async (pair) => {
+        if (
+          pair.asset.id === "0x0000000000000000000000000000000000000000" ||
+          pair.collateral.id === "0x0000000000000000000000000000000000000000"
+        ) {
+          return;
+        }
+        if (borrowed) {
+          if (BigNumber.from(pair.totalBorrow.elastic).lte(0)) {
+            return;
+          }
+          //count tokens borrowed
+          const shares = pair.totalBorrow.elastic;
+          //convert shares to amount
+          const amount = (
+            await sdk.api.abi.call({
+              abi: toAmountAbi,
+              chain: chain,
+              target: bentoboxes[chain],
+              params: [pair.asset.id, shares, false],
+              block: block,
+            })
+          ).output;
+          sdk.util.sumSingleBalance(balances, transform(pair.asset.id), amount);
+        } else {
+          if (
+            BigNumber.from(pair.totalAsset.elastic).lte(0) &&
+            BigNumber.from(pair.totalAsset.elastic).lte(0)
+          ) {
+            return;
+          }
+          //count tokens not borrowed + collateral
+          const assetShares = pair.totalAsset.elastic;
+          const collateralShares = pair.totalCollateralShare;
+          //convert shares to amount
+          const assetAmount = (
+            await sdk.api.abi.call({
+              abi: toAmountAbi,
+              chain: chain,
+              target: bentoboxes[chain],
+              params: [pair.asset.id, assetShares, false],
+              block: block,
+            })
+          ).output;
+          const collateralAmount = (
+            await sdk.api.abi.call({
+              abi: toAmountAbi,
+              chain: chain,
+              target: bentoboxes[chain],
+              params: [pair.collateral.id, collateralShares, false],
+              block: block,
+            })
+          ).output;
+          sdk.util.sumSingleBalance(
+            balances,
+            transform(pair.asset.id),
+            assetAmount
+          );
+          sdk.util.sumSingleBalance(
+            balances,
+            transform(pair.collateral.id),
+            collateralAmount
+          );
+        }
       })
-      box.kashiPairs.forEach(pair => {
-        if (filteredOutTokens.includes(pair.asset.id)) return;
-        sdk.util.sumSingleBalance(balances, transform(pair.asset.id), pair.totalBorrowElastic)
-      })
-    })
+    );
 
-    if (borrowed) return balances
-    return sumTokens2({ tokensAndOwners, chain, block, })
-  }
-}
-
-// Handle Kashi Lending on fantom differently for unwrapping correctly most important tokens like yvWFTM and wsSPA
-const { handleYearnTokens } = require("../creditum/helper.js");
-const { transformFantomAddress } = require("../helper/portedTokens");
-async function kashiLendingFantom(timestamp, ethBlock, chainBlocks) {
-  const transform = await transformFantomAddress()
-  const chain = "fantom"
-  const block = await getBlock(timestamp, chain, chainBlocks, false)
-  const box = "0xF5BCE5077908a1b7370B9ae04AdC565EBd643966"
-  const wsSPA = "0x89346b51a54263cf2e92da79b1863759efa68692";
-  const spa = "fantom:0x5602df4a94eb6c680190accfa2a475621e0ddbdc";
-
-  const boxTokens = [
-    "0x82f0b8b456c1a451378467398982d4834b6829c1", // mim
-    "0x21be370d5312f44cb42ce377bc9b8a0cef1a4c83", //wftm
-    "0xbe41772587872a92184873d55b09c6bb6f59f895", // mars
-    "0x8866414733f22295b7563f9c5299715d2d76caf4", //curve dai-usdc
-    "0xd4f94d0aaa640bbb72b5eec2d85f6d114d81a88e", //g3crv
-    "0x425ccc1390bed338d98daff91ff0f03738b534ef", //fake mim
-    "0xf710d90a1bd702daea619eebbe876e7085c2a1df", //moo g3crv
-    "0x2126be94443334fd71428dba3c638fb722d1838e", // spa
-    "0x0dec85e74a92c52b7f708c4b10207d9560cefaf0", //yvWFTM
-    "0x89346b51a54263cf2e92da79b1863759efa68692", //wsSPA
-  ]
-  const balances = {}
-  await sumTokens(balances, boxTokens.map(t => [t, box]), block, chain, addr => `${chain}:${addr}`)
-  await handleYearnTokens(
-    balances,
-    [
-      "0x0dec85e74a92c52b7f708c4b10207d9560cefaf0",
-    ],
-    box,
-    block,
-    chain,
-    transform
-  );
-  delete balances["fantom:0x0dec85e74a92c52b7f708c4b10207d9560cefaf0"];
-  const sSPA = (await sdk.api.abi.call({
-    target: wsSPA,
-    params: [balances["fantom:0x89346b51a54263cf2e92da79b1863759efa68692"]],
-    abi: { "inputs": [{ "internalType": "uint256", "name": "_amount", "type": "uint256" }], "name": "wOHMTosOHM", "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }], "stateMutability": "view", "type": "function" },
-    block,
-    chain: "fantom"
-  })).output;
-  balances[spa] = sSPA;
-  delete balances["fantom:0x89346b51a54263cf2e92da79b1863759efa68692"];
-  delete balances[chain + ":" + mimAddress[chain]]
-  return balances
+    return balances;
+  };
 }
 
 module.exports = {
-  kashiLendingFantom,
   kashiLending,
-  methodology: `TVL of Sushiswap Kashi lending consists of the tokens held in Sushiswap Bentoboxes contracts - one bentobox per chain - and borrows = supply - tvl`
-}
+  methodology: `TVL of Sushiswap Kashi lending consists of the tokens available to lend and the ones used as collateral, tokens borrowed are not counted to avoid inflating TVL through cycled lending.`,
+};


### PR DESCRIPTION
**NOTE**

1. The protocol is usually listed within 24 hours of merging the PR
2. Please fill the form below  **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
3. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can  edit it there and put up a PR
4. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
5. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap

---
Update of the Kashi adaptor to display only Kashi TVL and not Bentobox + Kashi TVL.

Since Kashi is a money market, the methodology used is the same as the AAVE one:

=> TVL of Sushiswap Kashi lending consists of the tokens available to borrow and the ones used as collateral, tokens borrowed are not counted to avoid inflating TVL through cycled lending.

The data fetched is 100 block late on current block as subgraphs used are sometime late by few minutes which cause the tests to throw an error.