### PR TITLE
updating enosys bridge and farms

### DIFF
--- a/projects/enosys-bridge/index.js
+++ b/projects/enosys-bridge/index.js
@@ -6,7 +6,10 @@ module.exports = {
   ethereum: { tvl: sumTokensExport({
       tokensAndOwners: [
       [ADDRESSES.ethereum.USDT,'0x8936761f2903ed1af2b269e6fa3a79ebb0162c51'],
-      [ADDRESSES.ethereum.USDT, '0x37aca97a99d1b4260a5e9821d0ef14947fb68970']
+      [ADDRESSES.ethereum.WETH,'0x8936761f2903ed1af2b269e6fa3a79ebb0162c51'],
+      [ADDRESSES.ethereum.USDT, '0x37aca97a99d1b4260a5e9821d0ef14947fb68970'],
+      [ADDRESSES.ethereum.WETH, '0x37aca97a99d1b4260a5e9821d0ef14947fb68970'],
+      ['0x4a220e6096b25eadb88358cb44068a3248254675', '0x37aca97a99d1b4260a5e9821d0ef14947fb68970'],
       ],
       logCalls: true
     }) 

--- a/projects/flarefarm/flare.js
+++ b/projects/flarefarm/flare.js
@@ -15,6 +15,8 @@ const LPs ={
   eUSDT_APS_LP:	'0x980Db8443D19B64B1d4616980ebbD44e7DD30C2E',
   HLN_eETH_LP:	'0x71b738DB182C780E2FFA5A09b5cc6dB92556E27B',
   eETH_APS_LP:	'0x05B623fd361109D0e47169eBa9e0514c80c40409',
+  WFLR_eQNT_LP:	'0x80A08BbAbB0A5C51A9ae53211Df09EF23Debd4f3',
+  HLN_eQNT_LP:	'0xEd920325b7dB1e909DbE2d562fCD07f714395e10',
 }
 
 const chain = 'flare'
@@ -34,6 +36,8 @@ async function farmTvl(timestamp, ethblock, { [chain]: block }) {
     [LPs.eUSDT_APS_LP, "0x437a586B04e8F0ed9E32d31aE897eaDEd8150Aea"], 
     [LPs.HLN_eETH_LP, "0x71b738DB182C780E2FFA5A09b5cc6dB92556E27B"], 
     [LPs.eETH_APS_LP, "0x05B623fd361109D0e47169eBa9e0514c80c40409"], 
+    [LPs.WFLR_eQNT_LP, "0xc786B4a2F9c314743Ed713184e5c94c244fF6c8D"], 
+    [LPs.HLN_eQNT_LP, "0x02321f8030208de54dBd3e2DbdEfbd07cc88Ad6D"], 
   ];
 
   return sumUnknownTokens({ tokensAndOwners: tokens, chain, block, useDefaultCoreAssets: true, })


### PR DESCRIPTION
Adding newest farms and updating bridged tokens. The bridged token `QNT` could be added to the `ADDRESSES.ethereum` object if desired, didnt want to do this myself though