### PR TITLE
Add stDYDX

### DIFF
--- a/projects/helper/chains.json
+++ b/projects/helper/chains.json
@@ -64,6 +64,7 @@
   "doge",
   "dogechain",
   "dsc",
+  "dydx",
   "echelon",
   "edg",
   "elastos",

--- a/projects/stride/index.js
+++ b/projects/stride/index.js
@@ -61,11 +61,17 @@ const chains = {
     denom: "usomm",
     coinGeckoId: "sommelier",
   },
+
+  dydx: {
+    chainId: "dydx-mainnet-1",
+    denom: "adydx",
+    coinGeckoId: "dydx-chain",
+  },
 };
 
 // inj uses 1e18 - https://docs.injective.network/learn/basic-concepts/inj_coin#base-denomination
 function getCoinDenimals(denom) {
-  return ["aevmos", "inj"].includes(denom) ? 1e18 : 1e6;
+  return ["aevmos", "inj", "adydx"].includes(denom) ? 1e18 : 1e6;
 }
 
 function makeTvlFn(chain) {


### PR DESCRIPTION
Adds TVL for stDYDX to DefiLlama

Tests give me this output:

```
❯ node test.js projects/stride/index.js
--- stride ---
Total: 0 

--- injective ---
INJ                       1.02 M
Total: 1.02 M 

--- juno ---
JUNO                      1.62 M
Total: 1.62 M 

--- dydx ---
DYDX                      75.17 k
Total: 75.17 k 

--- comdex ---
CMDX                      145.72 k
Total: 145.72 k 

--- stargaze ---
STARS                     2.31 M
Total: 2.31 M 

--- sommelier ---
SOMM                      332.26 k
Total: 332.26 k 

--- terra ---
LUNA                      119.88 k
Total: 119.88 k 

--- osmosis ---
OSMO                      39.20 M
Total: 39.20 M 

--- umee ---
UX                        145.82 k
Total: 145.82 k 

--- evmos ---
EVMOS                     1.60 M
Total: 1.60 M 

--- cosmos ---
ATOM                      42.39 M
Total: 42.39 M 

--- tvl ---
ATOM                      42.39 M
OSMO                      39.20 M
STARS                     2.31 M
JUNO                      1.62 M
EVMOS                     1.60 M
INJ                       1.02 M
SOMM                      332.26 k
UX                        145.82 k
CMDX                      145.72 k
LUNA                      119.88 k
DYDX                      75.17 k
Total: 88.95 M 

------ TVL ------
stride                    0
injective                 1.02 M
juno                      1.62 M
dydx                      75.17 k
comdex                    145.72 k
stargaze                  2.31 M
sommelier                 332.26 k
terra                     119.88 k
osmosis                   39.20 M
umee                      145.82 k
evmos                     1.60 M
cosmos                    42.39 M

total                    88.95 M 
```