### PR TITLE
Update to PR#9136: BlastNYAN to account for WETH earning yield in the background

### DIFF
--- a/projects/BlastNYAN/index.js
+++ b/projects/BlastNYAN/index.js
@@ -12,7 +12,7 @@ const opts = { useDefaultCoreAssets: true, lps: [BLNYAN_WETH_SLP] }
 module.exports = {
   misrepresentedTokens: true,
   blast: {
-    tvl: sumTokensExport({ owners: [BLNYAN_WETH_SLP, feeDistro, button], tokens: [WETH], ...opts, }),
+    tvl: sumTokensExport({ owners: [stakeLpEarnWeth, feeDistro, button], tokens: [WETH], ...opts, }),
     pool2: sumTokensExport({ ...opts, owners: [stakeLpEarnWeth], tokens: [BLNYAN_WETH_SLP], }),
     staking: sumTokensExport({ owners: [stakingBLNYANContract], tokens: [BLNYAN], ...opts, }),
   },

--- a/projects/BlastNYAN/index.js
+++ b/projects/BlastNYAN/index.js
@@ -12,10 +12,10 @@ const opts = { useDefaultCoreAssets: true, lps: [BLNYAN_WETH_SLP] }
 module.exports = {
   misrepresentedTokens: true,
   blast: {
-    tvl: sumTokensExport({ owners: [feeDistro, button], tokens: [WETH], ...opts, }),
+    tvl: sumTokensExport({ owners: [BLNYAN_WETH_SLP, feeDistro, button], tokens: [WETH], ...opts, }),
     pool2: sumTokensExport({ ...opts, owners: [stakeLpEarnWeth], tokens: [BLNYAN_WETH_SLP], }),
     staking: sumTokensExport({ owners: [stakingBLNYANContract], tokens: [BLNYAN], ...opts, }),
   },
   methodology:
-    'Counts as TVL the ETH, blNYAN and LP assets deposited through-out the protocol',
+    'Counts as TVL the ETH only. blNYAN and LP assets deposited are counted as Pool2 and staking Respectively',
 }


### PR DESCRIPTION
**Related PR: #9136**

@g1nt0ki Thank you for merging and fixing #9136. 

We noticed a slight omission in the update, specifically related to the tvl. The ETH held in stakeLpEarnWeth contract is the pending rewards that will be distributed over a reward period of >1 year. 

The ETH itself is earning yield which is then distributed throughout the protocol. This ETH is different to from the ETH in the LP and is[ specific to the staking contract](https://blastscan.io/address/0x0a3A757BE3049C2d9444d025E98D37b2a81a0a32). There is currently $15k of ETH that isn't accounted for.

My proposed change is to include the staking contract's ETH holdings toward TVL. I Hope this change is okay given the above