### PR TITLE
feat: Include all deployed chains to Steer adapter

### DIFF
--- a/projects/steer/index.js
+++ b/projects/steer/index.js
@@ -3,6 +3,13 @@ const config = {
   polygon: { registry: '0x24825b3c44742600d3995d1d3760ccee999a7f0b', fromBlock: 41535540, },
   arbitrum: { registry: '0x9f5b097AD23e2CF4F34e502A3E41D941678877Dc', fromBlock: 88698956, },
   optimism: { registry: '0xC1Ecd10398A6D7036CceE1f50551ff169715081c', fromBlock: 96971465, },
+  avax: { registry: '0x9f5b097AD23e2CF4F34e502A3E41D941678877Dc', fromBlock: 30434642, },
+  binance: { registry: '0x31e4ee367d4f2685BAfcAb9566e9C87E60D48983', fromBlock: 28461459, },
+  evmos: { registry: '0xD90c8970708FfdFC403bdb56636621e3E9CCe921', fromBlock: 13671900, },
+  metis: { registry: '0x116Dba5DcE9CcDA828218b7eB46406810632014C', fromBlock: 6067741, },
+  polygon_zkevm: { registry: '0x9f5b097AD23e2CF4F34e502A3E41D941678877Dc', fromBlock: 1022413, },
+  celo: { registry: '0x116Dba5DcE9CcDA828218b7eB46406810632014C', fromBlock: 19813127, },
+  thundercore: { registry: '0xa1Dd21fbd9e1F0BF28d41F18bDC22326e50C02e9', fromBlock: 135181847, },
 }
 
 module.exports = {};


### PR DESCRIPTION
Added chains: avax, bnb, metis, evmos, p_zkevm, celo, thundercore

binance historical node failing with atBlock call
polygon multicall giving trouble as well