### PR TITLE
fix: MeowProtocol outdated

### DIFF
--- a/projects/MeowProtocol/index.js
+++ b/projects/MeowProtocol/index.js
@@ -9,11 +9,13 @@ Object.keys(config).forEach(chain => {
   const lendingPoolCore = config[chain]
   module.exports[chain] = {
     tvl: async (api) => {
-      const tokens = await api.call({ abi: 'address[]:getReserves', target: lendingPoolCore })
-      return sumTokens2({api, tokens, owner: lendingPoolCore })
+      const tokens = await api.call({ abi: 'address[]:getReserves', target: lendingPoolCore, permitFailure: true })
+      if(!tokens) return
+      return sumTokens2({ api, tokens, owner: lendingPoolCore })
     },
     borrowed: async (api) => {
-      const tokens = await api.call({ abi: 'address[]:getReserves', target: lendingPoolCore })
+      const tokens = await api.call({ abi: 'address[]:getReserves', target: lendingPoolCore, permitFailure: true })
+      if(!tokens) return
       const bals = await api.multiCall({ abi: "function getReserveTotalBorrows(address _reserve) view returns (uint256)", target: lendingPoolCore, calls: tokens })
       api.add(tokens, bals)
       return api.getBalances()


### PR DESCRIPTION
Added a `permitFailure: true` on the calls, and a return in case of missing tokens to prevent errors during update. MeowProtocol seems to be down with a website outage, and a selfdestruct of the contract on Scroll 44 days ago, as shown in this image, making it impossible to call methods on the contract that no longer has an associated ABI

![image](https://github.com/user-attachments/assets/88ba7088-081b-4dc7-b830-3d15d34444a9)
