### PR TITLE
Update: Vega Protocol Staking Value

### DIFF
--- a/projects/vega-protocol/index.js
+++ b/projects/vega-protocol/index.js
@@ -14,7 +14,7 @@ const config = {
   vestingContract: '0x23d1bFE8fA50a167816fBD79D7932577c06011f4' },
 }
 
-contractAbis = {
+const contractAbis = {
   "totalStaked": "function total_staked() view returns (uint256)",
   "balanceOf": "function balanceOf(address account) view returns (uint256)"
 }

--- a/projects/vega-protocol/index.js
+++ b/projects/vega-protocol/index.js
@@ -1,18 +1,29 @@
 const { getLogs } = require('../helper/cache/getLogs')
 const { sumTokens2 } = require('../helper/unwrapLPs')
-const { staking } = require('../helper/staking')
 
 const assetListedEvent = "event Asset_Listed(address indexed asset_source, bytes32 indexed vega_asset_id, uint256 nonce)"
+const BigNumber = require("bignumber.js");
 
 const config = {
-  ethereum: { bridge: '0x124Dd8a6044ef048614AEA0AAC86643a8Ae1312D', fromBlock: 15263615, vega: '0xcb84d72e61e383767c4dfeb2d8ff7f4fb89abc6e', stakingContract: '0x195064D33f09e0c42cF98E665D9506e0dC17de68', assetPool: '0xF0f0FcDA832415b935802c6dAD0a6dA2c7EAed8f' }
+  ethereum: { bridge: '0x124Dd8a6044ef048614AEA0AAC86643a8Ae1312D', 
+  fromBlock: 15263615, 
+  vega: '0xcb84d72e61e383767c4dfeb2d8ff7f4fb89abc6e', 
+  stakingContract: '0x195064D33f09e0c42cF98E665D9506e0dC17de68', 
+  assetPool: '0xF0f0FcDA832415b935802c6dAD0a6dA2c7EAed8f',
+
+  vestingContract: '0x23d1bFE8fA50a167816fBD79D7932577c06011f4' },
+}
+
+contractAbis = {
+  "totalStaked": "function total_staked() view returns (uint256)",
+  "balanceOf": "function balanceOf(address account) view returns (uint256)"
 }
 
 module.exports = {
 };
 
 Object.keys(config).forEach(chain => {
-  const { bridge, fromBlock, vega, stakingContract, assetPool, } = config[chain]
+  const { bridge, fromBlock, vega, stakingContract, assetPool, vestingContract } = config[chain]
   module.exports[chain] = {
     tvl: async (_, _b, _cb, { api, }) => {
       const logs = await getLogs({
@@ -26,9 +37,27 @@ Object.keys(config).forEach(chain => {
       const blacklistedTokens = []
       if (vega) blacklistedTokens.push(vega)
       return sumTokens2({ api, blacklistedTokens, owner: assetPool, tokens: logs.map(i => i.asset_source) })
+    },
+    //staking: staking(stakingContract, vega)
+    staking: async (_, _b, cb, { chain, block, api } = {}) => { 
+
+      const vegaStakedInVesting = await api.call({ 
+        abi: contractAbis.totalStaked, 
+        target: vestingContract 
+      })
+
+      const vegaStakedInStaking = await api.call({
+        abi: contractAbis.balanceOf,
+        target: vega,
+        params: stakingContract
+      })
+
+      return {
+        '0xcb84d72e61e383767c4dfeb2d8ff7f4fb89abc6e': BigNumber(vegaStakedInVesting).plus(BigNumber(vegaStakedInStaking)).toFixed(0)
+      }
+      
     }
   }
 
-
-  if (staking) module.exports[chain].staking = staking(stakingContract, vega)
 })
+


### PR DESCRIPTION
VEGA token can be staked in the Vesting contract as well as the Staking contract. This has been updated.

Vesting (0x23d1bFE8fA50a167816fBD79D7932577c06011f4) 
has a method `function total_staked() view returns (uint256)`
which shows the amount of VEGA on the Vesting contract that is currently staked.

I've added this number to the `vegaToken.balanceOf(stakingContract)` which was the prev value (though through the staking helper)

see addresses here:
https://github.com/vegaprotocol/networks/blob/master/mainnet1/smart-contracts.json 

Thanks!