### PR TITLE
popcorn: add frax vaults on arbi

### DIFF
--- a/projects/popcorn/fraxVault.js
+++ b/projects/popcorn/fraxVault.js
@@ -1,0 +1,31 @@
+const sdk = require('@defillama/sdk');
+
+const getVaultsAbi = 'address[]:getRegisteredAddresses';
+const getAssetAbi = 'address:asset';
+const getStrategyAbi = 'address:strategy';
+const getTotalSupplyAbi = 'uint256:totalSupply';
+const convertToAssetsAbi = 'function convertToAssets(uint256) view returns (uint256)';
+
+
+async function addFraxVaultToTVL(balances, api) {
+    const vaultAddresses = await api.call({ target: "0x25172C73958064f9ABc757ffc63EB859D7dc2219", abi: getVaultsAbi });
+    const assets = await api.multiCall({ abi: getAssetAbi, calls: vaultAddresses, });
+    const totalSupply = await api.multiCall({ abi: getTotalSupplyAbi, calls: vaultAddresses, });
+    const strategies = await api.multiCall({ abi: getStrategyAbi, calls: vaultAddresses, });
+
+    const totalAssets = [];
+    for (let i = 0; i < vaultAddresses.length; i++) {
+        // if the vault has no strategy: 1 share = 1 asset
+        if (strategies[i] === "0x0000000000000000000000000000000000000000") {
+            totalAssets.push(totalSupply[i]);
+        } else {
+            const assets = await api.call({ target: strategies[i], abi: convertToAssetsAbi, params: [totalSupply[i]] })
+            totalAssets.push(assets);
+        }
+    }
+    assets.forEach((v, i) => sdk.util.sumSingleBalance(balances, v, totalAssets[i], api.chain))
+}
+
+module.exports = {
+    addFraxVaultToTVL
+}

--- a/projects/popcorn/index.js
+++ b/projects/popcorn/index.js
@@ -1,11 +1,16 @@
 const { ADDRESSES } = require("./constants");
 const { addVaultToTVL } = require("./vault");
+const { addFraxVaultToTVL } = require("./fraxVault");
 
 function getTVL(chain = undefined) {
   return async (timestamp, block, chainBlocks, { api }) => {
     let balances = {};
 
     await addVaultToTVL(balances, api, ADDRESSES[chain].vaultRegistry);
+
+    if (chain === "arbitrum") {
+      await addFraxVaultToTVL(balances, api);
+    }
 
     return balances;
   }


### PR DESCRIPTION
Adds additional vaults on arbitrum to the TVL calculation that are not part of the original registry.