### PR TITLE
feat: subtract the cgUSDT of withdrawal vault to reflect true TVL

### DIFF
--- a/projects/cygnus-finance/index.js
+++ b/projects/cygnus-finance/index.js
@@ -13,11 +13,14 @@ async function getJettonMetadata(addr) {
   const res = await get(`https://tonapi.io/v2/jettons/${addr}`)
   return res
 }
+async function getJettonBalance(address, jettonMasterAddress) {
+  const res = await get(`https://tonapi.io/v2/accounts/${address}/jettons/${jettonMasterAddress}`)
+  return res.balance
+}
 
 async function tonTvl() {
   const MINTER_ADDRESS = "EQCfvQW-thWpqKgyqtXCFbYayDlHqS0-frkyP6VD70paLFZa"
   const CGUSDT_ADDRESS = 'EQBIBw3mF_TDMJqWAZihVsyUBMWpWw_deftZLiCxTmrCUOKy'
-
 
   const minterResult = await call({ target: MINTER_ADDRESS, abi: "get_minter_data", stack: [] })
   // exchange rate from cgUSDT to USDT: decimal 9
@@ -27,8 +30,11 @@ async function tonTvl() {
   const jettonResult = await getJettonMetadata(CGUSDT_ADDRESS)
   const cgUsdtTotalSupply = jettonResult['total_supply']
 
+  // subtract the amount of cgUSDT in the withdrawal vault
+  const balance = await getJettonBalance(MINTER_ADDRESS, CGUSDT_ADDRESS)
+
   // caculate tvl
-  const tvl = (cgUsdtTotalSupply) / 10 ** 6 * cgusdtTousdt
+  const tvl = (cgUsdtTotalSupply - balance) / 10 ** 6 * cgusdtTousdt
   return { "coingecko:tether": tvl }
 }
 


### PR DESCRIPTION
Hi, we've discovered that in our previous method of calculating TON TVL, the cgUSDT locked in the withdrawal contract by users was still counted in the total supply. Therefore, we have removed this portion to reflect the true TVL.