### PR TITLE
dirac finance tvl infos

### DIFF
--- a/projects/dirac-finance/index.js
+++ b/projects/dirac-finance/index.js
@@ -1,0 +1,34 @@
+const DIRAC_VAULT_1_CONTRACT = '0xa9154A433E879fa0E948eA208Aa359271Dc40469';
+const USDCE_CONTRACT = '0x37eaa0ef3549a5bb7d431be78a3d99bd360d19e5';
+const USDC_CONTRACT = '0xA8CE8aee21bC2A48a5EF670afCc9274C7bbbC035';
+
+const DIRAC_VAULT_2_CONTRACT = '0x6d91E01A609e34d58678265ee6b821F0E1b9044E';
+const DIRAC_VAULT_3_CONTRACT = '0x714BEC23142375c1A6576A9B7cA302DD1B680237';
+const MINT_CLUB_BOND_CONTRACT = '0x8BBac0C7583Cc146244a18863E708bFFbbF19975';
+
+async function tvl(_, _1, _2, { api }) {
+    const collateralBalance1 = await api.call({
+        abi: 'erc20:balanceOf',
+        target: USDCE_CONTRACT,
+        params: [DIRAC_VAULT_1_CONTRACT],
+    });
+
+    // const collateralBalance2 = await api.call({
+    //     abi: 'erc20:balanceOf',
+    //     target: USDCE_CONTRACT,
+    //     params: [DIRAC_VAULT_2_CONTRACT],
+    // });
+
+    api.add(USDCE_CONTRACT, collateralBalance1)
+    // api.add(USDCE_CONTRACT, collateralBalance2)
+}
+
+module.exports = {
+    timetravel: true,
+    misrepresentedTokens: false,
+    methodology: 'counts the number of MINT tokens in the Club Bonding contract.',
+    start: 11251616,
+    polygon_zkevm: {
+        tvl,
+    }
+}; 

--- a/projects/dirac-finance/index.js
+++ b/projects/dirac-finance/index.js
@@ -13,14 +13,21 @@ async function tvl(_, _1, _2, { api }) {
         params: [DIRAC_VAULT_1_CONTRACT],
     });
 
-    // const collateralBalance2 = await api.call({
-    //     abi: 'erc20:balanceOf',
-    //     target: USDCE_CONTRACT,
-    //     params: [DIRAC_VAULT_2_CONTRACT],
-    // });
+    const collateralBalance2 = await api.call({
+        abi: 'erc20:totalSupply',
+        target: DIRAC_VAULT_2_CONTRACT,
+        params: [],
+    });
+
+    const collateralBalance3 = await api.call({
+        abi: 'erc20:totalSupply',
+        target: DIRAC_VAULT_3_CONTRACT,
+        params: [],
+    });
 
     api.add(USDCE_CONTRACT, collateralBalance1)
-    // api.add(USDCE_CONTRACT, collateralBalance2)
+    api.add(USDCE_CONTRACT, collateralBalance2)
+    api.add(USDCE_CONTRACT, collateralBalance3)
 }
 
 module.exports = {


### PR DESCRIPTION
Name (to be shown on DefiLlama): Dirac Finance
Twitter Link: https://twitter.com/DiracFinance
List of audit links if any:
Website Link: https://dirac.finance/
Logo (High resolution, will be shown with rounded borders): https://www.dirac.finance/black_icon.png
Current TVL:  5091,98 USDC 
Treasury Addresses (if the protocol has treasury)
Chain: Polygon ZKEVM
Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): 
Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): 
Short Description (to be shown on DefiLlama):
Onchain Derivatives Strategies. Earn yield through decentralized derivatives strategies, inspired by TradFi and adapted to DeFi.
Token address and ticker if any:
Category (full list at https://defillama.com/categories) *Please choose only one: Derivatives
Oracle Provider(s): Chainlink
Implementation Details: We use Chainlink to get on chain prices
Documentation/Proof:
forkedFrom (Does your project originate from another project):
methodology (what is being counted as tvl, how is tvl being calculated):
TVL is the value of usdc tokens locked in the protocol. The TVL calculation code does the below
Get the quantity of usdc.e/usdc tokens held by each vault.
Do the sum.
Github org/user (Optional, if your code is open source, we can track activity):