### PR TITLE
Update enki tvl

### DIFF
--- a/projects/enki/index.js
+++ b/projects/enki/index.js
@@ -1,9 +1,8 @@
 const ADDRESSES = require('../helper/coreAssets.json')
 async function tvl(_, _1, _2, { api }) {
     const stakedMetis = await api.call({
-        abi: 'erc20:balanceOf',
-        target: ADDRESSES.metis.Metis,
-        params: ['0x810Ef8Aa1326FB1c5Ce57cD79d549CF9B2cC32aF']
+        abi: 'erc20:totalSupply',
+        target: '0x97a2de3A09F4A4229369ee82c7F76be1a5564661',
     });
 
     api.add(ADDRESSES.metis.Metis, stakedMetis);


### PR DESCRIPTION
methodology (what is being counted as tvl, how is tvl being calculated):
ENKI has an eMetisMinter contract allowing users to stake their Metis, but to calculate accurate tvl, should call the totalSupply of eMetis token