### PR TITLE
PoolTogether V5 Update

### DIFF
--- a/projects/pooltogether-v4/index.js
+++ b/projects/pooltogether-v4/index.js
@@ -1,9 +1,12 @@
 const { tvl } = require('../pooltogether/v4.js')
+const { hallmarks, methodology } = require('../pooltogether/constants.js')
 
 const chains = ['ethereum', 'avax', 'polygon', 'optimism',]
 
 module.exports = {
   doublecounted: true,
+  hallmarks,
+  methodology
 }
 
 chains.forEach(chain => {

--- a/projects/pooltogether-v5/index.js
+++ b/projects/pooltogether-v5/index.js
@@ -1,9 +1,12 @@
 const { tvl } = require('../pooltogether/v5.js')
+const { hallmarks, methodology } = require('../pooltogether/constants.js')
 
 const chains = ['optimism']
 
 module.exports = {
   doublecounted: true,
+  hallmarks,
+  methodology
 }
 
 chains.forEach(chain => {

--- a/projects/pooltogether/constants.js
+++ b/projects/pooltogether/constants.js
@@ -1,0 +1,10 @@
+const hallmarks = [
+  [1_634_320_800, 'V4 Launch'],
+  [1_693_453_300, 'V5 Beta Launch'],
+  [1_697_738_400, 'V5 Canary Launch'],
+  [1_713_399_300, 'V5 Launch']
+]
+
+const methodology = 'TVL is the total tokens deposited in PoolTogether'
+
+module.exports = { hallmarks, methodology }

--- a/projects/pooltogether/index.js
+++ b/projects/pooltogether/index.js
@@ -1,16 +1,12 @@
 const { tvl } = require('./v3.js')
+const { hallmarks, methodology } = require('./constants.js')
 
 const chains = ['ethereum', 'polygon', 'bsc', 'celo']
 
 module.exports = {
   doublecounted: true,
-  hallmarks: [
-    [1_634_320_800, 'V4 Launch'],
-    [1_658_872_800, 'V4 OP Rewards Begin'],
-    [1_669_615_200, 'V4 OP Rewards Extended'],
-    [1_697_738_400, 'V5 Launch']
-  ],
-  methodology: `TVL is the total tokens deposited in PoolTogether`
+  hallmarks,
+  methodology
 }
 
 chains.forEach(chain => {

--- a/projects/pooltogether/v3.js
+++ b/projects/pooltogether/v3.js
@@ -31,6 +31,4 @@ async function tvl(api) {
   return api.getBalances()
 }
 
-module.exports = {
-  tvl,
-}
+module.exports = { tvl }

--- a/projects/pooltogether/v4.js
+++ b/projects/pooltogether/v4.js
@@ -19,6 +19,4 @@ async function tvl(api) {
   return sumTokens2({ api, tokensAndOwners: V4_POOLS[api.chain] })
 }
 
-module.exports = {
-  tvl
-}
+module.exports = { tvl }

--- a/projects/pooltogether/v5.js
+++ b/projects/pooltogether/v5.js
@@ -1,19 +1,27 @@
 const abi = require('./abi.json')
 
 const V5_VAULT_FACTORIES = {
-  optimism: '0xF65FA202907D6046D1eF33C521889B54BdE08081'
+  optimism: ['0xF65FA202907D6046D1eF33C521889B54BdE08081', '0x6B17EE3a95BcCd605340454c5919e693Ef8EfF0E', '0xF0F151494658baE060034c8f4f199F74910ea806', '0x0C379e9b71ba7079084aDa0D1c1Aeb85d24dFD39']
 }
 
 async function tvl(api) {
-  const factory = V5_VAULT_FACTORIES[api.chain]
-  if (!factory) return {}
-  const vaults = await api.fetchList({ lengthAbi: abi.totalVaults, itemAbi: abi.allVaults, target: factory })
-  const tokens = await api.multiCall({ abi: abi.asset, calls: vaults })
-  const bals = await api.multiCall({ abi: abi.totalAssets, calls: vaults })
+  const factories = V5_VAULT_FACTORIES[api.chain]
+
+  if (!factories) return {}
+
+  const allVaults = []
+
+  for (const factory of factories) {
+    const vaults = await api.fetchList({ lengthAbi: abi.totalVaults, itemAbi: abi.allVaults, target: factory })
+    allVaults.push(...vaults)
+  }
+
+  const tokens = await api.multiCall({ abi: abi.asset, calls: allVaults })
+  const bals = await api.multiCall({ abi: abi.totalAssets, calls: allVaults })
+
   api.addTokens(tokens, bals)
+
   return api.getBalances()
 }
 
-module.exports = {
-  tvl
-}
+module.exports = { tvl }


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
PoolTogether / PoolTogether V3 / PoolTogether V4 / PoolTogether V5

##### Twitter Link:
https://twitter.com/PoolTogether_

##### List of audit links if any:
https://docs.pooltogether.com/security/audits

##### Website Link:
https://pooltogether.com/

##### Methodology (what is being counted as tvl, how is tvl being calculated):
This PR simply adds more vault factories to the current script to calculate PoolTogether V5 TVL. Since the last update we've had more prize pool deployments with different vault factories. No ABI changes were necessary for this script.

The other changes are simply cleanup to avoid repeated code on each version's adapter, as well as including more relevant timestamps for the different V5 launches in `hallmarks`.