### PR TITLE
Adds adapter for Frontrun.market

### DIFF
--- a/projects/frontrun-market/index.js
+++ b/projects/frontrun-market/index.js
@@ -1,0 +1,37 @@
+const ADDRESSES = require('../helper/coreAssets.json');
+const { nullAddress } = require('../helper/unwrapLPs');
+const { sumTokensExport } = require('../helper/unwrapLPs');
+
+// The Ethereum address you're interested in
+const targetAddress = '0x849F4081899305A1Fd24aAC84db5174EB60DC28e';
+const config = {
+  ethereum: [
+    {
+      tokens: [
+        ADDRESSES.ethereum.SDAI,
+        ADDRESSES.ethereum.USDC,
+        ADDRESSES.ethereum.USDT,
+        nullAddress,
+      ],
+      holders: [targetAddress],
+    },
+  ],
+  blast: [
+    {
+      tokens: [ADDRESSES.blast.USDB, nullAddress],
+      holders: [targetAddress],
+    },
+  ],
+};
+
+module.exports = {};
+Object.keys(config).forEach((chain) => {
+  const tokensAndOwners = config[chain]
+    .map(({ tokens, holders }) =>
+      holders.map((o) => tokens.map((t) => [t, o])).flat(),
+    )
+    .flat();
+  module.exports[chain] = {
+    tvl: sumTokensExport({ tokensAndOwners }),
+  };
+});


### PR DESCRIPTION
Name (to be shown on DefiLlama):
Frontrun Market

Twitter Link:
http://twitter.com/Frontrun_market

Website Link:
https://frontrun.market/

Logo (High resolution, will be shown with rounded borders):
png: https://res.cloudinary.com/dje3fcsnv/image/upload/v1710584480/yju7wlm2kdaewodxekwd.png
svg: https://res.cloudinary.com/dje3fcsnv/image/upload/v1710584307/j7rqlix9qszl33jrozyl.svg

Chain:
Blast, Ethereum

Short Description (to be shown on DefiLlama):
OTC Dex to Trade Points, Airdrop Allocations, Pre Market Tokens and NFT Whitelists.

Category (full list at https://defillama.com/categories) *Please choose only one:
Dexes

forkedFrom (Does your project originate from another project):
NA

Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/frontrun-market