### PR TITLE
Added BSC Bridge exploit hallmark to Geist Finance

### DIFF
--- a/projects/geist/index.js
+++ b/projects/geist/index.js
@@ -32,4 +32,7 @@ module.exports = {
     staking: staking(stakingContract, GEIST, "fantom"),
     pool2: pool2(stakingContractPool2, GEIST_WFTM_spLP, "fantom"),
   },
+  hallmarks:[
+    [1665090175, "BSC Bridge exploit"]
+  ],
 };


### PR DESCRIPTION
Added BSC Bridge exploit hallmark to Geist Finance's adapter.

Used the timestamp from the deposit transaction : https://ftmscan.com/tx/0xe9e9e1371809f072ba43a292c8bfed4a070366e416d5f04bfc4f6d23b1c524c1