### PR TITLE
SwissBorg: Add new ETH wallet

### DIFF
--- a/projects/swissborg/index.js
+++ b/projects/swissborg/index.js
@@ -14,6 +14,7 @@ const config = {
       '0xff4606bd3884554cdbdabd9b6e25e2fad4f6fc54',
       '0x22bF0A4C4eff418b3306AbFeE20813D0b6E8Dc74',
       '0x11444C6389A26C8E41d7FD5CafBfCC511303b7d3',
+      '0x67FE3293FC4e877F3CDc3F0ed93721a600f72BdE',
     ],
   },
   bitcoin: {


### PR DESCRIPTION
This PR updates the list of wallets owned by SwissBorg. New wallet addition: https://github.com/SwissBorg/pub/commit/032284cf297f43d6e671123a763f1faee107e5c5