### PR TITLE
Update Colony - include vesting contract

### DIFF
--- a/projects/colony/clyVesting.js
+++ b/projects/colony/clyVesting.js
@@ -1,5 +1,4 @@
 const { getLogs } = require('../helper/cache/getLogs');
-const { getBlock } = require('../helper/http');
 const ethers = require("ethers");
 
 /**
@@ -49,7 +48,6 @@ class GroupDataSet {
       return unlockedAmount;
     }
 
-
     // return max available amount if the vesting ended
     const endTimestamp = startTimestamp + this.distributionOffset + this.distributionLength;
     if (currentTimestamp >= endTimestamp) {
@@ -88,6 +86,7 @@ function clyVesting(colonyGovernanceToken, vestingContract) {
   return async ({ api }) => {
 
     const START_BLOCK = 7669442; // 7669442 -> deployment block of the vesting contract
+    const END_BLOCK = 7675925; // The last block where the GroupDataSet event was emitted
 
     const vestingStartTimestamp = Number(
       await api.call({
@@ -95,10 +94,6 @@ function clyVesting(colonyGovernanceToken, vestingContract) {
         target: vestingContract,
       })
     );
-
-    // first block number after vestingStartTimestamp
-    const block = await getBlock(vestingStartTimestamp, api.chain, {});
-    const END_BLOCK = block.number + 1;
 
     const currentVestingBalance = BigInt(
       await api.call({

--- a/projects/colony/clyVesting.js
+++ b/projects/colony/clyVesting.js
@@ -1,0 +1,148 @@
+const { getLogs } = require('../helper/cache/getLogs');
+const { getBlock } = require('../helper/http');
+const ethers = require("ethers");
+
+/**
+ * Helper class to store GroupDataSet events.
+ *
+ * The class provides a method to calculate the amount of unlocked vested tokens.
+ */
+class GroupDataSet {
+  groupId;
+  groupName;
+  maxDistributionAmount;
+  distributionOffset;
+  distributionLength;
+  initialRelease;
+
+  constructor (eventArgs) {
+    this.groupId = eventArgs[0];
+    this.groupName = eventArgs[1];
+    this.maxDistributionAmount = eventArgs[2];
+    this.distributionOffset = Number(eventArgs[3]);
+    this.distributionLength = Number(eventArgs[4]);
+    this.initialRelease = eventArgs[5];
+  }
+
+  // for dbg purposes
+  toString () {
+    const secondsInDay = 3600 * 24;
+
+    return `Group ${this.groupId} (${this.groupName}): ` +
+           `maxDistributionAmount=${ethers.formatEther(this.maxDistributionAmount)}, ` +
+           `distributionOffset=${this.distributionOffset / secondsInDay} days, ` +
+           `distributionLength=${this.distributionLength / secondsInDay} days, ` +
+           `initialRelease=${ethers.formatEther(this.initialRelease) * 100}%`;
+  }
+
+
+  unlockedAmount (startTimestamp, currentTimestamp) {
+    let unlockedAmount = 0n;
+
+    if (startTimestamp < currentTimestamp) {
+      const initialReleaseAmount = this.initialRelease * this.maxDistributionAmount / ethers.parseEther("1");
+      unlockedAmount += initialReleaseAmount;
+    }
+
+    // return only the initial release if the offset is not reached
+    if (currentTimestamp < startTimestamp + this.distributionOffset) {
+      return unlockedAmount;
+    }
+
+
+    // return max available amount if the vesting ended
+    const endTimestamp = startTimestamp + this.distributionOffset + this.distributionLength;
+    if (currentTimestamp >= endTimestamp) {
+      return this.maxDistributionAmount;
+    }
+
+    // calculate the amount of unlocked tokens
+    const timePassed = BigInt(currentTimestamp - (startTimestamp + this.distributionOffset));
+    unlockedAmount += timePassed * (this.maxDistributionAmount - unlockedAmount) / BigInt(this.distributionLength);
+
+    return unlockedAmount;
+  }
+}
+
+/**
+ * Method to calculate the total amount of unlocked vested tokens:
+ *
+ * Collects GroupDataSet events (that were emitted only before the actual start of vesting).
+ *
+ * event GroupDataSet(
+ *    uint groupId, // Unique identifier for the group
+ *    string groupName, // Descriptive name of the group
+ *    uint maxDistributionAmount, // Total number of tokens allocated for distribution to this group
+ *    uint distributionOffset, // The offset in seconds from the start, when distribution begins
+ *    uint distributionLength, // The total time span of the distribution, in seconds
+ *    uint initialRelease, // The amount of tokens that are initially released as 18 dec mantissa
+ * );
+ *
+ * Events for all groups reveals the total number of tokens distributed and the manner
+ * in which they were unlocked over time.
+ *
+ * The total amount of tokens unlocked by vesting contract can be deduced by comparing this with the
+ * actual balance of the contract (which contains information about the tokens already withdrawn).
+ */
+function clyVesting(colonyGovernanceToken, vestingContract) {
+  return async ({ api }) => {
+
+    const START_BLOCK = 7669442; // 7669442 -> deployment block of the vesting contract
+
+    const vestingStartTimestamp = Number(
+      await api.call({
+        abi: "function vestingStartTimestamp() external view returns (uint256)",
+        target: vestingContract,
+      })
+    );
+
+    // first block number after vestingStartTimestamp
+    const block = await getBlock(vestingStartTimestamp, api.chain, {});
+    const END_BLOCK = block.number + 1;
+
+    const currentVestingBalance = BigInt(
+      await api.call({
+        abi: 'erc20:balanceOf',
+        target: colonyGovernanceToken,
+        params: vestingContract
+      })
+    );
+
+    const eventArgs = (
+      await getLogs({
+        target: vestingContract,
+        eventAbi: "event GroupDataSet(uint256,string,uint256,uint256,uint256,uint256)",
+        api,
+        fromBlock: START_BLOCK,
+        toBlock: END_BLOCK,
+        onlyArgs: true,
+      })
+    );
+
+    const groups = eventArgs.map((args) => new GroupDataSet(args));
+
+    // calculate total vested amount, summing maxDistributionAmount of all groups
+    let totalVestedAmount = 0n;
+    for (const group of groups) {
+      totalVestedAmount += group.maxDistributionAmount;
+    }
+
+    // calculate total unlocked amount
+    let totalUnlockedAmount = 0n
+    for (const group of groups) {
+      totalUnlockedAmount += group.unlockedAmount(vestingStartTimestamp, api.timestamp);
+    }
+
+    // calculate total withdrawn amount
+    const totalWithdrawn = totalVestedAmount - currentVestingBalance;
+
+    // total amount of tokens unlocked by vesting contract, but not yet withdrawn
+    const availableToWithdraw = totalUnlockedAmount - totalWithdrawn;
+
+    api.add(colonyGovernanceToken, availableToWithdraw);
+  }
+}
+
+module.exports = {
+  clyVesting,
+}

