### PR TITLE
fix: hashmix tvl api was down last week, now back online

### DIFF
--- a/projects/hashmix/index.js
+++ b/projects/hashmix/index.js
@@ -1,25 +1,31 @@
 const POOL = "0x587A7eaE9b461ad724391Aa7195210e0547eD11d";
-const { sumTokens2, nullAddress } = require('../helper/unwrapLPs')
+const { sumTokens2, nullAddress } = require("../helper/unwrapLPs");
 const { get } = require("../helper/http");
 const BigNumber = require("bignumber.js");
 const { sdk } = require("@defillama/sdk");
 
-async function tvl(_, _1, _2, { api }) {
-  const totalBorrows = await api.call({ target: POOL, abi: "uint256:totalBorrows", });
-  const totalReserves = await api.call({ target: POOL, abi: "uint256:totalReserves", });
-  api.add(nullAddress, totalBorrows)
-  api.add(nullAddress, totalReserves * -1)
+// async function tvl(_, _1, _2, { api }) {
+//   const totalBorrows = await api.call({
+//     target: POOL,
+//     abi: "uint256:totalBorrows",
+//   });
+//   const totalReserves = await api.call({
+//     target: POOL,
+//     abi: "uint256:totalReserves",
+//   });
+//   api.add(nullAddress, totalBorrows);
+//   api.add(nullAddress, totalReserves * -1);
+//
+//   return sumTokens2({ api, owner: POOL, tokens: [nullAddress] });
+// }
 
+async function tvl(_, _1, _2, { api }) {
+  let tvl = await get("https://fvm.hashmix.org/fevmapi/tvl");
+  api.add(nullAddress, tvl.data);
   return sumTokens2({ api, owner: POOL, tokens: [nullAddress] });
 }
 
 /* async function tvl1(_, _1, _2, { api }) {
-
-  // let tvl = await get("https://fvm.hashmix.org/fevmapi/tvl");
-
-  // api.add(nullAddress, tvl.data)
-
-  // return sumTokens2({ api, owner: POOL, tokens: [nullAddress] });
 
   const balances = {};
   const bal = await sdk.api2.eth.getBalance({ target: POOL, chain: api.chain, decimals: api.decimals });


### PR DESCRIPTION
**NOTE**

> - If you would like to add a `volume` adapter please submit the PR [here](https://github.com/DefiLlama/adapters).
> - If you would like to add a `liquidations` adapter, please refer to [this readme document](https://github.com/DefiLlama/DefiLlama-Adapters/tree/main/liquidations) for details.

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Please enable "Allow edits by maintainers" while putting up the PR.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. Please fill the form below  **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
5. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can  edit it there and put up a PR
6. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
7. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap

---

Hashmix TVL api was blocked last week. Now we have fixed the issue. Please merge my PR to show our real TVL.