### PR TITLE
Kujira: Use cosmos.directory for LCD

### DIFF
--- a/projects/helper/chain/cosmos.js
+++ b/projects/helper/chain/cosmos.js
@@ -14,7 +14,7 @@ const endPoints = {
   crescent: "https://mainnet.crescent.network:1317",
   osmosis: "https://lcd.osmosis.zone",
   cosmos: "https://cosmoshub-lcd.stakely.io",
-  kujira: "https://lcd.kaiyo.kujira.setten.io",
+  kujira: "https://rest.cosmos.directory/kujira",
   comdex: "https://rest.comdex.one",
   terra: "https://terraclassic-lcd-server-01.stakely.io",
   terra2: "https://phoenix-lcd.terra.dev",


### PR DESCRIPTION
This updates the LCD provider for Kujira to use https://cosmos.directory/kujira. Cosmos.directory operates a load balanced endpoint across the LCD endpoints registered in https://github.com/cosmos/chain-registry. This should help reduce reliance on any single provider (and can also be rolled out to other cosmos chains)