### PR TITLE
Add token breakdown link

### DIFF
--- a/projects/streamflow/index.js
+++ b/projects/streamflow/index.js
@@ -33,6 +33,7 @@ async function vesting() {
 }
 
 module.exports = {
+  methodology: 'Token breakdown: https://metabase.internal-streamflow.com/public/dashboard/fe3731c1-fbe4-4fb6-8960-515af1d6e72d', 
   timetravel: false,
   misrepresentedTokens: true,
   solana: {


### PR DESCRIPTION
Updating methodology to link to our public token breakdown dashboard.
This is merged PR for listing Streamflow: https://github.com/DefiLlama/DefiLlama-Adapters/pull/5425
