### PR TITLE
[Fix] Perennial V2 TVL

### DIFF
--- a/projects/perennial-v2/index.js
+++ b/projects/perennial-v2/index.js
@@ -1,21 +1,27 @@
-const { getLogs } = require('../helper/cache/getLogs')
+const { getLogs } = require('../helper/cache/getLogs');
 
 const config = {
-  arbitrum: { factory: '0xad3565680aecee27a39249d8c2d55dac79be5ad0', fromBlock: 135921947 },
-}
+  arbitrum: {
+    dsu: '0x52c64b8998eb7c80b6f526e99e29abdcc86b841b',
+    factory: '0xDaD8A103473dfd47F90168A0E46766ed48e26EC7',
+    fromBlock: 135921706,
+  },
+};
 
-Object.keys(config).forEach(chain => {
-  const { factory, fromBlock, } = config[chain]
+Object.keys(config).forEach((chain) => {
+  const { factory, fromBlock, dsu } = config[chain];
   module.exports[chain] = {
-    tvl: async (_, _b, _cb, { api, }) => {
+    tvl: async (_, _b, _cb, { api }) => {
       const logs = await getLogs({
         api,
         target: factory,
-        eventAbi: 'event VaultCreated (address indexed vault, address indexed asset, address initialMarket)',
+        eventAbi: 'event InstanceRegistered (address indexed instance)',
         onlyArgs: true,
         fromBlock,
-      })
-      return api.sumTokens({ tokensAndOwners: logs.map(log => [log.asset, log.initialMarket])})
-    }
-  }
-})
+      });
+      return api.sumTokens({
+        tokensAndOwners: logs.map((log) => [dsu, log.instance]),
+      });
+    },
+  };
+});


### PR DESCRIPTION
Fixes the Perennial V2 TVL aggregation. Instead of looking at the Vault events, it looks at the `MarketFactory.InstanceRegistered` event (topic[0] = `0x4fe45192317a7d3ad19c3eaa395c0c3a1b7a0f53c3536fb96764c3561a8e9dad`). This gives us a list of all Markets, each of which holds the DSU collateral for the given market.