### PR TITLE
Update, ocean-one (outdated) -> deadFrom

### DIFF
--- a/projects/ocean-one/index.js
+++ b/projects/ocean-one/index.js
@@ -18,6 +18,7 @@ async function fetch() {
 }
 
 module.exports = {
+  deadFrom: '2024-01-01',
   mixin: {
     fetch
   },


### PR DESCRIPTION
The Ocean One adapter hasn't been updated for over 200 days, the website and API are down, and the team's activity on Twitter has been inactive for more than a year