### PR TITLE
Fix: Xave-Finance update

### DIFF
--- a/projects/xave-finance/index.js
+++ b/projects/xave-finance/index.js
@@ -42,7 +42,8 @@ async function tvl(api) {
       const data = await api.multiCall({
         abi: "function liquidity() view returns (uint256 total_, uint256[] memory individual_)",
         calls: pools.map((v) => ({ target: v })),
-      });
+        permitFailure: true
+      })
 
       // Curve.derivatives(0)
       const derivatives0 = await api.multiCall({
@@ -67,6 +68,8 @@ async function tvl(api) {
       });
 
       data.forEach((d, i) => {
+        if (!d) return
+        
         const divisor0 = ethers.parseUnits(
           "1",
           parseInt(derivatives0Decimals[i])


### PR DESCRIPTION
Added permitFailure to the Data multicall for `CurveFactory` pools which sometimes returned null, as well as a checker to skip if data is null