### PR TITLE
integrate eris on terra classic

### DIFF
--- a/projects/eris-protocol/index.js
+++ b/projects/eris-protocol/index.js
@@ -1,16 +1,36 @@
 const axios = require("axios");
-const { queryContract, } = require('../helper/terra')
+const { queryContract } = require("../helper/terra");
+
+// For testing run
+// node test.js projects/eris-protocol/index.js
 
 const contracts = {
   terra2_hub:
     "terra10788fkzah89xrdm27zkj5yvhj9x3494lxawzm5qq3vvxcqz2yzaqyd3enk",
+  terra_hub: "terra1zmf49p3wl7ck2cwer7kghzumfpwhfqk6x893ah",
 };
 
 async function terra2Tvl() {
-  const res = await queryContract({ isTerra2: true, contract: contracts.terra2_hub, data: { state: { }}})
+  const res = await queryContract({
+    isTerra2: true,
+    contract: contracts.terra2_hub,
+    data: { state: {} },
+  });
 
   return {
     "terra-luna-2": +res.tvl_uluna / 1e6,
+  };
+}
+
+async function terraTvl() {
+  const res = await queryContract({
+    isTerra2: false,
+    contract: contracts.terra_hub,
+    data: { state: {} },
+  });
+
+  return {
+    "terra-luna": +res.tvl_uluna / 1e6,
   };
 }
 
@@ -19,4 +39,5 @@ module.exports = {
   misrepresentedTokens: false,
   methodology: "Liquid Staking and Arbitrage Protocol",
   terra2: { tvl: terra2Tvl },
+  terra: { tvl: terraTvl },
 };

--- a/projects/helper/terra.js
+++ b/projects/helper/terra.js
@@ -69,6 +69,13 @@ async function lpMinter(token, block, { isTerra2 = false } = {}) {
 async function queryContract({ contract, isTerra2 = false, data }) {
   if (typeof data !== 'string') data = JSON.stringify(data)
   data = Buffer.from(data).toString('base64')
+
+  if(!isTerra2) {
+    let path = `${getEndpoint(isTerra2)}/terra/wasm/v1beta1/contracts/${contract}/store?query_msg=${data}`;
+    let result = await axios.get(path)
+    return (result).data.query_result
+  }
+
   return (await axios.get(`${getEndpoint(isTerra2)}/cosmwasm/wasm/v1/contract/${contract}/smart/${data}`)).data.data
 }
 


### PR DESCRIPTION
Integrated our Terra Classic deployment.

Also changed the terra.js helper so that Terra Classic is supported for the queries. Different path should be used for these queries, as it does not exist on Terra Classic. We are the only protocol using isTerra2: false as far as I can see.


```
--- terra2 ---
terra-luna-2              136.64 k
Total: 136.64 k

--- terra ---
terra-luna                180.81 k
Total: 180.81 k

--- tvl ---
terra-luna                180.81 k
terra-luna-2              136.64 k
Total: 317.46 k

------ TVL ------
terra2                    136.64 k
terra                     180.81 k

total                    317.46 k
```