### PR TITLE
Update for DFX v2 pools.

### DIFF
--- a/projects/dfx/contracts.json
+++ b/projects/dfx/contracts.json
@@ -39,6 +39,38 @@
       "address": "0x57BC10876fEbdC57f0ABb8C82ffAE600eEcc03A2",
       "token": "0xC08512927D12348F6620a698105e1BAac6EcD911",
       "currency": "GYEN"
+    },
+	{
+      "address": "0xF3d7AA346965656E7c65FB4135531e0C2270AF83",
+      "token": "0xcadc0acd4b445166f12d2c07eac6e2544fbe2eef"
+    },
+    {
+      "address": "0x9a6c7ae10eb82a0d7dc3c296ecbc2e2bdc53e80b",
+      "token": "0x70e8de73ce538da2beed35d14187f6959a8eca96"
+    },
+    {
+      "address": "0x46161158b1947d9149e066d6d31af1283b2d377c",
+      "token": "0xebf2096e01455108badcbaf86ce30b6e5a72aa52"
+    },
+    {
+      "address": "0x764a5A29f982D3513e76fe07dF2034821fBdba72",
+      "token": "0xda446fad08277b4d2591536f204e018f32b6831c",
+      "currency": "NZDS"
+    },
+    {
+      "address": "0xcF3c8f51DE189C8d5382713B716B133e485b99b7",
+      "token": "0x2c537e5624e4af88a7ae4060c022609376c8d0eb",
+      "currency": "TRYb"
+    },
+    {
+      "address": "0x477658494c3541ba272a7120176d77674a0183ba",
+      "token": "0x1aBaEA1f7C830bD89Acc67eC4af516284b1bC33c",
+      "currency": "EUROC"
+    },
+	{
+      "address": "0x63cb0f59b7e67c7d4cb96214ca456597d85c587d",
+      "token": "0xC08512927D12348F6620a698105e1BAac6EcD911",
+      "currency": "GYEN"
     }
   ],
   "polygon": [
@@ -64,6 +96,31 @@
     },
     {
       "address": "0x931d6a6cc3f992beee80a1a14a6530d34104b000",
+      "token": "0xeafe31cd9e8e01c8f0073a2c974f728fb80e9dce",
+      "currency": "NZDs"
+    },
+	{
+      "address": "0xbe9fa3E654A1bf8fe740E9d930D595f31Fce1aE2",
+      "token": "0x9de41aFF9f55219D5bf4359F167d1D0c772A396D",
+      "currency": "CADC"
+    },
+    {
+      "address": "0x7e4a73278d6e578af34faaaba76ed29583ac0341",
+      "token": "0xe111178a87a3bff0c8d18decba5798827539ae99",
+      "currency": "EURS"
+    },
+    {
+      "address": "0x8c6eb8c26f166f87b4f886ce07116a823805602c",
+      "token": "0xDC3326e71D45186F113a2F448984CA0e8D201995",
+      "currency": "XSGD"
+    },
+    {
+      "address": "0x17f8ddcea03a8972559a8d32874e144c87baf5b6",
+      "token": "0x4fb71290ac171e1d144f7221d882becac7196eb5",
+      "currency": "TRYb"
+    },
+    {
+      "address": "0xefac71536feBE220D0Bb5128AeBBD1e3df2a1e67",
       "token": "0xeafe31cd9e8e01c8f0073a2c974f728fb80e9dce",
       "currency": "NZDs"
     }


### PR DESCRIPTION
DFX Recently launched V2 of the AMM. This means liquidity has largely been migrated to new pool contracts.
Some of the stablecoin tokens on Polygon are also now native rather than bridged tokens for example CADC, XSGD and XIDR.
