### PR TITLE
Muesli: Migrated to new price ep, as we are deprecating the old one

### DIFF
--- a/projects/muesliswap/index.js
+++ b/projects/muesliswap/index.js
@@ -33,13 +33,7 @@ async function adaTvl() {
     let totalAda = 0
 
     // fetch the prices of each traded token first
-    const tokenlistV2 = (await fetchURL("https://api.muesliswap.com/list?base-policy-id=&base-tokenname=")).data
-    const adaPrices = new Map(tokenlistV2.map(d => {
-        const ident = d.info.address.policyId + '.' + d.info.address.name
-        const bidPrice = parseFloat(d.price.bidPrice)
-        const price = parseFloat(d.price.price)
-        return [ident, { bidPrice, price }]
-    }))
+    const adaPrices = new Map(Object.entries((await fetchURL("https://api.muesliswap.com/defillama/prices")).data))
 
     // then first accumulate over the legacy orderbook
     const orderbookV1 = (await fetchURL("https://orders.muesliswap.com/all-orderbooks")).data


### PR DESCRIPTION
We are in the process of deprecating the list EP as it is designed in a way that introduces a lot of traffic costs on our side.

As defillama relies on this data, we have created a new EP that only returns the necessary price data for tokens that have a non-zero price, therefore keeping traffic at a minimum.