### PR TITLE
Kujira: USK updates

### DIFF
--- a/projects/kujira/index.js
+++ b/projects/kujira/index.js
@@ -1,26 +1,10 @@
-const { get } = require("../helper/http");
-const { sumTokens, endPoints } = require('../helper/chain/cosmos')
+const { sumTokens, queryContracts } = require('../helper/chain/cosmos')
 
+const chain = "kujira";
 
 async function tvl() {
-  const uskCDPs = [
-    "kujira1ecgazyd0waaj3g7l9cmy5gulhxkps2gmxu9ghducvuypjq68mq2smfdslf",
-    "kujira1f2jt3f9gzajp5uupeq6xm20h90uzy6l8klvrx52ujaznc8xu8d7s6av27t", 
-    "kujira1eydneup86kyhew5zqt5r7tkxefr3w5qcsn3ssrpcw9hm4npt3wmqa7as3u",
-    "kujira1fjews4jcm2yx7una77ds7jjjzlx5vgsessguve8jd8v5rc4cgw9s8rlff8",
-    "kujira1r80rh4t7zrlt8d6da4k8xptwywuv39esnt4ax7p7ca7ga7646xssrcu5uf",
-    "kujira1m0z0kk0qqug74n9u9ul23e28x5fszr628h20xwt6jywjpp64xn4qkxmjq3",
-    "kujira1pep6vkkjexjlsw3y5h4tj27g7s58vkypy8zg7f9qdvlh2992pncqduz84n",
-    "kujira1hjyjafrt09p4hwsnwch29nrrs40lprfgesqdy44wnp27td872hsse2rree",
-    "kujira1m4ves3ymz5hyrj3war3t7uxu9ewt8rwpunja87960n0gre3a5pzspgry4g",
-    "kujira1722g2rudg0rlw45nuuvjhg4a365xztfrdfjgyyfuzlmqmtu2plas34y6x3",
-    "kujira1twc28l5njc07xuxrs85yahy44y9lw5euwa7kpajc2zdh98w6uyksvjvruq",
-    "kujira1mjdmut3vq7n7zv6p9kdkdng0zpk2286qww0yy0ay4e8cvxd5p2zqvh9aqs"
-  ]
-  const owners = [
-    ...uskCDPs,
-  ]
-  return sumTokens({ owners, chain: 'kujira' })
+  const uskContracts = await queryContracts({ chain, codeId: 73 });
+  return sumTokens({ owners: uskContracts, chain })
 }
 
 module.exports = {


### PR DESCRIPTION
This PR fetches the list of USK vaults dynamically from the code ID, rather than a fixed list of addresses. 

@Define101 how long will https://github.com/DefiLlama/defillama-server/pull/3091 take to impact this TVL reading? I'm seeing balances as below: 

```
{
    'ibc:B4DCACF7753C05040AF0A7BF2B583402C4B8C9B0A86FCECE32EF63CB7F0A46B3': '176694003770483482163',
    'ibc:27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2': '65059059203',
    'ibc:DADB399E742FCEE71853E98225D13E44E90292852CD0033DF5CABAB96F80B833': '173197526430919913261',
    'ibc:F97BDCE220CCB52139C73066E36C45EC7EDCEEF1DAFF891A34F4FBA195A2E6E8': '33026644237',
    'ibc:0306D6B66EAA2EDBB7EAD23C0EC9DDFC69BB43E80B398035E90FBCFEF3FD1A87': '50896097413',
    'ibc:B37E4D9FB5B30F3E1E20A4B2DE2A005E584C5C822C44527546556AE2470B4539': '50892586803014',
    'ibc:DA59C009A0B3B95E0549E6BF7B075C8239285989FF457A8EDDBB56F10B2A6986': '58130702699',
    'ibc:1B38805B1C75352B28169284F96DF56BDEBD9E8FAC005BDCC8CF0378C82AA8E7': '227107179097592819989'
  }
```

However these two (stOSMO and stATOM) aren't being included in the output. Not sure if there's something else that needs configuring somewhere?

```
    'ibc:F97BDCE220CCB52139C73066E36C45EC7EDCEEF1DAFF891A34F4FBA195A2E6E8': '33026644237',
    'ibc:0306D6B66EAA2EDBB7EAD23C0EC9DDFC69BB43E80B398035E90FBCFEF3FD1A87': '50896097413',
```

Thanks! 