### PR TITLE
Update staking tvl address to v2 address

### DIFF
--- a/projects/indigo/index.js
+++ b/projects/indigo/index.js
@@ -10,6 +10,6 @@ module.exports = {
         cardano: data.reduce((a, i) => a + (i.collateralAmount/1e6), 0)
       }
     },
-    staking: sumTokensExport({ owner: 'addr1w92w34pys9h4h02zxdfsp8lhcvdd5t9aaln9z96szsgh73scty4aj', tokens: ['533bb94a8850ee3ccbe483106489399112b74c905342cb1792a797a0494e4459']})
+    staking: sumTokensExport({ owner: 'addr1wx3r0yl49yteuzwwlv7r0lr2uzq7p6v7nxl9ek645qy5rfgwwzxw6', tokens: ['533bb94a8850ee3ccbe483106489399112b74c905342cb1792a797a0494e4459']})
   },
 }


### PR DESCRIPTION
As part of the Indigo v2 launch, the staking address has changed to be `addr1wx3r0yl49yteuzwwlv7r0lr2uzq7p6v7nxl9ek645qy5rfgwwzxw6`
