### PR TITLE
Pirex TVL Updates

### DIFF
--- a/projects/pirex/abi.json
+++ b/projects/pirex/abi.json
@@ -1,0 +1,13 @@
+{
+  "balances": {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "balances",
+    "outputs": [
+      { "internalType": "uint112", "name": "locked", "type": "uint112" },
+      { "internalType": "uint112", "name": "boosted", "type": "uint112" },
+      { "internalType": "uint32", "name": "nextUnlockIndex", "type": "uint32" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+}

--- a/projects/pirex/index.js
+++ b/projects/pirex/index.js
@@ -1,24 +1,27 @@
-const sdk = require('@defillama/sdk')
+const sdk = require("@defillama/sdk");
+const abi = require("./abi.json");
 
-const CVX = '0x4e3fbd56cd56c3e72c1403e103b45db9da5b9d2b'
-const pxCVX = '0xbce0cf87f513102f22232436cca2ca49e815c3ac'
+const CVX = "0x4e3fbd56cd56c3e72c1403e103b45db9da5b9d2b";
+const PirexCVX = "0x35A398425d9f1029021A92bc3d2557D42C8588D7";
+const CVXLocker = "0x72a19342e8F1838460eBFCCEf09F6585e32db86E";
 
-async function tvl(timestamp, block, chainBlocks){
-    const balances = {}
-    const pxCVXSupply = await sdk.api.erc20.totalSupply({
-        target: pxCVX,
-        chain: 'ethereum',
-        block: chainBlocks['ethereum']
-    }).then(result => result.output)
-    sdk.util.sumSingleBalance(balances, CVX, pxCVXSupply)
+async function tvl(ts, block, _, { api }) {
+  const balances = {};
+  const { locked } = await api.call({
+    abi: abi.balances,
+    target: CVXLocker,
+    params: [PirexCVX],
+  });
 
-    return balances
+  sdk.util.sumSingleBalance(balances, CVX, locked);
+
+  return balances;
 }
 
 module.exports = {
-    timetravel: true,
-    methodology: "tvl = Total CVX locked in Pirex",
-    ethereum:{
-        tvl
-    },
-}
+  timetravel: true,
+  methodology: "TVL = Total CVX locked in Pirex",
+  ethereum: {
+    tvl,
+  },
+};


### PR DESCRIPTION
Update Pirex TVL to use locked CVX in convex locker instead of using supply of pxCVX. This is a different number since the pxCVX can be burnt for various reasons (ie Expert mode) but the CVX is still locked