### PR TITLE
Alongside: Change doublecounted to false

### DIFF
--- a/projects/alongside/index.js
+++ b/projects/alongside/index.js
@@ -10,7 +10,7 @@ async function tvl(_, block, _cb) {
 }
 
 module.exports = {
-  doublecounted: true,
+  doublecounted: false,
   misrepresentedTokens: true,
   methodology:
     "Data is retrieved from calculation of market price and total supply",

--- a/projects/alongside/index.js
+++ b/projects/alongside/index.js
@@ -1,4 +1,5 @@
 const sdk = require("@defillama/sdk");
+const { sumTokensExport } = require("../helper/unwrapLPs");
 
 const INDEX = "0xF17A3fE536F8F7847F1385ec1bC967b2Ca9caE8D";
 
@@ -10,11 +11,9 @@ async function tvl(_, block, _cb) {
 }
 
 module.exports = {
-  doublecounted: false,
-  misrepresentedTokens: true,
   methodology:
     "Data is retrieved from calculation of market price and total supply",
   ethereum: {
-    tvl,
+    tvl: sumTokensExport({ owner: '0xf3bCeDaB2998933c6AAD1cB31430D8bAb329dD8C', fetchCoValentTokens: true }),
   },
 };

--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -122,6 +122,14 @@ const fixBalancesTokens = {
   bitrock: {
     '0x413f0e3a440aba7a15137f4278121450416882d5': { coingeckoId: 'wrapped-bitrock', decimals: 18 },
     '0xde67d97b8770dc98c746a3fc0093c538666eb493': { coingeckoId: 'bitrock', decimals: 9 },
+  },
+  ethereum: {
+    '0x0d3bd40758df4f79aad316707fcb809cd4815ffe': { coingeckoId: 'ripple', decimals: 6 },
+    '0x9c05d54645306d4c4ead6f75846000e1554c0360': { coingeckoId: 'cardano', decimals: 6 },
+    '0xd2aee1ce2b4459de326971de036e82f1318270af': { coingeckoId: 'dogecoin', decimals: 8 },
+    '0xf4accd20bfed4dffe06d4c85a7f9924b1d5da819': { coingeckoId: 'polkadot', decimals: 10 },
+    '0xff4927e04c6a01868284f5c3fb9cba7f7ca4aec0': { coingeckoId: 'bitcoin-cash', decimals: 8 },
+    '0x9f2825333aa7bc2c98c061924871b6c016e385f3': { coingeckoId: 'litecoin', decimals: 8 },
   }
 }
 


### PR DESCRIPTION
Since our launch of [AMKT v2](https://snapshot.org/#/dao.amkt.eth/proposal/0xf83b33f54985cdbdf29b42438c812d9ebdd1d61f86fcc934c432f3472c66965a), the protocol no longer deposits assets to a custodian. All of the assets in the index are on-chain assets that have not been issued by Alongside. AMKT does include stETH in the index, however, we don't believe that fits the definition for double-counting. 

Thus, we're requesting that the doublecounted flag on AMKT is removed. Please let me know if I'm missing anything! 