### PR TITLE
[Refactor] Update projects to use `getUniTVL` instead of `uniTvlExport`

### DIFF
--- a/projects/3xcalibur/index.js
+++ b/projects/3xcalibur/index.js
@@ -1,11 +1,16 @@
-const { uniTvlExport } = require("../helper/calculateUniTvl.js");
+const {getUniTVL} = require('../helper/unknownTokens')
+
 
 module.exports = {
   doublecounted: false,
   timetravel: true,
   start: 1667689200,
   arbitrum: {
-    tvl: uniTvlExport("0xD158bd9E8b6efd3ca76830B66715Aa2b7Bad2218", "arbitrum"),
+    tvl: getUniTVL({
+      factory: "0xD158bd9E8b6efd3ca76830B66715Aa2b7Bad2218",
+      fetchBalances: true,
+      useDefaultCoreAssets: true,
+    }),
   },
   hallmarks: [[1668038400, "Emissions started"]],
 };

--- a/projects/BombFinance/index.js
+++ b/projects/BombFinance/index.js
@@ -1,9 +1,11 @@
-const {uniTvlExport} = require('../helper/calculateUniTvl.js')
-
-const factory = '0xD9473A05b2edf4f614593bA5D1dBd3021d8e0Ebe'
+const {getUniTVL} = require('../helper/unknownTokens')
 
 module.exports = {
-  fantom:{
-    tvl: uniTvlExport(factory, 'fantom'),
-  },
+    fantom: {
+        tvl: getUniTVL({
+            factory: '0xD9473A05b2edf4f614593bA5D1dBd3021d8e0Ebe',
+            fetchBalances: true,
+            useDefaultCoreAssets: true,
+        })
+    }
 }

--- a/projects/Equalizer/index.js
+++ b/projects/Equalizer/index.js
@@ -1,9 +1,13 @@
-const {uniTvlExport} = require('../helper/calculateUniTvl.js')
 const { staking } = require('../helper/staking')
+const { getUniTVL } = require("../helper/unknownTokens");
 
 module.exports = {
-  fantom:{
-    tvl: uniTvlExport("0xc6366EFD0AF1d09171fe0EBF32c7943BB310832a", "fantom"),
+  fantom: {
+    tvl: getUniTVL({
+      factory: '0xc6366EFD0AF1d09171fe0EBF32c7943BB310832a',
+      fetchBalances: true,
+      useDefaultCoreAssets: true,
+    }),
     staking: staking("0x8313f3551C4D3984FfbaDFb42f780D0c8763Ce94", "0x3Fd3A0c85B70754eFc07aC9Ac0cbBDCe664865A6","fantom"),
-  },
+  }
 }

--- a/projects/alligator-exchange/index.js
+++ b/projects/alligator-exchange/index.js
@@ -1,14 +1,17 @@
-const { uniTvlExport } = require("../helper/calculateUniTvl");
+const {getUniTVL} = require('../helper/unknownTokens')
 const { stakingUnknownPricedLP } = require("../helper/staking");
 
 const token = "0x43C812Ba28cb061b1Be7514145A15C9E18a27342";
 const stakingContract = "0x32A948F018870548bEd7e888Cd97a257b700D4c6";
-const factory = "0xD9362AA8E0405C93299C573036E7FB4ec3bE1240"
 
 module.exports = {
     misrepresentedTokens: true,
     avax:{
-        tvl: uniTvlExport(factory, 'avax'),
+        tvl: getUniTVL({
+            factory: '0xD9362AA8E0405C93299C573036E7FB4ec3bE1240',
+            fetchBalances: true,
+            useDefaultCoreAssets: true,
+          }),
         staking: stakingUnknownPricedLP(stakingContract, token, "avax", "0x039b4C79916b7ACc953f0f67e6181842EFBE6e6e")
     }
 }

--- a/projects/auroraswap/index.js
+++ b/projects/auroraswap/index.js
@@ -1,11 +1,16 @@
 const { staking } = require("../helper/staking");
-const { uniTvlExport } = require("../helper/calculateUniTvl");
 const masterchefAddress = "0x35CC71888DBb9FfB777337324a4A60fdBAA19DDE";
 const brlTokenAddress = "0x12c87331f086c3C926248f964f8702C0842Fd77F";
+const { getUniTVL } = require('../helper/unknownTokens')
 
 module.exports = {
   aurora: {
-    tvl: uniTvlExport('0xC5E1DaeC2ad401eBEBdd3E32516d90Ab251A3aA3', 'aurora'),
+    tvl: getUniTVL({
+      factory: '0xC5E1DaeC2ad401eBEBdd3E32516d90Ab251A3aA3',
+      fetchBalances: true,
+      useDefaultCoreAssets: true,
+    }),
     staking: staking(masterchefAddress, brlTokenAddress, "aurora"),
-  },
-};
+  }
+}
+

--- a/projects/bakeryswap/index.js
+++ b/projects/bakeryswap/index.js
@@ -1,4 +1,3 @@
-const {uniTvlExport} = require("../helper/calculateUniTvl");
 const {getUniTVL} = require('../helper/unknownTokens')
 
 const { staking } = require("../helper/staking");

