### PR TITLE
added dSOL tvl adapter

### DIFF
--- a/projects/dSOL/index.js
+++ b/projects/dSOL/index.js
@@ -1,0 +1,13 @@
+const { getSolBalanceFromStakePool } = require('../helper/solana')
+
+async function tvl(api) {
+  // dSOL sanctum stake pool : https://solscan.io/account/9mhGNSPArRMHpLDMSmxAvuoizBqtBGqYdT8WGuqgxNdn
+  await getSolBalanceFromStakePool('9mhGNSPArRMHpLDMSmxAvuoizBqtBGqYdT8WGuqgxNdn', api)
+}
+
+module.exports = {
+  timetravel: false,
+  solana: {
+    tvl
+  }
+}


### PR DESCRIPTION
added Drift Staked SOL (dSOL) tvl adapter

used [jupSOL/index.js](https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/jupSOL/index.js) as example to follow 

Can verify the address by comparing:
https://solanacompass.com/stake-pools/9mhGNSPArRMHpLDMSmxAvuoizBqtBGqYdT8WGuqgxNdn
https://solscan.io/account/9mhGNSPArRMHpLDMSmxAvuoizBqtBGqYdT8WGuqgxNdn

---
**Question**: Will this be grouped with Drift on Defillama's website - the same way jupSOL is with Jupiter?