### PR TITLE
feature: Add Umami treasury adapter

### DIFF
--- a/projects/treasury/umamifinance.js
+++ b/projects/treasury/umamifinance.js
@@ -1,0 +1,31 @@
+const { nullAddress, treasuryExports } = require("../helper/treasury");
+
+const owners = [
+  "0xb137d135dc8482b633265c21191f50a4ba26145d", // Main treasury
+  "0x8e52ca5a7a9249431f03d60d79dda5eab4930178", // ARB DAO delegate
+  "0xb0b4bd94d656353a30773ac883591ddbabc0c0ba", // Previous ARBI multisig
+];
+const ownTokens = [
+  "0x1622bF67e6e5747b81866fE0b85178a93C7F86e3", // UMAMI
+  "0x2AdAbD6E8Ce3e82f52d9998a7f64a90d294A92A4", // mUMAMI
+  "0x1922C36F3bc762Ca300b4a46bB2102F84B1684aB", // cmUMAMI
+];
+
+module.exports = treasuryExports({
+  arbitrum: {
+    tokens: [
+      nullAddress,
+      "0x1aDDD80E6039594eE970E5872D247bf0414C8903", // fsGLP
+      "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8", // USDC
+      "0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9", // USDT
+      "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1", // wETH
+      "0xfc5A1A6EB076a2C7aD06eD22C90d7E710E35ad0a", // GMX
+      "0x55ff62567f09906a85183b866df84bf599a4bf70", // KROM
+      "0x3d9907f9a368ad0a51be60f7da3b97cf940982d8", // GRAIL
+      "0x3CAaE25Ee616f2C8E13C74dA0813402eae3F496b", // xGRAIL
+      "0x912CE59144191C1204E64559FE8253a0e49E6548", // ARB
+    ],
+    owners,
+    ownTokens,
+  },
+});

--- a/projects/umamifinance/index.js
+++ b/projects/umamifinance/index.js
@@ -8,8 +8,9 @@ const mUMAMI = "0x2adabd6e8ce3e82f52d9998a7f64a90d294a92a4";
 // UMAMI staking from when it was still ohm fork with rebasing mechanics.
 // There's still some staked tokens that are yet not unstaked and migrated.
 const OHM_STAKING_sUMAMI = "0xc9ecFeF2fac1E38b951B8C5f59294a8366Dfbd81";
+// glpUSDC vault is now deprecated
 const glpUSDC = "0x2e2153fd13459eba1f277ab9acd624f045d676ce";
-const glpInitBlock = 18703806
+const glpInitBlock = 18703806;
 const USDC = "0xff970a61a04b1ca14834a43f5de4533ebddb5cc8";
 
 module.exports = {
@@ -19,7 +20,7 @@ module.exports = {
   arbitrum: {
     staking: stakings([mUMAMI, OHM_STAKING_sUMAMI], UMAMI, "arbitrum"),
     tvl: async (_, _b, { arbitrum: block }) => {
-      const balances = {}
+      const balances = {};
 
       if (!block || block > glpInitBlock + 10) {
         const totalAssets = await sdk.api.abi.call({
@@ -28,10 +29,14 @@ module.exports = {
           chain: "arbitrum",
           block,
         });
-        sdk.util.sumSingleBalance(balances, `arbitrum:${USDC}`, totalAssets.output)
+        sdk.util.sumSingleBalance(
+          balances,
+          `arbitrum:${USDC}`,
+          totalAssets.output
+        );
       }
 
-      return balances
+      return balances;
     },
   },
 };


### PR DESCRIPTION
Adding Umami Finance treasury adapter. 
All assets are held on Arbitrum by 2 wallets, the third one is the Arbitrum DAO airdrop recipient and also the DAO's delegate address. 

Our biggest holdings are in GMX's GLP so I added fsGLP as a token, not sure that's the proper way.

Docs listed treasury addresses : [Umami docs](https://docs.umami.finance/umami-finance/contract-addresses)
> Note : the "Main net Multisig" address isn't used anymore

Arbitrum DAO recipient verification tweet : [Twitter](https://twitter.com/UmamiDao/status/1638219569893351433)

Let me know if changes are needed.