--- a/projects/bakeryswap/index.js
+++ b/projects/bakeryswap/index.js
@@ -1,11 +1,15 @@
 const {uniTvlExport} = require("../helper/calculateUniTvl");
-const { staking } = require("../helper/staking");
+const {getUniTVL} = require('../helper/unknownTokens')
 
-const factory = "0x01bF7C66c6BD861915CdaaE475042d3c4BaE16A7";
+const { staking } = require("../helper/staking");
 
 module.exports = {
   bsc:{
     staking: staking("6a8dbbfbb5a57d07d14e63e757fb80b4a7494f81", "0xE02dF9e3e622DeBdD69fb838bB799E3F168902c5", "bsc"),
-    tvl: uniTvlExport(factory, "bsc") 
+    tvl: getUniTVL({
+      factory: '0x01bF7C66c6BD861915CdaaE475042d3c4BaE16A7',
+      fetchBalances: true,
+      useDefaultCoreAssets: true,
+    })
   }
 };

--- a/projects/baoswap/index.js
+++ b/projects/baoswap/index.js
@@ -1,3 +1,11 @@
-const { uniTvlExport } = require('../helper/unknownTokens')
+const {getUniTVL} = require('../helper/unknownTokens')
 
-module.exports = uniTvlExport('xdai', '0x45DE240fbE2077dd3e711299538A09854FAE9c9b')
+module.exports = {
+    xdai: {
+        tvl: getUniTVL({
+            factory: '0x45DE240fbE2077dd3e711299538A09854FAE9c9b',
+            fetchBalances: true,
+            useDefaultCoreAssets: true,
+        })
+    }
+}

--- a/projects/bitindi-dex/index.js
+++ b/projects/bitindi-dex/index.js
@@ -1,2 +1,11 @@
-const { uniTvlExport } = require('../helper/unknownTokens')
-module.exports = uniTvlExport('bitindi', '0x87cef801D44D6eDa8106087e7676153c30e36950')
+const {getUniTVL} = require('../helper/unknownTokens')
+
+module.exports = {
+    bitindi: {
+        tvl: getUniTVL({
+            factory: '0x87cef801D44D6eDa8106087e7676153c30e36950',
+            fetchBalances: true,
+            useDefaultCoreAssets: true,
+        })
+    }
+}

--- a/projects/bullionFX/index.js
+++ b/projects/bullionFX/index.js
@@ -1,3 +1,11 @@
-const { uniTvlExport } = require('../helper/unknownTokens')
+const { getUniTVL } = require('../helper/unknownTokens')
 
-module.exports = uniTvlExport('ethereum', '0x5E7CfE3DB397d3DF3F516d79a072F4C2ae5f39bb')
+module.exports = {
+    ethereum: {
+        tvl: getUniTVL({
+            factory: '0x5E7CfE3DB397d3DF3F516d79a072F4C2ae5f39bb',
+            fetchBalances: true,
+            useDefaultCoreAssets: true,
+        })
+    }
+}

--- a/projects/butterswap/index.js
+++ b/projects/butterswap/index.js
@@ -1,24 +1,30 @@
-const {uniTvlExport} = require("../helper/unknownTokens");
-const {staking} = require("../helper/staking");
+const { getUniTVL } = require("../helper/unknownTokens");
+const { staking } = require("../helper/staking");
 
 //HECO ADDRESSES
-const hecoFactory = "0x874D01CA682C9c26BA7E6D9f6F801d1a1fb49201";
 const hecoButter = "0xbf84214ea409A369774321727595F218889eD943";
 const hecoChef = "0x89a3BfA840CF4C9022789CC60500Ec03df8C2935";
 
 //BSC ADDRESSES
-const bscFactory = "0x1Ba94C0851D96b2c0a01382Bf895B5b25361CcB2";
 const bscButter = "0x5eF7814f4cB17b38408F1F641e4b5b61c5D023a8";
 const bscHButter = "0x2f3bca2631fff538b8a55207f6c2081457e229f7";
 const bscChef = "0xa49f4CF57eaFE0098D398DF3eD3A7dF10EAaBfAB";
 
 module.exports = {
     heco: {
-        tvl: uniTvlExport('heco', hecoFactory).heco.tvl,
+        tvl: getUniTVL({
+            factory: '0x874D01CA682C9c26BA7E6D9f6F801d1a1fb49201',
+            fetchBalances: true,
+            useDefaultCoreAssets: true,
+        }),
         staking: staking(hecoChef, hecoButter, 'heco'),
     },
     bsc: {
-        tvl: uniTvlExport('bsc', bscFactory).bsc.tvl,
+        tvl: getUniTVL({
+            factory: '0x1Ba94C0851D96b2c0a01382Bf895B5b25361CcB2',
+            fetchBalances: true,
+            useDefaultCoreAssets: true,
+        }),
         staking: staking(bscChef, bscButter, 'bsc'),
     },
 }

--- a/projects/bxh/index.js
+++ b/projects/bxh/index.js
@@ -1,20 +1,40 @@
 
