### PR TITLE
Add externally bridge token mapping for zklink nova

### DIFF
--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -74,7 +74,12 @@ const fixBalancesTokens = {
   },
   chz: {
     '0x677F7e16C7Dd57be1D4C8aD1244883214953DC47': { coingeckoId: "wrapped-chiliz", decimals: 18 }
-  }
+  },
+  zklink: {
+    '0xbEAf16cFD8eFe0FC97C2a07E349B9411F5dC272C': { coingeckoId: "solv-btc", decimals: 18 },
+    '0xFb8dBdc644eb54dAe0D7A9757f1e6444a07F8067': { coingeckoId: "bitcoin-trc20", decimals: 18 },
+    '0x85D431A3a56FDf2d2970635fF627f386b4ae49CC': { coingeckoId: "merlin-s-seal-btc", decimals: 18 },
+  },
 }
 
 ibcChains.forEach(chain => fixBalancesTokens[chain] = { ...ibcMappings, ...(fixBalancesTokens[chain] || {}) })

--- a/projects/zkLink/index.js
+++ b/projects/zkLink/index.js
@@ -117,6 +117,7 @@ const config = {
   merlin: {
     owners: [
       "0xf5b90fE755Aa2e3CcC69d9548cbeB7b38c661D73", // nova bridge address
+      "0xE12382e046DB998DE89aF19Ca799CbB757106781", // free.tech bridge: https://solvbtc.free.tech/
     ],
     tokens: [
       "0xB880fd278198bd590252621d4CD071b1842E9Bcd", //MBTC


### PR DESCRIPTION
### zkLink Nova Tokens List Page
https://explorer.zklink.io/tokens

#### Externally Bridged Token
| Token   | Nova Address                               | Source Token Address                       | Chain  |
|---------|--------------------------------------------|--------------------------------------------|--------|
| SolvBtc | 0xbEAf16cFD8eFe0FC97C2a07E349B9411F5dC272C | 0x41D9036454BE47d3745A823C4aaCD0e29cFB0f71 | Merlin |
| MBTC    | 0x85D431A3a56FDf2d2970635fF627f386b4ae49CC | 0xB880fd278198bd590252621d4CD071b1842E9Bcd | Merlin |
| BTCT    | 0xFb8dBdc644eb54dAe0D7A9757f1e6444a07F8067 | TN3W4H6rK2ce4vX9YnFQHwKENnHjoxb3m9         | Tron   |

<img width="1271" alt="image" src="https://github.com/DefiLlama/DefiLlama-Adapters/assets/162772307/5a1f96e0-66cc-4d06-8a2e-2e3453c282fd">

