### PR TITLE
Dyad Stable: Remove ETH in Dnft contract from tvl calcluatiobn

### DIFF
--- a/projects/dyad/index.js
+++ b/projects/dyad/index.js
@@ -9,8 +9,6 @@ const vaults = [
 
 async function tvl(api) {
   const tokens = await api.multiCall({ abi: 'address:asset', calls: vaults })
-  tokens.push(ADDRESSES.null)
-  vaults.push('0xdc400bbe0b8b79c07a962ea99a642f5819e3b712')
   return api.sumTokens({ tokensAndOwners2: [tokens, vaults] })
 }
 


### PR DESCRIPTION
The ETH in the Dnft contract from minting notes is the only fee in the Dyad Stablecoin system - this ETH should not be counted towards TVL as it is protocol revenue, not user funds/protocol TVL.