### PR TITLE
add nuri-exchange

### DIFF
--- a/projects/nuri-exchange-v1/index.js
+++ b/projects/nuri-exchange-v1/index.js
@@ -1,0 +1,10 @@
+const {getUniTVL} = require('../helper/unknownTokens')
+const { staking } = require('../helper/staking')
+
+module.exports = {
+  misrepresentedTokens: true,
+  scroll:{
+    tvl: getUniTVL({ factory: '0xAAA16c016BF556fcD620328f0759252E29b1AB57', useDefaultCoreAssets: true,  hasStablePools: true, stablePoolSymbol: 'crAMM' }),
+    staking: staking("0xAAAEa1fB9f3DE3F70E89f37B69Ab11B47eb9Ce6F", "0xAAAE8378809bb8815c08D3C59Eb0c7D1529aD769"),
+  },
+}

--- a/projects/nuri-exchange/index.js
+++ b/projects/nuri-exchange/index.js
@@ -1,0 +1,5 @@
+const { uniV3Export } = require('../helper/uniswapV3')
+
+module.exports = uniV3Export({
+  scroll: { factory: '0xAAA32926fcE6bE95ea2c51cB4Fcb60836D320C42', fromBlock: 5300905 },
+})


### PR DESCRIPTION
##### Name (to be shown on DefiLlama): Nuri Exchange


##### Twitter Link: https://twitter.com/NuriExchange


##### List of audit links if any: https://reports.yaudit.dev/reports/06-2023-RAMSES/


##### Website Link: https://www.nuri.exchange/


##### Logo (High resolution, will be shown with rounded borders): 
![Nuri_token](https://github.com/DefiLlama/DefiLlama-Adapters/assets/44497716/216b7f63-7016-4b2e-97b0-a0788cdaceac)



##### Current TVL: $0.3M


##### Treasury Addresses (if the protocol has treasury)


##### Chain: Scroll


##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description (to be shown on DefiLlama): NURI is a next-generation AMM designed to serve as Scroll's central liquidity hub, combining the secure and battle-tested superiority of Uniswap v3 with a custom incentive engine, vote-lock governance model, and streamlined user experience.


##### Token address and ticker if any: 0xAAAE8378809bb8815c08D3C59Eb0c7D1529aD769


##### Category (full list at https://defillama.com/categories) *Please choose only one: DEX

