### PR TITLE
Added Base chain to DerpDEX adapter

### DIFF
--- a/projects/DerpDEX/index.js
+++ b/projects/DerpDEX/index.js
@@ -5,4 +5,8 @@ module.exports = uniV3Export({
     factory: "0x52a1865eb6903bc777a02ae93159105015ca1517",
     fromBlock: 7790768,
   },
+  base: {
+    factory: "0xeddef4273518b137cdbcb3a7fa1c6a688303dfe2",
+    fromBlock: 2753388
+  }
 });


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
DerpDEX

##### Twitter Link:
https://twitter.com/DerpDEXcom

##### List of audit links if any:
https://derpdex.gitbook.io/home/contracts/audits

##### Website Link:
https://derpdex.com/

##### Logo (High resolution, will be shown with rounded borders):
![ZvHwGey9_400x400-modified](https://github.com/DefiLlama/DefiLlama-Adapters/assets/138676931/e95c3271-9a96-4d98-990d-c52e18fc8aca)


##### Current TVL:
$86k

##### Treasury Addresses (if the protocol has treasury)


##### Chain:
Base Chain
