### PR TITLE
jexchange: use new `/pools/v3` endpoint

### DIFF
--- a/projects/jexchange/index.js
+++ b/projects/jexchange/index.js
@@ -2,7 +2,7 @@ const { sumTokens } = require("../helper/chain/elrond");
 const { getConfig } = require('../helper/cache')
 
 async function tvl() {
-  const pools = await getConfig('jexchange', 'https://api.jexchange.io/pools')
+  const pools = await getConfig('jexchange', 'https://api.jexchange.io/pools/v3')
   const owners = [
     ...pools.map(pool => pool.sc_address),
     "erd1qqqqqqqqqqqqqpgqmmxzmktd09gq0hldtczerlv444ykt3pz6avsnys6m9",


### PR DESCRIPTION
Use new endpoint which is compatible with new types of pools