### PR TITLE
Upgrade to NovaSwap v2

### DIFF
--- a/projects/novaswap/index.js
+++ b/projects/novaswap/index.js
@@ -1,5 +1,5 @@
 const { uniV3Export } = require('../helper/uniswapV3')
 
 module.exports = uniV3Export({
-  zklink: { factory: '0xf8D35842f37800E349A993503372fb9E2CBb7E3d', fromBlock: 1676253 },
+  zklink: { factory: '0x9f94c91b178F5bc9fCcA3e5428b09A3d01CE5AC6', fromBlock: 3416798 },
 })


### PR DESCRIPTION
### NovaSwap V1 
domain name change: [novaswap.fi](https://novaswap.fi/#/swap) -> [legacy.novaswap.fi/#/pool](https://legacy.novaswap.fi/#/swap)


###  NovaSwap V2 
[novaswap.fi](https://novaswap.fi/#/swap) 