### PR TITLE
Update: Notional_v2 (Outdated)

### DIFF
--- a/projects/notional/index.js
+++ b/projects/notional/index.js
@@ -17,5 +17,7 @@ async function tvl(api) {
 }
 
 module.exports = {
+  deadFrom: '2024-08-22',
+  hallmarks: [1724284800, "Deprecation process for migrating from Notional V2 to Notional V3"],
   ethereum: { tvl },
 };

--- a/projects/notional/index.js
+++ b/projects/notional/index.js
@@ -18,6 +18,6 @@ async function tvl(api) {
 
 module.exports = {
   deadFrom: '2024-08-22',
-  hallmarks: [1724284800, "Deprecation process for migrating from Notional V2 to Notional V3"],
+  hallmarks: [1724284800, "End of Deprecation process for migrating from Notional V2 to Notional V3"],
   ethereum: { tvl },
 };


### PR DESCRIPTION
End of the migration process from V2 to V3 according to the team's plan:
https://blog.notional.finance/notional-v2-deprecation-plan/

Transfers of remaining funds to multiple addresses according to the logs + change of the main contract's implementation 20 days ago to an inactive router
https://etherscan.io/address/0x5c424c3d0f32b21cb3d51b780eb1b38b6ae8923f/advanced#internaltx
