### PR TITLE
add sns treasuries

### DIFF
--- a/projects/catalyze/index.js
+++ b/projects/catalyze/index.js
@@ -1,0 +1,36 @@
+axios = require("axios");
+
+const SNS_URL = "https://sns-api.internetcomputer.org/api/v1/snses/uly3p-iqaaa-aaaaq-aabma-cai"
+const ICP_URL = "https://ledger-api.internetcomputer.org/accounts/"
+
+async function tvl() {
+  var { data, status } = await axios.get(
+    SNS_URL
+    ,
+    {
+        headers: {
+            Accept: 'application/json',
+        },
+    },
+);
+
+let icp_ledger_treasury_accountidentifier = data.icp_treasury_account;
+var { data, status } = await axios.get(
+  ICP_URL + `${icp_ledger_treasury_accountidentifier}`
+  ,
+  {
+      headers: {
+          Accept: 'application/json',
+      },
+  },
+);
+
+let icp_balance = data.balance;
+
+  return icp_balance;
+}
+
+module.exports = {
+  methodology: `We count the ICP on the treasury account as the collateral for Catalyze`,
+  icp: { tvl: tvl },
+}


### PR DESCRIPTION
This MR adds the treasuries (the locked amount of ICP in for each SNS project) of SNSes to the list of adapters.