### PR TITLE
Update Peapods Finance adapter to add Arbitrum support

### DIFF
--- a/projects/peapods-finance/index.js
+++ b/projects/peapods-finance/index.js
@@ -1,7 +1,8 @@
 const { sumTokens2 } = require("../helper/unwrapLPs");
 
 const config = {
-  ethereum: { indexManager: "0x0Bb39ba2eE60f825348676f9a87B7CD1e3B4AE6B", peasToken: "0x02f92800F57BCD74066F5709F1Daa1A4302Df875" }
+  ethereum: { indexManager: "0x0Bb39ba2eE60f825348676f9a87B7CD1e3B4AE6B", peasToken: "0x02f92800F57BCD74066F5709F1Daa1A4302Df875" },
+  arbitrum: { indexManager: "0x0Bb39ba2eE60f825348676f9a87B7CD1e3B4AE6B", peasToken: "0x02f92800F57BCD74066F5709F1Daa1A4302Df875" },
 }
 
 const indexManagerABI =
@@ -40,6 +41,7 @@ const getTvl = async (api, isStaking) => {
 
 module.exports = {
   methodology: "Aggregates TVL in all Peapods Finance indexes created",
+  hallmarks: [[1710444951, "Arbitrum launch"]],
 }
 
 Object.keys(config).forEach(chain => {


### PR DESCRIPTION
This change adds the support for the Arbitrum chain and create a hallmark for this.

While the code seems correct, the PEAS token itself isn't included in the staking figure.
Is this because no price could be determined for the token?

Note PEAS main liquidity is on Camelot, against both ETH and USDC:
https://www.dextools.io/app/en/arbitrum/pair-explorer/0x44cc8b40b1483e62e59ef937441ba6aa8e584a77
https://www.dextools.io/app/en/arbitrum/pair-explorer/0xcf71459248557807b87cf988f30ae7845f7bd6d5