-const { uniTvlExport } = require('../helper/calculateUniTvl');
+const { getUniTVL } = require('../helper/unknownTokens');
 
 module.exports = {
     heco: {
-      tvl: uniTvlExport('0xe0367ec2bd4ba22b1593e4fefcb91d29de6c512a', 'heco'),
+      tvl: getUniTVL({
+        factory: '0xe0367ec2bd4ba22b1593e4fefcb91d29de6c512a',
+        fetchBalances: true,
+        useDefaultCoreAssets: true,
+      }),
     },
     bsc: {
-      tvl: uniTvlExport('0x7897c32cbda1935e97c0b59f244747562d4d97c1', 'bsc'),
+      tvl: getUniTVL({
+        factory: '0x7897c32cbda1935e97c0b59f244747562d4d97c1',
+        fetchBalances: true,
+        useDefaultCoreAssets: true,
+      }),
     },
     ethereum: {
-      tvl: uniTvlExport('0x8d0fCA60fDf50CFE65e3E667A37Ff3010D6d1e8d', 'ethereum'),
+      tvl: getUniTVL({
+        factory: '0x8d0fCA60fDf50CFE65e3E667A37Ff3010D6d1e8d',
+        fetchBalances: true,
+        useDefaultCoreAssets: true,
+      }),
     },
     avax: {
-      tvl: uniTvlExport('0xDeC9231b2492ccE6BA01376E2cbd2bd821150e8C', 'avax'),
+      tvl: getUniTVL({
+        factory: '0xDeC9231b2492ccE6BA01376E2cbd2bd821150e8C',
+        fetchBalances: true,
+        useDefaultCoreAssets: true,
+      }),
     },
     okexchain: {
-      tvl: uniTvlExport('0xff65bc42c10dcc73ac0924b674fd3e30427c7823', 'okexchain'),
+      tvl: getUniTVL({
+        factory: '0xff65bc42c10dcc73ac0924b674fd3e30427c7823',
+        fetchBalances: true,
+        useDefaultCoreAssets: true,
+      }),
     },
 }; // node test.js projects/bxh/index.js

--- a/projects/camelot/index.js
+++ b/projects/camelot/index.js
@@ -1,9 +1,14 @@
-const { uniTvlExport } = require("../helper/calculateUniTvl");
+const { getUniTVL } = require("../helper/unknownTokens");
+
 module.exports = {
   doublecounted: false,
   timetravel: true,
   start: 1669075200,
   arbitrum: {
-    tvl: uniTvlExport("0x6EcCab422D763aC031210895C81787E87B43A652", "arbitrum"),
+    tvl: getUniTVL({
+      factory: '0x6EcCab422D763aC031210895C81787E87B43A652',
+      fetchBalances: true,
+      useDefaultCoreAssets: true,
+    }),
   },
 };

--- a/projects/cobraswap/index.js
+++ b/projects/cobraswap/index.js
@@ -1,5 +1,11 @@
-const { uniTvlExport } = require("../helper/unknownTokens");
+const { getUniTVL } = require("../helper/unknownTokens");
 
-const factory = "0x3165d94dd2f71381495cb897832de02710a0dce5";
-
-module.exports = uniTvlExport('bsc', factory)
+module.exports = {
+    bsc: {
+        tvl: getUniTVL({
+            factory: '0x3165d94dd2f71381495cb897832de02710a0dce5',
+            fetchBalances: true,
+            useDefaultCoreAssets: true,
+        }),
+    }
+}

--- a/projects/crowfi/index.js
+++ b/projects/crowfi/index.js
@@ -1,6 +1,12 @@
-const {uniTvlExport} = require("../helper/unknownTokens");
-
+const { getUniTVL } = require("../helper/unknownTokens");
 const crow = "0x285c3329930a3fd3C7c14bC041d3E50e165b1517";
-const factory = "0xDdcf30c1A85e5a60d85310d6b0D3952A75a00db4"
 
-module.exports = uniTvlExport ('cronos', factory, 'cronos')
+module.exports = {
+    cronos: {
+        tvl: getUniTVL({
+            factory: '0xDdcf30c1A85e5a60d85310d6b0D3952A75a00db4',
+            fetchBalances: true,
+            useDefaultCoreAssets: true,
+        }),
+    }
+}

--- a/projects/degenhaus/index.js
+++ b/projects/degenhaus/index.js
@@ -1,11 +1,13 @@
-const {uniTvlExport} = require('../helper/calculateUniTvl.js')
-const {stakingPricedLP} = require('../helper/staking')
-
-const factory = '0xA01C3d760738c79e10334408aE59684Aa36B1131'
+const { stakingPricedLP } = require('../helper/staking')
+const { getUniTVL } = require("../helper/unknownTokens");
 
 module.exports = {
-  fantom:{
-    tvl: uniTvlExport(factory, 'fantom'),
+  fantom: {
+    tvl: getUniTVL({
+      factory: '0xA01C3d760738c79e10334408aE59684Aa36B1131',
+      fetchBalances: true,
+      useDefaultCoreAssets: true,
+    }),
     staking: stakingPricedLP("0x72A7A3770B4BC999026F3663F1534581E0c59f2a", "0xd948efcc99be419ca9bdace89b2bec31edf13adb", 'fantom', "0x1758d21f2915583f49cc2b3e583df3e55f0dd2c0", "fantom")
-  },
+  }
 }

