### PR TITLE
Refactor OliveFinance adapter to display MVLP TVL on Polygon

### DIFF
--- a/projects/polysynth/index.js
+++ b/projects/polysynth/index.js
@@ -3,6 +3,7 @@ const { getCache } = require('../helper/http');
 
 let _response;
 const GLP_TOKEN = "0x4277f8F2c384827B5273592FF7CeBd9f2C1ac258";
+const MVLP_TOKEN = "0x9f4f8bc00f48663b7c204c96b932c29ccc43a2e8";
 
 async function getVaults(chain) {
   if (!_response) _response = getCache('https://h.oliveapp.finance/api/rest/vaults/tvl')
@@ -13,6 +14,9 @@ async function getVaults(chain) {
 
 function transform(address) {
   if (address.toLowerCase() === '0x5402b5f40310bded796c7d0f3ff6683f5c0cffdf') return GLP_TOKEN
+  
+  // change the underlying asset(sMVLP) which comes from OliveFinance api with the MVLP token 
+  if (address.toLowerCase() === '0x2ee50C34392E7e7a1D17B0A42328a8D1Ad6894e3') return MVLP_TOKEN 
   return address
 }
 


### PR DESCRIPTION
At the request of friends in the Olive Finance team, a small addition has been made for the MVLP TVL calculation.  Only the conversion process for GLP token address and underlying asset address has been added for MVLP too.

Note: despite this improvement, MVLP tvl is not showing yet. The reason is that Price Api does not return price information for MVLP token. This api (https://coins.llama.fi/prices/current/) should return MVLP token price info. Can you add the MVLP token to this api, as you did in the GLP token? 


MVLP Token: 0x9f4f8bc00f48663b7c204c96b932c29ccc43a2e8 



Test: 
`node test.js projects/polysynth/index.js`

Result: 
--- polygon ---
USDC                      353.71 k
MaticX                    92.06 k
WMATIC                    58.12 k
WETH                      15.50 k
WBTC                      1.52 k
Total: 520.92 k 

--- ethereum ---
WETH                      1.76 M
USDC                      205.67 k
WBTC                      1.82 k
Total: 1.97 M 

--- arbitrum ---
GLP                       1.53 M
Total: 1.53 M 

--- tvl ---
WETH                      1.77 M
GLP                       1.53 M
USDC                      559.38 k
MaticX                    92.06 k
WMATIC                    58.12 k
WBTC                      3.34 k
Total: 4.02 M 

------ TVL ------
polygon                   520.92 k
ethereum                  1.97 M
arbitrum                  1.53 M

total                    4.02 M 