### PR TITLE
Add gasline staking

### DIFF
--- a/projects/gasline/index.js
+++ b/projects/gasline/index.js
@@ -1,14 +1,16 @@
+const { staking } = require("../helper/staking");
 const { sumTokensExport } = require("../helper/unwrapLPs");
 
 const config = {
-  blast: { gasline: '0xD5400cAc1D76f29bBb8Daef9824317Aaf9d3C0a1', weth: '0x4300000000000000000000000000000000000004', },
-  bsc: { gasline: '0x35138Ddfa39e00C642a483d5761C340E7b954F94', weth: '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c', },
+  blast: { gasline: '0xD5400cAc1D76f29bBb8Daef9824317Aaf9d3C0a1', gas: '0x5d61c3f602579873Bb58d8DF53a9d82942de5267', weth: '0x4300000000000000000000000000000000000004', },
+  bsc: { gasline: '0x35138Ddfa39e00C642a483d5761C340E7b954F94', gas: '0xd0245a9fe3D8366e8c019ce9CE4cAdFF0cEabB76', weth: '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c', },
 }
 
 Object.keys(config).forEach(chain => {
-  const {gasline, weth} = config[chain]
+  const {gasline, gas, weth} = config[chain]
   module.exports[chain] = {
     tvl: sumTokensExport({ owner: gasline, tokens: [weth] }),
+    staking: staking(gasline, gas, chain),
     borrowed: async (_, _b, _cb, { api, }) => {
       const supply = await api.call({  abi: 'erc20:totalSupply', target: gasline})
       api.addGasToken(supply)


### PR DESCRIPTION
Note that when I tested this code it gave me 0 TVL for staking

```
node test.js projects/gasline/index.js
--- bsc-borrowed ---
BNB                       321.0107698759914
Total: 321.0107698759914

--- bsc-staking ---
Total: 0

--- blast-staking ---
Total: 0

--- blast ---
WETH                      3.899940427117519
Total: 3.899940427117519

--- blast-borrowed ---
ETH                       258.332812601052
Total: 258.332812601052

--- bsc ---
WBNB                      0.048537000000000004
Total: 0.048537000000000004

--- borrowed ---
BNB                       321
ETH                       258
Total: 579.3435824770434

--- staking ---
Total: 0

--- tvl ---
WETH                      4
Total: 3.948477427117519

------ TVL ------
bsc-borrowed              321.0107698759914
bsc-staking               0
blast-staking             0
blast                     3.899940427117519
blast-borrowed            258.332812601052
bsc                       0.048537000000000004
borrowed                  579.3435824770434
staking                   0

total                    3.948477427117519
```

Is it because we only have listed on our own dex?