### PR TITLE
feat(silo-finance): exclude deprecated silos

### DIFF
--- a/projects/silo/index.js
+++ b/projects/silo/index.js
@@ -16,6 +16,8 @@ const config = {
   },
 }
 
+const fallbackBlacklist = ["0x6543ee07cf5dd7ad17aeecf22ba75860ef3bbaaa"];
+
 async function tvl(_, block, _1, { api }) {
   const siloArray = await getSilos(api)
   const assets = await api.multiCall({
@@ -59,7 +61,7 @@ async function getSilos(api) {
       })
     )
 
-    return logs.map((log) => `0x${log.topics[1].substring(26)}`)
+    return logs.map((log) => `0x${log.topics[1].substring(26)}`).filter((address) => fallbackBlacklist.indexOf(address.toLowerCase()) === -1);
   }
 }
 


### PR DESCRIPTION
Adds a simple fallback mechanism to exclude deprecated silos.

Currently, TVL is being significantly (and incorrectly) inflated by the deprecated FARM silo:

<img width="654" alt="Screenshot 2023-06-17 at 17 03 33" src="https://github.com/DefiLlama/DefiLlama-Adapters/assets/14224459/66699ad6-6d28-4151-8451-e29fb16bbdb8">

While the functionality to signal deprecations is being worked on for the subgraph, this will act as a fallback mechanism to avoid incorrect calculations.