### PR TITLE
add dyson

### DIFF
--- a/projects/dyson/index.js
+++ b/projects/dyson/index.js
@@ -1,0 +1,32 @@
+const USDC_TOKEN_CONTRACT = '0x176211869cA2b568f2A7D4EE941E073a821EE1ff';
+const ETH_TOKEN_CONTRACT = '0xe5D7C2a44FfDDf6b295A15c148167daaAf5Cf34f';
+
+const ETHUSDC_PAIR_CONTRACT = '0xCeC911f803D984ae2e5A134b2D15218466993869';
+
+
+async function tvl(_, _1, _2, { api }) {
+  const usdcBalance = await api.call({
+    abi: 'erc20:balanceOf',
+    target: USDC_TOKEN_CONTRACT,
+    params: [ETHUSDC_PAIR_CONTRACT],
+  });
+
+  const ethBalance = await api.call({
+    abi: 'erc20:balanceOf',
+    target: ETH_TOKEN_CONTRACT,
+    params: [ETHUSDC_PAIR_CONTRACT],
+  });
+
+  api.add(USDC_TOKEN_CONTRACT, usdcBalance)
+  api.add(ETH_TOKEN_CONTRACT, ethBalance)
+}
+
+module.exports = {
+  timetravel: true,
+  misrepresentedTokens: false,
+  methodology: 'counts the number of MINT tokens in the Club Bonding contract.',
+  start: 1000235,
+  linea: {
+    tvl,
+  }
+}; 

--- a/projects/dyson/index.js
+++ b/projects/dyson/index.js
@@ -1,32 +1,3 @@
-const USDC_TOKEN_CONTRACT = '0x176211869cA2b568f2A7D4EE941E073a821EE1ff';
-const ETH_TOKEN_CONTRACT = '0xe5D7C2a44FfDDf6b295A15c148167daaAf5Cf34f';
+const { uniTvlExport } = require('../helper/unknownTokens')
 
-const ETHUSDC_PAIR_CONTRACT = '0xCeC911f803D984ae2e5A134b2D15218466993869';
-
-
-async function tvl(_, _1, _2, { api }) {
-  const usdcBalance = await api.call({
-    abi: 'erc20:balanceOf',
-    target: USDC_TOKEN_CONTRACT,
-    params: [ETHUSDC_PAIR_CONTRACT],
-  });
-
-  const ethBalance = await api.call({
-    abi: 'erc20:balanceOf',
-    target: ETH_TOKEN_CONTRACT,
-    params: [ETHUSDC_PAIR_CONTRACT],
-  });
-
-  api.add(USDC_TOKEN_CONTRACT, usdcBalance)
-  api.add(ETH_TOKEN_CONTRACT, ethBalance)
-}
-
-module.exports = {
-  timetravel: true,
-  misrepresentedTokens: false,
-  methodology: 'counts the number of MINT tokens in the Club Bonding contract.',
-  start: 1000235,
-  linea: {
-    tvl,
-  }
-}; 
+module.exports = uniTvlExport('linea', '0xecD30C099c222AbffDaf3E2A3d2455FC8e8c739E', { fetchBalances: true, })


### PR DESCRIPTION
Description：Added access to tvl of dyson finance

##### Name (to be shown on DefiLlama):Dyson Finance


##### Twitter Link:https://twitter.com/DysonFinance


##### Website Link:  https://dyson.finance/


##### Logo (High resolution, will be shown with rounded borders): 
 https://www.figma.com/file/8o2EPOsQfQ2ztEwjtR8vvx/Dyson-Marketing-%26-Branding?type=design&node-id=1%3A9&mode=design&t=NgmOZyDj4fJOoLYj-1


##### Current TVL: 5.88k


##### Treasury Addresses (if the protocol has treasury)


##### Chain:  Linea

##### Short Description (to be shown on DefiLlama):
Dyson Finance aims to redefine the DeFi landscape by offering a more inclusive, profitable experience for retail investors. By combining the strengths of dynamic AMM, dual investment, and an exclusive Membership Program, Dyson Finance is well-positioned to onboard more users as liquidity providers and advance the DeFi ecosystem.


##### Token address and ticker if any: Native USDC,ETH 


##### Category (full list at https://defillama.com/categories) *Please choose only one: Dexes


##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using): DefiLlama default


##### forkedFrom (Does your project originate from another project): No


##### methodology (what is being counted as tvl, how is tvl being calculated): The balance in usdc and eth in the pool