### PR TITLE
Y2k: update adapter to fetch only available vaults at the timestamp

### DIFF
--- a/projects/y2k-finance/index.js
+++ b/projects/y2k-finance/index.js
@@ -1,12 +1,15 @@
 const { sumTokens2, sumTokensExport } = require('../helper/unwrapLPs')
-const { getLogs } = require('../helper/cache/getLogs')
+const { getLogs } = require('../helper/cache/getLogs');
+const { getBlock } = require('../helper/http');
 
 const chain = 'arbitrum'
 
 async function tvl(timestamp, _b, chainBlocks, { api }) {
+  const block = await getBlock(timestamp, chain, chainBlocks)
   const logs = await getLogs({
     api,
     fromBlock: 33934273,
+    toBlock: block,
     eventAbi: 'event MarketCreated(uint256 indexed mIndex, address hedge, address risk, address token, string name, int256 strikePrice)',
     topics: ['0xf38f00404415af51ddd0dd57ce975d015de2f40ba8a087ac48cd7552b7580f32'],
     target: '0x984e0eb8fb687afa53fc8b33e12e04967560e092',
@@ -16,6 +19,7 @@ async function tvl(timestamp, _b, chainBlocks, { api }) {
   const tokens = await api.multiCall({
     abi: 'address:asset',
     calls: vaults,
+    block
   })
   const tokensAndOwners = tokens.map((token, i) => ([token, vaults[i]]))
 

--- a/projects/y2k-v2/index.js
+++ b/projects/y2k-v2/index.js
@@ -1,12 +1,16 @@
 const { sumTokens2, sumTokensExport } = require('../helper/unwrapLPs')
-const { getLogs } = require('../helper/cache/getLogs')
+const { getLogs } = require('../helper/cache/getLogs');
+const { getBlock } = require('../helper/http');
 
 const chain = 'arbitrum'
 
 async function tvl(timestamp, _b, chainBlocks, { api }) {
+  const block = await getBlock(timestamp, chain, chainBlocks)
+  console.log(block);
   const logs = await getLogs({
     api,
     fromBlock: 33934273,
+    toBlock: block,
     eventAbi: 'event MarketCreated(uint256 indexed mIndex, address hedge, address risk, address token, string name, int256 strikePrice)',
     topics: ['0xf38f00404415af51ddd0dd57ce975d015de2f40ba8a087ac48cd7552b7580f32'],
     target: '0x984e0eb8fb687afa53fc8b33e12e04967560e092',
@@ -16,6 +20,7 @@ async function tvl(timestamp, _b, chainBlocks, { api }) {
   const tokens = await api.multiCall({
     abi: 'address:asset',
     calls: vaults,
+    block
   })
   const tokensAndOwners = tokens.map((token, i) => ([token, vaults[i]]))
 


### PR DESCRIPTION
##### Y2k (to be shown on DefiLlama):


##### Twitter Link:


##### List of audit links if any:


##### Website Link: https://y2k.finance


##### Logo (High resolution, will be shown with rounded borders):


##### Current TVL:


##### Treasury Addresses (if the protocol has treasury)


##### Chain: arbitrum


##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description (to be shown on DefiLlama):


##### Token address and ticker if any:


##### Category (full list at https://defillama.com/categories) *Please choose only one:


##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):


##### forkedFrom (Does your project originate from another project):


##### methodology (what is being counted as tvl, how is tvl being calculated):


##### Github org/user (Optional, if your code is open source, we can track activity):