### PR TITLE
fix(blast): update Blast adapter to include bridged over ETH and DAI

### DIFF
--- a/projects/blast/index.js
+++ b/projects/blast/index.js
@@ -1,27 +1,43 @@
-const ADDRESSES = require('../helper/coreAssets.json');
-const { sumTokens } = require('../helper/sumTokens');
+const ADDRESSES = require("../helper/coreAssets.json");
+const { sumTokens } = require("../helper/sumTokens");
 const { nullAddress } = require("../helper/treasury");
 
-const farm = "0x5f6ae08b8aeb7078cf2f96afb089d7c9f51da47d";
+// Blast addresses
+const blastPreLaunchDeposit = "0x5f6ae08b8aeb7078cf2f96afb089d7c9f51da47d";
+const blastEthYieldManagerProxy = "0x98078db053902644191f93988341e31289e1c8fe";
+const blastDaiYieldManagerProxy = "0xa230285d5683c74935ad14c446e137c8c8828438";
 
-async function tvl(_, _a, _b, {api}){
-    const dsr = await api.call({
-        target: "0x373238337bfe1146fb49989fc222523f83081ddb",
-        abi: "function pieOf(address) external view returns (int256)",
-        params: [farm]
-    })
-    const balances = {
-        [ADDRESSES.ethereum.DAI]: dsr
-    }
-    await sumTokens({
-        api,
-        balances,
-        owners: [farm],
-        tokens: [ADDRESSES.ethereum.STETH, ADDRESSES.ethereum.DAI, nullAddress]
-    })
-    return balances
+// DAI DSR address
+const dsrContract = "0x373238337bfe1146fb49989fc222523f83081ddb";
+const dsrPieOfABI = "function pieOf(address) external view returns (int256)"
+
+async function tvl(_, _a, _b, { api }) {
+  // Get the balances of DAI staked in DSR from the waiting contract and the yield manager
+  const data = await api.multiCall({
+    target: dsrContract,
+    abi: dsrPieOfABI,
+    calls: [blastPreLaunchDeposit, blastDaiYieldManagerProxy],
+  });
+  const daiBalancesInDsr = data
+    .reduce((total, daiBalance) => BigInt(total) + BigInt(daiBalance), 0)
+    .toString();
+  const balances = {
+    [ADDRESSES.ethereum.DAI]: daiBalancesInDsr,
+  };
+  // Get the balances of DAI and ETH that are not staked yet, and the stETH in each contract
+  await sumTokens({
+    api,
+    balances,
+    owners: [
+      blastPreLaunchDeposit,
+      blastEthYieldManagerProxy,
+      blastDaiYieldManagerProxy,
+    ],
+    tokens: [ADDRESSES.ethereum.STETH, ADDRESSES.ethereum.DAI, nullAddress],
+  });
+  return balances;
 }
 
 module.exports = {
-    ethereum: {tvl}
-}
+  ethereum: { tvl },
+};

--- a/projects/blast/index.js
+++ b/projects/blast/index.js
@@ -1,43 +1,38 @@
-const ADDRESSES = require("../helper/coreAssets.json");
-const { sumTokens } = require("../helper/sumTokens");
+const ADDRESSES = require('../helper/coreAssets.json');
+const { sumTokens } = require('../helper/sumTokens');
 const { nullAddress } = require("../helper/treasury");
 
 // Blast addresses
 const blastPreLaunchDeposit = "0x5f6ae08b8aeb7078cf2f96afb089d7c9f51da47d";
-const blastEthYieldManagerProxy = "0x98078db053902644191f93988341e31289e1c8fe";
-const blastDaiYieldManagerProxy = "0xa230285d5683c74935ad14c446e137c8c8828438";
+const blastEthYieldManagerProxy = "0x98078db053902644191f93988341e31289e1c8fe"
+const blastDaiYieldManagerProxy = "0xa230285d5683c74935ad14c446e137c8c8828438"
 
 // DAI DSR address
-const dsrContract = "0x373238337bfe1146fb49989fc222523f83081ddb";
+const dsrContract = "0x373238337bfe1146fb49989fc222523f83081ddb"
 const dsrPieOfABI = "function pieOf(address) external view returns (int256)"
 
-async function tvl(_, _a, _b, { api }) {
-  // Get the balances of DAI staked in DSR from the waiting contract and the yield manager
-  const data = await api.multiCall({
-    target: dsrContract,
-    abi: dsrPieOfABI,
-    calls: [blastPreLaunchDeposit, blastDaiYieldManagerProxy],
-  });
-  const daiBalancesInDsr = data
-    .reduce((total, daiBalance) => BigInt(total) + BigInt(daiBalance), 0)
-    .toString();
-  const balances = {
-    [ADDRESSES.ethereum.DAI]: daiBalancesInDsr,
-  };
-  // Get the balances of DAI and ETH that are not staked yet, and the stETH in each contract
-  await sumTokens({
-    api,
-    balances,
-    owners: [
-      blastPreLaunchDeposit,
-      blastEthYieldManagerProxy,
-      blastDaiYieldManagerProxy,
-    ],
-    tokens: [ADDRESSES.ethereum.STETH, ADDRESSES.ethereum.DAI, nullAddress],
-  });
-  return balances;
+async function tvl(_, _a, _b, {api}){
+    // Get the balances of DAI staked in DSR from the waiting contract and the yield manager
+    const data = await api.multiCall({
+        target: dsrContract,
+        abi: dsrPieOfABI,
+        calls: [blastPreLaunchDeposit, blastDaiYieldManagerProxy]
+    })
+    const daiBalancesInDsr = data.reduce((total, daiBalance ) => BigInt(total) + BigInt(daiBalance), 0).toString();
+    const balances = {
+        [ADDRESSES.ethereum.DAI]: daiBalancesInDsr
+    }
+    // Get the balances of DAI and ETH that are not staked yet, and the stETH in each contract
+    await sumTokens({
+        api,
+        balances,
+        owners: [blastPreLaunchDeposit, blastEthYieldManagerProxy, blastDaiYieldManagerProxy],
+        tokens: [ADDRESSES.ethereum.STETH, ADDRESSES.ethereum.DAI, nullAddress]
+    })
+    console.log(balances)
+    return balances
 }
 
 module.exports = {
-  ethereum: { tvl },
-};
+    ethereum: {tvl}
+}

--- a/projects/blast/index.js
+++ b/projects/blast/index.js
@@ -29,7 +29,6 @@ async function tvl(_, _a, _b, {api}){
         owners: [blastPreLaunchDeposit, blastEthYieldManagerProxy, blastDaiYieldManagerProxy],
         tokens: [ADDRESSES.ethereum.STETH, ADDRESSES.ethereum.DAI, nullAddress]
     })
-    console.log(balances)
     return balances
 }
 


### PR DESCRIPTION
* Adds two new addresses to account for Blast

[Eth yield manager (holds bridged over ETH/STETH)
](https://etherscan.io/address/0x98078db053902644191f93988341e31289e1c8fe)
[Dai yield manager (holds bridged over DAI in DSR or in itself)
](https://etherscan.io/address/0xa230285d5683c74935ad14c446e137c8c8828438)

---
> inb4 "Blast TVL pumps 4x within seconds the day after suffering MASSIVE withdraws" blog post
>
> https://www.coindesk.com/business/2024/03/01/blast-hyped-layer-2-chain-sees-most-deposits-leave-within-1-day-of-going-live/
>
> ![image](https://github.com/DefiLlama/DefiLlama-Adapters/assets/4276174/864b1b96-b54b-4745-aee4-8e474c5075ae)
