### PR TITLE
Core assets broken on Fantom, don't use

### DIFF
--- a/projects/Equalizer/index.js
+++ b/projects/Equalizer/index.js
@@ -4,7 +4,7 @@ const { staking } = require('../helper/staking')
 module.exports = {
   misrepresentedTokens: true,
   fantom:{
-    tvl: uniTvlExport("0xc6366EFD0AF1d09171fe0EBF32c7943BB310832a", "fantom", undefined, undefined, { hasStablePools: true, useDefaultCoreAssets: true, }),
+    tvl: uniTvlExport("0xc6366EFD0AF1d09171fe0EBF32c7943BB310832a", "fantom", undefined, undefined, { hasStablePools: true, useDefaultCoreAssets: false, }),
     staking: staking("0x8313f3551C4D3984FfbaDFb42f780D0c8763Ce94", "0x3Fd3A0c85B70754eFc07aC9Ac0cbBDCe664865A6","fantom"),
   },
 }

--- a/projects/spookyswap/index.js
+++ b/projects/spookyswap/index.js
@@ -2,6 +2,6 @@ const { getUniTVL } = require("../helper/unknownTokens")
 module.exports={
   misrepresentedTokens: true,
   fantom:{
-      tvl: getUniTVL({ useDefaultCoreAssets: true, factory: '0x152eE697f2E276fA89E96742e9bB9aB1F2E61bE3' }),
+      tvl: getUniTVL({ useDefaultCoreAssets: false, factory: '0x152eE697f2E276fA89E96742e9bB9aB1F2E61bE3' }),
   },
 }  


### PR DESCRIPTION
It seems the default core assets on Fantom are no longer valid. I'm not sure why these core assets are needed in the first place. Disabling this yields more accurate results.