### PR TITLE
Fix processing CHAR and other Toucan tokens

### DIFF
--- a/projects/toucan-protocol/config.js
+++ b/projects/toucan-protocol/config.js
@@ -16,7 +16,20 @@ const CONFIG_DATA = {
         nct_bridge: "0xdC1Dfa22824Af4e423a558bbb6C53a31c3c11DCC"
     },
 };
+const TOKEN_DATA = {
+    bct: {
+        coingecko: "toucan-protocol-base-carbon-tonne",
+        validUntil: 1709828986,
+    },
+    nct: {
+        coingecko: "toucan-protocol-nature-carbon-tonne",
+    },
+    char: {
+        coingecko: "biochar",
+    },
+};
 
 module.exports = {
     CONFIG_DATA,
+    TOKEN_DATA,
 };

--- a/projects/toucan-protocol/index.js
+++ b/projects/toucan-protocol/index.js
@@ -1,26 +1,43 @@
 const sdk = require('@defillama/sdk')
-const { CONFIG_DATA } = require("./config");
+const { CONFIG_DATA, TOKEN_DATA } = require("./config");
 
 const getCalculationMethod = (chain) => {
   return async (api,) => {
     const supplyCalls = []
+    const tokenInfo = []
     Object.keys(CONFIG_DATA[chain]).map((key) => {
       supplyCalls.push(CONFIG_DATA[chain][key]);
+      tokenInfo.push(TOKEN_DATA[key]);
     })
 
-    let [bct, nct, char] = await api.multiCall({ abi: 'erc20:totalSupply', calls: supplyCalls, })
+    const resp = await api.multiCall({ abi: 'erc20:totalSupply', calls: supplyCalls, })
+    const tokensArray = resp.map((obj, i) => {
+      const validUntil = tokenInfo[i].validUntil
+      if (validUntil && api.timestamp > validUntil)
+        tokenInfo[i].totalSupply = 0
+      else
+        tokenInfo[i].totalSupply = obj
+  
+      return {
+        [tokenInfo[i].coingecko]: dropDecimals(tokenInfo[i].totalSupply),
+      };
+    });
 
-    // If the current block is later than the date BCT was transferred to KlimaDAO, return 0
-    if (api.timestamp > 1709828986)
-      bct = 0
+    const tokens = tokensArray.reduce((acc, cur) => {
+      for (const entry of Object.entries(cur)) {
+        const [key, value] = entry;
+        acc[key] = value;
+      }
+      return acc;
+    } , {});
 
-    return {
-      'toucan-protocol-base-carbon-tonne': (bct ?? 0) / 1e18,
-      'toucan-protocol-nature-carbon-tonne': (nct ?? 0) / 1e18,
-      'biochar': (char ?? 0) / 1e18,
-    };
+    return tokens;
   };
 };
+
+const dropDecimals = (num) => {
+  return (num ?? 0) / 1e18;
+}
 
 const getRegenCredits = () => {
   return async () => {


### PR DESCRIPTION
399a3cf318e3a188b3d3232dd85b1242b0a2be8c was incorrectly setting supplies in
the destructured variables (bct, nct, char)
as for some networks (eg., base) not all
three tokens are found. Here I am fixing this
issue so now the final struct returned by
getCalculationMethod is created dynamically
and always contains the exact tokens with
the correct info.