### PR TITLE
fix ston project TVL calculation

### DIFF
--- a/projects/ston/index.js
+++ b/projects/ston/index.js
@@ -2,6 +2,17 @@ const { post } = require('../helper/http')
 const { transformDexBalances } = require('../helper/portedTokens')
 const sdk = require('@defillama/sdk')
 
+function mapTokenAddress(address) {
+  switch (address) {
+    // ston project use this address to represent TON asset
+    // (all zeroes raw address, by analogy with the ethereum null address)
+    case 'EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c':
+      return '0x0000000000000000000000000000000000000000';
+    default:
+      return address;
+  }
+}
+
 module.exports = {
   misrepresentedTokens: true,
   timetravel: false,
@@ -13,8 +24,8 @@ module.exports = {
       return transformDexBalances({
         chain: 'ton',
         data: pools.map(i => ({
-          token0: i.token0_address,
-          token1: i.token1_address,
+          token0: mapTokenAddress(i.token0_address),
+          token1: mapTokenAddress(i.token1_address),
           token0Bal: i.reserve0,
           token1Bal: i.reserve1,
         }))


### PR DESCRIPTION
This PR fixes the TVL calculation for [Ston](https://ston.fi/) project. 

Recently Ston began to use the `EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c` address to represent TON asset (all zeroes raw address, equivalent to Ethereum NULL address). You can find more details in the [following issue](https://github.com/DefiLlama/DefiLlama-Adapters/issues/5226)

Because of these changes to correctly calculate TVL, I added a `mapTokenAddress` fn that will map the TON address used by the Ston project to the `0x0000000000000000000000000000000000000000` address that DefiLlama uses.