### PR TITLE
Update BitStable-Finance

### DIFF
--- a/projects/bitstable-finance/index.js
+++ b/projects/bitstable-finance/index.js
@@ -1,8 +1,6 @@
 const ADDRESS = require("../helper/coreAssets.json");
-const { sumTokensExport } = require("../helper/unwrapLPs");
-const {
-  sumTokensExport: sumBRC20TokensExport,
-} = require("../helper/chain/brc20");
+const { sumTokensExport } = require("../helper/sumTokens");
+const { sumTokensExport: sumBRC20TokensExport } = require("../helper/chain/brc20");
 
 const owner = "0x103dd1184599c7511a3016E0a383E11F84AE7173";
 const tokens = {
@@ -13,19 +11,20 @@ const tokens = {
 module.exports = {
   methodology: "Staking tokens via BitStable counts as TVL",
   bitcoin: {
-    tvl: sumBRC20TokensExport({
-      // Deposit Address
-      owners: [
-        "bc1p0uw83vg0h32v7kypyvjn9nextku2h7axjdeefy2ewstevnqffaksjzhrdf",
-      ],
-      blacklistedTokens: ['BSSB', 'DAII'],
-    }),
+    tvl: [
+      // Native(BTC)
+      sumTokensExport({ owners: ["bc1p36wvtxursam9cq8zmc9ppvsqf9ulefm7grvlfc4tzc5j83rcggsqh6nxw5"] }),
+      // BRC20
+      sumBRC20TokensExport({
+        // Deposit Address
+        owners: ["bc1p0uw83vg0h32v7kypyvjn9nextku2h7axjdeefy2ewstevnqffaksjzhrdf"],
+        blacklistedTokens: ["BSSB", "DAII"],
+      }),
+    ],
     staking: sumBRC20TokensExport({
       // Farm Address
-      owners: [
-        "bc1pvngqf24g3hhr5s4ptv472prz576uye8qmagy880ydq5gzpd30pdqtua3rd",
-      ],
-      blacklistedTokens: ['DAII'],
+      owners: ["bc1pvngqf24g3hhr5s4ptv472prz576uye8qmagy880ydq5gzpd30pdqtua3rd"],
+      blacklistedTokens: ["DAII"],
     }),
   },
 };


### PR DESCRIPTION
## add BTC Assets to TVL
Added BTC assets in https://bitstable.finance. 
This address can be viewed via the link to the right.

![image](https://github.com/DefiLlama/DefiLlama-Adapters/assets/154438863/3fde1b30-9220-4f38-9316-2f510275ded7)

> Since the BRC20 interface requires a Key to access, it cannot run locally. 
> A team member is needed to help check.