### PR TITLE
[Mars Protocol] - Update computations for marsv2 on Osmosis and add recent hallmarks

### DIFF
--- a/projects/mars/index.js
+++ b/projects/mars/index.js
@@ -21,6 +21,7 @@ const addresses = {
 async function osmosisTVL() {
   let balances = {};
   await addRedBankTvl(balances, 'osmosis');
+  await addCreditManagerTvl(balances, 'osmosis');
   await osmosisSumVaultsTVL(balances);
   return balances;
 }
@@ -55,7 +56,6 @@ async function osmosisSumVaultsTVL(balances) {
 }
 
 async function osmosisAddCoinsForVaultsInfoPage(coins, roverVaultConfigsPage) {
-  console.log(roverVaultConfigsPage);
     let vaultsMetadata = roverVaultConfigsPage.map(rvi => ({ fieldsVaultInfo: rvi }));
 
     // query the vault info for the vault contract itself to get the vault's
@@ -78,7 +78,6 @@ async function osmosisAddCoinsForVaultsInfoPage(coins, roverVaultConfigsPage) {
       );
       vm.vaultShares = vaultShares;
     }));
-    console.log(vaultsMetadata);
 
     // convert vault shares to vault base asset
     await Promise.all(vaultsMetadata.map( async vm => {
@@ -124,6 +123,10 @@ async function neutronTVL() {
 
 async function addRedBankTvl(balances, chain) {
   await sumTokens({balances, owners: [addresses[chain].redBank], chain});
+}
+
+async function addCreditManagerTvl(balances, chain) {
+  await sumTokens({balances, owners: [addresses[chain].creditManager], chain});
 }
 
 function getEndpoint(chain) {

--- a/projects/mars/index.js
+++ b/projects/mars/index.js
@@ -148,7 +148,7 @@ async function cosmosDenomBalanceStr(chain, denom, owner) {
 
 module.exports = {
   timetravel: false,
-  methodology: 'For each chain, sum up token balances in Red Bank smart contracts and vault underlying assets in Fields smart contracts',
+  methodology: 'For each chain, sum token balances in Red Bank/Credit Manager smart contracts to approximate net deposits, plus vault underlying assets held in Rover',
   osmosis: {
     tvl: osmosisTVL,
   },

--- a/projects/mars/index.js
+++ b/projects/mars/index.js
@@ -1,13 +1,14 @@
 const sdk = require('@defillama/sdk');
 const axios = require('axios');
 
-const { endPoints, queryContract, sumTokens } = require('../helper/chain/cosmos');
+const { endPoints, queryContract, sumTokens} = require('../helper/chain/cosmos');
 const { getChainTransform } = require('../helper/portedTokens');
 
 const addresses = {
   osmosis: {
     redBank: 'osmo1c3ljch9dfw5kf52nfwpxd2zmj2ese7agnx0p9tenkrryasrle5sqf3ftpg',
     creditManager: 'osmo1f2m24wktq0sw3c0lexlg7fv4kngwyttvzws3a3r3al9ld2s2pvds87jqvf',
+    params: 'osmo1nlmdxt9ctql2jr47qd4fpgzg84cjswxyw6q99u4y4u4q6c2f5ksq7ysent'
   },
   neutron: {
     redBank: 'neutron1n97wnm7q6d2hrcna3rqlnyqw2we6k0l8uqvmyqq6gsml92epdu7quugyph',
@@ -32,20 +33,20 @@ async function osmosisSumVaultsTVL(balances) {
   const osmosisDenomTransform = await getChainTransform('osmosis');
 
   while (vaultPagesRemaining) {
-    const fieldsVaultsInfo = await queryContract({
-      contract: addresses.osmosis.creditManager,
+    const roverVaultConfigs = await queryContract({
+      contract: addresses.osmosis.params,
       chain: 'osmosis',
-      data: { 'vaults_info': { limit: pageLimit, 'start_after': startAfter } } 
+      data: { 'all_vault_configs': { limit: pageLimit, 'start_after': startAfter } } 
     });
 
-    if(fieldsVaultsInfo.length === pageLimit) {
-      startAfter = fieldsVaultsInfo[fieldsVaultsInfo.length - 1].vault;
+    if(roverVaultConfigs.length === pageLimit) {
+      startAfter = roverVaultConfigs[roverVaultConfigs.length - 1].vault;
       vaultPagesRemaining = true
     } else {
       vaultPagesRemaining = false;
     }
 
-    await osmosisAddCoinsForVaultsInfoPage(coins, fieldsVaultsInfo);
+    await osmosisAddCoinsForVaultsInfoPage(coins, roverVaultConfigs);
   }
 
   coins.forEach(coin =>  {
@@ -53,14 +54,15 @@ async function osmosisSumVaultsTVL(balances) {
   })
 }
 
-async function osmosisAddCoinsForVaultsInfoPage(coins, fieldsVaultsInfoPage) {
-    let vaultsMetadata = fieldsVaultsInfoPage.map(rvi => ({ fieldsVaultInfo: rvi }));
+async function osmosisAddCoinsForVaultsInfoPage(coins, roverVaultConfigsPage) {
+  console.log(roverVaultConfigsPage);
+    let vaultsMetadata = roverVaultConfigsPage.map(rvi => ({ fieldsVaultInfo: rvi }));
 
     // query the vault info for the vault contract itself to get the vault's
     // base token
     await Promise.all(vaultsMetadata.map(async vm => {
       let vaultInfo = await queryContract({
-        contract: vm.fieldsVaultInfo.vault.address,
+        contract: vm.fieldsVaultInfo.addr,
         chain: 'osmosis',
         data: { 'info': {} } 
       });
@@ -69,18 +71,19 @@ async function osmosisAddCoinsForVaultsInfoPage(coins, fieldsVaultsInfoPage) {
 
     // get total vault shares owned by fields for each vault
     await Promise.all(vaultsMetadata.map(async vm => {
-      let vaultShares = await queryContract({
-        contract: addresses.osmosis.creditManager,
-        chain: 'osmosis',
-        data: { 'total_vault_coin_balance': { vault: vm.fieldsVaultInfo.vault } } 
-      });
+      let vaultShares = await cosmosDenomBalanceStr(
+        'osmosis',
+        vm.vaultInfo.vault_token,
+        addresses.osmosis.creditManager
+      );
       vm.vaultShares = vaultShares;
     }));
+    console.log(vaultsMetadata);
 
     // convert vault shares to vault base asset
     await Promise.all(vaultsMetadata.map( async vm => {
       let query = {
-        contract: vm.fieldsVaultInfo.vault.address,
+        contract: vm.fieldsVaultInfo.addr,
         chain: 'osmosis',
         data: { 'convert_to_assets': { amount: vm.vaultShares } } 
       };
@@ -132,6 +135,12 @@ async function cosmosLCDQuery(url, chain) {
   let endpoint = `${getEndpoint(chain)}/${url}`;
   let request =  await axios.get(endpoint);
   return request.data;
+}
+
+async function cosmosDenomBalanceStr(chain, denom, owner) {
+  let url = `cosmos/bank/v1beta1/balances/${owner}/by_denom?denom=${denom}`;
+  let balance = await cosmosLCDQuery(url, chain);
+  return balance.balance.amount;
 }
 
 module.exports = {

--- a/projects/mars/index.js
+++ b/projects/mars/index.js
@@ -161,5 +161,7 @@ module.exports = {
    hallmarks:[
     [1651881600, 'UST depeg'],
     [1675774800, 'Relaunch on Osmosis'],
+    [1690945200, 'Red Bank launch on Neutron'],
+    [1696906800, 'Mars V2 launch on Osmosis'],
   ]
 };


### PR DESCRIPTION
Since v2 launch on Osmosis, there are two updates to tvl:
1. Credit Manager does not expose a total vault coin balance query so the vault needs to be queried directly instead.
2. Now users can deposit to the credit manager. The token balances on credit manager are used to approximate these values (similar to what is done on the Red Bank).

Added two hallmarks as well (launch on neutron and mars v2 upgrade) 