### PR TITLE
add zkSync Era Gate.io addresses

### DIFF
--- a/projects/gate-io/index.js
+++ b/projects/gate-io/index.js
@@ -59,6 +59,18 @@ const config = {
       '0xc882b111a75c0c657fc507c04fbfcd2cc984f071',
     ]
   },
+  era: {
+    owners: [
+      '0x0d0707963952f2fba59dd06f2b425ace40b492fe',
+      '0x1c4b70a3968436b9a0a9cf5205c787eb81bb558c',
+      '0x234ee9e35f8e9749a002fc42970d570db716453b',
+      '0x925206b8a707096Ed26ae47C84747fE0bb734F59',
+      '0xD793281182A0e3E023116004778F45c29fc14F19',
+      '0xc882b111a75c0c657fc507c04fbfcd2cc984f071',
+      '0x85FAa6C1F2450b9caEA300838981C2e6E120C35c',
+      '0xeb01f8cdae433e7b55023ff0b2da44c4c712dce2',
+    ]
+  },
   bitcoin: {
     owners: [
       '14kmvhQrWrNEHbrSKBySj4qHGjemDtS3SF',


### PR DESCRIPTION
Used existing address list from other EVM chains and added two new addresses:

0x85FAa6C1F2450b9caEA300838981C2e6E120C35c
0xeb01f8cdae433e7b55023ff0b2da44c4c712dce2

These are labeled as Gate.io addresses on Arkham and very large ETH transfers with 0x0D0707963952f2fBA59dD06f2b425ace40b492Fe should confirm the legitimacy of this labeling.