### PR TITLE
adding HLN-WFLR farm

### DIFF
--- a/projects/flarefarm/flare.js
+++ b/projects/flarefarm/flare.js
@@ -12,6 +12,7 @@ async function farmTvl(timestamp, ethblock, { [chain]: block }) {
   const tokens = [
     ['0x7520005032F43229F606d3ACeae97045b9D6F7ea', "0x22beb4c7166DbAa0A33052A770C3b358cAbE9089"], 
     ['0xef24D5155818d4bD16AF0Cea1148A147eb620743', "0x3DA590b357Cf17a413ec8db70FeB02119AfE707f"], 
+    ['0x02C6b5B1fbE01Da872E21f9Dab1B980933B0EF27', "0xd3a273329bab3e263015C1C2ab79C3731769a5b0"], 
   ];
 
   return sumUnknownTokens({ tokensAndOwners: tokens, chain, block, useDefaultCoreAssets: true, })


### PR DESCRIPTION
adding enosys newest farm on flare - HLN/WFLR

HLN is the second governance token along with APS, if possible would be great to add both to the core tokens on the Flare network
HLN - 0x140D8d3649Ec605CF69018C627fB44cCC76eC89f
APS - 0xfF56Eb5b1a7FAa972291117E5E9565dA29bc808d