### PR TITLE
Added Adapter for Swapscanner's GCKLAY

### DIFF
--- a/projects/swapscanner-staking/index.js
+++ b/projects/swapscanner-staking/index.js
@@ -1,0 +1,24 @@
+const sdk = require("@defillama/sdk");
+const { nullAddress } = require('../helper/unwrapLPs');
+const chain = 'klaytn'
+
+const SCNR = {
+  GCKLAY: '0x999999999939ba65abb254339eec0b2a0dac80e9'
+}
+
+module.exports = {
+  klaytn: {
+    tvl: async (_, _b, {klaytn:block}) => {
+      const gcklayBal = await sdk.api2.abi.call({
+        target: SCNR.GCKLAY,
+        abi: 'erc20:totalSupply',
+        chain, block,
+      })
+
+      const balances = {}
+      sdk.util.sumSingleBalance(balances, nullAddress, gcklayBal, chain)
+      return balances;
+    }
+  },
+  timetravel: false,
+}


### PR DESCRIPTION
- Swapscanner released Klaytn Liquid Staking called GCKLAY, so I'm adding it as `swapscanner-staking`
- GCKLAY(`0x999999999939ba65abb254339eec0b2a0dac80e9`) total supply equals underlying KLAY TVL
- https://news.swapscanner.io/en/2023/swapscanner-releases-official-klay-staking-protocol-gcklay