### PR TITLE
feat: Add bounce bit token config

### DIFF
--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -66,6 +66,9 @@ const fixBalancesTokens = {
   saakuru: {
     '0x557a526472372f1F222EcC6af8818C1e6e78A85f': { coingeckoId: 'oasys', decimals: 18 },
     '0x739222D8A9179fE05129C77a8fa354049c088CaA': { coingeckoId: 'usd-coin', decimals: 6 }
+  },
+  bouncebit: {
+    '0x8f083eafcbba2e126ad9757639c3a1e25a061a08': { coingeckoId: 'bouncebit-btc', decimals: 18 }
   }
 }
 


### PR DESCRIPTION
According to the native stBBTC contract design, directly using stBBTC to create a token pool (e.g., AAVE's Token Pool) can cause precision loss in the calculation of its BB token rewards. To ensure accurate BB reward calculations for stBBTC, we wrap stBBTC again. This wrapping adapts to the BB calculation and distribution in the pool model, similar to wstETH. For the specific contract implementation, please refer to https://bbscan.io/contract/0x8f083EaFcbba2e126AD9757639c3A1E25a061A08. The primary use cases currently include various lending protocols and restaking platforms, such as pell.network, among others.