### PR TITLE
breakdown predy versions

### DIFF
--- a/projects/predy-v3/api.js
+++ b/projects/predy-v3/api.js
@@ -1,0 +1,7 @@
+const { getExports } = require('../helper/heroku-api')
+
+module.exports = {
+  timetravel: false,
+  misrepresentedTokens: true,
+  ...getExports("predy-v3", ['predy']),
+}

--- a/projects/predy-v3/index.js
+++ b/projects/predy-v3/index.js
@@ -1,0 +1,44 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+const sdk = require('@defillama/sdk');
+const { sumTokensExport } = require('../helper/unwrapLPs')
+const BigNumber = require("bignumber.js");
+
+const v3Address = '0x4006A8840F8640A7D8F46D2c3155a58c76eCD56e';
+
+const WETH_CONTRACT = ADDRESSES.arbitrum.WETH;
+const USDC_CONTRACT = ADDRESSES.arbitrum.USDC;
+
+const abi = {
+    v3: {
+        getTokenState: 'function getTokenState() returns (tuple(uint256 totalCompoundDeposited, uint256 totalCompoundBorrowed, uint256 totalNormalDeposited, uint256 totalNormalBorrowed, uint256 assetScaler, uint256 debtScaler, uint256 assetGrowth, uint256 debtGrowth), tuple(uint256 totalCompoundDeposited, uint256 totalCompoundBorrowed, uint256 totalNormalDeposited, uint256 totalNormalBorrowed, uint256 assetScaler, uint256 debtScaler, uint256 assetGrowth, uint256 debtGrowth))'
+    },
+    v320: {
+        getAsset: 'function getAsset(uint256 _id) external view returns (tuple(uint256 id, address token, address supplyTokenAddress, tuple(uint256 riskRatio, int24 rangeSize, int24 rebalanceThreshold), tuple(uint256 totalCompoundDeposited, uint256 totalCompoundBorrowed, uint256 totalNormalDeposited, uint256 totalNormalBorrowed, uint256 assetScaler, uint256 debtScaler, uint256 assetGrowth, uint256 debtGrowth), tuple(address uniswapPool, int24 tickLower, int24 tickUpper, uint256 totalAmount, uint256 borrowedAmount, uint256 supplyPremiumGrowth, uint256 borrowPremiumGrowth, uint256 fee0Growth, uint256 fee1Growth, tuple(int256 positionAmount, uint256 lastFeeGrowth), tuple(int256 positionAmount, uint256 lastFeeGrowth), int256 rebalanceFeeGrowthUnderlying, int256 rebalanceFeeGrowthStable), bool isMarginZero, tuple(uint256 baseRate, uint256 kinkRate, uint256 slope1, uint256 slope2), tuple(uint256 baseRate, uint256 kinkRate, uint256 slope1, uint256 slope2), uint256 lastUpdateTimestamp, uint256 accumulatedProtocolRevenue))'
+    }
+}
+
+
+async function borrowed(_time, _ethBlock, chainBlocks, { api }) {
+    let balances = {};
+
+    // V3
+    const v3TokenState = await api.call({ abi: abi.v3.getTokenState, target: v3Address, })
+
+    await sdk.util.sumSingleBalance(balances, WETH_CONTRACT, v3TokenState[0]['totalNormalBorrowed'], api.chain);
+    await sdk.util.sumSingleBalance(balances, USDC_CONTRACT, v3TokenState[1]['totalNormalBorrowed'], api.chain);
+    
+    return balances;
+}
+
+
+module.exports = {
+    methodology: "USDC and WETH locked on predy contracts",
+    arbitrum: {
+        tvl: sumTokensExport({ owners: [v3Address], tokens: [USDC_CONTRACT, WETH_CONTRACT,] }),
+        borrowed
+    },
+    hallmarks: [
+        [1671092333, "Launch Predy V3"],
+        [1678734774, "Launch Predy V3.2"]
+    ],
+};

--- a/projects/predy-v320/api.js
+++ b/projects/predy-v320/api.js
@@ -1,0 +1,7 @@
+const { getExports } = require('../helper/heroku-api')
+
+module.exports = {
+  timetravel: false,
+  misrepresentedTokens: true,
+  ...getExports("predy-v3.2", ['predy']),
+}

--- a/projects/predy-v320/index.js
+++ b/projects/predy-v320/index.js
@@ -3,9 +3,6 @@ const sdk = require('@defillama/sdk');
 const { sumTokensExport } = require('../helper/unwrapLPs')
 const BigNumber = require("bignumber.js");
 
-const v2Address = '0xc7ec02AEeCdC9087bf848c4C4f790Ed74A93F2AF';
-const v202Address = '0xAdBAeE9665C101413EbFF07e20520bdB67C71AB6';
-const v3Address = '0x4006A8840F8640A7D8F46D2c3155a58c76eCD56e';
 const v320Address = '0x68a154fB3e8ff6e4DA10ECd54DEF25D9149DDBDE';
 
 const WETH_CONTRACT = ADDRESSES.arbitrum.WETH;
