### PR TITLE
fix ContraxFinance update

### DIFF
--- a/projects/contrax-finance/index.js
+++ b/projects/contrax-finance/index.js
@@ -34,20 +34,15 @@ const STEER_VAULTS = [
 ];
 
 async function getHopMagicData(api) {
-  const tokenAddress = await api.call({
-    abi: "function token() view returns (address token)",
-    target: HOP_MAGIC_VAULT,
-    params: [],
-  });
-  const balance = await api.call({
-    abi: "uint256:balance",
-    target: HOP_MAGIC_VAULT,
-  });
+  const [tokenAddress, balance] = await Promise.all([
+    api.call({ abi: "function token() view returns (address token)", target: HOP_MAGIC_VAULT,params: [] }),
+    api.call({ abi: "uint256:balance", target: HOP_MAGIC_VAULT })
+  ])
   api.add(tokenAddress, balance);
 }
 
 async function getSteerData(api) {
-  let tokens = await api.multiCall({ abi: "address:token", calls: STEER_VAULTS });
+  const tokens = await api.multiCall({ abi: "address:token", calls: STEER_VAULTS });
   const [token0s, token1s, supplies, reserves, bals] = await Promise.all([
     api.multiCall({ abi: "address:token0", calls: tokens }),
     api.multiCall({ abi: "address:token1", calls: tokens }),
@@ -59,6 +54,7 @@ async function getSteerData(api) {
     api.multiCall({
       abi: "uint256:balance",
       calls: STEER_VAULTS,
+      permitFailure: true
     }),
   ]);
 
@@ -80,22 +76,20 @@ async function getGMXData(api) {
 }
 
 async function tvl(api) {
-  let tokens = await api.multiCall({ abi: "address:token", calls: Vaults });
-  let bals = await api.multiCall({
-    abi: "uint256:balance",
-    calls: Vaults,
-  });
+  const [tokens, bals] = await Promise.all([
+    api.multiCall({ abi: "address:token", calls: Vaults }),
+    api.multiCall({ abi: "uint256:balance", calls: Vaults }),
+    getHopMagicData(api),
+    getGMXData(api),
+    getSteerData(api)
+  ])
 
   // const bals = await api.multiCall({
   //   abi: "erc20:balanceOf",
   //   calls: tokens.map((t, i) => ({ target: targets[i], params: [t] })),
   // });
-  await getHopMagicData(api);
-  await getGMXData(api);
-  await getSteerData(api);
 
   api.addTokens(tokens, bals);
-
   return sumTokens2({ api, resolveLP: true });
 }
 


### PR DESCRIPTION
Minor fix on the Contrax-finance protocol

- Added a permitFailure:true on bals multicall,  there was an address that returned  `null`
- Small refacto to parallelize some calls using Promise.All() when possible