### PR TITLE
feat: adding Lombard (LBTC)

### DIFF
--- a/projects/lombard/index.js
+++ b/projects/lombard/index.js
@@ -1,0 +1,21 @@
+const sdk = require("@defillama/sdk");
+
+async function tvl(timestamp, block) {
+  const lbtcAddress = "0x8236a87084f8B84306f72007F36F2618A5634494";
+  
+  const totalSupply = await sdk.api.erc20.totalSupply({
+    target: lbtcAddress,
+    block
+  });
+
+  return {
+    bitcoin: totalSupply.output / 1e8
+  };
+}
+
+module.exports = {
+  bitcoin: {
+    tvl,
+  },
+  methodology: `TVL for LBTC consists of the total supply of the LBTC ERC-20 token on Ethereum, representing locked Bitcoin`,
+};

--- a/projects/lombard/test-lombard.tvl.js
+++ b/projects/lombard/test-lombard.tvl.js
@@ -1,0 +1,16 @@
+const { ethereum } = require('./index.js');
+
+async function testTVL() {
+  try {
+    // Use a recent timestamp and block number
+    const timestamp = Math.floor(Date.now() / 1000);
+    const block = 'latest'; // Or use a specific block number
+
+    const result = await ethereum.tvl(timestamp, block);
+    console.log('TVL Result:', result);
+  } catch (error) {
+    console.error('Error:', error);
+  }
+}
+
+testTVL();


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `volume` adapter please submit the PR [here](https://github.com/DefiLlama/adapters).
> - If you would like to add a `liquidations` adapter, please refer to [this readme document](https://github.com/DefiLlama/DefiLlama-Adapters/tree/main/liquidations) for details.

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
3. Please fill the form below  **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
4. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can  edit it there and put up a PR
5. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
6. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap

---
##### Name (to be shown on DefiLlama):

Liquid Bitcoin

##### Twitter Link:

https://x.com/Lombard_Finance

##### List of audit links if any:

https://www.halborn.com/audits/lombard/lbtc
https://veridise.com/wp-content/uploads/2024/08/VAR_Lombard_240506.pdf
https://www.halborn.com/audits/lombard/consortium

##### Website Link:

https://www.lombard.finance/

##### Logo (High resolution, will be shown with rounded borders):

https://github.com/user-attachments/assets/39a99cf3-98cb-4cce-b6a1-913993d4bc41
https://github.com/user-attachments/assets/f3f67979-b949-4a91-a389-38f04bf045e7

##### Current TVL:

$163,173,356 USD

##### Treasury Addresses (if the protocol has treasury)

##### Chain:

Ethereum Main

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description (to be shown on DefiLlama):

LBTC is liquid, yield-bearing, natively cross-chain, and 1:1 backed by bitcoin.

##### Token address and ticker if any:

0x8236a87084f8B84306f72007F36F2618A5634494

LBTC

##### Category (full list at https://defillama.com/categories) *Please choose only one:

Liquid Staking

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

Redstone

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

Redstone ensures our 1:1 ratio. Redstone tracks our staked BTC deposited into Lombard Deposit Addresses and the corresponding LBTC minted on destination chains (only ETH for now)

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

Redstone feed is compatible with the chainlink's AggregatorV3Interface:
https://github.com/redstone-finance/redstone-oracles-monorepo/blob/5ac1df8850fd9a0a4970953240229299f41d9bbd/packages/on-chain-relayer/contracts/price-feeds/interfaces/IPriceFeed.sol#L5C9-L5C30

Feed Contract: 0xb415eAA355D8440ac7eCB602D3fb67ccC1f0bc81

##### forkedFrom (Does your project originate from another project):

No

##### methodology (what is being counted as tvl, how is tvl being calculated):

TVL is the total BTC deposited into Lombard Deposit Addresses. This is equal to the amount of LBTC in circulation, it is calculated by retrieving all the LBTC supply.

##### Github org/user (Optional, if your code is open source, we can track activity):
