### PR TITLE
feat: add lcro-cro pool to ferro

### DIFF
--- a/projects/ferro/index.js
+++ b/projects/ferro/index.js
@@ -2,6 +2,7 @@ const { sumTokens2 } = require('../helper/unwrapLPs')
 
 const SWAP_3FER_ADDR = '0xe8d13664a42B338F009812Fa5A75199A865dA5cD';
 const SWAP_2FER_ADDR = '0xa34C0fE36541fB085677c36B4ff0CCF5fa2B32d6';
+const SWAP_LCRO_WCRO_ADDRESSES = '0x1578C5CF4f8f6064deb167d1eeAD15dF43185afa';
 const chain = 'cronos'
 
 const tokens = {
@@ -18,6 +19,14 @@ const tokens = {
   "0x66e428c3f67a68878562e79A0234c1F83c208770": [
     SWAP_3FER_ADDR,
     SWAP_2FER_ADDR,
+  ],
+  // LCRO
+  "0x9fae23a2700feecd5b93e43fdbc03c76aa7c08a6": [
+    SWAP_LCRO_WCRO_ADDRESSES,
+  ],
+  // WCRO
+  "0x5C7F8A570d578ED84E63fdFA7b1eE72dEae1AE23": [
+    SWAP_LCRO_WCRO_ADDRESSES,
   ],
 };
 


### PR DESCRIPTION
adding `LCRO-CRO` pool for [ferro integration](https://github.com/DefiLlama/DefiLlama-Adapters/pull/3157)

---

##### Name (to be shown on DefiLlama):

Ferro

##### Twitter Link:

https://twitter.com/FerroProtocol

##### List of audit links if any:

https://docs.ferroprotocol.com/extras/security

##### Website Link:

https://ferroprotocol.com/

##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):

![ferro](https://user-images.githubusercontent.com/106642922/177089290-845b9c4d-79a9-433d-869b-de6418d662a2.svg)

##### Current TVL:

50.80 M

##### Chain:

Cronos

##### Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)

ferro

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

20716

##### Short Description (to be shown on DefiLlama):

a stableswap AMM protocol on Cronos

##### Token address and ticker if any:

0x39bC1e38c842C60775Ce37566D03B41A7A66C782

##### Category (full list at https://defillama.com/categories) *Please choose only one:

Dexes

##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):


##### forkedFrom (Does your project originate from another project):

Saddle

##### methodology (what is being counted as tvl, how is tvl being calculated):

sum of ferro pool contracts balance