### PR TITLE
Fix: Bean update

### DIFF
--- a/projects/bean/index.js
+++ b/projects/bean/index.js
@@ -100,7 +100,7 @@ async function getPoolReserves(api, pool) {
 
   pool = pool.toLowerCase();
   const poolBalances = await api.multiCall({
-    calls: ALL_POOLS[pool].underlying.map(token => ({
+    calls: (ALL_POOLS[pool] && ALL_POOLS[pool].underlying || []).map(token => ({
       target: token,
       params: pool
     })),


### PR DESCRIPTION
Add a handler to prevent errors when the `underlying` prop is undefined which breaks the subsequent multicall