### PR TITLE
move liquid staked fantom tvl from stader to beethovenx

### DIFF
--- a/projects/beethovenx-sftmx/index.js
+++ b/projects/beethovenx-sftmx/index.js
@@ -1,0 +1,17 @@
+const ADDRESSES = require("../helper/coreAssets.json");
+const liquidStakingContract = "0xB458BfC855ab504a8a327720FcEF98886065529b";
+
+async function tvl(_, _1, _2, { api }) {
+  const supply = await api.call({
+    abi: "uint256:totalFTMWorth",
+    target: liquidStakingContract,
+  });
+  api.add(ADDRESSES.null, supply);
+}
+
+module.exports = {
+  methodology: "Retrieve the total underlying FTM supply",
+  fantom: {
+    tvl,
+  },
+};

--- a/projects/stader/index.js
+++ b/projects/stader/index.js
@@ -21,13 +21,6 @@ async function maticTvl() {
   };
 }
 
-async function ftmTvl() {
-  const res = await getData();
-  return {
-    fantom: res.fantom.native,
-  };
-}
-
 async function terra2Tvl() {
   const res = await getData();
   return {


### PR DESCRIPTION
Beethoven X took over the liquid staked Fantom product from Stader (SFTMX). We would like to have that reflected on DefiLlama as well.

Here are the two gov votes enabling the transition: 
https://snapshot.org/#/beets.eth/proposal/0x52148d5bcc4cf5437a3399c66551367d3fead39c1be0eb83fdf0b7f036fc09bb
https://snapshot.org/#/staderdao.eth/proposal/0xd159b266ee52c28a78a8ceb8b8b96422bcae992cdd42f3c6819633b00cf373d7

Let me know if you need anything else.