### PR TITLE
fix: `deepbook-sui` tvl

### DIFF
--- a/projects/deepbook-sui/index.js
+++ b/projects/deepbook-sui/index.js
@@ -1,10 +1,9 @@
 const { toUSDTBalances } = require("../helper/balances");
 const { get } = require("../helper/http");
-const axios = require("axios");
 
 async function tvl(ts) {
-  const { data } = await axios.get(
-    "https://kx58j6x5me.execute-api.us-east-1.amazonaws.com/sui/deepbook?interval=hour&timeFrame=all&dataType=tvl"
+  const data = await get(
+    "https://kx58j6x5me.execute-api.us-east-1.amazonaws.com/sui/deepbook?interval=day&timeFrame=all&dataType=tvl"
   );
   return toUSDTBalances(findClosestTvl(data, ts));
 }
@@ -29,17 +28,12 @@ function findClosestTvl(data, ts) {
 
   let aggregatedTvl = {};
   data.forEach((item) => {
-    if (!aggregatedTvl[item.alias]) {
-      aggregatedTvl[item.alias] = 0;
-    }
-    aggregatedTvl[item.alias] += item.value;
+    // there should be no duplicate alias, if they are, the latest one will be used
+    aggregatedTvl[item.alias] = item.value;
   });
 
   // Sum all unique values together
-  let totalTvl = Object.values(aggregatedTvl).reduce(
-    (acc, current) => acc + current,
-    0
-  );
+  let totalTvl = Object.values(aggregatedTvl).reduce((acc, current) => acc + current, 0);
 
   return totalTvl;
 }

--- a/projects/deepbook-sui/index.js
+++ b/projects/deepbook-sui/index.js
@@ -1,23 +1,45 @@
-const { toUSDTBalances } = require('../helper/balances')
-const { get } = require('../helper/http')
+const { toUSDTBalances } = require("../helper/balances");
+const { get } = require("../helper/http");
+const axios = require("axios");
 
 async function tvl(ts) {
-  const {data} = await get('https://49490zsfv2.execute-api.us-east-1.amazonaws.com/sui/deepbook?interval=hour&timeFrame=1&dataType=tvl')
-  return toUSDTBalances(findClosestTvl(data, ts)) 
+  const { data } = await axios.get(
+    "https://kx58j6x5me.execute-api.us-east-1.amazonaws.com/sui/deepbook?interval=hour&timeFrame=all&dataType=tvl"
+  );
+  return toUSDTBalances(findClosestTvl(data, ts));
 }
 
 module.exports = {
   timetravel: false,
   misrepresentedTokens: true,
   sui: {
-    tvl
-  }
-}
+    tvl,
+  },
+};
 
 function findClosestTvl(data, ts) {
-  ts = ts * 1000
-  data.forEach(i => i.ts = new Date(i.timestamp))
-  data = data.filter(i => i.ts < ts && (ts -i.ts) < 86400000) // filter for recent tvl but less than day old
-  data.sort((a, b) => b.ts - a.ts)
-  return data[0].tvl
+  ts = ts * 1000; // Convert to milliseconds
+  // Parsing the date string to a Date object
+  data.forEach((i) => {
+    i.ts = new Date(i.date);
+  });
+
+  // Filtering data less than a day old and before timestamp ts
+  data = data.filter((i) => i.ts < ts && ts - i.ts < 86400000);
+
+  let aggregatedTvl = {};
+  data.forEach((item) => {
+    if (!aggregatedTvl[item.alias]) {
+      aggregatedTvl[item.alias] = 0;
+    }
+    aggregatedTvl[item.alias] += item.value;
+  });
+
+  // Sum all unique values together
+  let totalTvl = Object.values(aggregatedTvl).reduce(
+    (acc, current) => acc + current,
+    0
+  );
+
+  return totalTvl;
 }


### PR DESCRIPTION
- Updates the `deepbook-sui` project's tvl
- Updated endpoint that is utilised for tvl calculation is: `https://kx58j6x5me.execute-api.us-east-1.amazonaws.com/sui/deepbook?interval=hour&timeFrame=all&dataType=tvl`