### PR TITLE
Add Ease protocol

### DIFF
--- a/projects/ease/index.js
+++ b/projects/ease/index.js
@@ -1,0 +1,47 @@
+const sdk = require('@defillama/sdk');
+const axios = require("axios");
+
+const VAULT_LIST_URL = 'https://devapi.ease.org/api/v1/vaults';
+
+const RCA_SHIELD = {
+  abis: {
+    uBalance: {
+      constant: true,
+      inputs: [],
+      name: "uBalance",
+      outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+      payable: false,
+      stateMutability: "view",
+      type: "function",
+    },
+  },
+};
+
+async function tvl(timestamp, block, chainBlocks) {
+
+  let resp = await axios.get(VAULT_LIST_URL);
+  let vaults = resp.data
+  const balances = {};
+
+  for(let i = 0; i < vaults.length; i++) {
+    let vs = vaults[i];
+
+    const collateralBalance = (await sdk.api.abi.call({
+      abi: RCA_SHIELD.abis.uBalance,
+      target: vs.address,
+      params: [],
+      block,
+    })).output;
+    await sdk.util.sumSingleBalance(balances, vs.token.address, collateralBalance);
+  }
+  return balances;
+}
+
+module.exports = {
+  misrepresentedTokens: false,
+  //TODO: get exact number
+  start: 14000000,
+  ethereum:{
+    tvl
+  },
+}; 

--- a/projects/ease/index.js
+++ b/projects/ease/index.js
@@ -1,8 +1,15 @@
 const sdk = require('@defillama/sdk');
 const axios = require("axios");
+const { stakings } = require("../helper/staking");
 
 const VAULT_LIST_URL = 'https://devapi.ease.org/api/v1/vaults';
-
+const EASE = "0xEa5eDef1287AfDF9Eb8A46f9773AbFc10820c61c";
+const STAKING_CONTRACTS = [
+  //BRIBE_POT
+ "0xEA5EdeF17C9be57228389962ba50b98397f1E28C",
+  //GV_EASE
+  "0xEa5edeF1eDB2f47B9637c029A6aC3b80a7ae1550",
+];
 const RCA_SHIELD = {
   abis: {
     uBalance: {
@@ -18,14 +25,12 @@ const RCA_SHIELD = {
 };
 
 async function tvl(timestamp, block, chainBlocks) {
-
   let resp = await axios.get(VAULT_LIST_URL);
   let vaults = resp.data
   const balances = {};
 
   for(let i = 0; i < vaults.length; i++) {
     let vs = vaults[i];
-
     const collateralBalance = (await sdk.api.abi.call({
       abi: RCA_SHIELD.abis.uBalance,
       target: vs.address,
@@ -42,6 +47,7 @@ module.exports = {
   //TODO: get exact number
   start: 14000000,
   ethereum:{
-    tvl
+    tvl,
+    staking: stakings(STAKING_CONTRACTS, EASE),
   },
 }; 


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
Ease.org DeFi Cover

##### Twitter Link:
https://twitter.com/EaseDeFi

##### List of audit links if any:
https://github.com/EaseDeFi/Audits/blob/main/Dedaub_RCA_Audit.pdf
https://github.com/EaseDeFi/gvToken/tree/main/audits

##### Website Link:
https://ease.org/

##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):
https://ease.org/wp-content/uploads/2022/03/logo.png

##### Current TVL:
-

##### Chain:
Ethereum

##### Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)
ease

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
WIP

##### Short Description (to be shown on DefiLlama):
Ease is a decentralized coverage protocol that enables users to protect their DeFi tokens without a premium while earning compounding yield.

##### Token address and ticker if any:
0xEa5eDef1287AfDF9Eb8A46f9773AbFc10820c61c - $EASE

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Insurance

##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):
-

##### forkedFrom (Does your project originate from another project):
-

##### methodology (what is being counted as tvl, how is tvl being calculated):
Tokens that users deposit into our contracts are being counted as TVL.
Additionally, if users stake our $EASE token into our bribing contract or $gvEASE contract, we count that as TVL.
