### PR TITLE
SwissBorg: Add Solana wallet

### DIFF
--- a/projects/swissborg/index.js
+++ b/projects/swissborg/index.js
@@ -45,6 +45,7 @@ const config = {
       '2XxP4kS2vfkiMvpLpGNxry3fPUYimsuAmSbqL1KnuwZ8',
       'Cet3t77x2BBVSmiEFm8ZPoDSngbpso2RuWPL79Ky7SpA',
       '9qoUcyhKSWMbk6tqGUYQUpeosPcdUnJszG4eQKwfe4gL',
+      'Fe7SEekiKygziaEGKxsDsgLVzrCfNvVBvAYsaJBwFA8s',
     ],
   },
   polkadot: {


### PR DESCRIPTION
This PR updates the list of wallets owned by SwissBorg. New wallet addition: https://github.com/SwissBorg/pub/commit/04bb67b82696d8a49b1cece3d7f5ce1c32f3b35a