### PR TITLE
Add Taiko network config for Minterest project TVL calculation

### DIFF
--- a/projects/minterest/index.js
+++ b/projects/minterest/index.js
@@ -4,12 +4,14 @@ module.exports = {
   hallmarks: [
     [1677133355, "MINTY distribution begins on Ethereum"],
     [1704369540, "MINTY distribution begins on Mantle"],
+    [1717164347, "MINTY distribution begins on Taiko"],
   ],
 }
 
 const config = {
   ethereum: "0xD13f50274a68ABF2384C79248ADc259b3777c081",
   mantle: "0xe53a90EFd263363993A3B41Aa29f7DaBde1a932D",
+  taiko: "0xe56c0d4d6A08C05ec42E923EFd06497F115D4799",
 }
 
 


### PR DESCRIPTION
Update of existing Minterest adapter to include the recent Taiko release in TVL calculations:
- Hallmark added for the Taiko release,
- Supervisor [Comptroller] address added for the Taiko network,

There are no other changes in calculations since the last update (https://github.com/DefiLlama/DefiLlama-Adapters/pull/8689)

Current TVL:
------ TVL ------
borrowed                  7.84 M
mantle-borrowed           7.83 M
mantle                    6.22 M
taiko                     227.94 k
ethereum                  103.22 k
ethereum-borrowed         11.78 k
taiko-borrowed            0

total                    6.55 M 