### PR TITLE
add chi-protocol adapter

### DIFF
--- a/projects/chi-protocol/index.js
+++ b/projects/chi-protocol/index.js
@@ -1,0 +1,56 @@
+const { sumTokens2 } = require('../helper/unwrapLPs');
+const { pool2s } = require("../helper/pool2");
+
+const RESERVE_HOLDER = '0x037528457Cf5b0b9DAb641Fd7F0Ce8Fc9690318d';
+const USC_STAKING = '0x60aBb55c8488698153dB0AF2af362EdB25A505e3';
+const CHI_STAKING = '0xaB1dCa1C0f948c268652eedC676966002Ae241c6';
+const CHI_LOCKING = '0xE3dD17ff009bAC84e32130fcA5f01C908e956603';
+const CHI_VESTING = '0x426DBAa2B33cE1B833C13b72503F5128AFef79fC';
+const STETH = '0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84';
+const WETH = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'
+const USC = '0x38547D918b9645F2D94336B6b61AEB08053E142c';
+const CHI = '0x3b21418081528845a6DF4e970bD2185545b712ba';
+
+const stakingPool2Contracts = [
+    "0x85CD2803223C864D625b1D289fDD3Cee7e4bB307",
+    "0xD66DAbE0c898Ec74DA03AE4e90b9c051408685e6",
+];
+const lpAddresses = [
+    "0x88d1fFB9F94Fc881ea0D83Dddcdb196EE9DA8739",
+    "0x9f93F419d0267877247A39b4eb6b2775AbAC6bdc",
+];
+
+async function tvl(api) {
+    const owner = RESERVE_HOLDER;
+    const tokens = [
+        STETH,
+        WETH
+    ];
+    return sumTokens2({ owner, tokens, api })
+}
+
+async function staking(api) {
+    const tokensAndOwners = [
+        [USC, USC_STAKING],
+        [CHI, CHI_STAKING],
+        [CHI, CHI_LOCKING]
+    ];
+    return sumTokens2({ api, tokensAndOwners })
+}
+
+async function vesting(api) {
+    const owner = CHI_VESTING;
+    const tokens = [
+        CHI
+    ];
+    return sumTokens2({ owner, tokens, api })
+}
+
+module.exports = {
+    ethereum: {
+        tvl: tvl,
+        staking: staking,
+        pool2: pool2s(stakingPool2Contracts, lpAddresses),
+        vesting: vesting
+    }
+}

--- a/projects/chi-protocol/index.js
+++ b/projects/chi-protocol/index.js
@@ -31,7 +31,7 @@ async function tvl(api) {
 
 async function staking(api) {
     const tokensAndOwners = [
-        [USC, USC_STAKING],
+        // [USC, USC_STAKING],
         [CHI, CHI_STAKING],
         [CHI, CHI_LOCKING]
     ];


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `volume` adapter please submit the PR [here](https://github.com/DefiLlama/adapters).
> - If you would like to add a `liquidations` adapter, please refer to [this readme document](https://github.com/DefiLlama/DefiLlama-Adapters/tree/main/liquidations) for details.

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
3. Please fill the form below  **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
4. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can  edit it there and put up a PR
5. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
6. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap

---
##### Name (to be shown on DefiLlama):
Chi Protocol


##### Twitter Link:
https://twitter.com/ProtocolChi


##### List of audit links if any:
https://github.com/abdk-consulting/audits/blob/main/chi/ABDK_Chi_ChiProtocol_v_1_0.pdf


##### Website Link:
https://chiprotocol.io/


##### Logo (High resolution, will be shown with rounded borders):
https://docsend.com/view/u3d5ckj6tu5w8g6m


##### Current TVL:
$846.53k

##### Treasury Addresses (if the protocol has treasury)
0xcdB8d92FA641106fdAEe3CCC6B53a029eDb9c458


##### Chain:
Ethereum


##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)
{"id":"chi-protocol","symbol":"chi","name":"Chi Protocol"}


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description (to be shown on DefiLlama):
Chi Protocol is the scalable LST-backed stablecoin protocol powered by USC and CHI. Users can mint USC 1:1 vs. ETH/stETH, and LSTs are used to payout real yield to the governance token CHI. Smart contracts and arbitrage incentives automatically maintain the protocol's stability and solvency.


##### Token address and ticker if any:
CHI

0x3b21418081528845a6DF4e970bD2185545b712ba



##### Category (full list at https://defillama.com/categories) *Please choose only one:
Decentralized Stablecoin (https://defillama.com/protocols/Decentralized%20Stablecoin)


##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
Assets:
stETH, ETH (WETH) - Chainlink Oracle
CHI, USC - TWAP from Uniswap V2 pool

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
For USC and CHI oracles we use 1 hour TWAP Oracle adapter deployed on this addresses:
USC_USD_oracle: 0x488490185c32f183A39d787ED311ee8EfAd715C9

CHI_USD_oracle: 0x7945142B3ef3914b038B65c940DEFFF419AE29f0

Code source is: https://github.com/Uniswap/v2-periphery/blob/master/contracts/examples/ExampleOracleSimple.sol

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

##### forkedFrom (Does your project originate from another project):


##### methodology (what is being counted as tvl, how is tvl being calculated):
Default TVL: stETH From Reserves
Staking: USC Staking, CHI Staking and CHI Locking
Pool 2: USC/ETH LP and CHI/ETH LP
Vesting: CHI Vesting


##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/Chi-Protocol/chi-protocol-smart-contracts