### PR TITLE
Add Ethereum chain for Pell Network

### DIFF
--- a/projects/pell/index.js
+++ b/projects/pell/index.js
@@ -1,7 +1,7 @@
 const { sumTokens2 } = require('../helper/unwrapLPs')
 const { getConfig } = require('../helper/cache')
 
-const chains = ['merlin', 'bouncebit', 'btr', 'bsc', 'bsquared', 'core', 'bevm', 'mantle', 'scroll', 'bob']
+const chains = ['ethereum', 'merlin', 'bouncebit', 'btr', 'bsc', 'bsquared', 'core', 'bevm', 'mantle', 'scroll', 'bob']
 
 chains.forEach(chain => {
   module.exports[chain] = {


### PR DESCRIPTION
Add Ethereum chain for Pell Network
------ TVL ------
btr                       68.21 M
bouncebit                 59.47 M
bsquared                  33.23 M
merlin                    30.82 M
core                      5.63 M
bsc                       425.80 k
bob                       127.80 k
scroll                    2.49 k
bevm                      347
mantle                    85
ethereum                  14

total                    197.92 M