### PR TITLE
feat: Add bsc token config

### DIFF
--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -125,7 +125,10 @@ const fixBalancesTokens = {
   xdai: {
     '0x6c76971f98945ae98dd7d4dfca8711ebea946ea6': { coingeckoId: "wrapped-steth", decimals: 18 },
     '0xaf204776c7245bf4147c2612bf6e5972ee483701': { coingeckoId: "savings-dai", decimals: 18 },
-  }
+  },
+  bsc: {
+    '0xf6718b2701D4a6498eF77D7c152b2137Ab28b8A3': { coingeckoId: "wrapped-bitcoin", decimals: 18 }
+  },
 
 }
 


### PR DESCRIPTION
stBTC is the official Liquid Principal Token (LPT) issued by staking BTC in Lorenzo Protocol, pegged to the value of BTC. It represents the right to claim staked BTC when staking is over. It allows Bitcoin stakers to maintain liquidity while staking, avoiding fragmentation by standardizing stBTC for all low-risk staking plans. By staking Bitcoin, users receive an equivalent amount of stBTC, which can be later used to reclaim their staked BTC principal, facilitating seamless liquidity and yield generation within the ecosystem.For the specific contract implementation, please refer to https://bscscan.com/address/0xf6718b2701D4a6498eF77D7c152b2137Ab28b8A3