### PR TITLE
chore: mito tvl

### DIFF
--- a/projects/mito/index.js
+++ b/projects/mito/index.js
@@ -1,41 +1,19 @@
-const axios = require('axios');
-const { BigNumber } = require('bignumber.js');
-const { transformBalances } = require('../helper/portedTokens')
-const sdk = require('@defillama/sdk');
+const { get } = require('../helper/http')
 
-async function getVaultBalances(vaultAddress) {
+async function getVaultBalances(vaultAddress, api) {
   const vaultBalances = `https://sentry.exchange.grpc-web.injective.network/api/exchange/portfolio/v2/portfolio/${vaultAddress}/balances`;
-  try {
-    const response = await axios.get(vaultBalances);
-    const subaccounts = response.data.portfolio.subaccounts;
-    return subaccounts.reduce((balances, account) => {
-      const balance = new BigNumber(account.deposit.availableBalance);
-      const existingBalance = balances[account.denom] ? new BigNumber(balances[account.denom]) : new BigNumber(0);
-      balances[account.denom] = existingBalance.plus(balance).toFixed(0);
-      return balances;
-    }, {});
-  } catch (error) {
-    console.error('Error fetching vault balances', error);
-    return {};
-  }
+  const response = await get(vaultBalances);
+  const subaccounts = response.portfolio.subaccounts;
+  return subaccounts.map(i => api.add(i.denom, +i.deposit.availableBalance))
 }
 
-
-async function getVaultsTvl() {
+async function tvl(_, _1, _2, { api }) {
   const MASTER_VAULT_ADDRESS = 'inj1vcqkkvqs7prqu70dpddfj7kqeqfdz5gg662qs3';
-  const vaultBalances = await getVaultBalances(MASTER_VAULT_ADDRESS);
-  const aggregatedBalances = Object.keys(vaultBalances).reduce((totalBalances, denom) => {
-    sdk.util.sumSingleBalance(totalBalances, denom, vaultBalances[denom]);
-    return totalBalances;
-  }, {});
-
-  return transformBalances('injective', aggregatedBalances);
+  await getVaultBalances(MASTER_VAULT_ADDRESS, api);
 }
 
 module.exports = {
   timetravel: false,
   methodology: 'TVL accounts for the liquidity locked up in the Injective protocol vaults that is not being used towards posting orders to orderbook. The data comes back from the Injective API.',
-  injective: {
-    tvl: () => getVaultsTvl()
-  }
+  injective: { tvl }
 }

--- a/projects/mito/index.js
+++ b/projects/mito/index.js
@@ -1,0 +1,41 @@
+const axios = require('axios');
+const { BigNumber } = require('bignumber.js');
+const { transformBalances } = require('../helper/portedTokens')
+const sdk = require('@defillama/sdk');
+
+async function getVaultBalances(vaultAddress) {
+  const vaultBalances = `https://sentry.exchange.grpc-web.injective.network/api/exchange/portfolio/v2/portfolio/${vaultAddress}/balances`;
+  try {
+    const response = await axios.get(vaultBalances);
+    const subaccounts = response.data.portfolio.subaccounts;
+    return subaccounts.reduce((balances, account) => {
+      const balance = new BigNumber(account.deposit.availableBalance);
+      const existingBalance = balances[account.denom] ? new BigNumber(balances[account.denom]) : new BigNumber(0);
+      balances[account.denom] = existingBalance.plus(balance).toFixed(0);
+      return balances;
+    }, {});
+  } catch (error) {
+    console.error('Error fetching vault balances', error);
+    return {};
+  }
+}
+
+
+async function getVaultsTvl() {
+  const MASTER_VAULT_ADDRESS = 'inj1vcqkkvqs7prqu70dpddfj7kqeqfdz5gg662qs3';
+  const vaultBalances = await getVaultBalances(MASTER_VAULT_ADDRESS);
+  const aggregatedBalances = Object.keys(vaultBalances).reduce((totalBalances, denom) => {
+    sdk.util.sumSingleBalance(totalBalances, denom, vaultBalances[denom]);
+    return totalBalances;
+  }, {});
+
+  return transformBalances('injective', aggregatedBalances);
+}
+
+module.exports = {
+  timetravel: false,
+  methodology: 'TVL accounts for the liquidity locked up in the Injective protocol vaults that is not being used towards posting orders to orderbook. The data comes back from the Injective API.',
+  injective: {
+    tvl: () => getVaultsTvl()
+  }
+}


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.


1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
3. Please fill the form below  **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
4. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can  edit it there and put up a PR
5. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
6. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap

---
##### Name (to be shown on DefiLlama):
Mito

##### Twitter Link:
https://twitter.com/MitoFinance

##### List of audit links if any:
https://github.com/SCV-Security/PublicReports/blob/9fb984896b44bc8518f77a4aa94cdb9186b94743/Mito%20Finance/Mito%20Finance%20-%20Mito%20Contracts%20-%20Audit%20Report%20v1.0.pdf

##### Website Link:
https://mito.fi/


##### Logo (High resolution, will be shown with rounded borders):
![mito](https://github.com/DefiLlama/DefiLlama-Adapters/assets/41407272/35935758-239b-4098-8027-a7633dcde12c)


##### Current TVL:
 $2350000 USD (at minimum, since missing some token metadata for some of denoms in vaults, can check `npm run tvl` to see missing denoms atm)


##### Treasury Addresses (if the protocol has treasury)
N/A

##### Chain:
Injective

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama):
Mito is a groundbreaking Web3 protocol that revolutionizes
automated trading, launchpads, RWAs and real yield generation.

##### Token address and ticker if any:
N/A

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Yield, however the app is also a launchpad, do I make another PR for Mito Launchpad? would tvl for the mito launchpad be sum of all new tokens minted by the launchpad and given to subscribers?


##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.): Pyth
##### Implementation Details: Briefly describe how the oracle is integrated into your project: price feeds for perp vaults
##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage: 
N/A

##### forkedFrom (Does your project originate from another project):
N/A

##### methodology (what is being counted as tvl, how is tvl being calculated):
Flow:
1. User subscribes to a vault in hopes to attain yield. By subscribing, they send funds to a master vault smart contract. Each vault is a subaccount of the main master vault.
2. The main vault smart contract immediately moves the user's funds to the chain's exchange module where the funds will sit in a subaccount, specific to the vault
3. This PR is only counting TVL from the vault's `availableBalance` in the subaccount, which is the funds that stay locked up in the subaccount and are NOT in use as limit orders posted by the vault to the onchain orderbook. This ensures no double counting of TVL between the Injective apps Helix and Mito, since Helix is taking credit for TVL of limit orders on the onchain orderbook. 

##### Github org/user (Optional, if your code is open source, we can track activity):
N/A