### PR TITLE
update sociogram adapter

### DIFF
--- a/projects/sociogram/index.js
+++ b/projects/sociogram/index.js
@@ -1,11 +1,38 @@
+const { sumTokensExport } = require("../helper/unwrapLPs")
 const ADDRESSES = require('../helper/coreAssets.json')
-const { sumTokensExport } = require("../helper/unwrapLPs");
+
+const TREASURY = '0xcf2a2540f31b0f4a443a5bddb01b35eca059ab60'
+
 
 module.exports = {
-    arbitrum: {
-        tvl: sumTokensExport({ 
-          owner: '0x25f5967B0FB3182d7fcacef3b53E1B2517a31dAf',
-          tokens: [ ADDRESSES.arbitrum.USDT ],
-        }),
-    }
-};
+	arbitrum: {
+		tvl: sumTokensExport({
+			owner: TREASURY,
+			tokens: [ADDRESSES.arbitrum.USDT, ADDRESSES.null],
+		})
+	},
+	ethereum: {
+		tvl: sumTokensExport({
+			owner: TREASURY,
+			tokens: [ADDRESSES.ethereum.USDT, ADDRESSES.null],
+		})
+	},
+	polygon: {
+		tvl: sumTokensExport({
+			owner: TREASURY,
+			tokens: [ADDRESSES.polygon.USDT, ADDRESSES.null],
+		})
+	},
+	bsc: {
+		tvl: sumTokensExport({
+			owner: TREASURY,
+			tokens: [ADDRESSES.bsc.USDT, ADDRESSES.null],
+		})
+	},
+	optimism: {
+		tvl: sumTokensExport({
+			owner: TREASURY,
+			tokens: [ADDRESSES.optimism.USDT, ADDRESSES.null],
+		})
+	}
+}


### PR DESCRIPTION
Token manager was removed. Currently user assets managed on treasury address

[previous adapter](https://github.com/DefiLlama/DefiLlama-Adapters/pull/7777)
