### PR TITLE
making notional v2 tvl dynamic

### DIFF
--- a/projects/notional/abi.json
+++ b/projects/notional/abi.json
@@ -1,4 +1,4 @@
 {
-  "maxCurrencyId": "uint16:maxCurrencyId",
-  "currencyIdToAddress": "function currencyIdToAddress(uint16) view returns (address)"
+  "getMaxCurrencyId": "function getMaxCurrencyId() view returns (uint16)",
+  "getCurrency": "function getCurrency(uint16) view returns ((address,bool,int256,uint8,uint256),(address,bool,int256,uint8,uint256))"
 }

--- a/projects/notional/index.js
+++ b/projects/notional/index.js
@@ -1,36 +1,35 @@
 const abi = require('./abi');
 const sdk = require('@defillama/sdk');
-const { sumTokensAndLPsSharedOwners } = require('../helper/unwrapLPs');
 
-const escrowContract = '0x9abd0b8868546105F6F48298eaDC1D9c82f7f683';
 const v2Contract = "0x1344A36A1B56144C3Bc62E7757377D288fDE0369"
 
 async function tvl (timestamp, block) {
   const maxCurrencyId = (await sdk.api.abi.call({
     block,
-    target: escrowContract,
-    abi: abi['maxCurrencyId']
+    target: v2Contract,
+    abi: abi['getMaxCurrencyId']
   })).output;
 
   const addressCalls = []
-  for (let i = 0; i <= maxCurrencyId; i++) {
+  for (let i = 1; i <= maxCurrencyId; i++) {
     addressCalls.push({
-      target: escrowContract,
+      target: v2Contract,
       params: i
     })
   }
 
   const supportedTokens = (await sdk.api.abi.multiCall({
     calls: addressCalls,
-    target: escrowContract,
-    abi: abi['currencyIdToAddress'],
+    target: v2Contract,
+    abi: abi['getCurrency'],
     block,
   })).output
 
   const balanceCalls = supportedTokens.map((s) => {
     return {
-      target: s.output,
-      params: escrowContract
+      // Target is the asset token address, first parameter, first slot in tuple
+      target: s.output[0][0],
+      params: v2Contract
     }
   })
 
@@ -44,13 +43,6 @@ async function tvl (timestamp, block) {
     obj[b.input.target] = b.output
     return obj
   }, {})
-
-  await sumTokensAndLPsSharedOwners(balanceMap, [
-    "0x39aa39c021dfbae8fac545936693ac917d5e7563",
-    "0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643",
-    "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
-    "0xccf4429db6322d5c611ee964527d42e5d685dd6a"
-  ].map(a=>[a, false]), [v2Contract], block)
 
   return balanceMap
 }

--- a/projects/notional/index.js
+++ b/projects/notional/index.js
@@ -11,9 +11,7 @@ async function tvl(timestamp, block, _, { api }) {
   let nwBals = await api.multiCall({  abi: 'erc20:balanceOf', calls: nwTokens.map(i => ({ target: i, params: v2Contract}))})
   const underlyingTokens = await api.multiCall({  abi: 'address:underlying', calls: nwTokens})
   const exchangeRate = await api.multiCall({  abi: 'uint256:getExchangeRateView', calls: nwTokens})
-  const tDecimals = await api.multiCall({  abi: 'erc20:decimals', calls: nwTokens})
-  const uDecimals =( await api.multiCall({  abi: 'erc20:decimals', calls: nwTokens, permitFailure: true,})).map(i => i ?? 18)
-  nwBals = nwBals.map((bal, i) => bal * (exchangeRate[i]/1e18) * (10 ** uDecimals[i] / 10 ** tDecimals[i]))
+  nwBals = nwBals.map((bal, i) => bal * (exchangeRate[i]/1e18))
   api.addTokens(underlyingTokens, nwBals)
   return sumTokens2({ api, owner: v2Contract, tokens, blacklistedTokens: nwTokens })
 }


### PR DESCRIPTION
Changes Notional V2 TVL to look at the currency address fetched from the contract directly.

Prior to the migration described in this [blog post](https://blog.notional.finance/vulnerability-report/), the currency addresses are Compound V2 cTokens. Post migration, it is a wrapped nwToken which can be valued using this methodology:
https://github.com/notional-finance/contracts-v2/blob/master/contracts/external/adapters/nwToken.sol

Currently, the nwTokens returned do not get a valuation so need some help with fixing that. The approximate current TVL is $34 million.