### PR TITLE
Update to point to the new bridge contract

### DIFF
--- a/projects/lagobridge/index.js
+++ b/projects/lagobridge/index.js
@@ -1,6 +1,6 @@
 const sdk = require("@defillama/sdk");
 
-const bridgecontract = '0x3765f3e827f4AB5393c1cb2D85bAcd37664cE8cA';
+const bridgecontract = '0xc6895a02F9dFe64341c7B1d03e77018E24Db15eD';
 const usdc = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
 const wbtc = '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599'
 


### PR DESCRIPTION
The Lago Bridge contract was updated and redeployed at a new contract address on Ethereum.