### PR TITLE
Updated TheGraph query request limit for Vendor Finance

### DIFF
--- a/projects/vendor-finance/index.js
+++ b/projects/vendor-finance/index.js
@@ -14,7 +14,7 @@ async function getPools() {
     {
       query: `
       {
-        pools {
+        pools (first: 300) {
           id,
           _colToken,
           _lendToken


### PR DESCRIPTION
Updated TheGraph query request limit. Not all pools were being counted because TheGraph automatically limits default queries to ~100 responses.