### PR TITLE
fix:Adapter,Axelar

### DIFF
--- a/projects/alexar/index.js
+++ b/projects/alexar/index.js
@@ -10,7 +10,7 @@ const chainMapping = {
   bsc: 'binance'
 };
 
-const chainListSupply = ['juno', 'cosmos', 'comdex', 'carbon', 'crescent', 'injective', 'kujira', 'osmosis', 'persistence', 'stargaze', 'secret', 'stargaze', 'umee', 'evmos', 'terra2'];
+const chainListSupply = ['juno', 'cosmos', 'comdex', 'carbon', /*'crescent',*/ 'injective', 'kujira', 'osmosis', 'persistence', 'stargaze', 'secret', 'stargaze', 'umee', 'evmos', 'terra2'];
 const chainListTotal = ['avax', 'bsc', 'moonbeam', 'polygon', 'fantom', 'arbitrum', 'aurora', 'celo', 'kava', 'mantle', 'ethereum', 'base'];
 
 


### PR DESCRIPTION
> Fix Axelar: it seems that the Crescent network has been down for some time. Since there was only one dollar coming from Crescent on Axelar, it is better to remove Crescent in order to allow Axelar to continue being updated on DL (non-refillable adapter)