### PR TITLE
feat: add line token rewards

### DIFF
--- a/projects/line-token-rewards/index.js
+++ b/projects/line-token-rewards/index.js
@@ -1,0 +1,27 @@
+/**
+ * Get a share of Kava Rise rewards by simply holding tokens imported from Kava in your Obyte wallet.
+ * Kava Rise program rewards us for the TVL that our dapps Counterstake and LINE create on the Kava network. 
+ * We share 50% of these rewards with you if you actually contribute to this TVL and hold the tokens imported through Counterstake bridge in your Obyte wallet.
+ * 
+ * @see https://kava.obyte.org
+ */
+
+const utils = require("../helper/utils");
+const BACKEND_API_URL = "https://kava.obyte.org/api";
+
+const tvl = async () => {
+    const avgBalances = await utils.fetchURL(`${BACKEND_API_URL}/average_balances/latest`).then(data => data.data.data);
+
+    const tvl = avgBalances.reduce((currentValue, { effective_usd_balance = 0, home_symbol }) => {
+        return currentValue + (effective_usd_balance / (home_symbol === "LINE" ? 2 : 1));
+    }, 0);
+
+    return ({ tether: tvl });
+};
+
+module.exports = {
+    methodology: 'The TVL is calculated as USD value of all the assets transferred from Kava to Obyte and eligible for rewards.',
+    obyte: {
+        tvl
+    }
+}


### PR DESCRIPTION
---
##### Name (to be shown on DefiLlama): LINE token rewards


##### Twitter Link: @ObyteOrg


##### List of audit links if any: - 


##### Website Link: https://kava.obyte.org/ 


##### Logo (High resolution, will be shown with rounded borders): https://kava.obyte.org/logo192.png


##### Current TVL: 708.27k


##### Treasury Addresses (if the protocol has treasury)


##### Chain: Obyte


##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): byteball (https://api.coingecko.com/api/v3/coins/list)


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):  1492 (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description (to be shown on DefiLlama): Get a share of Kava Rise rewards by simply holding tokens imported from Kava in your Obyte wallet. Kava Rise program rewards us for the TVL that our dapps Counterstake and LINE create on the Kava network. We share 50% of these rewards with you if you actually contribute to this TVL and hold the tokens imported through Counterstake bridge in your Obyte wallet.


##### Token address and ticker if any: -


##### Category (full list at https://defillama.com/categories) *Please choose only one: Staking Pool


##### forkedFrom (Does your project originate from another project): - 


##### methodology (what is being counted as tvl, how is tvl being calculated): The TVL is calculated as USD value of all the assets transferred from Kava to Obyte and eligible for rewards.


##### Github org/user (Optional, if your code is open source, we can track activity): byteball and you can check all calculations here: https://github.com/byteball/kava-rewards
