### PR TITLE
Update Blastoff TVL

### DIFF
--- a/projects/blastoff/index.js
+++ b/projects/blastoff/index.js
@@ -3,10 +3,15 @@ const ADDRESSES = require('../helper/coreAssets.json')
 
 const LOCKED_STAKING = "0xd95773e5b1eedc7ff302a70acd0eb370927397d2";
 const NONLOCK_STAKING = "0xd9747a98624f0B64B4412632C420672E16432334";
+const OFF_STAKING = "0xC9B6c67af496E92F64b1C136B3FaD15e3b02cbb4";
+const OFF_TOKEN = "0xD55eDfc79c0d14084260D16f38BdA75e28AbFb6A";
 
 module.exports = {
   blast: {
-    tvl: sumTokensExport({ owners: [LOCKED_STAKING, NONLOCK_STAKING], tokens: [ADDRESSES.null, ADDRESSES.blast.USDB] }),
+    tvl: sumTokensExport({ 
+      owners: [LOCKED_STAKING, NONLOCK_STAKING, OFF_STAKING], 
+      tokens: [ADDRESSES.null, ADDRESSES.blast.USDB, OFF_TOKEN] 
+    }),
   },
-  methodology: "counts the amount of USDB and ETH locked in 2 staking contracts",
+  methodology: "counts the amount of USDB, ETH, and OFF tokens locked in 3 staking contracts",
 };

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -41,8 +41,11 @@
 
 ##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)
 
+blastoff
 
 ##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
+
+31300
 
 
 ##### Short Description (to be shown on DefiLlama):


### PR DESCRIPTION
Gm, I'm updating the blastoff TVL information.

I have not used the `helper/unknownTokens` file with it's `sumTokensExport` as there already was one. Would that have been better ?

Additionally, I have not listed the coin on `https://github.com/DefiLlama/defillama-server/tree/master/coins/src/adapters`. Let me know if that is more convenient.

I've added the Coingecko and CMC information that is now available.
