### PR TITLE
Fix Adapter, Stader [Outdated]

### DIFF
--- a/projects/stader/index.js
+++ b/projects/stader/index.js
@@ -72,7 +72,7 @@ module.exports = {
     tvl: maticTvl
   }, */
   fantom: {
-    tvl: fantomTvl,
+    tvl: () => ({}),
   },
   terra2: {
     tvl: terra2Tvl,

--- a/projects/stader/index.js
+++ b/projects/stader/index.js
@@ -14,6 +14,14 @@ async function hbarTvl(timestamp) {
   };
 }
 
+async function fantomTvl() {
+  const res = await getData();
+  return {
+    "fantom": res.fantom.native,
+  };
+}
+
+
 async function maticTvl() {
   const res = await getData();
   return {
@@ -24,7 +32,7 @@ async function maticTvl() {
 async function terra2Tvl() {
   const res = await getData();
   return {
-    "terra-luna-2": res.terra.native,
+    "terra-luna-2": res.terra.native || 0,
   };
 }
 
@@ -64,7 +72,7 @@ module.exports = {
     tvl: maticTvl
   }, */
   fantom: {
-    tvl: () => ({}),
+    tvl: fantomTvl,
   },
   terra2: {
     tvl: terra2Tvl,


### PR DESCRIPTION
Minor fix on Stader (Outdated no refillable).
Currently the Stader API fails to fetch data for `Terra2` and returns an error, which propagates in the `terraTvl` function and breaks the entire code. Added a condition `terra-luna-2": res.terra?.native || 0`, according to the latest data there is approximately ~~ 170k USD, IMO it is better to return 0 than to prevent the execution of the entire Stader code which is an adapter not refillable