### PR TITLE
feat: add ve_zoo and x_zoo contracts for staking

### DIFF
--- a/projects/zoodao/index.js
+++ b/projects/zoodao/index.js
@@ -1,11 +1,19 @@
 const ADDRESSES = require('../helper/coreAssets.json')
 const battleArenaAbi = require('./abis/battle-arena-abi.json');
-const { staking } = require('../helper/staking');
+const { stakings } = require('../helper/staking');
 
 const VAULT_CONTRACT = '0x1C55649f73CDA2f72CEf3DD6C5CA3d49EFcF484C';
 const BATTLE_ARENA_CONTRACT = '0x0ADeb5A930875606F325e114FD5147148e042828';
 const FRAX_TOKEN = ADDRESSES.moonbeam.FRAX
 const ZOODAO_TOKEN = "0x7cd3e6e1A69409deF0D78D17a492e8e143F40eC5"
+const VE_ZOO_CONTRACT = "0x1bd77c71568f723d6906ea80fee45f1f52834c15"
+const X_ZOO_CONTRACT = "0x1c535c24f911a8741018cf09f3030ab6e1b910cf"
+
+const stakingContracts = [
+  BATTLE_ARENA_CONTRACT,
+  VE_ZOO_CONTRACT,
+  X_ZOO_CONTRACT
+];
 
 async function tvl(_, _1, _2, { api }) {
   const vaultStablecoinStaked = await api.call({ abi: 'erc20:balanceOf', target: VAULT_CONTRACT, params: [BATTLE_ARENA_CONTRACT] });
@@ -19,6 +27,6 @@ module.exports = {
   methodology: "Counts the supplied value of FRAX and ZOO through ZooDAO's contracts",
   moonbeam: {
     tvl,
-    staking: staking(BATTLE_ARENA_CONTRACT, ZOODAO_TOKEN)
+    staking: stakings(stakingContracts, ZOODAO_TOKEN)
   },
 };


### PR DESCRIPTION
**NOTE**

> - If you would like to add a `volume` adapter please submit the PR [here](https://github.com/DefiLlama/adapters).
> - If you would like to add a `liquidations` adapter, please refer to [this readme document](https://github.com/DefiLlama/DefiLlama-Adapters/tree/main/liquidations) for details.

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
3. The protocol is usually listed within 24 hours of merging the PR
4. Please fill the form below  **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
5. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can  edit it there and put up a PR
6. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
7. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap

---

Added following new contract addresses on staking TVL.
1. veZOO: veZOO allows holders to influence the distribution of ZOO rewards within the dApp by locking ZOO in support of NFT collections. 
2. xZOO: xZOO stands as a simple staking reward mechanism within the ZooDAO ecosystem. By staking ZOO tokens, users earn a small share of the yield generated across all Battles.