### PR TITLE
Update Sushi (Sushiswap) Trident Polygon subgraph

### DIFF
--- a/projects/sushiswap-bentobox/helper.js
+++ b/projects/sushiswap-bentobox/helper.js
@@ -132,7 +132,7 @@ const kashiQuery = gql`
 `;
 
 const tridentSubgraphs = {
-  polygon: "https://api.thegraph.com/subgraphs/name/sushi-0m/trident-polygon",
+  polygon: "https://api.thegraph.com/subgraphs/name/sushi-qa/trident-polygon",
   optimism: "https://api.thegraph.com/subgraphs/name/sushi-qa/trident-optimism",
   //kava: "https://pvt.graph.kava.io/subgraphs/name/sushi-qa/trident-kava",
   //metis: "https://andromeda.thegraph.metis.io/subgraphs/name/sushi-qa/trident-metis",

--- a/projects/sushiswap-trident/trident.js
+++ b/projects/sushiswap-trident/trident.js
@@ -3,7 +3,7 @@ const { request, gql } = require("graphql-request");
 const { getChainTransform } = require("../helper/portedTokens");
 
 const graphUrls = {
-  polygon: "https://api.thegraph.com/subgraphs/name/sushi-0m/trident-polygon",
+  polygon: "https://api.thegraph.com/subgraphs/name/sushi-qa/trident-polygon",
   optimism: "https://api.thegraph.com/subgraphs/name/sushi-qa/trident-optimism",
   kava: "https://pvt.graph.kava.io/subgraphs/name/sushi-qa/trident-kava",
   metis:


### PR DESCRIPTION
Update the subgraphs used for Polygon Trident as a new router has been deployed and liquidity is being moved over.