### PR TITLE
Moved Boosted stake from borrowed to actual value inside the contract

### DIFF
--- a/projects/fluidtokens/index.js
+++ b/projects/fluidtokens/index.js
@@ -53,8 +53,13 @@ async function tvl() {
   const repay_tvl = parseInt(await get("https://api.fluidtokens.com/get-total-available-repayments"));
 
   const pools_tvl= parseInt(await get("https://api.fluidtokens.com/get-total-available-pools"));
+
+  const boosted_tvl= await get("https://api.fluidtokens.com/get-ft-stats");
+
+  const boosted=parseInt(boosted_tvl.bs_available_volume)+parseInt(boosted_tvl.bs_active_volume);
+  
   return {
-    cardano: (SC_offers_tvl+repay_tvl+pools_tvl) / 1e6,
+    cardano: (SC_offers_tvl+repay_tvl+pools_tvl+boosted) / 1e6,
   };
 }
 
@@ -63,7 +68,7 @@ async function borrowed(
   ts //timestamp in seconds
 ) {
   const data = await get("https://api.fluidtokens.com/get-ft-stats");
-  let SC_tvl = parseInt(data.active_loans_volume)+parseInt(data.bs_available_volume)+parseInt(data.bs_active_volume);
+  let SC_tvl = parseInt(data.active_loans_volume);
 
  
   const dataOffers = await get("https://api.fluidtokens.com/get-available-collection-offers");


### PR DESCRIPTION
Moved the values from "Borrowed" to "Active" because the ADA is actually locked in the contract and not sent to the users