### PR TITLE
feat: add gauge staked lp token for crv pools

### DIFF
--- a/projects/good-ghosting/index.js
+++ b/projects/good-ghosting/index.js
@@ -33,7 +33,7 @@ async function tvl(_, _b, _cb, { api, }) {
   Object.values(gameData)
       .filter((game) => game.networkId == chainIdMap[api.chain])
       .map((game) => {
-        const tokens = [game.depositTokenAddress, game.liquidityTokenAddress].filter(i => i)
+        const tokens = [game.depositTokenAddress, game.liquidityTokenAddress, game.gaugeLiquidityTokenAddress].filter(i => i)
         ownerTokens.push([tokens, game.id])
 
         if (isV2Game(game.contractVersion))


### PR DESCRIPTION

Context: HaloFi CRV pools stake the LP token during ongoing games. These pools were not accounted for in the DeFiLlama TVL calculation. The HaloFi API now returns the address of the gauge LP token for Curve pools that support gauge staking.

This is a small PR that incorporates the staked LP token in the TVL calculation.