### PR TITLE
chore: add shapeshift fox farm v9

### DIFF
--- a/projects/shapeshift/index.js
+++ b/projects/shapeshift/index.js
@@ -11,6 +11,7 @@ const stakingUNIv2Contracts = [
   "0xEbB1761Ad43034Fd7FaA64d84e5BbD8cB5c40b68", // v6
   "0x5939783dbf3e9f453a69bc9ddc1e492efac1fbcb", // v7
   "0x662da6c777a258382f08b979d9489c3fbbbd8ac3", // v8
+  "0x721720784b76265aa3e34c1c7ba02a6027bcd3e5", // v9
 ];
 const stakingFoxy = "0xee77aa3Fd23BbeBaf94386dD44b548e9a785ea4b";
 


### PR DESCRIPTION
Adds the new ShapeShift FOX Farm (v9) for FOX/WETH

The rewards for the farm will only start on [May 11th 2024](https://github.com/shapeshift/fox-staking-3?tab=readme-ov-file#updates-for-round-9-of-liquidity-mining-rewards), but as far as I can see it shouldn't hurt to have it updated now. 