@@ -24,12 +21,6 @@ const abi = {
 async function borrowed(_time, _ethBlock, chainBlocks, { api }) {
     let balances = {};
 
-    // V3
-    const v3TokenState = await api.call({ abi: abi.v3.getTokenState, target: v3Address, })
-
-    await sdk.util.sumSingleBalance(balances, WETH_CONTRACT, v3TokenState[0]['totalNormalBorrowed'], api.chain);
-    await sdk.util.sumSingleBalance(balances, USDC_CONTRACT, v3TokenState[1]['totalNormalBorrowed'], api.chain);
-
     // V3.2
     const v320USDCState = await api.call({ abi: abi.v320.getAsset, target: v320Address, params: 1})
     const v320ETHState = await api.call({ abi: abi.v320.getAsset, target: v320Address, params: 2 })
@@ -47,7 +38,7 @@ async function borrowed(_time, _ethBlock, chainBlocks, { api }) {
 module.exports = {
     methodology: "USDC and WETH locked on predy contracts",
     arbitrum: {
-        tvl: sumTokensExport({ owners: [v202Address, v2Address, v3Address, v320Address], tokens: [USDC_CONTRACT, WETH_CONTRACT,] }),
+        tvl: sumTokensExport({ owners: [v320Address], tokens: [USDC_CONTRACT, WETH_CONTRACT,] }),
         borrowed
     },
     hallmarks: [

--- a/projects/predy.js
+++ b/projects/predy.js
@@ -1,0 +1,19 @@
+const ADDRESSES = require('./helper/coreAssets.json')
+const { sumTokensExport } = require('./helper/unwrapLPs')
+
+const v2Address = '0xc7ec02AEeCdC9087bf848c4C4f790Ed74A93F2AF';
+const v202Address = '0xAdBAeE9665C101413EbFF07e20520bdB67C71AB6';
+
+const WETH_CONTRACT = ADDRESSES.arbitrum.WETH;
+const USDC_CONTRACT = ADDRESSES.arbitrum.USDC;
+
+module.exports = {
+  methodology: "USDC and WETH locked on predy contracts",
+  arbitrum: {
+      tvl: sumTokensExport({ owners: [v202Address, v2Address], tokens: [USDC_CONTRACT, WETH_CONTRACT,] }),
+  },
+  hallmarks: [
+      [1671092333, "Launch Predy V3"],
+      [1678734774, "Launch Predy V3.2"]
+  ],
+};


### PR DESCRIPTION
The related PR is here:
https://github.com/DefiLlama/dimension-adapters/pull/532

We want to add fees for predy v3.2. I got the reply in the above PR:

```
 it seem tvl adapter does not have breakdown about v320
```

I got the example hydradex. What I want to do in this PR is to breakdown predy TVL into `(v2 and v2.2)`, `v3`, `v3.2`.

##### Name (to be shown on DefiLlama):

Predy Finance

--- FOLLOWING SECTIONS COPY PASTE FROM OUR BEFORE PR ---

Twitter Link:
https://twitter.com/predyfinance

List of audit links if any:
https://www.linkedin.com/posts/zokyo_predy-smart-contract-audit-reportzokyoio-activity-6914551796023627777-8jWC?utm_source=linkedin_share&utm_medium=member_desktop_web

Website Link:
https://www.predy.finance/

Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):
https://user-images.githubusercontent.com/1442395/163708733-eadcbbdc-bf51-4372-922c-2f08b766db07.png

Current TVL:

projects/predy.js
total                    17.29 k 

projects/predy-v3/index.js
total                    5.17 k 

projects/predy-v320/index.js
total                    248.39 k 

Chain:
Arbitrum

Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)
Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
Short Description (to be shown on DefiLlama):
Introducing Predy V3.2 on Arbitrum, featuring Squart: a unique perpetual with DeFi gamma from Uniswap LP positions, offering portfolio margin for Squart and ETH trading, simplifying delta-neutral and leveraged LP positions, and addressing liquidity fragmentation by eliminating strikes.

specification:
Introducing Predy V3.2, now available on the Arbitrum chain, featuring our innovative product, "Squart."
Squart is a unique perpetual with DeFi native gamma derived from Uniswap LP positions. Long Squart positions receive a premium based on Uniswap's trading fees in exchange for negative gamma, while short positions pay premiums for positive gamma.
Predy V3.2 allows traders to utilize portfolio margin for Squart and ETH perpetual trading while simplifying the creation of delta-neutral and leveraged LP positions. Rest assured, LP positions will always remain in-range!
Squart addresses the liquidity fragmentation issue commonly found in perpetual options by eliminating strikes. This ensures positions consistently possess gamma, similar to at-the-money options.

Token address and ticker if any:
Category (full list at https://defillama.com/categories) *Please choose only one:
Derivatives

Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):

forkedFrom (Does your project originate from another project):

methodology (what is being counted as tvl, how is tvl being calculated):
USDC and WETH locked on predy contracts.