### PR TITLE
Update Ondo USDY with Arbitrum

### DIFF
--- a/projects/ondofinance/index.js
+++ b/projects/ondofinance/index.js
@@ -32,6 +32,12 @@ const config = {
   noble: {
     USDY: "ausdy",
   },
+  arbitrum: {
+    USDY: "0x35e050d3C0eC2d29D269a8EcEa763a183bDF9A9D",
+  },
+  xlayer: {
+    USDY: "0x5903E2Be82832c42a868A4748B64b5c401DE91Eb",
+  },
 };
 
 async function getUSDYTotalSupplySUI() {
@@ -79,6 +85,7 @@ Object.keys(config).forEach((chain) => {
           abi: "erc20:totalSupply",
           calls: fundAddresses,
         });
+
         if (chain === "ethereum") {
           const usdycIndex = fundAddresses.indexOf(config.ethereum.USDYc);
           const usdyIndex = fundAddresses.indexOf(config.ethereum.USDY);
@@ -87,8 +94,13 @@ Object.keys(config).forEach((chain) => {
             parseInt(supplies[usdyIndex]) + parseInt(supplies[usdycIndex]);
           fundAddresses.splice(usdycIndex, 1);
           supplies.splice(usdycIndex, 1);
+          api.addTokens(fundAddresses, supplies);
+        } else if (chain === "arbitrum" || chain === "xlayer") {
+          // Use ethereum price
+          api.addTokens(config.ethereum.USDY, supplies[0], { skipChain: true, });
+        } else {
+          api.addTokens(fundAddresses, supplies);
         }
-        api.addTokens(fundAddresses, supplies);
       }
       return api.getBalances();
     },

--- a/projects/ondofinance/index.js
+++ b/projects/ondofinance/index.js
@@ -35,9 +35,6 @@ const config = {
   arbitrum: {
     USDY: "0x35e050d3C0eC2d29D269a8EcEa763a183bDF9A9D",
   },
-  xlayer: {
-    USDY: "0x5903E2Be82832c42a868A4748B64b5c401DE91Eb",
-  },
 };
 
 async function getUSDYTotalSupplySUI() {
@@ -95,7 +92,7 @@ Object.keys(config).forEach((chain) => {
           fundAddresses.splice(usdycIndex, 1);
           supplies.splice(usdycIndex, 1);
           api.addTokens(fundAddresses, supplies);
-        } else if (chain === "arbitrum" || chain === "xlayer") {
+        } else if (chain === "arbitrum") {
           // Use ethereum price
           api.addTokens(config.ethereum.USDY, supplies[0], { skipChain: true, });
         } else {


### PR DESCRIPTION
Adding support for USDY on Arbitrum

As these tokens are not trading widely on Arbitrum yet, I've written the code to use the USDY price on Ethereum.

Expected arbitrum supply: 10,000,000 USDY as of Aug 26

Verification:
- https://docs.ondo.finance/addresses#arbitrum
- https://twitter.com/OndoFinance/status/1828419000524775446