### PR TITLE
Calculate veTT pool size by contract call

### DIFF
--- a/projects/vett/index.js
+++ b/projects/vett/index.js
@@ -1,8 +1,27 @@
-const { nullAddress, sumTokensExport } = require('../helper/unwrapLPs');
+const sdk = require("@defillama/sdk");
+
+
+const chain = "thundercore";
+const posStaking = "0xC3C857a9E5Be042C8acF4F2827Aa053e93b5d039"
+const posABI = {
+  getTTPoolAbi: "uint256:getTTPool"
+}
+
+async function tvl(_timestamp, _b, { thundercore: block }) {
+  const params = { chain, block, target: posStaking, }
+  // staking pool = balanceOf(posStaking) + sum(voterStakings) - sum(userUnstakings)
+  const ttTvl = await sdk.api2.abi.call({
+    ...params,
+    abi: posABI.getTTPoolAbi,
+  });
+  return {
+    "thunder-token": ttTvl / 1e18,
+  };
+}
 
 module.exports = {
   methodology: 'calculate the total amount of TT locked in the veTT contract',
   thundercore: {
-    tvl: sumTokensExport({ owners: ['0xC3C857a9E5Be042C8acF4F2827Aa053e93b5d039'], tokens: [nullAddress], })
+    tvl,
   },
 }


### PR DESCRIPTION
After the latest hardfork on ThunderCore, the team moved all TT in the posStaking contract to running voters to achieve a true "Proof of Staking".

The real-time staking amount can be obtained by calling getTTPool(), which calculates the pool size using the formula:
```
pool size = balanceOf(posStaking) + sum(posVoterStakings) - sum(userUnstakings)
```
This formula takes into account the balance of the posStaking contract, the total staking amount of all voters, and the total amount of TT being unstaked by users.

---

Name (to be shown on DefiLlama):
ThunderCore PoS Staking

Twitter Link:
https://twitter.com/ThunderCoreLab

List of audit links if any:
Website Link:
https://pos-staking.thundercore.com/

Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):
https://drive.google.com/file/d/19gfvG79i_mAcAKioODSXf_xzzDuzdOus/view

Current TVL:
3.77 M USD

Treasury Addresses (if the protocol has treasury)
Chain:
ThunderCore

Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)
thunder-token

Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
3930

Short Description (to be shown on DefiLlama):
Anyone can join ThunderCore PoS Staking to secure the network and earn staking rewards.

Token address and ticker if any:
TT

Category (full list at https://defillama.com/categories) *Please choose only one:
Liquid staking

Oracle used (Chainlink/Band/API3/TWAP or any other that you are using): No

forkedFrom (Does your project originate from another project): No

methodology (what is being counted as tvl, how is tvl being calculated): 
tvl = pool size = balanceOf(posStaking) + sum(posVoterStakings) - sum(userUnstakings)

