### PR TITLE
Added Rosy Burnt Steak protocol adapter.

### DIFF
--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -70,6 +70,7 @@ const fixBalancesTokens = {
   },
   sapphire: {
     [nullAddress]: { coingeckoId: 'oasis-network', decimals: 18 },
+    '0x6665a6Cae3F52959f0f653E3D04270D54e6f13d8': { coingeckoId: 'rosy', decimals: 18 },
   },
   // Sample Code
   ozone: {

--- a/projects/rosy-burnt-steak/index.js
+++ b/projects/rosy-burnt-steak/index.js
@@ -1,21 +1,13 @@
+const { staking } = require("../helper/staking");
+
 const ROSY_TOKEN_CONTRACT = '0x6665a6Cae3F52959f0f653E3D04270D54e6f13d8';
 const STEAK_CONTRACT = '0x3e7ab819878bEcaC57Bd655Ab547C8e128e5b208';
 
-async function tvl(_, _1, _2, { api }) {
-  const stakedBalance = await api.call({
-    abi: 'erc20:balanceOf',
-    target: ROSY_TOKEN_CONTRACT,
-    params: [STEAK_CONTRACT],
-  });
-
-  api.add(ROSY_TOKEN_CONTRACT, stakedBalance)
-}
-
 module.exports = {
-  misrepresentedTokens: false,
   methodology: 'counts the number of ROSY tokens in the Steak contract.',
   start: 1711020000,
   sapphire: {
-    tvl,
+    tvl: () => ({}),
+    staking: staking(STEAK_CONTRACT, ROSY_TOKEN_CONTRACT)
   }
 }; 

--- a/projects/rosy-burnt-steak/index.js
+++ b/projects/rosy-burnt-steak/index.js
@@ -1,0 +1,21 @@
+const ROSY_TOKEN_CONTRACT = '0x6665a6Cae3F52959f0f653E3D04270D54e6f13d8';
+const STEAK_CONTRACT = '0x3e7ab819878bEcaC57Bd655Ab547C8e128e5b208';
+
+async function tvl(_, _1, _2, { api }) {
+  const stakedBalance = await api.call({
+    abi: 'erc20:balanceOf',
+    target: ROSY_TOKEN_CONTRACT,
+    params: [STEAK_CONTRACT],
+  });
+
+  api.add(ROSY_TOKEN_CONTRACT, stakedBalance)
+}
+
+module.exports = {
+  misrepresentedTokens: false,
+  methodology: 'counts the number of ROSY tokens in the Steak contract.',
+  start: 1711020000,
+  sapphire: {
+    tvl,
+  }
+}; 


### PR DESCRIPTION
Note to reviewer:  The test.js script returns zero because I assume our token isn't on your pricing API.  Someone from the discord said to push this as-is and you'd add it to your coin pricing repo.

I had some difficulty in knowing which TVL and TVL filters to export.  It's staking contract, but user's stake the native token, not a protocol-created token.  Should I just be exporting `staking` with `tvl` set to the empty function?

Further - since our token is currently only on the Illuminex dex, we could alternatively use `stakingPricedLP` like below, but since we'll be listed on other exchanges, I figured it would be better to have you use CoinGecko's price.

 `// staking: stakingPricedLP(STEAK_CONTRACT, ROSY_TOKEN_CONTRACT, "sapphire", "0x4ebA1A83d00C0CCCBE680ecC730a5b1Dc2189F86", "oasis-network", true),`


-------------------------------------------------------
##### Name (to be shown on DefiLlama): Rosy


##### Twitter Link: https://x.com/rosytoken


##### List of audit links if any: https://www.cyberscope.io/audits/rosy


##### Website Link: https://rosytoken.com


##### Logo (High resolution, will be shown with rounded borders): https://rosytoken.com/rosy-fits-ellipse.png


##### Current TVL:  $352.32 k


##### Treasury Addresses (if the protocol has treasury)


##### Chain: Oasis Sapphire (Chain ID: 23294)


##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): rosy
https://www.coingecko.com/en/coins/rosy

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):


##### Short Description (to be shown on DefiLlama):
Rosy is the first memecoin on Oasis Network.  Rosy's "Burnt Steak" protocol" is a memecoin hype protool that allows ROSY token holders to stake and earn Carbon points and to increase the token's deflationary rate.

Once a threshold of 250m ROSY is staked, the token becomes deflationary at a rate of 10 ROSY burned per second.  After that, additional staked ROSY increases the burn rate.  The more ROSY is staked, the faster the supply is burned from a pre-allocated pool (not the user's ROSY).

Carbon points can be redeemed for in-game items and more.


##### Token address and ticker if any:
0x6665a6Cae3F52959f0f653E3D04270D54e6f13d8
ticker ROSY

##### Category (full list at https://defillama.com/categories) *Please choose only one: Gaming


##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
##### Implementation Details: Briefly describe how the oracle is integrated into your project:
##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

##### forkedFrom (Does your project originate from another project):


##### methodology (what is being counted as tvl, how is tvl being calculated):
Staked ROSY is found in the "Steak" contract.  It's a standard erc20:balanceOf call on this contract.

##### Github org/user (Optional, if your code is open source, we can track activity):
