### PR TITLE
added shimmersea adapter

### DIFF
--- a/projects/helper/chains.json
+++ b/projects/helper/chains.json
@@ -189,6 +189,7 @@
   "sei",
   "shibarium",
   "shiden",
+  "shimmer_evm",
   "sifchain",
   "smartbch",
   "solana",

--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -55,6 +55,9 @@ const fixBalancesTokens = {
   pg: {
     '0x0cf4071940782b640d0b595cb17bdf3e90869d70': { coingeckoId: 'pego-network-2', decimals: 18 },
   },
+  shimmer_evm: {
+    '0x1074010000000000000000000000000000000000': { coingeckoId: 'shimmer', decimals: 6 },
+  },
   manta: {
     '0x0Dc808adcE2099A9F62AA87D9670745AbA741746': { coingeckoId: 'ethereum', decimals: 18 },
     '0xb73603c5d87fa094b7314c74ace2e64d165016fb': { coingeckoId: 'usd-coin', decimals: 6 },

--- a/projects/shimmersea/index.js
+++ b/projects/shimmersea/index.js
@@ -1,0 +1,13 @@
+const { getChainTvl } = require('../helper/getUniSubgraphTvl');
+
+const v2graph = getChainTvl({
+  shimmer_evm: 'https://graph.shimmersea.finance/subgraphs/name/shimmersea/shimmer-dex'
+})
+
+module.exports = {
+  misrepresentedTokens: true,
+  methodology: `Counts the tokens locked on AMM pools, pulling the data from subgraph`,
+  shimmer_evm: {
+    tvl: v2graph('shimmer_evm'),
+  },
+}

--- a/projects/shimmersea/index.js
+++ b/projects/shimmersea/index.js
@@ -1,13 +1,3 @@
-const { getChainTvl } = require('../helper/getUniSubgraphTvl');
+const { uniTvlExport } = require('../helper/unknownTokens');
 
-const v2graph = getChainTvl({
-  shimmer_evm: 'https://graph.shimmersea.finance/subgraphs/name/shimmersea/shimmer-dex'
-})
-
-module.exports = {
-  misrepresentedTokens: true,
-  methodology: `Counts the tokens locked on AMM pools, pulling the data from subgraph`,
-  shimmer_evm: {
-    tvl: v2graph('shimmer_evm'),
-  },
-}
+module.exports = uniTvlExport('shimmer_evm', '0x4fb5d3a06f5de2e88ce490e2e11d22b840d5ac47')


### PR DESCRIPTION
This PR consists of adding a new dex: ShimmerSea.

Name (to be shown on DefiLlama):
ShimmerSea

Twitter Link:
https://twitter.com/ShimmerSeaDEX

List of audit links if any:
https://github.com/HashEx/public_audits/blob/master/ShimmerSea/ShimmerSea.pdf

Website Link:
https://shimmersea.finance/

Logo (High resolution, will be shown with rounded borders):
https://www.file.io/UNIQ/download/1wWZhC8Zi6h6

Current TVL:
~15.000$

Treasury Addresses (if the protocol has treasury)
n/a

Chain:
ShimmerEVM

Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)
n/a

Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
n/a

Short Description (to be shown on DefiLlama):
ShimmerSea is a leading decentralized exchange (DEX) on Shimmer focused on offering a premier trading experience.

Token address and ticker if any:
n/a

Category (full list at https://defillama.com/categories) *Please choose only one:
Dexes

Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):
n/a

forkedFrom (Does your project originate from another project):
Uniswap

methodology (what is being counted as tvl, how is tvl being calculated):
Counts the tokens locked on AMM pools, pulling the data from subgraph

Github org/user (Optional, if your code is open source, we can track activity):
n/a