### PR TITLE
Update vega protocol tvl calculation

### DIFF
--- a/projects/vega-protocol/index.js
+++ b/projects/vega-protocol/index.js
@@ -2,16 +2,22 @@ const { getLogs } = require('../helper/cache/getLogs')
 const { sumTokens2 } = require('../helper/unwrapLPs')
 
 const assetListedEvent = "event Asset_Listed(address indexed asset_source, bytes32 indexed vega_asset_id, uint256 nonce)"
+const assetListedTopic = "0x4180d77d05ff0d31650c548c23f2de07a3da3ad42e3dd6edd817b438a150452e"
 const BigNumber = require("bignumber.js");
 
 const config = {
   ethereum: { 
-    fromBlock: 17343884, 
+    fromBlock: 17343884,
     vega: '0xcb84d72e61e383767c4dfeb2d8ff7f4fb89abc6e', 
     stakingContract: '0x195064D33f09e0c42cF98E665D9506e0dC17de68', 
     assetPool: '0xA226E2A13e07e750EfBD2E5839C5c3Be80fE7D4d',
     bridge: '0x23872549cE10B40e31D6577e0A920088B0E0666a', 
     vestingContract: '0x23d1bFE8fA50a167816fBD79D7932577c06011f4' 
+  },
+  arbitrum: {
+    fromBlock: 213213680,
+    bridge: "0x475B597652bCb2769949FD6787b1DC6916518407",
+    assetPool: "0xCc006887FE2bfABB535030b3a9877Bb8C1e35201"
   }
 }
 
@@ -25,23 +31,24 @@ module.exports = {
 
 Object.keys(config).forEach(chain => {
   const { bridge, fromBlock, vega, stakingContract, assetPool, vestingContract } = config[chain]
-  module.exports[chain] = {
+  const sums = {
     tvl: async (api) => {
-      const logs = await getLogs({
+      const listedAssets = await getLogs({
         api,
         target: bridge,
-        topics: ['0x4180d77d05ff0d31650c548c23f2de07a3da3ad42e3dd6edd817b438a150452e'],
+        topics: [assetListedTopic],
         eventAbi: assetListedEvent,
         onlyArgs: true,
         fromBlock,
       })
       const blacklistedTokens = []
       if (vega) blacklistedTokens.push(vega)
-      return sumTokens2({ api, blacklistedTokens, owner: assetPool, tokens: logs.map(i => i.asset_source) })
-    },
-    //staking: staking(stakingContract, vega)
-    staking: async (_, _b, cb, { chain, block, api } = {}) => { 
+      return sumTokens2({ api, blacklistedTokens, owner: assetPool, tokens: listedAssets.map(i => i.asset_source) })
+    }
+  }
 
+  if (vestingContract && stakingContract) {
+    sums.staking = async (_, _b, cb, { chain, block, api } = {}) => {
       const vegaStakedInVesting = await api.call({ 
         abi: contractAbis.totalStaked, 
         target: vestingContract 
@@ -56,9 +63,8 @@ Object.keys(config).forEach(chain => {
       return {
         '0xcb84d72e61e383767c4dfeb2d8ff7f4fb89abc6e': BigNumber(vegaStakedInVesting).plus(BigNumber(vegaStakedInStaking)).toFixed(0)
       }
-      
     }
   }
-
+  module.exports[chain] = sums
 })
 


### PR DESCRIPTION
In addition to Ethereum ERC20 assets, Vega Protocol now supports assets on the Arbitrum network. This PR adds support for including the values of Arbitrum bridged assets in the TVL. Staking calculations are unchanged.

- Update vega-protol script with arbritrum contract & asset pool addresses

---

* Project documentation's release notes about the Arbitrum bridge: https://docs.vega.xyz/mainnet/releases/overview#release-version-v0768--2024-05-29
* Project X/Twitter account mentioning the Arbitrum bridge: https://x.com/vegaprotocol/status/1796154834711724115
* Vega Explorer (source for Arbitrum contract address): https://explorer.vega.xyz/network-parameters#blockchains.evmBridgeConfigs
* Arbiscan deployment (source for Asset pool contract address & deployment block height): https://arbiscan.io/address/0x475B597652bCb2769949FD6787b1DC6916518407#code