### PR TITLE
Updates with XDC Network | XSwap Protocol

### DIFF
--- a/projects/helper/coreAssets.json
+++ b/projects/helper/coreAssets.json
@@ -1098,12 +1098,10 @@
     "BUSD": "0xf61eb8999f2f222f425d41da4c2ff4b6d8320c87"
   },
   "xdc": {
-    "xUSDT": "0xd4b5f10d61916bd6e0860144a91ac658de8a1437",
     "WXDC": "0x951857744785e80e2de051c32ee7b25f9c458c42",
     "XSP": "0x36726235dadbdb4658d33e62a249dca7c4b2bc68",
-    "SRX": "0x5d5f074837f5d4618b3916ba74de1bf9662a3fed",
-    "USNOTA": "0xd04275e2fd2875beaade6a80b39a75d4fe267df6",
-    "PLI": "0xff7412ea7c8445c46a8254dfb557ac1e48094391"
+    "FXD": "0x49d3f7543335cf38Fa10889CCFF10207e22110B5",
+    "xUSDT": "0xd4b5f10d61916bd6e0860144a91ac658de8a1437"
   },
   "kardia": {
     "WKAI": "0xaf984e23eaa3e7967f3c5e007fbe397d8566d23d",

--- a/projects/helper/coreAssets.json
+++ b/projects/helper/coreAssets.json
@@ -1099,9 +1099,7 @@
   },
   "xdc": {
     "WXDC": "0x951857744785e80e2de051c32ee7b25f9c458c42",
-    "XSP": "0x36726235dadbdb4658d33e62a249dca7c4b2bc68",
-    "FXD": "0x49d3f7543335cf38Fa10889CCFF10207e22110B5",
-    "xUSDT": "0xd4b5f10d61916bd6e0860144a91ac658de8a1437"
+    "XSP": "0x36726235dadbdb4658d33e62a249dca7c4b2bc68"
   },
   "kardia": {
     "WKAI": "0xaf984e23eaa3e7967f3c5e007fbe397d8566d23d",

--- a/projects/xspswap-v3/index.js
+++ b/projects/xspswap-v3/index.js
@@ -2,5 +2,5 @@ const { uniV3Export } = require('../helper/uniswapV3')
 const factory = '0x30F317A9EC0f0D06d5de0f8D248Ec3506b7E4a8A'
 
 module.exports = uniV3Export({
-  xdc: { factory, fromBlock: 59782067, },
+  xdc: { factory, fromBlock: 59782067, methodology: 'TVL accounts for the liquidity on all AMM pools taken from the factory contract', },
 })

--- a/projects/xspswap/index.js
+++ b/projects/xspswap/index.js
@@ -4,6 +4,7 @@ module.exports = {
   misrepresentedTokens: true,
   xdc: {
     tvl: getUniTVL({
+      useDefaultCoreAssets: true,
       factory: '0x347D14b13a68457186b2450bb2a6c2Fd7B38352f',
     })
   },

--- a/projects/xspswap/index.js
+++ b/projects/xspswap/index.js
@@ -5,7 +5,6 @@ module.exports = {
   xdc: {
     tvl: getUniTVL({
       factory: '0x347D14b13a68457186b2450bb2a6c2Fd7B38352f',
-      useDefaultCoreAssets: true,
     })
   },
 }


### PR DESCRIPTION
- update core assets. there is no USNOTA in XDC Network anymore. removed erc20 projects and added main STABLE COIN of XDC Network.
- methodology is explained for V3 
- flag useDefaultCoreAssets is removed from V2. there is no need to rely on default core assets