### PR TITLE
enosys farm with newly bridged XDC - exXDC

### DIFF
--- a/projects/flarefarm/index.js
+++ b/projects/flarefarm/index.js
@@ -28,6 +28,7 @@ async function farmTvl(timestamp, ethblock, { [chain]: block }) {
     [EXFI, '0xD02C3e166223EE78F4d0ae99F5396142b48D97FE'], 
     [WSGB, '0x745d8896629842ef8E44D269f89A7A873086A6F2'],
     [EXFI, "0x61128b44C299b0f7a752BF6278f44f1EcefD9109"],
+    ['0x3233642aCf7664a69c33e5a6FFAb321608d7A65f','0xF81B465C562ED3f54Aea772D8A56FAF93884ea2E']
   ];
 
   return sumUnknownTokens({ tokensAndOwners: tokens, chain, block, useDefaultCoreAssets: true, })


### PR DESCRIPTION
Adding the newest farm on Enosys with the newly bridged exXDC token - a WSGB/exXDC farm.