### PR TITLE
feat: :sparkles: Delete staking key in hatom protocol to avoid double…

### DIFF
--- a/projects/hatom-lending/index.js
+++ b/projects/hatom-lending/index.js
@@ -35,18 +35,10 @@ const borrowed = async (_, _1, _2, { api }) => {
   api.addTokens(tokens, bals)
 };
 
-const staking = async (_, _1, _2, { api }) => {
-  const hatomBooster = 'erd1qqqqqqqqqqqqqpgqw4dsh8j9xafw45uwr2f6a48ajvcqey8s78sstvn7xd'
-  const bals = await call({ target: hatomBooster, abi: 'getTotalStake', responseTypes: ['number'] })
-  api.add(hatom, bals.toString())
-  return api.getBalances()
-};
-
 module.exports = {
   timetravel: false,
   elrond: {
     tvl,
     borrowed,
-    staking,
   },
 };


### PR DESCRIPTION
In the latest update, I introduced a sub-listing under hatom-protocol named `hatom-booster.` Prior to this, @g1nt0ki had implemented a staking feature in `hatom-lending`. However, this has now become problematic as it leads to double counting. 

The things deleted in this PR are here now. #8196 

Thanks