### PR TITLE
feat: fix Staq wrong address

### DIFF
--- a/projects/bitstaq/index.js
+++ b/projects/bitstaq/index.js
@@ -4,7 +4,7 @@ async function tvl(api) {
   const mapLockedAmount = await api.call({
     target: "0x000000000000000000000000000000000000d011",
     abi: "function getAccountTotalLockedGold(address) view returns (uint256)",
-    params: ["0x2Ef75B32C26bC92977998C6D19e527E49fAD0D9B"],
+    params: ["0x9bD1E0a3A727D0d4F4e9A6d59022E071DDc79924"],
   });
 
   api.add(ADDRESSES.map.WMAPO, mapLockedAmount)


### PR DESCRIPTION
Sorry, I submitted an incorrect parameter before, which caused the tvl calculation error. 
This pre address is the stake amount of our validator, not the total stake amount.