### PR TITLE
feat: add era tvl for fulcrom

### DIFF
--- a/projects/fulcrom/index.js
+++ b/projects/fulcrom/index.js
@@ -1,6 +1,7 @@
 const { sumTokens2 } = require('../helper/unwrapLPs')
 
-const VAULT_ADDR = '0x8C7Ef34aa54210c76D6d5E475f43e0c11f876098';
+const CRO_VAULT_ADDR = '0x8C7Ef34aa54210c76D6d5E475f43e0c11f876098';
+const ZKSYNC_VAULT_ADDR = '0x7d5b0215EF203D0660BC37d5D09d964fd6b55a1E';
 
 function fulExports({ vault, }) {
   return async (ts, _block, _, { api }) => {
@@ -21,6 +22,9 @@ const abis = {
 
 module.exports = {
   cronos: {
-    tvl: fulExports({ vault: VAULT_ADDR, }),
-  }
+    tvl: fulExports({ vault: CRO_VAULT_ADDR, }),
+  },
+  era: {
+    tvl: fulExports({ vault: ZKSYNC_VAULT_ADDR, }),
+  },
 }


### PR DESCRIPTION
Add Fulcrom on zkSync Era

---
##### Name (to be shown on DefiLlama):
Fulcrom

##### Twitter Link:
https://twitter.com/FulcromFinance

##### List of audit links if any:


##### Website Link:
https://fulcrom.finance/

##### Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):
![fulcrom-icon](https://user-images.githubusercontent.com/106642922/223367022-46842d21-f607-41ef-9601-de97ea08bf9f.png)


##### Current TVL:
1.49 M

##### Treasury Addresses (if the protocol has treasury)


##### Chain:
Cronos

##### Coingecko ID (so your TVL can appear on Coingecko): (https://api.coingecko.com/api/v3/coins/list)


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description (to be shown on DefiLlama):
Decentralised Perpetual Exchange on Cronos

##### Token address and ticker if any:


##### Category (full list at https://defillama.com/categories) *Please choose only one:
Derivatives

##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):
Pyth Network

##### forkedFrom (Does your project originate from another project):
GMX

##### methodology (what is being counted as tvl, how is tvl being calculated):

