### PR TITLE
Add kamino lending

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "license": "ISC",
   "dependencies": {
     "@defillama/sdk": "latest",
-    "@project-serum/anchor": "^0.25.0",
+    "@coral-xyz/borsh": "^0.29.0",
+    "@project-serum/anchor": "^0.26.0",
     "@solana/web3.js": "^1.36.0",
     "@solendprotocol/solend-sdk": "^0.6.2",
     "@supercharge/promise-pool": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "license": "ISC",
   "dependencies": {
     "@defillama/sdk": "latest",
-    "@coral-xyz/borsh": "^0.29.0",
     "@project-serum/anchor": "^0.26.0",
     "@solana/web3.js": "^1.36.0",
     "@solendprotocol/solend-sdk": "^0.6.2",

--- a/projects/kamino-lending/index.js
+++ b/projects/kamino-lending/index.js
@@ -1,9 +1,9 @@
-const { PublicKey, Keypair } = require('@solana/web3.js');
+const { PublicKey } = require('@solana/web3.js');
 const { getConnection, sumTokens } = require('../helper/solana');
 const { Program } = require('@project-serum/anchor');
 const kaminoIdl = require('./kamino-lending-idl.json');
 const scopeIdl = require('./scope-idl.json');
-const { Token, TOKEN_PROGRAM_ID } = require('@solana/spl-token');
+const { MintLayout } = require("../helper/utils/solana/layouts/mixed-layout");
 
 async function tvl() {
   const connection = getConnection();
@@ -55,15 +55,17 @@ async function tvl() {
 }
 
 async function isKToken(mint, connection) {
-  const mintAcc = new Token(connection, mint, TOKEN_PROGRAM_ID, Keypair.generate());
-  const mintInfo = await mintAcc.getMintInfo();
+  const mintInfo = await connection.getAccountInfo(new PublicKey(mint.toString()));
+  const rawMint = MintLayout.decode(mintInfo.data.slice(0, MintLayout.span));
   const KAMINO_PROGRAM_ID = new PublicKey('6LtLpnUFNByNXLyCoK9wA2MykKAmQNZKBdY8s47dehDc');
   const [expectedMintAuthority] = PublicKey.findProgramAddressSync(
     [Buffer.from('authority'), mint.toBuffer()],
     KAMINO_PROGRAM_ID
   );
-  return mintInfo.mintAuthority !== null && mintInfo.mintAuthority.equals(expectedMintAuthority);
+  return rawMint.mintAuthority !== null && rawMint.mintAuthority.equals(expectedMintAuthority);
 }
+
+
 
 const U16_MAX = 2 ** 16 - 1;
 

--- a/projects/kamino-lending/index.js
+++ b/projects/kamino-lending/index.js
@@ -2,20 +2,23 @@ const { PublicKey, Keypair } = require('@solana/web3.js');
 const { getConnection, sumTokens } = require('../helper/solana');
 const { Program } = require('@project-serum/anchor');
 const kaminoIdl = require('./kamino-lending-idl.json');
-const { Scope } = require('@hubbleprotocol/scope-sdk');
+const scopeIdl = require('./scope-idl.json');
 const { Token, TOKEN_PROGRAM_ID } = require('@solana/spl-token');
 
 async function tvl() {
   const connection = getConnection();
   const programId = new PublicKey('KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD');
+  const scopeProgramId = new PublicKey('HFn8GnPADiny6XqUoWE8uRPPxb29ikn4yTuPa9MF2fWJ');
   const markets = ['7u3HeHxYDLhnCoErrtycNokbQYbWGzLs6JSDqGAv5PfF'];
+  const oraclePricesAddress = '3NJYftD5sjVfxSnUdZ1wVML8f3aC6mp1CXCL6L7TnU8C';
   const lendingMarketAuthSeed = 'lma';
-  const scope = new Scope('mainnet-beta', connection);
-  const oraclePrices = await scope.getOraclePrices();
   const tokensAndOwners = [];
   const ktokens = {};
 
   const kaminoLendProgram = new Program(kaminoIdl, programId, { connection, publicKey: PublicKey.unique() });
+  const scopeProgram = new Program(scopeIdl, scopeProgramId, { connection, publicKey: PublicKey.unique() });
+
+  const oraclePrices = await scopeProgram.account.oraclePrices.fetch(oraclePricesAddress);
   let tvl = 0;
   for (const market of markets) {
     const reserves = await kaminoLendProgram.account.reserve.all([
@@ -25,25 +28,26 @@ async function tvl() {
 
     for (const reserveData of reserves) {
       const reserve = reserveData.account;
+      const mint = reserve.liquidity.mintPubkey.toString();
       if (
-        ktokens[reserve.liquidity.mintPubkey] ||
-        (await isKToken(new PublicKey(reserve.liquidity.mintPubkey), connection))
+        ktokens[mint] ||
+        (await isKToken(new PublicKey(mint), connection))
       ) {
-        ktokens[reserve.liquidity.mintPubkey] = true;
+        ktokens[mint] = true;
         const liq = Number(reserve.liquidity.availableAmount.toString()) / 10 ** Number(reserve.liquidity.mintDecimals);
         const oracle = reserve.config.tokenInfo.scopeConfiguration.priceFeed;
         const chain = reserve.config.tokenInfo.scopeConfiguration.priceChain;
-        if (oracle && chain && Scope.isScopeChainValid(chain)) {
-          const price = await scope.getPriceFromChain(chain, oraclePrices);
-          tvl += liq * price.toNumber();
+        if (oracle && chain && isScopeChainValid(chain)) {
+          const price = getPriceFromScopeChain(chain, oraclePrices);
+          tvl += liq * price;
         }
       } else {
-        ktokens[reserve.liquidity.mintPubkey] = false;
+        ktokens[mint] = false;
         const [authority] = PublicKey.findProgramAddressSync(
           [Buffer.from(lendingMarketAuthSeed), new PublicKey(market).toBuffer()],
           programId
         );
-        tokensAndOwners.push([reserve.liquidity.mintPubkey, authority]);
+        tokensAndOwners.push([mint, authority]);
       }
     }
   }
@@ -59,6 +63,44 @@ async function isKToken(mint, connection) {
     KAMINO_PROGRAM_ID
   );
   return mintInfo.mintAuthority !== null && mintInfo.mintAuthority.equals(expectedMintAuthority);
+}
+
+const U16_MAX = 2 ** 16 - 1;
+
+function isScopeChainValid(chain) {
+
+  return !(
+    chain.length === 0 ||
+    chain.every((tokenId) => tokenId === 0) ||
+    chain.every((tokenId) => tokenId === U16_MAX)
+  );
+}
+
+function getPriceFromScopeChain(chain, prices) {
+  // Protect from bad defaults
+  if (chain.every((tokenId) => tokenId === 0)) {
+    throw new Error('Token chain cannot be all 0s');
+  }
+  // Protect from bad defaults
+  chain = chain.filter((tokenId) => tokenId !== U16_MAX);
+  if (chain.length === 0) {
+    throw new Error(`Token chain cannot be all ${U16_MAX}s (u16 max)`);
+  }
+  const priceChain = chain.map((tokenId) => {
+    const datedPrice = prices.prices[tokenId];
+    if (!datedPrice) {
+      throw Error(`Could not get price for token ${tokenId}`);
+    }
+    const priceInfo = datedPrice.price;
+    return Number(priceInfo.value.toString())*(10**(-Number(priceInfo.exp.toString())));
+  });
+
+  if (priceChain.length === 1) {
+    return priceChain[0];
+  }
+
+  // Compute token value by multiplying all values of the chain
+  return priceChain.reduce((acc, price) => acc * price, 1);
 }
 
 module.exports = {

--- a/projects/kamino-lending/index.js
+++ b/projects/kamino-lending/index.js
@@ -66,6 +66,6 @@ module.exports = {
   solana: {
     tvl,
   },
-  methodology:
-    'TVL consists of deposits made to the protocol and like other lending protocols, borrowed tokens are not counted.',
+  methodology: 'TVL consists of deposits made to the protocol, borrowed tokens are not counted.',
+  misrepresentedTokens: true,
 };

--- a/projects/kamino-lending/index.js
+++ b/projects/kamino-lending/index.js
@@ -1,0 +1,71 @@
+const { PublicKey, Keypair } = require('@solana/web3.js');
+const { getConnection, sumTokens } = require('../helper/solana');
+const { Program } = require('@project-serum/anchor');
+const kaminoIdl = require('./kamino-lending-idl.json');
+const { Scope } = require('@hubbleprotocol/scope-sdk');
+const { Token, TOKEN_PROGRAM_ID } = require('@solana/spl-token');
+
+async function tvl() {
+  const connection = getConnection();
+  const programId = new PublicKey('KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD');
+  const markets = ['7u3HeHxYDLhnCoErrtycNokbQYbWGzLs6JSDqGAv5PfF'];
+  const lendingMarketAuthSeed = 'lma';
+  const scope = new Scope('mainnet-beta', connection);
+  const oraclePrices = await scope.getOraclePrices();
+  const tokensAndOwners = [];
+  const ktokens = {};
+
+  const kaminoLendProgram = new Program(kaminoIdl, programId, { connection, publicKey: PublicKey.unique() });
+  let tvl = 0;
+  for (const market of markets) {
+    const reserves = await kaminoLendProgram.account.reserve.all([
+      { dataSize: 8624 },
+      { memcmp: { offset: 32, bytes: market } },
+    ]);
+
+    for (const reserveData of reserves) {
+      const reserve = reserveData.account;
+      if (
+        ktokens[reserve.liquidity.mintPubkey] ||
+        (await isKToken(new PublicKey(reserve.liquidity.mintPubkey), connection))
+      ) {
+        ktokens[reserve.liquidity.mintPubkey] = true;
+        const liq = Number(reserve.liquidity.availableAmount.toString()) / 10 ** Number(reserve.liquidity.mintDecimals);
+        const oracle = reserve.config.tokenInfo.scopeConfiguration.priceFeed;
+        const chain = reserve.config.tokenInfo.scopeConfiguration.priceChain;
+        if (oracle && chain && Scope.isScopeChainValid(chain)) {
+          const price = await scope.getPriceFromChain(chain, oraclePrices);
+          tvl += liq * price.toNumber();
+        }
+      } else {
+        ktokens[reserve.liquidity.mintPubkey] = false;
+        const [authority] = PublicKey.findProgramAddressSync(
+          [Buffer.from(lendingMarketAuthSeed), new PublicKey(market).toBuffer()],
+          programId
+        );
+        tokensAndOwners.push([reserve.liquidity.mintPubkey, authority]);
+      }
+    }
+  }
+  return { tether: tvl, ...(await sumTokens(tokensAndOwners)) };
+}
+
+async function isKToken(mint, connection) {
+  const mintAcc = new Token(connection, mint, TOKEN_PROGRAM_ID, Keypair.generate());
+  const mintInfo = await mintAcc.getMintInfo();
+  const KAMINO_PROGRAM_ID = new PublicKey('6LtLpnUFNByNXLyCoK9wA2MykKAmQNZKBdY8s47dehDc');
+  const [expectedMintAuthority] = PublicKey.findProgramAddressSync(
+    [Buffer.from('authority'), mint.toBuffer()],
+    KAMINO_PROGRAM_ID
+  );
+  return mintInfo.mintAuthority !== null && mintInfo.mintAuthority.equals(expectedMintAuthority);
+}
+
+module.exports = {
+  timetravel: false,
+  solana: {
+    tvl,
+  },
+  methodology:
+    'TVL consists of deposits made to the protocol and like other lending protocols, borrowed tokens are not counted.',
+};

--- a/projects/kamino-lending/kamino-lending-idl.json
+++ b/projects/kamino-lending/kamino-lending-idl.json
@@ -1,0 +1,3915 @@
+{
+  "version": "0.1.0",
+  "name": "kamino_lending",
+  "instructions": [
+    {
+      "name": "initLendingMarket",
+      "accounts": [
+        {
+          "name": "lendingMarketOwner",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarketAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "quoteCurrency",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "updateLendingMarket",
+      "accounts": [
+        {
+          "name": "lendingMarketOwner",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "mode",
+          "type": "u64"
+        },
+        {
+          "name": "value",
+          "type": {
+            "array": [
+              "u8",
+              72
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "updateLendingMarketOwner",
+      "accounts": [
+        {
+          "name": "lendingMarketOwnerCached",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initReserve",
+      "accounts": [
+        {
+          "name": "lendingMarketOwner",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarketAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserve",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveLiquidityMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserveLiquiditySupply",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "feeReceiver",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveCollateralMint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveCollateralSupply",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initFarmsForReserve",
+      "accounts": [
+        {
+          "name": "lendingMarketOwner",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarketAuthority",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserve",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "farmsProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "farmsGlobalConfig",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "farmState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "farmsVaultAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "mode",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "updateReserveConfig",
+      "accounts": [
+        {
+          "name": "lendingMarketOwner",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserve",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "mode",
+          "type": "u64"
+        },
+        {
+          "name": "value",
+          "type": {
+            "array": [
+              "u8",
+              648
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "refreshReserve",
+      "accounts": [
+        {
+          "name": "reserve",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "pythOracle",
+          "isMut": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "name": "switchboardPriceOracle",
+          "isMut": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "name": "switchboardTwapOracle",
+          "isMut": false,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "name": "scopePrices",
+          "isMut": false,
+          "isSigner": false,
+          "isOptional": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "depositReserveLiquidity",
+      "accounts": [
+        {
+          "name": "owner",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "reserve",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarketAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserveLiquiditySupply",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveCollateralMint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userSourceLiquidity",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userDestinationCollateral",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidityAmount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "redeemReserveCollateral",
+      "accounts": [
+        {
+          "name": "owner",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserve",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarketAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserveCollateralMint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveLiquiditySupply",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userSourceCollateral",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userDestinationLiquidity",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "collateralAmount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "initObligation",
+      "accounts": [
+        {
+          "name": "obligationOwner",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "obligation",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "seed1Account",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "seed2Account",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "ownerUserMetadata",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": "InitObligationArgs"
+          }
+        }
+      ]
+    },
+    {
+      "name": "initObligationFarmsForReserve",
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "owner",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "obligation",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarketAuthority",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserve",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveFarmState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "obligationFarm",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "farmsProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "mode",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "refreshObligationFarmsForReserve",
+      "accounts": [
+        {
+          "name": "crank",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "obligation",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarketAuthority",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserve",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserveFarmState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "obligationFarmUserState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "farmsProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "mode",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "refreshObligation",
+      "accounts": [
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "obligation",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "depositObligationCollateral",
+      "accounts": [
+        {
+          "name": "owner",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "obligation",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "depositReserve",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveDestinationCollateral",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userSourceCollateral",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructionSysvarAccount",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "collateralAmount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "withdrawObligationCollateral",
+      "accounts": [
+        {
+          "name": "owner",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "obligation",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarketAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "withdrawReserve",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserveSourceCollateral",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userDestinationCollateral",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructionSysvarAccount",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "collateralAmount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "borrowObligationLiquidity",
+      "accounts": [
+        {
+          "name": "owner",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "obligation",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarketAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "borrowReserve",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveSourceLiquidity",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "borrowReserveLiquidityFeeReceiver",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userDestinationLiquidity",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "referrerTokenState",
+          "isMut": true,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructionSysvarAccount",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidityAmount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "repayObligationLiquidity",
+      "accounts": [
+        {
+          "name": "owner",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "obligation",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "repayReserve",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveDestinationLiquidity",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userSourceLiquidity",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructionSysvarAccount",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidityAmount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "depositReserveLiquidityAndObligationCollateral",
+      "accounts": [
+        {
+          "name": "owner",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "obligation",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarketAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserve",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveLiquiditySupply",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveCollateralMint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveDestinationDepositCollateral",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userSourceLiquidity",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userDestinationCollateral",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructionSysvarAccount",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidityAmount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "withdrawObligationCollateralAndRedeemReserveCollateral",
+      "accounts": [
+        {
+          "name": "owner",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "obligation",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarketAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "withdrawReserve",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveSourceCollateral",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveCollateralMint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveLiquiditySupply",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userDestinationLiquidity",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userDestinationCollateral",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructionSysvarAccount",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "collateralAmount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "liquidateObligationAndRedeemReserveCollateral",
+      "accounts": [
+        {
+          "name": "liquidator",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "obligation",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarketAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "repayReserve",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "repayReserveLiquiditySupply",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "withdrawReserve",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "withdrawReserveCollateralMint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "withdrawReserveCollateralSupply",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "withdrawReserveLiquiditySupply",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "withdrawReserveLiquidityFeeReceiver",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userSourceLiquidity",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userDestinationCollateral",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userDestinationLiquidity",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructionSysvarAccount",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidityAmount",
+          "type": "u64"
+        },
+        {
+          "name": "minAcceptableReceivedCollateralAmount",
+          "type": "u64"
+        },
+        {
+          "name": "maxAllowedLtvOverridePercent",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "redeemFees",
+      "accounts": [
+        {
+          "name": "reserve",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveLiquidityFeeReceiver",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveSupplyLiquidity",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarketAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "flashRepayReserveLiquidity",
+      "accounts": [
+        {
+          "name": "userTransferAuthority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "lendingMarketAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserve",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveDestinationLiquidity",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userSourceLiquidity",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveLiquidityFeeReceiver",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "referrerTokenState",
+          "isMut": true,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "name": "referrerAccount",
+          "isMut": true,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "name": "sysvarInfo",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidityAmount",
+          "type": "u64"
+        },
+        {
+          "name": "borrowInstructionIndex",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "flashBorrowReserveLiquidity",
+      "accounts": [
+        {
+          "name": "userTransferAuthority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "lendingMarketAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserve",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveSourceLiquidity",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "userDestinationLiquidity",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveLiquidityFeeReceiver",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "referrerTokenState",
+          "isMut": true,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "name": "referrerAccount",
+          "isMut": true,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "name": "sysvarInfo",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidityAmount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "socializeLoss",
+      "accounts": [
+        {
+          "name": "riskCouncil",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "obligation",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserve",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "instructionSysvarAccount",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidityAmount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "requestElevationGroup",
+      "accounts": [
+        {
+          "name": "owner",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "obligation",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "elevationGroup",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "initReferrerTokenState",
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserve",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "referrerTokenState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "referrer",
+          "type": "publicKey"
+        }
+      ]
+    },
+    {
+      "name": "initUserMetadata",
+      "accounts": [
+        {
+          "name": "owner",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "userMetadata",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "referrer",
+          "type": "publicKey"
+        },
+        {
+          "name": "userLookupTable",
+          "type": "publicKey"
+        }
+      ]
+    },
+    {
+      "name": "withdrawReferrerFees",
+      "accounts": [
+        {
+          "name": "referrer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "referrerTokenState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserve",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "reserveSupplyLiquidity",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "referrerTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarketAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "withdrawProtocolFee",
+      "accounts": [
+        {
+          "name": "lendingMarketOwner",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "lendingMarket",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "reserve",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarketAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "feeVault",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "lendingMarketOwnerAta",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "initReferrerStateAndShortUrl",
+      "accounts": [
+        {
+          "name": "referrer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "referrerState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "referrerShortUrl",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "shortUrl",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "name": "deleteReferrerStateAndShortUrl",
+      "accounts": [
+        {
+          "name": "referrer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "referrerState",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "shortUrl",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    }
+  ],
+  "accounts": [
+    {
+      "name": "LendingMarket",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "version",
+            "docs": [
+              "Version of lending market"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "bumpSeed",
+            "docs": [
+              "Bump seed for derived authority address"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "lendingMarketOwner",
+            "docs": [
+              "Owner authority which can add new reserves"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "lendingMarketOwnerCached",
+            "docs": [
+              "Temporary cache of the lending market owner, used in update_lending_market_owner"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "quoteCurrency",
+            "docs": [
+              "Currency market prices are quoted in",
+              "e.g. \"USD\" null padded (`*b\"USD\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\"`) or a SPL token mint pubkey"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "referralFeeBps",
+            "docs": [
+              "Referral fee for the lending market, as bps out of the total protocol fee"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "emergencyMode",
+            "type": "u8"
+          },
+          {
+            "name": "reserved",
+            "docs": [
+              "Padding used for alignment"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                2
+              ]
+            }
+          },
+          {
+            "name": "priceRefreshTriggerToMaxAgePct",
+            "docs": [
+              "Refresh price from oracle only if it's older than this percentage of the price max age.",
+              "e.g. if the max age is set to 100s and this is set to 80%, the price will be refreshed if it's older than 80s.",
+              "Price is always refreshed if this set to 0."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "liquidationMaxDebtCloseFactorPct",
+            "docs": [
+              "Percentage of the total borrowed value in an obligation available for liquidation"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "insolvencyRiskUnhealthyLtvPct",
+            "docs": [
+              "Minimum acceptable unhealthy LTV before max_debt_close_factor_pct becomes 100%"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "minFullLiquidationAmountThreshold",
+            "docs": [
+              "Minimum liquidation amount threshold triggering full liquidation for an obligation"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "maxLiquidatableDebtMarketValueAtOnce",
+            "docs": [
+              "Max allowed liquidation value in one ix call"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "globalUnhealthyBorrowValue",
+            "docs": [
+              "Global maximum unhealthy borrow value allowed for any obligation"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "globalAllowedBorrowValue",
+            "docs": [
+              "Global maximum allowed borrow value allowed for any obligation"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "riskCouncil",
+            "docs": [
+              "The address of the risk council, in charge of making parameter and risk decisions on behalf of the protocol"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "multiplierPointsTagBoost",
+            "docs": [
+              "Reward points multiplier per obligation type"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          },
+          {
+            "name": "elevationGroups",
+            "docs": [
+              "Elevation groups are used to group together reserves that have the same risk parameters and can bump the ltv and liquidation threshold"
+            ],
+            "type": {
+              "array": [
+                {
+                  "defined": "ElevationGroup"
+                },
+                32
+              ]
+            }
+          },
+          {
+            "name": "elevationGroupPadding",
+            "type": {
+              "array": [
+                "u64",
+                90
+              ]
+            }
+          },
+          {
+            "name": "padding1",
+            "type": {
+              "array": [
+                "u64",
+                180
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Obligation",
+      "docs": [
+        "Lending market obligation state"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "tag",
+            "docs": [
+              "Version of the struct"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "lastUpdate",
+            "docs": [
+              "Last update to collateral, liquidity, or their market values"
+            ],
+            "type": {
+              "defined": "LastUpdate"
+            }
+          },
+          {
+            "name": "lendingMarket",
+            "docs": [
+              "Lending market address"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "owner",
+            "docs": [
+              "Owner authority which can borrow liquidity"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "deposits",
+            "docs": [
+              "TODO: Does this break the stack size when copied onto the stack, if too big?",
+              "Deposited collateral for the obligation, unique by deposit reserve address"
+            ],
+            "type": {
+              "array": [
+                {
+                  "defined": "ObligationCollateral"
+                },
+                8
+              ]
+            }
+          },
+          {
+            "name": "lowestReserveDepositLtv",
+            "docs": [
+              "Worst LTV for the collaterals backing the loan, represented as a percentage"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "depositedValueSf",
+            "docs": [
+              "Market value of deposits (scaled fraction)"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "borrows",
+            "docs": [
+              "Borrowed liquidity for the obligation, unique by borrow reserve address"
+            ],
+            "type": {
+              "array": [
+                {
+                  "defined": "ObligationLiquidity"
+                },
+                5
+              ]
+            }
+          },
+          {
+            "name": "borrowFactorAdjustedDebtValueSf",
+            "docs": [
+              "Risk adjusted market value of borrows/debt (sum of price * borrowed_amount * borrow_factor) (scaled fraction)"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "borrowedAssetsMarketValueSf",
+            "docs": [
+              "Market value of borrows - used for max_liquidatable_borrowed_amount (scaled fraction)"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "allowedBorrowValueSf",
+            "docs": [
+              "The maximum borrow value at the weighted average loan to value ratio (scaled fraction)"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "unhealthyBorrowValueSf",
+            "docs": [
+              "The dangerous borrow value at the weighted average liquidation threshold (scaled fraction)"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "depositsAssetTiers",
+            "docs": [
+              "The asset tier of the deposits"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          },
+          {
+            "name": "borrowsAssetTiers",
+            "docs": [
+              "The asset tier of the borrows"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                5
+              ]
+            }
+          },
+          {
+            "name": "elevationGroup",
+            "docs": [
+              "The elevation group id the obligation opted into."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "reserved",
+            "type": {
+              "array": [
+                "u8",
+                2
+              ]
+            }
+          },
+          {
+            "name": "referrer",
+            "docs": [
+              "Wallet address of the referrer"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "padding3",
+            "type": {
+              "array": [
+                "u64",
+                128
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ReferrerTokenState",
+      "docs": [
+        "Referrer account -> each owner can have multiple accounts for specific reserves"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "referrer",
+            "docs": [
+              "Pubkey of the referrer/owner"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "mint",
+            "docs": [
+              "Token mint for the account"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "amountUnclaimedSf",
+            "docs": [
+              "Amount that has been accumulated and not claimed yet -> available to claim (scaled fraction)"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "amountCumulativeSf",
+            "docs": [
+              "Amount that has been accumulated in total -> both already claimed and unclaimed (scaled fraction)"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "Referrer token state bump, used for address validation"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u64",
+                31
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "UserMetadata",
+      "docs": [
+        "Referrer account -> each owner can have multiple accounts for specific reserves"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "referrer",
+            "docs": [
+              "Pubkey of the referrer/owner - pubkey::default if no referrer"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "Bump used for validation of account address"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "userLookupTable",
+            "docs": [
+              "User lookup table - used to store all user accounts - atas for each reserve mint, each obligation PDA, UserMetadata itself and all referrer_token_states if there is a referrer"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "padding1",
+            "type": {
+              "array": [
+                "u64",
+                55
+              ]
+            }
+          },
+          {
+            "name": "padding2",
+            "type": {
+              "array": [
+                "u64",
+                64
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ReferrerState",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "shortUrl",
+            "type": "publicKey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ShortUrl",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "referrer",
+            "type": "publicKey"
+          },
+          {
+            "name": "shortUrl",
+            "type": "string"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Reserve",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "version",
+            "docs": [
+              "Version of the reserve"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "lastUpdate",
+            "docs": [
+              "Last slot when supply and rates updated"
+            ],
+            "type": {
+              "defined": "LastUpdate"
+            }
+          },
+          {
+            "name": "lendingMarket",
+            "docs": [
+              "Lending market address"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "farmCollateral",
+            "type": "publicKey"
+          },
+          {
+            "name": "farmDebt",
+            "type": "publicKey"
+          },
+          {
+            "name": "liquidity",
+            "docs": [
+              "Reserve liquidity"
+            ],
+            "type": {
+              "defined": "ReserveLiquidity"
+            }
+          },
+          {
+            "name": "reserveLiquidityPadding",
+            "type": {
+              "array": [
+                "u64",
+                150
+              ]
+            }
+          },
+          {
+            "name": "collateral",
+            "docs": [
+              "Reserve collateral"
+            ],
+            "type": {
+              "defined": "ReserveCollateral"
+            }
+          },
+          {
+            "name": "reserveCollateralPadding",
+            "type": {
+              "array": [
+                "u64",
+                150
+              ]
+            }
+          },
+          {
+            "name": "config",
+            "docs": [
+              "Reserve configuration values"
+            ],
+            "type": {
+              "defined": "ReserveConfig"
+            }
+          },
+          {
+            "name": "configPadding",
+            "type": {
+              "array": [
+                "u64",
+                150
+              ]
+            }
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u64",
+                240
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "types": [
+    {
+      "name": "LastUpdate",
+      "docs": [
+        "Last update state"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "slot",
+            "docs": [
+              "Last slot when updated"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "stale",
+            "docs": [
+              "True when marked stale, false when slot updated"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "placeholder",
+            "type": {
+              "array": [
+                "u8",
+                7
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ElevationGroup",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "maxLiquidationBonusBps",
+            "type": "u16"
+          },
+          {
+            "name": "id",
+            "type": "u8"
+          },
+          {
+            "name": "ltvPct",
+            "type": "u8"
+          },
+          {
+            "name": "liquidationThresholdPct",
+            "type": "u8"
+          },
+          {
+            "name": "allowNewLoans",
+            "type": "u8"
+          },
+          {
+            "name": "reserved",
+            "type": {
+              "array": [
+                "u8",
+                2
+              ]
+            }
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u64",
+                8
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "InitObligationArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "tag",
+            "type": "u8"
+          },
+          {
+            "name": "id",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ObligationCollateral",
+      "docs": [
+        "Obligation collateral state"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "depositReserve",
+            "docs": [
+              "Reserve collateral is deposited to"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "depositedAmount",
+            "docs": [
+              "Amount of collateral deposited"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "marketValueSf",
+            "docs": [
+              "Collateral market value in quote currency (scaled fraction)"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u64",
+                10
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ObligationLiquidity",
+      "docs": [
+        "Obligation liquidity state"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "borrowReserve",
+            "docs": [
+              "Reserve liquidity is borrowed from"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "cumulativeBorrowRateBsf",
+            "docs": [
+              "Borrow rate used for calculating interest (big scaled fraction)"
+            ],
+            "type": {
+              "defined": "BigFractionBytes"
+            }
+          },
+          {
+            "name": "padding",
+            "type": "u64"
+          },
+          {
+            "name": "borrowedAmountSf",
+            "docs": [
+              "Amount of liquidity borrowed plus interest (scaled fraction)"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "marketValueSf",
+            "docs": [
+              "Liquidity market value in quote currency (scaled fraction)"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "borrowFactorAdjustedMarketValueSf",
+            "docs": [
+              "Risk adjusted liquidity market value in quote currency - DEBUG ONLY - use market_value instead"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "padding2",
+            "type": {
+              "array": [
+                "u64",
+                8
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "BigFractionBytes",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "value",
+            "type": {
+              "array": [
+                "u64",
+                4
+              ]
+            }
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u64",
+                2
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ReserveLiquidity",
+      "docs": [
+        "Reserve liquidity"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "mintPubkey",
+            "docs": [
+              "Reserve liquidity mint address"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "supplyVault",
+            "docs": [
+              "Reserve liquidity supply address"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "feeVault",
+            "docs": [
+              "Reserve liquidity fee collection address"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "availableAmount",
+            "docs": [
+              "Reserve liquidity available"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "borrowedAmountSf",
+            "docs": [
+              "Reserve liquidity borrowed (scaled fraction)"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "marketPriceSf",
+            "docs": [
+              "Reserve liquidity market price in quote currency (scaled fraction)"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "marketPriceLastUpdatedTs",
+            "docs": [
+              "Unix timestamp of the market price (from the oracle)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "mintDecimals",
+            "docs": [
+              "Reserve liquidity mint decimals"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "depositLimitCrossedSlot",
+            "docs": [
+              "Timestamp in slots when the last refresh reserve detected that the liquidity amount is above the deposit cap. When this threshold is crossed, then redemptions (auto-deleverage) are enabled.",
+              "If the threshold is not crossed, then the timestamp is set to 0"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "borrowLimitCrossedSlot",
+            "docs": [
+              "Timestamp in slots when the last refresh reserve detected that the borrowed amount is above the borrow cap. When this threshold is crossed, then redemptions (auto-deleverage) are enabled.",
+              "If the threshold is not crossed, then the timestamp is set to 0"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "cumulativeBorrowRateBsf",
+            "docs": [
+              "Reserve liquidity cumulative borrow rate (scaled fraction)"
+            ],
+            "type": {
+              "defined": "BigFractionBytes"
+            }
+          },
+          {
+            "name": "accumulatedProtocolFeesSf",
+            "docs": [
+              "Reserve cumulative protocol fees (scaled fraction)"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "accumulatedReferrerFeesSf",
+            "docs": [
+              "Reserve cumulative referrer fees (scaled fraction)"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "pendingReferrerFeesSf",
+            "docs": [
+              "Reserve pending referrer fees, to be claimed in refresh_obligation by referrer or protocol (scaled fraction)"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "absoluteReferralRateSf",
+            "docs": [
+              "Reserve referrer fee absolute rate calculated at each refresh_reserve operation (scaled fraction)"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "padding2",
+            "type": {
+              "array": [
+                "u64",
+                55
+              ]
+            }
+          },
+          {
+            "name": "padding3",
+            "type": {
+              "array": [
+                "u128",
+                32
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ReserveCollateral",
+      "docs": [
+        "Reserve collateral"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "mintPubkey",
+            "docs": [
+              "Reserve collateral mint address"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "mintTotalSupply",
+            "docs": [
+              "Reserve collateral mint supply, used for exchange rate"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "supplyVault",
+            "docs": [
+              "Reserve collateral supply address"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "padding1",
+            "type": {
+              "array": [
+                "u128",
+                32
+              ]
+            }
+          },
+          {
+            "name": "padding2",
+            "type": {
+              "array": [
+                "u128",
+                32
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ReserveConfig",
+      "docs": [
+        "Reserve configuration values"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "status",
+            "docs": [
+              "Status of the reserve Active/Obsolete/Hidden"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "assetTier",
+            "docs": [
+              "Asset tier -> 0 - regular (collateral & debt), 1 - isolated collateral, 2 - isolated debt"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "reserved0",
+            "type": {
+              "array": [
+                "u8",
+                2
+              ]
+            }
+          },
+          {
+            "name": "multiplierSideBoost",
+            "docs": [
+              "Boost for side (debt or collateral)"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                2
+              ]
+            }
+          },
+          {
+            "name": "multiplierTagBoost",
+            "docs": [
+              "Reward points multiplier per obligation type"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          },
+          {
+            "name": "protocolTakeRatePct",
+            "docs": [
+              "Protocol take rate is the amount borrowed interest protocol receives, as a percentage"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "protocolLiquidationFeePct",
+            "docs": [
+              "Cut of the liquidation bonus that the protocol receives, as a percentage"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "loanToValuePct",
+            "docs": [
+              "Target ratio of the value of borrows to deposits, as a percentage",
+              "0 if use as collateral is disabled"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "liquidationThresholdPct",
+            "docs": [
+              "Loan to value ratio at which an obligation can be liquidated, as percentage"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "minLiquidationBonusBps",
+            "docs": [
+              "Minimum bonus a liquidator receives when repaying part of an unhealthy obligation, as bps"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "maxLiquidationBonusBps",
+            "docs": [
+              "Maximum bonus a liquidator receives when repaying part of an unhealthy obligation, as bps"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "badDebtLiquidationBonusBps",
+            "docs": [
+              "Bad debt liquidation bonus for an undercollateralized obligation, as bps"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "deleveragingMarginCallPeriodSecs",
+            "docs": [
+              "Time in seconds that must pass before redemptions are enabled after the deposit limit is crossed"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "deleveragingThresholdSlotsPerBps",
+            "docs": [
+              "The rate at which the deleveraging threshold decreases in slots per bps",
+              "e.g. 1 bps per hour would be 7200 slots per bps (assuming 2 slots per second)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "fees",
+            "docs": [
+              "Program owner fees assessed, separate from gains due to interest accrual"
+            ],
+            "type": {
+              "defined": "ReserveFees"
+            }
+          },
+          {
+            "name": "borrowRateCurve",
+            "docs": [
+              "Borrow rate curve based on utilization"
+            ],
+            "type": {
+              "defined": "BorrowRateCurve"
+            }
+          },
+          {
+            "name": "borrowFactorPct",
+            "docs": [
+              "Borrow factor in percentage - used for risk adjustment"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "depositLimit",
+            "docs": [
+              "Maximum deposit limit of liquidity in native units, u64::MAX for inf"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "borrowLimit",
+            "docs": [
+              "Maximum amount borrowed, u64::MAX for inf, 0 to disable borrows (protected deposits)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "tokenInfo",
+            "docs": [
+              "Token id from TokenInfos struct"
+            ],
+            "type": {
+              "defined": "TokenInfo"
+            }
+          },
+          {
+            "name": "depositWithdrawalCap",
+            "docs": [
+              "Deposit withdrawl caps - deposit & redeem"
+            ],
+            "type": {
+              "defined": "WithdrawalCaps"
+            }
+          },
+          {
+            "name": "debtWithdrawalCap",
+            "docs": [
+              "Debt withdrawl caps - borrow & repay"
+            ],
+            "type": {
+              "defined": "WithdrawalCaps"
+            }
+          },
+          {
+            "name": "elevationGroups",
+            "type": {
+              "array": [
+                "u8",
+                20
+              ]
+            }
+          },
+          {
+            "name": "reserved1",
+            "type": {
+              "array": [
+                "u8",
+                4
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "WithdrawalCaps",
+      "docs": [
+        "Reserve Withdrawal Caps State"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "configCapacity",
+            "type": "i64"
+          },
+          {
+            "name": "currentTotal",
+            "type": "i64"
+          },
+          {
+            "name": "lastIntervalStartTimestamp",
+            "type": "u64"
+          },
+          {
+            "name": "configIntervalLengthSeconds",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ReserveFees",
+      "docs": [
+        "Additional fee information on a reserve",
+        "",
+        "These exist separately from interest accrual fees, and are specifically for the program owner",
+        "and referral fee. The fees are paid out as a percentage of liquidity token amounts during",
+        "repayments and liquidations."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "borrowFeeSf",
+            "docs": [
+              "Fee assessed on `BorrowObligationLiquidity`, as scaled fraction (60 bits fractional part)",
+              "Must be between `0` and `2^60`, such that `2^60 = 1`.  A few examples for",
+              "clarity:",
+              "1% = (1 << 60) / 100 = 11529215046068470",
+              "0.01% (1 basis point) = 115292150460685",
+              "0.00001% (Aave borrow fee) = 115292150461"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "flashLoanFeeSf",
+            "docs": [
+              "Fee for flash loan, expressed as scaled fraction.",
+              "0.3% (Aave flash loan fee) = 0.003 * 2^60 = 3458764513820541"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "Used for allignment"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "TokenInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "name",
+            "docs": [
+              "UTF-8 encoded name of the token (null-terminated)"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "heuristic",
+            "docs": [
+              "Heuristics limits of acceptable price"
+            ],
+            "type": {
+              "defined": "PriceHeuristic"
+            }
+          },
+          {
+            "name": "maxTwapDivergenceBps",
+            "docs": [
+              "Max divergence between twap and price in bps"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "maxAgePriceSeconds",
+            "type": "u64"
+          },
+          {
+            "name": "maxAgeTwapSeconds",
+            "type": "u64"
+          },
+          {
+            "name": "scopeConfiguration",
+            "docs": [
+              "Scope price configuration"
+            ],
+            "type": {
+              "defined": "ScopeConfiguration"
+            }
+          },
+          {
+            "name": "switchboardConfiguration",
+            "docs": [
+              "Switchboard configuration"
+            ],
+            "type": {
+              "defined": "SwitchboardConfiguration"
+            }
+          },
+          {
+            "name": "pythConfiguration",
+            "docs": [
+              "Pyth configuration"
+            ],
+            "type": {
+              "defined": "PythConfiguration"
+            }
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u64",
+                20
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PriceHeuristic",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lower",
+            "docs": [
+              "Lower value of acceptable price"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "upper",
+            "docs": [
+              "Upper value of acceptable price"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "exp",
+            "docs": [
+              "Number of decimals of the previously defined values"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ScopeConfiguration",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "priceFeed",
+            "docs": [
+              "Pubkey of the scope price feed (disabled if `null` or `default`)"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "priceChain",
+            "docs": [
+              "This is the scope_id price chain that results in a price for the token"
+            ],
+            "type": {
+              "array": [
+                "u16",
+                4
+              ]
+            }
+          },
+          {
+            "name": "twapChain",
+            "docs": [
+              "This is the scope_id price chain for the twap"
+            ],
+            "type": {
+              "array": [
+                "u16",
+                4
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "SwitchboardConfiguration",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "priceAggregator",
+            "docs": [
+              "Pubkey of the base price feed (disabled if `null` or `default`)"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "twapAggregator",
+            "type": "publicKey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PythConfiguration",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "price",
+            "docs": [
+              "Pubkey of the base price feed (disabled if `null` or `default`)"
+            ],
+            "type": "publicKey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BorrowRateCurve",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "points",
+            "type": {
+              "array": [
+                {
+                  "defined": "CurvePoint"
+                },
+                11
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "CurvePoint",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "utilizationRateBps",
+            "type": "u32"
+          },
+          {
+            "name": "borrowRateBps",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidationTokenTest",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Sol"
+          },
+          {
+            "name": "Usdh"
+          }
+        ]
+      }
+    },
+    {
+      "name": "WithdrawalCapAccumulatorAction",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "KeepAccumulator"
+          },
+          {
+            "name": "ResetAccumulator"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ReserveFarmKind",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Collateral"
+          },
+          {
+            "name": "Debt"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ReserveStatus",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Active"
+          },
+          {
+            "name": "Obsolete"
+          },
+          {
+            "name": "Hidden"
+          }
+        ]
+      }
+    },
+    {
+      "name": "FeeCalculation",
+      "docs": [
+        "Calculate fees exlusive or inclusive of an amount"
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Exclusive"
+          },
+          {
+            "name": "Inclusive"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AssetTier",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Regular"
+          },
+          {
+            "name": "IsolatedCollateral"
+          },
+          {
+            "name": "IsolatedDebt"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UpdateReserveConfigValue",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Bool",
+            "fields": [
+              "bool"
+            ]
+          },
+          {
+            "name": "U8",
+            "fields": [
+              "u8"
+            ]
+          },
+          {
+            "name": "U8Tuple",
+            "fields": [
+              "u8",
+              "u8"
+            ]
+          },
+          {
+            "name": "U16",
+            "fields": [
+              "u16"
+            ]
+          },
+          {
+            "name": "U64",
+            "fields": [
+              "u64"
+            ]
+          },
+          {
+            "name": "Pubkey",
+            "fields": [
+              "publicKey"
+            ]
+          },
+          {
+            "name": "ScopeChain",
+            "fields": [
+              {
+                "array": [
+                  "u16",
+                  4
+                ]
+              }
+            ]
+          },
+          {
+            "name": "Name",
+            "fields": [
+              {
+                "array": [
+                  "u8",
+                  32
+                ]
+              }
+            ]
+          },
+          {
+            "name": "BorrowRateCurve",
+            "fields": [
+              {
+                "defined": "BorrowRateCurve"
+              }
+            ]
+          },
+          {
+            "name": "Full",
+            "fields": [
+              {
+                "defined": "ReserveConfig"
+              }
+            ]
+          },
+          {
+            "name": "WithdrawalCap",
+            "fields": [
+              "u64",
+              "u64"
+            ]
+          },
+          {
+            "name": "ElevationGroups",
+            "fields": [
+              {
+                "array": [
+                  "u8",
+                  20
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "UpdateConfigMode",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "UpdateLoanToValuePct"
+          },
+          {
+            "name": "UpdateMaxLiquidationBonusBps"
+          },
+          {
+            "name": "UpdateLiquidationThresholdPct"
+          },
+          {
+            "name": "UpdateProtocolLiquidationFee"
+          },
+          {
+            "name": "UpdateProtocolTakeRate"
+          },
+          {
+            "name": "UpdateFeesBorrowFee"
+          },
+          {
+            "name": "UpdateFeesFlashLoanFee"
+          },
+          {
+            "name": "UpdateFeesReferralFeeBps"
+          },
+          {
+            "name": "UpdateDepositLimit"
+          },
+          {
+            "name": "UpdateBorrowLimit"
+          },
+          {
+            "name": "UpdateTokenInfoLowerHeuristic"
+          },
+          {
+            "name": "UpdateTokenInfoUpperHeuristic"
+          },
+          {
+            "name": "UpdateTokenInfoExpHeuristic"
+          },
+          {
+            "name": "UpdateTokenInfoTwapDivergence"
+          },
+          {
+            "name": "UpdateTokenInfoScopeTwap"
+          },
+          {
+            "name": "UpdateTokenInfoScopeChain"
+          },
+          {
+            "name": "UpdateTokenInfoName"
+          },
+          {
+            "name": "UpdateTokenInfoPriceMaxAge"
+          },
+          {
+            "name": "UpdateTokenInfoTwapMaxAge"
+          },
+          {
+            "name": "UpdateScopePriceFeed"
+          },
+          {
+            "name": "UpdatePythPrice"
+          },
+          {
+            "name": "UpdateSwitchboardFeed"
+          },
+          {
+            "name": "UpdateSwitchboardTwapFeed"
+          },
+          {
+            "name": "UpdateBorrowRateCurve"
+          },
+          {
+            "name": "UpdateEntireReserveConfig"
+          },
+          {
+            "name": "UpdateDebtWithdrawalCap"
+          },
+          {
+            "name": "UpdateDepositWithdrawalCap"
+          },
+          {
+            "name": "UpdateDebtWithdrawalCapCurrentTotal"
+          },
+          {
+            "name": "UpdateDepositWithdrawalCapCurrentTotal"
+          },
+          {
+            "name": "UpdateBadDebtLiquidationBonusBps"
+          },
+          {
+            "name": "UpdateMinLiquidationBonusBps"
+          },
+          {
+            "name": "DeleveragingMarginCallPeriod"
+          },
+          {
+            "name": "UpdateBorrowFactor"
+          },
+          {
+            "name": "UpdateAssetTier"
+          },
+          {
+            "name": "UpdateElevationGroup"
+          },
+          {
+            "name": "DeleveragingThresholdSlotsPerBps"
+          },
+          {
+            "name": "UpdateMultiplierSideBoost"
+          },
+          {
+            "name": "UpdateMultiplierTagBoost"
+          },
+          {
+            "name": "UpdateReserveStatus"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UpdateLendingMarketConfigValue",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Bool",
+            "fields": [
+              "bool"
+            ]
+          },
+          {
+            "name": "U8",
+            "fields": [
+              "u8"
+            ]
+          },
+          {
+            "name": "U8Array",
+            "fields": [
+              {
+                "array": [
+                  "u8",
+                  8
+                ]
+              }
+            ]
+          },
+          {
+            "name": "U16",
+            "fields": [
+              "u16"
+            ]
+          },
+          {
+            "name": "U64",
+            "fields": [
+              "u64"
+            ]
+          },
+          {
+            "name": "Pubkey",
+            "fields": [
+              "publicKey"
+            ]
+          },
+          {
+            "name": "ElevationGroup",
+            "fields": [
+              {
+                "defined": "ElevationGroup"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "UpdateLendingMarketMode",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "UpdateOwner"
+          },
+          {
+            "name": "UpdateEmergencyMode"
+          },
+          {
+            "name": "UpdateLiquidationCloseFactor"
+          },
+          {
+            "name": "UpdateLiquidationMaxValue"
+          },
+          {
+            "name": "UpdateGlobalUnhealthyBorrow"
+          },
+          {
+            "name": "UpdateGlobalAllowedBorrow"
+          },
+          {
+            "name": "UpdateRiskCouncil"
+          },
+          {
+            "name": "UpdateMinFullLiquidationThreshold"
+          },
+          {
+            "name": "UpdateInsolvencyRiskLtv"
+          },
+          {
+            "name": "UpdateElevationGroup"
+          },
+          {
+            "name": "UpdateReferralFeeBps"
+          },
+          {
+            "name": "UpdateMultiplierPoints"
+          },
+          {
+            "name": "UpdatePriceRefreshTriggerToMaxAgePct"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RequiredIxType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "RefreshReserve"
+          },
+          {
+            "name": "RefreshFarmsForObligationForReserve"
+          },
+          {
+            "name": "RefreshObligation"
+          }
+        ]
+      }
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "InvalidMarketAuthority",
+      "msg": "Market authority is invalid"
+    },
+    {
+      "code": 6001,
+      "name": "InvalidMarketOwner",
+      "msg": "Market owner is invalid"
+    },
+    {
+      "code": 6002,
+      "name": "InvalidAccountOwner",
+      "msg": "Input account owner is not the program address"
+    },
+    {
+      "code": 6003,
+      "name": "InvalidAmount",
+      "msg": "Input amount is invalid"
+    },
+    {
+      "code": 6004,
+      "name": "InvalidConfig",
+      "msg": "Input config value is invalid"
+    },
+    {
+      "code": 6005,
+      "name": "InvalidSigner",
+      "msg": "Input account must be a signer"
+    },
+    {
+      "code": 6006,
+      "name": "InvalidAccountInput",
+      "msg": "Invalid account input"
+    },
+    {
+      "code": 6007,
+      "name": "MathOverflow",
+      "msg": "Math operation overflow"
+    },
+    {
+      "code": 6008,
+      "name": "InsufficientLiquidity",
+      "msg": "Insufficient liquidity available"
+    },
+    {
+      "code": 6009,
+      "name": "ReserveStale",
+      "msg": "Reserve state needs to be refreshed"
+    },
+    {
+      "code": 6010,
+      "name": "WithdrawTooSmall",
+      "msg": "Withdraw amount too small"
+    },
+    {
+      "code": 6011,
+      "name": "WithdrawTooLarge",
+      "msg": "Withdraw amount too large"
+    },
+    {
+      "code": 6012,
+      "name": "BorrowTooSmall",
+      "msg": "Borrow amount too small to receive liquidity after fees"
+    },
+    {
+      "code": 6013,
+      "name": "BorrowTooLarge",
+      "msg": "Borrow amount too large for deposited collateral"
+    },
+    {
+      "code": 6014,
+      "name": "RepayTooSmall",
+      "msg": "Repay amount too small to transfer liquidity"
+    },
+    {
+      "code": 6015,
+      "name": "LiquidationTooSmall",
+      "msg": "Liquidation amount too small to receive collateral"
+    },
+    {
+      "code": 6016,
+      "name": "ObligationHealthy",
+      "msg": "Cannot liquidate healthy obligations"
+    },
+    {
+      "code": 6017,
+      "name": "ObligationStale",
+      "msg": "Obligation state needs to be refreshed"
+    },
+    {
+      "code": 6018,
+      "name": "ObligationReserveLimit",
+      "msg": "Obligation reserve limit exceeded"
+    },
+    {
+      "code": 6019,
+      "name": "InvalidObligationOwner",
+      "msg": "Obligation owner is invalid"
+    },
+    {
+      "code": 6020,
+      "name": "ObligationDepositsEmpty",
+      "msg": "Obligation deposits are empty"
+    },
+    {
+      "code": 6021,
+      "name": "ObligationBorrowsEmpty",
+      "msg": "Obligation borrows are empty"
+    },
+    {
+      "code": 6022,
+      "name": "ObligationDepositsZero",
+      "msg": "Obligation deposits have zero value"
+    },
+    {
+      "code": 6023,
+      "name": "ObligationBorrowsZero",
+      "msg": "Obligation borrows have zero value"
+    },
+    {
+      "code": 6024,
+      "name": "InvalidObligationCollateral",
+      "msg": "Invalid obligation collateral"
+    },
+    {
+      "code": 6025,
+      "name": "InvalidObligationLiquidity",
+      "msg": "Invalid obligation liquidity"
+    },
+    {
+      "code": 6026,
+      "name": "ObligationCollateralEmpty",
+      "msg": "Obligation collateral is empty"
+    },
+    {
+      "code": 6027,
+      "name": "ObligationLiquidityEmpty",
+      "msg": "Obligation liquidity is empty"
+    },
+    {
+      "code": 6028,
+      "name": "NegativeInterestRate",
+      "msg": "Interest rate is negative"
+    },
+    {
+      "code": 6029,
+      "name": "InvalidOracleConfig",
+      "msg": "Input oracle config is invalid"
+    },
+    {
+      "code": 6030,
+      "name": "InsufficientProtocolFeesToRedeem",
+      "msg": "Insufficient protocol fees to claim or no liquidity available"
+    },
+    {
+      "code": 6031,
+      "name": "FlashBorrowCpi",
+      "msg": "No cpi flash borrows allowed"
+    },
+    {
+      "code": 6032,
+      "name": "NoFlashRepayFound",
+      "msg": "No corresponding repay found for flash borrow"
+    },
+    {
+      "code": 6033,
+      "name": "InvalidFlashRepay",
+      "msg": "Invalid repay found"
+    },
+    {
+      "code": 6034,
+      "name": "FlashRepayCpi",
+      "msg": "No cpi flash repays allowed"
+    },
+    {
+      "code": 6035,
+      "name": "MultipleFlashBorrows",
+      "msg": "Multiple flash borrows not allowed in the same transaction"
+    },
+    {
+      "code": 6036,
+      "name": "FlashLoansDisabled",
+      "msg": "Flash loans are disabled for this reserve"
+    },
+    {
+      "code": 6037,
+      "name": "SwitchboardV2Error",
+      "msg": "Switchboard error"
+    },
+    {
+      "code": 6038,
+      "name": "CouldNotDeserializeScope",
+      "msg": "Cannot deserialize the scope price account"
+    },
+    {
+      "code": 6039,
+      "name": "PriceTooOld",
+      "msg": "Price too old"
+    },
+    {
+      "code": 6040,
+      "name": "PriceTooDivergentFromTwap",
+      "msg": "Price too divergent from twap"
+    },
+    {
+      "code": 6041,
+      "name": "InvalidTwapPrice",
+      "msg": "Invalid twap price"
+    },
+    {
+      "code": 6042,
+      "name": "GlobalEmergencyMode",
+      "msg": "Emergency mode is enabled"
+    },
+    {
+      "code": 6043,
+      "name": "InvalidFlag",
+      "msg": "Invalid lending market config"
+    },
+    {
+      "code": 6044,
+      "name": "PriceNotValid",
+      "msg": "Price is not valid"
+    },
+    {
+      "code": 6045,
+      "name": "PriceIsBiggerThanHeuristic",
+      "msg": "Price is bigger than allowed by heuristic"
+    },
+    {
+      "code": 6046,
+      "name": "PriceIsLowerThanHeuristic",
+      "msg": "Price lower than allowed by heuristic"
+    },
+    {
+      "code": 6047,
+      "name": "PriceIsZero",
+      "msg": "Price is zero"
+    },
+    {
+      "code": 6048,
+      "name": "PriceConfidenceTooWide",
+      "msg": "Price confidence too wide"
+    },
+    {
+      "code": 6049,
+      "name": "IntegerOverflow",
+      "msg": "Conversion between integers failed"
+    },
+    {
+      "code": 6050,
+      "name": "NoFarmForReserve",
+      "msg": "This reserve does not have a farm"
+    },
+    {
+      "code": 6051,
+      "name": "IncorrectInstructionInPosition",
+      "msg": "Wrong instruction at expected position"
+    },
+    {
+      "code": 6052,
+      "name": "NoPriceFound",
+      "msg": "No price found"
+    },
+    {
+      "code": 6053,
+      "name": "InvalidTwapConfig",
+      "msg": "Invalid Twap configuration: Twap is enabled but one of the enabled price doesn't have a twap"
+    },
+    {
+      "code": 6054,
+      "name": "InvalidPythPriceAccount",
+      "msg": "Pyth price account does not match configuration"
+    },
+    {
+      "code": 6055,
+      "name": "InvalidSwitchboardAccount",
+      "msg": "Switchboard account(s) do not match configuration"
+    },
+    {
+      "code": 6056,
+      "name": "InvalidScopePriceAccount",
+      "msg": "Scope price account does not match configuration"
+    },
+    {
+      "code": 6057,
+      "name": "ObligationCollateralLtvZero",
+      "msg": "The obligation has one collateral with an LTV set to 0. Withdraw it before withdrawing other collaterals"
+    },
+    {
+      "code": 6058,
+      "name": "InvalidObligationSeedsValue",
+      "msg": "Seeds must be default pubkeys for tag 0, and mint addresses for tag 1 or 2"
+    },
+    {
+      "code": 6059,
+      "name": "InvalidObligationId",
+      "msg": "Obligation id must be 0"
+    },
+    {
+      "code": 6060,
+      "name": "InvalidBorrowRateCurvePoint",
+      "msg": "Invalid borrow rate curve point"
+    },
+    {
+      "code": 6061,
+      "name": "InvalidUtilizationRate",
+      "msg": "Invalid utilization rate"
+    },
+    {
+      "code": 6062,
+      "name": "CannotSocializeObligationWithCollateral",
+      "msg": "Obligation hasn't been fully liquidated and debt cannot be socialized."
+    },
+    {
+      "code": 6063,
+      "name": "ObligationEmpty",
+      "msg": "Obligation has no borrows or deposits."
+    },
+    {
+      "code": 6064,
+      "name": "WithdrawalCapReached",
+      "msg": "Withdrawal cap is reached"
+    },
+    {
+      "code": 6065,
+      "name": "LastTimestampGreaterThanCurrent",
+      "msg": "The last interval start timestamp is greater than the current timestamp"
+    },
+    {
+      "code": 6066,
+      "name": "LiquidationSlippageError",
+      "msg": "The reward amount is less than the minimum acceptable received collateral"
+    },
+    {
+      "code": 6067,
+      "name": "IsolatedAssetTierViolation",
+      "msg": "Isolated Asset Tier Violation"
+    },
+    {
+      "code": 6068,
+      "name": "InconsistentElevationGroup",
+      "msg": "The obligation's elevation group and the reserve's are not the same"
+    },
+    {
+      "code": 6069,
+      "name": "InvalidElevationGroup",
+      "msg": "The elevation group chosen for the reserve does not exist in the lending market"
+    },
+    {
+      "code": 6070,
+      "name": "InvalidElevationGroupConfig",
+      "msg": "The elevation group updated has wrong parameters set"
+    },
+    {
+      "code": 6071,
+      "name": "UnhealthyElevationGroupLtv",
+      "msg": "The current obligation must have most or all its debt repaid before changing the elevation group"
+    },
+    {
+      "code": 6072,
+      "name": "ElevationGroupNewLoansDisabled",
+      "msg": "Elevation group does not accept any new loans or any new borrows/withdrawals"
+    },
+    {
+      "code": 6073,
+      "name": "ReserveDeprecated",
+      "msg": "Reserve was deprecated, no longer usable"
+    },
+    {
+      "code": 6074,
+      "name": "ReferrerAccountNotInitialized",
+      "msg": "Referrer account not initialized"
+    },
+    {
+      "code": 6075,
+      "name": "ReferrerAccountMintMissmatch",
+      "msg": "Referrer account mint does not match the operation reserve mint"
+    },
+    {
+      "code": 6076,
+      "name": "ReferrerAccountWrongAddress",
+      "msg": "Referrer account address is not a valid program address"
+    },
+    {
+      "code": 6077,
+      "name": "ReferrerAccountReferrerMissmatch",
+      "msg": "Referrer account referrer does not match the owner referrer"
+    },
+    {
+      "code": 6078,
+      "name": "ReferrerAccountMissing",
+      "msg": "Referrer account missing for obligation with referrer"
+    },
+    {
+      "code": 6079,
+      "name": "InsufficientReferralFeesToRedeem",
+      "msg": "Insufficient referral fees to claim or no liquidity available"
+    },
+    {
+      "code": 6080,
+      "name": "CpiDisabled",
+      "msg": "CPI disabled for this instruction"
+    },
+    {
+      "code": 6081,
+      "name": "ShortUrlNotAsciiAlphanumeric",
+      "msg": "Referrer short_url is not ascii alphanumeric"
+    },
+    {
+      "code": 6082,
+      "name": "ReserveObsolete",
+      "msg": "Reserve is marked as obsolete"
+    },
+    {
+      "code": 6083,
+      "name": "ElevationGroupAlreadyActivated",
+      "msg": "Obligation already part of the same elevation group"
+    }
+  ]
+}

--- a/projects/kamino-lending/scope-idl.json
+++ b/projects/kamino-lending/scope-idl.json
@@ -1,0 +1,1755 @@
+{
+  "version": "0.1.0",
+  "name": "scope",
+  "instructions": [
+    {
+      "name": "initialize",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "configuration",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "oraclePrices",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "oracleMappings",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "feedName",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "name": "refreshOnePrice",
+      "accounts": [
+        {
+          "name": "oraclePrices",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "oracleMappings",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "priceInfo",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "clock",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructionSysvarAccountInfo",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "token",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "refreshPriceList",
+      "accounts": [
+        {
+          "name": "oraclePrices",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "oracleMappings",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "clock",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "instructionSysvarAccountInfo",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "tokens",
+          "type": {
+            "vec": "u16"
+          }
+        }
+      ]
+    },
+    {
+      "name": "updateMapping",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "configuration",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "oracleMappings",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "priceInfo",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "token",
+          "type": "u64"
+        },
+        {
+          "name": "priceType",
+          "type": "u8"
+        },
+        {
+          "name": "feedName",
+          "type": "string"
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "WhirlpoolStrategy",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "adminAuthority",
+            "type": "publicKey"
+          },
+          {
+            "name": "globalConfig",
+            "type": "publicKey"
+          },
+          {
+            "name": "baseVaultAuthority",
+            "type": "publicKey"
+          },
+          {
+            "name": "baseVaultAuthorityBump",
+            "type": "u64"
+          },
+          {
+            "name": "pool",
+            "type": "publicKey"
+          },
+          {
+            "name": "poolTokenVaultA",
+            "type": "publicKey"
+          },
+          {
+            "name": "poolTokenVaultB",
+            "type": "publicKey"
+          },
+          {
+            "name": "tickArrayLower",
+            "type": "publicKey"
+          },
+          {
+            "name": "tickArrayUpper",
+            "type": "publicKey"
+          },
+          {
+            "name": "position",
+            "type": "publicKey"
+          },
+          {
+            "name": "positionMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "positionMetadata",
+            "type": "publicKey"
+          },
+          {
+            "name": "positionTokenAccount",
+            "type": "publicKey"
+          },
+          {
+            "name": "tokenAVault",
+            "type": "publicKey"
+          },
+          {
+            "name": "tokenBVault",
+            "type": "publicKey"
+          },
+          {
+            "name": "tokenAVaultAuthority",
+            "type": "publicKey"
+          },
+          {
+            "name": "tokenBVaultAuthority",
+            "type": "publicKey"
+          },
+          {
+            "name": "tokenAVaultAuthorityBump",
+            "type": "u64"
+          },
+          {
+            "name": "tokenBVaultAuthorityBump",
+            "type": "u64"
+          },
+          {
+            "name": "tokenAMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "tokenBMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "tokenAMintDecimals",
+            "type": "u64"
+          },
+          {
+            "name": "tokenBMintDecimals",
+            "type": "u64"
+          },
+          {
+            "name": "tokenAAmounts",
+            "type": "u64"
+          },
+          {
+            "name": "tokenBAmounts",
+            "type": "u64"
+          },
+          {
+            "name": "tokenACollateralId",
+            "type": "u64"
+          },
+          {
+            "name": "tokenBCollateralId",
+            "type": "u64"
+          },
+          {
+            "name": "scopePrices",
+            "type": "publicKey"
+          },
+          {
+            "name": "scopeProgram",
+            "type": "publicKey"
+          },
+          {
+            "name": "sharesMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "sharesMintDecimals",
+            "type": "u64"
+          },
+          {
+            "name": "sharesMintAuthority",
+            "type": "publicKey"
+          },
+          {
+            "name": "sharesMintAuthorityBump",
+            "type": "u64"
+          },
+          {
+            "name": "sharesIssued",
+            "type": "u64"
+          },
+          {
+            "name": "status",
+            "type": "u64"
+          },
+          {
+            "name": "reward0Amount",
+            "type": "u64"
+          },
+          {
+            "name": "reward0Vault",
+            "type": "publicKey"
+          },
+          {
+            "name": "reward0CollateralId",
+            "type": "u64"
+          },
+          {
+            "name": "reward0Decimals",
+            "type": "u64"
+          },
+          {
+            "name": "reward1Amount",
+            "type": "u64"
+          },
+          {
+            "name": "reward1Vault",
+            "type": "publicKey"
+          },
+          {
+            "name": "reward1CollateralId",
+            "type": "u64"
+          },
+          {
+            "name": "reward1Decimals",
+            "type": "u64"
+          },
+          {
+            "name": "reward2Amount",
+            "type": "u64"
+          },
+          {
+            "name": "reward2Vault",
+            "type": "publicKey"
+          },
+          {
+            "name": "reward2CollateralId",
+            "type": "u64"
+          },
+          {
+            "name": "reward2Decimals",
+            "type": "u64"
+          },
+          {
+            "name": "depositCapUsd",
+            "type": "u64"
+          },
+          {
+            "name": "feesACumulative",
+            "type": "u64"
+          },
+          {
+            "name": "feesBCumulative",
+            "type": "u64"
+          },
+          {
+            "name": "reward0AmountCumulative",
+            "type": "u64"
+          },
+          {
+            "name": "reward1AmountCumulative",
+            "type": "u64"
+          },
+          {
+            "name": "reward2AmountCumulative",
+            "type": "u64"
+          },
+          {
+            "name": "depositCapUsdPerIxn",
+            "type": "u64"
+          },
+          {
+            "name": "withdrawalCapA",
+            "type": {
+              "defined": "WithdrawalCaps"
+            }
+          },
+          {
+            "name": "withdrawalCapB",
+            "type": {
+              "defined": "WithdrawalCaps"
+            }
+          },
+          {
+            "name": "maxPriceDeviationBps",
+            "type": "u64"
+          },
+          {
+            "name": "swapVaultMaxSlippageBps",
+            "type": "u32"
+          },
+          {
+            "name": "swapVaultMaxSlippageFromReferenceBps",
+            "type": "u32"
+          },
+          {
+            "name": "strategyType",
+            "type": "u64"
+          },
+          {
+            "name": "depositFee",
+            "type": "u64"
+          },
+          {
+            "name": "withdrawFee",
+            "type": "u64"
+          },
+          {
+            "name": "feesFee",
+            "type": "u64"
+          },
+          {
+            "name": "reward0Fee",
+            "type": "u64"
+          },
+          {
+            "name": "reward1Fee",
+            "type": "u64"
+          },
+          {
+            "name": "reward2Fee",
+            "type": "u64"
+          },
+          {
+            "name": "positionTimestamp",
+            "type": "u64"
+          },
+          {
+            "name": "kaminoRewards",
+            "type": {
+              "array": [
+                {
+                  "defined": "KaminoRewardInfo"
+                },
+                3
+              ]
+            }
+          },
+          {
+            "name": "strategyDex",
+            "type": "u64"
+          },
+          {
+            "name": "raydiumProtocolPositionOrBaseVaultAuthority",
+            "type": "publicKey"
+          },
+          {
+            "name": "allowDepositWithoutInvest",
+            "type": "u64"
+          },
+          {
+            "name": "raydiumPoolConfigOrBaseVaultAuthority",
+            "type": "publicKey"
+          },
+          {
+            "name": "depositBlocked",
+            "type": "u8"
+          },
+          {
+            "name": "creationStatus",
+            "type": "u8"
+          },
+          {
+            "name": "investBlocked",
+            "type": "u8"
+          },
+          {
+            "name": "shareCalculationMethod",
+            "docs": [
+              "share_calculation_method can be either DOLAR_BASED=0 or PROPORTION_BASED=1"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "withdrawBlocked",
+            "type": "u8"
+          },
+          {
+            "name": "reservedFlag2",
+            "type": "u8"
+          },
+          {
+            "name": "localAdminBlocked",
+            "type": "u8"
+          },
+          {
+            "name": "flashVaultSwapAllowed",
+            "type": "u8"
+          },
+          {
+            "name": "referenceSwapPriceA",
+            "type": {
+              "defined": "KaminoPrice"
+            }
+          },
+          {
+            "name": "referenceSwapPriceB",
+            "type": {
+              "defined": "KaminoPrice"
+            }
+          },
+          {
+            "name": "isCommunity",
+            "type": "u8"
+          },
+          {
+            "name": "rebalanceType",
+            "type": "u8"
+          },
+          {
+            "name": "padding0",
+            "type": {
+              "array": [
+                "u8",
+                6
+              ]
+            }
+          },
+          {
+            "name": "rebalanceRaw",
+            "type": {
+              "defined": "RebalanceRaw"
+            }
+          },
+          {
+            "name": "padding1",
+            "type": {
+              "array": [
+                "u8",
+                7
+              ]
+            }
+          },
+          {
+            "name": "tokenAFeesFromRewardsCumulative",
+            "type": "u64"
+          },
+          {
+            "name": "tokenBFeesFromRewardsCumulative",
+            "type": "u64"
+          },
+          {
+            "name": "strategyLookupTable",
+            "type": "publicKey"
+          },
+          {
+            "name": "padding3",
+            "type": {
+              "array": [
+                "u128",
+                26
+              ]
+            }
+          },
+          {
+            "name": "padding4",
+            "type": {
+              "array": [
+                "u128",
+                32
+              ]
+            }
+          },
+          {
+            "name": "padding5",
+            "type": {
+              "array": [
+                "u128",
+                32
+              ]
+            }
+          },
+          {
+            "name": "padding6",
+            "type": {
+              "array": [
+                "u128",
+                32
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "GlobalConfig",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "emergencyMode",
+            "type": "u64"
+          },
+          {
+            "name": "blockDeposit",
+            "type": "u64"
+          },
+          {
+            "name": "blockInvest",
+            "type": "u64"
+          },
+          {
+            "name": "blockWithdraw",
+            "type": "u64"
+          },
+          {
+            "name": "blockCollectFees",
+            "type": "u64"
+          },
+          {
+            "name": "blockCollectRewards",
+            "type": "u64"
+          },
+          {
+            "name": "blockSwapRewards",
+            "type": "u64"
+          },
+          {
+            "name": "blockSwapUnevenVaults",
+            "type": "u32"
+          },
+          {
+            "name": "blockEmergencySwap",
+            "type": "u32"
+          },
+          {
+            "name": "feesBps",
+            "type": "u64"
+          },
+          {
+            "name": "scopeProgramId",
+            "type": "publicKey"
+          },
+          {
+            "name": "scopePriceId",
+            "type": "publicKey"
+          },
+          {
+            "name": "swapRewardsDiscountBps",
+            "type": {
+              "array": [
+                "u64",
+                256
+              ]
+            }
+          },
+          {
+            "name": "actionsAuthority",
+            "type": "publicKey"
+          },
+          {
+            "name": "adminAuthority",
+            "type": "publicKey"
+          },
+          {
+            "name": "treasuryFeeVaults",
+            "type": {
+              "array": [
+                "publicKey",
+                256
+              ]
+            }
+          },
+          {
+            "name": "tokenInfos",
+            "type": "publicKey"
+          },
+          {
+            "name": "blockLocalAdmin",
+            "type": "u64"
+          },
+          {
+            "name": "minPerformanceFeeBps",
+            "type": "u64"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u64",
+                2042
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "CollateralInfos",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "infos",
+            "type": {
+              "array": [
+                {
+                  "defined": "CollateralInfo"
+                },
+                256
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Whirlpool",
+      "docs": [
+        "External types"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "whirlpoolsConfig",
+            "type": "publicKey"
+          },
+          {
+            "name": "whirlpoolBump",
+            "type": {
+              "array": [
+                "u8",
+                1
+              ]
+            }
+          },
+          {
+            "name": "tickSpacing",
+            "type": "u16"
+          },
+          {
+            "name": "tickSpacingSeed",
+            "type": {
+              "array": [
+                "u8",
+                2
+              ]
+            }
+          },
+          {
+            "name": "feeRate",
+            "type": "u16"
+          },
+          {
+            "name": "protocolFeeRate",
+            "type": "u16"
+          },
+          {
+            "name": "liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "sqrtPrice",
+            "type": "u128"
+          },
+          {
+            "name": "tickCurrentIndex",
+            "type": "i32"
+          },
+          {
+            "name": "protocolFeeOwedA",
+            "type": "u64"
+          },
+          {
+            "name": "protocolFeeOwedB",
+            "type": "u64"
+          },
+          {
+            "name": "tokenMintA",
+            "type": "publicKey"
+          },
+          {
+            "name": "tokenVaultA",
+            "type": "publicKey"
+          },
+          {
+            "name": "feeGrowthGlobalA",
+            "type": "u128"
+          },
+          {
+            "name": "tokenMintB",
+            "type": "publicKey"
+          },
+          {
+            "name": "tokenVaultB",
+            "type": "publicKey"
+          },
+          {
+            "name": "feeGrowthGlobalB",
+            "type": "u128"
+          },
+          {
+            "name": "rewardLastUpdatedTimestamp",
+            "type": "u64"
+          },
+          {
+            "name": "rewardInfos",
+            "type": {
+              "array": [
+                {
+                  "defined": "WhirlpoolRewardInfo"
+                },
+                3
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Position",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "whirlpool",
+            "type": "publicKey"
+          },
+          {
+            "name": "positionMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "tickLowerIndex",
+            "type": "i32"
+          },
+          {
+            "name": "tickUpperIndex",
+            "type": "i32"
+          },
+          {
+            "name": "feeGrowthCheckpointA",
+            "type": "u128"
+          },
+          {
+            "name": "feeOwedA",
+            "type": "u64"
+          },
+          {
+            "name": "feeGrowthCheckpointB",
+            "type": "u128"
+          },
+          {
+            "name": "feeOwedB",
+            "type": "u64"
+          },
+          {
+            "name": "rewardInfos",
+            "type": {
+              "array": [
+                {
+                  "defined": "PositionRewardInfo"
+                },
+                3
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "TickArray",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "startTickIndex",
+            "type": "i32"
+          },
+          {
+            "name": "ticks",
+            "type": {
+              "array": [
+                {
+                  "defined": "Tick"
+                },
+                88
+              ]
+            }
+          },
+          {
+            "name": "whirlpool",
+            "type": "publicKey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OraclePrices",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "oracleMappings",
+            "type": "publicKey"
+          },
+          {
+            "name": "prices",
+            "type": {
+              "array": [
+                {
+                  "defined": "DatedPrice"
+                },
+                512
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "OracleMappings",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "priceInfoAccounts",
+            "type": {
+              "array": [
+                "publicKey",
+                512
+              ]
+            }
+          },
+          {
+            "name": "priceTypes",
+            "type": {
+              "array": [
+                "u8",
+                512
+              ]
+            }
+          },
+          {
+            "name": "reserved2",
+            "type": {
+              "array": [
+                "u64",
+                512
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Configuration",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "admin",
+            "type": "publicKey"
+          },
+          {
+            "name": "oracleMappings",
+            "type": "publicKey"
+          },
+          {
+            "name": "oraclePrices",
+            "type": "publicKey"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u64",
+                1267
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "types": [
+    {
+      "name": "RebalanceRaw",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "params",
+            "type": {
+              "array": [
+                "u8",
+                128
+              ]
+            }
+          },
+          {
+            "name": "state",
+            "type": {
+              "array": [
+                "u8",
+                256
+              ]
+            }
+          },
+          {
+            "name": "referencePriceType",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "KaminoRewardInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "decimals",
+            "type": "u64"
+          },
+          {
+            "name": "rewardVault",
+            "type": "publicKey"
+          },
+          {
+            "name": "rewardMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "rewardCollateralId",
+            "type": "u64"
+          },
+          {
+            "name": "lastIssuanceTs",
+            "type": "u64"
+          },
+          {
+            "name": "rewardPerSecond",
+            "type": "u64"
+          },
+          {
+            "name": "amountUncollected",
+            "type": "u64"
+          },
+          {
+            "name": "amountIssuedCumulative",
+            "type": "u64"
+          },
+          {
+            "name": "amountAvailable",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CollateralInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "mint",
+            "type": "publicKey"
+          },
+          {
+            "name": "lowerHeuristic",
+            "type": "u64"
+          },
+          {
+            "name": "upperHeuristic",
+            "type": "u64"
+          },
+          {
+            "name": "expHeuristic",
+            "type": "u64"
+          },
+          {
+            "name": "maxTwapDivergenceBps",
+            "type": "u64"
+          },
+          {
+            "name": "scopePriceIdTwap",
+            "type": "u64"
+          },
+          {
+            "name": "scopePriceChain",
+            "type": {
+              "array": [
+                "u16",
+                4
+              ]
+            }
+          },
+          {
+            "name": "name",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "maxAgePriceSeconds",
+            "type": "u64"
+          },
+          {
+            "name": "maxAgeTwapSeconds",
+            "type": "u64"
+          },
+          {
+            "name": "maxIgnorableAmountAsReward",
+            "type": "u64"
+          },
+          {
+            "name": "disabled",
+            "type": "u8"
+          },
+          {
+            "name": "padding0",
+            "type": {
+              "array": [
+                "u8",
+                7
+              ]
+            }
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u64",
+                9
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "KaminoPrice",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "value",
+            "type": "u64"
+          },
+          {
+            "name": "exp",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "WithdrawalCaps",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "configCapacity",
+            "type": "i64"
+          },
+          {
+            "name": "currentTotal",
+            "type": "i64"
+          },
+          {
+            "name": "lastIntervalStartTimestamp",
+            "type": "u64"
+          },
+          {
+            "name": "configIntervalLengthSeconds",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PositionRewardInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "growthInsideCheckpoint",
+            "type": "u128"
+          },
+          {
+            "name": "amountOwed",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "WhirlpoolRewardInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "mint",
+            "docs": [
+              "Reward token mint."
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "vault",
+            "docs": [
+              "Reward vault token account."
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "authority",
+            "docs": [
+              "Authority account that has permission to initialize the reward and set emissions."
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "emissionsPerSecondX64",
+            "docs": [
+              "Q64.64 number that indicates how many tokens per second are earned per unit of liquidity."
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "growthGlobalX64",
+            "docs": [
+              "Q64.64 number that tracks the total tokens earned per unit of liquidity since the reward",
+              "emissions were turned on."
+            ],
+            "type": "u128"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Tick",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "initialized",
+            "type": "bool"
+          },
+          {
+            "name": "liquidityNet",
+            "type": "i128"
+          },
+          {
+            "name": "liquidityGross",
+            "type": "u128"
+          },
+          {
+            "name": "feeGrowthOutsideA",
+            "type": "u128"
+          },
+          {
+            "name": "feeGrowthOutsideB",
+            "type": "u128"
+          },
+          {
+            "name": "rewardGrowthsOutside",
+            "type": {
+              "array": [
+                "u128",
+                3
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "SwitchboardDecimal",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "mantissa",
+            "type": "i128"
+          },
+          {
+            "name": "scale",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AggregatorAccountData",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "name",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "metadata",
+            "type": {
+              "array": [
+                "u8",
+                128
+              ]
+            }
+          },
+          {
+            "name": "authorWallet",
+            "type": "publicKey"
+          },
+          {
+            "name": "queuePubkey",
+            "type": "publicKey"
+          },
+          {
+            "name": "oracleRequestBatchSize",
+            "type": "u32"
+          },
+          {
+            "name": "minOracleResults",
+            "type": "u32"
+          },
+          {
+            "name": "minJobResults",
+            "type": "u32"
+          },
+          {
+            "name": "minUpdateDelaySeconds",
+            "type": "u32"
+          },
+          {
+            "name": "startAfter",
+            "type": "i64"
+          },
+          {
+            "name": "varianceThreshold",
+            "type": {
+              "defined": "SwitchboardDecimal"
+            }
+          },
+          {
+            "name": "forceReportPeriod",
+            "type": "i64"
+          },
+          {
+            "name": "expiration",
+            "type": "i64"
+          },
+          {
+            "name": "consecutiveFailureCount",
+            "type": "u64"
+          },
+          {
+            "name": "nextAllowedUpdateTime",
+            "type": "i64"
+          },
+          {
+            "name": "isLocked",
+            "type": "bool"
+          },
+          {
+            "name": "schedule",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "latestConfirmedRound",
+            "type": {
+              "defined": "AggregatorRound"
+            }
+          },
+          {
+            "name": "currentRound",
+            "type": {
+              "defined": "AggregatorRound"
+            }
+          },
+          {
+            "name": "jobPubkeysData",
+            "type": {
+              "array": [
+                "publicKey",
+                16
+              ]
+            }
+          },
+          {
+            "name": "jobHashes",
+            "type": {
+              "array": [
+                {
+                  "defined": "Hash"
+                },
+                16
+              ]
+            }
+          },
+          {
+            "name": "jobPubkeysSize",
+            "type": "u32"
+          },
+          {
+            "name": "jobsChecksum",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "authority",
+            "type": "publicKey"
+          },
+          {
+            "name": "ebuf",
+            "type": {
+              "array": [
+                "u8",
+                224
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "AggregatorRound",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "numSuccess",
+            "type": "u32"
+          },
+          {
+            "name": "numError",
+            "type": "u32"
+          },
+          {
+            "name": "isClosed",
+            "type": "bool"
+          },
+          {
+            "name": "roundOpenSlot",
+            "type": "u64"
+          },
+          {
+            "name": "roundOpenTimestamp",
+            "type": "i64"
+          },
+          {
+            "name": "result",
+            "type": {
+              "defined": "SwitchboardDecimal"
+            }
+          },
+          {
+            "name": "stdDeviation",
+            "type": {
+              "defined": "SwitchboardDecimal"
+            }
+          },
+          {
+            "name": "minResponse",
+            "type": {
+              "defined": "SwitchboardDecimal"
+            }
+          },
+          {
+            "name": "maxResponse",
+            "type": {
+              "defined": "SwitchboardDecimal"
+            }
+          },
+          {
+            "name": "oraclePubkeysData",
+            "type": {
+              "array": [
+                "publicKey",
+                16
+              ]
+            }
+          },
+          {
+            "name": "mediansData",
+            "type": {
+              "array": [
+                {
+                  "defined": "SwitchboardDecimal"
+                },
+                16
+              ]
+            }
+          },
+          {
+            "name": "currentPayout",
+            "type": {
+              "array": [
+                "i64",
+                16
+              ]
+            }
+          },
+          {
+            "name": "mediansFulfilled",
+            "type": {
+              "array": [
+                "bool",
+                16
+              ]
+            }
+          },
+          {
+            "name": "errorsFulfilled",
+            "type": {
+              "array": [
+                "bool",
+                16
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Hash",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "data",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Price",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "value",
+            "type": "u64"
+          },
+          {
+            "name": "exp",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DatedPrice",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "price",
+            "type": {
+              "defined": "Price"
+            }
+          },
+          {
+            "name": "lastUpdatedSlot",
+            "type": "u64"
+          },
+          {
+            "name": "unixTimestamp",
+            "type": "u64"
+          },
+          {
+            "name": "reserved",
+            "type": {
+              "array": [
+                "u64",
+                2
+              ]
+            }
+          },
+          {
+            "name": "reserved2",
+            "type": {
+              "array": [
+                "u16",
+                3
+              ]
+            }
+          },
+          {
+            "name": "index",
+            "type": "u16"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OracleType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Pyth"
+          },
+          {
+            "name": "SwitchboardV1"
+          },
+          {
+            "name": "SwitchboardV2"
+          },
+          {
+            "name": "DeprecatedPlaceholder"
+          },
+          {
+            "name": "CToken"
+          },
+          {
+            "name": "SplStake"
+          },
+          {
+            "name": "KToken"
+          },
+          {
+            "name": "PythEMA"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ScopeChainError",
+      "docs": [
+        "Errors that can be raised while creating or manipulating a scope chain"
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "PriceChainTooLong"
+          },
+          {
+            "name": "PriceChainConversionFailure"
+          },
+          {
+            "name": "NoChainForToken"
+          },
+          {
+            "name": "InvalidPricesInChain"
+          },
+          {
+            "name": "MathOverflow"
+          },
+          {
+            "name": "IntegerConversionOverflow"
+          }
+        ]
+      }
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "IntegerOverflow",
+      "msg": "Integer overflow"
+    },
+    {
+      "code": 6001,
+      "name": "ConversionFailure",
+      "msg": "Conversion failure"
+    },
+    {
+      "code": 6002,
+      "name": "MathOverflow",
+      "msg": "Mathematical operation with overflow"
+    },
+    {
+      "code": 6003,
+      "name": "OutOfRangeIntegralConversion",
+      "msg": "Out of range integral conversion attempted"
+    },
+    {
+      "code": 6004,
+      "name": "UnexpectedAccount",
+      "msg": "Unexpected account in instruction"
+    },
+    {
+      "code": 6005,
+      "name": "PriceNotValid",
+      "msg": "Price is not valid"
+    },
+    {
+      "code": 6006,
+      "name": "AccountsAndTokenMismatch",
+      "msg": "The number of tokens is different from the number of received accounts"
+    },
+    {
+      "code": 6007,
+      "name": "BadTokenNb",
+      "msg": "The token index received is out of range"
+    },
+    {
+      "code": 6008,
+      "name": "BadTokenType",
+      "msg": "The token type received is invalid"
+    },
+    {
+      "code": 6009,
+      "name": "SwitchboardV2Error",
+      "msg": "There was an error with the Switchboard V2 retrieval"
+    },
+    {
+      "code": 6010,
+      "name": "InvalidAccountDiscriminator",
+      "msg": "Invalid account discriminator"
+    },
+    {
+      "code": 6011,
+      "name": "UnableToDeserializeAccount",
+      "msg": "Unable to deserialize account"
+    },
+    {
+      "code": 6012,
+      "name": "BadScopeChainOrPrices",
+      "msg": "Error while computing price with ScopeChain"
+    },
+    {
+      "code": 6013,
+      "name": "RefreshInCPI",
+      "msg": "Refresh price instruction called in a CPI"
+    },
+    {
+      "code": 6014,
+      "name": "RefreshWithUnexpectedIxs",
+      "msg": "Refresh price instruction preceded by unexpected ixs"
+    }
+  ]
+}


### PR DESCRIPTION
1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Please enable "Allow edits by maintainers" while putting up the PR.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. Please fill the form below  **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
5. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can  edit it there and put up a PR
6. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
7. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap

---
Kamino Lend should be listed as a new protocol but should be part of Kamino (which already exists on DefiLlama). Please make it similar to how Frax (https://defillama.com/protocol/frax) works, where you have multiple Frax protocols on the same page and accessible via the tab view.

##### Name (to be shown on DefiLlama):
Kamino Lend

##### Twitter Link:
https://twitter.com/kamino_finance

##### List of audit links if any:
https://github.com/hubbleprotocol/kamino-audits

##### Website Link:
https://kamino.finance/

##### Logo (High resolution, will be shown with rounded borders):
please use the same logo that is currently used for Kamino

##### Current TVL:
$342k

##### Treasury Addresses (if the protocol has treasury)


##### Chain:
Solana

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description (to be shown on DefiLlama):
Kamino Lend (K-Lend) is a novel peer-to-pool borrowing primitive designed as foundational infrastructure to power complex financial products with leverage and automation and as a decentralized matchmaker between borrowers and lenders.

##### Token address and ticker if any:


##### Category (full list at https://defillama.com/categories) *Please choose only one:
Lending

##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):
Scope, Pyth, Switchboard

##### forkedFrom (Does your project originate from another project):


##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL consists of deposits made to the protocol, borrowed tokens are not counted.

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/hubbleprotocol

---
### Notes about this PR:
- we use Anchor 0.26.0 which has new features (like enums), that's why I bumped the package.json version to 0.26.0:
  `"@project-serum/anchor": "^0.26.0",`
- your API currently doesn't support kTokens (Kamino tokens used by the main Kamino program, which are also available in Kamino Lending for borrows/deposits) which meant I would get this message when testing out the adapter:
```
Balance table for [solana] Unrecognized tokens
┌─────────┬──────┬────────┬─────────────────┬───────────────────────────────────────────────────────┬───────────┐
│ (index) │ name │ symbol │     balance     │                         label                         │ decimals  │
├─────────┼──────┼────────┼─────────────────┼───────────────────────────────────────────────────────┼───────────┤
│    0    │ '-'  │  '-'   │  '18491562800'  │ 'solana:9HB4kAMLSYfGFfN142DKMyPyHyZQ8pXF8M1STbDudodY' │ undefined │
│    1    │ '-'  │  '-'   │ '4948136636667' │ 'solana:GYiUmJ8reqYAdTQtx6CRFawHqPXx9yzkUFvaUVE8PskP' │ undefined │
│    2    │ '-'  │  '-'   │  '6269646393'   │ 'solana:4G9USgnbg6fDTQ5AUfpCjM89zqbzWj32xfqvsaAu66DM' │ undefined │
│    3    │ '-'  │  '-'   │ '763617741702'  │ 'solana:Dk2X1HCbwJae44P7FpqdFoeT6LEw4JVyyHvZMHUzHWbi' │ undefined │
│    4    │ '-'  │  '-'   │   '385000484'   │ 'solana:3Fb5DMRWoBLWD36Lp4BtG41LaFjVeEJNCH9YLNPYdVqj' │ undefined │
└─────────┴──────┴────────┴─────────────────┴───────────────────────────────────────────────────────┴───────────┘
```
This meant the TVL of kTokens would not get counted. To counter this I've added a function that checks if a reserve contains kTokens and uses our own internal price Oracle for those only. Since I could not add those to the token balances, I've added them as 'tether' so they get counted towards the total TVL number. Let me know if we can change this, maybe you can integrate the kToken oracle as well.