### PR TITLE
feat: add blast endpoint for Sablier

### DIFF
--- a/projects/sablier-v2/index.js
+++ b/projects/sablier-v2/index.js
@@ -40,6 +40,7 @@ const config = {
   polygon: { endpoints: ['https://api.thegraph.com/subgraphs/name/sablier-labs/sablier-v2-polygon'], },
   avax: { endpoints: ['https://api.thegraph.com/subgraphs/name/sablier-labs/sablier-v2-avalanche'], },
   base: { endpoints: ['https://api.thegraph.com/subgraphs/name/sablier-labs/sablier-v2-base'], },
+  blast: { endpoints: ['https://api.studio.thegraph.com/query/57079/sablier-v2-blast/version/latest'], },
 }
 
 Object.keys(config).forEach(chain => {


### PR DESCRIPTION
Sablier is already added to Defillama. This PR adds `Blast` endpoint to it.