### PR TITLE
fix: Stader

### DIFF
--- a/projects/stader/index.js
+++ b/projects/stader/index.js
@@ -7,20 +7,12 @@ async function getData() {
   return _res;
 }
 
-async function hbarTvl(timestamp) {
+async function hbarTvl() {
   const res = await get("https://universe.staderlabs.com/common/tvl");
   return {
     "hedera-hashgraph": res.hedera.native,
   };
 }
-
-async function fantomTvl() {
-  const res = await getData();
-  return {
-    "fantom": res.fantom.native,
-  };
-}
-
 
 async function maticTvl() {
   const res = await getData();
@@ -29,24 +21,10 @@ async function maticTvl() {
   };
 }
 
-async function terra2Tvl() {
-  const res = await getData();
-  return {
-    "terra-luna-2": res.terra.native || 0,
-  };
-}
-
 async function bscTvl() {
   const res = await getData();
   return {
     binancecoin: res.bnb.native,
-  };
-}
-
-async function nearTvl() {
-  const res = await getData();
-  return {
-    near: res.near.native,
   };
 }
 
@@ -61,27 +39,15 @@ module.exports = {
   timetravel: false,
   methodology:
     "We aggregated the assets staked across Stader staking protocols",
-  /*terra: {
-    tvl,
-  },*/
   hedera: {
     tvl: hbarTvl,
   },
   // its on ethereum because funds are locked there
-  /* ethereum: {
-    tvl: maticTvl
-  }, */
-  fantom: {
-    tvl: () => ({}),
-  },
-  terra2: {
-    tvl: terra2Tvl,
-  },
+  // ethereum: {
+  //   tvl: maticTvl
+  // },
   bsc: {
     tvl: bscTvl,
-  },
-  near: {
-    tvl: nearTvl,
   },
   ethereum: {
     tvl: async (api) => {

--- a/projects/stader/index.js
+++ b/projects/stader/index.js
@@ -39,15 +39,27 @@ module.exports = {
   timetravel: false,
   methodology:
     "We aggregated the assets staked across Stader staking protocols",
+  /*terra: {
+    tvl,
+  },*/
   hedera: {
     tvl: hbarTvl,
   },
   // its on ethereum because funds are locked there
-  // ethereum: {
-  //   tvl: maticTvl
-  // },
+  /* ethereum: {
+    tvl: maticTvl
+  }, */
+  fantom: {
+    tvl: () => ({}),
+  },
+  terra2: {
+    tvl: () => ({}),
+  },
   bsc: {
     tvl: bscTvl,
+  },
+  near: {
+    tvl: () => ({}),
   },
   ethereum: {
     tvl: async (api) => {


### PR DESCRIPTION
> Since the latest fix on Stader, they have now completely removed the data from their API that was being returned with errors, keeping only the chains on which they are still active

> rm terra2, rm near

https://universe.staderlabs.com/common/tvl