### PR TITLE
remove MUX methodology

### DIFF
--- a/projects/mux/index.js
+++ b/projects/mux/index.js
@@ -37,10 +37,6 @@ async function tvl(chain, block) {
   return balances
 }
 
-module.exports = {
-  methodology: `This is the total value of all tokens in the MUXLP Pool. The liquidity pool consists of a token portfolio used for margin trading and third-party DEX mining.`,
-}
-
 Object.keys(readerContract).forEach(chain => {
   module.exports[chain] = {
     tvl: async (_, _b, {[chain]: block}) => {


### PR DESCRIPTION
**NOTE**

> - If you would like to add a `volume` adapter please submit the PR [here](https://github.com/DefiLlama/adapters).
> - If you would like to add a `liquidations` adapter, please refer to [this readme document](https://github.com/DefiLlama/DefiLlama-Adapters/tree/main/liquidations) for details.

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
3. The protocol is usually listed within 24 hours of merging the PR
4. Please fill the form below  **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
5. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can  edit it there and put up a PR
6. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
7. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap

---
We feel that the existing methodology on the MUX protocol is not accurate and have decided to remove it.
