### PR TITLE
feat: add Polkadot Asset Hub adapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "license": "ISC",
   "dependencies": {
     "@defillama/sdk": "latest",
+    "@polkadot/api": "^10.10.1",
     "@project-serum/anchor": "^0.25.0",
     "@solana/web3.js": "^1.36.0",
     "@solendprotocol/solend-sdk": "^0.6.2",

--- a/projects/helper/chains.json
+++ b/projects/helper/chains.json
@@ -175,6 +175,7 @@
   "pokt",
   "polis",
   "polkadot",
+  "polkadot_asset_hub",
   "polygon",
   "polygon_zkevm",
   "pool2",

--- a/projects/polkadot-asset-hub/index.js
+++ b/projects/polkadot-asset-hub/index.js
@@ -1,0 +1,102 @@
+const { ApiPromise, WsProvider } = require("@polkadot/api");
+
+async function offers(_, _1, _2, { api: _api }) {
+	const wsProvider = new WsProvider("wss://polkadot-asset-hub-rpc.polkadot.io");
+	const api = await ApiPromise.create({ provider: wsProvider });
+
+	// Assets (from pallet `assets`) with real value in Polkadot Asset Hub.
+	// As of now, the tokens that we identified with real value are three : 
+	// 1. polkadot, 2. usdt and 3. usdc
+	const assets = {
+		DOT: ['polkadot'],
+		USDt: [1984, 'tether'],
+		USDC: [1337, 'usd-coin'],
+	}
+
+	const assetPromiseResults = Object.entries(assets).map(async ([assetSymbol, assetData]) => {
+        if (assetSymbol === 'DOT') {
+			const [ { tokenDecimals }, dotIssuance] = await Promise.all([
+                api.registry.getChainProperties(),
+                api.query.balances.totalIssuance(),
+            ]);
+
+			const decimals = tokenDecimals.toJSON()[0];
+            const balance = dotIssuance.toNumber() / (10 ** decimals);
+
+            return ['polkadot', balance];
+        } else {
+            const [assetInfo, assetMetaData] = await Promise.all([
+                api.query.assets.asset(assetData[0]),
+                api.query.assets.metadata(assetData[0]),
+            ]);
+
+            const supply = assetInfo.unwrap().supply.toNumber();
+            const decimals = assetMetaData.decimals.toHuman();
+            const balance = supply / (10 ** decimals);
+
+            return [assetData[1], balance];
+        }
+    });
+
+    const assetResults = await Promise.all(assetPromiseResults);
+
+	// Foreign Assets with real value in Polkadot Asset Hub.
+	// We retrieve all foreign assets found in the foreign assets storage.
+	const foreignAssetInfo = await api.query.foreignAssets.asset.entries();
+	for (const [assetStorageKeyData, assetInfo] of foreignAssetInfo) {
+		const foreignAssetData = assetStorageKeyData.toHuman();
+
+		if (foreignAssetData) {
+			const foreignAssetMultiLocationStr = JSON.stringify(
+				foreignAssetData[0]
+			).replace(/(\d),/g, '$1');
+
+			const foreignAssetMultiLocation = api.registry.createType(
+				'XcmV3MultiLocation',
+				JSON.parse(foreignAssetMultiLocationStr)
+			);
+
+			const assetMetadata =
+				await api.query.foreignAssets.metadata(
+					foreignAssetMultiLocation
+				);
+			
+			if (assetInfo.isSome) {
+				// If the foreign asset is the Kusama token, we have to hardcode the related information 
+				// since the metadata for KSM are empty right now.
+				if (foreignAssetMultiLocationStr == '{"parents":"2","interior":{"X1":{"GlobalConsensus":"Kusama"}}}') {
+					const supply = assetInfo.unwrap().supply.toHuman();
+					const decimals = 12;
+					const name = 'Kusama';
+					const balance = supply / (10 ** decimals);
+					const token = name.toLowerCase();
+
+					assetResults.push([token, balance]);
+				} else {
+					const supply = assetInfo.unwrap().supply.toHuman();
+					const decimals = assetMetadata.decimals.toHuman();
+					const name = assetMetadata.name.toHuman();			
+					const balance = supply / (10 ** decimals);
+					const token = name.toLowerCase();
+
+					assetResults.push([token, balance]);
+				}
+			}
+		}
+	}
+
+	// Adding all assets & foreign assets to the SDK's balances dictionary
+    assetResults.forEach(([token, balance]) => {
+        _api.add(token, balance, { skipChain: true });
+    });
+
+	return _api.getBalances()
+}
+
+module.exports = {
+	methodology: "Total Value of Offers - funds of Assets in Polkadot Asset Hub",
+	"polkadot_asset_hub": {
+		offers,
+		tvl: async () => ({})
+	}
+};


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
Polkadot Asset Hub

##### Twitter Link:
N/A

##### List of audit links if any:
N/A

##### Website Link:
https://parachains.info/details/statemint
https://metadata.parity.io/#/polkadot-statemint

##### Logo (High resolution, will be shown with rounded borders):
https://drive.google.com/file/d/1Un0J46IXWC1Jr4U8F80BWrHW9dbQbOXl/view?usp=drive_link

##### Current TVL:
--- polkadot_asset_hub-offers ---
USDC                      250.27 M
USDT                      18.00 M
DOT                       62.38 k
Total: 268.33 M

To Exclude the [pre-minted USDC address](https://assethub-polkadot.subscan.io/account/15QjVp1rx6tjbBjmaWhhwUV7ESHMG6KjdDdhRuw5dQKWkqzB)

##### Treasury Addresses (if the protocol has treasury)
13UVJyLgBASGhE2ok3TvxUfaQBGUt88JCcdYjHvUhvQkFTTx

##### Chain:
Polkadot Asset Hub
1000 (substrate/ parachain on polkadot)

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)
N/A

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
N/A

##### Short Description (to be shown on DefiLlama):
The Asset Hub on both Polkadot and Kusama are the first system parachains.
The Asset Hub is an asset portal for the entire network. It helps asset creators (e.g. reserve backed stablecoin issuers) to track the total issuance of their asset in the Polkadot network, including amounts that have been transferred to other parachains. It is also the point where they can transact, mint and burn, and manage the on-chain asset.

##### Token address and ticker if any:
DOT (native)

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Cross Chain (please check appropriateness [here](https://defillama.com/categories))

##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):
`-`

##### forkedFrom (Does your project originate from another project):
`-`

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL is calculated as sum of all assets listed in AssetHub recalculated to their respective token prices. AssetHub by the nature/purpose of this system parachain should count all of its assets toward TVL, meaning, it should be categorized into this type "Offers - funds that are approved for spending on a non-custodial platform, but not actually deposited into the platform contracts" (source - DefiLlama-What to include as TVL?).

The tokens we included in the `Offers` section are the ones we consider that have "real" value in Polkadot Asset Hub.

The tokens that we identified with real value are the following :
1. native in Polkadot Asset Hub -> DOT (Polkadot) 
2. Registered Assets 
    2.1 USDC (USD Coin)
    2.2 USDt (Tether)
4. Registered Foreign Assets as of now (27/10/2023) : 
    3.1 KSM (Kusama)
    3.2 EQ (Equilibrium)
    3.3. EQD (Equilibrium Dollar)

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/paritytech/polkadot-sdk

### Aditional information
PR to add `Offers` adapter for Polkadot Asset Hub.

#### Implementation 
Based on the docs of Defi Llama to add a new project I added : 
- a new folder `polkadot-asset-hub` inside the folder `projects`
- a new entry for `polkadot-asset-hub` in the [chains.json](https://github.com/DefiLlama/DefiLlama-Adapters/blob/fab3cb094364f178882d6fd92b2c5218a7464945/projects/helper/chains.json#L4) file.

#### Run
To run the Polkadot Asset Hub script and test the results you need to do the following :
- `git clone` current repo
- `git checkout` in this branch
- `npm install`
- `npm install @polkadot/api`
- `node test.js projects/polkadot-asset-hub/index.js`
- The object returned is
```
{
  polkadot: 15141.1970349293,
  tether: 17998747.607192,
  'usd-coin': 250019990.612722
}
```

#### Output
The output is : 
```
-------------------
Warning:
Token coingecko:usd-coin has more than 100M in value (250.019991 M) , price data:  {
  price: 1,
  symbol: 'USDC',
  timestamp: 1698410399,
  confidence: 0.99,
  mcap: 25102765089.485973
}
-------------------
--- polkadot_asset_hub ---
Total: 0

--- polkadot_asset_hub-offers ---
USDC                      250.02 M
USDT                      18.02 M
DOT                       62.38 k
Total: 268.10 M

--- tvl ---
Total: 0

--- offers ---
USDC                      250.02 M
USDT                      18.02 M
DOT                       62.38 k
Total: 268.10 M

------ TVL ------
polkadot_asset_hub        0
polkadot_asset_hub-offers 268.10 M
offers                    268.10 M

total                    0
```

### Additional Requests from DefiLlama team 

#### 1. Exclude Address
From the above results, we think it is best to exclude this specific [pre-minted USDC address](https://assethub-polkadot.subscan.io/account/15QjVp1rx6tjbBjmaWhhwUV7ESHMG6KjdDdhRuw5dQKWkqzB): 

```
15QjVp1rx6tjbBjmaWhhwUV7ESHMG6KjdDdhRuw5dQKWkqzB
```

so that the results are more accurate. Kindly asking the DefiLlama team if you can advice on how can we do this in the current implementation ? 

#### 2. Change in Label
In https://defillama.com/chains/Parachain --> Preferably this “Parachain” label should be renamed to “Polkadot” in the light of upcoming agile Polkadot changes.
