### PR TITLE
fixes injective endpoint

### DIFF
--- a/projects/helper/chain/cosmos.js
+++ b/projects/helper/chain/cosmos.js
@@ -27,7 +27,7 @@ const endPoints = {
   persistence: "https://rest.cosmos.directory/persistence",
   secret: "https://lcd.secret.express",
   // chihuahua: "https://api.chihuahua.wtf",
-  injective: "https://lcd-injective.whispernode.com:443",
+  injective: "https://sentry.lcd.injective.network:443",
   migaloo: "https://migaloo-api.polkachu.com",
   fxcore: "https://fx-rest.functionx.io",
   xpla: "https://dimension-lcd.xpla.dev",


### PR DESCRIPTION
Currently the old injective endpoint has a cloudflare 502 error, so replaced with the official lcd endpoint