### PR TITLE
add nether.fi on base

### DIFF
--- a/projects/nether-fi/index.js
+++ b/projects/nether-fi/index.js
@@ -1,0 +1,13 @@
+const { staking } = require("../helper/staking");
+const { gmxExports } = require("../helper/gmx");
+
+const vaultBase = "0xAd378C374f7996235E927e693eDea32605C0A61F";
+const stakingBase = "0x6ffC50886775D4A26AF1B0f88F9df61267e69aec";
+const NFI = "0x60359A0DD148B18d5cF1Ddf8Aa1916221ED0cbCd";
+
+module.exports = {
+  base: {
+    staking: staking(stakingBase, NFI, "base"),
+    tvl: gmxExports({ vault: vaultBase }),
+  }
+};


### PR DESCRIPTION
**NOTE**

> - If you would like to add a `volume` adapter please submit the PR [here](https://github.com/DefiLlama/adapters).
> - If you would like to add a `liquidations` adapter, please refer to [this readme document](https://github.com/DefiLlama/DefiLlama-Adapters/tree/main/liquidations) for details.

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Please enable "Allow edits by maintainers" while putting up the PR.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. Please fill the form below  **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
5. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can  edit it there and put up a PR
6. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
7. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap

---
##### Name (to be shown on DefiLlama):
**Nether.Fi**


##### Twitter Link:
[https://twitter.com/netherlabs_](https://twitter.com/netherlabs_)

##### List of audit links if any:
N/A

##### Website Link:
https://nether.fi/

##### Logo (High resolution, will be shown with rounded borders):
![nether-fi-logo](https://github.com/DefiLlama/DefiLlama-Adapters/assets/143496268/5af80a1c-9c13-4990-807e-235f325e4251)

##### Current TVL:
~ $100,000

##### Treasury Addresses (if the protocol has treasury)
https://basescan.org/address/0xCf2fCef5B778419eFc231e8AC91884Fc7FbAf13C

##### Chain:
`Base`

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)
`netherfi`

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
N/A

##### Short Description (to be shown on DefiLlama):
Trade confidently on [Nether.Fi](https://nether.fi), offering both spot and leveraged trading up to 50x with remarkably low transaction fees. We prioritize your protection against sudden price fluctuations by utilizing Chainlink price feeds for enhanced trade stability. Stake NFI or mint NLP to benefit from our unique reward system, ensuring participants share in the protocol's success.

##### Token address and ticker if any:
Ticker - `NFI`
Address - `0x60359A0DD148B18d5cF1Ddf8Aa1916221ED0cbCd`


##### Category (full list at https://defillama.com/categories) *Please choose only one:
`Dexes`

##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):
`Chainlink`

##### forkedFrom (Does your project originate from another project):
`GMX`

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL is counted from 2 sources:
1. NLP Trading Vault - amount of liquidity provided
2. NFI Staking Pool - amount of NFI/esNFI staked 

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/nether-labs