### PR TITLE
Listing of Tropykus in zkEVM

### DIFF
--- a/projects/tropykus/index.js
+++ b/projects/tropykus/index.js
@@ -1,7 +1,22 @@
+const sdk = require('@defillama/sdk');
+const { aaveChainTvl } = require('../helper/aave');
 const { usdCompoundExports } = require('../helper/compound')
 
+function v2(chain, v2Registry){
+  const section = borrowed => sdk.util.sumChainTvls([
+    aaveChainTvl(chain, v2Registry, undefined, undefined, borrowed),
+  ])
+  return {
+    tvl: section(false),
+    borrowed: section(true)
+  }
+}
+
 module.exports = {
+  timetravel: true,
+  methodology: `Counts the tokens locked in the contracts to be used as collateral to borrow or to earn yield. Borrowed coins are not counted towards the TVL, so only the coins actually locked in the contracts are counted. There's multiple reasons behind this but one of the main ones is to avoid inflating the TVL through cycled lending`,
+  polygon_zkevm: v2("polygon_zkevm", "0x4Dac514F520D051551372d277d1b2Fa3cF2AfdFF"),
   rsk: {
     ...usdCompoundExports("0x962308fEf8edFaDD705384840e7701F8f39eD0c0", "rsk"),
   }
-}
+};

--- a/projects/tropykus/index.js
+++ b/projects/tropykus/index.js
@@ -19,4 +19,4 @@ module.exports = {
   rsk: {
     ...usdCompoundExports("0x962308fEf8edFaDD705384840e7701F8f39eD0c0", "rsk"),
   }
-};
+}


### PR DESCRIPTION
The reason for this PR is to add the deployment of Tropykus in zkEVM. There is an importante change between v1  in RSK and v2 in zkEVM. 
In v2 we forked the AAVE v2 contracts, whereas in v1 we forked and modified the contracts from Compound