--- a/projects/dexit-swap/index.js
+++ b/projects/dexit-swap/index.js
@@ -1,3 +1,11 @@
+const { getUniTVL } = require("../helper/unknownTokens");
 
-const { uniTvlExport } = require('../helper/unknownTokens')
-module.exports = uniTvlExport('dexit', '0xed7e00862c73eF3a53f33d785c62d312Cc8827d2')
+module.exports = {
+    dexit: {
+        tvl: getUniTVL({
+            factory: '0xed7e00862c73eF3a53f33d785c62d312Cc8827d2',
+            fetchBalances: true,
+            useDefaultCoreAssets: true,
+        }),
+    }
+}

--- a/projects/dinoexchange/index.js
+++ b/projects/dinoexchange/index.js
@@ -1,13 +1,17 @@
-const {uniTvlExport} = require('../helper/calculateUniTvl.js');
+const { getUniTVL } = require("../helper/unknownTokens");
 const { staking } = require("../helper/staking.js");
 
 const DINO_TOKEN = '0xf317932ee2c30fa5d0e14416775977801734812d'
 const MASTER_DINO = '0x26CB55795Cff07Df3a1Fa9Ad0f51d6866a80943b'
-const FACTORY_DINO = "0x35E9455c410EacD6B4Dc1D0ca3144031f6251Dc2";
+
 
 module.exports = {
-  bsc:{
-    tvl: uniTvlExport(FACTORY_DINO, 'bsc'),
+  bsc: {
+    tvl: getUniTVL({
+      factory: '0x35E9455c410EacD6B4Dc1D0ca3144031f6251Dc2',
+      fetchBalances: true,
+      useDefaultCoreAssets: true,
+    }),
     staking: staking(MASTER_DINO, DINO_TOKEN, "bsc")
-  },
+  }
 }

--- a/projects/dinosaureggs/index.js
+++ b/projects/dinosaureggs/index.js
@@ -1,7 +1,11 @@
-const {uniTvlExport} = require("../helper/calculateUniTvl");
-
-const factory = "0x73d9f93d53505cb8c4c7f952ae42450d9e859d10";
+const { getUniTVL } = require("../helper/unknownTokens");
 
 module.exports = {
-  bsc: { tvl: uniTvlExport(factory, 'bsc') }
-};
+    bsc: {
+        tvl: getUniTVL({
+            factory: '0x73d9f93d53505cb8c4c7f952ae42450d9e859d10',
+            fetchBalances: true,
+            useDefaultCoreAssets: true,
+        }),
+    }
+}

--- a/projects/duckydefi/index.js
+++ b/projects/duckydefi/index.js
@@ -1,10 +1,12 @@
-const {uniTvlExport} = require("../helper/calculateUniTvl")
-
 const degg = "0xFD71FC52D34eD1Cfc8363e5528285B12b6b942c2";
-const duckyFactory = "0x796E38Bb00f39a3D39ab75297D8d6202505f52e2";
+const { getUniTVL } = require("../helper/unknownTokens");
 
 module.exports = {
-    cronos: {
-        tvl: uniTvlExport(duckyFactory, "cronos")
-    }
+  cronos: {
+    tvl: getUniTVL({
+      factory: '0x796E38Bb00f39a3D39ab75297D8d6202505f52e2',
+      fetchBalances: true,
+      useDefaultCoreAssets: true,
+    }),
+  }
 }

--- a/projects/duneswap.js
+++ b/projects/duneswap.js
@@ -1,6 +1,11 @@
-const { getUniTVL } = require('./helper/unknownTokens')
+const {getUniTVL} = require('./helper/unknownTokens')
+
 module.exports = {
     oasis: {
-        tvl: getUniTVL({ factory: '0x9dd422B52618f4eDD13E08c840f2b6835F3C0585', chain: 'oasis', useDefaultCoreAssets: true }),
+        tvl: getUniTVL({
+            factory: '0x9dd422B52618f4eDD13E08c840f2b6835F3C0585',
+            fetchBalances: true,
+            useDefaultCoreAssets: true,
+        })
     }
 }

--- a/projects/excalibur/index.js
+++ b/projects/excalibur/index.js
@@ -1,16 +1,11 @@
-const {uniTvlExport} = require('../helper/calculateUniTvl')
+const { getUniTVL } = require("../helper/unknownTokens");
 
