### PR TITLE
Corrects the calculation of avax borrowed positions.

### DIFF
--- a/projects/term-finance/index.js
+++ b/projects/term-finance/index.js
@@ -4,8 +4,8 @@ const { getLogs } = require('../helper/cache/getLogs')
 const graphs = {
   ethereum:
     "https://public-graph-proxy.mainnet.termfinance.io",
-    avax:
-      "https://public-graph-proxy.avalanche.mainnet.termfinance.io",
+  avax:
+    "https://public-graph-proxy.avalanche.mainnet.termfinance.io",
 };
 
 const query = `
@@ -40,7 +40,7 @@ query auctionsQuery($lastId: ID) {
 
 const startBlocks = {
   "ethereum": 16380765,
-  "avalanche": 43162228,
+  "avax": 43162228,
 };
 const emitters = {
   "ethereum": [
@@ -48,7 +48,7 @@ const emitters = {
     "0xf268E547BC77719734e83d0649ffbC25a8Ff4DB3",  // 0.4.1
     "0xc60e0f5cD9EE7ACd22dB42F7f56A67611ab6429F",  // 0.6.0
   ],
-  "avalanche": [
+  "avax": [
     "0xb81afB6724ba9d19a3572Fb29ed7ef633fD50093",  // 0.6.0
   ],
 };


### PR DESCRIPTION
Currently the `term-finance` avalanche borrowed shows `$0`. This PR should fix the incorrect balance calculation