### PR TITLE
Industry standard TVL calc

### DIFF
--- a/projects/milky-way/index.js
+++ b/projects/milky-way/index.js
@@ -2,15 +2,20 @@ const ADDRESSES = require('../helper/coreAssets.json')
 const sdk = require('@defillama/sdk')
 const { get } = require('../helper/http');
 
-const milkTiaCoinGeckoId = "milkyway-staked-tia";
-const milkTiaDenom = "factory/osmo1f5vfcph2dvfeqcqkhetwv75fda69z7e5c2dldm3kvgj23crkv6wqcn47a0/umilkTIA";
+const milkywayDelegationAddress = "celestia1vxzram63f7mvseufc83fs0gnt5383lvrle3qpt"
+const celestiaCoinGeckoId = "celestia";
 
 async function tvl() {
   const balances = {}
   
-  const assetAmount = await get("https://osmosis-api.polkachu.com/cosmos/bank/v1beta1/supply/by_denom?denom=" + milkTiaDenom);
-  const amount = parseInt(assetAmount.amount.amount) / 1e6;
-  sdk.util.sumSingleBalance(balances, milkTiaCoinGeckoId, amount)
+  // get the total amount staked on chain by milkyway
+  const delegationAmounts = await get("https://celestia-api.polkachu.com/cosmos/staking/v1beta1/delegations/" + milkywayDelegationAddress);
+  let totalDelegataed = 0;
+  delegationAmounts.delegation_responses.forEach(response => {
+    totalDelegataed += parseInt(response.balance.amount) / 1e6;
+  });
+
+  sdk.util.sumSingleBalance(balances, celestiaCoinGeckoId, totalDelegataed)
   return balances
 }
 module.exports = {

--- a/projects/milky-way/index.js
+++ b/projects/milky-way/index.js
@@ -10,12 +10,12 @@ async function tvl() {
   
   // get the total amount staked on chain by milkyway
   const delegationAmounts = await get("https://celestia-api.polkachu.com/cosmos/staking/v1beta1/delegations/" + milkywayDelegationAddress);
-  let totalDelegataed = 0;
+  let totalDelegated = 0;
   delegationAmounts.delegation_responses.forEach(response => {
-    totalDelegataed += parseInt(response.balance.amount) / 1e6;
+    totalDelegated += parseInt(response.balance.amount) / 1e6;
   });
 
-  sdk.util.sumSingleBalance(balances, celestiaCoinGeckoId, totalDelegataed)
+  sdk.util.sumSingleBalance(balances, celestiaCoinGeckoId, totalDelegated)
   return balances
 }
 module.exports = {


### PR DESCRIPTION
##### methodology (what is being counted as tvl, how is tvl being calculated):

This PR fixes the milkTIA TVL calculation. It implements the industry standard: liquid staking protocol TVL as sum of all the delegations (same as total USD value of the outstanding supply of the liquid staking token).

This is important so comparisons on defillama are apples-to-apples.

stETH, stTIA, stDYDX, stATOM, stOSMO etc all measure TVL this way. 

- stETH: Lido uses getTotalPooledEther (see [defillama adapter](https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/lido/index.js#L13-L17), [contract code](https://etherscan.io/address/0x17144556fd3424edc8fc8a4c940b2d04936d17eb#code)) which equals the stETH supply, per the Lido [docs](https://docs.lido.fi/contracts/lido/#gettotalpooledether) (See "NOTE: The sum of all ETH balances in the protocol, equals to the total supply of stETH). 
- stTIA, stDYDX, stATOM, stOSMO etc: Stride uses x/bank/supply, the Cosmos endpoint for stTIA supply (see [defillama adapter](https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/stride/index.js#L95)). 