### PR TITLE
Add Ebisu's Bay project

### DIFF
--- a/projects/ebisus-bay/index.js
+++ b/projects/ebisus-bay/index.js
@@ -1,0 +1,20 @@
+const { staking } = require('../helper/staking')
+const { getUniTVL } = require('../helper/unknownTokens')
+
+const factory = '0x5f1d751f447236f486f4268b883782897a902379'
+const frtnToken = '0xaF02D78F39C0002D14b95A3bE272DA02379AfF21'
+const bankContract = '0x1E16Aa4Bb965478Df310E8444CD18Fa56603A25F'
+
+
+module.exports = {
+    misrepresentedTokens: true,
+    methodology: "The TVL accounts for all LP on the dex, using the factory address 0x5f1d751f447236f486f4268b883782897a902379). Staking accounts for the FRTN staked in the bank on our platform.",
+  cronos: {
+    staking: staking(bankContract, frtnToken),
+    tvl: getUniTVL({
+      factory,
+      useDefaultCoreAssets: true,
+    }),
+  },
+}
+


### PR DESCRIPTION
##### Name (to be shown on DefiLlama): 
Ebisu's Bay


##### Twitter Link: 
https://twitter.com/EbisusBay


##### List of audit links if any: 
N/A


##### Website Link: 
https://app.ebisusbay.com


##### Logo (High resolution, will be shown with rounded borders): 
![android-chrome-512x512](https://github.com/DefiLlama/DefiLlama-Adapters/assets/17624338/7acac564-a4de-4efe-a736-0f6d9aebc7e0)


##### Current TVL: 
709K

##### Treasury Addresses (if the protocol has treasury)
0x289A94c5cf403691aca3d222E30335a4957b3ae6

##### Chain: 
Cronos


##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): 
ebisusbay-fortune


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): 
ebisusbay-fortune


##### Short Description (to be shown on DefiLlama):
Ebisu's Bay is a dynamic platform that combines NFT and DEX trading with GameFi, enabling users to join factions for market dominance. It transforms NFTs into engaging game elements, adding an interactive dimension to trading and gaming.

##### Token address and ticker if any:
FRTN - 0xaF02D78F39C0002D14b95A3bE272DA02379AfF21

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Dexes

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.): 
N/A

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
N/A

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
N/A

##### forkedFrom (Does your project originate from another project):
Uniswap V2


##### methodology (what is being counted as tvl, how is tvl being calculated):
The TVL accounts for all LP on the dex, using the factory address 0x5f1d751f447236f486f4268b883782897a902379. Staking accounts for the FRTN staked in the bank on our platform.


##### Github org/user (Optional, if your code is open source, we can track activity):
N/A
