### PR TITLE
[ferro] add 2FER pool

### DIFF
--- a/projects/ferro/index.js
+++ b/projects/ferro/index.js
@@ -1,20 +1,23 @@
 const { sumTokens2 } = require('../helper/unwrapLPs')
 
-const threeFerPoolAddress = '0xe8d13664a42B338F009812Fa5A75199A865dA5cD';
+const SWAP_3FER_ADDR = '0xe8d13664a42B338F009812Fa5A75199A865dA5cD';
+const SWAP_2FER_ADDR = '0xa34C0fE36541fB085677c36B4ff0CCF5fa2B32d6';
 const chain = 'cronos'
 
 const tokens = {
   // DAI
   "0xF2001B145b43032AAF5Ee2884e456CCd805F677D": [
-    threeFerPoolAddress,
+    SWAP_3FER_ADDR,
   ],
   // USDC
   "0xc21223249CA28397B4B6541dfFaEcC539BfF0c59": [
-    threeFerPoolAddress,
+    SWAP_3FER_ADDR,
+    SWAP_2FER_ADDR,
   ],
   // USDT
   "0x66e428c3f67a68878562e79A0234c1F83c208770": [
-    threeFerPoolAddress,
+    SWAP_3FER_ADDR,
+    SWAP_2FER_ADDR,
   ],
 };
 


### PR DESCRIPTION
adding `2FER` pool for [ferro integration](https://github.com/DefiLlama/DefiLlama-Adapters/pull/3157)

---

##### Name (to be shown on DefiLlama):

Ferro

##### Twitter Link:

https://twitter.com/FerroProtocol

##### List of audit links if any:

https://docs.ferroprotocol.com/extras/security

##### Website Link:

https://ferroprotocol.com/

##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):

![ferro](https://user-images.githubusercontent.com/106642922/177089290-845b9c4d-79a9-433d-869b-de6418d662a2.svg)

##### Current TVL:

101.5M

##### Chain:

Cronos

##### Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)

ferro

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

20716

##### Short Description (to be shown on DefiLlama):

a stableswap AMM protocol on Cronos

##### Token address and ticker if any:

0x39bC1e38c842C60775Ce37566D03B41A7A66C782

##### Category (full list at https://defillama.com/categories) *Please choose only one:

Dexes

##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):


##### forkedFrom (Does your project originate from another project):

Saddle

##### methodology (what is being counted as tvl, how is tvl being calculated):

sum of ferro stablecoin pool contracts balance