### PR TITLE
Add Mars protocol on Osmosis

### DIFF
--- a/projects/helper/chains.json
+++ b/projects/helper/chains.json
@@ -185,6 +185,5 @@
   "nuls",
   "libre",
   "wemix",
-  "stargaze",
-  "mars"
+  "stargaze"
 ]

--- a/projects/helper/chains.json
+++ b/projects/helper/chains.json
@@ -183,5 +183,6 @@
   "nuls",
   "map",
   "libre",
-  "stargaze"
+  "stargaze",
+  "mars"
 ]

--- a/projects/mars/index.js
+++ b/projects/mars/index.js
@@ -7,7 +7,8 @@ module.exports = {
     tvl: zero,
     borrowed: zero,
   },
-   hallmarks:[
+  hallmarks:[
     [1651881600, "UST depeg"],
-  ]
+    [1675177200, "Relaunch"],
+  ],
 };

--- a/projects/mars/index.js
+++ b/projects/mars/index.js
@@ -3,10 +3,19 @@ const BigNumber = require("bignumber.js");
 
 const zero = (timestamp, block) => ({});
 
+const SCALING_FACTOR = 6;
+
+/**
+ * Encode a javascript object into a base64 string.
+ */
+function encodeBase64(msg) {
+  return Buffer.from(JSON.stringify(msg), "utf8").toString("base64");
+}
+
 /**
  * Query the total amount of MARS tokens staked on Mars Hub app-chain.
  */
