### PR TITLE
fix: remove bonded CACAO from MAYAChain staking tvl

### DIFF
--- a/projects/mayachain/index.js
+++ b/projects/mayachain/index.js
@@ -94,21 +94,12 @@ async function tvl(_, _1, _2, { api }) {
   }
 }
 
-async function staking() {
-  var res = await get("https://midgard.mayachain.info/v2/network");
-  const { totalActiveBond, totalStandbyBond } = res.bondMetrics;
-  return {
-    cacao: (Number(totalActiveBond) + Number(totalStandbyBond)) / 1e10,
-  };
-}
-
 module.exports = {
   timetravel: false,
   methodology:
-    "Counts bonded CACAO on Mayachain + assets locked in Asgard vaults on other chains + CACAO in LPs on Mayachain",
+    "Counts assets locked in Asgard vaults on other chains + CACAO in LPs on Mayachain",
   mayachain: {
     tvl,
-    staking,
   },
 };
 


### PR DESCRIPTION
This PR fixes a double counting issue with MAYAChain TVL due to a difference to THORChain between how bonded CACAO is treated.

THORChain stakers can bond the native asset RUNE where it is locked in a specific address (counted in staking).
Users can also LP with RUNE, where RUNE is stored within the Asgard vault (essentially the LP pool) and this is counted in TVL.

MAYAChain differs in that stakers will bond CACAO + ETH/BTC/KUJI/USK LPs instead of solo CACAO. The LP is stored in the Asgard vault along with the non-bonded LPs.

Hence, the current methodology of counting CACAO in the Asgard vault + bonded CACAO is incorrect as all bonded CACAO is in the Asgard vault.

This fix will remove the additional staking TVL and only count the TVL as it currently stands (around $42m which matches https://www.mayascan.org/pools)