### PR TITLE
update: equilibrium-lending deadFrom

### DIFF
--- a/projects/equilibrium/index.js
+++ b/projects/equilibrium/index.js
@@ -1,6 +1,8 @@
 const { getExports } = require('../helper/heroku-api')
 
 module.exports = {
+	hallmarks: [1714550400, 'Sunset of Equilibrium Network'],
+	deadFrom: "2024-09-01",
 	timetravel: false,
 	...getExports("equilibrium", ['equilibrium'])
 }


### PR DESCRIPTION
End of the Equilibrium Lending project with the network shutdown and withdraw-only mode since April 2024. As of today, the chain no longer allows transactions.
The team announced the network shutdown in April 2024:

![image](https://github.com/user-attachments/assets/96e7135d-0ab2-47ac-b4f9-0e21e9d77106)
![image](https://github.com/user-attachments/assets/e3b2f362-1678-4637-ae67-7a61b9cbd109)
