### PR TITLE
Add Ethereum wallet

### DIFF
--- a/projects/swissborg/index.js
+++ b/projects/swissborg/index.js
@@ -13,6 +13,7 @@ const config = {
       '0x7153D2ef9F14a6b1Bb2Ed822745f65E58d836C3F',
       '0xff4606bd3884554cdbdabd9b6e25e2fad4f6fc54',
       '0x22bF0A4C4eff418b3306AbFeE20813D0b6E8Dc74',
+      '0x11444C6389A26C8E41d7FD5CafBfCC511303b7d3',
     ],
   },
   bitcoin: {


### PR DESCRIPTION
This PR updates the list of wallets owned by SwissBorg. New wallet addition: https://github.com/SwissBorg/pub/commit/1ab5ebcd5ae9525c4c73298ee439ca4d78e00216