### PR TITLE
Streamflow: use different api endpoint

### DIFF
--- a/projects/streamflow/index.js
+++ b/projects/streamflow/index.js
@@ -1,27 +1,22 @@
 const { getCache } = require('../helper/http')
 
-const TVL_KEY = "TVL (unlocked) (L1+stables)";
-const VESTING_KEY = "TVL (locked) (vesting)";
+const SOLANA = "SOLANA";
+const TVL_KEY = "tvl";
+const VESTING_KEY = "tvl_vested";
 const api =
-  "https://app.datawisp.io/api/exec/sheet_results/8fd98286-f0e1-4a32-91cd-d88d827ae9d7";
-
-const flatten = (arr) => {
-  return arr.reduce((acc, next) => [...acc, ...next], []);
-}
+  "https://metabase.internal-streamflow.com/_public/api/v1/stats/accumulated";
 
 const getValueForKey = (arr, key) => {
   for (let i = 0; i < arr.length; i++) {
-    const el = arr[i];
-    if (el[key] !== undefined) {
-      return el[key];
+    if (arr[i].chain === SOLANA && arr[i][key] !== undefined) {
+      return arr[i][key];
     }
   }
   return null;
 }
 
 async function getCachedApiRespnse() {
-  let apiResponse = (await getCache(api)).data;
-  apiResponse = flatten(Object.values(apiResponse));
+  let apiResponse = (await getCache(api));
 
   return apiResponse;
 }


### PR DESCRIPTION
Hey everyone, we've had some stability issues with the previous solution that provided the API results so we'd like to set up a different API source as you can see in the PR.

The API source is an internal Metabase storage, it polls on-chain data, token prices and expose that through an API endpoint provided.

Here is a run-through of the Metabase setup: https://www.loom.com/share/2f41c0da320b4be9809949c2da4337dd

If you'd like we can provide you with access and run through the details of how it works let us know.

Thank you in advance.