### PR TITLE
DSU: Change collateral to native USDC on Arbitrum

### DIFF
--- a/projects/dsu-money/index.js
+++ b/projects/dsu-money/index.js
@@ -11,7 +11,7 @@ module.exports = {
   },
   arbitrum: {
     tvl: sumTokensExport({ tokensAndOwners: [
-      [ADDRESSES.arbitrum.USDC, '0x0d49c416103cbd276d9c3cd96710db264e3a0c27'],
+      [ADDRESSES.arbitrum.USDC_CIRCLE, '0x0d49c416103cbd276d9c3cd96710db264e3a0c27'],
     ]})
   }
 }

--- a/projects/dsu-money/index.js
+++ b/projects/dsu-money/index.js
@@ -11,6 +11,7 @@ module.exports = {
   },
   arbitrum: {
     tvl: sumTokensExport({ tokensAndOwners: [
+      [ADDRESSES.arbitrum.USDC, '0x0d49c416103cbd276d9c3cd96710db264e3a0c27'],
       [ADDRESSES.arbitrum.USDC_CIRCLE, '0x0d49c416103cbd276d9c3cd96710db264e3a0c27'],
     ]})
   }


### PR DESCRIPTION
##### Name (to be shown on DefiLlama): DSU Money

##### Website Link: https://dsu.money

##### Current TVL: ~2m

##### Changes: DSU recently migrated to native USDC collateral on Arbitrum. This changed the token from bridged USDC to native USDC.