### PR TITLE
add bitnet and xenwave

### DIFF
--- a/env.sample
+++ b/env.sample
@@ -21,3 +21,4 @@ KLAYTN_RPC=https://public-node-api.klaytnapi.com/v1/cypress
 FINDORA_RPC=https://prod-mainnet.prod.findora.org:8545
 SOLANA_RPC=https://solana-api.projectserum.com
 NOVA_RPC=http://dataseed-0.rpc.novanetwork.io:8545/
+BITNET_RPC=https://rpc.bitnet.money/

--- a/projects/helper/chains.json
+++ b/projects/helper/chains.json
@@ -22,6 +22,7 @@
   "bitcoincash",
   "bitgert",
   "bitindi",
+  "bitnet",
   "bittorrent",
   "boba",
   "boba_avax",

--- a/projects/helper/coreAssets.json
+++ b/projects/helper/coreAssets.json
@@ -501,6 +501,11 @@
     "BNB": "0xf8ab4aaf70cef3f3659d3f466e35dc7ea10d4a5d",
     "kBUSD": "0xdd2bb4e845bd97580020d8f9f58ec95bf549c3d9"
   },
+  "bitnet": {
+    "WBTN": "0x8148b71232162ea7a0b1c8bfe2b8f023934bfb58",
+    "ReUSDT": "0xd9b4225b1872a008870bae4797ec6ebabf5e2e2f",
+    "STRAT": "0x738f255b9d3386e49e1c4392a9c7d850c6c7c86d"
+  },
   "solana": {
     "SOL": "So11111111111111111111111111111111111111112",
     "BONK": "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263",

--- a/projects/helper/utils.js
+++ b/projects/helper/utils.js
@@ -86,6 +86,7 @@ function isLP(symbol, token, chain) {
   if (chain === 'base' && /^(v|s)-/.test(symbol)) return true // Equalizer LP
   if (chain === 'bsc' && /(-APE-LP-S)/.test(symbol)) return false
   if (chain === 'scroll' && /(cSLP|sSLP)$/.test(symbol)) return true //syncswap LP
+  if (chain === 'bitnet' && /(XLT|XLT)$/.test(symbol)) return true //xenwave LP
   if (['fantom', 'nova',].includes(chain) && ['NLT'].includes(symbol)) return true
   let label
 

--- a/projects/xenwave/index.js
+++ b/projects/xenwave/index.js
@@ -1,0 +1,28 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+const { getUniTVL } = require("../helper/unknownTokens");
+const { mergeExports } = require("../helper/utils");
+
+// const nullAddress = ADDRESSES.null;
+//const wbtnBitnet = "0x8148b71232162ea7a0b1c8bfe2b8f023934bfb58"; // 210
+//const usdtBitnet = "0xd9b4225b1872a008870bae4797ec6ebabf5e2e2f"; // 210
+const dexFactory = "0xCba3Dc15Cfbcd900cF8133E39257c26727E86e3a"; // 210
+
+const dexTVL = {
+
+  /* Bitnet */
+  bitnet: {
+    tvl: getUniTVL({
+      factory: dexFactory,
+      useDefaultCoreAssets: true,
+    }),
+  },
+  
+};
+
+const exportMethodoly = {
+  
+  methodology: `Xenwave calculated the TVL based on the amount of tokens pooled in its Liquidity Pools. You can visit https://xenwave.com for more information.`,
+
+};
+
+module.exports = mergeExports([dexTVL, exportMethodology]);


### PR DESCRIPTION
##### Name: Xenwave
##### Twitter Link: https://twitter.com/RestratagemTech
##### List of audit links if any: n/a
##### Website Link: https://xenwave.com (app) and https://restratagem.com (company)
##### Logo: https://github.com/restratagem/xenwave-public/blob/e617bb4ed9db1d41b4aa0af4da5031933510021f/_xenwave/logoRound4000.png
##### Current TVL: $16,998
##### Treasury Addresses: n/a
##### Chain: Bitnet
##### Coingecko ID: STRAT (our token) isn't yet listed on CG, but BTN is ~> https://api.coingecko.com/api/v3/coins/bitnet
##### Coinmarketcap ID: n/a
##### Short Description: Join Xenwave to immerse yourself in the vibrant Bitnet community. Xenwave allows you to make more, do more, and be more social.
##### Token address and ticker if any: STRAT 0x738f255b9d3386e49e1c4392a9c7d850c6c7c86d
##### Category (full list at https://defillama.com/categories): DEX
##### Oracle used: n/a
##### forkedFrom: n/a
##### methodology: Xenwave calculated the TVL based on the amount of tokens pooled in its Liquidity Pools.
##### Github: https://github.com/Restratagem