### PR TITLE
Add wrapped token markets to Seamless TVL

### DIFF
--- a/projects/seamless/index.js
+++ b/projects/seamless/index.js
@@ -42,7 +42,7 @@ async function geyserTvl(api) {
   return api.getBalances()
 }
 
-const baseAAVE = aaveExports("base", AAVE_ADDRESSES_PROVIDER_REGISTRY, undefined, [AAVE_POOL_DATA_PROVIDER], { v3: true });
+const baseAAVE = aaveExports("base", AAVE_ADDRESSES_PROVIDER_REGISTRY, undefined, [AAVE_POOL_DATA_PROVIDER], { v3: true, hasWrappedTokens: true });
 
 module.exports = mergeExports([{
   methodology: methodologies.lendingMarket,


### PR DESCRIPTION
Seamless has some lending/borrowing markets that use wrapped tokens. This is a mechanism that is used to create isolated markets with different lending/borrowing parameters for the same underlying token. Up until now these markets were not counted in TVL since the addresses of the market reserves were for the wrapped token not the actual underlying token. This PR adds the capability to unwrap these tokens to get their underlying supply and borrow balances to be included in TVL