### PR TITLE
Add wand protocol V2 contract addresses

### DIFF
--- a/projects/wand/index.js
+++ b/projects/wand/index.js
@@ -8,7 +8,11 @@ module.exports = {
         '0xDC3985196D263E5259AB946a4b52CEDCBaDC1390', // $ETH vault's token pot
         '0xfD7D3d51b081FBeA178891839a9FEd5ca7896bDA', // $ETH vault's pty pool buy low
         '0x2F5007df87c043552f3c6b6e5487B2bDc92F0232', // $ETH vault's pty pool sell high
-        '0x05c061126A82DC1AfF891b9184c1bC42D380a2ff'  // $USDB vault's token pot
+        '0x05c061126A82DC1AfF891b9184c1bC42D380a2ff',  // $USDB vault's token pot
+        '0x7063ea2dBa364aCd9135752Da5395ac7CD12313D', // $ETH V2 vault's token pot
+        '0x3ee083573FceA8c015dcbfC7a51777B5770cbe64', // $ETH V2 vault's pty pool buy low
+        '0x39db7083C97d2C298C1A88fD27b0bd1C9c9f6fa8', // $ETH V2 vault's pty pool sell high
+        '0x565e325B7197d6105b0Ee74563ea211Cc838e2c3'  // $USDB V2 vault's token pot
       ],
       tokens: [
         ADDRESSES.null,  // $ETH


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
Wand Protocol

##### Twitter Link:
https://twitter.com/WandProtocol

##### List of audit links if any:
https://github.com/wandfi/resources/blob/main/audits/Beosin_202403.pdf

##### Website Link:
https://wand.fi

##### Logo (High resolution, will be shown with rounded borders):
https://twitter.com/WandProtocol/photo

##### Current TVL:
$4.36m

##### Treasury Addresses (if the protocol has treasury)
0x462bd2d3c020f6986c98160bc4e189954f49634b

##### Chain:
Blast

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description (to be shown on DefiLlama):
Wand protocol offers stablecoins for low-risk stability and margin tokens for higher volatility, catering to diverse investment strategies through standardized, pooled assets.

##### Token address and ticker if any:

##### Category (full list at https://defillama.com/categories) *Please choose only one:
CDP

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
Redstone

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
We are using Redstone's classic model price feed for $ETH and $USDB in chainlink-compatible manner.


##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
https://docs.redstone.finance/docs/smart-contract-devs/price-feeds

##### forkedFrom (Does your project originate from another project):


##### methodology (what is being counted as tvl, how is tvl being calculated):


##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/wandfi
