### PR TITLE
Add Zenith Protocol

### DIFF
--- a/projects/zenith/contracts.json
+++ b/projects/zenith/contracts.json
@@ -1,0 +1,23 @@
+{
+  "admin": "0x3a11537C0e1f1cc80820a1EEd973bB367Bf3276A",
+  "ZTH": "0x00000000A82B4758df44fcB124e26a9B441E59a0",
+  "masterChef": "0xb9e7008FA856D66680BeE9E0a24da407D9d7fAD5",
+  "esZTH": "0x4DC377c2B63d06fF47BBd2B3B1177cfAC1906b1e",  
+  "treasury": "0x648F3eC98da4De19b92598CF384662d494D881AB",
+  "ZTHETHPairV2":"0xAC0155CBd306e41C1287E2c53e1306178397b823",
+  "config": {
+    "startTime": 1683469800
+  },
+  "stakePools":  [
+    {
+        "pid": 0,
+        "name":"ETH",
+        "asset": "0x0000000000000000000000000000000000000000"
+    },
+    {
+        "pid": 1,
+        "name":"ZTH-ETH",
+        "asset": "0xAC0155CBd306e41C1287E2c53e1306178397b823"
+    }
+  ] 
+}

--- a/projects/zenith/index.js
+++ b/projects/zenith/index.js
@@ -12,8 +12,7 @@ module.exports = {
   methodology:
     "TVL is comprised of tokens deposited to Zenith protocol as collateral, similar to Compound Finance and other lending protocols the borrowed tokens are not counted as TVL.",
   ethereum: {
-    tvl: (async) => ({}),
     pool2: pool2s([contracts.masterChef], pool2),
-    staking: stakings([contracts.masterChef], stakeTokens),
+    tvl: stakings([contracts.masterChef], stakeTokens),
   },
 };

--- a/projects/zenith/index.js
+++ b/projects/zenith/index.js
@@ -1,0 +1,19 @@
+const { stakings } = require("../helper/staking");
+const { pool2s } = require("../helper/pool2"); 
+
+const contracts = require("./contracts.json");
+
+var pool2= [contracts.ZTHETHPairV2];
+var stakeTokens=[];
+contracts.stakePools.forEach(r=> {if(r.asset!=contracts.ZTHETHPairV2) stakeTokens.push(r.asset) }); 
+
+ 
+module.exports = {
+  methodology:
+    "TVL is comprised of tokens deposited to Zenith protocol as collateral, similar to Compound Finance and other lending protocols the borrowed tokens are not counted as TVL.",
+  ethereum: {
+    tvl: (async) => ({}),
+    pool2: pool2s([contracts.masterChef], pool2),
+    staking: stakings([contracts.masterChef], stakeTokens),
+  },
+};


### PR DESCRIPTION
##### Name : Zenith

##### Twitter Link: https://twitter.com/Zenith_cash

##### List of audit links if any: N/A
##### Website Link: https://zenith.cash/

##### Logo (High resolution, will be shown with rounded borders):

https://user-images.githubusercontent.com/132888027/236868673-e3a255ab-e34d-4fcf-8145-291cb9eac119.png


##### Current TVL:  $22,709,123



##### Treasury Addresses :  0x648F3eC98da4De19b92598CF384662d494D881AB



##### Chain: Ethereum

##### Coingecko ID :    `zenith-token-306740ae-2497-41a7-aef9-ec34e7f12aa3`
##### Coinmarketcap ID :   Listing request is pending 
##### Short Description :

Zenith is the first leveraged yield farming protocol based on LSD. 
Users can stake ETH or LSD on Zenith and the platform will automatically select the liquidity mining pool with the highest APR for users to earn passive income. Moreover, Zenith provides leverage for users to amplify their assets and increase potential returns. By introducing leveraged yield farming into LSD protocols, Zenith is able to continuously earn competitive yields for users.

##### Token address and ticker if any: 0x00000000A82B4758df44fcB124e26a9B441E59a0

##### Category : Leveraged Farming

##### Oracle used : N/A

##### forkedFrom : N/A

##### methodology :

Now only the staked part, staked ETH and staked ZTH-ETH LP Pool2
