### PR TITLE
Add Snark Launch

### DIFF
--- a/projects/snarklaunch/index.js
+++ b/projects/snarklaunch/index.js
@@ -1,0 +1,11 @@
+const { sumTokensExport } = require('../helper/unwrapLPs')
+
+const STAKING_SNRK_CONTRACT = "0xEbA49A81501b036234578D10e78685ca8BbD2901";
+const SNRK_TOKEN = "0x533b5F887383196C6bc642f83338a69596465307";
+
+module.exports = {
+  methodology: 'TVL for SNRK staking is computed by summing the balance of SNRK tokens held by the staking contract.',
+  era: {
+    tvl: sumTokensExport({ owners: [STAKING_SNRK_CONTRACT], tokens: [SNRK_TOKEN] })
+  },
+}

--- a/projects/snarklaunch/index.js
+++ b/projects/snarklaunch/index.js
@@ -6,6 +6,7 @@ const SNRK_TOKEN = "0x533b5F887383196C6bc642f83338a69596465307";
 module.exports = {
   methodology: 'TVL for SNRK staking is computed by summing the balance of SNRK tokens held by the staking contract.',
   era: {
-    tvl: sumTokensExport({ owners: [STAKING_SNRK_CONTRACT], tokens: [SNRK_TOKEN] })
+    staking: sumTokensExport({ owners: [STAKING_SNRK_CONTRACT], tokens: [SNRK_TOKEN] }),
+    tvl: () => 0,
   },
 }


### PR DESCRIPTION
##### Name (to be shown on DefiLlama): Snark Launch


##### Twitter Link: https://twitter.com/SnarkLaunch


##### List of audit links if any: https://skynet.certik.com/projects/snark-launch


##### Website Link: https://app.snarklaunch.com/


##### Logo (High resolution, will be shown with rounded borders): https://we.tl/t-wgFjlC3Qnw


##### Current TVL: $150k


##### Treasury Addresses (if the protocol has treasury): -


##### Chain: zkSync


##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): snark-launch


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): 24659


##### Short Description (to be shown on DefiLlama): Snark Launch is a decentralized launchpad on the zkSync blockchain that launches and accelerates new blockchain projects on the network, while also providing growth opportunities for new projects.


##### Token address and ticker if any:  0x533b5F887383196C6bc642f83338a69596465307 , $SNRK


##### Category (full list at https://defillama.com/categories) *Please choose only one: 13. Launchpad


##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using): No oracles being used.


##### forkedFrom (Does your project originate from another project): No.


##### methodology (what is being counted as tvl, how is tvl being calculated): TVL for SNRK staking is computed by summing the balance of SNRK tokens held by the staking contract.