### PR TITLE
fetch kujira contracts from canonical source

### DIFF
--- a/projects/bow/index.js
+++ b/projects/bow/index.js
@@ -1,13 +1,11 @@
-const { get } = require("../helper/http");
-const { sumTokens, endPoints } = require('../helper/chain/cosmos')
+
+const { getConfig } = require("../helper/cache");
+const { sumTokens } = require('../helper/chain/cosmos')
 
 
 async function tvl() {
-  const bowPoolCodes = [46, 54, 36];
-  const bowPools = (await Promise.all(bowPoolCodes.map(async (code) => {
-    const result = await get(endPoints.kujira + `/cosmwasm/wasm/v1/code/${code}/contracts?pagination.limit=100`);
-    return result.contracts;
-  }))).flat();
+  const contracts = await getConfig("kujira/contracts", "https://raw.githubusercontent.com/Team-Kujira/kujira.js/master/src/resources/contracts.json");
+  const bowPools = contracts["kaiyo-1"].bow.map(x => x.address)
   const owners = [
   ...bowPools
 ]

--- a/projects/fin/index.js
+++ b/projects/fin/index.js
@@ -1,15 +1,14 @@
-const { get } = require("../helper/http");
 const { getConfig } = require("../helper/cache");
 const { sumTokens, } = require('../helper/chain/cosmos');
 
 async function tvl() {
-  const { pairs } = await getConfig("kujira/fin", "https://api.kujira.app/api/coingecko/pairs");
+  const contracts = await getConfig("kujira/contracts", "https://raw.githubusercontent.com/Team-Kujira/kujira.js/master/src/resources/contracts.json");
   const blacklist = [
     'kujira1hs95lgvuy0p6jn4v7js5x8plfdqw867lsuh5xv6d2ua20jprkgesw2pujt',
     'kujira1gl8js9zn7h9u2h37fx7qg8xy65jrk9t4zpa6s7j5hdlanud2uwxshqq67m'
   ]
   let owners = [
-    ...pairs.map((pair) => pair.pool_id),
+    ...contracts["kaiyo-1"].fin.map(x => x.address),
   ]
 
   owners = owners.filter(item => {

--- a/projects/ghost/index.js
+++ b/projects/ghost/index.js
@@ -2,11 +2,13 @@ const {
   queryContracts,
   queryContract,
 } = require("../helper/chain/cosmos");
+const { getConfig } = require("../helper/cache");
 
 async function tvl(_, _1, _2, { api }) {
   const chain = api.chain
-  const vaultContracts = await queryContracts({ chain, codeId: 106 });
-  const marketContracts = await queryContracts({ chain, codeId: 113 });
+  const contracts = await getConfig("kujira/contracts", "https://raw.githubusercontent.com/Team-Kujira/kujira.js/master/src/resources/contracts.json");
+  const vaultContracts = contracts["kaiyo-1"].ghostVault.map(x => x.address)
+  const marketContracts = contracts["kaiyo-1"].ghostMarket.map(x => x.address)
   for (const contract of vaultContracts) {
     const { deposited, borrowed } = await queryContract({ contract, chain, data: { status: {}  } })
     const { denom } = await queryContract({ contract, chain, data: { config: {}  } })

--- a/projects/kujira/index.js
+++ b/projects/kujira/index.js
@@ -1,9 +1,11 @@
-const { sumTokens, queryContracts } = require('../helper/chain/cosmos')
+const { sumTokens } = require('../helper/chain/cosmos')
+const { getConfig } = require("../helper/cache");
 
 const chain = "kujira";
 
 async function tvl() {
-  const uskContracts = await queryContracts({ chain, codeId: 73 });
+  const contracts = await getConfig("kujira/contracts", "https://raw.githubusercontent.com/Team-Kujira/kujira.js/master/src/resources/contracts.json");
+  const uskContracts = contracts["kaiyo-1"].uskMarket.map(x => x.address)
   return sumTokens({ owners: uskContracts, chain })
 }
 

--- a/projects/orca-kujira/index.js
+++ b/projects/orca-kujira/index.js
@@ -1,9 +1,10 @@
-const { get } = require("../helper/http");
-const { sumTokens, endPoints } = require('../helper/chain/cosmos')
+const { sumTokens } = require('../helper/chain/cosmos')
+const { getConfig } = require("../helper/cache");
 
 
 async function tvl() {
-  const { contracts: orcaPools } = await get(endPoints.kujira + "/cosmwasm/wasm/v1/code/59/contracts?pagination.limit=100");
+  const contracts = await getConfig("kujira/contracts", "https://raw.githubusercontent.com/Team-Kujira/kujira.js/master/src/resources/contracts.json");
+  const orcaPools = contracts["kaiyo-1"].orca.map(x => x.address)
   const owners = [
     ...orcaPools,
   ]


### PR DESCRIPTION
Updates the Kujira protocol adapters to fetch the contract lists from a published json file. The old methods of hard-coding contract addresses or fetching via code ID is fragile and needs updating every time either a contract is added or a new code ID for a protocol is created