### PR TITLE
Fix tvl double subtract bug

### DIFF
--- a/projects/glif/index.js
+++ b/projects/glif/index.js
@@ -11,9 +11,8 @@ module.exports = {
     "The GLIF Pools protocol is a liquid staking protocol for Filecoin that requires borrowers to collateralize FIL in order to borrow for their storage providing operation. This TVL calculation adds the total amount of FIL staked into the protocol, and the total amount of locked FIL collateral by borrowers, to arrive at TVL.",
   filecoin: {
     tvl: async (_, _1, _2, { api }) => {
-      const [totalAssets, totalIssued, totalLockedByMiners] = await Promise.all([
+      const [totalAssets, totalLockedByMiners] = await Promise.all([
         api.call({ abi: totalAssetsABI, target: INFINITY_POOL_CONTRACT }),
-        api.call({ abi: totalBorrowedABI, target: INFINITY_POOL_CONTRACT }),
         // this call is too costly to perform on chain in this environment,
         // we wrapped the locked miners collateral in a server that derives the information directly on-chain
         // but serves it in a more efficient manner to not overload defillama frontend
@@ -21,17 +20,15 @@ module.exports = {
         get("https://pools-metrics.vercel.app/api/v0/miner-collaterals"),
       ]);
 
-      const totalAssetsBN = BigNumber.from(totalAssets)
-      const totalIssuedBN = BigNumber.from(totalIssued)
-      const totalLockedByMinersBN = BigNumber.from(totalLockedByMiners.totalMinerCollaterals)
-
-      // first we remove the totalIssued by the Pool from its totalAssets, to avoid double counting in the next step
-      const totalAssetsMinusIssued = totalAssetsBN.sub(totalIssuedBN);
+      const totalAssetsBN = BigNumber.from(totalAssets);
+      const totalLockedByMinersBN = BigNumber.from(
+        totalLockedByMiners.totalMinerCollaterals
+      );
       // then we add the totalLockedByMiners to the totalAssets, to account for the FIL locked by miners as borrow collateral
       // this gets our tvl in attoFIL (wei denominated) without double counting
-      const tvl = totalAssetsMinusIssued.add(totalLockedByMinersBN).toString();
+      const tvl = totalAssetsBN.add(totalLockedByMinersBN).toString();
 
-      api.add(nullAddress, tvl)
+      api.add(nullAddress, tvl);
     },
   },
 };


### PR DESCRIPTION
Hi! We had a unknown bug occur on the DeFiLlama TVL because our server-side miner collaterals was already subtracting issued FIL, and the Adapter here then subtracts that issued FIL value _again_, so our TVL was showing up far too low.

You can see from our website that the numbers now align: https://glif.io