### PR TITLE
marinade.finance: Show in native SOL

### DIFF
--- a/projects/marinade.js
+++ b/projects/marinade.js
@@ -1,4 +1,4 @@
-const { getProvider, sumTokens2, } = require('./helper/solana')
+const { getProvider, getSolBalance, } = require("./helper/solana")
 const { Program, } = require("@project-serum/anchor");
 
 async function tvl() {
@@ -6,17 +6,21 @@ async function tvl() {
   const programId = 'MarBmsSgKXdrN1egZf5sqe1TMai9K1rChYNDJgjq7aD'
   const idl = await Program.fetchIdl(programId, provider)
   const program = new Program(idl, programId, provider)
-  const [{
-    account: {
-        validatorSystem: { totalActiveBalance }, availableReserveBalance
-    }
-  }] = await program.account.state.all()
-  const balances = {
-    solana: (+totalActiveBalance + +availableReserveBalance)/1e9
+  const [
+    {
+      account: {
+        validatorSystem: { totalActiveBalance },
+        availableReserveBalance,
+      },
+    },
+  ] = await program.account.state.all()
+  return {
+    solana:
+      (+totalActiveBalance +
+        +availableReserveBalance +
+        (await getSolBalance("UefNb6z6yvArqe4cJHTXCqStRsKmWhGxnZzuHbikP5Q"))) / // Liq Pool Sol Leg Pda
+      1e9,
   }
-  return sumTokens2({ balances, solOwners: [
-    'UefNb6z6yvArqe4cJHTXCqStRsKmWhGxnZzuHbikP5Q', // Liq Pool Sol Leg Pda
-  ]})
 }
 
 module.exports = {


### PR DESCRIPTION
Marinade.finance showed tokens distributed between native SOL and wSOL tokens because of a combination of using the sumTokens2 function counting native SOL balance as wSOL token on solana and custom balance entry using the plain solana key. This change will remove sumTokens2 usage and all balances will be summed into a single solana balance to show 100% TVL as a native solana token