### PR TITLE
Update GLIF Project adapter

### DIFF
--- a/projects/glif/index.js
+++ b/projects/glif/index.js
@@ -4,7 +4,7 @@ const { get } = require("../helper/http");
 
 module.exports = {
   methodology:
-    "The GLIF Pools protocol is a liquid leasing protocol for Filecoin that requires borrowers to collateralize FIL in order to borrow for their storage providing operation. This TVL calculation adds the total amount of FIL staked into the protocol, and the total amount of locked FIL collateral by borrowers, to arrive at TVL.",
+    "The GLIF Pools protocol is a liquid leasing protocol for Filecoin that requires borrowers to collateralize FIL in order to borrow for their storage providing operation. This TVL calculation adds the total amount of FIL deposited into the protocol, and the total amount of locked FIL collateral by borrowers, to arrive at TVL.",
   filecoin: {
     tvl: async (_, height, _1, { api }) => {
       // this call is too costly to perform on chain in this environment,

--- a/projects/glif/index.js
+++ b/projects/glif/index.js
@@ -22,7 +22,7 @@ module.exports = {
     // timestamp, event
     [1680206490, "Early deposits open"], // 2023-03-30
     [1685035830, "Protocol deployed"], // 2023-05-25
-    [1691781060, "Exit ramp deployed"] // 2023-08-11
+    [1691781060, "Exit ramp deployed"], // 2023-08-11
     [1711641600, "GLIF Points released"] // 2024-03-28
   ],
 

--- a/projects/glif/index.js
+++ b/projects/glif/index.js
@@ -9,7 +9,7 @@ module.exports = {
   filecoin: {
     tvl: async (_, height, _1, { api }) => {
       let url = INDEXER_API;
-      if (!!height && height > 0) {
+      if (!!height && height >= 0) {
         url += `?height=${height}`;
       }
       // this call is too costly to perform on chain in this environment,

--- a/projects/glif/index.js
+++ b/projects/glif/index.js
@@ -1,29 +1,28 @@
 const { nullAddress } = require("../helper/tokenMapping");
 const { get } = require("../helper/http");
 
-const INFINITY_POOL_CONTRACT = "0x43dAe5624445e7679D16a63211c5ff368681500c"; // pool address
-const totalAssetsABI = "function totalAssets() view returns (uint256)";
-const totalBorrowedABI = "function totalBorrowed() view returns (uint256)";
 
 module.exports = {
   methodology:
-    "The GLIF Pools protocol is a liquid staking protocol for Filecoin that requires borrowers to collateralize FIL in order to borrow for their storage providing operation. This TVL calculation adds the total amount of FIL staked into the protocol, and the total amount of locked FIL collateral by borrowers, to arrive at TVL.",
+    "The GLIF Pools protocol is a liquid leasing protocol for Filecoin that requires borrowers to collateralize FIL in order to borrow for their storage providing operation. This TVL calculation adds the total amount of FIL staked into the protocol, and the total amount of locked FIL collateral by borrowers, to arrive at TVL.",
   filecoin: {
-    tvl: async (api) => {
-      const [totalAssets, totalLockedByMiners] = await Promise.all([
-        api.call({ abi: totalAssetsABI, target: INFINITY_POOL_CONTRACT }),
-        // this call is too costly to perform on chain in this environment,
-        // we wrapped the locked miners collateral in a server that derives the information directly on-chain
-        // but serves it in a more efficient manner to not overload defillama frontend
-        // github repo: https://github.com/glifio/pools-metrics
-        get("https://events.glif.link/metrics"),
-      ]);
-
-      const totalAssetsBN = +totalAssets
-      const totalLockedByMinersBN = +totalLockedByMiners.totalMinerCollaterals
-      // then we add the totalLockedByMiners to the totalAssets, to account for the FIL locked by miners as borrow collateral
+    tvl: async (_, height, _1, { api }) => {
+      // this call is too costly to perform on chain in this environment,
+      // we wrapped the tvl in a server that derives the information directly on-chain
+      // but serves it in a more efficient manner to not overload defillama frontend
+      // github repo: https://github.com/glifio/pools-metrics
+      const { tvl } = await get(`https://events.glif.link/pool/0/tvl?height=${height}`);
       // this gets our tvl in attoFIL (wei denominated) without double counting
-      api.add(nullAddress, totalAssetsBN+totalLockedByMinersBN);
+      api.add(nullAddress, tvl);
     },
   },
+  timetravel: true,
+  start: 1677628800, // 2023-03-01
+  hallmarks:[
+    // timestamp, event
+    [1680206490, "Early deposits open"], // 2023-03-30
+    [1685035830, "Protocol deployed"], // 2023-05-25
+    [1691781060, "Exit ramp deployed"] // 2023-08-11
+  ],
+
 };

--- a/projects/glif/index.js
+++ b/projects/glif/index.js
@@ -23,6 +23,7 @@ module.exports = {
     [1680206490, "Early deposits open"], // 2023-03-30
     [1685035830, "Protocol deployed"], // 2023-05-25
     [1691781060, "Exit ramp deployed"] // 2023-08-11
+    [1711641600, "GLIF Points released"] // 2024-03-28
   ],
 
 };

--- a/projects/glif/index.js
+++ b/projects/glif/index.js
@@ -1,29 +1,33 @@
 const { nullAddress } = require("../helper/tokenMapping");
 const { get } = require("../helper/http");
 
+const INDEXER_API = "https://events.glif.link/pool/0/tvl";
 
 module.exports = {
   methodology:
     "The GLIF Pools protocol is a liquid leasing protocol for Filecoin that requires borrowers to collateralize FIL in order to borrow for their storage providing operation. This TVL calculation adds the total amount of FIL deposited into the protocol, and the total amount of locked FIL collateral by borrowers, to arrive at TVL.",
   filecoin: {
     tvl: async (_, height, _1, { api }) => {
+      let url = INDEXER_API;
+      if (!!height && height > 0) {
+        url += `?height=${height}`;
+      }
       // this call is too costly to perform on chain in this environment,
       // we wrapped the tvl in a server that derives the information directly on-chain
       // but serves it in a more efficient manner to not overload defillama frontend
       // github repo: https://github.com/glifio/pools-metrics
-      const { tvl } = await get(`https://events.glif.link/pool/0/tvl?height=${height}`);
+      const { tvl } = await get(url);
       // this gets our tvl in attoFIL (wei denominated) without double counting
       api.add(nullAddress, tvl);
     },
   },
   timetravel: true,
   start: 1677628800, // 2023-03-01
-  hallmarks:[
+  hallmarks: [
     // timestamp, event
     [1680206490, "Early deposits open"], // 2023-03-30
     [1685035830, "Protocol deployed"], // 2023-05-25
     [1691781060, "Exit ramp deployed"], // 2023-08-11
-    [1711641600, "GLIF Points released"] // 2024-03-28
+    [1711641600, "GLIF Points released"], // 2024-03-28
   ],
-
 };


### PR DESCRIPTION
- Offload more work to a server to allow DeFiLlama frontend to perform better (the Filecoin TVL is a heavy computation at this stage due to our scale)
- Fix bug in TVL calculation (we will report incorrect data through the website and can backfill historically to get fresh, accurate data since GLIF's launch)
- Add timetravel and start timestamp
- Add hallmarks 

*NOTE to the maintainers* - when I test this adapter and return a `0` for TVL, the test fails. Even attempting to hardcode any value in this call:

`api.add(nullAddress, tvl);` 

such as:

`api.add(nullAddress, "0");`<br />
`api.add(nullAddress, 0);`<br />
`api.add(nullAddress, new BN(0));`<br />

All fail - is this something we're doing wrong on our side?
