### PR TITLE
Added Stronghands DEX

### DIFF
--- a/projects/stronghands-dex/index.js
+++ b/projects/stronghands-dex/index.js
@@ -1,0 +1,25 @@
+const { getUniTVL } = require('../helper/unknownTokens')
+
+module.exports={
+    bsc: {
+		tvl: getUniTVL({
+			chain: 'bsc',
+			factory: '0x2C3408a4827DF0419DA2f53eAe92f338B4d314ec',
+			useDefaultCoreAssets: true,
+		}),
+    },
+	cronos: {
+		tvl: getUniTVL({
+			chain: 'cronos',
+			factory: '0x1Ed37E4323E429C3fBc28461c14A181CD20FC4E8',
+			useDefaultCoreAssets: true,
+		}),
+	},
+	polygon: {
+		tvl: getUniTVL({
+			chain: 'polygon',
+			factory: '0xDD4047F11c80f7831922904Ddb61E370E83D5fbb',
+			useDefaultCoreAssets: true,
+		}),
+	},
+}


### PR DESCRIPTION
Added Stronghands DEX SwapFactory contracts for BSC, Cronos and Polygon.

##### Name: Stronghands DEX


##### Twitter Link: https://twitter.com/StronghandsDev


##### Website Link: https://stronghandsprotocol.org


##### Logo: https://stronghandsprotocol.org/src/img/logo.png


##### Current TVL: $0


##### Chain: BSC, Cronos, Polygon


##### Short Description: Stronghands DEX enables fast and easy swap of tokens on BSC, Cronos and Polygon - based on UniswapV2 with ERC-31337 technology at its fee-sharing core! Maintained by Stronghands Protocol.


##### Token address and ticker if any: 
(BSC) :: 0xEf709B3aC94BD9976FB25F74E96922D6B407c44A - 'Stronghands DEX Elite', 'SDE'


##### Category: Dexes


##### forkedFrom: UniswapV2


##### methodology: All pairs and LP tokens created by SwapFactory contracts of Stronghands DEX.

