### PR TITLE
add start timestamp to pingu exchange tvl

### DIFF
--- a/projects/pingu/index.js
+++ b/projects/pingu/index.js
@@ -5,8 +5,9 @@ const PINGU = "0x4615fa30fFA5716984d4372030ce28D99fCB702f"; // PINGU
 const assets = [nullAddress, "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"] // ETH, USDC
 
 module.exports = {
-  arbitrum: {
-    tvl: sumTokensExport({ owners: [fundStore], tokens: assets}),
-    staking: sumTokensExport({ owners: [fundStore], tokens: [PINGU]}),
-  },
+	start: 1704844800,
+	arbitrum: {
+		tvl: sumTokensExport({ owners: [fundStore], tokens: assets }),
+		staking: sumTokensExport({ owners: [fundStore], tokens: [PINGU] }),
+	},
 }


### PR DESCRIPTION
I added the start timestamp of the tvl so that it is the same as in dexs/pingu and fees/pingu
I hadn't thought about putting it on because I didn't know exactly how the adapters worked during my first PR