### PR TITLE
fix(factor-leverage-vault): wrong subgraph usage

### DIFF
--- a/projects/factor-leverage-vault/index.js
+++ b/projects/factor-leverage-vault/index.js
@@ -1,8 +1,12 @@
 const { blockQuery } = require('../helper/http')
 
-const queryBlock = `query  data($block: Int){
-  leverageVaultPoolTokenStates(where: { balanceRaw_gt: 0} block: { number: $block }) {
-    id type underlyingAssetAddress      balanceRaw
+const queryBlock = `query data($block: Int){
+  leverageVaultPairStates(block: { number: $block }) {
+      id
+      assetBalanceRaw
+      assetTokenAddress
+      debtBalanceRaw
+      debtTokenAddress
   }
 }`
 
@@ -10,12 +14,13 @@ const SUBGRAPH_URL =
   "https://api.thegraph.com/subgraphs/name/dimasriat/factor-leverage-vault";
 
 async function tvl(timestamp, ethBlock, chainBlocks, { api }) {
-  const { leverageVaultPoolTokenStates } = await blockQuery(SUBGRAPH_URL, queryBlock, { api })
+  const { leverageVaultPairStates } = await blockQuery(SUBGRAPH_URL, queryBlock, { api })
 
-  for (let poolTokenState of leverageVaultPoolTokenStates) {
-    let { underlyingAssetAddress, balanceRaw } = poolTokenState;
-    if (poolTokenState.type === 'debt') balanceRaw *= -1
-    api.add(underlyingAssetAddress, balanceRaw)
+  for (let pairState of leverageVaultPairStates) {
+    const { assetTokenAddress, assetBalanceRaw, debtTokenAddress, debtBalanceRaw } = pairState
+    const decreasingDebt = debtBalanceRaw * -1
+    api.add(assetTokenAddress, assetBalanceRaw)
+    api.add(debtTokenAddress, decreasingDebt)
   }
 
   return api.getBalances()


### PR DESCRIPTION
Fix the wrong subgraph usage in the Defillama Adapter of `factor-leverage-vault` protocol (#7716)

The problem arises in the Compound V3 Leverage Vault since their asset pool and debt pool are the same. So this PR solves that by using different query in the subgraph to get the correct TVL