### PR TITLE
Add Umee to Stride TVL

### DIFF
--- a/projects/stride/index.js
+++ b/projects/stride/index.js
@@ -9,6 +9,7 @@ const coinGeckoIds = {
   uluna: "terra-luna-2",
   aevmos: "evmos",
   inj: "injective-protocol",
+  uumee: "umee",
 };
 
 function getCoinDenom(denom) {
@@ -26,7 +27,7 @@ async function tvl() {
   const balances = {};
 
   const { host_zone: hostZones } = await get(
-    "https://stride-library.main.stridenet.co/api/Stride-Labs/stride/stakeibc/host_zone"
+    "https://stride-fleet.main.stridenet.co/api/Stride-Labs/stride/stakeibc/host_zone"
   );
 
   const { supply: assetBalances } = await get(


### PR DESCRIPTION
Stride stUMEE is live on the backend, this just adds the field to the DefiLlama adapter. Running the test script it looks like everything is working:

```
❯ node test.js projects/stride/index.js
--- stride ---
ATOM                      26.40 M
OSMO                      4.64 M
INJ                       1.12 M
LUNA                      1.04 M
EVMOS                     582.95 k
STARS                     304.59 k
JUNO                      158.72 k
UMEE                      11.66 k
Total: 34.25 M 

--- tvl ---
ATOM                      26.40 M
OSMO                      4.64 M
INJ                       1.12 M
LUNA                      1.04 M
EVMOS                     582.95 k
STARS                     304.59 k
JUNO                      158.72 k
UMEE                      11.66 k
Total: 34.25 M 

------ TVL ------
stride                    34.25 M

total                    34.25 M 
```

