### PR TITLE
Update cosmos query contracts

### DIFF
--- a/projects/helper/chain/cosmos.js
+++ b/projects/helper/chain/cosmos.js
@@ -232,16 +232,14 @@ async function queryManyContracts({ contracts = [], chain, data }) {
 
 async function queryContracts({ chain, codeId, }) {
   const res = []
-  const limit = 1000
-  let offset = 0
-  let paginationKey = undefined
+  const limit = 100
+  let paginationKey
 
   do {
-    let endpoint = `${getEndpoint(chain)}/cosmwasm/wasm/v1/code/${codeId}/contracts?pagination.limit=${limit}&pagination.offset=${offset}`
+    let endpoint = `${getEndpoint(chain)}/cosmwasm/wasm/v1/code/${codeId}/contracts?pagination.limit=${limit}${paginationKey ? `&pagination.key=${encodeURIComponent(paginationKey)}` : ''}`
     const { data: { contracts, pagination } } = await axios.get(endpoint)
     paginationKey =  pagination.next_key
       res.push(...contracts)
-    offset += limit
   } while (paginationKey)
 
   return res


### PR DESCRIPTION
Since the release of wasmd v0.42.* pagination offset got depricated and max limit was caped at 100:
https://github.com/CosmWasm/wasmd/blob/03f3c72a6ce447fafc2da023a1322899327433f8/x/wasm/keeper/querier.go#L396

This requires to remake the function to use the more efficient way for pagination using `pagination.key`