### PR TITLE
add Lynex V1 pool adapter

### DIFF
--- a/projects/lynex-v1/index.js
+++ b/projects/lynex-v1/index.js
@@ -1,0 +1,10 @@
+const { uniTvlExport } = require("../helper/unknownTokens");
+
+module.exports = uniTvlExport(
+  "linea",
+  "0x6ed7b91c8133e85921f8028b51a8248488b3336c",
+  {
+    hasStablePools: true,
+    useDefaultCoreAssets: true,
+  }
+);

--- a/projects/lynex/index.js
+++ b/projects/lynex/index.js
@@ -1,5 +1,9 @@
 const { uniV3Export } = require("../helper/uniswapV3");
 
 module.exports = uniV3Export({
-  linea: { factory: "0x622b2c98123D303ae067DB4925CD6282B3A08D0F", fromBlock: 143660, isAlgebra: true, },
+  linea: {
+    factory: "0x622b2c98123D303ae067DB4925CD6282B3A08D0F",
+    fromBlock: 143660,
+    isAlgebra: true,
+  },
 });


### PR DESCRIPTION
**NOTE**

> - If you would like to add a `volume` adapter please submit the PR [here](https://github.com/DefiLlama/adapters).
> - If you would like to add a `liquidations` adapter, please refer to [this readme document](https://github.com/DefiLlama/DefiLlama-Adapters/tree/main/liquidations) for details.

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Please enable "Allow edits by maintainers" while putting up the PR.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. Please fill the form below  **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
5. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can  edit it there and put up a PR
6. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
7. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap

---
Hi Team, we just added V1 (UniV2 permissionless liquidity pools) to Lynex. I hope this tracks the liquidity correctly. Our V1 analytics page for reference: https://app.lynex.fi/analytics/v1

Thanks,

Krugo