### PR TITLE
Add ABC Pool adapter

### DIFF
--- a/projects/abc-pool/index.js
+++ b/projects/abc-pool/index.js
@@ -1,0 +1,39 @@
+const PoSPoolProxy1967 = "cfx:type.contract:accpx9uxky39pg1hzav757vdej95w1kbcp13d0hvm7";
+const rpc = "https://main.confluxrpc.com";
+
+async function tvl(_, _1, _2, { api }) {
+  // this result has to be multiplied by 1000, 
+  // as you can stake minimum 1000 tokens
+  const poolSummaryResponse = await fetch(rpc, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'cfx_call',
+      params: [{
+        to: PoSPoolProxy1967,
+        data: '0x7571fcf6' // poolSummary() in keccak256
+      }, 'latest_state'],
+      id: 1
+    })
+  })
+    .then(res => res.json())
+    .then(res => res.result)
+
+  // the result returns 3 values, we only need the first one
+  // every value is 32 bytes long, so we slice the first 32 bytes ("0x" + 64 characters)
+  const cfxTVL = parseInt(poolSummaryResponse.slice(2, 66), 16)
+
+  return {
+    'conflux-token': cfxTVL * 1000
+  }
+}
+
+module.exports = {
+  methodology: 'Calls poolSummary() in the proxy contract. The result is multiplied by 1000, as you can stake minimum 1000 CFX.',
+  conflux: {
+    tvl,
+  }
+};


### PR DESCRIPTION
**NOTE**

> 2. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.

I discussed it in the discord, and this seems the best way to do it (it's not the Conflux EVM chain)

> 4. Please fill the form below  **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR

---
##### Name (to be shown on DefiLlama):
ABC PoS Pool

##### Twitter Link: 
https://twitter.com/ABCpospool

##### Website Link: 
https://confluxpos.cn/

##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):

![abc](https://user-images.githubusercontent.com/22419450/228876188-e5128fc7-49ec-42e9-87ca-22f003a3901d.png)

##### Current TVL: 
16.84M USD (39.86M CFX)

##### Chain: 
Conflux Core Space

##### Short Description (to be shown on DefiLlama):
ABC PoS Pool is a staking solution that allows users to participate in PoS safely and pledge CFX without loss to obtain CFX+ABC reward.

##### Token address and ticker if any: 
Conflux Core Space: cfx:acb78besxg2tnxs1ccca45g2fm412mdpr6b0ve6wtc
Conflux eSpace: 0x905f2202003453006eaf975699545f2e909079b8
Ticker: $ABC

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Staking

##### methodology (what is being counted as tvl, how is tvl being calculated):
Calls poolSummary() in the proxy contract. The result is multiplied by 1000, as you can stake minimum 1000 CFX.

