### PR TITLE
add wETH.e to Struct Finance

### DIFF
--- a/projects/struct-finance/index.js
+++ b/projects/struct-finance/index.js
@@ -18,7 +18,12 @@ async function tvl(ts, _, __, { api }) {
   return sumTokens2({
     api,
     owners: vaults,
-    tokens: [ADDRESSES.avax.BTC_b, ADDRESSES.avax.USDC, addresses.token.fsGlp],
+    tokens: [
+      ADDRESSES.avax.BTC_b,
+      ADDRESSES.avax.USDC,
+      ADDRESSES.avax.WETH_e,
+      addresses.token.fsGlp,
+    ],
   });
 }
 


### PR DESCRIPTION
### Description
* feature: add wETH.e address to `sumTokens2` array

### Motivation & Context
Struct has introduced [wETH.e tranches](https://app.struct.fi/vault?mid=gmx-btc.b-weth&productId=&open=false), so we want to add wETH.e to our TVL calculations