### PR TITLE
adding midas sdk

### DIFF
--- a/projects/midas/index.js
+++ b/projects/midas/index.js
@@ -1,0 +1,35 @@
+const ADDRESSES = require("../helper/coreAssets.json");
+const MTBILL_TOKEN_CONTRACT = "0xDD629E5241CbC5919847783e6C96B2De4754e438";
+
+async function getTokenData(api, tokenContract) {
+  const totalSupply = await api.call({
+    abi: "erc20:totalSupply",
+    target: tokenContract,
+  });
+
+  return totalSupply / 1e18;
+}
+
+async function tvl(api) {
+  const mtbillSupply = await getTokenData(api, MTBILL_TOKEN_CONTRACT);
+
+  const rate = await api.call({
+    target: "0x32d1463EB53b73C095625719Afa544D5426354cB", // IB01/USD
+    abi: "function latestRoundData() external view returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)",
+  });
+  // format chainlink return 
+  const normalizedRate = rate.answer / 1e8;
+
+  // times feed price and convert to expected format
+  const mtbillValue = (mtbillSupply * normalizedRate) * 1_000_000;
+
+  return {
+    [ADDRESSES.ethereum.USDC]: mtbillValue,
+  };
+}
+
+const chains = ["ethereum"];
+
+chains.forEach((chain) => {
+  module.exports[chain] = { tvl };
+});

--- a/projects/midas/index.js
+++ b/projects/midas/index.js
@@ -1,31 +1,12 @@
-const ADDRESSES = require("../helper/coreAssets.json");
-const MTBILL_TOKEN_CONTRACT = "0xDD629E5241CbC5919847783e6C96B2De4754e438";
-
-async function getTokenData(api, tokenContract) {
-  const totalSupply = await api.call({
-    abi: "erc20:totalSupply",
-    target: tokenContract,
-  });
-
-  return totalSupply / 1e18;
-}
-
 async function tvl(api) {
-  const mtbillSupply = await getTokenData(api, MTBILL_TOKEN_CONTRACT);
+  const MTBILL_TOKEN_CONTRACT = "0xDD629E5241CbC5919847783e6C96B2De4754e438";
+  const mtbillSupply = await await api.call({ abi: "erc20:totalSupply", target: MTBILL_TOKEN_CONTRACT, });
 
   const rate = await api.call({
     target: "0x32d1463EB53b73C095625719Afa544D5426354cB", // IB01/USD
     abi: "function latestRoundData() external view returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)",
   });
-  // format chainlink return 
-  const normalizedRate = rate.answer / 1e8;
-
-  // times feed price and convert to expected format
-  const mtbillValue = (mtbillSupply * normalizedRate) * 1_000_000;
-
-  return {
-    [ADDRESSES.ethereum.USDC]: mtbillValue,
-  };
+  api.addCGToken('tether', (mtbillSupply / 1e18) * (rate.answer / 1e8))
 }
 
 const chains = ["ethereum"];
@@ -33,3 +14,5 @@ const chains = ["ethereum"];
 chains.forEach((chain) => {
   module.exports[chain] = { tvl };
 });
+
+module.exports.misrepresentedTokens = true


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `volume` adapter please submit the PR [here](https://github.com/DefiLlama/adapters).
> - If you would like to add a `liquidations` adapter, please refer to [this readme document](https://github.com/DefiLlama/DefiLlama-Adapters/tree/main/liquidations) for details.

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
3. Please fill the form below  **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
4. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can  edit it there and put up a PR
5. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
6. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap

---
##### Name (to be shown on DefiLlama):
Midas

##### Twitter Link:
[Twitter](https://x.com/MidasRWA)

##### List of audit links if any:
[Hacken #1](https://2732961456-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FsPjk0ggBxEJCCnVFFkDR%2Fuploads%2F1wxK6TgqaRsSgt3ixVMx%2FMidas_SC%20Audit%20Report_25092023_%5BSA-1833%5D%20-%20POST%20REMEDIATION.pdf?alt=media&token=cdcf6533-7366-42db-9d3b-224efac85b9a)

[Hacken #2](https://2732961456-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FsPjk0ggBxEJCCnVFFkDR%2Fuploads%2F38N1bo36K8FLriRrPDXb%2FHacken_Midas_%5BSCA%5D%20Midas_Vault_Dec2023_P-2023-076_1_20240118%2016_22.pdf?alt=media&token=2c58f6f7-889e-4c64-ac84-35bad59eb51a)

##### Website Link:
[midas.app](https://midas.app/)

##### Logo (High resolution, will be shown with rounded borders):
![color_normal_logomark@4x](https://github.com/user-attachments/assets/b7feb4d9-46e2-43e9-a5d2-947b90e6dff9)


##### Current TVL:
$4,115,028.78

##### Treasury Addresses (if the protocol has treasury)


##### Chain:
Ethereum

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/midas-mtbill/)


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): 


##### Short Description (to be shown on DefiLlama):
Midas US Treasury Bills Token (mTBILL) is a permissionless yield-bearing token tracking short-dated US Treasury Bills.



##### Token address and ticker if any:
[**mTBILL**: 0xDD629E5241CbC5919847783e6C96B2De4754e438](https://etherscan.io/token/0xDD629E5241CbC5919847783e6C96B2De4754e438)

##### Category (full list at https://defillama.com/categories) *Please choose only one:
RWA

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
Chainlink IB01 / USD

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
mTBILL utilizes Chainlink's IB01/USD price feed to accurately price mTBILL tokens. mTBILL 1:1 tracks the price of BlackRock's short-dated IB01 fund.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage: [mTBILL/USDC oracle](https://app.morpho.org/market?id=0xbe4c211adca4400078db69af91ea0df98401adb5959510ae99edd06fee5146f7&network=mainnet)

##### forkedFrom (Does your project originate from another project):

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL encompasses USDC deposits into the primary DepositVault.sol contract through midas.app.

##### Github org/user (Optional, if your code is open source, we can track activity):
