### PR TITLE
lympo: fix tvl

### DIFF
--- a/projects/lympo/index.js
+++ b/projects/lympo/index.js
@@ -4,7 +4,7 @@ const { sumTokens2 } = require('../helper/unwrapLPs')
 const poolsUrl = 'https://api.lympo.io/pools/poolsV2/pools.json';
 const sportTokenAddress = "0x503836c8c3A453c57f58CC99B070F2E78Ec14fC0"
 
-async function staking(timestamp, _, { polygon: block }) {
+async function tvl(timestamp, _, { polygon: block }) {
     const pools = await get(poolsUrl)
     const owners = pools.map(i => i.address)
     return sumTokens2({ chain: 'polygon', block, owners, tokens: [sportTokenAddress]})
@@ -12,8 +12,7 @@ async function staking(timestamp, _, { polygon: block }) {
 
 module.exports = {
     polygon: {
-        tvl: () => ({}),
-        staking,
+        tvl: tvl
     },
     methodology: "TVL is calculated as value of SPORT tokens in Lympo pools staking",
 }


### PR DESCRIPTION
Our ultimate goal is to reflect TVL data on CoinMarketCap (CMC)

But currently, SPORT token TVL shows under staking "toggle," and CMC is not pulling this data. How should we manage the adapter, so it pulls TVL from Polygon and not from Staking toggle.