### PR TITLE
feat(button-wrappers): updating sdk-adapter to track new instances of button-token factory

### DIFF
--- a/projects/buttonwood-button-wrappers/index.js
+++ b/projects/buttonwood-button-wrappers/index.js
@@ -3,39 +3,54 @@ const { sumTokens2 } = require('../helper/unwrapLPs')
 
 const config = {
   ethereum: {
-    buttonTokenFactory: "0x84D0F1Cd873122F2A87673e079ea69cd80b51960",
-    unbuttonTokenFactory: "0x75ff649d6119fab43dea5e5e9e02586f27fc8b8f",
+    buttonTokenFactories: [
+      "0x84D0F1Cd873122F2A87673e079ea69cd80b51960",
+      "0x65bC95AC790F8afd47Fc9b83640Bf722a73BC021",
+    ],
+    unbuttonTokenFactories: [
+      "0x75ff649d6119fab43dea5e5e9e02586f27fc8b8f",
+    ],
     fromBlock: 14611058
   },
   avax: {
-    buttonTokenFactory: "0x033D23c8371354BF1110001386E97298F48Fc0a9",
+    buttonTokenFactories: [
+      "0x033D23c8371354BF1110001386E97298F48Fc0a9",
+    ],
     fromBlock: 35710946
   },
   base: {
-    buttonTokenFactory: "0x5f51466C781E74C53c043F441E700d3Bb80373E1",
+    buttonTokenFactories: [
+      "0x5f51466C781E74C53c043F441E700d3Bb80373E1",
+    ],
     fromBlock: 3839432
   },
 }
 
 Object.keys(config).forEach(chain => {
-  const { buttonTokenFactory, unbuttonTokenFactory } = config[chain];
+  const { buttonTokenFactories, unbuttonTokenFactories } = config[chain];
   module.exports[chain] = {
     tvl: async (_, _b, _cb, { api, }) => {
 
-      // Get buttton-token count
-      const buttonTokenCount = buttonTokenFactory ? await api.call({ abi: abi.instanceCount, target: buttonTokenFactory }) : 0;
-
-      // Get unbutton-token count
-      const unbuttonTokenCount = unbuttonTokenFactory ? await api.call({ abi: abi.instanceCount, target: unbuttonTokenFactory }) : 0;
-
       // Collecting all the wrapper tokens
       const calls = [];
-      for (let i = 0; i < buttonTokenCount; i++) {
-        calls.push({ target: buttonTokenFactory, params: i });
+
+      // Add all the button tokens to calls array
+      for (const buttonTokenFactory of buttonTokenFactories || []) {
+        const buttonTokenCount = await api.call({ abi: abi.instanceCount, target: buttonTokenFactory });
+        for (let i = 0; i < buttonTokenCount; i++) {
+          calls.push({ target: buttonTokenFactory, params: i });
+        }
       }
-      for (let i = 0; i < unbuttonTokenCount; i++) {
-        calls.push({ target: unbuttonTokenFactory, params: i });
+
+      // Add all the unbutton tokens to calls array
+      for (const unbuttonTokenFactory of unbuttonTokenFactories || []) {
+        const unbuttonTokenCount = await api.call({ abi: abi.instanceCount, target: unbuttonTokenFactory });
+        for (let i = 0; i < unbuttonTokenCount; i++) {
+          calls.push({ target: unbuttonTokenFactory, params: i });
+        }
       }
+
+      // Fetching the wrapper token instances
       const wrapperTokens = await api.multiCall({ abi: abi.instanceAt, calls });
 
       // Fetching the underlying of each wrapper token


### PR DESCRIPTION
**NOTE**

> - If you would like to add a `volume` adapter please submit the PR [here](https://github.com/DefiLlama/adapters).
> - If you would like to add a `liquidations` adapter, please refer to [this readme document](https://github.com/DefiLlama/DefiLlama-Adapters/tree/main/liquidations) for details.

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Please enable "Allow edits by maintainers" while putting up the PR.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. Please fill the form below  **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
5. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can  edit it there and put up a PR
6. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
7. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap

---

Updating the adapter for button-wrappers to enable tracking for multiple button-token factories. A new one was deployed to enable support for rebasing to different base values (before they only supported rebasing to 1 USD, now LSTs can rebase to 1 ETH or 1 AVAX).