### PR TITLE
Updated Genius Yield Adapter: Added EMP staking

### DIFF
--- a/projects/genius-yield/index.js
+++ b/projects/genius-yield/index.js
@@ -3,13 +3,14 @@ const { sumTokensExport,  } = require('../helper/chain/cardano')
 const gens = 'dda5fdb1002f7389b33e036b6afee82a8189becb6cba852e8b79b4fb0014df1047454e53'
 const nmkr = '5dac8536653edc12f6f5e1045d8164b9f59998d3bdc300fc928434894e4d4b52'
 const ntx = 'edfd7a1d77bcb8b884c474bdc92a16002d1fb720e454fa6e993444794e5458'
+const emp = '6c8642400e8437f737eb86df0fc8a8437c760f48592b1ba8f5767e81456d706f7761'
 
 const owner = 'addr1w8r99sv75y9tqfdzkzyqdqhedgnef47w4x7y0qnyts8pznq87e4wh'
 
 module.exports = {
   timetravel: false,
   cardano: {
-    staking: sumTokensExport({ owner, tokens: [gens, nmkr, ntx]}),
+    staking: sumTokensExport({ owner, tokens: [gens, nmkr, ntx, emp]}),
     tvl: () => ({})
   }
 };


### PR DESCRIPTION
 - Added [EMP](https://cardanoscan.io/token/6c8642400e8437f737eb86df0fc8a8437c760f48592b1ba8f5767e81456d706f7761) staking to the TVL of Genius Yield, since now not only GENS, NTX and NMKR, but also EMP tokens are locked in the [staking contract](https://pool.pm/addr1w8r99sv75y9tqfdzkzyqdqhedgnef47w4x7y0qnyts8pznq87e4wh/).
 - The EMP token can be already staked via the [Genius Yield Staking feature](https://app.geniusyield.co/earn).
  
![image](https://user-images.githubusercontent.com/2914096/234844218-fe485acb-837c-4096-908a-fc8ccdc2c63d.png)

Source: https://pool.pm/addr1w8r99sv75y9tqfdzkzyqdqhedgnef47w4x7y0qnyts8pznq87e4wh/