### PR TITLE
Remove assignment to undeclared variable

### DIFF
--- a/projects/helper/sumTokens.js
+++ b/projects/helper/sumTokens.js
@@ -47,7 +47,6 @@ async function sumTokens(options) {
   let { chain, owner, owners = [], tokens = [], tokensAndOwners = [], blacklistedTokens = [], balances = {}, token, api } = options 
   if (api) {
     chain = api.chain
-    block = api.block
   }
 
   if (token) tokens = [token]


### PR DESCRIPTION
Removed assignment to the variable `block` which was undeclared. This variable is also not used afterwards, so it can be safely removed. The bug was introduced in the previous commit and was breaking the pipeline during the linting process.