### PR TITLE
feat: Added PoolTogether V5 TVL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,4 @@ historical-data.js
 /.idea
 yarn.lock
 .DS_Store
-projects/pooltogether/index.js
 .vscode

--- a/projects/pooltogether/abi.json
+++ b/projects/pooltogether/abi.json
@@ -1,3 +1,7 @@
 {
-  "accountedBalance": "uint256:accountedBalance"
+  "accountedBalance": "uint256:accountedBalance",
+  "totalVaults": "uint256:totalVaults",
+  "allVaults": "function allVaults(uint256) view returns (address)",
+  "asset": "address:asset",
+  "totalAssets": "uint256:totalAssets"
 }

--- a/projects/pooltogether/index.js
+++ b/projects/pooltogether/index.js
@@ -1,153 +1,70 @@
-const ADDRESSES = require('../helper/coreAssets.json')
-const sdk = require("@defillama/sdk");
-const { request, gql } = require("graphql-request");
-const abi = require('./abi.json')
-const { getChainTransform } = require("../helper/portedTokens");
-const { getBlock } = require("../helper/http");
-const { sumTokens } = require("../helper/unwrapLPs");
-const { default: BigNumber } = require("bignumber.js");
+const { default: BigNumber } = require('bignumber.js')
+const v3 = require('./v3.js')
+const v4 = require('./v4.js')
 
