### PR TITLE
Add new fixes coins TVL in Fixes World

### DIFF
--- a/projects/fixes-coins/index.js
+++ b/projects/fixes-coins/index.js
@@ -1,0 +1,93 @@
+// Fixes Inscription Protocol - 𝔉rc20 Treasury Pool: https://fixes.world/
+const { post } = require("../helper/http");
+
+let queryTVLCode = `
+import LiquidStaking from 0xd6f80565193ad727
+import stFlowToken from 0xd6f80565193ad727
+// Fixes Imports
+import FRC20AccountsPool from 0xd2abb5dbf5e08666
+import FixesFungibleTokenInterface from 0xd2abb5dbf5e08666
+import FixesTokenLockDrops from 0xd2abb5dbf5e08666
+import FixesTradablePool from 0xd2abb5dbf5e08666
+import FRC20Indexer from 0xd2abb5dbf5e08666
+
+access(all)
+fun main(): UFix64 {
+    // singleton resource and constants
+    let acctsPool = FRC20AccountsPool.borrowAccountsPool()
+    let frc20Indexer = FRC20Indexer.getIndexer()
+    let stFlowTokenKey = "@".concat(Type<@stFlowToken.Vault>().identifier)
+
+    // dictionary of addresses
+    let addrsDict = acctsPool.getAddresses(type: FRC20AccountsPool.ChildAccountType.FungibleToken)
+    // dictionary of tickers and total locked token balances
+    let tickerTotal: {String: UFix64} = {}
+    // This is the soft burned LP value which is fully locked in the BlackHole Vault
+    var burnedLPValue = 0.0
+    var flowLockedInBondingCurve = 0.0
+    addrsDict.forEachKey(fun (key: String): Bool {
+        if let addr = addrsDict[key] {
+            // sum up all locked token balances in LockDrops Pool
+            if let dropsPool = FixesTokenLockDrops.borrowDropsPool(addr) {
+                let lockedTokenSymbol = dropsPool.getLockingTokenTicker()
+                tickerTotal[lockedTokenSymbol] = (tickerTotal[lockedTokenSymbol] ?? 0.0) + dropsPool.getTotalLockedTokenBalance()
+            }
+            // sum up all burned LP value in Tradable Pool
+            if let tradablePool = FixesTradablePool.borrowTradablePool(addr) {
+                burnedLPValue = burnedLPValue + tradablePool.getBurnedLiquidityValue()
+                flowLockedInBondingCurve = flowLockedInBondingCurve + tradablePool.getFlowBalanceInPool()
+            }
+        }
+        return true
+    })
+    // sum up all locked token balances in LockDrops Pool
+    var totalLockingTokenTVL = 0.0
+    tickerTotal.forEachKey(fun (key: String): Bool {
+        let lockedAmount = tickerTotal[key]!
+        if key == "" {
+            // this is locked FLOW
+            totalLockingTokenTVL = totalLockingTokenTVL + lockedAmount
+        } else if key == "fixes" {
+            // this is locked FIXES
+            let price = frc20Indexer.getBenchmarkValue(tick: "fixes")
+            totalLockingTokenTVL = totalLockingTokenTVL + lockedAmount * price
+        } else if key == stFlowTokenKey {
+            // this is locked stFlow
+            totalLockingTokenTVL = totalLockingTokenTVL + LiquidStaking.calcFlowFromStFlow(stFlowAmount: lockedAmount)
+        }
+        return true
+    })
+    return totalLockingTokenTVL + burnedLPValue + flowLockedInBondingCurve
+}
+`;
+
+const queryCodeBase64 = Buffer.from(queryTVLCode, "utf-8").toString("base64");
+
+async function tvl() {
+  try {
+    const response = await post(
+      "https://rest-mainnet.onflow.org/v1/scripts",
+      { script: queryCodeBase64 },
+      {
+        headers: { "content-type": "application/json" },
+      }
+    );
+    let resEncoded = response;
+    let resString = Buffer.from(resEncoded, "base64").toString("utf-8");
+    let resJson = JSON.parse(resString);
+    let flowTokenTVL = Number(resJson.value);
+
+    return { flow: flowTokenTVL };
+  } catch (error) {
+    throw new Error("Couln't query scripts of Fixes coins", error);
+  }
+}
+
+module.exports = {
+  timetravel: false,
+  methodology:
+    "Counting the $FLOW token locked in Fixes Coins' Bonding Curve, Fixes Coins' Burned Pool, and Fixes Coins' LockDrop Pool.",
+  flow: {
+    tvl,
+  },
+};

