### PR TITLE
update TokenPocket staking value

### DIFF
--- a/projects/TokenPocket/index.js
+++ b/projects/TokenPocket/index.js
@@ -11,7 +11,19 @@ async function tvl() {
       }
     )
   )
-  return { ethereum: tvlData.data.data.staking.total_amount} 
+  const tvlDataOld = (
+    await axios.get(
+      "https://preserver.mytokenpocket.vip/v1/pledge/method_any_v1",
+      {
+        headers: {
+          api: "/eth2/v1/global",
+        },
+      }
+    )
+  )
+  const total = tvlData.data.data.staking.total_amount + tvlDataOld.data.data.data.staking_total
+  // return { ethereum: tvlData.data.data.staking.total_amount} 
+  return { ethereum: total} 
 }
 
 module.exports = {


### PR DESCRIPTION
We have two types of staking methods. Previously, the total staked amount was the sum of staking at least 32 ETH in a single transaction. Now, we have also included the total staked amount from small stakes. The combined staked amount from these two methods represents the total number of ETH we have currently staked.