### PR TITLE
shapeshift: list new pools and foxy

### DIFF
--- a/projects/shapeshift/index.js
+++ b/projects/shapeshift/index.js
@@ -1,18 +1,30 @@
 const { staking } = require("../helper/staking");
 
 // Contracts
-const StakingYieldContract = "0xDd80E21669A664Bce83E3AD9a0d74f8Dad5D9E72";
-const StakingYieldContractV2 = "0xc54b9f82c1c54e9d4d274d633c7523f2299c42a0";
+const stakingUNIv2Contracts = [
+  "0xDd80E21669A664Bce83E3AD9a0d74f8Dad5D9E72", // v1
+  "0xc54b9f82c1c54e9d4d274d633c7523f2299c42a0", // v2
+  "0x212ebf9fd3c10f371557b08e993eaab385c3932b", // v3
+  "0x24FD7FB95dc742e23Dc3829d3e656FEeb5f67fa0", // v4
+  "0xC14eaA8284feFF79EDc118E06caDBf3813a7e555", // v5
+  "0xEbB1761Ad43034Fd7FaA64d84e5BbD8cB5c40b68", // v6
+];
+const stakingFoxy = "0xee77aa3Fd23BbeBaf94386dD44b548e9a785ea4b";
 
 // Tokens Or LPs
 const ETH_FOX_UNIV2 = "0x470e8de2eBaef52014A47Cb5E6aF86884947F08c";
 const FOX = "0xc770eefad204b5180df6a14ee197d99d808ee52d";
+const tFOX = "0x808D3E6b23516967ceAE4f17a5F9038383ED5311";
+const FOXy = "0xDc49108ce5C57bc3408c3A5E95F3d864eC386Ed3";
 
 module.exports = {
   ethereum: {
-    pool2: staking([StakingYieldContract, StakingYieldContractV2], [ETH_FOX_UNIV2]),
-    tvl: async ()=>({}),
+    pool2: staking(
+      [...stakingUNIv2Contracts, stakingFoxy],
+      [ETH_FOX_UNIV2, FOX, tFOX, FOXy]
+    ),
+    tvl: async () => ({}),
   },
   methodology:
-    "We count liquidity of ETH-FOX LP deposited on Uniswap V2 pool through StakingYieldContract contract; and the staking of native token",
+    "We count liquidity of ETH-FOX LP deposited on Uniswap V2 pool through StakingYieldContract contracts; and the staking of native token",
 };


### PR DESCRIPTION
Hello,  I'm a ShapeShift DAO contributor and I'd like to update the TLV for our project with the current Staking pools.

I've made this PR as a draft because I have a couple questions:

- I've listed all the new contracts we have and if I compare the total USD value on Etherscan of the 6 UNIv2 contracts (currently $3,506,615.69) and the output of the modified script (`FOX-WETH-UNI-V2           2.81 M`), there's quite a big difference, what is causing it ?

    Here are the Etherscan links for these pools: [v1](https://etherscan.io/token/0x470e8de2ebaef52014a47cb5e6af86884947f08c?a=0xDd80E21669A664Bce83E3AD9a0d74f8Dad5D9E72) / [v2](https://etherscan.io/token/0x470e8de2ebaef52014a47cb5e6af86884947f08c?a=0xc54b9f82c1c54e9d4d274d633c7523f2299c42a0) / [v3](https://etherscan.io/token/0x470e8de2ebaef52014a47cb5e6af86884947f08c?a=0x212ebf9fd3c10f371557b08e993eaab385c3932b) / [v4](https://etherscan.io/token/0x470e8de2ebaef52014a47cb5e6af86884947f08c?a=0x24FD7FB95dc742e23Dc3829d3e656FEeb5f67fa0) / [v5](https://etherscan.io/token/0x470e8de2ebaef52014a47cb5e6af86884947f08c?a=0xC14eaA8284feFF79EDc118E06caDBf3813a7e555) / [v6](https://etherscan.io/token/0x470e8de2ebaef52014a47cb5e6af86884947f08c?a=0xEbB1761Ad43034Fd7FaA64d84e5BbD8cB5c40b68)

- The `stakingFoxy` [contract](https://etherscan.io/address/0xee77aa3Fd23BbeBaf94386dD44b548e9a785ea4b) allows our users to stake `FOX` and get 1:1 `FOXy`(another ERC-20 token we have created) in exchange, and the users get the yield generated by allocating these `FOX` on various strategies (currently in a Tokemak reactor so `tFOX` gets locked in our contract) as well as any other revenue streams that the community allocates (e.g. 10% of KeepKey sales). Can this be added to our TLV using the same function `staking` function? If not, how should we do it?

Thanks in advance for your help!