### PR TITLE
getChainTvl multiple factories support

### DIFF
--- a/projects/helper/getUniSubgraphTvl.js
+++ b/projects/helper/getUniSubgraphTvl.js
@@ -12,7 +12,7 @@ query get_tvl($block: Int) {
   }
 }
 `;
-  return (chain) => {
+  return (chain, supportMultipleFactories = false) => {
     return async (_, _b, _cb, { api }) => {
       await api.getBlock()
       const block = api.block
@@ -24,9 +24,9 @@ query get_tvl($block: Int) {
         uniswapFactories = (await blockQuery(graphUrls[chain], graphQuery, { api, blockCatchupLimit, }))[factoriesName];
       }
 
-      const usdTvl = uniswapFactories.reduce((acc, cur) => {
+      const usdTvl = supportMultipleFactories ? uniswapFactories.reduce((acc, cur) => {
         return acc + Number(cur[tvlName])
-      }, 0)
+      }, 0) : Number(uniswapFactories[0][tvlName])
       return toUSDTBalances(usdTvl)
     }
   }

--- a/projects/helper/getUniSubgraphTvl.js
+++ b/projects/helper/getUniSubgraphTvl.js
@@ -24,7 +24,9 @@ query get_tvl($block: Int) {
         uniswapFactories = (await blockQuery(graphUrls[chain], graphQuery, { api, blockCatchupLimit, }))[factoriesName];
       }
 
-      const usdTvl = Number(uniswapFactories[0][tvlName])
+      const usdTvl = uniswapFactories.reduce((acc, cur) => {
+        return acc + Number(cur[tvlName])
+      }, 0)
       return toUSDTBalances(usdTvl)
     }
   }

--- a/projects/pancake-swap-stableswap/index.js
+++ b/projects/pancake-swap-stableswap/index.js
@@ -2,7 +2,7 @@ const { getChainTvl } = require("../helper/getUniSubgraphTvl");
 
 const stableGraph = getChainTvl(
   {
-    bsc: "https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-stableswap",
+    bsc: "https://api.thegraph.com/subgraphs/name/chef-jojo/exchange-stableswap",
   },
   "factories"
 );

--- a/projects/pancake-swap-stableswap/index.js
+++ b/projects/pancake-swap-stableswap/index.js
@@ -13,6 +13,6 @@ module.exports = {
   methodology:
     "TVL accounts for the liquidity on all StableSwap pools, using the TVL chart on https://pancakeswap.finance/info?type=stableSwap as the source.",
   bsc: {
-    tvl: stableGraph("bsc"),
+    tvl: stableGraph("bsc", true),
   },
 };

--- a/projects/pancake-swap-stableswap/index.js
+++ b/projects/pancake-swap-stableswap/index.js
@@ -2,7 +2,7 @@ const { getChainTvl } = require("../helper/getUniSubgraphTvl");
 
 const stableGraph = getChainTvl(
   {
-    bsc: "https://api.thegraph.com/subgraphs/name/chef-jojo/exchange-stableswap",
+    bsc: "https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-stableswap",
   },
   "factories"
 );

--- a/projects/pancake-swap-stableswap/index.js
+++ b/projects/pancake-swap-stableswap/index.js
@@ -1,6 +1,6 @@
-const { getChainTvl } = require("../helper/getUniSubgraphTvl");
+const { getChainTvlByMultipleFactories } = require("../helper/getUniSubgraphTvl");
 
-const stableGraph = getChainTvl(
+const stableGraph = getChainTvlByMultipleFactories(
   {
     bsc: "https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-stableswap",
   },
@@ -13,6 +13,6 @@ module.exports = {
   methodology:
     "TVL accounts for the liquidity on all StableSwap pools, using the TVL chart on https://pancakeswap.finance/info?type=stableSwap as the source.",
   bsc: {
-    tvl: stableGraph("bsc", true),
+    tvl: stableGraph("bsc"),
   },
 };


### PR DESCRIPTION
Add support for `getChainTvl` with more than one factory
We have to update the Stableswap subgraph to support multiple factories.
The subgraph is reindexing the update. Here's my version with new factory 
https://thegraph.com/hosted-service/subgraph/chef-jojo/exchange-stableswap

```
    "factories": [
      {
        "id": "0x25a55f9f2279a54951133d503490342b50e5cd15",
        "totalPairs": "1",
        "totalTransactions": "277",
        "totalVolumeUSD": "102732.5081393438304051202162486122",
        "totalLiquidityUSD": "1058432.186025179491474092093649387"
      },
      {
        "id": "0x36bbb126e75351c0dfb651e39b38fe0bc436ffd2",
        "totalPairs": "4",
        "totalTransactions": "269620",
        "totalVolumeUSD": "577159665.7966458276316853658991515",
        "totalLiquidityUSD": "181531122.9595483604362173879047532"
      }
    ],
```

