### PR TITLE
Update Mars contract query

### DIFF
--- a/projects/mars/index.js
+++ b/projects/mars/index.js
@@ -7,7 +7,7 @@ const chain = 'osmosis'
 const contract = 'osmo1c3ljch9dfw5kf52nfwpxd2zmj2ese7agnx0p9tenkrryasrle5sqf3ftpg'
 
 async function borrowed() {
-  const res = await queryContract({ contract, chain: 'osmosis', data: { markets: {} } })
+  const res = await queryContract({ contract, chain: 'osmosis', data: { markets: { limit: 10 } } })
   const borrowed = {};
   res.forEach(i => {
     sdk.util.sumSingleBalance(borrowed, i.denom, i.debt_total_scaled * i.borrow_index / 1e6)


### PR DESCRIPTION
The `{ markets: {} }` query by default [only returns the first 5 assets](https://github.com/mars-protocol/red-bank/blob/master/contracts/red-bank/src/query.rs#L23-L24). We now have 6 supported assets so one is missed.

This PR adds an additional parameter `limit: 10` so it returns the first 10.

The contract only supports a maximum of 10 per query. If we do have more than 10 assets in the future, we will need to implement a loop to fetch all assets, 10 at a time. I can do a PR later when this becomes necessary.