### PR TITLE
updates grizzly fi TVLS

### DIFF
--- a/projects/grizzlyfi/index.js
+++ b/projects/grizzlyfi/index.js
@@ -2,11 +2,21 @@ const sdk = require("@defillama/sdk");
 const { transformBscAddress } = require("../helper/portedTokens");
 const { stakings } = require("../helper/staking");
 const { pool2 } = require("../helper/pool2");
-const { unwrapUniswapLPs } = require("../helper/unwrapLPs");
+const { unwrapUniswapLPs, unwrapLPsAuto } = require("../helper/unwrapLPs");
+const { BigNumber } = require("bignumber.js");
 
-const abi = "uint256:grizzlyStrategyDeposits"
+const abiGrizzly = "uint256:grizzlyStrategyDeposits"
+const abiStandard = "uint256:standardStrategyDeposits"
+const abiStable = "uint256:stablecoinStrategyDeposits"
+const abiFarm = "uint256:totalDeposits"
+const abiYearn = "uint256:totalAssets"
 
-const hives = [
+const lpReservesAbi = 'function balances(uint256 index) view returns (uint256)'
+const tokenAbi = 'function coins(uint256 index) view returns (address)'
+const lpSuppliesAbi = "uint256:totalSupply"
+
+const pcsHives = [
+  // PCS hives
   {
     hive: "0xDa0Ae0710b080AC64e72Fa3eC44203F27750F801",
     token: "0x58F876857a02D6762E0101bb5C46A8c1ED44Dc16"
@@ -34,31 +44,185 @@ const hives = [
   {
     hive: "0x6fc2FEed99A97105B988657f9917B771CD809f40",
     token: "0xF45cd219aEF8618A92BAa7aD848364a158a24F33"
-  }
+  },
+  // Biswap hives
+  {
+    hive: "0x0286A72F055A425af9096b187bf7f88e9f7D96A9",
+    token: "0x8840C6252e2e86e545deFb6da98B2a0E26d8C1BA"
+  },
+  {
+    hive: "0xB07a180735657a92d8e2b77D213bCBE5ab819089",
+    token: "0xa987f0b7098585c735cD943ee07544a84e923d1D"
+  },
+  {
+    hive: "0xe178eaDBcb4A64476B8E4673D99192C25ef1B42e",
+    token: "0x63b30de1A998e9E64FD58A21F68D323B9BcD8F85"
+  },
 ];
+
+const farms = [
+  {
+    hive: "0x3641676bFe07F07DD2f79244BcdBb751f95F67Ca",
+    token: "0x2b702b4e676b51f98c6b4af1b2cafd6a9fc2a3e0"
+  },
+  {
+    hive: "0xF530B259fFf408aaB2B02aa60dd6fe48FCDC2FC9",
+    token: "0x352008bf4319c3b7b8794f1c2115b9aa18259ebb"
+  },
+]
+
+const stableHives = [
+  {
+    hive: "0x7Bf5005F9a427cB4a3274bFCf36125cE979F77cb",
+    token: "0x36842f8fb99d55477c0da638af5ceb6bbf86aa98",
+    swap: "0x169f653a54acd441ab34b73da9946e2c451787ef"
+  },
+  {
+    hive: "0x7E5762A7D68Fabcba39349229014c59Db6dc5eB0",
+    token: "0xee1bcc9f1692e81a281b3a302a4b67890ba4be76",
+    swap: "0x3efebc418efb585248a0d2140cfb87afcc2c63dd"
+  },
+  {
+    hive: "0xCCf6356C96Eadd2702fe6f5Ef99B1C0a3966EDf7",
+    token: "0x1a77c359d0019cd8f4d36b7cdf5a88043d801072",
+    swap: "0xc2f5b9a3d9138ab2b74d581fc11346219ebf43fe"
+  },
+]
+
+const yearnHives = [
+  // Thena hives
+  {
+    hive: "0x5Aa6dd6bA3091ba151B4E5c0C0c4f06335e91482",
+    token: "0xa97e46dc17e2b678e5f049a2670fae000b57f05e"
+  },
+  {
+    hive: "0x38b2f5038F70b8A4a54A2CC8d35d85Cc5f0794e4",
+    token: "0xc8da40f8a354530f04ce2dde98ebc2960a9ea449"
+  },
+  {
+    hive: "0x3dF96fE4E92f38F7C931fA5A00d1f644D1c60dbF",
+    token: "0x075e794f631ee81df1aadb510ac6ec8803b0fa35"
+  },
+  {
+    hive: "0x9Ce89aba449135539A61C57665547444a92784aB",
+    token: "0x3c552e8ac4473222e3d794adecfa432eace85929"
+  },
+  {
+    hive: "0xc750432473eABE034e84d373CB92f16e6EB0d273",
+    token: "0x3ec80a1f547ee6fd5d7fc0dc0c1525ff343d087c"
+  },
+  {
+    hive: "0xf01F9e8A5C6B9Db49e851e8d72B70569042F0e1C",
+    token: "0x63db6ba9e512186c2faadacef342fb4a40dc577c"
+  },
+  {
+    hive: "0xF7DE4A13669CB33D54b59f35FE71dFcD67e4635E",
+    token: "0x34b897289fccb43c048b2cea6405e840a129e021"
+  }
+]
 
 async function tvl(timestamp, block, chainBlocks) {
   const balances = {};
   block = chainBlocks.bsc;
 
-  const [{ output: bnbBalance }, { output: hiveBalances }] = await Promise.all([
-    sdk.api.eth.getBalance({
-      target: "0x1022a84f347fc1E6D47128E5364C9Aa1f43a2630",
-      block: chainBlocks.bsc,
-      chain: "bsc"
-    }),
-    sdk.api.abi.multiCall({
-      calls: hives.map(h => ({ target: h.hive })),
-      abi,
-      chain: "bsc",
-      block
-    })
-  ]);
+  const [{ output: hiveBalancesGrizzly },
+    { output: hiveBalancesStandard },
+    { output: hiveBalancesStable },
+    { output: stableHiveBalancesGrizzly },
+    { output: stableHiveBalancesStandard },
+    { output: stableHiveBalancesStable },
+    { output: farmBalances },
+    { output: yearnBalances }] = await Promise.all([
+      sdk.api.abi.multiCall({
+        calls: pcsHives.map(h => ({ target: h.hive })),
+        abi: abiGrizzly,
+        chain: "bsc",
+        block
+      }),
+      sdk.api.abi.multiCall({
+        calls: pcsHives.map(h => ({ target: h.hive })),
+        abi: abiStandard,
+        chain: "bsc",
+        block
+      }),
+      sdk.api.abi.multiCall({
+        calls: pcsHives.map(h => ({ target: h.hive })),
+        abi: abiStable,
+        chain: "bsc",
+        block
+      }),
+      sdk.api.abi.multiCall({
+        calls: stableHives.map(h => ({ target: h.hive })),
+        abi: abiGrizzly,
+        chain: "bsc",
+        block
+      }),
+      sdk.api.abi.multiCall({
+        calls: stableHives.map(h => ({ target: h.hive })),
+        abi: abiStandard,
+        chain: "bsc",
+        block
+      }),
+      sdk.api.abi.multiCall({
+        calls: stableHives.map(h => ({ target: h.hive })),
+        abi: abiStable,
+        chain: "bsc",
+        block
+      }),
+      sdk.api.abi.multiCall({
+        calls: farms.map(h => ({ target: h.hive })),
+        abi: abiFarm,
+        chain: "bsc",
+        block
+      }),
+      sdk.api.abi.multiCall({
+        calls: yearnHives.map(h => ({ target: h.hive })),
+        abi: abiYearn,
+        chain: "bsc",
+        block
+      }),
+    ]);
 
-  const lpPositions = hiveBalances.map((b, i) => ({
+  const lpPositions = hiveBalancesGrizzly.map((b, i) => {
+    const grizzly = new BigNumber(b.output);
+    const standard = new BigNumber(hiveBalancesStandard[i].output);
+    const stable = new BigNumber(hiveBalancesStable[i].output);
+
+    return {
+      balance: grizzly.plus(standard).plus(stable).toString(),
+      token: pcsHives[i].token
+    }
+  });
+
+  const lpPositionsStable = stableHiveBalancesGrizzly.map((b, i) => {
+    const grizzly = new BigNumber(b.output);
+    const standard = new BigNumber(stableHiveBalancesStandard[i].output);
+    const stable = new BigNumber(stableHiveBalancesStable[i].output);
+
+    return {
+      balance: grizzly.plus(standard).plus(stable).toString(),
+      token: stableHives[i].token,
+      swap: stableHives[i].swap
+    }
+  });
+
+  const farmLpPositions = farmBalances.map((b, i) => ({
     balance: b.output,
-    token: hives[i].token
+    token: farms[i].token
   }));
+
+  const thenaLpPositions = yearnBalances.map((b, i) => ({
+    balance: b.output,
+    token: yearnHives[i].token
+  }));
+
+  await unwrapStablePcsLPs(
+    balances,
+    lpPositionsStable,
+    block,
+    "bsc",
+    await transformBscAddress()
+  )
 
   await unwrapUniswapLPs(
     balances,
@@ -68,26 +232,122 @@ async function tvl(timestamp, block, chainBlocks) {
     await transformBscAddress()
   );
 
-  sdk.util.sumSingleBalance(
+  await unwrapUniswapLPs(
     balances,
-    "bsc:0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c",
-    bnbBalance
+    farmLpPositions,
+    block,
+    "bsc",
+    await transformBscAddress()
+  )
+
+  await unwrapUniswapLPs(
+    balances,
+    thenaLpPositions,
+    block,
+    "bsc",
+    await transformBscAddress()
   );
 
   return balances;
 }
 
+async function unwrapStablePcsLPs(balances, lpPositions, block, chain = 'ethereum', transformAddress = null, excludeTokensRaw = [],) {
+  if (!transformAddress)
+    transformAddress = await getChainTransform(chain)
+  lpPositions = lpPositions.filter(i => +i.balance > 0)
+  const excludeTokens = excludeTokensRaw.map(addr => addr.toLowerCase())
+  const lpTokenCalls = lpPositions.map(lpPosition => ({
+    target: lpPosition.token
+  }))
+  const lpTokenCalls0 = lpPositions.map(lpPosition => ({
+    target: lpPosition.swap,
+    params: [0]
+  }))
+  const lpTokenCalls1 = lpPositions.map(lpPosition => ({
+    target: lpPosition.swap,
+    params: [1]
+  }))
+  const lpStableSwapCalls0 = lpPositions.map(lpPosition => ({
+    target: lpPosition.swap,
+    params: [0]
+  }))
+  const lpStableSwapCalls1 = lpPositions.map(lpPosition => ({
+    target: lpPosition.swap,
+    params: [1]
+  }))
+  const lpReserves0 = sdk.api.abi.multiCall({
+    block,
+    abi: lpReservesAbi,
+    calls: lpStableSwapCalls0,
+    chain
+  })
+  const lpReserves1 = sdk.api.abi.multiCall({
+    block,
+    abi: lpReservesAbi,
+    calls: lpStableSwapCalls1,
+    chain
+  })
+  const lpSupplies = sdk.api.abi.multiCall({
+    block,
+    abi: lpSuppliesAbi,
+    calls: lpTokenCalls,
+    chain
+  })
+  const tokens0 = sdk.api.abi.multiCall({
+    block,
+    abi: tokenAbi,
+    calls: lpTokenCalls0,
+    chain
+  })
+  const tokens1 = sdk.api.abi.multiCall({
+    block,
+    abi: tokenAbi,
+    calls: lpTokenCalls1,
+    chain
+  })
+  await Promise.all(lpPositions.map(async lpPosition => {
+    try {
+      let token0, token1, supply
+      const lpToken = lpPosition.token
+      const swap = lpPosition.swap
+      const token0_ = (await tokens0).output.find(call => call.input.target === swap)
+      const token1_ = (await tokens1).output.find(call => call.input.target === swap)
+      const supply_ = (await lpSupplies).output.find(call => call.input.target === lpToken)
+
+      token0 = token0_.output.toLowerCase()
+      token1 = token1_.output.toLowerCase()
+      supply = supply_.output
+      //console.log(token0_, supply_, token1_, lpToken)
+      if (supply === "0") {
+        return
+      }
+
+      let _reserve0, _reserve1
+      _reserve0 = (await lpReserves0).output.find(call => call.input.target === swap).output;
+      _reserve1 = (await lpReserves1).output.find(call => call.input.target === swap).output;
+
+      if (!excludeTokens.includes(token0)) {
+        const token0Balance = BigNumber(lpPosition.balance).times(BigNumber(_reserve0)).div(BigNumber(supply))
+        sdk.util.sumSingleBalance(balances, await transformAddress(token0), token0Balance.toFixed(0))
+      }
+      if (!excludeTokens.includes(token1)) {
+        const token1Balance = BigNumber(lpPosition.balance).times(BigNumber(_reserve1)).div(BigNumber(supply))
+        sdk.util.sumSingleBalance(balances, await transformAddress(token1), token1Balance.toFixed(0))
+      }
+    } catch (e) {
+      sdk.log(e)
+      console.log(`Failed to get data for LP token at ${lpPosition.token} on chain ${chain}`)
+      throw e
+    }
+  }))
+}
+
 module.exports = {
   bsc: {
     tvl,
-    pool2: pool2(
-      "0xF530B259fFf408aaB2B02aa60dd6fe48FCDC2FC9",
-      "0x352008bf4319c3B7B8794f1c2115B9Aa18259EBb",
-      "bsc"
-    ),
     staking: stakings(
       [
-        "0x6F42895f37291ec45f0A307b155229b923Ff83F1", 
+        "0x6F42895f37291ec45f0A307b155229b923Ff83F1",
         "0xB80287c110a76e4BbF0315337Dbc8d98d7DE25DB"
       ],
       "0xa045e37a0d1dd3a45fefb8803d22457abc0a728a",

--- a/projects/numoen/index.js
+++ b/projects/numoen/index.js
@@ -1,0 +1,56 @@
+const { getLogs, getAddress, } = require('../helper/cache/getLogs')
+const { sumTokens2 } = require('../helper/unwrapLPs')
+
+const config = {
+  arbitrum: {
+    factory: '0x1B327eFf5033922B0f88FC4D56C29d7AF5a8ecdB',
+    fromBlock: 43951762,
+  },
+}
+
+const tvlCelo = async (_, _b, _cb, { api, }) => {
+  const ownerTokens = []
+
+  const logs = await getLogs({
+    api,
+    fromBlock: 17976668,
+    target: '0x8396a792510a402681812ece6ad3ff19261928ba',
+    topics: ['0x581e7fde17a1f90a422f4ef8f75f22c3437a96787d3bf54aa93c838b740183c3'],
+  })
+  logs.forEach(i => {
+    const base = getAddress(i.topics[1])
+    const speculative = getAddress(i.topics[2])
+    const lendgine = getAddress(i.data.slice(154-26))
+    const tokens = [base, speculative]
+    ownerTokens.push([tokens, lendgine])
+  })
+  return sumTokens2({ api, ownerTokens})
+}
+
+module.exports = {};
+
+Object.keys(config).forEach(chain => {
+  const { factory, fromBlock, } = config[chain]
+  module.exports[chain] = {
+    tvl: async (_, _b, _cb, { api, }) => {
+      const ownerTokens = []
+
+      const logs = await getLogs({
+        api, fromBlock, target: factory,
+        topics: ['0x1c8c5ae778c5728afc9c5b6cd391acf7cb01a6c6d4988fb2de551001ec7dc644'],
+        eventAbi: 'event LendgineCreated(address indexed base, address indexed speculative, uint256 baseScaleFactor, uint256 speculativeScaleFactor, uint256 indexed upperBound, address lendgine, address pair)',
+        onlyArgs: true,
+      })
+      logs.forEach(i => {
+        const tokens = [i.base, i.speculative]
+        ownerTokens.push([tokens, i.lendgine])
+        ownerTokens.push([tokens, i.pair])
+      })
+      return sumTokens2({ api, ownerTokens})
+    }
+  }
+})
+
+module.exports.celo = {
+  tvl: tvlCelo
+}


### PR DESCRIPTION
This PR updates the TVL of the Grizzly.fi project. It contains all new pools on the BSC version to be summed to the TVL. These pools are aggregator contracts, which provide liquidity in different protocols and handle the LP Tokens.

The following pools were added:

- 3 Biswap hives
- 2 GHNY Farm contracts
- 7 Thena Hives (yearn vault forks)
- 3 Pancakeswap Stable Hives

The Biswap, The Farms, and the Thena hives are aggregator contracts containing UniswapV2-like LP tokens so they were unwrapped using unwrapUniswapLPs helper function. The Pancakeswap Stable Hives were unwrapped using a custom function unwrapStablePcsLPs. As these Pancakeswap Stable Hives are based on curve stableSwap, this function extracts the underlying coins and their balances, the total supply, and calculates the underlying token prices.

In addition, a bug from the previous version was fixed. The Pancakeswap hives and the Biswap Hives contain 3 different strategies (standard, stable, grizzly). The contracts track the LP values separately so 3 calls per hive need to be executed for each strategy and then summed up to get the total value locked in LP tokens.

The resulting TVL can be compared to the TVL on the Webapp of Grizzly.fi: https://app.grizzly.fi/en
In the top left corner, there is the project's internal calculation of the TVL shown which is approximately the same as the script for DefiLlama.