### PR TITLE
enosys: adding FLR/APS farm

### DIFF
--- a/projects/flarefarm/flare.js
+++ b/projects/flarefarm/flare.js
@@ -11,6 +11,7 @@ const chain = 'flare'
 async function farmTvl(timestamp, ethblock, { [chain]: block }) {
   const tokens = [
     ['0x7520005032F43229F606d3ACeae97045b9D6F7ea', "0x22beb4c7166DbAa0A33052A770C3b358cAbE9089"], 
+    ['0xef24D5155818d4bD16AF0Cea1148A147eb620743', "0x3DA590b357Cf17a413ec8db70FeB02119AfE707f"], 
   ];
 
   return sumUnknownTokens({ tokensAndOwners: tokens, chain, block, useDefaultCoreAssets: true, })


### PR DESCRIPTION
Adding the newest farm on flare mainnet between FLR and the main governance token, APS