### PR TITLE
feat: add retrospective tvl flags

### DIFF
--- a/projects/prePo/index.js
+++ b/projects/prePo/index.js
@@ -44,6 +44,8 @@ Object.keys(config).forEach(chain => {
 Object.keys(config2).forEach(chain => {
   const { fromBlock, factory, } = config2[chain]
   module.exports[chain] = {
+    timetravel: true,
+    start: 1709428055,
     tvl: async (api) => {
       const logs = await getLogs({
         api,
@@ -61,6 +63,8 @@ Object.keys(config2).forEach(chain => {
 Object.keys(config3).forEach(chain => {
   const { factory, tokens } = config3[chain]
   module.exports[chain] = {
+    timetravel: true,
+    start: 1697676421,
     tvl: async (api) => {
       return api.sumTokens({ owner: factory, tokens })
     }


### PR DESCRIPTION
We've opened this PR to have our TVL retroactively reflected on the page. Currently the TVL for these contracts, while correct, has only been reflected at the time we updated our adapter.
