### PR TITLE
fix: update rif on chain contract address because USDRIF v2

### DIFF
--- a/projects/rif-on-chain/index.js
+++ b/projects/rif-on-chain/index.js
@@ -2,6 +2,6 @@ const { sumTokensExport } = require('../helper/unwrapLPs')
 
 module.exports = {
   rsk: {
-    tvl: sumTokensExport({ owner: '0xCff3FCaEc2352C672C38d77cB1A064B7d50CE7e1', tokens: ['0x2aCc95758f8b5F583470bA265Eb685a8f45fC9D5']})
+    tvl: sumTokensExport({ owner: '0xA27024eD70035E46DBa712609FC2AFA1c97aa36a', tokens: ['0x2aCc95758f8b5F583470bA265Eb685a8f45fC9D5']})
   }
 }


### PR DESCRIPTION
Updated to USDRIF V2. We have to update the contract address.

[Technical Proposal to Launch an enhanced version of the RIF on Chain Protocol](https://forum.moneyonchain.com/t/technical-proposal-to-launch-an-enhanced-version-of-the-rif-on-chain-protocol/389)

PR To add USDRIF to Defillama: https://github.com/DefiLlama/DefiLlama-Adapters/pull/8638
