### PR TITLE
Add BSC for Morphex

### DIFF
--- a/projects/morphex/index.js
+++ b/projects/morphex/index.js
@@ -1,14 +1,24 @@
 const { staking } = require("../helper/staking");
 const { gmxExports } = require("../helper/gmx");
 
-const vaultAddress = "0x3CB54f0eB62C371065D739A34a775CC16f46563e";
-const stakingAddress = "0xa4157E273D88ff16B3d8Df68894e1fd809DbC007";
-const tokenAddressMPX = "0x66eEd5FF1701E6ed8470DC391F05e27B1d0657eb";
+// Fantom
+const vaultAddressFantom = "0x3CB54f0eB62C371065D739A34a775CC16f46563e";
+const stakingAddressFantom = "0xa4157E273D88ff16B3d8Df68894e1fd809DbC007";
+const tokenAddressMPXFantom = "0x66eEd5FF1701E6ed8470DC391F05e27B1d0657eb";
+
+// BNB Chain
+const vaultAddressBSC = "0x46940Dc651bFe3F2CC3E04cf9dC5579B50Cf0765";
+const stakingAddressBSC = "0x13d2bBAE955c54Ab99F71Ff70833dE64482519B1";
+const tokenAddressMPXBSC = "0x94C6B279b5df54b335aE51866d6E2A56BF5Ef9b7";
 
 module.exports = {
     methodology: "Morphex liquidity is calculated by the value of tokens in the MLP pool. TVL also includes MPX staked.",
     fantom: {
-        staking: staking(stakingAddress, tokenAddressMPX, "fantom"),
-        tvl: gmxExports({ vault: vaultAddress })
-    }
+        staking: staking(stakingAddressFantom, tokenAddressMPXFantom, "fantom"),
+        tvl: gmxExports({ vault: vaultAddressFantom })
+    },
+    bsc: {
+        staking: staking(stakingAddressBSC, tokenAddressMPXBSC, "bsc"),
+        tvl: gmxExports({ vault: vaultAddressBSC })
+    },
 };


### PR DESCRIPTION
**NOTE**

> - If you would like to add a `volume` adapter please submit the PR [here](https://github.com/DefiLlama/adapters).
> - If you would like to add a `liquidations` adapter, please refer to [this readme document](https://github.com/DefiLlama/DefiLlama-Adapters/tree/main/liquidations) for details.

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Please enable "Allow edits by maintainers" while putting up the PR.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. Please fill the form below  **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
5. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can  edit it there and put up a PR
6. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
7. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap

---
Adding BSC support for Morphex, as Morphex is now deployed on Fantom and BSC. Ty!