--- a/projects/colony/index.js
+++ b/projects/colony/index.js
@@ -1,4 +1,5 @@
 const { clyVesting } = require("./clyVesting")
+const { staking } = require('../helper/staking')
 
 const colonyGovernanceToken = "0xec3492a2508DDf4FDc0cD76F31f340b30d1793e6";
 
@@ -8,46 +9,25 @@ const stakingV3Contract = "0x62685d3EAacE96D6145D35f3B7540d35f482DE5b";
 
 const vestingContract = "0xEFAc81f709d314604a7DaEe9ca234dA978c2Be20";
 
-async function staking({ api }) {
-  const stakingV1 = (
-    await api.call({
-      abi: "function totalStaked() external view returns (uint256)",
-      target: stakingV1Contract,
-    })
-  )
-
-  const stakingV2 = (
-    await api.call({
-      abi: "function totalStake() external view returns (uint256)",
-      target: stakingV2Contract,
-    })
-  )
-
-  const stakingV3 = (
-    await api.call({
-      abi: "function totalStake() external view returns (uint256)",
-      target: stakingV3Contract,
-    })
-  )
-
-  api.add(colonyGovernanceToken, stakingV1)
-  api.add(colonyGovernanceToken, stakingV2)
-  api.add(colonyGovernanceToken, stakingV3)
+async function _staking(api) {
+  const bals = await api.multiCall({ abi: 'uint256:totalStaked', calls: [stakingV1Contract,] })
+  const bals1 = await api.multiCall({ abi: 'uint256:totalStake', calls: [stakingV2Contract, stakingV3Contract] })
+  api.add(colonyGovernanceToken, bals.concat(bals1))
 }
 
 module.exports = {
-  timetravel: true,
   methodology:
     "Staking is calculated based on CLY tokens locked on Colony staking contracts. " +
     "Vesting is calculated as already unlocked and available to claim CLY tokens in the vesting contract",
-  avax:{
+  avax: {
     start: 1638367059, // CLY Token deployment
     hallmarks: [
       [1651241728, "Staking V2 Launch"],
       [1711370069, "Staking V3 Launch"]
     ],
     tvl: async () => ({}),
-    staking,
-    vesting: clyVesting(colonyGovernanceToken, vestingContract),
+    staking: _staking,
+    // vesting: clyVesting(colonyGovernanceToken, vestingContract),
+    vesting: staking(vestingContract, colonyGovernanceToken),
   },
 };

--- a/projects/colony/index.js
+++ b/projects/colony/index.js
@@ -1,7 +1,12 @@
+const { clyVesting } = require("./clyVesting")
+
+const colonyGovernanceToken = "0xec3492a2508DDf4FDc0cD76F31f340b30d1793e6";
+
 const stakingV1Contract = "0x5B0d74C78F2588B3C5C49857EdB856cC731dc557";
 const stakingV2Contract = "0x7CcDa6E26dCeD1Ba275c67CD20235790ed615A8D";
 const stakingV3Contract = "0x62685d3EAacE96D6145D35f3B7540d35f482DE5b";
-const colonyGovernanceToken = "0xec3492a2508DDf4FDc0cD76F31f340b30d1793e6";
+
+const vestingContract = "0xEFAc81f709d314604a7DaEe9ca234dA978c2Be20";
 
 async function staking({ api }) {
   const stakingV1 = (
@@ -31,10 +36,12 @@ async function staking({ api }) {
 }
 
 module.exports = {
+  timetravel: true,
   methodology:
     "Staking is calculated based on CLY tokens locked on Colony staking contracts",
   avax:{
     tvl: async () => ({}),
     staking,
+    vesting: clyVesting(colonyGovernanceToken, vestingContract),
   },
 };

--- a/projects/colony/index.js
+++ b/projects/colony/index.js
@@ -38,7 +38,8 @@ async function staking({ api }) {
 module.exports = {
   timetravel: true,
   methodology:
-    "Staking is calculated based on CLY tokens locked on Colony staking contracts",
+    "Staking is calculated based on CLY tokens locked on Colony staking contracts. " +
+    "Vesting is calculated as already unlocked and available to claim CLY tokens in the vesting contract",
   avax:{
     tvl: async () => ({}),
     staking,

--- a/projects/colony/index.js
+++ b/projects/colony/index.js
@@ -41,6 +41,11 @@ module.exports = {
     "Staking is calculated based on CLY tokens locked on Colony staking contracts. " +
     "Vesting is calculated as already unlocked and available to claim CLY tokens in the vesting contract",
   avax:{
+    start: 1638367059, // CLY Token deployment
+    hallmarks: [
+      [1651241728, "Staking V2 Launch"],
+      [1711370069, "Staking V3 Launch"]
+    ],
     tvl: async () => ({}),
     staking,
     vesting: clyVesting(colonyGovernanceToken, vestingContract),


### PR DESCRIPTION
Update Colony - include vesting contract

This pull request updates the Colony adapter to include the vesting contract in the TVL calculation.
It also adds hallmarks for important deployments, such as the launch of StakingV2 and StakingV3.

##### methodology

This update was implemented by parsing event logs extracted from the defined period between START_BLOCK and END_BLOCK, specifically targeting when vesting groups were established. Knowing the details about these groups, their amounts, and parameters, and considering the tokens that have already been withdrawn, it was possible to accurately calculate and include only the CLY tokens that are already unlocked and available for claim.