### PR TITLE
Fix getDenomBalance result for Terra/Risk Harbor

### DIFF
--- a/projects/helper/chain/terra.js
+++ b/projects/helper/chain/terra.js
@@ -50,7 +50,7 @@ async function getDenomBalance(denom, owner, block, { isTerra2 = false } = {}) {
   if (block !== undefined) {
     endpoint += `?height=${block - (block % 100)}`
   }
-  const data = (await axios.get(endpoint)).data.result
+  const data = (await axios.get(endpoint)).data.balances;
 
   const balance = data.find(balance => balance.denom === denom);
   return balance ? Number(balance.amount) : 0

--- a/projects/helper/chain/terra.js
+++ b/projects/helper/chain/terra.js
@@ -50,7 +50,9 @@ async function getDenomBalance(denom, owner, block, { isTerra2 = false } = {}) {
   if (block !== undefined) {
     endpoint += `?height=${block - (block % 100)}`
   }
-  const data = (await axios.get(endpoint)).data.balances;
+  let {data} = (await axios.get(endpoint));
+  if (isTerra2) data = data.balances
+  else data = data.result
 
   const balance = data.find(balance => balance.denom === denom);
   return balance ? Number(balance.amount) : 0


### PR DESCRIPTION
This should fix the querying of balances on Terra

Risk Harbor has not been reporting any data since April 20th. This change will resume reporting of TVL values.