### PR TITLE
update the tvl calculation for Joltify rwa adapter

### DIFF
--- a/projects/joltify-rwa/index.js
+++ b/projects/joltify-rwa/index.js
@@ -14,7 +14,7 @@ const tvl = async (api) => {
     const [market, borrowed_denom] = pool.borrowed_amount.denom.split('-');
     const market_id = `${market}:usd`;
     const price = price_info.prices.find(price => price.market_id === market_id)?.price;
-    api.add(borrowed_denom, pool.borrowed_amount.amount * price);
+    api.add(borrowed_denom, pool.total_transfer_ownership_amount.amount * price);
     api.add(pool.usable_amount.denom, pool.usable_amount.amount);
     api.add(pool.escrow_principal_amount.denom, pool.escrow_principal_amount.amount);
     api.add(pool.escrow_principal_amount.denom, pool.escrow_interest_amount);

--- a/projects/joltify-rwa/index.js
+++ b/projects/joltify-rwa/index.js
@@ -6,7 +6,15 @@ const tvl = async (api) => {
     queryV1Beta1({ chain, url: `spv/list_pools` }),
   ]);
 
+  const [price_info] = await Promise.all([
+    queryV1Beta1({ chain, url: `third_party/pricefeed/v1beta1/prices` }),
+  ]);
+
   pools.pools_info.forEach(async pool => {
+    const [market, borrowed_denom] = pool.borrowed_amount.denom.split('-');
+    const market_id = `${market}:usd`;
+    const price = price_info.prices.find(price => price.market_id === market_id)?.price;
+    api.add(borrowed_denom, pool.borrowed_amount.amount * price);
     api.add(pool.usable_amount.denom, pool.usable_amount.amount);
     api.add(pool.escrow_principal_amount.denom, pool.escrow_principal_amount.amount);
     api.add(pool.escrow_principal_amount.denom, pool.escrow_interest_amount);


### PR DESCRIPTION
We involve this borrowed amount in the TVL calculation due to the difference between traditional digital lending and RWA lending.

I understand the concept of RWA lending can be quite confusing. To help clarify, I've compared it to digital lending. Hopefully, this side-by-side comparison brings more clarity.
For digital lending, the process typically involves User A depositing 100 worth of tokens and User B depositing 100 worth of tokens into the protocol. Subsequently, User A borrows 80 tokens from User B's deposit. In this scenario, User A can withdraw the borrowed 80 tokens, taking them out of the protocol. Despite this withdrawal, the protocol still retains a Total Value Locked (TVL) of 120, calculated as the sum of User A's remaining 20 tokens and User B's 100 tokens**.

It's important to note that the TVL is not double-counted; it is calculated as 100 (User A's deposit) + 100 (User B's deposit) - 80 (User A's withdrawal) = 120, reflecting the accurate value locked within the protocol after User A's token withdrawal.

In the case of Real-World Asset (RWA) lending, a Special Purpose Vehicle (SPV) entity, let's call it 'C,' utilizes contracts collateralized by assets like bonds or other securities to borrow 100 dollars from User D. In this scenario, the SPV mints a 100 dollar Non-Fungible Token (NFT) backed by real-world assets, and User D deposits 100 worth of USDT/USDC into the protocol. Consequently, User D receives the 100 dollar NFT as proof of ownership, which remains within the protocol, while the SPV takes out the 100 USDT/USDC.

In this scenario, the protocol maintains a TVL of 100, calculated as the sum of the 100 dollar NFT and the 100 USDT/USDC initially deposited by User D, minus the 100 USDT/USDC withdrawn by the SPV. The TVL is not double-counted, as it accurately reflects the stablecoins taken out of the protocol, while the NFT representing the RWA remains locked within.

It's crucial to acknowledge that the collateral's value may fluctuate or even collapse over time, potentially decreasing the corresponding NFT's value. To address this, we will continuously assess and update the NFT's value based on the underlying collateral's performance. For example, in the event of a default, the NFT's value will be adjusted accordingly, reflecting the outcome of legal proceedings and the realization of the underlying RWA's value. Our protocol will dynamically update these valuations to ensure transparency and accurate representation of the locked assets.