### PR TITLE
Remove dead Aperture Terra TVL code; add Aperture's AVAX TVL calculation.

### DIFF
--- a/projects/aperture/abi.json
+++ b/projects/aperture/abi.json
@@ -1,0 +1,52 @@
+{
+    "getLeverage": {
+      "inputs": [],
+      "name": "leverageLevel",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    "getEquityETHValue": {
+      "inputs": [],
+      "name": "getEquityETHValue",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    "getETHPx": {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "oracle",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "getETHPx",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    }
+}


### PR DESCRIPTION
Aperture has recently launched a crab-market leveraged farming strategy on AVAX; see https://medium.com/@aperturefinance/introducing-apertures-crab-market-leveraged-farming-strategy-1b2e32139a89 for details.

This PR includes:
(1) Code that calculates Aperture's TVL on AVAX;
(2) Cleans up Aperture's Terra TVL calculation code.  Currently one of Aperture's Terra strategy's dependency, Mirror Protocol, is frozen due to lack of oracle source, so the list of open positions won't change (it's not possible to open additional positions); therefore, `updatePositionsList()` has been deleted.