### PR TITLE
add sAVAX/AVAX autopool vaults to Struct Finance TVL

### DIFF
--- a/projects/helper/coreAssets.json
+++ b/projects/helper/coreAssets.json
@@ -73,6 +73,7 @@
   },
   "avax": {
     "WAVAX": "0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7",
+    "SAVAX": "0x2b2c81e08f1af8835a78bb2a90ae924ace0ea4be",
     "USDC": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
     "EURC": "0xc891eb4cbdeff6e073e859e987815ed1505c2acd",
     "DAI": "0xd586E7F844cEa2F87f50152665BCbc2C279D8d70",

--- a/projects/struct-finance/constants.js
+++ b/projects/struct-finance/constants.js
@@ -17,6 +17,7 @@ const addresses = {
       yieldSourceAvaxBtcb: "0x736A826cF94dA966EE8ea924c5F0D079Bb25691d",
       yieldSourceAvaxWeth: "0x3BAf708e49669d54753366Bec0e77f112CF76662",
       yieldSourceEurcUsdc: "0xB35C3e0A1B889f6eC4e8e2bFFC8fE792FCF85884",
+      yieldSourceSavaxAvax: "0x8696F212D12FdFbfFD40209Fd926c3E45e62DA28",
       factory: "0x269B0AA870f1257DE00fA7E786Fd07d46cE8d26b",
     },
   },
@@ -29,6 +30,7 @@ const addresses = {
       avaxBtcbAutovault: "0x1C739A43606794849750C50bC7C43FBbDAcdf801",
       avaxWetheAutovault: "0x6178dE6E552055862CF5c56310763EeC0145688d",
       eurcUsdcAutovault: "0x052AF5B8aC73082D8c4C8202bB21F4531A51DC73",
+      savaxAvaxAutovault: "0xF812a978A08F370b9AB358a620377c0A261AA403",
     },
   },
 };
@@ -57,6 +59,12 @@ const autopoolsMetaData = {
     yieldSource: addresses.struct.tjap.yieldSourceEurcUsdc,
     tokenX: ADDRESSES.avax.EURC,
     tokenY: ADDRESSES.avax.USDC,
+  },
+  [addresses.token.tjap.savaxAvaxAutovault]: {
+    farmId: 4,
+    yieldSource: addresses.struct.tjap.yieldSourceSavaxAvax,
+    tokenX: ADDRESSES.avax.SAVAX,
+    tokenY: ADDRESSES.avax.WAVAX,
   },
 };
 

--- a/projects/struct-finance/index.js
+++ b/projects/struct-finance/index.js
@@ -52,6 +52,7 @@ async function tvl(ts, _, __, { api }) {
       ADDRESSES.avax.WETH_e,
       ADDRESSES.avax.EURC,
       ADDRESSES.avax.WAVAX,
+      ADDRESSES.avax.SAVAX,
       addresses.token.gmx.fsGlp,
     ],
   });


### PR DESCRIPTION
We recently launched an sAVAX/AVAX TraderJoe autopool integration. This PR allows us to track the TVL of those vaults