### PR TITLE
Add Kadena Cabinet Adapter

### DIFF
--- a/projects/cabinet/index.js
+++ b/projects/cabinet/index.js
@@ -1,0 +1,42 @@
+const { fetchLocal, mkMeta } = require("../helper/pact");
+
+const chainId = "5";
+const network = `https://api.chainweb.com/chainweb/0.0/mainnet01/chain/${chainId}/pact`;
+const GAS_PRICE = 0.00000001;
+const creationTime = () => Math.round(new Date().getTime() / 1000) - 10;
+
+
+const getReserve = (tokenData) => {
+  return parseFloat(tokenData.decimal ? tokenData.decimal : tokenData);
+};
+
+
+const getCabinetTvl = async () => {
+    const data = await fetchLocal(
+        {
+            pactCode: `(coin.get-balance "c:86aaCQXT8uRkyXGXu9k-eNn1kXqV_nNmjTYErKpZ6vE")`,
+            meta: mkMeta("", chainId, GAS_PRICE, 3000, creationTime(), 600)
+        },
+        network
+    );
+      if (data.result.status === "success") {
+          return getReserve(data.result.data);
+      }
+      throw new Error("Failed do fetch TVL");
+
+}
+
+async function tvl() {
+    const cabinetTvl = await getCabinetTvl();
+  return {
+      kadena: cabinetTvl,
+  };
+}
+
+module.exports = {
+  timetravel: false,
+  misrepresentedTokens: true,
+  kadena: {
+    tvl: tvl,
+  },
+};


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):

Kadena Cabinet

##### Twitter Link:

https://x.com/kadena_io

##### List of audit links if any:

N/A

##### Website Link:

https://kadena.io/cabinet

##### Logo (High resolution, will be shown with rounded borders):
[Link](
https://academy.kadena.io/wp-content/uploads/cropped-kadena-favicon-512.png )

##### Current TVL:

235,459.17 USD (458,180.92 KDA)

##### Treasury Addresses (if the protocol has treasury):

k:70256a7952552138188f0f327e141cd4ae6ad4c75f172a164e5f9ac1d1675328

##### Chain:

Kadena (KDA)

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):

`kadena`

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):

`5647`

##### Short Description (to be shown on DefiLlama):

Kadena Cabinet is a community advisory board where users can lock their $KDA to gain the ability to vote in polls on ecosystem-based proposals. Through their participation in polls, users can earn $KDA rewards.

##### Token address and ticker if any:

ADDRESS: coin
TICKER: $KDA

##### Category (full list at https://defillama.com/categories) *Please choose only one:

9 - Yield

##### Oracle Provider(s):

This project does not use oracles.

##### Implementation Details:

This project does not use oracles.

#####  Documentation/Proof:

This project does not use oracles.

##### ForkedFrom (Does your project originate from another project):

Not forked.

##### Methodology (what is being counted as TVL, how is TVL being calculated):

Kadena Cabinet relies on a single account to manage lockups and rewards. The TVL is the balance of that account.

**P.S:** 

We thought that the 9 - yield category was the closest to suiting our product, however participating in community polls is required for reward accrual. Can you reccomend a category that would be a better fit for us?