### PR TITLE
Yield Yak updates

### DIFF
--- a/projects/yieldyak/index.js
+++ b/projects/yieldyak/index.js
@@ -1,14 +1,10 @@
 const { staking } = require('../helper/staking');
-const { cachedGraphQuery, getConfig } = require('../helper/cache')
-const sdk = require('@defillama/sdk')
+const { getConfig } = require('../helper/cache')
 
-const graphUrl = sdk.graph.modifyEndpoint('7oSYYdK5RKmqggdzFyfUnojP6puDAj31C4ezDGrgVfk9')
-const graphQuery = `{ farms(first: 1000) { id }}`;
-
-async function tvl(api) {
-  const { farms } = await cachedGraphQuery('yieldyak/avax', graphUrl, graphQuery)
-  const tokens = await api.multiCall({ abi: 'address:depositToken', calls: farms.map(i => i.id), permitFailure: true, })
-  const vals = await api.multiCall({ abi: 'uint256:totalDeposits', calls: farms.map(i => i.id), permitFailure: true, })
+async function avaxTvl(api) {
+  const farms = await getConfig('yieldyak/avax', 'https://staging-api.yieldyak.com/43114/farms')
+  const tokens = await api.multiCall({ abi: 'address:depositToken', calls: farms.map(i => i.address), permitFailure: true, })
+  const vals = await api.multiCall({ abi: 'uint256:totalDeposits', calls: farms.map(i => i.address), permitFailure: true, })
   tokens.forEach((token, i) => {
     if (!token || !vals[i]) return;
     api.add(token, vals[i])
@@ -35,12 +31,21 @@ async function mantleTvl(api) {
 
 const masterYak = "0x0cf605484A512d3F3435fed77AB5ddC0525Daf5f"
 const yakToken = "0x59414b3089ce2af0010e7523dea7e2b35d776ec7"
+const arbiYyStaking = "0xbb82b43Bf2057B804253D5Db8c18A647fC1f3403"
+const mantleYyStaking = "0xF54D65AeB65b093A6BF717b541894ee6471A6CE1"
+const bridgedYakToken = "0x7f4dB37D7bEb31F445307782Bc3Da0F18dF13696"
 
 module.exports = {
   avax: {
-    tvl,
+    tvl: avaxTvl,
     staking: staking(masterYak, yakToken),
   },
-  arbitrum: { tvl: arbiTvl },
-  mantle: { tvl: mantleTvl}
+  arbitrum: {
+    tvl: arbiTvl,
+    staking: staking(arbiYyStaking, bridgedYakToken),
+  },
+  mantle: {
+    tvl: mantleTvl,
+    staking: staking(mantleYyStaking, bridgedYakToken),
+  }
 }


### PR DESCRIPTION
Updated source for Avalanche TVL for Yield Yak (previous subgraph that was being used is not as up to date as the API), and added staking for Arbitrum and Mantle.

Note: YAK token needs to be added to DefiLlama's prices for that staking value to be accurate. Can do that after this.