-const queryBondedTokens = async (timestamp, block) => {
+async function queryBondedTokens(timestamp, block) {
   const res = await axios.get(
     "https://rest.marsprotocol.io/cosmos/staking/v1beta1/pool"
   );
@@ -39,15 +48,77 @@ const queryBondedTokens = async (timestamp, block) => {
   return {
     "mars-protocol": bondedTokens.toNumber(),
   };
-};
+}
+
+/**
+ * Query the TVL of a Red Bank deployment.
+ */
+async function queryRedBankTvl(restUrl, contractAddr, assets) {
+  const query = encodeBase64({ markets: {} });
+  const res = await axios.get(`${restUrl}/cosmwasm/wasm/v1/contract/${contractAddr}/smart/${query}`);
+
+  const tvl = {};
+  const borrowed = {};
+
+  for (const asset of assets) {
+    const market = res
+      .data
+      .data
+      .find((market) => market.denom === asset.denom);
+
+    tvl[asset.coingeckoId] = BigNumber(market.collateral_total_scaled)
+      .times(Number(market.liquidity_index))
+      .div(BigNumber(10).pow(SCALING_FACTOR))
+      .div(BigNumber(10).pow(asset.decimals))
+      .toNumber();
+
+    borrowed[asset.coingeckoId] = BigNumber(market.debt_total_scaled)
+      .times(Number(market.borrow_index))
+      .div(BigNumber(10).pow(SCALING_FACTOR))
+      .div(BigNumber(10).pow(asset.decimals))
+      .toNumber();
+  }
+
+  return { tvl, borrowed };
+}
+
+/**
+ * Query the TVL of the Osmosis Red Bank deployment.
+ */
+async function queryOsmosis(timestamp, block) {
+  return queryRedBankTvl(
+    "https://lcd.osmosis.zone",
+    "osmo1c3ljch9dfw5kf52nfwpxd2zmj2ese7agnx0p9tenkrryasrle5sqf3ftpg",
+    [
+      {
+        denom: "uosmo",
+        decimals: 6,
+        coingeckoId: "osmosis",
+      },
+      {
+        denom: "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+        decimals: 6,
+        coingeckoId: "cosmos",
+      },
+      {
+        denom: "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
+        decimals: 6,
+        coingeckoId: "usd-coin",
+      },
+    ],
+  );
+}
 
 module.exports = {
   timetravel: false,
-  methodology:
-    "We query Mars protocol smart contracts to get the amount of assets deposited and borrowed, then use CoinGecko to price the assets in USD.",
+  methodology: "We query Mars protocol smart contracts to get the amount of assets deposited and borrowed, then use CoinGecko to price the assets in USD.",
   mars: {
     tvl: queryBondedTokens,
     staking: queryBondedTokens,
+  },
+  osmosis: {
+    tvl: () => queryOsmosis().then((result) => result.tvl),
+    borrowed: () => queryOsmosis().then((result) => result.borrowed),
   },
   terra: {
     tvl: zero,

--- a/projects/mars/index.js
+++ b/projects/mars/index.js
@@ -1,13 +1,41 @@
+const axios = require("axios");
+const BigNumber = require("bignumber.js");
+
 const zero = (timestamp, block) => ({});
+
+/**
+ * Query the total amount of MARS tokens staked on Mars Hub app-chain.
+ */
+const queryBondedTokens = async (timestamp, block) => {
+  const res = await axios.get(
+    "https://rest.marsprotocol.io/cosmos/staking/v1beta1/pool"
+  );
+
+  // Staked MARS tokens can be in one of three states: bonded, unbonding, or
+  // unbonded. Here we only include those in the bonded state in the TVL.
+  const bondedTokensRaw = BigNumber(res.data.pool.bonded_tokens);
+
+  // MARS token has 6 decimal places
+  const bondedTokens = bondedTokensRaw.div(1e6);
+
+  return {
+    "mars-protocol": bondedTokens.toNumber(),
+  };
+};
 
 module.exports = {
   timetravel: false,
-  methodology: "We query Mars protocol smart contracts to get the amount of assets deposited and borrowed, then use CoinGecko to price the assets in USD.",
+  methodology:
+    "We query Mars protocol smart contracts to get the amount of assets deposited and borrowed, then use CoinGecko to price the assets in USD.",
+  mars: {
+    tvl: queryBondedTokens,
+    staked: queryBondedTokens,
+  },
   terra: {
     tvl: zero,
     borrowed: zero,
   },
-  hallmarks:[
+  hallmarks: [
     [1651881600, "UST depeg"],
     [1675177200, "Relaunch"],
   ],

--- a/projects/mars/index.js
+++ b/projects/mars/index.js
@@ -24,24 +24,6 @@ async function queryBondedTokens(timestamp, block) {
   // unbonded. Here we only include those in the bonded state in the TVL.
   let bondedTokensRaw = BigNumber(res.data.pool.bonded_tokens);
 
-  // For the first month after Mars Hub's launch, in order to bootstrap the
-  // chain's security, 50M MARS from the community pool are delegated to the
-  // genesis validators via a smart contract. These 50M should not be counted in
-  // the TVL.
-  //
-  // After the 1 month mark, this delegation will be unstaked and returned to
-  // the community pool.
-  //
-  // TODO: Once unstaked, delete this part
-  const res2 = await axios.get(
-    "https://rest.marsprotocol.io/cosmos/staking/v1beta1/delegations/mars1nc5tatafv6eyq7llkr2gv50ff9e22mnf70qgjlv737ktmt4eswrqhnhf0l"
-  );
-  const communityDelegationRaw = res2.data.delegation_responses.reduce(
-    (acc, curr) => acc.plus(BigNumber(curr.balance.amount)),
-    BigNumber(0)
-  );
-  bondedTokensRaw = bondedTokensRaw.minus(communityDelegationRaw);
-
   // MARS token has 6 decimal places
   const bondedTokens = bondedTokensRaw.div(1e6);
 
@@ -112,10 +94,10 @@ async function queryOsmosis(timestamp, block) {
 module.exports = {
   timetravel: false,
   methodology: "We query Mars protocol smart contracts to get the amount of assets deposited and borrowed, then use CoinGecko to price the assets in USD.",
-  mars: {
-    tvl: queryBondedTokens,
-    staking: queryBondedTokens,
-  },
+  // mars: {
+  //   tvl: queryBondedTokens,
+  //   staking: queryBondedTokens,
+  // },
   osmosis: {
     tvl: () => queryOsmosis().then((result) => result.tvl),
     borrowed: () => queryOsmosis().then((result) => result.borrowed),

--- a/projects/mars/index.js
+++ b/projects/mars/index.js
@@ -84,6 +84,6 @@ module.exports = {
   },
   hallmarks: [
     [1651881600, "UST depeg"],
-    [1675177200, "Relaunch"],
+    [1675774800, "Relaunch on Osmosis"],
   ],
 };

--- a/projects/mars/index.js
+++ b/projects/mars/index.js
@@ -13,26 +13,6 @@ function encodeBase64(msg) {
 }
 
 /**
- * Query the total amount of MARS tokens staked on Mars Hub app-chain.
- */
-async function queryBondedTokens(timestamp, block) {
-  const res = await axios.get(
-    "https://rest.marsprotocol.io/cosmos/staking/v1beta1/pool"
-  );
-
-  // Staked MARS tokens can be in one of three states: bonded, unbonding, or
-  // unbonded. Here we only include those in the bonded state in the TVL.
-  let bondedTokensRaw = BigNumber(res.data.pool.bonded_tokens);
-
-  // MARS token has 6 decimal places
-  const bondedTokens = bondedTokensRaw.div(1e6);
-
-  return {
-    "mars-protocol": bondedTokens.toNumber(),
-  };
-}
-
-/**
  * Query the TVL of a Red Bank deployment.
  */
 async function queryRedBankTvl(restUrl, contractAddr, assets) {
@@ -94,10 +74,6 @@ async function queryOsmosis(timestamp, block) {
 module.exports = {
   timetravel: false,
   methodology: "We query Mars protocol smart contracts to get the amount of assets deposited and borrowed, then use CoinGecko to price the assets in USD.",
-  // mars: {
-  //   tvl: queryBondedTokens,
-  //   staking: queryBondedTokens,
-  // },
   osmosis: {
     tvl: () => queryOsmosis().then((result) => result.tvl),
     borrowed: () => queryOsmosis().then((result) => result.borrowed),

--- a/projects/mars/index.js
+++ b/projects/mars/index.js
@@ -47,7 +47,7 @@ module.exports = {
     "We query Mars protocol smart contracts to get the amount of assets deposited and borrowed, then use CoinGecko to price the assets in USD.",
   mars: {
     tvl: queryBondedTokens,
-    staked: queryBondedTokens,
+    staking: queryBondedTokens,
   },
   terra: {
     tvl: zero,

--- a/projects/mars/index.js
+++ b/projects/mars/index.js
@@ -13,7 +13,25 @@ const queryBondedTokens = async (timestamp, block) => {
 
   // Staked MARS tokens can be in one of three states: bonded, unbonding, or
   // unbonded. Here we only include those in the bonded state in the TVL.
-  const bondedTokensRaw = BigNumber(res.data.pool.bonded_tokens);
+  let bondedTokensRaw = BigNumber(res.data.pool.bonded_tokens);
+
+  // For the first month after Mars Hub's launch, in order to bootstrap the
+  // chain's security, 50M MARS from the community pool are delegated to the
+  // genesis validators via a smart contract. These 50M should not be counted in
+  // the TVL.
+  //
+  // After the 1 month mark, this delegation will be unstaked and returned to
+  // the community pool.
+  //
+  // TODO: Once unstaked, delete this part
+  const res2 = await axios.get(
+    "https://rest.marsprotocol.io/cosmos/staking/v1beta1/delegations/mars1nc5tatafv6eyq7llkr2gv50ff9e22mnf70qgjlv737ktmt4eswrqhnhf0l"
+  );
+  const communityDelegationRaw = res2.data.delegation_responses.reduce(
+    (acc, curr) => acc.plus(BigNumber(curr.balance.amount)),
+    BigNumber(0)
+  );
+  bondedTokensRaw = bondedTokensRaw.minus(communityDelegationRaw);
 
   // MARS token has 6 decimal places
   const bondedTokens = bondedTokensRaw.div(1e6);

--- a/projects/mars/index.test.js
+++ b/projects/mars/index.test.js
@@ -1,9 +1,6 @@
 const { mars, osmosis } = require("./index.js");
 
 (async function () {
-  console.log("querying mars tvl...");
-  console.log(await mars.tvl());
-
   console.log("querying osmosis tvl...");
   console.log(await osmosis.tvl());
 

--- a/projects/mars/index.test.js
+++ b/projects/mars/index.test.js
@@ -1,4 +1,4 @@
-const { mars, osmosis } = require("./index.js");
+const { osmosis } = require("./index.js");
 
 (async function () {
   console.log("querying osmosis tvl...");

--- a/projects/mars/index.test.js
+++ b/projects/mars/index.test.js
@@ -1,0 +1,12 @@
+const { mars, osmosis } = require("./index.js");
+
+(async function () {
+  console.log("querying mars tvl...");
+  console.log(await mars.tvl());
+
+  console.log("querying osmosis tvl...");
+  console.log(await osmosis.tvl());
+
+  console.log("querying osmosis borrowed...");
+  console.log(await osmosis.borrowed());
+})();


### PR DESCRIPTION
Mars protocol was previously been shutdown after the Terra crash, at which time we made a PR to set the protocol's TVL to zero: https://github.com/DefiLlama/DefiLlama-Adapters/pull/2787

Just now, Mars is relaunched on Osmosis. This PR adds TVL tracking for the lending market on Osmosis.