### PR TITLE
Dyson - Remove staking export

### DIFF
--- a/projects/dyson-money/index.js
+++ b/projects/dyson-money/index.js
@@ -32,6 +32,5 @@ module.exports = {
   doublecounted: true,
   ...Object.fromEntries(Object.entries(chains).map(chain => [chain[0], {
     tvl: fetchChain(chain[1], false),
-    staking: fetchChain(chain[1], true),
   }]))
 }


### PR DESCRIPTION
Removing staking export so that the staking option does not show up on the Dyson page