### PR TITLE
add zkswap(zksync)

### DIFF
--- a/projects/ZKSwap(ZKSync)/index.js
+++ b/projects/ZKSwap(ZKSync)/index.js
@@ -1,0 +1,9 @@
+const { getUniTVL } = require('../helper/unknownTokens')
+
+const factory = "0xeeE1Af1CE68D280e9cAfD861B7d4af776798F18d";
+const zks = "";
+
+module.exports = {
+  misrepresentedTokens: true,
+  era: { tvl: getUniTVL({ factory, useDefaultCoreAssets: true, fetchBalances: true }) },
+};


### PR DESCRIPTION
Name (to be shown on DefiLlama):
ZKSwap (ZKSync) 

Twitter Link:
https://twitter.com/ZKSpaceOfficial

List of audit links if any:

Website Link:
https://zksync.zks.app/swap

Logo (High resolution, will be shown with rounded borders):
https://pbs.twimg.com/profile_images/1648881691111587840/rc1Lrsvk_400x400.jpg

Current TVL:
~2.2K

Treasury Addresses (if the protocol has treasury)

Chain:
zksync-era

Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): 

Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): 

Short Description (to be shown on DefiLlama):
ZKSwap is the first Layer 2 AMM DEX powered by ZK-Rollups technology. It operates on both ZKSpace and the EVM chain ZKSync Era.

Token address and ticker if any:
https://etherscan.io/token/0xe4815ae53b124e7263f08dcdbbb757d41ed658c6

Category (full list at https://defillama.com/categories) *Please choose only one:
Dex

Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):

forkedFrom (Does your project originate from another project):
univ2

methodology (what is being counted as tvl, how is tvl being calculated):

Github org/user (Optional, if your code is open source, we can track activity):