### PR TITLE
added refunding balance to /helper/chain/eos

### DIFF
--- a/projects/helper/chain/eos.js
+++ b/projects/helper/chain/eos.js
@@ -40,7 +40,12 @@ function get_precision(symbol) {
 async function get_staked(account_name, symbol, chain = "eos") {
     const response = await post(`${RPC_ENDPOINTS[chain]}/v1/chain/get_account`, { account_name })
     try {
-        return response.voter_info.staked / (10 ** get_precision(symbol))
+        let refunding = 0;
+        if(response.refund_request){
+            refunding += parseFloat(response.refund_request.cpu_amount);
+            refunding += parseFloat(response.refund_request.net_amount);
+        }
+        return refunding + (response.voter_info.staked / (10 ** get_precision(symbol)))
     } catch (e) {
         return 0;
     }


### PR DESCRIPTION
The eos.js helper previously counted native-staked tokens held by an account (e.g. staking EOS or WAX directly to the system contract, for securing the network).

It was not counting native assets in the "refunding" stage (there is a 3 day unlock period if you initiate an unstake).

I added logic to count native assets in the refunding stage, as they are still held by the account owner. They are just returned in a different param from the API, which can result in a project's TVL dropping significantly, even though the funds are still held by the project.