### PR TITLE
Fix Stride TVL

### DIFF
--- a/projects/stride/index.js
+++ b/projects/stride/index.js
@@ -32,18 +32,17 @@ async function tvl() {
     "https://stride-fleet.main.stridenet.co/api/Stride-Labs/stride/stakeibc/host_zone"
   );
 
-  const { supply: assetBalances } = await get(
-    "https://stride-fleet.main.stridenet.co/api/cosmos/bank/v1beta1/supply"
-  );
-
-  hostZones.map((hostZone) => {
-    const assetBalance = assetBalances.find((asset) => {
-      return asset.denom === `st${hostZone.host_denom}`;
-    });
+  const hostZonePromises = hostZones.map(async (hostZone) => {
+    const stDenom = "st".concat(hostZone.host_denom);
+    console.log(stDenom)
+    const { amount: assetBalances } = await get(
+      "https://stride-fleet.main.stridenet.co/api/cosmos/bank/v1beta1/supply/by_denom?denom=".concat(stDenom)
+    );
+    const assetBalance = assetBalances['amount']
 
     const coinDecimals = getCoinDenom(hostZone.host_denom);
 
-    const amount = assetBalance.amount / coinDecimals;
+    const amount = assetBalance / coinDecimals;
 
     const geckoId = coinGeckoIds[hostZone.host_denom];
 
@@ -57,6 +56,8 @@ async function tvl() {
       amount * hostZone.redemption_rate
     );
   });
+
+  await Promise.all(hostZonePromises);
 
   return balances;
 }

--- a/projects/stride/index.js
+++ b/projects/stride/index.js
@@ -34,7 +34,6 @@ async function tvl() {
 
   const hostZonePromises = hostZones.map(async (hostZone) => {
     const stDenom = "st".concat(hostZone.host_denom);
-    console.log(stDenom)
     const { amount: assetBalances } = await get(
       "https://stride-fleet.main.stridenet.co/api/cosmos/bank/v1beta1/supply/by_denom?denom=".concat(stDenom)
     );


### PR DESCRIPTION
This fixes a bug with calculating Stride TVL. 

In particular, the query "https://stride-fleet.main.stridenet.co/api/cosmos/bank/v1beta1/supply" is paginated to only list 100 denoms. We switch to a different query that checks each TVL metric specifically. 