### PR TITLE
fix Swell rswETH tvl query to support withdrawals

### DIFF
--- a/projects/swell-restaking/index.js
+++ b/projects/swell-restaking/index.js
@@ -1,13 +1,12 @@
 const { nullAddress } = require("../helper/tokenMapping")
 
 async function tvl(api) {
-    const tvl = await api.call({
-        target: "0xFAe103DC9cf190eD75350761e95403b7b8aFa6c0",
-        abi: "uint256:totalETHDeposited"
-    })
+    const totalSupply = await api.call({ target: '0xFAe103DC9cf190eD75350761e95403b7b8aFa6c0', abi: 'uint256:totalSupply'});
+    const rate = await api.call({ target: '0xFAe103DC9cf190eD75350761e95403b7b8aFa6c0', abi: 'uint256:getRate'});
+    
     return {
-        [nullAddress]: tvl
-    }
+      [nullAddress]: (totalSupply * rate)/1e18
+    };
 }
 
 module.exports = {


### PR DESCRIPTION
Withdrawals went live for Swell Liquid Restaking. 
The current methodology doesn't reflect the actual ETH number. 

Hence updating methodology to show the post Withdrawn amount