### PR TITLE
Update elysia protocol

### DIFF
--- a/projects/elysia/abi.json
+++ b/projects/elysia/abi.json
@@ -1,0 +1,71 @@
+{
+  "inputs": [
+    {
+      "internalType": "address",
+      "name": "asset",
+      "type": "address"
+    }
+  ],
+  "name": "getReserveData",
+  "outputs": [
+    {
+      "components": [
+        {
+          "internalType": "uint256",
+          "name": "totalLTokenSupply",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "implicitLTokenSupply",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "lTokenInterestIndex",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "principalDTokenSupply",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "totalDTokenSupply",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "averageRealAssetBorrowRate",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "dTokenLastUpdateTimestamp",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "borrowAPY",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "depositAPY",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "moneyPooLastUpdateTimestamp",
+          "type": "uint256"
+        }
+      ],
+      "internalType": "struct DataPipeline.ReserveDataLocalVars",
+      "name": "",
+      "type": "tuple"
+    }
+  ],
+  "stateMutability": "view",
+  "type": "function"
+}

--- a/projects/elysia/index.js
+++ b/projects/elysia/index.js
@@ -1,15 +1,16 @@
 const sdk = require("@defillama/sdk");
 const { stakings } = require("../helper/staking");
-const { sumTokensExport,  } = require('../helper/unwrapLPs')
+const { sumTokensExport } = require("../helper/unwrapLPs");
+const abi = require("./abi.json");
 
 const addresses = {
   elfi: "0x4da34f8264cb33a5c9f17081b9ef5ff6091116f4",
   el: "0x2781246fe707bb15cee3e5ea354e2154a2877b16",
   elStaking: "0x3F0c3E32bB166901AcD0Abc9452a3f0c5b8B2C9D",
-  dai: "0x6b175474e89094c44da98b954eedeac495271d0f",
-  usdt: "0xdac17f958d2ee523a2206206994597c13d831ec7",
-  busd: "0x4fabb145d64652a948d72533023f6e7a623c7c53",
-  usdc: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+  dai: "0x6b175474e89094c44da98b954eedeac495271d0f", // ETH
+  usdt: "0xdac17f958d2ee523a2206206994597c13d831ec7", // ETH
+  usdc: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // ETH
+  busd: "0xe9e7cea3dedca5984780bafc599bd69add087d56", // BSC
   elfiStaking: [
     "0xb41bcd480fbd986331eeed516c52e447b50dacb4",
     "0xCD668B44C7Cf3B63722D5cE5F655De68dD8f2750",
@@ -24,46 +25,82 @@ const addresses = {
 
 const moneyPools = {
   ethereum: [
-    [addresses.dai, '0x527c901e05228f54a9a63151a924a97622f9f173'],
-    [addresses.usdt, '0xe0bda8e3a27e889837ae37970fe97194453ee79c'],
-    [addresses.usdc, '0x3fea4cc5a03e372ac9cded96bd07795ac9034d71'],
+    [addresses.dai, "0x527c901e05228f54a9a63151a924a97622f9f173"],
+    [addresses.usdt, "0xe0bda8e3a27e889837ae37970fe97194453ee79c"],
+    [addresses.usdc, "0x3fea4cc5a03e372ac9cded96bd07795ac9034d71"],
   ],
-  bsc: [['0xe9e7cea3dedca5984780bafc599bd69add087d56', '0x5bb4d02a0ba38fb8b916758f11d9b256967a1f7f']]
+  bsc: [[addresses.busd, "0x5bb4d02a0ba38fb8b916758f11d9b256967a1f7f"]],
+};
+
+const dataPipelines = {
+  ethereum: "0x128AF7E290ECCDe0050f33A1b5A4Bc8b2BB4d817",
+  bsc: "0xA63830cCCDcd380b00EF00f070357Cb03cDc2E7b",
+};
+
+function deposited(chain) {
+  return async (_, _b, { [chain]: block }) => {
+    const dataPipeline = dataPipelines[chain];
+    const pools = moneyPools[chain];
+
+    const { output: reserves } = await sdk.api.abi.multiCall({
+      abi,
+      calls: pools.map((i) => ({ target: dataPipeline, params: i[0] })),
+      chain,
+      block,
+    });
+
+    const balances = {};
+    reserves.forEach(({ input: { params }, output }, i) => {
+      sdk.util.sumSingleBalance(
+        balances,
+        params[0],
+        output.totalLTokenSupply,
+        chain
+      );
+    });
+
+    return balances;
+  };
 }
 
 function borrowed(chain) {
-  return async (_, _b, {[chain]: block}) => {
-    const pools = moneyPools[chain]
-    const { output: bals } = await sdk.api.abi.multiCall({
-      abi: 'erc20:balanceOf',
-      calls: pools.map(i => ({ target: i[0], params: i[1]})),
-      chain, block,
-    })
-    const { output: totalSupplies } = await sdk.api.abi.multiCall({
-      abi: 'erc20:totalSupply',
-      calls: pools.map(i => ({ target: i[1]})),
-      chain, block,
-    })
-    const balances = {}
-    bals.forEach(({ input: { target }, output }, i) => {
-      sdk.util.sumSingleBalance(balances,target,totalSupplies[i].output - output, chain)
-    })
-    return balances
-  }
+  return async (_, _b, { [chain]: block }) => {
+    const dataPipeline = dataPipelines[chain];
+    const pools = moneyPools[chain];
+
+    const { output: reserves } = await sdk.api.abi.multiCall({
+      abi,
+      calls: pools.map((i) => ({ target: dataPipeline, params: i[0] })),
+      chain,
+      block,
+    });
+
+    const balances = {};
+    reserves.forEach(({ input: { params }, output }, i) => {
+      sdk.util.sumSingleBalance(
+        balances,
+        params[0],
+        output.totalDTokenSupply,
+        chain
+      );
+    });
+
+    return balances;
+  };
 }
 
 module.exports = {
   ethereum: {
-    borrowed: borrowed('ethereum'),
-    tvl: sumTokensExport({ tokensAndOwners: moneyPools.ethereum}),
+    borrowed: borrowed("ethereum"),
+    tvl: deposited("ethereum"),
     staking: sumTokensExport({
       tokens: [addresses.el, addresses.elfi],
       owners: [addresses.elStaking, ...addresses.elfiStaking],
     }),
   },
   bsc: {
-    borrowed: borrowed('bsc'),
-    tvl: sumTokensExport({ tokensAndOwners: moneyPools.bsc, chain: 'bsc'}),
+    borrowed: borrowed("bsc"),
+    tvl: deposited("bsc"),
     staking: stakings(addresses.bscElfiStaking, addresses.bscElfi, "bsc"),
   },
 }; // node test.js projects/elysia/index.js


### PR DESCRIPTION
**NOTE**

> If you would like to add a `volume` adapter please submit the PR [here](https://github.com/DefiLlama/adapters).

1. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
2. The protocol is usually listed within 24 hours of merging the PR
3. Please fill the form below  **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
4. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can  edit it there and put up a PR
5. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
6. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap

---
Hi team! I love DefiLlama.

I updated our protocol's adapter.
Previous adapter only added erc20 balances of our moneypool for TVL. That was wrong.
Our protocol's TVL is sum of the amount deposited.
This PR use our DataPipeline contract that return moneypool status like deposited amount and borrowed ammount.
I hope this PR will be applied soon.

`node test.js projects/elysia/index.js` result is blow.

```
--- ethereum-borrowed ---
DAI                       296.03 k
USDC                      173.66 k
USDT                      164.55 k
Total: 634.25 k 

--- ethereum-staking ---
EL                        872.89 k
ELFI                      109.46 k
Total: 982.35 k 

--- ethereum ---
DAI                       409.69 k
USDT                      306.74 k
USDC                      177.63 k
Total: 894.06 k 

--- bsc-borrowed ---
BUSD                      698.23 k
Total: 698.23 k 

--- bsc ---
BUSD                      770.37 k
Total: 770.37 k 

--- bsc-staking ---
ELFI                      52.39 k
Total: 52.39 k 

--- borrowed ---
BUSD                      698.23 k
DAI                       296.03 k
USDC                      173.66 k
USDT                      164.55 k
Total: 1.33 M 

--- staking ---
EL                        872.89 k
ELFI                      161.84 k
Total: 1.03 M 

--- tvl ---
BUSD                      770.37 k
DAI                       409.69 k
USDT                      306.74 k
USDC                      177.63 k
Total: 1.66 M 

------ TVL ------
ethereum-borrowed         634.25 k
ethereum-staking          982.35 k
ethereum                  894.06 k
bsc-borrowed              698.23 k
bsc                       770.37 k
bsc-staking               52.39 k
borrowed                  1.33 M
staking                   1.03 M

total                    1.66 M 
```
