### PR TITLE
summerfi + instadapp lite

### DIFF
--- a/projects/instadapp-lite/index.js
+++ b/projects/instadapp-lite/index.js
@@ -1,0 +1,25 @@
+const vaults = [
+    { "vault": "0xc383a3833A87009fD9597F8184979AF5eDFad019", "token": "0x0000000000000000000000000000000000000000" },
+    { "vault": "0xc8871267e07408b89aA5aEcc58AdCA5E574557F8", "token": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" },
+    { "vault": "0xEC363faa5c4dd0e51f3D9B5d0101263760E7cdeB", "token": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599" },
+    { "vault": "0x40a9d39aa50871Df092538c5999b107f34409061", "token": "0x6B175474E89094C44Da98b954EedeAC495271d0F" }
+]
+const vaultsV2 = ["0xA0D3707c569ff8C87FA923d3823eC5D81c98Be78"]
+
+async function tvl(api) {
+    const calls = vaults.map(v => ({ target: v.vault }))
+    const prices = await api.multiCall({
+        calls,
+        abi: "function getCurrentExchangePrice() public view returns (uint256 exchangePrice_, uint256 newTokenRevenue_)"
+    })
+    const supply = await api.multiCall({
+        calls,
+        abi: "erc20:totalSupply"
+    })
+    prices.forEach((price, i)=>api.add(vaults[i].token, price.exchangePrice_*supply[i]/1e18))
+    return api.erc4626Sum({ calls: vaultsV2, tokenAbi: 'address:asset', balanceAbi: 'uint256:totalAssets' });
+}
+
+module.exports = {
+    ethereum: { tvl }
+}

--- a/projects/summer-fi/index.js
+++ b/projects/summer-fi/index.js
@@ -1,8 +1,7 @@
-const { automationTvl, dpmPositions, makerTvl } = require("./handlers");
+const { automationTvl } = require("./handlers");
 const { getAutomationCdpIdList, setCallCache } = require("./helpers");
 const sdk = require("@defillama/sdk");
-const { getConfig, getCache, setCache } = require("../helper/cache");
-const { endpoints } = require("./constants/endpoints");
+const { getCache, setCache } = require("../helper/cache");
 
 module.exports = {
   doublecounted: true,
@@ -12,8 +11,7 @@ module.exports = {
 async function tvl(api) {
   await api.getBlock();
   const executionStart = Date.now() / 1000;
-  const [confirmedSummerFiMakerVaults, cdpIdList, cache] = await Promise.all([
-    await getConfig("summer-fi/maker-vaults", endpoints.makerVaults()),
+  const [cdpIdList, cache] = await Promise.all([
     getAutomationCdpIdList({ api }),
     getCache("summer-fi/cache", api.chain),
   ]);
@@ -23,9 +21,7 @@ async function tvl(api) {
   sdk.log([...cdpIdList].length, "cdpIdList");
 
   await Promise.all([
-    dpmPositions({ api }),
     automationTvl({ api, cdpIdList }),
-    makerTvl({ api, cdpIdList, confirmedSummerFiMakerVaults }),
   ]);
 
   await setCache("summer-fi/cache", api.chain, cache);


### PR DESCRIPTION
goal is to normalize methodologies better.

specifically we are not tracking gnosis safe tvl or other smart wallets, so we shouldnt be tracking it there either

these changes make it so only automated tvl will be tracked for instadapp, summerfi and defisaver

also brings everything onchain so that we dont have any more opaque apis