### PR TITLE
fix: tholgar TVL now counts redeemed AURA/CVX

### DIFF
--- a/projects/tholgar/abi.json
+++ b/projects/tholgar/abi.json
@@ -3,5 +3,6 @@
   "getCurrentLockedTokens": "uint256:getCurrentLockedTokens",
   "lockers": "function lockers(uint256) view returns (address)",
   "totalAssets": "uint256:totalAssets",
-  "totalSupply": "erc20:totalSupply"
+  "totalSupply": "erc20:totalSupply",
+  "queuedForWithdrawal": "function queuedForWithdrawal(address) view returns (uint256)"
 }

--- a/projects/tholgar/index.js
+++ b/projects/tholgar/index.js
@@ -3,6 +3,7 @@ const abi = require("./abi.json");
 const { BigNumber } = require("ethers");
 
 const WAR_CONTROLLER = "0xFDeac9F9e4a5A7340Ac57B47C67d383fb4f13DBb";
+const WAR_REDEEMER = "0x4787Ef084c1d57ED87D58a716d991F8A9CD3828C";
 const VAULT = '0x188cA46Aa2c7ae10C14A931512B62991D5901453';
 const WAR = '0xa8258deE2a677874a48F5320670A869D74f0cbC1';
 
@@ -32,12 +33,13 @@ async function ethTvl(timestamp, block, _, { api },) {
 
   const bals = await api.multiCall({ abi: abi["getCurrentLockedTokens"], calls: lockers.map(i => ({ target: i})) })
   const tokens = await api.multiCall({ abi: abi["token"], calls:  lockers.map(i => ({ target: i})) })
+  const tokensQueued = await api.multiCall({ abi: abi["queuedForWithdrawal"], calls: tokens.map(i => ({ target: WAR_REDEEMER, params: [i] })) })
 
   const totalSupply = await api.call({target: WAR, abi: abi['totalSupply']});
   const vaultBalance = await api.call({ target: VAULT, abi: abi['totalAssets']});
   const ratio = vaultBalance / totalSupply;
 
-  bals.forEach((v, i) => sdk.util.sumSingleBalance(balances, tokens[i], v * ratio))
+  bals.forEach((v, i) => sdk.util.sumSingleBalance(balances, tokens[i], (v - tokensQueued[i]) * ratio))
 
   return balances;
 }


### PR DESCRIPTION
Update Tholgar TVL as it was too big compared to the actual value because it counted the amount  of cvx / aura being redemed.