### PR TITLE
Avoid double-counting Caviar TVL

### DIFF
--- a/projects/caviar/index.js
+++ b/projects/caviar/index.js
@@ -15,10 +15,8 @@ async function tvl(_, _b, _cb, { api, }) {
   const pools = await api.multiCall({  abi: "function pairs(address, address, bytes32) view returns (address)", calls: calls.map(i => ({ params: i})), target: factory }) 
 
   const balances = await sumTokens2({ api, owners: pools, tokens: [nullAddress]})
-  const ethKey = 'ethereum:'+nullAddress
   return {
-    ...balances,
-    [ethKey]: (balances[nullAddress] ?? 0) * 2
+    [nullAddress]: (balances[nullAddress] ?? 0) * 2
   }
 }
 


### PR DESCRIPTION
The doubling of the ETH TVL to account for the
NFTs has to override properly the ETH TVL itself
otherwise the ETH TVL is double-counted.