### PR TITLE
Add carbondefi sei evm deployment

### DIFF
--- a/projects/carbondefi/index.js
+++ b/projects/carbondefi/index.js
@@ -6,7 +6,7 @@ const config = {
     fromBlock: 17087375,
     controller: "0xC537e898CD774e2dCBa3B14Ea6f34C93d5eA45e1",
   },
-  sei_evm: {
+  sei: {
     fromBlock: 79146720,
     controller: "0xe4816658ad10bF215053C533cceAe3f59e1f1087",
   },

--- a/projects/carbondefi/index.js
+++ b/projects/carbondefi/index.js
@@ -1,21 +1,33 @@
-const { getLogs } = require('../helper/cache/getLogs')
-const { sumTokens2 } = require('../helper/unwrapLPs')
+const { getLogs } = require("../helper/cache/getLogs");
+const { sumTokens2 } = require("../helper/unwrapLPs");
 
-const controller = '0xC537e898CD774e2dCBa3B14Ea6f34C93d5eA45e1'
+const config = {
+  ethereum: {
+    fromBlock: 17087375,
+    controller: "0xC537e898CD774e2dCBa3B14Ea6f34C93d5eA45e1",
+  },
+  sei_evm: {
+    fromBlock: 79146720,
+    controller: "0xe4816658ad10bF215053C533cceAe3f59e1f1087",
+  },
+};
 
-async function tvl(api) {
-	const logs = await getLogs({
-		api,
-		target: controller,
-		topic: 'PairCreated(uint128,address,address)',
-		eventAbi: 'event PairCreated(uint128 indexed pairId, address indexed token0, address indexed token1)',
-		onlyArgs: true,
-		fromBlock: 17087375,
-	})
-	const tokens = logs.map(i => [i.token0, i.token1]).flat()
+Object.keys(config).forEach((chain) => {
+  const { controller, fromBlock } = config[chain];
+  module.exports[chain] = {
+    tvl: async (api) => {
+      const logs = await getLogs({
+        api,
+        target: controller,
+        topic: "PairCreated(uint128,address,address)",
+        eventAbi:
+          "event PairCreated(uint128 indexed pairId, address indexed token0, address indexed token1)",
+        onlyArgs: true,
+        fromBlock,
+      });
+      const tokens = logs.map((i) => [i.token0, i.token1]).flat();
 
-	return sumTokens2({ api, owner: controller, tokens, })
-}
-
-
-module.exports = { ethereum: { tvl } }
+      return sumTokens2({ api, owner: controller, tokens });
+    },
+  };
+});

--- a/projects/carbondefi/index.js
+++ b/projects/carbondefi/index.js
@@ -1,4 +1,3 @@
-const { getLogs } = require("../helper/cache/getLogs");
 const { sumTokens2 } = require("../helper/unwrapLPs");
 
 const config = {
@@ -16,16 +15,11 @@ Object.keys(config).forEach((chain) => {
   const { controller, fromBlock } = config[chain];
   module.exports[chain] = {
     tvl: async (api) => {
-      const logs = await getLogs({
-        api,
-        target: controller,
-        topic: "PairCreated(uint128,address,address)",
-        eventAbi:
-          "event PairCreated(uint128 indexed pairId, address indexed token0, address indexed token1)",
-        onlyArgs: true,
-        fromBlock,
-      });
-      const tokens = logs.map((i) => [i.token0, i.token1]).flat();
+      const pairs = await api.call({
+        target:controller,
+        abi: 'function pairs() view returns (address[2][])',
+      })
+      const tokens = [...new Set(pairs.flat())];
 
       return sumTokens2({ api, owner: controller, tokens });
     },


### PR DESCRIPTION
# Description

Carbon DeFi's deployment on Ethereum already exists at https://defillama.com/protocol/carbon-defi. This PR seeks to add Sei support for the new deployment on Sei EVM as well.

# Information

##### Name (to be shown on DefiLlama): Carbon DeFi

##### Twitter Link: https://x.com/carbondefixyz

##### List of audit links if any: https://docs.carbondefi.xyz/carbon-defi/security-and-audits

##### Website Link: https://www.carbondefi.xyz/

##### Logo (High resolution, will be shown with rounded borders): 

##### Current TVL: $1.08m on Ethereum

##### Treasury Addresses (if the protocol has treasury) N/A

##### Chain: Ethereum, Sei Network EVM

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): 1309 (BNT), 1310 (vBNT)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): 449 (BNT), 6164 (vBNT)

##### Short Description (to be shown on DefiLlama):

Carbon is a decentralized trading protocol allowing users to perform automated trading strategies using custom on-chain limit, range, and concentrated liquidity orders.

##### Token address and ticker if any: BNT (0x1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C on Ethereum), vBNT (0x48Fb253446873234F2fEBbF9BdeAA72d9d387f94 on Ethereum)

##### Category: Dexes

##### Oracle Provider(s): N/A
##### Implementation Details: Briefly describe how the oracle is integrated into your project: N/A
##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage: N/A

##### forkedFrom: Original ([Graphene](https://defillama.com/protocol/graphene-by-velocimeter) is a fork of CarbonDefi)

##### methodology (what is being counted as tvl, how is tvl being calculated): Balance of the CarbonController contract on Ethereum (0xC537e898CD774e2dCBa3B14Ea6f34C93d5eA45e1) and Sei (0xe4816658ad10bF215053C533cceAe3f59e1f1087)

##### Github org/user: https://github.com/bancorprotocol
