### PR TITLE
Add USD Coin to Alien Base, Add Area51 to Alien Base

### DIFF
--- a/projects/alienbase-area51/index.js
+++ b/projects/alienbase-area51/index.js
@@ -1,0 +1,12 @@
+const { getUniTVL } = require('../helper/unknownTokens')
+const ALB = "0x1dd2d631c92b1aCdFCDd51A0F7145A50130050C4";
+const FACTORY = "0x2d5dd5fa7B8a1BFBDbB0916B42280208Ee6DE51e"
+
+
+module.exports = {
+    misrepresentedTokens: true,
+    methodology: `Uses Uniswap-style factory address to find and price liquidity pairs.`,
+    base: {
+        tvl: getUniTVL({ factory: FACTORY, useDefaultCoreAssets: true, fetchBalances: true, }),
+    }
+};

--- a/projects/alienbase-stableswap/index.js
+++ b/projects/alienbase-stableswap/index.js
@@ -1,5 +1,6 @@
 const pools = Object.values({
   'aUsdc-Dai': '0x927860797d07b1C46fbBe7f6f73D45C7E1BFBb27',
+  'USDC-Dai': '0x410d28fbcd00c677bae1cce2261546c8db4f6a2d',  
 })
 
 async function tvl(_, _b, _cb, { api, }) {


### PR DESCRIPTION
**NOTE**

Add Area51 as sub-dex of Alien Base

##### Name (to be shown on DefiLlama): Area 51 (Alien Base)


##### Twitter Link: same as alienbase


##### List of audit links if any:


##### Website Link: https://area51.alienbase.xyz


##### Logo (High resolution, will be shown with rounded borders): 


##### Current TVL: 61k


##### Treasury Addresses (if the protocol has treasury)


##### Chain: Base (8435)


##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): alienbase (https://api.coingecko.com/api/v3/coins/list)


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description (to be shown on DefiLlama): Area51 is the special section of Alien Base for new projects launching on Base Chain


##### Token address and ticker if any:


##### Category (full list at https://defillama.com/categories) *Please choose only one:


##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):


##### forkedFrom (Does your project originate from another project): Alien Base (Uniswap)


##### methodology (what is being counted as tvl, how is tvl being calculated):


##### Github org/user (Optional, if your code is open source, we can track activity):