### PR TITLE
RockX Bedrock Liquid Staking TVL

### DIFF
--- a/projects/unieth/index.js
+++ b/projects/unieth/index.js
@@ -15,13 +15,13 @@ async function tvl(_, _1, _2, {api}) {
 
 	const balances = {
 		"ethereum": totalSupply * exchangeRatio / 1e18,
-  	}
+	}
 	return balances;
 }
 
 module.exports = {
   methodology: 'Counts the total ethers staked with RockX Staking Contract.',
   ethereum: {
-	  tvl,
+	tvl,
   }
 };

--- a/projects/unieth/index.js
+++ b/projects/unieth/index.js
@@ -1,0 +1,27 @@
+const sdk = require('@defillama/sdk');
+const UNIETH_TOKEN= '0xf1376bcef0f78459c0ed0ba5ddce976f1ddf51f4';
+const UNIETH_STAKING = "0x4beFa2aA9c305238AA3E0b5D17eB20C045269E9d";
+
+async function tvl(_, _1, _2, {api}) {
+	const totalSupply = await api.call({
+		abi: 'erc20:totalSupply',
+		target: UNIETH_TOKEN,
+	});
+
+	const exchangeRatio = await api.call({
+		abi: 'function exchangeRatio() external view returns (uint256)',
+		target: UNIETH_STAKING,
+	});
+
+	const balances = {
+		"ethereum": totalSupply * exchangeRatio / 1e18,
+  	}
+	return balances;
+}
+
+module.exports = {
+  methodology: 'Counts the total ethers staked with RockX Staking Contract.',
+  ethereum: {
+	  tvl,
+  }
+};


### PR DESCRIPTION
**NOTE**

> - If you would like to add a `volume` adapter please submit the PR [here](https://github.com/DefiLlama/adapters).
> - If you would like to add a `liquidations` adapter, please refer to [this readme document](https://github.com/DefiLlama/DefiLlama-Adapters/tree/main/liquidations) for details.

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
3. The protocol is usually listed within 24 hours of merging the PR
4. Please fill the form below  **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
5. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can  edit it there and put up a PR
6. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
7. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap

---
##### Name (to be shown on DefiLlama):
uniETH

##### Twitter Link:
https://twitter.com/rockx_official

##### List of audit links if any:
https://github.com/RockX-SG/stake/blob/main/PeckShield-Audit-Report-RockXStaking-v1.0.pdf

##### Website Link:
https://bedrock.rockx.com/unieth

##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):
https://github.com/RockX-SG/stake/blob/main/uniETH.svg
https://github.com/RockX-SG/stake/blob/main/uniETH.png
https://github.com/RockX-SG/stake/blob/main/uniETH_dark_32.png
https://github.com/RockX-SG/stake/blob/main/uniETH_light_32.png

##### Current TVL:
871.77694 ETH

##### Treasury Addresses (if the protocol has treasury)


##### Chain:
Ethereum

##### Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)
https://www.coingecko.com/en/coins/universal-eth

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
https://coinmarketcap.com/currencies/universal-eth/

##### Short Description (to be shown on DefiLlama):
uniETH represents the staked ETH in Bedrock plus all future staking rewards. uniETH is non-rebasing, i.e. does not grow in quantity over time but grows in value instead. In other words, 1 uniETH will be worth more than 1 ETH as time goes on, and its value will continue to increase as more time passes.

##### Token address and ticker if any:
https://etherscan.io/address/0xF1376bceF0f78459C0Ed0ba5ddce976F1ddF51F4

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Liquid Staking

##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):


##### forkedFrom (Does your project originate from another project):


##### methodology (what is being counted as tvl, how is tvl being calculated):
The overall ETH values belongs to all uniETH holders.

```
TVL( total wei of eth) := (uniETH Total Supply * Current Official Exchange Ratio) / 1e18
```
i.e.
```
TVL := ERC20(0xF1376bceF0f78459C0Ed0ba5ddce976F1ddF51F4).totalSupply() * (0x4beFa2aA9c305238AA3E0b5D17eB20C045269E9d).exchangeRatio() /1e18
```
```

