### PR TITLE
Update to City coins on Stacks: Treasury re-added

### DIFF
--- a/projects/citycoins/index.js
+++ b/projects/citycoins/index.js
@@ -6,13 +6,11 @@ const MIAMI_CONTRACT = 'SP466FNC0P7JWTNM2R9T199QRZN1MYEDTAR0KP27.miamicoin-core-
 const MIAMI_CONTRACT_V2 = 'SP1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8Y634C7R.miamicoin-core-v2'
 const MIAMI_CITY_WALLET = 'SM2MARAVW6BEJCD13YV2RHGYHQWT7TDDNMNRB1MVT'
 const NYC_CITY_WALLET = 'SM18VBF2QYAAHN57Q28E2HSM15F6078JZYZ2FQBCX'
-const MIAMI_DAO_TREASURY = 'SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.ccd002-treasury-mia-mining-v2'
-const NYC_DAO_TREASURY = 'SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.ccd002-treasury-nyc-mining-v2'
 
 module.exports = {
   stacks: {
     tvl: sumTokensExport({
-      owners: [NYC_CONTRACT, NYC_CONTRACT_V2, MIAMI_CONTRACT, MIAMI_CONTRACT_V2, MIAMI_DAO_TREASURY, NYC_DAO_TREASURY],
+      owners: [NYC_CONTRACT, NYC_CONTRACT_V2, MIAMI_CONTRACT, MIAMI_CONTRACT_V2],
       tokens: [nullAddress]
     }),
     // treasury, Note: Treasury has been disabled upon team request since they view it as amount reserved for city governers and does not belong to team

--- a/projects/citycoins/index.js
+++ b/projects/citycoins/index.js
@@ -6,11 +6,13 @@ const MIAMI_CONTRACT = 'SP466FNC0P7JWTNM2R9T199QRZN1MYEDTAR0KP27.miamicoin-core-
 const MIAMI_CONTRACT_V2 = 'SP1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8Y634C7R.miamicoin-core-v2'
 const MIAMI_CITY_WALLET = 'SM2MARAVW6BEJCD13YV2RHGYHQWT7TDDNMNRB1MVT'
 const NYC_CITY_WALLET = 'SM18VBF2QYAAHN57Q28E2HSM15F6078JZYZ2FQBCX'
+const MIAMI_DAO_TREASURY = 'SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.ccd002-treasury-mia-mining-v2'
+const NYC_DAO_TREASURY = 'SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.ccd002-treasury-nyc-mining-v2'
 
 module.exports = {
   stacks: {
     tvl: sumTokensExport({
-      owners: [NYC_CONTRACT, NYC_CONTRACT_V2, MIAMI_CONTRACT, MIAMI_CONTRACT_V2],
+      owners: [NYC_CONTRACT, NYC_CONTRACT_V2, MIAMI_CONTRACT, MIAMI_CONTRACT_V2, MIAMI_DAO_TREASURY, NYC_DAO_TREASURY],
       tokens: [nullAddress]
     }),
     // treasury, Note: Treasury has been disabled upon team request since they view it as amount reserved for city governers and does not belong to team

--- a/projects/treasury/citycoins.js
+++ b/projects/treasury/citycoins.js
@@ -1,0 +1,13 @@
+const { sumTokensExport, nullAddress } = require('../helper/sumTokens')
+
+const MIAMI_DAO_TREASURY = 'SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.ccd002-treasury-mia-mining-v2'
+const NYC_DAO_TREASURY = 'SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.ccd002-treasury-nyc-mining-v2'
+
+module.exports = {
+  stacks: {
+    tvl: sumTokensExport({
+      owners: [MIAMI_DAO_TREASURY, NYC_DAO_TREASURY],
+      tokens: [nullAddress]
+    }),
+  },
+};


### PR DESCRIPTION
MIA and NYC cities have moved their funds into the MIA and NYC dao. The funds are now part of the protocol and generate yield for MIA and NYC token holders in STX.