### PR TITLE
Add new SwissBorg wallet

### DIFF
--- a/projects/swissborg/index.js
+++ b/projects/swissborg/index.js
@@ -108,6 +108,11 @@ const config = {
     owners: [
         'cosmos10dfzd2wpnpeuy2lgan35ah8dg5p4l298v0n8e8',
     ]
+  },
+  arbitrum: {
+    owners: [
+      '0x8F0d8b27bF808976Fa94f03e2230b4bca95bf3C4',
+    ]
   }
 }
 

--- a/projects/swissborg/index.js
+++ b/projects/swissborg/index.js
@@ -17,6 +17,7 @@ const config = {
       '0x67FE3293FC4e877F3CDc3F0ed93721a600f72BdE',
       '0x178Fb204c1ff2Ed7d0651C522A3a5B15480Eb76d',
       '0xFbA64167e4f091Ca625FA79aa6f83665856f8Bf2',
+      '0x8F0d8b27bF808976Fa94f03e2230b4bca95bf3C4',
     ],
   },
   bitcoin: {


### PR DESCRIPTION
This PR updates the list of wallets owned by SwissBorg. New wallet addition: https://github.com/SwissBorg/pub/commit/2dc33a990320a8ebaa434e84376be42727ac82e2