### PR TITLE
zkSwap era staking data fix

### DIFF
--- a/projects/zk-swap/index.js
+++ b/projects/zk-swap/index.js
@@ -1,0 +1,20 @@
+const { getUniTVL } = require('../helper/unknownTokens')
+const { stakings } = require("../helper/staking");
+
+const factory = "0x5da48a338647e2DD79329b557b5729D8496aD83D";
+const masterchef = "0x7bA76d4e4cBD4A9B7E3fd9a3B7Db067a51ca9682";
+const zks = "0xAbdb137D013b8B328FA43Fc04a6fA340D1CeA733";
+
+module.exports = {
+  misrepresentedTokens: true,
+  era: {
+    tvl: getUniTVL({ factory, chain: 'era', useDefaultCoreAssets: true }),
+    staking: stakings(
+        [masterchef], 
+        [zks], 
+        'era',
+        'zkswap',
+        18),
+  },
+};
+

--- a/projects/zk-swap/index.js
+++ b/projects/zk-swap/index.js
@@ -1,5 +1,5 @@
 const { getUniTVL } = require('../helper/unknownTokens')
-const { stakings } = require("../helper/staking");
+const { stakingUnknownPricedLP } = require("../helper/staking");
 
 const factory = "0x5da48a338647e2DD79329b557b5729D8496aD83D";
 const masterchef = "0x7bA76d4e4cBD4A9B7E3fd9a3B7Db067a51ca9682";
@@ -9,7 +9,13 @@ module.exports = {
   misrepresentedTokens: true,
   era: {
     tvl: getUniTVL({ factory, useDefaultCoreAssets: true, fetchBalances: true, }),
-    staking: stakings([masterchef], zks),
+    staking: stakingUnknownPricedLP(
+      masterchef,
+      zks,
+      "era",
+      "0x8489727b22Dd7eF8BbC91E0E88ee781cb2B27274",
+      (addr) => `era:${addr}`
+    ),
   },
 };
 

--- a/projects/zk-swap/index.js
+++ b/projects/zk-swap/index.js
@@ -8,13 +8,8 @@ const zks = "0xAbdb137D013b8B328FA43Fc04a6fA340D1CeA733";
 module.exports = {
   misrepresentedTokens: true,
   era: {
-    tvl: getUniTVL({ factory, chain: 'era', useDefaultCoreAssets: true }),
-    staking: stakings(
-        [masterchef], 
-        [zks], 
-        'era',
-        'zkswap',
-        18),
+    tvl: getUniTVL({ factory, useDefaultCoreAssets: true, fetchBalances: true, }),
+    staking: stakings([masterchef], zks),
   },
 };
 


### PR DESCRIPTION
**NOTE**

> - If you would like to add a `volume` adapter please submit the PR [here](https://github.com/DefiLlama/adapters).
> - If you would like to add a `liquidations` adapter, please refer to [this readme document](https://github.com/DefiLlama/DefiLlama-Adapters/tree/main/liquidations) for details.

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
3. The protocol is usually listed within 24 hours of merging the PR
4. Please fill the form below  **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
5. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can  edit it there and put up a PR
6. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
7. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap

** fixed zkSwap Era staking data 
it was showing 0 & now its fixed to show the correct data.

