### PR TITLE
chore: added base `aftermath-fi-aggregator` adapter.

### DIFF
--- a/projects/aftermath-fi-aggregator/index.ts
+++ b/projects/aftermath-fi-aggregator/index.ts
@@ -1,0 +1,14 @@
+async function suiTVL() {
+    return {
+        sui: 0,
+    }
+}
+
+module.exports = {
+    timetravel: true,
+    misrepresentedTokens: false,
+    methodology: "The total value locked within Aftermath's Aggregator.",
+    sui: {
+        tvl: suiTVL,
+    }
+}


### PR DESCRIPTION
This adapter always reports 0 TVL for the Aftermath Aggregator. I am using this PR to get our aggregator listed underneath Aftermath Finance [here](https://defillama.com/chain/Sui) with our volume adapter connected [[GitHub Link](https://github.com/DefiLlama/dimension-adapters/tree/master/aggregators/aftermath-aggregator)] [[DefiLlama Link](https://defillama.com/aggregators/aftermath-finance)]