### PR TITLE
morpho-blue markets: increasing the list of markets to be considered

### DIFF
--- a/projects/morpho-blue/addresses.js
+++ b/projects/morpho-blue/addresses.js
@@ -1,12 +1,24 @@
-const wethWstethChainlinkAdaptiveCurveIRM945 =
+const wstethWethChainlinkAdaptiveCurveIRM945 =
   "0xc54d7acf14de29e0e5527cabd7a576506870346a78a11a6762e2cca66322ec41";
-const usdcWstethChainlinkAdaptiveCurveIRM860 =
+const wstethUsdcChainlinkAdaptiveCurveIRM860 =
   "0xb323495f7e4148be5643a4ea4a8221eef163e4bccfdedc2a6f4696baacbc86cc";
+const weethWethChainlinkAdaptiveCurveIRM860 =
+  "0x698fe98247a40c5771537b5786b2f3f9d78eb487b4ce4d75533cd0e94d88a115";
+const wbib01UsdcChainlinkAdaptiveCurveIRM965 =
+  "0x495130878b7d2f1391e21589a8bcaef22cbc7e1fbbd6866127193b3cc239d8b1";
+const osethWethChainlinkAdaptiveCurveIRM860 =
+  "0xd5211d0e3f4a30d5c98653d988585792bb7812221f04801be73a44ceecb11e89";
+const idleWETH =
+  "0x58e212060645d18eab6d9b2af3d56fbc906a92ff5667385f616f662c70372284";
 
 module.exports = {
   morphoBlue: "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb",
   whitelistedIds: [
-    wethWstethChainlinkAdaptiveCurveIRM945,
-    usdcWstethChainlinkAdaptiveCurveIRM860,
+    wstethWethChainlinkAdaptiveCurveIRM945,
+    wstethUsdcChainlinkAdaptiveCurveIRM860,
+    weethWethChainlinkAdaptiveCurveIRM860,
+    wbib01UsdcChainlinkAdaptiveCurveIRM965,
+    osethWethChainlinkAdaptiveCurveIRM860,
+    idleWETH,
   ],
 };


### PR DESCRIPTION
Hello,

I added few markets in the section. 
However I have 2 concerns by running the following command:

node test.js projects/morpho-blue/index.js

- 1. I think the wbIB01 token (https://etherscan.io/address/0xcA2A7068e551d5C4482eb34880b194E4b945712F), deployed 34 days ago is not taken into account: basically a wrapper of the ib01 token. 
- 2. I tried to remove the 'whitelisting ids' part of the script, however no 'CreateMarket' events are logging properly on my end. is there anything you can do? (basically consider all id from the 'CreateMarket' event to be taken into account in the tvl)

Thanks a lot and at you disposal