### PR TITLE
feat: add flow balance from lottery jackpot pool to the fixes-frc20 TVL

### DIFF
--- a/projects/fixes-frc20/index.js
+++ b/projects/fixes-frc20/index.js
@@ -3,15 +3,28 @@ const { post } = require("../helper/http");
 
 let queryTVLCode = `
 import FRC20Indexer from 0xd2abb5dbf5e08666
+import FGameLottery from 0xd2abb5dbf5e08666
+import FGameLotteryRegistry from 0xd2abb5dbf5e08666
+import FGameLotteryFactory from 0xd2abb5dbf5e08666
 
 access(all)
 fun main(): UFix64 {
     let indexer = FRC20Indexer.getIndexer()
     let tokens = indexer.getTokens()
     var totalBalance = 0.0
+    // all treasury pool balance
     for tick in tokens {
         let balance = indexer.getPoolBalance(tick: tick)
         totalBalance = totalBalance + balance
+    }
+    // FLOW lottery jackpot balance
+    let registry = FGameLotteryRegistry.borrowRegistry()
+    let flowLotteryPoolName = FGameLotteryFactory.getFIXESMintingLotteryPoolName()
+    if let poolAddr = registry.getLotteryPoolAddress(flowLotteryPoolName) {
+        if let poolRef = FGameLottery.borrowLotteryPool(poolAddr) {
+            let jackpotBalance = poolRef.getJackpotPoolBalance()
+            totalBalance = totalBalance + jackpotBalance
+        }
     }
     return totalBalance
 }


### PR DESCRIPTION
Update fixes-frc20 TVL

##### methodology (what is being counted as tvl, how is tvl being calculated):

As a service platform,  we added a new pool for locking $FLOW that is the lottery Jackpot Pool.
This feature is a new gameplay that is independent of the original Treasury Pool. 
The FLOW purchased by users for lottery is locked in the Jackpot pool.

Until Jackpot winners are drawn, this portion of $FLOW will be locked.