### PR TITLE
chore: update injective tvl calcs

### DIFF
--- a/projects/helper/chain/injective.js
+++ b/projects/helper/chain/injective.js
@@ -1,9 +1,13 @@
 const { getNetworkInfo, Network } = require('@injectivelabs/networks')
-const { protoObjectToJson, IndexerGrpcSpotApi, IndexerGrpcDerivativesApi, } = require('@injectivelabs/sdk-ts')
+const { protoObjectToJson, DenomClient, IndexerGrpcSpotApi, IndexerGrpcDerivativesApi, ChainGrpcBankApi } = require('@injectivelabs/sdk-ts')
+const { TokenType } = require('@injectivelabs/token-metadata')
+const { default: BigNumber } = require('bignumber.js')
+
 const { sliceIntoChunks } = require('../utils')
 let clients = {}
 
 const TYPES = {
+  BANK: 'BANK',
   SPOT: 'SPOT',
   DERIVATIVES: 'DERIVATIVES',
 }
@@ -14,13 +18,20 @@ function getClient(type = TYPES.SPOT) {
   if (!clients[type]) {
     const network = getNetworkInfo(Network.Mainnet)
     if (type === TYPES.SPOT)
-      clients[type] = new IndexerGrpcSpotApi(network.indexerApi);
+      clients[type] = new IndexerGrpcSpotApi(network.indexer);
     else if (type === TYPES.DERIVATIVES)
-      clients[type] = new IndexerGrpcDerivativesApi(network.indexerApi)
+      clients[type] = new IndexerGrpcDerivativesApi(network.indexer)
+    else if(type === TYPES.BANK)
+    clients[type] = new ChainGrpcBankApi(network.grpc)
     else
       throw new Error('Unknown type')
   }
   return clients[type]
+}
+
+function getDenomClient() {
+  const network = getNetworkInfo(Network.Mainnet)
+  return new DenomClient(network.grpc)
 }
 
 async function getMarkets({ type = TYPES.SPOT, marketStatus = 'active' } = {}) {
@@ -36,10 +47,41 @@ async function getOrders({ type = TYPES.SPOT, marketIds }) {
   return response
 }
 
+async function getAssets(type = TYPES.BANK) {
+  const denomClient = getDenomClient();
+  const { supply } = await getClient(type).fetchAllTotalSupply();
+  const supplyWithTokensOrUnknown = supply.map((coin) =>
+    denomClient.getDenomToken(coin.denom)
+  ).filter(token => token);
+  const supplyWithToken = supplyWithTokensOrUnknown.filter(
+    (token) => token.tokenType !== TokenType.Unknown
+  );
+  const assets = supplyWithToken.map((token) => ({
+    token,
+    ...supply.find((coin) => coin.denom === token.denom)
+  }));
+  return assets
+}
+
+function formatTokenAmounts(balances) {
+  const denomClient = getDenomClient();
+  return Object.entries(balances).reduce((formattedAmounts, [denom, amount]) => {
+    const token = denomClient.getDenomToken(denom)
+    if(!token || !token.decimals || !token.coinGeckoId) {
+      return formattedAmounts
+    }
+    const formattedAmount = new BigNumber(amount).div(10 ** token.decimals).toFixed(2)
+    formattedAmounts[token.coinGeckoId] = formattedAmount;
+    return formattedAmounts
+  }, {});
+}
+
 module.exports = {
   TYPES,
   getClient,
   p2j,
   getMarkets,
   getOrders,
+  getAssets,
+  formatTokenAmounts
 }

--- a/projects/injective/apiCache.js
+++ b/projects/injective/apiCache.js
@@ -1,5 +1,4 @@
-const { getMarkets, getOrders, TYPES } = require('../helper/chain/injectve')
-const { transformBalances } = require('../helper/portedTokens')
+const { getMarkets, getOrders, formatTokenAmounts, TYPES } = require('../helper/chain/injective')
 const sdk = require('@defillama/sdk')
 const { default: BigNumber } = require('bignumber.js')
 
@@ -27,16 +26,26 @@ function getOrderBookTvl(typeStr) {
         }
       }
     }
-    return transformBalances('injective', balances)
+    return formatTokenAmounts(balances)
   }
+}
+
+async function mergeAndSumAmounts() {
+  const spotAmounts = await getOrderBookTvl(TYPES.SPOT)()
+  const derivativesAmounts = await getOrderBookTvl(TYPES.DERIVATIVES)()
+  const coinGeckoIdList = new Set([...Object.keys(spotAmounts), ...Object.keys(derivativesAmounts)])
+
+  return Array.from(coinGeckoIdList).reduce((tvlMap, coinGeckoId) => {
+    const spotAmount = new BigNumber(spotAmounts[coinGeckoId] || 0)
+    const derivativesAmount = new BigNumber(derivativesAmounts[coinGeckoId] || 0);
+    tvlMap[coinGeckoId] = spotAmount.plus(derivativesAmount).toFixed(2)
+    return tvlMap
+  }, {})
 }
 
 module.exports = {
   timetravel: false,
   injective: {
-    tvl: sdk.util.sumChainTvls([
-      getOrderBookTvl(TYPES.SPOT),
-      getOrderBookTvl(TYPES.DERIVATIVES)
-    ])
+    tvl: () => mergeAndSumAmounts()
   }
 }

--- a/projects/injective/index.js
+++ b/projects/injective/index.js
@@ -1,32 +1,18 @@
-const ADDRESSES = require('../helper/coreAssets.json')
-const { sumTokensExport } = require('../helper/unwrapLPs')
+const { getAssets } = require('../helper/chain/injective')
+const BigNumber = require("bignumber.js");
 
