### PR TITLE
feat(florence-finance): add borrowed for base

### DIFF
--- a/projects/florence-finance/index.js
+++ b/projects/florence-finance/index.js
@@ -5,6 +5,9 @@ const ETH_EURS = "0xdb25f211ab05b1c97d595516f45794528a807ad8";
 const ARB_FLR = "0x9b6226dd0191a77d032f56a6d383044ee99944c3";
 const ARB_AGEUR = "0xfa5ed56a203466cbbc2430a43c66b9d8723528e7";
 
+const BASE_FLR = "0x4ee4bea687D5cE6245198db136D32aeC02806A83";
+const BASE_EURC = "0x60a3E35Cc302bFA44Cb288Bc5a4F316Fdb1adb42";
+
 async function getTotalSupply(token, { api }) {
   const totalSupply = await api.call({
     abi: "function totalSupply() external view returns (uint256)",
@@ -30,9 +33,15 @@ async function getBorrowedOnArbitrum(api) {
   api.add(ARB_AGEUR, borrowed); //Decimals of FLR and agEUR are both 18. No conversion needed.
 }
 
+async function getBorrowedOnBase(api) {
+  const borrowed = await getTotalSupply(BASE_FLR, { api }); //FLR on Base are not multi-chain so there is no need to subtract anything yet.
+  api.add(BASE_EURC, borrowed / 1e12); //12 decimals (FLR) -> 2 decimals (EURC)
+}
+
 module.exports = {
   methodology:
     "The Florin token (FLR) is minted whenever a new loan is funded and burned when a loan matures and is repaid. Since the Florin token is 1:1 redeemable for EUR the borrowed amount is denominated in the protocols treasuries EUR stablecoin of the respective chain. Consequently the total supply of Florin equals the amount borrowed through the protocol. To avoid double counting, the amount of FLR held in the bridge contract is subtracted from the total supply. ",
   ethereum: { start: 16077400, borrowed: getBorrowedOnEthereum, tvl: () => ({}) },
   arbitrum: { start: 126183369, borrowed: getBorrowedOnArbitrum, tvl: () => ({}) },
+  base: { start: 18941407, borrowed: getBorrowedOnBase, tvl: () => ({}) },
 };


### PR DESCRIPTION
florence finance is on base now as well. this pull request includes the necessary changes to calculate 'borrowed' in the same it is done for ethereum and arbitrum