--- a/projects/fixes-coins/index.js
+++ b/projects/fixes-coins/index.js
@@ -23,7 +23,6 @@ fun main(): UFix64 {
     // dictionary of tickers and total locked token balances
     let tickerTotal: {String: UFix64} = {}
     // This is the soft burned LP value which is fully locked in the BlackHole Vault
-    var burnedLPValue = 0.0
     var flowLockedInBondingCurve = 0.0
     addrsDict.forEachKey(fun (key: String): Bool {
         if let addr = addrsDict[key] {
@@ -34,7 +33,6 @@ fun main(): UFix64 {
             }
             // sum up all burned LP value in Tradable Pool
             if let tradablePool = FixesTradablePool.borrowTradablePool(addr) {
-                burnedLPValue = burnedLPValue + tradablePool.getBurnedLiquidityValue()
                 flowLockedInBondingCurve = flowLockedInBondingCurve + tradablePool.getFlowBalanceInPool()
             }
         }
@@ -57,7 +55,7 @@ fun main(): UFix64 {
         }
         return true
     })
-    return totalLockingTokenTVL + burnedLPValue + flowLockedInBondingCurve
+    return totalLockingTokenTVL + flowLockedInBondingCurve
 }
 `;
 

--- a/projects/fixes-coins/index.js
+++ b/projects/fixes-coins/index.js
@@ -84,7 +84,7 @@ async function tvl() {
 module.exports = {
   timetravel: false,
   methodology:
-    "Counting the $FLOW token locked in Fixes Coins' Bonding Curve, Fixes Coins' Burned Pool, and Fixes Coins' LockDrop Pool.",
+    "Counting the $FLOW token locked in Fixes Coins' Bonding Curve, and Fixes Coins' LockDrop Pool.",
   flow: {
     tvl,
   },


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):

Fixes World (Prev. Fixes Inscription)

##### Twitter Link:

https://twitter.com/fixesworld

##### List of audit links if any:

N/A

##### Website Link:

https://fixes.world/

##### Logo (High resolution, will be shown with rounded borders):

##### Current TVL: 

##### Treasury Addresses (if the protocol has treasury)

0xd2abb5dbf5e08666

##### Chain:

Flow

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): 

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): 

##### Short Description (to be shown on DefiLlama):

Fixes World provides multiple fungible token issuance, trading, staking, and governance services. It is driven by the inscription mechanism to enable underlying programmable features.

##### Token address and ticker if any:

##### Category (full list at https://defillama.com/categories) *Please choose only one:

[Launchpad](https://defillama.com/protocols/Launchpad)

Fixes Coins is a pump.fun like coin launchpad

Parent in DefiLlama: [parent#fixes-inscription]

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
##### Implementation Details: Briefly describe how the oracle is integrated into your project:
##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

##### forkedFrom (Does your project originate from another project):

Original

##### methodology (what is being counted as tvl, how is tvl being calculated):

Fixes Coins has implemented a token launchpad similar to pump.fun, so $FLOW will be temporarily locked in the Bonding Curve before the LP formed.

In addition, Fixes Coins has an LockDrops module, where the token issuer can choose to enable the LockDrops module and specify tokens such as $FLOW, $stFLOW, etc., which can be converted into a fixed value of $FLOW as collateral, locked for a period of time to obtain the opportunity to claim coins.

Therefore, both the $FLOW in the Bonding Curve and the $FLOW during the lock-up period are recorded as TVL.

##### Github org/user (Optional, if your code is open source, we can track activity):

https://github.com/fixes-world/fixes
