### PR TITLE
SwissBorg: Add new Solana wallet

### DIFF
--- a/projects/swissborg/index.js
+++ b/projects/swissborg/index.js
@@ -44,6 +44,7 @@ const config = {
       '2E1UKoiiZPwsp4vn6tUh5k61kG2UqYpT7oBrFaJUJXXd',
       '2XxP4kS2vfkiMvpLpGNxry3fPUYimsuAmSbqL1KnuwZ8',
       'Cet3t77x2BBVSmiEFm8ZPoDSngbpso2RuWPL79Ky7SpA',
+      '9qoUcyhKSWMbk6tqGUYQUpeosPcdUnJszG4eQKwfe4gL',
     ],
   },
   polkadot: {


### PR DESCRIPTION
This PR updates the list of wallets owned by SwissBorg. It adds the address for our new GLMR Staking strategy.

New wallet addition: https://github.com/SwissBorg/pub/commit/708ab283dc96728a4479834ba45cf2f0361717ac