### PR TITLE
Fetch kamino lend markets dynamically

### DIFF
--- a/projects/kamino-lending/index.js
+++ b/projects/kamino-lending/index.js
@@ -3,11 +3,12 @@ const { getConnection, sumTokens } = require('../helper/solana');
 const { Program } = require('@project-serum/anchor');
 const kaminoIdl = require('./kamino-lending-idl.json');
 const { MintLayout } = require("../helper/utils/solana/layouts/mixed-layout");
+const axios = require("axios");
 
 async function tvl() {
   const connection = getConnection();
   const programId = new PublicKey('KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD');
-  const markets = ['7u3HeHxYDLhnCoErrtycNokbQYbWGzLs6JSDqGAv5PfF', 'DxXdAyU3kCjnyggvHmY5nAwg5cRbbmdyX3npfDMjjMek'];
+  const markets = (await axios.get('https://api.kamino.finance/v2/kamino-market')).data.map(x => x.lendingMarket);
   const lendingMarketAuthSeed = 'lma';
   const tokensAndOwners = [];
   const ktokens = {};


### PR DESCRIPTION
Added functionality to kamino lend to fetch all markets dynamically by using our API endpoint. Unfortunately, we can't fetch these using the on-chain data as some of them have been deprecated or are not usable anymore, so the TVL from those should not be included.

Hopefully this works - it just fetches the market pubkeys from our API and then uses on-chain stats of each of these to calculate the kamino lend TVL. We will be releasing a bunch of new markets and don't want to keep making pull requests every time we add a new one.