### PR TITLE
Add BNB Chain to Revert Compoundor

### DIFF
--- a/projects/helper/unwrapLPs.js
+++ b/projects/helper/unwrapLPs.js
@@ -455,6 +455,7 @@ async function unwrapUniswapV3NFTs({ balances = {}, nftsAndOwners = [], block, c
         case 'polygon':
         case 'optimism':
         case 'arbitrum': nftAddress = '0xC36442b4a4522E871399CD717aBDD847Ab11FE88'; break;
+        case 'bsc': nftAddress = '0x7b8a01b39d58278b5de7e48c8449c9f4f5170613'; break;
         default: throw new Error('missing default uniswap nft address')
       }
 

--- a/projects/revert-compoundor/index.js
+++ b/projects/revert-compoundor/index.js
@@ -13,6 +13,9 @@ const config = {
   optimism: {
     owners: ['0x5411894842e610C4D0F6Ed4C232DA689400f94A1'],
   },
+  bsc: {
+    owners: ['0x98eC492942090364AC0736Ef1A741AE6C92ec790']
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
Adds support for BNB Chain to Revert Compoundor protocol. 

NOTE: BNB Chain Uniswap contracts were deployed to different addresses than on the other chains.