### PR TITLE
Add Wrapped  stBBTC Token

### DIFF
--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -135,6 +135,7 @@ const fixBalancesTokens = {
     '0xf4c20e5004c6fdcdda920bdd491ba8c98a9c5863': { coingeckoId: 'bouncebit', decimals: 18 },
     '0x77776b40c3d75cb07ce54dea4b2fd1d07f865222': { coingeckoId: 'tether', decimals: 18 },
     '0xF5e11df1ebCf78b6b6D26E04FF19cD786a1e81dC': { coingeckoId: 'bitcoin', decimals: 18 },
+    '0x8f083EaFcbba2e126AD9757639c3A1E25a061A08': { coingeckoId: 'wrapped-bitcoin', decimals: 18 },
   },
   linea: {
     '0x63ba74893621d3d12f13cec1e86517ec3d329837': { coingeckoId: 'liquity-usd', decimals: 18 },


### PR DESCRIPTION
Using stBBTC directly can cause issues with BB Token reward calculations, so it needs to be wrapped