### PR TITLE
Fix Pendle v2 TVL (Accounting for interest bearing token exchangeRate)

### DIFF
--- a/projects/pendle/v2.js
+++ b/projects/pendle/v2.js
@@ -1,46 +1,75 @@
-const ADDRESSES = require('../helper/coreAssets.json')
+const ADDRESSES = require("../helper/coreAssets.json");
 const contracts = require("./contracts");
-const { staking } = require('../helper/staking')
-const { getLogs } = require('../helper/cache/getLogs')
+const { staking } = require("../helper/staking");
+const { getLogs } = require("../helper/cache/getLogs");
 const steth = ADDRESSES.ethereum.STETH;
 const config = {
-  ethereum: { factory: '0x27b1dacd74688af24a64bd3c9c1b143118740784', fromBlock: 16032059 },
-  arbitrum: { factory: '0xf5a7de2d276dbda3eef1b62a9e718eff4d29ddc8', fromBlock: 62979673 },
-  bsc: { factory: '0x2bEa6BfD8fbFF45aA2a893EB3B6d85D10EFcC70E', fromBlock: 29484286 },
-}
+  ethereum: {
+    factory: "0x27b1dacd74688af24a64bd3c9c1b143118740784",
+    fromBlock: 16032059,
+  },
+  arbitrum: {
+    factory: "0xf5a7de2d276dbda3eef1b62a9e718eff4d29ddc8",
+    fromBlock: 62979673,
+  },
+  bsc: {
+    factory: "0x2bEa6BfD8fbFF45aA2a893EB3B6d85D10EFcC70E",
+    fromBlock: 29484286,
+  },
+};
 
-module.exports = {}
+module.exports = {};
 
-Object.keys(config).forEach(chain => {
-  const { factory, fromBlock } = config[chain]
+Object.keys(config).forEach((chain) => {
+  const { factory, fromBlock } = config[chain];
   module.exports[chain] = {
-    tvl: async (_, _b, _cb, { api, }) => {
+    tvl: async (_, _b, _cb, { api }) => {
       const logs = await getLogs({
         api,
         target: factory,
-        topics: ['0x166ae5f55615b65bbd9a2496e98d4e4d78ca15bd6127c0fe2dc27b76f6c03143'],
-        eventAbi: 'event CreateNewMarket (address indexed market, address indexed PT, int256 scalarRoot, int256 initialAnchor)',
+        topics: [
+          "0x166ae5f55615b65bbd9a2496e98d4e4d78ca15bd6127c0fe2dc27b76f6c03143",
+        ],
+        eventAbi:
+          "event CreateNewMarket (address indexed market, address indexed PT, int256 scalarRoot, int256 initialAnchor)",
         onlyArgs: true,
         fromBlock,
-      })
-      const pt = logs.map(i => i.PT)
-      const sy = [
+      });
+      const pt = logs.map((i) => i.PT);
+      let sy = [
         ...new Set(
-          (await api.multiCall({
-            abi: "address:SY",
-            calls: pt,
-          })).map(s => s.toLowerCase()),
+          (
+            await api.multiCall({
+              abi: "address:SY",
+              calls: pt,
+            })
+          ).map((s) => s.toLowerCase())
         ),
-      ]
+      ];
+
       const [data, supply, decimals] = await Promise.all([
-        api.multiCall({ abi: 'function assetInfo() view returns (uint8 assetType , address uAsset , uint8 decimals )', calls: sy }),
-        api.multiCall({ abi: 'erc20:totalSupply', calls: sy }),
-        api.multiCall({ abi: 'erc20:decimals', calls: sy }),
-      ])
+        api.multiCall({
+          abi: "function assetInfo() view returns (uint8 assetType , address uAsset , uint8 decimals )",
+          calls: sy,
+        }),
+        api.multiCall({ abi: "erc20:totalSupply", calls: sy }),
+        api.multiCall({ abi: "erc20:decimals", calls: sy }),
+      ]);
+
+      const tokenAssetTypeSy = sy.filter((_, i) => data[i].assetType === "0");
+      const exchangeRates = await api.multiCall({
+        abi: "function exchangeRate() view returns (uint256 res)",
+        calls: tokenAssetTypeSy,
+      });
+
       data.forEach((v, i) => {
-        let value = supply[i] * (10 ** (v.decimals - decimals[i]))
-        api.add(v.uAsset.toLowerCase(), value)
-      })
+        let value = supply[i] * 10 ** (v.decimals - decimals[i]);
+        let index = tokenAssetTypeSy.indexOf(sy[i]);
+        if (index !== -1) {
+          value = (value * exchangeRates[index]) / 10 ** 18;
+        }
+        api.add(v.uAsset.toLowerCase(), value);
+      });
       let balances = api.getBalances();
       const bridged = `arbitrum:${steth}`;
       if (bridged in balances) {
@@ -48,8 +77,11 @@ Object.keys(config).forEach(chain => {
         delete balances[bridged];
       }
       return balances;
-    }
-  }
-})
+    },
+  };
+});
 
-module.exports.ethereum.staking = staking(contracts.v2.vePENDLE, contracts.v2.PENDLE)
+module.exports.ethereum.staking = staking(
+  contracts.v2.vePENDLE,
+  contracts.v2.PENDLE
+);


### PR DESCRIPTION
**NOTE**

> - If you would like to add a `volume` adapter please submit the PR [here](https://github.com/DefiLlama/adapters).
> - If you would like to add a `liquidations` adapter, please refer to [this readme document](https://github.com/DefiLlama/DefiLlama-Adapters/tree/main/liquidations) for details.

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Please enable "Allow edits by maintainers" while putting up the PR.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. Please fill the form below  **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
5. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can  edit it there and put up a PR
6. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
7. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap

---
##### Name (to be shown on DefiLlama): Pendle

##### Website Link: https://pendle.finance/

This PR added a fix on TVL calculation for Pendle specifically on SY token ([EIP-5115](https://eips.ethereum.org/EIPS/eip-5115)) pricing. 

As described in the EIP, the `1` SY token with `assetType = 0` is worth `exchangeRate()` underlying asset while the current implementation only assumes 1 SY = 1 underlying asset.