### PR TITLE
Add linea data to Aloe adapter

### DIFF
--- a/projects/aloe/index.js
+++ b/projects/aloe/index.js
@@ -6,6 +6,7 @@ const config = {
   optimism: { fromBlock: 113464669, },
   base: { fromBlock: 7869252, },
   arbitrum: { fromBlock: 159919891, },
+  linea: { factory: '0x00000000333288eBA83426245D144B966Fd7e82E', fromBlock: 3982456 },
 };
 
 async function getVaults(api) {


### PR DESCRIPTION
Aloe was recently deployed to Linea; this just adds the config for that chain to our adapter.

Separately, in my [original PR](#9544) I requested that the project name be "Aloe" but we were listed as "Aloe Capital". I assume it's too late to easily change that, but if you could I'd really appreciate it. Thanks!