### PR TITLE
add taiko core assets(USDC_e and USDT)

### DIFF
--- a/projects/helper/coreAssets.json
+++ b/projects/helper/coreAssets.json
@@ -1799,6 +1799,8 @@
   },
   "taiko": {
     "USDC": "0x07d83526730c7438048D55A4fc0b850e2aaB6f0b",
+    "USDT": "0x2def195713cf4a606b49d07e520e22c17899a736",
+    "USDC_e": "0x19e26b0638bf63aa9fa4d14c6baf8d52ebe86c5c",
     "WETH": "0xA51894664A773981C6C112C43ce576f315d5b1B6"
   },
   "stellar": {

--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -160,6 +160,8 @@ const fixBalancesTokens = {
     [ADDRESSES.null]: { coingeckoId: 'ethereum', decimals: 18 },
     [ADDRESSES.taiko.WETH]: { coingeckoId: 'ethereum', decimals: 18 },
     [ADDRESSES.taiko.USDC]: { coingeckoId: 'usd-coin', decimals: 6 },
+    [ADDRESSES.taiko.USDC_e]: { coingeckoId: 'usd-coin', decimals: 6 },
+    [ADDRESSES.taiko.USDT]: { coingeckoId: 'tether', decimals: 6 },
   },
   sei: {
     '0x3894085ef7ff0f0aedf52e2a2704928d1ec074f1': { coingeckoId: 'usd-coin', decimals: 6 },


### PR DESCRIPTION
added two stable coin assets on taiko:

"USDT": "0x2def195713cf4a606b49d07e520e22c17899a736"
USDT comes from taiko's official bridge (from ethereum to taiko)
(here: https://bridge.taiko.xyz/)

"USDC_e": "0x19e26b0638bf63aa9fa4d14c6baf8d52ebe86c5c"
USDC_e is from stargate's bridge

Check the token info from Taiko Scan: https://taikoscan.network
