### PR TITLE
Add Scroll Chain Integration to Impermax Protocol Adapter

### DIFF
--- a/projects/impermax/impermaxHelper.js
+++ b/projects/impermax/impermaxHelper.js
@@ -104,6 +104,7 @@ function impermaxHelper(exportsObj, config, blacklistedPools) {
       case 'canto':
       case 'era':
       case 'fantom':
+      case 'scroll':
       default:
         impermaxSymbol = 'STKD-UNI-V2'
         return underlyings.filter((_, i) => uSymbols[i] === impermaxSymbol)

--- a/projects/impermax/index.js
+++ b/projects/impermax/index.js
@@ -48,6 +48,11 @@ const config = {
       '0x9b4ae930255CB8695a9F525dA414F80C4C7a945B',
     ]
   },
+  scroll: { 
+    factories: [
+      '0x02Ff7B4d96EeBF8c9B34Fae0418E591e11da3099',
+    ]
+  },
 }
 
 const blacklistedPools = {
@@ -89,6 +94,7 @@ const blacklistedPools = {
     '0x877a330af63094d88792b9ca28ac36c71673eb1c', // IMX-FTM
     '0xb97b6ed451480fe6466a558e9c54eaac32e6c696', // OXD-FTM
   ],
+  scroll: [],
 }
 
 module.exports = {}


### PR DESCRIPTION
### Description

This PR adds the necessary configuration for the Scroll chain to the Impermax protocol adapter. By including Scroll-specific factory addresses and updating the blacklist, this integration allows DeFiLlama to support Impermax on the Scroll chain.

### Changes Made

- **Configuration Update**: Added Scroll-specific factory addresses to the existing `config` object.

### Testing

- Verified that the Scroll chain configuration is correctly integrated and does not interfere with existing chains.
- Tested the adapter using the `test.js` script to ensure that the integration works without errors.


### Related Issues

No related issues at this time.
