### PR TITLE
Stargaze Adapter Upgrade - Adding Staking Toggle

### DIFF
--- a/projects/stargaze/index.js
+++ b/projects/stargaze/index.js
@@ -1,26 +1,39 @@
 const sdk = require("@defillama/sdk");
 const { get } = require('../helper/http')
+//const { staking, stakings } = require("../helper/staking");
+//const { pool2 } = require("../helper/pool2");
 
 async function tvl() {
   const balances = {};
 
   /**
-   * The denom is the official API.  bids was custom made for this use.  @pen.so on #Stargaze
-   * Bids has already been converted from ustars to stars.
+   * Bids has already been converted from ustars to stars in the constellations api.  Must be converted back for tvl.
    */
 
-  // const denomURL = `https://rest.stargaze-apis.com/cosmos/staking/v1beta1/params`;
-  const bidsURL = `https://metabase.constellations.zone/api/public/card/4bd16e60-7e77-4206-8ad2-8b04f362afed/query`
+  const bidsURL = `https://metabase.constellations.zone/api/public/card/4bd16e60-7e77-4206-8ad2-8b04f362afed/query`;
 
   const bidsResponse = await get(bidsURL);
   // const denomResponse = await utils.fetchURL(denomURL);
-  sdk.util.sumSingleBalance(balances, 'ustars', bidsResponse.data.rows[0] * 1e6, 'stargaze')
+  sdk.util.sumSingleBalance(balances, 'ustars', bidsResponse.data.rows[0] * 1e6, 'stargaze');
 
   return balances;
-}
+};
+
+async function staking() {
+  const balances = {};
+  const url = `https://rest.stargaze-apis.com/cosmos/staking/v1beta1/pool`;
+  const response = await get(url);
+
+  sdk.util.sumSingleBalance(balances, 'ustars', response.pool.bonded_tokens, 'stargaze');
+  
+  return balances;
+};
 
 module.exports = {
   timetravel: false,
-  methodology: 'Queries the chain API for the how many STARS are locked in bids.',
-  stargaze: { tvl }
+  methodology: 'Queries Constellations API for how many $STARS are locked in bids.',
+  stargaze: {
+    tvl,
+    staking
+  }
 };

--- a/projects/stargaze/index.js
+++ b/projects/stargaze/index.js
@@ -1,7 +1,5 @@
 const sdk = require("@defillama/sdk");
-const { get } = require('../helper/http')
-//const { staking, stakings } = require("../helper/staking");
-//const { pool2 } = require("../helper/pool2");
+const { get } = require("../helper/http");
 
 async function tvl() {
   const balances = {};

--- a/projects/stargaze/index.js
+++ b/projects/stargaze/index.js
@@ -7,7 +7,6 @@ async function tvl() {
   /**
    * Bids has already been converted from ustars to stars in the constellations api.  Must be converted back for tvl.
    */
-
   const bidsURL = `https://metabase.constellations.zone/api/public/card/4bd16e60-7e77-4206-8ad2-8b04f362afed/query`;
 
   const bidsResponse = await get(bidsURL);
@@ -22,6 +21,9 @@ async function staking() {
   const url = `https://rest.stargaze-apis.com/cosmos/staking/v1beta1/pool`;
   const response = await get(url);
 
+  /**
+   * Stargaze API reports bonded_tokens as ustars, so we do not need to do any conversion.
+   */
   sdk.util.sumSingleBalance(balances, 'ustars', response.pool.bonded_tokens, 'stargaze');
   
   return balances;

--- a/projects/stargaze/index.js
+++ b/projects/stargaze/index.js
@@ -11,10 +11,15 @@ async function tvl() {
 
   const bidsResponse = await get(bidsURL);
   // const denomResponse = await utils.fetchURL(denomURL);
-  sdk.util.sumSingleBalance(balances, 'ustars', bidsResponse.data.rows[0] * 1e6, 'stargaze');
+  sdk.util.sumSingleBalance(
+    balances,
+    "ustars",
+    bidsResponse.data.rows[0] * 1e6,
+    "stargaze"
+  );
 
   return balances;
-};
+}
 
 async function staking() {
   const balances = {};
@@ -24,10 +29,15 @@ async function staking() {
   /**
    * Stargaze API reports bonded_tokens as ustars, so we do not need to do any conversion.
    */
-  sdk.util.sumSingleBalance(balances, 'ustars', response.pool.bonded_tokens, 'stargaze');
-  
+  sdk.util.sumSingleBalance(
+    balances,
+    "ustars",
+    response.pool.bonded_tokens,
+    "stargaze"
+  );
+
   return balances;
-};
+}
 
 module.exports = {
   timetravel: false,


### PR DESCRIPTION
This update to the Stargaze Adapter is intended to add the staking toggle to the page, but not add it to the TVL of the on-chain bids.

Ive inquired in chat and was pointed to the TVL docs, and figured since this isn't being added to the TVL, it would be okay?
