### PR TITLE
Update Connext Adapter

### DIFF
--- a/projects/connext/index.js
+++ b/projects/connext/index.js
@@ -49,21 +49,8 @@ const chains = [
   "optimism",
   "arbitrum",
   "mode",
-
-  // deprecated?
-  "moonriver",
-  "fantom",
-  "avax",
-  "moonbeam",
-  "fuse",
-  "cronos",
-  "milkomeda",
-  "boba",
-  "evmos",
-  "harmony",
-  // "okexchain",
-  // "metis",
-  // "heco",
-  // "aurora",
+  "metis",
+  "base",
+  "linea",
 ];
 module.exports = chainExports(chainTvl, Array.from(chains));

--- a/projects/connext/index.js
+++ b/projects/connext/index.js
@@ -19,7 +19,6 @@ async function getDeployedContractAddress(chainId) {
 
   // Manually adding Connext-specific xERC20 lockboxes on L1. Don't yet have a programmatic way to retrieve these, so hardcoding the largest lockboxes only for now.
   if (chainId === 1) {
-    result.push("0x22f424Bca11FE154c403c277b5F8dAb54a4bA29b"); // NEXT
     result.push("0xC8140dA31E6bCa19b287cC35531c2212763C2059"); // ezETH
   }
   return result;
@@ -34,9 +33,8 @@ async function getAssetIds(chainId) {
   const data = await getAssetsPromise
   const chainData = data.find(item => item.chainId === chainId) || {}
   const result = Object.entries(chainData.assetId || {}).filter(i => i[0].length && !i[1].symbol.startsWith('next')).map(i => i[0])
-  // crossChain.json returns the xERC20 representations of NEXT & ezETH instead of canonical addresses on L1. Manually add these below until a better JSON is available.
+  // crossChain.json returns the xERC20 representation of ezETH instead of canonical addresses on L1. Manually add these below until a better JSON is available.
   if (chainId === 1) {
-    result.push("0xFE67A4450907459c3e1FFf623aA927dD4e28c67a"); // NEXT
     result.push("0xbf5495Efe5DB9ce00f80364C8B423567e58d2110"); // ezETH
   }
   return result;
@@ -65,5 +63,21 @@ const chains = [
   "metis",
   "base",
   "linea",
+
+  // deprecated?
+  "moonriver",
+  "fantom",
+  "avax",
+  "moonbeam",
+  "fuse",
+  "cronos",
+  "milkomeda",
+  "boba",
+  "evmos",
+  "harmony",
+  // "okexchain",
+  // "metis",
+  // "heco",
+  // "aurora",
 ];
 module.exports = chainExports(chainTvl, Array.from(chains));

--- a/projects/connext/index.js
+++ b/projects/connext/index.js
@@ -11,10 +11,18 @@ async function getDeployedContractAddress(chainId) {
   const allContracts = await getContracts()
   const record = allContracts[chainId + ''] ?? []
   const contracts =  (record ?? [])[0]?.contracts ?? {}
-  return [
+
+  const result = [
     contracts.Connext?.address,
     contracts.Connext_DiamondProxy?.address,
-  ].filter(i => i)
+  ].filter(i => i);
+
+  // Manually adding Connext-specific xERC20 lockboxes on L1. Don't yet have a programmatic way to retrieve these, so hardcoding the largest lockboxes only for now.
+  if (chainId === 1) {
+    result.push("0x22f424Bca11FE154c403c277b5F8dAb54a4bA29b"); // NEXT
+    result.push("0xC8140dA31E6bCa19b287cC35531c2212763C2059"); // ezETH
+  }
+  return result;
 }
 
 let getAssetsPromise
@@ -25,13 +33,18 @@ async function getAssetIds(chainId) {
     getAssetsPromise = getConfig('connect/assets/'+chainId, url)
   const data = await getAssetsPromise
   const chainData = data.find(item => item.chainId === chainId) || {}
-  return Object.entries(chainData.assetId || {}).filter(i => i[0].length && !i[1].symbol.startsWith('next')).map(i => i[0])
+  const result = Object.entries(chainData.assetId || {}).filter(i => i[0].length && !i[1].symbol.startsWith('next')).map(i => i[0])
+  // crossChain.json returns the xERC20 representations of NEXT & ezETH instead of canonical addresses on L1. Manually add these below until a better JSON is available.
+  if (chainId === 1) {
+    result.push("0xFE67A4450907459c3e1FFf623aA927dD4e28c67a"); // NEXT
+    result.push("0xbf5495Efe5DB9ce00f80364C8B423567e58d2110"); // ezETH
+  }
+  return result;
 }
 
 
 function chainTvl(chain) {
   return async (api) => {
-
     const chainId = api.chainId
     const owners = await getDeployedContractAddress(chainId)
     if (!owners.length)


### PR DESCRIPTION
Updating Connext adapter to:
- Add new chains supported by the protocol
- Track xERC20s bridged by Connext to other chains
