### PR TITLE
Adding New Staking Contract Support to Decuabte Adapter

### DIFF
--- a/projects/decubate/index.js
+++ b/projects/decubate/index.js
@@ -1,27 +1,31 @@
 const sdk = require("@defillama/sdk");
 
 const DCBToken = "0xEAc9873291dDAcA754EA5642114151f3035c67A2";
-const stakingPool = "0xD1748192aE1dB982be2FB8C3e6d893C75330884a";
+const stakingPools = [
+    "0xD1748192aE1dB982be2FB8C3e6d893C75330884a", // Legacy staking pool contract
+    "0xe740758a8cd372c836857defe8011e4e80e48723"  // New staking pools contract
+];
 
-async function staking (timestamp, block, chainBlocks) {
+async function staking(timestamp, block, chainBlocks) {
     let balances = {};
 
-    let {output: balance} =  await sdk.api.erc20.balanceOf({
-        target: DCBToken,
-        owner: stakingPool,
-        block: chainBlocks.bsc,
-        chain: "bsc"
-    });
+    for (let pool of stakingPools) {
+        let {output: balance} = await sdk.api.erc20.balanceOf({
+            target: DCBToken,
+            owner: pool,
+            block: chainBlocks.bsc,
+            chain: "bsc"
+        });
 
-    sdk.util.sumSingleBalance(balances, `bsc:${DCBToken}`, balance)
+        sdk.util.sumSingleBalance(balances, `bsc:${DCBToken}`, balance);
+    }
 
     return balances;
 }
 
 module.exports = {
     bsc: {
-        tvl: async () => ({}), 
+        tvl: async () => ({}),
         staking
     },
-    
-}
+};

--- a/projects/decubate/index.js
+++ b/projects/decubate/index.js
@@ -1,31 +1,14 @@
-const sdk = require("@defillama/sdk");
+const { staking } = require('../helper/staking')
 
-const DCBToken = "0xEAc9873291dDAcA754EA5642114151f3035c67A2";
+const DCBToken = "0xEAc9873291dDAcA754EA5642114151f3035c67A2"
 const stakingPools = [
-    "0xD1748192aE1dB982be2FB8C3e6d893C75330884a", // Legacy staking pool contract
-    "0xe740758a8cd372c836857defe8011e4e80e48723"  // New staking pools contract
-];
-
-async function staking(timestamp, block, chainBlocks) {
-    let balances = {};
-
-    for (let pool of stakingPools) {
-        let {output: balance} = await sdk.api.erc20.balanceOf({
-            target: DCBToken,
-            owner: pool,
-            block: chainBlocks.bsc,
-            chain: "bsc"
-        });
-
-        sdk.util.sumSingleBalance(balances, `bsc:${DCBToken}`, balance);
-    }
-
-    return balances;
-}
+  "0xD1748192aE1dB982be2FB8C3e6d893C75330884a", // Legacy staking pool contract
+  "0xe740758a8cd372c836857defe8011e4e80e48723"  // New staking pools contract
+]
 
 module.exports = {
-    bsc: {
-        tvl: async () => ({}),
-        staking
-    },
-};
+  bsc: {
+    tvl: async () => ({}),
+    staking: staking(stakingPools, DCBToken,)
+  },
+}


### PR DESCRIPTION
Update Decubate Staking Pools in Adapter

This PR adds support for new staking pools within the Decubate adapter. The update ensures accurate TVL calculations by including balances from both the original and newly added staking contracts.

**Changes:**
- Added new staking pool contract address to the `stakingPools` array.
- Updated the `staking` function to iterate over multiple pool addresses, aggregating the total balance.

This update is crucial for maintaining accurate TVL metrics on DefiLlama for the Decubate project. Please let me know if any further modifications or information is required.

**Note:** I've enabled "Allow edits by maintainers" to facilitate any necessary adjustments to this PR.
