### PR TITLE
Update collateral tokens

### DIFF
--- a/projects/ip/index.js
+++ b/projects/ip/index.js
@@ -208,5 +208,6 @@ module.exports = {
   For Interest Protocol, TVL is Reserve + Total Collateral Value
   Reserve is found through calling USDC.getBalances(USDI)
   Balances are found through VaultController.vaultSummaries(1,VaultController.vaultsMinted())
+  Capped tokens converted 1:1 to underlying
   `
 };

--- a/projects/ip/index.js
+++ b/projects/ip/index.js
@@ -86,6 +86,54 @@ const tokens = {
   },
 }
 
+const cappedTokens = {
+  "0x5aC39Ed42e14Cf330A864d7D1B82690B4D1B9E61": {
+    address: '0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0',
+    symbol: 'MATIC',
+    decimals: 18,
+  },
+  "0xfb42f5AFb722d2b01548F77C31AC05bf80e03381": {
+    address: '0xc18360217d8f7ab5e7c516566761ea12ce7f9d72',
+    symbol: 'ENS',
+    decimals: 18,
+  },
+  "0x05498574BD0Fa99eeCB01e1241661E7eE58F8a85": {
+    address: '0xba100000625a3754423978a60c9317c58a424e3d',
+    symbol: 'BAL',
+    decimals: 18,
+  },
+  "0xd3bd7a8777c042De830965de1C1BCC9784135DD2": {
+    address: '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9',
+    symbol: 'AAVE',
+    decimals: 18,
+  },
+  "0x7C1Caa71943Ef43e9b203B02678000755a4eCdE9": {
+    address: '0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32',
+    symbol: 'LDO',
+    decimals: 18,
+  },
+  "0xDDB3BCFe0304C970E263bf1366db8ed4DE0e357a": {
+    address: '0x92d6c1e31e14520e676a687f0a93788b716beff5',
+    symbol: 'DYDX',
+    decimals: 18,
+  },
+  "0x9d878eC06F628e883D2F9F1D793adbcfd52822A8": {
+    address: '0xD533a949740bb3306d119CC777fa900bA034cd52',
+    symbol: 'CRV',
+    decimals: 18,
+  },
+  "0x64eA012919FD9e53bDcCDc0Fc89201F484731f41": {
+    address: '0xae78736cd615f374d3085123a210448e74fc6393',
+    symbol: 'rETH',
+    decimals: 18,
+  },
+  "0x99bd1f28a5A7feCbE39a53463a916794Be798FC3": {
+    address: '0xBe9895146f7AF43049ca1c1AE358B0541Ea49704',
+    symbol: 'cbETH',
+    decimals: 18,
+  },
+}
+
 const getVaultCount = async (block) => {
   return (await sdk.api.abi.call({
     block,
@@ -121,6 +169,9 @@ const collateral = async (timestamp, block)=>{
   const vaults = await getVaults()
   vaults.forEach(x=>{
     x.tokenAddresses.forEach((token, i)=>{
+      if (cappedTokens[token] != undefined){
+        token = cappedTokens[token].address
+      }
       sdk.util.sumSingleBalance(balances, token, x.tokenBalances[i])
     })
   })


### PR DESCRIPTION
Adding capped collateral tokens to collateral calculation.

Tokens:
MATIC
ENS
BAL
AAVE
LDO
DYDX
CRV
rETH
cbETH

Twitter Link:
https://twitter.com/interestDeFi/

List of audit links if any:
https://gfx.cafe/ip/contracts/-/blob/master/audit/GFX_IP_Protocol_Audit_Report.pdf

Website Link:
https://interestprotocol.io/

Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):
https://interestprotocol.io/images/ip_green.svg

Current TVL:
905k

Chain:
ethereum

Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)
interest-protocol

Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
interest-protocol

Short Description (to be shown on DefiLlama):
Interest Protocol is a borrow/lend protocol that is highly capital-efficient thanks to its unique combination of fractional reserves and over-collateralization. Depositors may mint USDi, which is a stablecoin pegged 1-1 with USDC that automatically pays interest to holders via rebasing.

Token address and ticker if any:
stablecoin: 0x2a54ba2964c8cd459dc568853f79813a60761b58
gov token : 0xd909C5862Cdb164aDB949D92622082f0092eFC3d

Category (full list at https://defillama.com/categories) *Please choose only one:
CDP

Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):
chainlink + uniswap v3 twap anchor

forkedFrom (Does your project originate from another project):
n/a

methodology (what is being counted as tvl, how is tvl being calculated):
For Interest Protocol, TVL = Reserve + Total Collateral Value
Reserve is found through calling USDC.getBalances(USDI)
Deposit Balances are found by obtaining all vaults and their deposits through VaultController.vaultSummaries(1,VaultController.vaultsMinted()), and finding the sum
Capped tokens converted 1:1 to underlying 