### PR TITLE
Add Aloe borrowed amounts

### DIFF
--- a/projects/aloe/index.js
+++ b/projects/aloe/index.js
@@ -23,7 +23,7 @@ async function getVaults(api) {
 
 async function tvl(api) {
   const vaults = await getVaults(api);
-  return api.erc4626Sum({ calls: vaults, isOG4626: true });
+  return api.erc4626Sum({ calls: vaults, tokenAbi: 'address:asset', balanceAbi: 'uint256:lastBalance' });
 }
 
 async function borrowed(api) {

--- a/projects/aloe/index.js
+++ b/projects/aloe/index.js
@@ -26,12 +26,22 @@ async function tvl(api) {
   return api.erc4626Sum({ calls: vaults, isOG4626: true });
 }
 
+async function borrowed(api) {
+  const vaults = await getVaults(api);
+  const tokens = await api.multiCall({ calls: vaults, abi: "address:asset" });
+  const stats = await api.multiCall({
+    calls: vaults,
+    abi: "function stats() view returns (uint72 borrowIndex, uint256 totalAssets, uint256 totalBorrows, uint256 totalSupply)",
+  });
+  api.addTokens(tokens, stats.map(x => x.totalBorrows));
+}
+
 module.exports = {
-  doublecounted: true,
+  doublecounted: false,
   methodology:
-    "Sums up deposits and borrows across Aloe's ERC4626 lending vaults to get TVL. Does not include collateral value.",
+    "Sums up deposits and borrows across Aloe's ERC4626 lending vaults to get TVL and Borrowed amounts, respectively. Does not include collateral value.",
 };
 
 Object.keys(config).forEach(chain => {
-  module.exports[chain] = { tvl }
+  module.exports[chain] = { tvl, borrowed }
 })


### PR DESCRIPTION
This change adds tracking for borrows in the Aloe protocol.

This wasn't done in #9544, as there was some concern that we'd be double-counting TVL. I do not think this is the case, as Aloe isn't a leveraged yield farming service -- it's a full lending protocol. As such, lending/borrowing on Aloe should be tracked the same as any other lending protocol.

It's possible that I've misunderstood the DefiLlama categorization/reporting requirements, so I'm happy to have a conversation here. Let me know if you have any questions. Thanks!