### PR TITLE
Added tokens to tokenMapping on Merlin and Bitlayer

### DIFF
--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -112,10 +112,6 @@ const fixBalancesTokens = {
     '0xA984b70f7B41EE736B487D5F3D9C1e1026476Ea3': { coingeckoId: 'wrapped-bitcoin', decimals: 18 },
     // Avalon Finance - aSolvBTC
     '0xC39E757dCb2b17B79A411eA1C2810735dc9032F8': { coingeckoId: 'wrapped-bitcoin', decimals: 18 },
-    // Avalon Finance - aWBTC
-    '0xA984b70f7B41EE736B487D5F3D9C1e1026476Ea3': { coingeckoId: 'wrapped-bitcoin', decimals: 18 }, //eslint-disable-line
-    // Avalon Finance - aMBTC
-    '0x9A6Ae5622990BA5eC1691648c3A2872469d161f9': { coingeckoId: 'wrapped-bitcoin', decimals: 18 },
   },
   cyeth: {
     '0x4200000000000000000000000000000000000006': { coingeckoId: 'ethereum', decimals: 18 },

--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -91,6 +91,14 @@ const fixBalancesTokens = {
     '0xFb8dBdc644eb54dAe0D7A9757f1e6444a07F8067': { coingeckoId: "bitcoin-trc20", decimals: 18 },
     '0x85D431A3a56FDf2d2970635fF627f386b4ae49CC': { coingeckoId: "merlin-s-seal-btc", decimals: 18 },
   },
+  merlin: {
+    // Avalon Finance - aSolvBTC
+    '0xC39E757dCb2b17B79A411eA1C2810735dc9032F8': { coingeckoId: 'wrapped-bitcoin', decimals: 18 },
+    // Avalon Finance - aWBTC
+    '0xA984b70f7B41EE736B487D5F3D9C1e1026476Ea3': { coingeckoId: 'wrapped-bitcoin', decimals: 18 },
+    // Avalon Finance - aMBTC
+    '0xF5b689D772e4Bd839AD9247A326A21a0A74a07f0': { coingeckoId: 'wrapped-bitcoin', decimals: 18 },
+  },
   btr: {
     '0x0000000000000000000000000000000000000000': { coingeckoId: 'bitcoin', decimals: 18 },
     '0xff204e2681a6fa0e2c3fade68a1b28fb90e4fc5f': { coingeckoId: 'wrapped-bitcoin', decimals: 18 },
@@ -102,6 +110,12 @@ const fixBalancesTokens = {
     '0xf6718b2701d4a6498ef77d7c152b2137ab28b8a3': { coingeckoId: 'wrapped-bitcoin', decimals: 18 },
     '0x9a6ae5622990ba5ec1691648c3a2872469d161f9': { coingeckoId: 'wrapped-bitcoin', decimals: 18 },
     '0xA984b70f7B41EE736B487D5F3D9C1e1026476Ea3': { coingeckoId: 'wrapped-bitcoin', decimals: 18 },
+    // Avalon Finance - aSolvBTC
+    '0xC39E757dCb2b17B79A411eA1C2810735dc9032F8': { coingeckoId: 'wrapped-bitcoin', decimals: 18 },
+    // Avalon Finance - aWBTC
+    '0xA984b70f7B41EE736B487D5F3D9C1e1026476Ea3': { coingeckoId: 'wrapped-bitcoin', decimals: 18 }, //eslint-disable-line
+    // Avalon Finance - aMBTC
+    '0x9A6Ae5622990BA5eC1691648c3A2872469d161f9': { coingeckoId: 'wrapped-bitcoin', decimals: 18 },
   },
   cyeth: {
     '0x4200000000000000000000000000000000000006': { coingeckoId: 'ethereum', decimals: 18 },


### PR DESCRIPTION
Added Avalon Finance aTokens to `tokenMapping` on Merlin and Bitlayer.

Avalon Finance is an AAVE V3 fork lending protocol. The `aTokens` are the receipt tokens of underlying users supported, with the same price as the corresponding underlying.

Some DeFi protocols support restaking mechanisms, e.g. Pell Network(https://app.pell.network/restake), which allows users to restake with Avalon aTokens on Merlin and Bitlayer chain. Thus when calculate the TVL of restaking protocol like _Pell Network_ , we should consider the value of aToken. 

**aToken price == underlying token price**

--- 

## Melrin: aToken <> Underlying Token

| aToken Symbol | aToken Address                             | Underlying Symbol | Underlying Address                         |
| ------------- | ------------------------------------------ | ----------------- | ------------------------------------------ |
| aSolvBTC      | 0xC39E757dCb2b17B79A411eA1C2810735dc9032F8 | SolvBTC           | 0x41d9036454be47d3745a823c4aacd0e29cfb0f71 |
| aMBTC         | 0xA984b70f7B41EE736B487D5F3D9C1e1026476Ea3 | MBTC              | 0xb880fd278198bd590252621d4cd071b1842e9bcd |
| aWBTC         | 0xF5b689D772e4Bd839AD9247A326A21a0A74a07f0 | WBTC              | 0xF6D226f9Dc15d9bB51182815b320D3fBE324e1bA |


## Bitlayer: aToken <> Underlying Token

| aToken Symbol | aToken Address                             | Underlying Symbol | Underlying Address                         |
| ------------- | ------------------------------------------ | ----------------- | ------------------------------------------ |
| aSolvBTC      | 0xC39E757dCb2b17B79A411eA1C2810735dc9032F8 | SolvBTC           | 0xe04d21d999faedf1e72ade6629e20a11a1ed14fa |
| aWBTC         | 0xA984b70f7B41EE736B487D5F3D9C1e1026476Ea3 | WBTC              | 0xff204e2681a6fa0e2c3fade68a1b28fb90e4fc5f |
| astBTC        | 0xf6718b2701d4a6498ef77d7c152b2137ab28b8a3 | stBTC             | 0x9A6Ae5622990BA5eC1691648c3A2872469d161f9 |




