### PR TITLE
[Mars Protocol] - Take Fields of Mars into account for TVL

### DIFF
--- a/projects/mars/index.js
+++ b/projects/mars/index.js
@@ -18,7 +18,7 @@ async function osmosisSumVaultsTVL(balances) {
   let coins = [];
   let vaultPagesRemaining = true;
   let startAfter = null;
-  const pageLimit = 2;
+  const pageLimit = 10;
   const osmosisDenomTransform = await getChainTransform('osmosis');
 
   while (vaultPagesRemaining) {


### PR DESCRIPTION
##### methodology (what is being counted as tvl, how is tvl being calculated):

Update computation of Mars Protocol's TVL:

1. Add vaults farmed by Fields of Mars. Vault positions are opened using assets from both the user and the Red Bank (there's a credit line users can use to open positions from Fields). Current vaults are all [Apollo vaults](https://github.com/apollodao/apollo-vaults), which take a base asset and give vault tokens in return. The strategy autocompounds rewards in the base asset that the user redeems by burning the vault tokens when exiting the position. In all current cases the vault asset is an LP token. So there's a bit of queries and transformations involved to value the global vault positions that Fields of Mars has:
   
    1. Get the amount of vault tokens owned by fields's contract (aka Credit Manager).

    2. Get how many LP tokens those are those vault tokens are worth
 
    3. Get the amount of underlying assets the LP token represents and add those as TVL

&nbsp;&nbsp;&nbsp;&nbsp;This amounts to a bunch of queries needed for each vault. The implementation takes the vaults in pages of 10 and does parallel queries  in sets of 10 max as well. Currently there are 5 vaults.

2. Remove borrowing field as there's some overlap between red bank total borrows and field's vault positions that are created by taking loans from the red bank. 




