### PR TITLE
[Do Not Merge] - Fix: Splash

### DIFF
--- a/projects/splash.js
+++ b/projects/splash.js
@@ -1,12 +1,9 @@
 const { get } = require('./helper/http');
+const ADDRESSES = require('./helper/coreAssets.json')
 
-async function cardanoTVL() {
-  let { tvlAda } = await get('https://api2.splash.trade/platform-api/v1/platform/stats')
-  if(tvlAda>1e9){
-    throw new Error("wrong")
-  }
-
-  return { cardano: tvlAda };
+async function cardanoTVL(api) {
+  const { tvlAda } = await get('https://api2.splash.trade/platform-api/v1/platform/stats')
+  api.add(ADDRESSES.cardano.ADA, tvlAda)
 }
 
 module.exports = {


### PR DESCRIPTION
> There is an issue with ADA's decimals, which is causing exorbitant figures. The logic is functional, but do not merge until the changes on the ADA token are made; otherwise, it will display values that are 1e6 times too high