### PR TITLE
Added ixETH to stakedotlink TVL

### DIFF
--- a/projects/stakedotlink/index.js
+++ b/projects/stakedotlink/index.js
@@ -2,8 +2,14 @@ const sdk = require("@defillama/sdk");
 
 const sdlToken = "0xA95C5ebB86E0dE73B4fB8c47A45B792CFeA28C23";
 const sdlStakingPool = "0xAEF186611EC96427d161107fFE14bba8aA1C2284";
+
 const linkToken = "0x514910771af9ca656af840dff83e8264ecf986ca";
 const linkStakingPool = "0xb8b295df2cd735b15BE5Eb419517Aa626fc43cD5";
+
+const stETHToken = "0xae7ab96520de3a18e5e111b5eaab095312d7fe84";
+const rETHToken = "0xae78736cd615f374d3085123a210448e74fc6393";
+const stETHIndexPoolAdapter = "0xEb9f29b6395Db28C0861C24f1cbFCEee1ff0791D";
+const rETHIndexPoolAdapter = "0x6025533B9E095AB2730E1Ad50219be8293d66220";
 
 async function tvl(timestamp, ethBlock, chainBlocks) {
   const stakedLINK = await sdk.api.abi.call({
@@ -12,8 +18,21 @@ async function tvl(timestamp, ethBlock, chainBlocks) {
     abi: "uint256:totalStaked",
   });
 
+  const stakedSTETH = await sdk.api.abi.call({
+    block: ethBlock,
+    target: stETHIndexPoolAdapter,
+    abi: "uint256:getTotalDepositsLSD",
+  });
+  const stakedRETH = await sdk.api.abi.call({
+    block: ethBlock,
+    target: rETHIndexPoolAdapter,
+    abi: "uint256:getTotalDepositsLSD",
+  });
+
   return {
     [linkToken]: stakedLINK.output,
+    [stETHToken]: stakedSTETH.output,
+    [rETHToken]: stakedRETH.output,
   };
 }
 
@@ -33,7 +52,7 @@ module.exports = {
   timetravel: true,
   misrepresentedTokens: false,
   methodology:
-    "Queries LINK and SDL staking pools for the total amount of tokens staked",
+    "Queries ETH index pool and LINK and SDL staking pools for the total amount of tokens staked",
   start: 1670337984,
   ethereum: {
     tvl,


### PR DESCRIPTION
**NOTE**

> - If you would like to add a `volume` adapter please submit the PR [here](https://github.com/DefiLlama/adapters).
> - If you would like to add a `liquidations` adapter, please refer to [this readme document](https://github.com/DefiLlama/DefiLlama-Adapters/tree/main/liquidations) for details.

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
3. The protocol is usually listed within 24 hours of merging the PR
4. Please fill the form below  **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
5. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can  edit it there and put up a PR
6. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
7. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap

---
Launched a new ETH LSD index pool that accepts stETH/rETH and mints ixETH in return - added ixETH pool to TVL


