### PR TITLE
Add Lympo

### DIFF
--- a/projects/lympo/index.js
+++ b/projects/lympo/index.js
@@ -4,7 +4,7 @@ const { sumTokens2 } = require('../helper/unwrapLPs')
 const poolsUrl = 'https://api.lympo.io/pools/poolsV2/pools.json';
 const sportTokenAddress = "0x503836c8c3A453c57f58CC99B070F2E78Ec14fC0"
 
-async function staking(timestamp, _, { polygon: block }) {
+async function tvl(timestamp, _, { polygon: block }) {
     const pools = await get(poolsUrl)
     const owners = pools.map(i => i.address)
     return sumTokens2({ chain: 'polygon', block, owners, tokens: [sportTokenAddress]})
@@ -12,8 +12,7 @@ async function staking(timestamp, _, { polygon: block }) {
 
 module.exports = {
     polygon: {
-        tvl: () => ({}),
-        staking,
+        tvl: tvl,
     },
     methodology: "TVL is calculated as value of SPORT tokens in Lympo pools staking",
 }

--- a/projects/lympo/index.js
+++ b/projects/lympo/index.js
@@ -34,5 +34,6 @@ async function tvl(timestamp, block) {
 module.exports = {
     polygon: {
         tvl
-    }
+    },
+    methodology: "TVL is calculated as value of SPORT tokens in Lympo pools staking",
 }

--- a/projects/lympo/index.js
+++ b/projects/lympo/index.js
@@ -17,8 +17,6 @@ async function getBalances(pools, block) {
         })
 
         sdk.util.sumSingleBalance(balances, sportTokenAddress, balanceResponse.output);
-
-        balances[sportTokenAddress] = balanceResponse.output;
     }
 
     return balances

--- a/projects/lympo/index.js
+++ b/projects/lympo/index.js
@@ -12,7 +12,7 @@ async function staking(timestamp, _, { polygon: block }) {
 
 module.exports = {
     polygon: {
-        tvl: () => ({}),
+        tvl: staking,
         staking,
     },
     methodology: "TVL is calculated as value of SPORT tokens in Lympo pools staking",

--- a/projects/lympo/index.js
+++ b/projects/lympo/index.js
@@ -12,7 +12,7 @@ async function staking(timestamp, _, { polygon: block }) {
 
 module.exports = {
     polygon: {
-        tvl: staking,
+        tvl: () => ({}),
         staking,
     },
     methodology: "TVL is calculated as value of SPORT tokens in Lympo pools staking",

--- a/projects/lympo/index.js
+++ b/projects/lympo/index.js
@@ -1,39 +1,19 @@
-const axios = require('axios');
-const sdk = require("@defillama/sdk");
+const { get } = require('../helper/http')
+const { sumTokens2 } = require('../helper/unwrapLPs')
 
 const poolsUrl = 'https://api.lympo.io/pools/poolsV2/pools.json';
 const sportTokenAddress = "0x503836c8c3A453c57f58CC99B070F2E78Ec14fC0"
 
-async function getBalances(pools, block) {
-
-    const balances = {};
-
-    for(pool of pools) {
-        const balanceResponse = await sdk.api.abi.call({
-            target: sportTokenAddress,
-            abi: "erc20:balanceOf",
-            params: pool.address,
-            chain: "polygon"
-        })
-
-        sdk.util.sumSingleBalance(balances, sportTokenAddress, balanceResponse.output);
-    }
-
-    return balances
-}
-
-async function tvl(timestamp, block) {
-    const pools = (await axios.get(poolsUrl)).data;
-    const balances = await getBalances(pools, block);
-
-    return {
-        "sport": balances[sportTokenAddress] / 1e18
-    };
+async function staking(timestamp, _, { polygon: address }) {
+    const pools = await get(poolsUrl)
+    const owners = pools.map(i => i.address)
+    return sumTokens2({ chain: 'polygon', block, owners, tokens: [sportTokenAddress]})
 }
 
 module.exports = {
     polygon: {
-        tvl
+        tvl: () => ({}),
+        staking,
     },
     methodology: "TVL is calculated as value of SPORT tokens in Lympo pools staking",
 }

--- a/projects/lympo/index.js
+++ b/projects/lympo/index.js
@@ -4,7 +4,7 @@ const { sumTokens2 } = require('../helper/unwrapLPs')
 const poolsUrl = 'https://api.lympo.io/pools/poolsV2/pools.json';
 const sportTokenAddress = "0x503836c8c3A453c57f58CC99B070F2E78Ec14fC0"
 
-async function tvl(timestamp, _, { polygon: block }) {
+async function staking(timestamp, _, { polygon: block }) {
     const pools = await get(poolsUrl)
     const owners = pools.map(i => i.address)
     return sumTokens2({ chain: 'polygon', block, owners, tokens: [sportTokenAddress]})
@@ -12,7 +12,8 @@ async function tvl(timestamp, _, { polygon: block }) {
 
 module.exports = {
     polygon: {
-        tvl: tvl,
+        tvl: () => ({}),
+        staking,
     },
     methodology: "TVL is calculated as value of SPORT tokens in Lympo pools staking",
 }

--- a/projects/lympo/index.js
+++ b/projects/lympo/index.js
@@ -1,0 +1,40 @@
+const axios = require('axios');
+const sdk = require("@defillama/sdk");
+
+const poolsUrl = 'https://api.lympo.io/pools/poolsV2/pools.json';
+const sportTokenAddress = "0x503836c8c3A453c57f58CC99B070F2E78Ec14fC0"
+
+async function getBalances(pools, block) {
+
+    const balances = {};
+
+    for(pool of pools) {
+        const balanceResponse = await sdk.api.abi.call({
+            target: sportTokenAddress,
+            abi: "erc20:balanceOf",
+            params: pool.address,
+            chain: "polygon"
+        })
+
+        sdk.util.sumSingleBalance(balances, sportTokenAddress, balanceResponse.output);
+
+        balances[sportTokenAddress] = balanceResponse.output;
+    }
+
+    return balances
+}
+
+async function tvl(timestamp, block) {
+    const pools = (await axios.get(poolsUrl)).data;
+    const balances = await getBalances(pools, block);
+
+    return {
+        "sport": balances[sportTokenAddress] / 1e18
+    };
+}
+
+module.exports = {
+    polygon: {
+        tvl
+    }
+}

--- a/projects/lympo/index.js
+++ b/projects/lympo/index.js
@@ -4,7 +4,7 @@ const { sumTokens2 } = require('../helper/unwrapLPs')
 const poolsUrl = 'https://api.lympo.io/pools/poolsV2/pools.json';
 const sportTokenAddress = "0x503836c8c3A453c57f58CC99B070F2E78Ec14fC0"
 
-async function staking(timestamp, _, { polygon: address }) {
+async function staking(timestamp, _, { polygon: block }) {
     const pools = await get(poolsUrl)
     const owners = pools.map(i => i.address)
     return sumTokens2({ chain: 'polygon', block, owners, tokens: [sportTokenAddress]})


### PR DESCRIPTION
##### Name (to be shown on DefiLlama): Lympo


##### Twitter Link: https://twitter.com/Lympo_io


##### List of audit links if any: https://www.fairyproof.com/report/Sport


##### Website Link: https://lympo.io/


##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):
https://api.lympo.io/pools/extData/lympo.svg
https://api.lympo.io/pools/extData/lympo.png


##### Current TVL: 585280 USD


##### Chain: Polygon


##### Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list):  sport


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000): sport


##### Short Description (to be shown on DefiLlama): The SPORT token was launched in 2022 and became the primary Lympo utility token to mint, stake and purchase sports collectibles (NFTs). The SPORT token is also the main currency of the Lympo Treasury, which will be governed by a Decentralized Autonomous Organization (DAO) made of Lympo community members. The SPORT token will also have limited application in Lympo Play-and-Earn games, depending on the tokenomics of each particular game and might be used as a token to enter special game events or acquire exclusive in-game items.


##### Token address and ticker if any: 0x503836c8c3A453c57f58CC99B070F2E78Ec14fC0


##### Category (full list at https://defillama.com/categories) *Please choose only one: Gaming


##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using): No


##### forkedFrom (Does your project originate from another project): Originate 


##### methodology (what is being counted as tvl, how is tvl being calculated): TVL is calculated as value of SPORT tokens in Lympo pools staking