-const graphUrls = ['https://api.thegraph.com/subgraphs/name/pooltogether/pooltogether-v3_1_0',
-  'https://api.thegraph.com/subgraphs/name/pooltogether/pooltogether-v3_3_2',
-  'https://api.thegraph.com/subgraphs/name/pooltogether/pooltogether-v3_3_8',
-  'https://api.thegraph.com/subgraphs/name/pooltogether/pooltogether-v3_4_3']
-const celoGraphUrl = 'https://api.thegraph.com/subgraphs/name/pooltogether/celo-v3_4_5'
-const bscGraphUrl = 'https://api.thegraph.com/subgraphs/name/pooltogether/bsc-v3_4_3'
+function mergeVersionTvls(tvls) {
+  if (tvls.length === 0) return {}
+  if (tvls.length === 1) return tvls[0]
 
-const graphQuery = gql`
-query GET_POOLS($block: Int) {
-  prizePools{
-    id
-    underlyingCollateralSymbol
-    underlyingCollateralToken
-    compoundPrizePool{
-      cToken
-    }
-  }
-}
-`;
+  const result = { ...tvls[0] }
 
-const v4pools={
-  ethereum:[
-    ["0xbcca60bb61934080951369a648fb03df4f96263c", "0x32e8d4c9d1b711bc958d0ce8d14b41f77bb03a64"]
-  ],
-  polygon:[
-    ["0x1a13f4ca1d028320a707d99520abfefca3998b7f", "0xD4F6d570133401079D213EcF4A14FA0B4bfB5b9C"]
-  ],
-  avax:[
-    ['0x46a51127c3ce23fb7ab1de06226147f446e4a857', '0x7437db21A0dEB844Fa64223e2d6Db569De9648Ff']
-  ],
-  optimism:[
-    ['0x625E7708f30cA75bfd92586e17077590C60eb4cD', '0x4ecB5300D9ec6BCA09d66bfd8Dcb532e3192dDA1']
-  ]
-}
-
-async function getChainBalances(allPrizePools, chain, block, transform) {
-  const balances = {};
-  transform = transform || (addr=>`${chain}:${addr}`);
-  const lockedTokens = await sdk.api.abi.multiCall({
-    abi: abi['accountedBalance'],
-    calls: allPrizePools.map(pool => ({
-      target: pool.id
-    })),
-    block,
-    chain
-  })
-  lockedTokens.output.forEach(call => {
-    const underlyingToken = transform(allPrizePools.find(pool =>
-      pool.id === call.input.target).underlyingCollateralToken);
-    const underlyingTokenBalance = ((underlyingToken.includes('0x')) ?
-      call.output : call.output / 10 ** 18)
-    sdk.util.sumSingleBalance(balances, underlyingToken, BigNumber(underlyingTokenBalance).toFixed(0))
-  })
-  if(v4pools[chain]!== undefined){
-    await sumTokens(balances, v4pools[chain], block, chain, transform)
-  }
-  return balances
-}
-
-async function eth(timestamp, block) {
-  let allPrizePools = []
-  let combinedPrizePools = []
-  for (const graphUrl of graphUrls) {
-    const { prizePools } = await request(
-      graphUrl,
-      graphQuery,
-      {
-        block,
+  for (let i = 1; i < tvls.length; i++) {
+    Object.entries(tvls[i]).forEach(([address, balance]) => {
+      if (result[address] === undefined) {
+        result[address] = balance
+      } else {
+        const newBalance = BigNumber.sum(BigNumber(result[address]), BigNumber(balance))
+        result[address] = newBalance.toString()
       }
-    );
-    allPrizePools = allPrizePools.concat(prizePools)
+    })
   }
-  combinedPrizePools = allPrizePools.flat()
-  allPrizePools = [...new Set(combinedPrizePools.map(a => JSON.stringify(a)))].map(a => JSON.parse(a))
-  return getChainBalances(allPrizePools, 'ethereum', block, addr=>{
-    if(addr === "0x04f2694c8fcee23e8fd0dfea1d4f5bb8c352111f") return "0x383518188c0c6d7730d91b2c03a03c837814a899" // OHM
-    return addr
-  })
+
+  return result
+}
+
+async function ethereum(timestamp, block, chainBlocks) {
+  const tvl_v3 = await v3.ethereum(timestamp, block, chainBlocks)
+  const tvl_v4 = await v4.ethereum(timestamp, block, chainBlocks)
+  return mergeVersionTvls([tvl_v3, tvl_v4])
 }
 
 async function polygon(timestamp, block, chainBlocks) {
-  return getChainBalances([{
-    id: "0x887E17D791Dcb44BfdDa3023D26F7a04Ca9C7EF4",
-    underlyingCollateralToken: ADDRESSES.ethereum.USDT
-  },
-  {
-    id: "0xee06abe9e2af61cabcb13170e01266af2defa946",
-    underlyingCollateralToken: ADDRESSES.ethereum.USDC
-  }], 'polygon', chainBlocks.polygon)
+  const tvl_v3 = await v3.polygon(timestamp, block, chainBlocks)
+  const tvl_v4 = await v4.polygon(timestamp, block, chainBlocks)
+  return mergeVersionTvls([tvl_v3, tvl_v4])
 }
 
 async function avax(timestamp, block, chainBlocks) {
-  return getChainBalances([], 'avax', chainBlocks.avax, ()=>`avax:0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664`)
+  const tvl_v4 = await v4.avax(timestamp, block, chainBlocks)
+  return tvl_v4
 }
 
 async function optimism(timestamp, block, chainBlocks) {
-  return getChainBalances([], 'optimism', chainBlocks.optimism, ()=>`optimism:0x7F5c764cBc14f9669B88837ca1490cCa17c31607`)
+  const tvl_v4 = await v4.optimism(timestamp, block, chainBlocks)
+  return tvl_v4
 }
 
 async function celo(timestamp, block, chainBlocks) {
-  const transform = await getChainTransform('celo')
-  let allPrizePools = []
-  block = chainBlocks.celo
-  const { prizePools } = await request(
-    celoGraphUrl, graphQuery, { block })
-  allPrizePools = allPrizePools.concat(prizePools)
-  return getChainBalances(allPrizePools, 'celo', block, transform)
+  const tvl_v3 = await v3.celo(timestamp, block, chainBlocks)
+  return tvl_v3
 }
 
-async function bsc(timestamp, _, chainBlocks) {
-  const transform = await getChainTransform('bsc')
-  let allPrizePools = []
-  const blockG = await getBlock(timestamp, 'bsc', chainBlocks) - 1000
-  const { prizePools } = await request(bscGraphUrl, graphQuery, { block: blockG })
-  allPrizePools = allPrizePools.concat(prizePools)
-  return getChainBalances(allPrizePools, 'bsc', chainBlocks.bsc, transform)
+async function bsc(timestamp, block, chainBlocks) {
+  const tvl_v3 = await v3.bsc(timestamp, block, chainBlocks)
+  return tvl_v3
 }
 
 module.exports = {
   doublecounted: true,
-  ethereum: {
-    tvl: eth
-  },
-  polygon: {
-    tvl: polygon
-  },
-  avax:{
-    tvl: avax
-  },
-  optimism:{
-    tvl: optimism
-  },
-  celo: {
-    tvl: celo
-  },
-  bsc: {
-    tvl: bsc,
-  },
-  hallmarks:[
-    [1658872800, "OP Rewards Start"],
-    [1669615200, "OP Rewards Start"],
+  ethereum: { tvl: ethereum },
+  polygon: { tvl: polygon },
+  avax: { tvl: avax },
+  optimism: { tvl: optimism },
+  celo: { tvl: celo },
+  bsc: { tvl: bsc },
+  hallmarks: [
+    [1_658_872_800, 'V4 OP Rewards Begin'],
+    [1_669_615_200, 'V4 OP Rewards Extended']
   ],
-  methodology: `TVL is the total quantity of tokens locked in PoolTogether pools on Ethereum, Polygon, Avalanche, Optimism, Celo, and BSC`
+  methodology: `TVL is the total tokens deposited in PoolTogether amongst V3, V4 and V5 on Ethereum, Polygon, Avalanche, Optimism, Celo and BSC`
 }

--- a/projects/pooltogether/index.js
+++ b/projects/pooltogether/index.js
@@ -1,6 +1,7 @@
 const { default: BigNumber } = require('bignumber.js')
 const v3 = require('./v3.js')
 const v4 = require('./v4.js')
+const v5 = require('./v5.js')
 
 function mergeVersionTvls(tvls) {
   if (tvls.length === 0) return {}
@@ -41,7 +42,8 @@ async function avax(timestamp, block, chainBlocks) {
 
 async function optimism(timestamp, block, chainBlocks) {
   const tvl_v4 = await v4.optimism(timestamp, block, chainBlocks)
-  return tvl_v4
+  const tvl_v5 = await v5.optimism(timestamp, block, chainBlocks)
+  return mergeVersionTvls([tvl_v4, tvl_v5])
 }
 
 async function celo(timestamp, block, chainBlocks) {
@@ -63,8 +65,10 @@ module.exports = {
   celo: { tvl: celo },
   bsc: { tvl: bsc },
   hallmarks: [
+    [1_634_320_800, 'V4 Launch'],
     [1_658_872_800, 'V4 OP Rewards Begin'],
-    [1_669_615_200, 'V4 OP Rewards Extended']
+    [1_669_615_200, 'V4 OP Rewards Extended'],
+    [1_697_738_400, 'V5 Launch']
   ],
   methodology: `TVL is the total tokens deposited in PoolTogether amongst V3, V4 and V5 on Ethereum, Polygon, Avalanche, Optimism, Celo and BSC`
 }

--- a/projects/pooltogether/v3.js
+++ b/projects/pooltogether/v3.js
@@ -1,0 +1,132 @@
+const { getChainTransform } = require('../helper/portedTokens')
+const { default: BigNumber } = require('bignumber.js')
+const { request, gql } = require('graphql-request')
+const { getBlock } = require('../helper/http')
+const ADDRESSES = require('../helper/coreAssets.json')
+const sdk = require('@defillama/sdk')
+const abi = require('./abi.json')
+
+const GRAPH_URLS = {
+  eth: [
+    'https://api.thegraph.com/subgraphs/name/pooltogether/pooltogether-v3_1_0',
+    'https://api.thegraph.com/subgraphs/name/pooltogether/pooltogether-v3_3_2',
+    'https://api.thegraph.com/subgraphs/name/pooltogether/pooltogether-v3_3_8',
+    'https://api.thegraph.com/subgraphs/name/pooltogether/pooltogether-v3_4_3'
+  ],
+  celo: ['https://api.thegraph.com/subgraphs/name/pooltogether/celo-v3_4_5'],
+  bsc: ['https://api.thegraph.com/subgraphs/name/pooltogether/bsc-v3_4_3']
+}
+const GRAPH_QUERY = gql`
+  query GET_POOLS($block: Int) {
+    prizePools {
+      id
+      underlyingCollateralSymbol
+      underlyingCollateralToken
+      compoundPrizePool {
+        cToken
+      }
+    }
+  }
+`
+
+async function getChainBalances(allPrizePools, chain, block, transform) {
+  const balances = {}
+
+  transform = transform || ((addr) => `${chain}:${addr}`)
+
+  const lockedTokens = await sdk.api.abi.multiCall({
+    abi: abi['accountedBalance'],
+    calls: allPrizePools.map((pool) => ({
+      target: pool.id
+    })),
+    block,
+    chain
+  })
+
+  lockedTokens.output.forEach((call) => {
+    const underlyingToken = transform(
+      allPrizePools.find((pool) => pool.id === call.input.target).underlyingCollateralToken
+    )
+    const underlyingTokenBalance = underlyingToken.includes('0x')
+      ? call.output
+      : call.output / 10 ** 18
+    sdk.util.sumSingleBalance(
+      balances,
+      underlyingToken,
+      BigNumber(underlyingTokenBalance).toFixed(0)
+    )
+  })
+
+  return balances
+}
+
+async function ethereum(timestamp, block) {
+  let allPrizePools = []
+  let combinedPrizePools = []
+
+  for (const graphUrl of GRAPH_URLS['eth']) {
+    const { prizePools } = await request(graphUrl, GRAPH_QUERY, {
+      block
+    })
+    allPrizePools = allPrizePools.concat(prizePools)
+  }
+
+  combinedPrizePools = allPrizePools.flat()
+  allPrizePools = [...new Set(combinedPrizePools.map((a) => JSON.stringify(a)))].map((a) =>
+    JSON.parse(a)
+  )
+
+  return getChainBalances(allPrizePools, 'ethereum', block, (addr) => {
+    if (addr === '0x04f2694c8fcee23e8fd0dfea1d4f5bb8c352111f')
+      return '0x383518188c0c6d7730d91b2c03a03c837814a899' // OHM
+    return addr
+  })
+}
+
+async function polygon(timestamp, block, chainBlocks) {
+  return getChainBalances(
+    [
+      {
+        id: '0x887E17D791Dcb44BfdDa3023D26F7a04Ca9C7EF4',
+        underlyingCollateralToken: ADDRESSES.ethereum.USDT
+      },
+      {
+        id: '0xee06abe9e2af61cabcb13170e01266af2defa946',
+        underlyingCollateralToken: ADDRESSES.ethereum.USDC
+      }
+    ],
+    'polygon',
+    chainBlocks.polygon
+  )
+}
+
+async function celo(timestamp, block, chainBlocks) {
+  const transform = await getChainTransform('celo')
+  let allPrizePools = []
+
+  block = chainBlocks.celo
+
+  const { prizePools } = await request(GRAPH_URLS['celo'], GRAPH_QUERY, { block })
+  allPrizePools = allPrizePools.concat(prizePools)
+
+  return getChainBalances(allPrizePools, 'celo', block, transform)
+}
+
+async function bsc(timestamp, _, chainBlocks) {
+  const transform = await getChainTransform('bsc')
+  let allPrizePools = []
+
+  const blockG = (await getBlock(timestamp, 'bsc', chainBlocks)) - 1000
+
+  const { prizePools } = await request(GRAPH_URLS['bsc'], GRAPH_QUERY, { block: blockG })
+  allPrizePools = allPrizePools.concat(prizePools)
+
+  return getChainBalances(allPrizePools, 'bsc', chainBlocks.bsc, transform)
+}
+
+module.exports = {
+  ethereum,
+  polygon,
+  celo,
+  bsc
+}

--- a/projects/pooltogether/v4.js
+++ b/projects/pooltogether/v4.js
@@ -1,0 +1,57 @@
+const { sumTokens } = require('../helper/unwrapLPs')
+
+const V4_POOLS = {
+  ethereum: [
+    ['0xbcca60bb61934080951369a648fb03df4f96263c', '0x32e8d4c9d1b711bc958d0ce8d14b41f77bb03a64']
+  ],
+  polygon: [
+    ['0x1a13f4ca1d028320a707d99520abfefca3998b7f', '0xD4F6d570133401079D213EcF4A14FA0B4bfB5b9C']
+  ],
+  avax: [
+    ['0x46a51127c3ce23fb7ab1de06226147f446e4a857', '0x7437db21A0dEB844Fa64223e2d6Db569De9648Ff']
+  ],
+  optimism: [
+    ['0x625E7708f30cA75bfd92586e17077590C60eb4cD', '0x4ecB5300D9ec6BCA09d66bfd8Dcb532e3192dDA1']
+  ]
+}
+
+async function getChainBalances(chain, block, transform) {
+  const balances = {}
+
+  transform = transform || ((addr) => `${chain}:${addr}`)
+
+  await sumTokens(balances, V4_POOLS[chain], block, chain, transform)
+
+  return balances
+}
+
+async function ethereum(timestamp, block) {
+  return getChainBalances('ethereum', block)
+}
+
+async function polygon(timestamp, block, chainBlocks) {
+  return getChainBalances('polygon', chainBlocks.polygon)
+}
+
+async function avax(timestamp, block, chainBlocks) {
+  return getChainBalances(
+    'avax',
+    chainBlocks.avax,
+    () => `avax:0xa7d7079b0fead91f3e65f86e8915cb59c1a4c664`
+  )
+}
+
+async function optimism(timestamp, block, chainBlocks) {
+  return getChainBalances(
+    'optimism',
+    chainBlocks.optimism,
+    () => `optimism:0x7F5c764cBc14f9669B88837ca1490cCa17c31607`
+  )
+}
+
+module.exports = {
+  ethereum,
+  polygon,
+  avax,
+  optimism
+}

--- a/projects/pooltogether/v5.js
+++ b/projects/pooltogether/v5.js
@@ -1,0 +1,71 @@
+const { default: BigNumber } = require('bignumber.js')
+const sdk = require('@defillama/sdk')
+const abi = require('./abi.json')
+
+const V5_VAULT_FACTORIES = {
+  optimism: '0xF65FA202907D6046D1eF33C521889B54BdE08081'
+}
+
+async function getChainBalances(chain, block) {
+  const balances = {}
+
+  // Finding total number of vaults deployed through the factory:
+  const { output: totalVaults } = await sdk.api.abi.call({
+    target: V5_VAULT_FACTORIES[chain],
+    abi: abi.totalVaults,
+    block,
+    chain
+  })
+
+  // Finding all vault addresses:
+  const vaultIndexes = Array.from({ length: totalVaults }, (_, i) => i)
+  const { output: vaultAddressesMulticallResult } = await sdk.api.abi.multiCall({
+    target: V5_VAULT_FACTORIES[chain],
+    abi: abi.allVaults,
+    block,
+    chain,
+    calls: vaultIndexes.map((i) => ({
+      params: [i]
+    }))
+  })
+  const vaultAddresses = vaultAddressesMulticallResult.map((result) => result.output)
+
+  // Finding all underlying asset addresses and balances:
+  const vaultCalls = vaultAddresses.map((address) => ({ target: address }))
+  const { output: assetAddressesMulticallResult } = await sdk.api.abi.multiCall({
+    abi: abi.asset,
+    block,
+    chain,
+    calls: vaultCalls
+  })
+  const { output: assetBalancesMulticallResult } = await sdk.api.abi.multiCall({
+    abi: abi.totalAssets,
+    block,
+    chain,
+    calls: vaultCalls
+  })
+  const assetAddresses = assetAddressesMulticallResult.map((result) => result.output)
+  const assetBalances = assetBalancesMulticallResult.map((result) => result.output)
+
+  // Assigning balances:
+  assetAddresses.forEach((address, i) => {
+    const token = `${chain}:${address}`
+    const balance = assetBalances[i]
+    if (balances[token] === undefined) {
+      balances[token] = balance
+    } else {
+      const newBalance = BigNumber.sum(BigNumber(balances[token]), BigNumber(balance))
+      balances[token] = newBalance.toString()
+    }
+  })
+
+  return balances
+}
+
+async function optimism(timestamp, block, chainBlocks) {
+  return getChainBalances('optimism', chainBlocks.optimism)
+}
+
+module.exports = {
+  optimism
+}


### PR DESCRIPTION
This PR adds TVL data for PoolTogether V5.

The implementation is in `projects/pooltogether/v5.js`.

I have split up the code for V3, V4 and V5 into separate files. `index.js` calls each of these files and adds the TVLs together.

The V3 and V4 code has been linted and cleaned up a bit, but otherwise no real changes were made to those.

**Other Notes**
- I've removed a seemingly random pooltogether reference in the .gitignore. This was added a really long time ago for apparently no reason. Unsure why that was there.
- I've added a couple more "hallmark" timestamps; the launch of V4 and the launch of V5.