### PR TITLE
add underlying pool assets to TVL of Mars Protocol

### DIFF
--- a/projects/mars/index.js
+++ b/projects/mars/index.js
@@ -73,11 +73,11 @@ async function tvl(api) {
           const totalShares = poolInfo.poolTotalShare;
           const poolAssets = poolInfo.assets;
           poolAssets.forEach((asset) => {
-            const amount = new BigNumber(asset.amount).shiftedBy(-asset.decimals);
+            const amount = new BigNumber(asset.amount);
             const amountPerShare = amount.div(totalShares);
 
             // add the underlying tokens to the api
-            api.add(asset.denom, amountPerShare.times(totalDepositInfo.amount).toNumber());
+            api.add(asset.denom, amountPerShare.times(totalDepositInfo.amount).integerValue(BigNumber.ROUND_DOWN).toString());
           });
         } else {
           // if the it's a token and not a liquidity pool share, add it to the api

--- a/projects/mars/index.js
+++ b/projects/mars/index.js
@@ -1,5 +1,6 @@
-
 const { queryContract } = require('../helper/chain/cosmos');
+const axios = require('axios');
+const BigNumber = require('bignumber.js');
 
 const contractAddresses = {
   osmosis: {
@@ -10,10 +11,15 @@ const contractAddresses = {
     params: 'neutron1x4rgd7ry23v2n49y7xdzje0743c5tgrnqrqsvwyya2h6m48tz4jqqex06x',
     redBank: 'neutron1n97wnm7q6d2hrcna3rqlnyqw2we6k0l8uqvmyqq6gsml92epdu7quugyph',
   },
-}
+};
+
+const poolsApis = {
+  osmosis: 'https://api.astroport.fi/api/pools?chainId=osmosis-1',
+  neutron: 'https://api.astroport.fi/api/pools?chainId=neutron-1',
+};
 
 async function tvl(api) {
-  const chain = api.chain
+  const chain = api.chain;
   const { params, redBank } = contractAddresses[chain];
   let startAfter = null;
   const pageLimit = 5;
@@ -22,72 +28,91 @@ async function tvl(api) {
     const assetParams = await queryContract({
       contract: params,
       chain,
-      data: { 'all_asset_params': { limit: pageLimit, 'start_after': startAfter } }
+      data: { all_asset_params: { limit: pageLimit, start_after: startAfter } },
     });
 
-    if (assetParams.length === pageLimit)
-      startAfter = assetParams[assetParams.length - 1].denom;
-    else
-      startAfter = null;
-
+    if (assetParams.length === pageLimit) startAfter = assetParams[assetParams.length - 1].denom;
+    else startAfter = null;
 
     await addCoinsFromAssetParams(assetParams);
-  } while (startAfter)
-
+  } while (startAfter);
 
   do {
     const markets = await queryContract({
       contract: contractAddresses[chain].redBank,
       chain,
-      data: { 'markets': { limit: pageLimit, 'start_after': startAfter } }
+      data: { 'markets': { 'limit': pageLimit, 'start_after': startAfter } },
     });
 
-    if (markets.length === pageLimit)
-      startAfter = markets[markets.length - 1].denom;
-    else
-      startAfter = null;
-
+    if (markets.length === pageLimit) startAfter = markets[markets.length - 1].denom;
+    else startAfter = null;
 
     await deductCoinsFromMarkets(markets);
-  } while (startAfter)
+  } while (startAfter);
 
   async function addCoinsFromAssetParams(assetParams) {
-    const assetDenoms = assetParams.map(asset => asset.denom);
+    const assetDenoms = assetParams.map((asset) => asset.denom);
+
+    // fetch pool infos from the poolsApi based on chain
+    const poolInfos = await axios.get(poolsApis[chain]);
 
     // query the deposited amount for each asset and add it to the depositCoins array
-    await Promise.all(assetDenoms.map(async denom => {
-      let totalDepositInfo = await queryContract({
-        contract: params, chain,
-        data: { 'total_deposit': { 'denom': denom, } }
-      });
-      api.add(denom, totalDepositInfo.amount);
-    }));
+    await Promise.all(
+      assetDenoms.map(async (denom) => {
+        const totalDepositInfo = await queryContract({
+          contract: params,
+          chain,
+          data: { 'total_deposit': { 'denom': denom } },
+        });
+        // check if the token is a liquidity pool share (deposited via farm)
+        // and find it in the api data
+        const poolInfo = poolInfos.data.find((pool) => pool.lpAddress === denom);
+
+        if (poolInfo) {
+          // check for the underlying asset and calculate how much underlying assets a pool share holds
+          const totalShares = poolInfo.poolTotalShare;
+          const poolAssets = poolInfo.assets;
+          poolAssets.forEach((asset) => {
+            const amount = new BigNumber(asset.amount).shiftedBy(-asset.decimals);
+            const amountPerShare = amount.div(totalShares);
+
+            // add the underlying tokens to the api
+            api.add(asset.denom, amountPerShare.times(totalDepositInfo.amount).toNumber());
+          });
+        } else {
+          // if the it's a token and not a liquidity pool share, add it to the api
+          api.add(denom, totalDepositInfo.amount);
+        }
+      }),
+    );
   }
 
   async function deductCoinsFromMarkets(markets) {
-
     // query the underlying debt amount from the debt_total_scaled
-    await Promise.all(markets.map(async market => {
-      let totalDebt = await queryContract({
-        contract: redBank, chain,
-        data: {
-          'underlying_debt_amount': {
-            'denom': market.denom,
-            'amount_scaled': market['debt_total_scaled']
-          }
-        }
-      });
-      api.add(market.denom, totalDebt * -1)
-    }));
+    await Promise.all(
+      markets.map(async (market) => {
+        const totalDebt = await queryContract({
+          contract: redBank,
+          chain,
+          data: {
+            'underlying_debt_amount': {
+              'denom': market.denom,
+              'amount_scaled': market['debt_total_scaled'],
+            },
+          },
+        });
+        api.add(market.denom, totalDebt * -1);
+      }),
+    );
   }
 }
 
-
 module.exports = {
   timetravel: false,
-  methodology: 'For each chain, sum token balances by querying the total deposit amount for each asset in the chain\'s params contract.',
-  osmosis: { tvl, },
-  neutron: { tvl, },
+  methodology:
+    "For each chain, sum token balances by querying the total deposit amount for each asset in the chain's params contract.",
+  osmosis: { tvl },
+  neutron: { tvl },
   terra: {
     tvl: () => 0,
   },
@@ -96,6 +121,6 @@ module.exports = {
     [1675774800, 'Relaunch on Osmosis'],
     [1690945200, 'Launch on Neutron'],
     [1696906800, 'Mars v2 launch on Osmosis'],
-    [1724166000, 'Mars v2 launch on Neutron']
-  ]
+    [1724166000, 'Mars v2 launch on Neutron'],
+  ],
 };


### PR DESCRIPTION
This PR adds the underlying assets of the pool shares, which are deposited via the farm feature on Mars Protocol.
Since the share tokens have no price in the DefiLlama token registry, they must be split into the underlying tokens to be added to the TVL. 
Share tokens are not borrowable, so no deduction is taken.