### PR TITLE
[Update] Fetch TVL data from contract calls

### DIFF
--- a/projects/strxfinance/index.js
+++ b/projects/strxfinance/index.js
@@ -1,19 +1,28 @@
-const { getTrxBalance } = require('../helper/chain/tron');
-const STAKINGPOOL_ADDRESS = 'TGrdCu9fu8csFmQptVE25fDzFmPU9epamH';
-const FREEZE_ADDRESS = 'TSTrx3UteLMBdeGe9Edwwi2hLeQCmLPZ5g';
+const {
+	postURL
+} = require('../helper/utils');
+
+async function getCurrentStake() {
+	let postdata = {
+		"contract_address": "414b8a2c619bccb710206b3d11e28dce62d8d72a8b",
+		"owner_address": "4128fb7be6c95a27217e0e0bff42ca50cd9461cc9f",
+		"function_selector": "reservedTRX()",
+		"parameter": "",
+		"call_value": 0
+	};
+	let result = await postURL('https://api.trongrid.io/wallet/triggerconstantcontract', postdata);
+	let trx = parseInt(result.data.constant_result[0], 16) / 10 ** 6;
+	return trx;
+}
 
 async function tvl() {
-  const [stakingBalance, freezeBalance] = await Promise.all([
-    getTrxBalance(STAKINGPOOL_ADDRESS),
-    getTrxBalance(FREEZE_ADDRESS),
-  ]);
-  return  {
-    "tron": (stakingBalance + freezeBalance) / 10 ** 6,
-  };
+	return {
+		"tron": await getCurrentStake()
+	}
 }
 
 module.exports = {
-  tron: {
-    tvl,
-  },
+	tron: {
+		tvl,
+	},
 }


### PR DESCRIPTION
This pull request updates the API to fetch data from contract calls to get the precise TVL rather than checking balance only. The previous method was inaccurate as it relied on balance data, which can be changed or not reflect the true value locked in the contract.

By using contract calls to fetch the TVL data, we can ensure that the data displayed in the API is accurate and reflects the true value locked in the contract.

Please review and let me know if there are any questions or concerns.

Changes Made:
- Updated the API to fetch TVL data from contract calls rather than balance
- Tested the updated API to ensure it is working correctly and returning accurate data

Thank you for considering this pull request.