### PR TITLE
Add free.tech bridge address to zklink-nova

### DIFF
--- a/projects/zkLink/index.js
+++ b/projects/zkLink/index.js
@@ -117,6 +117,7 @@ const config = {
   merlin: {
     owners: [
       "0xf5b90fE755Aa2e3CcC69d9548cbeB7b38c661D73", // nova bridge address
+      "0xE12382e046DB998DE89aF19Ca799CbB757106781", // free.tech bridge: https://solvbtc.free.tech/
     ],
     tokens: [
       "0xB880fd278198bd590252621d4CD071b1842E9Bcd", //MBTC


### PR DESCRIPTION
### Add new externally bridge information
`free.tech` is a lock&mint bridge, supporting mBTC and SolvBTC. The contract address on merlin is `0xE12382e046DB998DE89aF19Ca799CbB757106781`.

### Free.tech
website : https://free.tech
solvBTC bridge interface : https://solvbtc.free.tech/