### PR TITLE
[Baseline] Track YES collateral locked in protocol as staking

### DIFF
--- a/projects/baseline/index.js
+++ b/projects/baseline/index.js
@@ -16,8 +16,7 @@ async function tvl(api) {
   //baseline V2 Positions
   const v2Positions = await api.multiCall({ target: BASELINE_CONTRACT_V2, calls: positions, abi: v2Abi.getPosition });
   //account for collateral now locked in protocol from borrowing activity
-  const v2CollateralLocked = await api.call({ target: CREDT_CONTRACT, abi: credtAbi.totalCollateralized });
-  // api.add(BASELINE_CONTRACT_V2, v2CollateralLocked);  // YES considered own token and should not be counted towards tvl
+
   api.addGasToken(v2Positions.map(i => i.reserves));
 }
 
@@ -28,6 +27,11 @@ async function borrowed(api) {
   api.addGasToken(lentReservesV2)
 }
 
+async function staking(api) {
+  const v2CollateralLocked = await api.call({ target: CREDT_CONTRACT, abi: credtAbi.totalCollateralized });
+  api.add(BASELINE_CONTRACT_V2, v2CollateralLocked);  // YES considered own token and should not be counted towards tvl
+}
+
 module.exports = {
   hallmarks: [
     [1714251306, "self-whitehack"]
@@ -36,6 +40,7 @@ module.exports = {
   blast: {
     tvl,
     borrowed,
+    staking,
   },
 };
 

--- a/projects/baseline/index.js
+++ b/projects/baseline/index.js
@@ -29,7 +29,7 @@ async function borrowed(api) {
 
 async function staking(api) {
   const v2CollateralLocked = await api.call({ target: CREDT_CONTRACT, abi: credtAbi.totalCollateralized });
-  api.add(BASELINE_CONTRACT_V2, v2CollateralLocked);  // YES considered own token and should not be counted towards tvl
+  api.add(BASELINE_CONTRACT_V2, v2CollateralLocked);  // collateral deposited into protocol by EOA in exchange for a loan
 }
 
 module.exports = {


### PR DESCRIPTION
Follow up on https://github.com/DefiLlama/DefiLlama-Adapters/pull/10816

can we at least track YES collateral under 'staking'?

This is external $YES not owned by the protocol that factors into circulating supply, it's really really important for people to factor this in because it helps show systemic leverage.

This YES does not belong to the protocol. It is deposited by an EOA in exchange for a  loan