### PR TITLE
feat(silo): add hallmark for XAI genesis spike

### DIFF
--- a/projects/silo/index.js
+++ b/projects/silo/index.js
@@ -120,4 +120,7 @@ async function getSilos(block) {
 
 module.exports = {
   ethereum: { tvl, borrowed, },
+  hallmarks: [
+    [1668816000, "XAI Genesis"]
+  ]
 }


### PR DESCRIPTION
Adds a hallmark event to the TVL chart for https://defillama.com/protocol/silo-finance (I am making this change by request from the Silo team, if you need further details on this please let me know)