### PR TITLE
Fix: Swaap-v2

### DIFF
--- a/projects/helper/balancer.js
+++ b/projects/helper/balancer.js
@@ -1,7 +1,7 @@
 const { sumTokens2 } = require('./unwrapLPs');
 const { getLogs } = require('./cache/getLogs')
 
-function onChainTvl(vault, fromBlock, { blacklistedTokens = [], preLogTokens = [], onlyUseExistingCache } = {}) {
+function onChainTvl(vault, fromBlock, permitFailure, { blacklistedTokens = [], preLogTokens = [], onlyUseExistingCache } = {}) {
   return async (api) => {
     const logs = await getLogs({
       api,
@@ -29,7 +29,7 @@ function onChainTvl(vault, fromBlock, { blacklistedTokens = [], preLogTokens = [
     const pools = logs.map(i => i.poolAddress)
     blacklistedTokens = [...blacklistedTokens, ...pools]
 
-    return sumTokens2({ api, owner: vault, tokens, blacklistedTokens, })
+    return sumTokens2({ api, owner: vault, tokens, blacklistedTokens, permitFailure })
   }
 }
 

--- a/projects/helper/balancer.js
+++ b/projects/helper/balancer.js
@@ -1,7 +1,7 @@
 const { sumTokens2 } = require('./unwrapLPs');
 const { getLogs } = require('./cache/getLogs')
 
-function onChainTvl(vault, fromBlock, permitFailure, { blacklistedTokens = [], preLogTokens = [], onlyUseExistingCache } = {}) {
+function onChainTvl(vault, fromBlock, { blacklistedTokens = [], preLogTokens = [], onlyUseExistingCache, permitFailure } = {}) {
   return async (api) => {
     const logs = await getLogs({
       api,

--- a/projects/swaap-v2/index.js
+++ b/projects/swaap-v2/index.js
@@ -24,6 +24,6 @@ const config = {
 Object.keys(config).forEach(chain => {
   const { vault, fromBlock, permitFailure } = config[chain]
   module.exports[chain] = {
-    tvl: onChainTvl(vault, fromBlock, permitFailure)
+    tvl: onChainTvl(vault, fromBlock, { permitFailure })
   }
 })

--- a/projects/swaap-v2/index.js
+++ b/projects/swaap-v2/index.js
@@ -6,7 +6,7 @@ const {onChainTvl} = require("../helper/balancer");
  */
 const config = {
   ethereum: { vault: '0xd315a9c38ec871068fec378e4ce78af528c76293', fromBlock: 17598578, },
-  arbitrum: { vault: '0xd315a9c38ec871068fec378e4ce78af528c76293', fromBlock: 137451745,},
+  arbitrum: { vault: '0xd315a9c38ec871068fec378e4ce78af528c76293', fromBlock: 137451745, permitFailure: true },
   polygon: { vault: '0xd315a9c38ec871068fec378e4ce78af528c76293', fromBlock: 44520023,},
   optimism: { vault: '0xd315a9c38ec871068fec378e4ce78af528c76293', fromBlock: 120693792, },
   bsc: { vault: '0x03c01acae3d0173a93d819efdc832c7c4f153b06', fromBlock: 39148730,},
@@ -22,8 +22,8 @@ const config = {
 
 
 Object.keys(config).forEach(chain => {
-  const { vault, fromBlock } = config[chain]
+  const { vault, fromBlock, permitFailure } = config[chain]
   module.exports[chain] = {
-    tvl: onChainTvl(vault, fromBlock)
+    tvl: onChainTvl(vault, fromBlock, permitFailure)
   }
 })


### PR DESCRIPTION
Small fix -> added a `permitFailure` for swaap-v2 as well as in the balancer helper which now accepts permitFailure in `onChainTvl` without significant impact on the rest of the codebase since `sumTokens2` is already capable of handling permitFailure