### PR TITLE
feat: add Haiko adapter

### DIFF
--- a/projects/haiko/index.js
+++ b/projects/haiko/index.js
@@ -1,0 +1,27 @@
+const { getConfig } = require("../helper/cache");
+const { sumTokens } = require("../helper/chain/starknet");
+
+const MarketManager =
+  "0x38925b0bcf4dce081042ca26a96300d9e181b910328db54a6c89e5451503f5";
+const ReplicatingStrategy =
+  "0x2ffce9d48390d497f7dfafa9dfd22025d9c285135bcc26c955aea8741f081d2";
+
+async function tvl(_, _1, _2, { api }) {
+  const tokens = await getConfig(
+    "haiko",
+    "https://app.haiko.xyz/api/v1/tokens?network=mainnet"
+  );
+  return sumTokens({
+    api,
+    owners: [MarketManager, ReplicatingStrategy],
+    tokens: tokens.map((t) => t.addressWith0s),
+  });
+}
+
+module.exports = {
+  methodology:
+    "Value of deposits in LP positions and Strategy Vaults, an automation layer that provides and rebalances pool liquidity on behalf of LPs.",
+  starknet: {
+    tvl,
+  },
+};

--- a/projects/haiko/index.js
+++ b/projects/haiko/index.js
@@ -14,7 +14,7 @@ async function tvl(_, _1, _2, { api }) {
   return sumTokens({
     api,
     owners: [MarketManager, ReplicatingStrategy],
-    tokens: tokens.map((t) => t.addressWith0s),
+    tokens: tokens.map((t) => t.coingeckoAddress),
   });
 }
 


### PR DESCRIPTION
# Description

Add TVL adapter for [Haiko](https://haiko.xyz/), a V4 AMM for Starknet that automates liquidity provision with strategies.

## STRK token address

~~A significant share of our TVL is in STRK, which is not yet supported by DeFiLlama.~~

~~We suggest adding it as the token listed last week and [Coingecko](https://www.coingecko.com/en/coins/starknet) pricing is now available.~~

Edit: 

The STRK token is in fact supported but must be supplied with no leading 0:
`0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d`

Rather than with leading 0 as per convention for other Starknet tokens:
`0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d`

We suggest updating this for consistency. We have updated our API for now so Coingecko detects the right address.