### PR TITLE
Update Metavault Derivatives V2 chains

### DIFF
--- a/projects/metavault-derivatives-v2/index.js
+++ b/projects/metavault-derivatives-v2/index.js
@@ -2,14 +2,23 @@ const ADDRESSES = require("../helper/coreAssets.json");
 
 const { nullAddress } = require("../helper/unwrapLPs");
 
-async function LineaTvl(_time, _ethBlock, _cb, { api}) {
+async function LineaTvl(_time, _ethBlock, _cb, { api }) {
   const tokens = [nullAddress, ADDRESSES.linea.USDC];
-  const owners = ["0xf3Ef1c95aecf5B5025815014890dC14488599883"];
-  return api.sumTokens({ owners, tokens})
+  const owners = ["0xb514Ee8a1e00B102cE2312048abcbc3E57bfED94"];
+  return api.sumTokens({ owners, tokens });
+}
+
+async function PolygonTvl(_time, _ethBlock, _cb, { api }) {
+  const tokens = [nullAddress, ADDRESSES.polygon.USDC];
+  const owners = ["0xAb36984e4952e5a9d08536C4dE5190ed37725017"];
+  return api.sumTokens({ owners, tokens });
 }
 
 module.exports = {
   linea: {
     tvl: LineaTvl,
+  },
+  polygon: {
+    tvl: PolygonTvl,
   },
 };


### PR DESCRIPTION
Metavault Derivatives V2 adapter chains updated.

Derivatives V2 available on both Linea and Polygon chains now.

--- polygon ---
MATIC                     32.742634129952904
Total: 32.742634129952904 

--- linea ---
ETH                       40.42 k
USDC                      20.05 k
Total: 60.47 k 

--- tvl ---
ETH                       40.42 k
USDC                      20.05 k
MATIC                     33
Total: 60.50 k 

------ TVL ------
polygon                   32.742634129952904
linea                     60.47 k

total                    60.50 k 
