### PR TITLE
SwissBorg: Add GLMR Staking address

### DIFF
--- a/projects/swissborg/index.js
+++ b/projects/swissborg/index.js
@@ -90,6 +90,7 @@ const config = {
   moonbeam: {
     owners: [
       '0x87cbc48075d7aa1760Ac71C41e8Bc289b6A31F56',
+      '0xFF4606bd3884554CDbDabd9B6e25E2faD4f6fc54',
     ]
   }
 }


### PR DESCRIPTION
This PR updates the list of wallets owned by SwissBorg. It adds the address for our new GLMR Staking strategy.

Source: https://github.com/SwissBorg/pub