### PR TITLE
[EBISU'S BAY] Add Cronos zkEVM chain

### DIFF
--- a/projects/ebisus-bay/index.js
+++ b/projects/ebisus-bay/index.js
@@ -6,15 +6,25 @@ const frtnToken = '0xaF02D78F39C0002D14b95A3bE272DA02379AfF21'
 const bankContract = '0x1E16Aa4Bb965478Df310E8444CD18Fa56603A25F'
 
 
-module.exports = {
-    misrepresentedTokens: true,
-    methodology: "The TVL accounts for all LP on the dex, using the factory address 0x5f1d751f447236f486f4268b883782897a902379). Staking accounts for the FRTN staked in the bank on our platform.",
-  cronos: {
-    staking: staking(bankContract, frtnToken),
-    tvl: getUniTVL({
-      factory,
-      useDefaultCoreAssets: true,
-    }),
-  },
+const factoryConfig = {
+  cronos: '0x5f1d751f447236f486f4268b883782897a902379',
+  cronos_zkevm: '0x1A695B3aC30D41F9A1D856A27DD0D9DdaaCe750d',
 }
+
+Object.keys(factoryConfig).forEach(chain => {
+  const factory = factoryConfig[chain]
+  if (chain === 'cronos') {
+    module.exports[chain] = {
+      staking: staking(bankContract, frtnToken),
+      tvl: getUniTVL({ factory, useDefaultCoreAssets: true, })
+    }
+  } else {
+    module.exports[chain] = {
+      tvl: getUniTVL({ factory, useDefaultCoreAssets: true, })
+    }
+  }
+})
+
+module.exports.misrepresentedTokens = true;
+module.exports.methodology = "The TVL accounts for all LP on the dex. Staking accounts for the FRTN staked in the bank on our Cronos."
 


### PR DESCRIPTION
##### Name (to be shown on DefiLlama): 
Ebisu's Bay


##### Twitter Link: 
https://twitter.com/EbisusBay


##### List of audit links if any: 
N/A


##### Website Link: 
https://app.ebisusbay.com


##### Logo (High resolution, will be shown with rounded borders): 
https://github.com/DefiLlama/DefiLlama-Adapters/assets/17624338/7acac564-a4de-4efe-a736-0f6d9aebc7e0


##### Current TVL: 
709K

##### Treasury Addresses (if the protocol has treasury)
0x289A94c5cf403691aca3d222E30335a4957b3ae6

##### Chain: 
Cronos
Cronos zkEVM


##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): 
ebisusbay-fortune


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): 
ebisusbay-fortune


##### Short Description (to be shown on DefiLlama):
Ebisu's Bay is a dynamic platform that combines NFT and DEX trading with GameFi, enabling users to join factions for market dominance. It transforms NFTs into engaging game elements, adding an interactive dimension to trading and gaming.

##### Token address and ticker if any:
FRTN (Cronos) - 0xaF02D78F39C0002D14b95A3bE272DA02379AfF21
FRTN (Cronos zkEVM) - 0x96e03fa6c5ab3a7f2e7098dd07c8935493294e26

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Dexes

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.): 
N/A

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
N/A

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
N/A

##### forkedFrom (Does your project originate from another project):
Uniswap V2


##### methodology (what is being counted as tvl, how is tvl being calculated):
The TVL accounts for all LP on the dex on both chains. Staking accounts for the FRTN staked in the bank on Cronos.


##### Github org/user (Optional, if your code is open source, we can track activity):
N/A
