### PR TITLE
Update Genius Yield adapter: added new address

### DIFF
--- a/projects/genius-yield/index.js
+++ b/projects/genius-yield/index.js
@@ -7,12 +7,16 @@ const emp = '6c8642400e8437f737eb86df0fc8a8437c760f48592b1ba8f5767e81456d706f776
 const gensx = 'fbae99b8679369079a7f6f0da14a2cf1c2d6bfd3afdf3a96a64ab67a0014df1047454e5358'
 
 const staking = 'addr1w8r99sv75y9tqfdzkzyqdqhedgnef47w4x7y0qnyts8pznq87e4wh'
-const orders = 'addr_vkh1ahllvc7n0lzljafmcs3zurdzhlsg4fydkzph6tpjnt0tx0asedu'
+
+const orders = [
+  'addr_vkh1ahllvc7n0lzljafmcs3zurdzhlsg4fydkzph6tpjnt0tx0asedu', // v1.0
+  'addr_vkh14rtl7h85cytjwq5gxuhe4j8peedhtzhptfu9r3qkvxjgcz7xfs0'  // v1.1
+]
 
 module.exports = {
   timetravel: false,
   cardano: {
     staking: sumTokensExport({ owner: staking, tokens: [gens, nmkr, ntx, emp, gensx]}),
-    tvl: sumTokensExport({ owner: orders })
+    tvl: (sumTokensExport({ owners : orders }))
   }
 };


### PR DESCRIPTION
**Problem:**
- The current implementation does not take v1.1 on-chain orders into account.

**Solution:**
- Take both v1.0 and v1.1 on-chain orders into account by calculating the TVL locked in both variants.