### PR TITLE
DO NOT MERGE: Ondo Return Balances in TVL Adapter

### DIFF
--- a/projects/ondofinance/index.js
+++ b/projects/ondofinance/index.js
@@ -1,4 +1,4 @@
-const sdk = require('@defillama/sdk')
+const sdk = require('@defillama/sdk');
 
 module.exports = {
   methodology: "Sums Ondo's fund supplies.",
@@ -15,12 +15,13 @@ const config = {
   polygon: {
     OUSG: '0xbA11C5effA33c4D6F8f593CFA394241CfE925811',
   }
-}
+};
 
 Object.keys(config).forEach((chain) => {
   let funds = config[chain];
-  const fundKeys = Object.keys(funds); // Capture the keys (OUSG, USDYc, etc.)
+  const fundKeys = Object.keys(funds);
   funds = Object.values(funds);
+
   module.exports[chain] = {
     tvl: async (_, _b, _cb, { api }) => {
       const ethApi = new sdk.ChainApi({ chain: 'ethereum', block: _b });
@@ -36,21 +37,24 @@ Object.keys(config).forEach((chain) => {
         target: '0x7fb0228c6338da4EC948Df7b6a8E22aD2Bb2bfB5',
       })) / 1e18;
 
-      let totalTvl = 0;
+      const balances = {};
 
       supplies.forEach((supply, index) => {
         const key = fundKeys[index];
-
+        let tokenPrice;
+        
         if (key === 'USDYc' || key === 'USDY') {
-          // Use the specific price for USDYc
-          totalTvl += (supply / 1e18) * usdyTokenPrice;
+          tokenPrice = usdyTokenPrice;
         } else {
-          // Use the general token price
-          totalTvl += (supply / 1e18) * ousgTokenPrice;
+          tokenPrice = ousgTokenPrice;
         }
-      });
 
-      return { 'usd-coin': totalTvl };
+        const tokenTvl = (supply/1e18 * tokenPrice);
+
+        balances[`${chain}:${funds[index]}`] = tokenTvl; 
+      });
+      
+      return balances;  // Return the balances object
     },
   };
 });


### PR DESCRIPTION
NOTE: Not production ready, there is a bug. 

This PR updates the Ondo TVL adapter to return the balances per token in order to have a pie-chart on the TVL page with a breakdown per token. The PR returns an array of balances of the _usd value_ of each token. Is there a better way to do this? The result is that the actual TVL is incorrect:

`--- ethereum ---
OUSG                      1.5626082454065048e-8
USDYc                     3.0334575901865074e-11
Total: 1.5656417029966913e-8 

--- polygon ---
OUSG                      2.0813866065690624e-9
Total: 2.0813866065690624e-9 

--- tvl ---
Total: 1.7737803636535975e-8 

------ TVL ------
ethereum                  1.5656417029966913e-8
polygon                   2.0813866065690624e-9

total                    1.7737803636535975e-8 `

Note that the calculation of balances is correct:
`{
  'ethereum:0x1B19C19393e2d034D8Ff31ff34c81252FcBbee92': 151767281.78662494,
  'ethereum:0x96F6eF951840721AdBF46Ac996b59E0235CB985C': 144750.29734709577,
  'ethereum:0xe86845788d6e3e5c2393ade1a051ae617d974c09': 30140561.11159925
}
{
  'polygon:0xbA11C5effA33c4D6F8f593CFA394241CfE925811': 20215328.353878714
}`