-const newHolder = '0xf955c57f9ea9dc8781965feae0b6a2ace2bad6f3'
-module.exports = {
-  ethereum: {
-    tvl: sumTokensExport({
-      owner: newHolder, tokens: [
-        ADDRESSES.ethereum.WETH,
-        ADDRESSES.ethereum.DAI,
-        ADDRESSES.ethereum.USDC,
-        ADDRESSES.ethereum.USDT,
-        ADDRESSES.ethereum.LINK,
-        ADDRESSES.ethereum.WBTC,
-        '0xaaef88cea01475125522e117bfe45cf32044e238',
-        '0x4a220e6096b25eadb88358cb44068a3248254675',
-        '0xde4c5a791913838027a2185709e98c5c6027ea63',
-        '0x92d6c1e31e14520e676a687f0a93788b716beff5',
-        ADDRESSES.ethereum.UNI,
-        '0xBB0E17EF65F82Ab018d8EDd776e8DD940327B28b',
-        ADDRESSES.ethereum.STETH,
-        '0x4d224452801ACEd8B2F0aebE155379bb5D594381',
-        ADDRESSES.ethereum.MATIC,
-        ADDRESSES.ethereum.AAVE,
-        ADDRESSES.ethereum.SNX,
-        '0x45804880De22913dAFE09f4980848ECE6EcbAf78',
-        ADDRESSES.ethereum.SUSHI,
-        '0xc944E90C64B2c07662A292be6244BDf05Cda44a7'
-      ]
-    })
-  }
+async function fetchTvl() {
+  const chainAssets = await getAssets()
+  return chainAssets.reduce((tvlMap, { token, amount }) => {
+    const formattedAmount = new BigNumber(amount).div(10 ** token.decimals).toFixed(2)
+      tvlMap[token.coinGeckoId] = formattedAmount
+      return tvlMap
+    }, {})
 }
+
+module.exports = {
+  timetravel: false,
+  misrepresentedTokens: true,
+  methodology: 'TVL accounts for all liquidity on the Injective chain, using the chain\'s bank module as the source.',
+  injective: { tvl: () => fetchTvl() },
+};


### PR DESCRIPTION
**NOTE**

> - If you would like to add a `volume` adapter please submit the PR [here](https://github.com/DefiLlama/adapters).
> - If you would like to add a `liquidations` adapter, please refer to [this readme document](https://github.com/DefiLlama/DefiLlama-Adapters/tree/main/liquidations) for details.

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Please enable "Allow edits by maintainers" while putting up the PR.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. Please fill the form below  **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
5. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can  edit it there and put up a PR
6. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
7. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap

## Reason for Update
- Injective's tvl is currently being calculated based off a list of ETH addresses. The chain is cosmos based, so the tvl should be calculated based off the denoms and amounts held in the bank module.
- there are many types of tokens held in the bank module, some have been bridged over from Ethereum/Solana/other cosmos chains, and the resulting denom in the bank module is unique to Injective chain, as it would be for any other cosmos chain. Therefore, there is an open-source [mappings](https://github.com/InjectiveLabs/injective-ts/blob/dev/packages/token-metadata/src/tokens/tokens/tokens.ts) of token denoms to `decimals`/`coingeckoId` that can be used to determine the human readable amount using the `decimals` and then convert to USD for tvl using the `coingeckoId`.

## Changes
- `injective chain`:
  - tvl is now being calculated based off of assets held in the bank module on chain, and the chain formatted numbers are then transformed to human readable. we are now exporting the tvl in the format of `{[coingeckoId]: formattedAmount}`. Running `npm run tvl` for `injective` resulted in the correct tvl after the refactor, which I was able to check against the [explorer](https://explorer.injective.network/assets/).
- `injective-orderbook`
  - refactored to produce tvl in the format `{[coingeckoId]: formattedAmount}` for the same reasons as above
  
 ## Unvalidated Assumptions
 - it looks like the `injective-orderbook` tvl is being calculated based off of https://sushi-analytics.onrender.com/, which recalculates hourly. I am not sure how to test whether the modifications made to `injective-orderbook` will actually propagate to https://sushi-analytics.onrender.com/ and then read in via the `injective-orderbook` adapter correctly
- the corresponding [sushi-analytics](https://github.com/DefiLlama/sushi-analytics) repo holds the `injectivelabs` npm packages required for both the `injective chain` and `injective-orderbook` modifications made in this PR. I also needed to add the `@injectivelabs/token-metadata` package as to get access to the [token mappings](https://github.com/InjectiveLabs/injective-ts/blob/dev/packages/token-metadata/src/tokens/tokens/tokens.ts).  The `token-metadata` package will be added to `sushi-analytics` in a [PR](https://github.com/DefiLlama/sushi-analytics/pull/10). 
- This is tricky because both this repo and the [sushi-analytics](https://github.com/DefiLlama/sushi-analytics) are interconnected, and I believe that if both PRs are not merged at pretty much the same time, then the `require` statements, i.e. `require('@injectivelabs/token-metadata')` will break.
- I added the `@injectivelabs/token-metadata'` package in a [PR](https://github.com/DefiLlama/sushi-analytics/pull/10) to [sushi-analytics](https://github.com/DefiLlama/sushi-analytics) repo assuming that this repo will be able to access the sushi-analytics `node_modules` when tvl is being calculated. It seems like this whole repo gets read into the `sushi-analytics` repo, is why I think this is correct.
   