### PR TITLE
feat: added FeeFree tvl adapter

### DIFF
--- a/projects/FeeFree/index.js
+++ b/projects/FeeFree/index.js
@@ -1,0 +1,43 @@
+const { getLogs } = require('../helper/cache/getLogs')
+const { sumTokens2 } = require('../helper/unwrapLPs')
+
+const EVENT_ABI = 'event Initialize(bytes32 id, address indexed currency0, address indexed currency1, uint24 fee, int24 tickSpacing, address hooks)'
+const TOPICS = ['0x3fd553db44f207b1f41348cfc4d251860814af9eadc470e8e7895e4d120511f4']
+
+const CONFIGS = {
+  zora: {
+    pool: "0xB43287b2106BC044F07aE674794f5492E851d3dC",
+    router: "0x0Fee97363deEFBE4De038D437D805A98dbEbA400",
+    fromBlock: 13704184,
+  },
+}
+
+const getTVL = ({ pool, router, fromBlock }) => {
+  return async api => {
+    const logs = await getLogs({
+      api,
+      target: pool,
+      eventAbi: EVENT_ABI,
+      topics: TOPICS,
+      fromBlock,
+      onlyArgs: true,
+    })
+  
+    const tokens = logs.filter(log => log[5] === router).map(log => [log[1], log[2]]).flat()
+  
+    return sumTokens2({
+      api,
+      ownerTokens: [[tokens, pool]],
+      useDefaultCoreAssets: true,
+    })
+  }
+}
+
+const chains = Object.fromEntries(Object.entries(CONFIGS).map(([chain, config]) => [chain, { tvl: getTVL(config) }]))
+
+module.exports = {
+  misrepresentedTokens: true,
+  timetravel: false,
+  ...chains,
+  start: 1714060800, // Apr 26 2024
+}

--- a/projects/helper/coreAssets.json
+++ b/projects/helper/coreAssets.json
@@ -1715,5 +1715,8 @@
   },
   "genesys": {
     "WGSYS": "0xAa7aE83eb30DDdd14A017D4222121776317EA8Ba"
+  },
+  "zora": {
+    "USDzC": "0xcccccccc7021b32ebb4e8c08314bd62f7c653ec4"
   }
 }

--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -138,6 +138,10 @@ const fixBalancesTokens = {
   genesys: {
     [ADDRESSES.genesys.WGSYS]: { coingeckoId: "genesys", decimals: 18 },
   },
+  zora: {
+    [ADDRESSES.null]: { coingeckoId: "ethereum", decimals: 18, },
+    [ADDRESSES.zora.USDzC]: { coingeckoId: "usd-coin", decimals: 6, },
+  },
 }
 
 ibcChains.forEach(chain => fixBalancesTokens[chain] = { ...ibcMappings, ...(fixBalancesTokens[chain] || {}) })


### PR DESCRIPTION
##### Name:
FeeFree


##### Twitter Link:
https://x.com/FeeFreeFi


##### Website Link:
https://app.feefree.fi


##### Logo:
![logo](https://github.com/DefiLlama/DefiLlama-Adapters/assets/98699779/0dfd133a-65ac-4978-8a49-7c68a5522960)



##### Current TVL:
~6.30k


##### Chain:
zora


##### Short Description:
FeeFree aims to build a RobinHood-Style DEX in blockchain industry, enable every individual in the world to participate in DeFi!


##### Category:
Dexes


##### methodology:
Tokens in the pool multiplied by their price in usd


##### Github org:
https://github.com/FeeFreeFi