-function transformFantomAddress(addr){
-  return ((addr) => {
-    if(addr === "0x846e4d51d7e2043c1a87e0ab7490b93fb940357b"){ // UST address
-      return 'ethereum:0xa693b19d2931d498c5b318df961919bb4aee87a5'
-    }
-    return `fantom:${addr}`;
-  })
-}
-
-module.exports={
-    fantom:{
-        tvl: uniTvlExport("0x08b3CCa975a82cFA6f912E0eeDdE53A629770D3f", "fantom", transformFantomAddress)
+module.exports = {
+    fantom: {
+        tvl: getUniTVL({
+            factory: '0x08b3CCa975a82cFA6f912E0eeDdE53A629770D3f',
+            fetchBalances: true,
+            useDefaultCoreAssets: true,
+        }),
     }
 }

--- a/projects/frogswap-kekchain/index.js
+++ b/projects/frogswap-kekchain/index.js
@@ -1,3 +1,11 @@
-const { uniTvlExport } = require('../helper/unknownTokens')
+const { getUniTVL } = require("../helper/unknownTokens");
 
-module.exports = uniTvlExport('kekchain', '0xfe0139503a1B97F7f6c2b72f4020df7A6c1EE399')
+module.exports = {
+    kekchain: {
+        tvl: getUniTVL({
+            factory: '0xfe0139503a1B97F7f6c2b72f4020df7A6c1EE399',
+            fetchBalances: true,
+            useDefaultCoreAssets: true,
+        }),
+    }
+}

--- a/projects/fuzzfinance/index.js
+++ b/projects/fuzzfinance/index.js
@@ -1,8 +1,7 @@
 const sdk = require("@defillama/sdk");
-const { uniTvlExport } = require("../helper/calculateUniTvl");
+const { getUniTVL } = require("../helper/unknownTokens");
 
 const fuzz = "0x984b969a8e82f5ce1121ceb03f96ff5bb3f71fee";
-const factory = "0x5245d2136dc79Df222f00695C0c29d0c4d0E98A6";
 const masterchef = "0x847b46ed6c3df75e34a0496ef148b89bf5eb41b1";
 
 async function staking(timestamp, block, chainBlocks) {
@@ -22,7 +21,13 @@ async function staking(timestamp, block, chainBlocks) {
 module.exports = {
   methodology: `Counts the tokens locked on AMM pools from the factory contract.`,
   harmony: {
-    tvl: uniTvlExport(factory, 'harmony'),
+    tvl: getUniTVL({
+      factory: '0x5245d2136dc79Df222f00695C0c29d0c4d0E98A6',
+      fetchBalances: true,
+      useDefaultCoreAssets: true,
+    }),
     staking,
   },
 };
+
+

--- a/projects/gravity-finance/index.js
+++ b/projects/gravity-finance/index.js
@@ -1,9 +1,13 @@
-const {uniTvlExport} = require('../helper/calculateUniTvl.js');
+const { getUniTVL } = require("../helper/unknownTokens");
 
 module.exports = {
   methodology: `Counts the liquidity on all AMM pools.
   We get the TVL by first fetching all the PairCreated() events emitted by the factory contract in order to get all the pairs and then we get the amount of tokens on each pair by calling getReserves() on that pair's contract. Once we have the total amount locked of each token we just price them using coingecko, and, if coingecko doesn't have the price of one of the tokens we just exclude that token from the TVL.`,
   polygon: {
-    tvl: uniTvlExport('0x3ed75AfF4094d2Aaa38FaFCa64EF1C152ec1Cf20', 'polygon'),
+    tvl: getUniTVL({
+      factory: '0x3ed75AfF4094d2Aaa38FaFCa64EF1C152ec1Cf20',
+      fetchBalances: true,
+      useDefaultCoreAssets: true,
+    }),
   }
 };

--- a/projects/hakuswap/index.js
+++ b/projects/hakuswap/index.js
@@ -1,14 +1,16 @@
-
-const { uniTvlExport } = require("../helper/calculateUniTvl");
+const { getUniTVL } = require("../helper/unknownTokens");
 const { stakingUnknownPricedLP } = require("../helper/staking");
 
-const FACTORY_ADDRESS = "0x2Db46fEB38C57a6621BCa4d97820e1fc1de40f41";
 const HAKU_TOKEN_ADDRESS = "0x695Fa794d59106cEbd40ab5f5cA19F458c723829";
 const XHAKU_ADDRESS = "0xa95C238B5a72f481f6Abd50f951F01891130b441";
 
 module.exports = {
   avax:{
-    tvl: uniTvlExport(FACTORY_ADDRESS, 'avax'),
+    tvl: getUniTVL({
+      factory: '0x2Db46fEB38C57a6621BCa4d97820e1fc1de40f41',
+      fetchBalances: true,
+      useDefaultCoreAssets: true,
+    }),
     staking: stakingUnknownPricedLP(XHAKU_ADDRESS, HAKU_TOKEN_ADDRESS, "avax", "0x7943Acd42c41a345841cB22Bd846794a22d8682d")
   },
   misrepresentedTokens: true,

--- a/projects/hermes-protocol/index.js
+++ b/projects/hermes-protocol/index.js
@@ -1,9 +1,13 @@
-const {uniTvlExport} = require('../helper/calculateUniTvl.js')
+const { getUniTVL } = require("../helper/unknownTokens");
 const { staking } = require('../helper/staking')
 
 module.exports = {
   metis:{
-    tvl: uniTvlExport("0x633a093C9e94f64500FC8fCBB48e90dd52F6668F", "metis"),
+    tvl: getUniTVL({
+      factory: '0x633a093C9e94f64500FC8fCBB48e90dd52F6668F',
+      fetchBalances: true,
+      useDefaultCoreAssets: true,
+    }),
     staking: staking("0xa4C546c8F3ca15aa537D2ac3f62EE808d915B65b", "0xb27bbeaaca2c00d6258c3118bab6b5b6975161c8","metis"),
   },
 }

--- a/projects/hiveswap/index.js
+++ b/projects/hiveswap/index.js
@@ -1,3 +1,11 @@
-const { uniTvlExport } = require("../helper/unknownTokens")
+const { getUniTVL } = require("../helper/unknownTokens");
 
-module.exports = uniTvlExport('map', '0x29c3d087302e3fCb75F16175A09E4C39119459B2')
+module.exports = {
+    map: {
+        tvl: getUniTVL({
+            factory: '0x29c3d087302e3fCb75F16175A09E4C39119459B2',
+            fetchBalances: true,
+            useDefaultCoreAssets: true,
+        }),
+    }
+}

--- a/projects/hswap.js
+++ b/projects/hswap.js
@@ -1,11 +1,3 @@
-// const { uniTvlExport } = require("./helper/calculateUniTvl")
-
-// module.exports = {
-//     heco: {
-//         tvl: uniTvlExport('0x13D1EA691C8153F5bc9a491d41b927E2baF8A6b1', "heco")
-//     }
-// }
-
 const {getUniTVL} = require('./helper/unknownTokens')
 
 module.exports = {

--- a/projects/hswap.js
+++ b/projects/hswap.js
@@ -1,7 +1,20 @@
-const { uniTvlExport } = require("./helper/calculateUniTvl")
+// const { uniTvlExport } = require("./helper/calculateUniTvl")
+
+// module.exports = {
+//     heco: {
+//         tvl: uniTvlExport('0x13D1EA691C8153F5bc9a491d41b927E2baF8A6b1', "heco")
+//     }
+// }
+
+const {getUniTVL} = require('./helper/unknownTokens')
 
 module.exports = {
-    heco: {
-        tvl: uniTvlExport('0x13D1EA691C8153F5bc9a491d41b927E2baF8A6b1', "heco")
-    }
+  misrepresentedTokens: true,
+  heco:{
+    tvl: getUniTVL({
+      factory: '0x13D1EA691C8153F5bc9a491d41b927E2baF8A6b1',
+      fetchBalances: true,
+      useDefaultCoreAssets: true,
+    })
+  },
 }

--- a/projects/jetfuelfinance/index.js
+++ b/projects/jetfuelfinance/index.js
@@ -3,7 +3,7 @@ const abi = require("./abi.json");
 const { unwrapUniswapLPs } = require("../helper/unwrapLPs");
 const { transformBscAddress } = require("../helper/portedTokens");
 const { compoundExports } = require("../helper/compound");
-const {uniTvlExport} = require("../helper/calculateUniTvl");
+const { getUniTVL } = require("../helper/unknownTokens");
 
 // Jetswap section
 const factory = "0x0eb58E5c8aA63314ff5547289185cC4583DfCBD5";
@@ -50,7 +50,7 @@ const single_side_assets = [
   "0x7130d2a12b9bcbfae4f2634d864a1ee1ce3ead9c",
 ];
 
-const factoryTvl = uniTvlExport(factory, 'bsc')
+const factoryTvl = getUniTVL({factory, fetchBalances: true, useDefaultCoreAssets: true})
 
 const bscTvl = async (timestamp, block, chainBlocks) => {
   // Jetswap section

--- a/projects/jetswap/index.js
+++ b/projects/jetswap/index.js
@@ -1,9 +1,5 @@
 const sdk = require("@defillama/sdk");
-const { uniTvlExport } = require("../helper/calculateUniTvl");
-
-const bscFactory = "0x0eb58E5c8aA63314ff5547289185cC4583DfCBD5";
-const polygonFactory = "0x668ad0ed2622C62E24f0d5ab6B6Ac1b9D2cD4AC7";
-const fantomFactory = "0xf6488205957f0b4497053d6422F49e27944eE3Dd";
+const { getUniTVL } = require("../helper/unknownTokens");
 
 const WINGS_TOKEN_BSC = "0x0487b824c8261462f88940f97053e65bdb498446";
 const WINGS_TOKEN_POLYGON = "0x845E76A8691423fbc4ECb8Dd77556Cb61c09eE25";
@@ -31,15 +27,27 @@ function staking(masterchef, token, chain) {
 
 module.exports = {
   bsc: {
-    tvl: uniTvlExport(bscFactory, 'bsc'),
+    tvl: getUniTVL({
+      factory: '0x0eb58E5c8aA63314ff5547289185cC4583DfCBD5',
+      fetchBalances: true,
+      useDefaultCoreAssets: true,
+    }),
     staking: staking(MASTER_BSC, WINGS_TOKEN_BSC, "bsc"),
   },
   polygon: {
-    tvl: uniTvlExport(polygonFactory, 'polygon'),
+    tvl: getUniTVL({
+      factory: '0x668ad0ed2622C62E24f0d5ab6B6Ac1b9D2cD4AC7',
+      fetchBalances: true,
+      useDefaultCoreAssets: true,
+    }),
     staking: staking(MASTER_POLYGON, WINGS_TOKEN_POLYGON, "polygon"),
   },
   fantom: {
-    tvl: uniTvlExport(fantomFactory, 'fantom'),
+    tvl: getUniTVL({
+      factory: '0xf6488205957f0b4497053d6422F49e27944eE3Dd',
+      fetchBalances: true,
+      useDefaultCoreAssets: true,
+    }),
     staking: staking(MASTER_FANTOM, WINGS_TOKEN_FANTOM, "fantom"),
   },
 };

--- a/projects/kaco/index.js
+++ b/projects/kaco/index.js
@@ -1,6 +1,5 @@
 
 const { getUniTVL } = require('../helper/unknownTokens')
-const { uniTvlExport } = require("../helper/calculateUniTvl.js");
 const { staking, stakingUnknownPricedLP} = require("../helper/staking");
 
 const KACMasterChefContract = {
@@ -23,7 +22,7 @@ module.exports = {
   bsc: {
     staking: stakingUnknownPricedLP("0x81b71D0bC2De38e37978E6701C342d0b7AA67D59", "0xf96429A7aE52dA7d07E60BE95A3ece8B042016fB", "bsc", "0x315F25Cea80AC6c039B86e79Ffc46aE6b2e30922", addr=>`bsc:${addr}`),
 
-    tvl: uniTvlExport(KACFactory.bsc, 'bsc'),
+    tvl: getUniTVL({ factory: KACFactory.bsc, fetchBalances: true, useDefaultCoreAssets: true }),
   },
   shiden: {
     staking: staking(

--- a/projects/kekswap/index.js
+++ b/projects/kekswap/index.js
@@ -1,3 +1,11 @@
-const { uniTvlExport } = require('../helper/unknownTokens')
+const { getUniTVL } = require("../helper/unknownTokens");
 
-module.exports = uniTvlExport('kekchain', '0x558e20804CDFff6d98945b12CE47FeB46D6a4Dc4')
+module.exports = {
+    kekchain: {
+        tvl: getUniTVL({
+            factory: '0x558e20804CDFff6d98945b12CE47FeB46D6a4Dc4',
+            fetchBalances: true,
+            useDefaultCoreAssets: true,
+        }),
+    }
+}

--- a/projects/knightswap/index.js
+++ b/projects/knightswap/index.js
@@ -1,8 +1,5 @@
-const { uniTvlExport } = require("../helper/calculateUniTvl");
+const { getUniTVL } = require("../helper/unknownTokens");
 const { stakingUnknownPricedLP } = require("../helper/staking");
-
-const bscFactory = "0xf0bc2E21a76513aa7CC2730C7A1D6deE0790751f";
-const ftmFactory = "0x7d82F56ea0820A9d42b01C3C28F1997721732218";
 
 const bscStaking = "0xE50cb76A71b0c52Ab091860cD61b9BA2FA407414";
 const bscKnight = "0xd23811058eb6e7967d9a00dc3886e75610c4abba";
@@ -15,7 +12,11 @@ const knightUsdcLP = "0x68D47D67b893c44A72BCAC39b1b658D4Cbdf87CA";
 module.exports = {
   methodology: "TVL consists of pools created by the factory contract",
   bsc: {
-    tvl: uniTvlExport(bscFactory, 'bsc'),
+    tvl: getUniTVL({
+      factory: '0xf0bc2E21a76513aa7CC2730C7A1D6deE0790751f',
+      fetchBalances: true,
+      useDefaultCoreAssets: true,
+    }),
     staking: stakingUnknownPricedLP(
       bscStaking,
       bscKnight,
@@ -25,7 +26,11 @@ module.exports = {
     ),
   },
   fantom: {
-    tvl: uniTvlExport(ftmFactory, 'fantom'),
+    tvl: getUniTVL({
+      factory: '0x7d82F56ea0820A9d42b01C3C28F1997721732218',
+      fetchBalances: true,
+      useDefaultCoreAssets: true,
+    }),
     staking: stakingUnknownPricedLP(
       ftmStaking,
       ftmKnight,

--- a/projects/kronosdao/index.js
+++ b/projects/kronosdao/index.js
@@ -1,7 +1,6 @@
-const { uniTvlExport } = require("../helper/calculateUniTvl");
+const { getUniTVL } = require("../helper/unknownTokens");
 const { stakingUnknownPricedLP } = require("../helper/staking");
 
-const kronosFactory = "0xcc045ebC2664Daf316aa0652E72237609EA6CB4f";
 const kRONOSMasterChef = "0x30e9f20414515116598D073F3EBA116c68A6f4aC";
 const kronosDaoToken = "0xbeC68a941feCC79E57762e258fd1490F29235D75";
 const kronosBusdLP = "0xDBB34E29D345788273e85DE84814CfAA95c9c5f7";
@@ -9,7 +8,11 @@ const kronosBusdLP = "0xDBB34E29D345788273e85DE84814CfAA95c9c5f7";
 module.exports = {
   methodology: "TVL consists of pools created by the factory contract",
   bsc: {
-    tvl: uniTvlExport(kronosFactory, 'bsc'),
+    tvl: getUniTVL({
+      factory: '0xcc045ebC2664Daf316aa0652E72237609EA6CB4f',
+      fetchBalances: true,
+      useDefaultCoreAssets: true,
+    }),
     staking: stakingUnknownPricedLP(
       kRONOSMasterChef,
       kronosDaoToken,

--- a/projects/kswap/index.js
+++ b/projects/kswap/index.js
@@ -1,4 +1,11 @@
-const { uniTvlExport } = require('../helper/unknownTokens')
-const factory = '0xEFD3ad14E5cF09b0EbE435756337fb2e9D10Dc1a' // v2 factory address
+const { getUniTVL } = require("../helper/unknownTokens");
 
-module.exports = uniTvlExport('kava', factory)
+module.exports = {
+    kava: {
+        tvl: getUniTVL({
+            factory: '0xEFD3ad14E5cF09b0EbE435756337fb2e9D10Dc1a',
+            fetchBalances: true,
+            useDefaultCoreAssets: true,
+        }),
+    }
+}

--- a/projects/latte/index.js
+++ b/projects/latte/index.js
@@ -1,8 +1,7 @@
 
 const sdk = require("@defillama/sdk");
-const { uniTvlExport } = require("../helper/calculateUniTvl");
+const { getUniTVL } = require("../helper/unknownTokens");
 
-const factory = "0x4DcE5Bdb81B8D5EdB66cA1b8b2616A8E0Dd5f807";
 const latteToken = "0x8D78C2ff1fB4FBA08c7691Dfeac7bB425a91c81A";
 const lattev2Token = "0xa269A9942086f5F87930499dC8317ccC9dF2b6CB";
 const masterchef = "0xbCeE0d15a4402C9Cc894D52cc5E9982F60C463d6";
@@ -34,7 +33,11 @@ async function staking(timestamp, block, chainBlocks) {
 
 module.exports = {
   bsc: {
-    tvl: uniTvlExport(factory, 'bsc'),
+    tvl: getUniTVL({
+      factory: '0x4DcE5Bdb81B8D5EdB66cA1b8b2616A8E0Dd5f807',
+      fetchBalances: true,
+      useDefaultCoreAssets: true,
+    }),
     staking,
   },
 };

--- a/projects/leonicornswap/index.js
+++ b/projects/leonicornswap/index.js
@@ -1,9 +1,8 @@
 const sdk = require("@defillama/sdk");
-const { uniTvlExport } = require("../helper/calculateUniTvl");
+const { getUniTVL } = require("../helper/unknownTokens");
 
 const leos = "0x2c8368f8F474Ed9aF49b87eAc77061BEb986c2f1";
 const leon = "0x27E873bee690C8E161813DE3566E9E18a64b0381";
-const factory = "0xEB10f4Fe2A57383215646b4aC0Da70F8EDc69D4F";
 const masterchef = "0x72F8fE2489A4d480957d5dF9924166e7a8DDaBBf";
 
 async function staking(timestamp, block, chainBlocks) {
@@ -31,7 +30,11 @@ async function staking(timestamp, block, chainBlocks) {
 
 module.exports = {
     bsc: {
-        tvl: uniTvlExport(factory, 'bsc'),
+        tvl: getUniTVL({
+            factory: '0xEB10f4Fe2A57383215646b4aC0Da70F8EDc69D4F',
+            fetchBalances: true,
+            useDefaultCoreAssets: true,
+        }),
         staking
     },
 }

--- a/projects/levinswap/index.js
+++ b/projects/levinswap/index.js
@@ -1,13 +1,16 @@
-const { uniTvlExport } = require("../helper/calculateUniTvl");
+const { getUniTVL } = require("../helper/unknownTokens");
 const { staking } = require("../helper/staking");
 
-const factory = "0x965769C9CeA8A7667246058504dcdcDb1E2975A5";
 const levin = "0x1698cD22278ef6E7c0DF45a8dEA72EDbeA9E42aa";
 const xlevin = "0xafa57Fb9d8D63Ff8124E17c1495C73bc3a7678D0";
 
 module.exports = {
   xdai: {
-    tvl: uniTvlExport(factory, 'xdai'),
+    tvl: getUniTVL({
+      factory: '0x965769C9CeA8A7667246058504dcdcDb1E2975A5',
+      fetchBalances: true,
+      useDefaultCoreAssets: true,
+    }),
     staking: staking(xlevin, levin, "xdai")
   }
 }

--- a/projects/wanswap.js
+++ b/projects/wanswap.js
@@ -1,3 +1,11 @@
-const { uniTvlExport } = require('./helper/unknownTokens')
+const {getUniTVL} = require('./helper/unknownTokens')
 
-module.exports = uniTvlExport('wan', '0x1125C5F53C72eFd175753d427aA116B972Aa5537')
+module.exports = {
+    wan: {
+        tvl: getUniTVL({
+            factory: '0x1125C5F53C72eFd175753d427aA116B972Aa5537',
+            fetchBalances: true,
+            useDefaultCoreAssets: true,
+        })
+    }
+}


### PR DESCRIPTION
Will create a list of projects that have been updated for reference.

- [x] HSwap
- [x] Wanswap
- [x] 3xcalibur