### PR TITLE
Update index.js

### DIFF
--- a/projects/thetanuts/index.js
+++ b/projects/thetanuts/index.js
@@ -79,8 +79,15 @@ const arbCallVault = '0x0833EC3262Dcc417D88f85Ed5E1EBAf768080f41'
 const arbPutVault = '0xf94ea5B18401821BE07FBfF535B8211B061A7F70'
 const ethCallVaultArb = '0x1D1CD4abe0F2AF9d79b5e3149BF4A503f97C1EAd'
 const ethPutVaulArb = '0xA8459eC6DF0D9a61058C43a308dD8A2CEc9d550E'
-const aArb = '0x116a7f52556a57F807CEACe228242C3c91D2C7E5'
+// Assets locked in Aave V2 fork
+const aArb = '0x116a7f52556a57F807CEACe228242C3c91D2C7E5' 
 const aUsdc = '0xBEe683e6e5CE1e7Ea07c6f11DF240AcD92c33632'
+const aWeth = '0xBbf03fC0C8441e9cc50cC087f74899C137597b6e'
+// LongLiquidityVaults - Holds aAssets (not counted) and V3 liquidity NFTs
+const arbC_LLV = '0x721Bba1556649e9c70E2dF1EAFC04270376025f7'
+const arbP_LLV = '0x57eD79afD32c616E4631231636F4597188d20C5e'
+const ethC_LLV = '0x078F98Be8A1bb1bD64799B8F05Aca08f5850A69D'
+const ethP_LLV = '0xE84CB9daF67644734051c7f6e978968f04F6751e'
 
 // Polygon zkEVM vaults
 const stMaticCallVault = '0x7bF3c7C23501EA3E09B237D6F8AdcB7Ea3CeF41C'
@@ -129,6 +136,7 @@ const wcro = '0x5C7F8A570d578ED84E63fdFA7b1eE72dEae1AE23'
 // Arbitrum assets
 const arb = ADDRESSES.arbitrum.ARB
 const usdc_arb = ADDRESSES.arbitrum.USDC_CIRCLE
+const univ3nft_arb = '0xC36442b4a4522E871399CD717aBDD847Ab11FE88'
 
 // Polygon zkEVM assets
 const stMatic = '0x83b874c1e09D316059d929da402dcB1A98e92082'
@@ -192,6 +200,12 @@ const config = {
       [usdc_arb, ethPutVaulArb,],
       [arb, aArb,],
       [usdc_arb, aUsdc,],
+    ],
+    LLVOwners: [
+      [univ3nft_arb, arbC_LLV,],
+      [univ3nft_arb, arbP_LLV,],
+      [univ3nft_arb, ethC_LLV,],
+      [univ3nft_arb, ethP_LLV,],
     ]
   },
   fantom: {
@@ -251,8 +265,8 @@ const config = {
 }
 
 Object.keys(config).forEach(chain => {
-  const { tokensAndOwners } = config[chain]
+  const { tokensAndOwners, LLVOwners } = config[chain]
   module.exports[chain] = {
-    tvl: sumTokensExport({ tokensAndOwners, })
+    tvl: sumTokensExport({ tokensAndOwners, resolveUniV3 : LLVOwners != null && LLVOwners.length > 0 ? true : false,  uniV3nftsAndOwners : LLVOwners })
   }
 })


### PR DESCRIPTION
Add Uniswap V3 locked positions in Thetanuts V3 LongLiquidityVault contracts

- 4 LLV contracts added (LLV_ARB_Call, LLV_ARB_Put, LLV_ETH_Call, LLV_ETH_Put)
- Added aWETH address to track (Aave V2 fork, this tracks only the WETH in the aWETH contract e.g. available WETH liquidity)

Local run:

------ TVL ------
fantom                    613.51 k
avax                      44.13 k
polygon_zkevm             24.64 k
bsc                       108.17 k
polygon                   155.05 k
ethereum                  9.23 M
cronos                    4.61 k
aurora                    4.86 k
arbitrum                  691.19 k
boba                      69.99 k

total                    10.95 M
