### PR TITLE
[OlympusDAO] update tvl calculations to account for cross chain

### DIFF
--- a/projects/olympus/index.js
+++ b/projects/olympus/index.js
@@ -1,5 +1,4 @@
 const sdk = require("@defillama/sdk");
-const { toUSDTBalances } = require("../helper/balances");
 const { blockQuery } = require("../helper/http");
 const BigNumber = require("bignumber.js");
 

--- a/projects/olympus/index.js
+++ b/projects/olympus/index.js
@@ -15,6 +15,8 @@ const OHM = "0x383518188c0c6d7730d91b2c03a03c837814a899";
  * All balances are 1: 1 to their unstaked counterpart that has the price feed.
  **/
 const addressMap = {
+  "0xb23dfc0c4502a271976f1ee65321c51be2529640":
+    "0x76fcf0e8c7ff37a47a799fa2cd4c13cde0d981c9", //aura50OHM-50DAI -> 50OHM-50DAI
   "0xc8418af6358ffdda74e09ca9cc3fe03ca6adc5b0":
     "0x3432b6a60d23ca0dfca7761b7ab56459d9c964d0", // veFXS -> FXS
   "0x3fa73f1e5d8a792c80f426fc8f84fbf7ce9bbcac":
@@ -76,8 +78,7 @@ query {
 }`;
 
 const subgraphUrls = {
-  ethereum:
-    "https://api.thegraph.com/subgraphs/name/olympusdao/olympus-protocol-metrics",
+  ethereum: `https://gateway.thegraph.com/api/${process.env.OLYMPUS_GRAPH_API_KEY}/subgraphs/id/DTcDcUSBRJjz9NeoK5VbXCVzYbRTyuBwdPUqMi8x32pY`,
   arbitrum:
     "https://api.thegraph.com/subgraphs/name/olympusdao/protocol-metrics-arbitrum",
   fantom:

--- a/projects/olympus/index.js
+++ b/projects/olympus/index.js
@@ -175,6 +175,8 @@ module.exports = {
   start: 1616569200, // March 24th, 2021
   timetravel: false,
   misrepresentedTokens: true,
+  methodology:
+    "TVL is the sum of the value of all assets held by the treasury (excluding pTokens). Please visit https://app.olympusdao.finance/#/dashboard for more info.",
   ethereum: {
     tvl: tvl,
     staking,

--- a/projects/olympus/index.js
+++ b/projects/olympus/index.js
@@ -31,6 +31,10 @@ const addressMap = {
     "0x3175df0976dfa876431c2e9ee6bc45b65d3473cc", //stkcvxcrvFRAX-frax -> crvFRAX-frax
   "0xb0c22d8d350c67420f06f48936654f567c73e8c8":
     "0x4e78011ce80ee02d2c3e649fb657e45898257815", //sKLIMA -> KLIMA
+  "0x742b70151cd3bc7ab598aaff1d54b90c3ebc6027":
+    "0xc55126051B22eBb829D00368f4B12Bde432de5Da", //rlBTRFLY -> BTRFLY V2
+  "0xc0d4ceb216b3ba9c3701b291766fdcba977cec3a":
+    "0xc55126051B22eBb829D00368f4B12Bde432de5Da", //BTRFLY -> BTRFLYV2
 };
 
 /*** Staking of native token (OHM) TVL Portion ***/


### PR DESCRIPTION
- Previous calculations were not taking into consideration crosschain. TokenRecords endpoint is consistently used across our subgraph on all chains. Move implementation to query tokenRecords and add subgraphs for other chains.  
- also pulls individual balances from our subgraph so they appear as part of the treasury breakdown.

I've mapped unpriced (staked) tokens to their priced counterparts. See comments in adapter. 

I've chatted w/ ulysses and provided him with an API key for our decentralized graph instance. This will need to be added to various defillama environments for our graph queries to work in this adapter.  
