### PR TITLE
add FBTC1 for Vault on Ethereum and Mantle networks

### DIFF
--- a/projects/unibtc/index.js
+++ b/projects/unibtc/index.js
@@ -1,10 +1,13 @@
 const ADDRESSES = require('../helper/coreAssets.json')
 const defaultVault = '0xF9775085d726E782E83585033B58606f7731AB18'
 
+const fbtc0  = '0xc96de26018a54d51c097160568752c4e3bd6c364'
+const fbtc1 = '0xd681C5574b7F4E387B608ed9AF5F5Fc88662b37c'
+
 const config = {
   ethereum: {
     vault: '0x047D41F2544B7F63A8e991aF2068a363d210d6Da',
-    tokens: [ADDRESSES['ethereum'].WBTC, '0xc96de26018a54d51c097160568752c4e3bd6c364']
+    tokens: [ADDRESSES['ethereum'].WBTC, fbtc0, fbtc1]
   },
   optimism: {
     vault: defaultVault,
@@ -12,7 +15,7 @@ const config = {
   },
   mantle: {
     vault: defaultVault,
-    tokens: ['0xC96dE26018A54D51c097160568752c4E3BD6C364']
+    tokens: [fbtc0, fbtc1]
   },
   bsquared: {
     vault: defaultVault,


### PR DESCRIPTION
The [Vault](https://github.com/Bedrock-Technology/uniBTC/blob/main/contracts/contracts/Vault.sol#L79) contracts have now been enabled through the [FBTCProxy](https://github.com/Bedrock-Technology/uniBTC/blob/main/contracts/contracts/proxies/FBTCProxy.sol) contract to receive [LockedFBTC](https://docs.fbtc.com/ecosystem/locked-fbtc-token), namely FBTC1, with the corresponding FBTC amount burned. We need to account for the FBTC1 balance for TVL.