### PR TITLE
Added Juicebox terminal V3.1.1 and V3.1.2

### DIFF
--- a/projects/juicebox-v3/index.js
+++ b/projects/juicebox-v3/index.js
@@ -4,6 +4,8 @@ const { sumTokens2 } = require('../helper/unwrapLPs')
 // V3 Juicebox Terminals
 const Terminal_V3 = "0x594Cb208b5BB48db1bcbC9354d1694998864ec63";
 const Terminal_V3_1 = "0xFA391De95Fcbcd3157268B91d8c7af083E607A5C";
+const Terminal_V3_1_1 = "0x457cD63bee88ac01f3cD4a67D5DCc921D8C0D573";
+const Terminal_V3_1_2 = "0x1d9619E10086FdC1065B114298384aAe3F680CC0";
 // Tokens
 const ETH = ADDRESSES.null
 
@@ -18,6 +20,8 @@ module.exports = {
       tokensAndOwners: [
         [ETH, Terminal_V3],
         [ETH, Terminal_V3_1],
+        [ETH, Terminal_V3_1_1],
+        [ETH, Terminal_V3_1_2],
       ]
     })
   }


### PR DESCRIPTION
This PR adds two terminal versions for the Juicebox V3 protocol, [these addresses can be found here](https://docs.juicebox.money/dev/resources/addresses/#ethereum-mainnet). 