### PR TITLE
Remove deprecated fetchOrderbooks for fetchOrderbooksV2

### DIFF
--- a/projects/helper/chain/injective.js
+++ b/projects/helper/chain/injective.js
@@ -32,7 +32,7 @@ async function getOrders({ type = TYPES.SPOT, marketIds }) {
   const chunks = sliceIntoChunks(marketIds, 20)
   const response = []
   for (const chunk of chunks)
-    response.push(...await getClient(type).fetchOrderbooks(chunk))
+    response.push(...await getClient(type).fetchOrderbooksV2(chunk))
   return response
 }
 


### PR DESCRIPTION
Appears fetchOrderbooks is deprecated and has been replaced by fetchOrderbooksV2 in @injectives/sdk-ts

Helix has not been reporting TVL values since April 19th due to this
