### PR TITLE
Add uPRISMA support to Llama Airforce

### DIFF
--- a/projects/llama-airforce/index.js
+++ b/projects/llama-airforce/index.js
@@ -5,6 +5,7 @@ const contracts = {
   uCRV3: "0xde2bef0a01845257b4aef2a2eaa48f6eaeafa8b7",
   uFXS1: "0xf964b0e3ffdea659c44a5a52bc0b82a24b89ce0e",
   uFXS2: "0x3a886455e5b33300a31c5e77bac01e76c0c7b29c",
+  uPRISMA: "0x9bfd08d7b3cc40129132a17b4d5b9ea3351464bd",
   uCVX: "0x8659fc767cad6005de79af65dafe4249c57927af",
   uBAL: "0x8c4eb0fc6805ee7337ac126f89a807271a88dd67",
   pxCvx: "0xBCe0Cf87F513102F22232436CCa2ca49e815C3aC",
@@ -17,6 +18,7 @@ const vaults = [
   contracts.uBAL,
   contracts.uFXS1,
   contracts.uFXS2,
+  contracts.uPRISMA,
 ]
 
 async function tvl(time, block, _, { api },) {


### PR DESCRIPTION
Using `node test.js projects/llama-airforce/index.js` you can see there's cvxPrisma showing up in the TVL overview. It can be verified using the TVL of the Prisma pounder from https://next.llama.airforce/#/union/pounders.

Unrelated to uPRISMA, could you guys look into the price of pxCVX? We're missing ~$9m in TVL because our CVX pounder is missing from the TVL. I think there's a bug somewhere where the price of pxCVX is zero, which results in the TVL being zero as well, but I'm having some trouble debugging.

More specifically, the line `sdk.util.sumSingleBalance(balances, contracts.pxCvx, await api.call({ target: contracts.uCVX, abi: "uint256:totalAssets", }), api.chain)` returns a TVL of zero.