### PR TITLE
Update Meow Miner to the correct start time

### DIFF
--- a/projects/MeowMiner/index.js
+++ b/projects/MeowMiner/index.js
@@ -5,7 +5,7 @@ const LP_MEOW_WAVAX = "0xbbf8e4b9AD041edE1F5270CAf5b7B41F0e55f719"
 
 module.exports = {
   methodology: 'counts the number of MEOW tokens in the Meow Miner contract.',
-  start: 1000235,
+  start: 42830364,
   avax: {
     tvl: sumTokensExport({ owner: MEOW_MINER_CONTRACT, tokens: [MEOW_TOKEN_CONTRACT], lps: [LP_MEOW_WAVAX], useDefaultCoreAssets: true, })
   }


### PR DESCRIPTION
This pull request updates the Meow Miner start to the correct block. 
The deployment of the contract occurred at avalanche block [42830364]
(https://snowscan.xyz/tx/0x19c14e99d55adc44750791d7532b98a577cc8877ff04908a4eb45b58bfea97f1)

Thanks!
 