### PR TITLE
fix: yieldwolf (outdated)

### DIFF
--- a/projects/yieldwolf/index.js
+++ b/projects/yieldwolf/index.js
@@ -26,7 +26,7 @@ Object.keys(config).forEach(chain => {
       const tokens = poolInfos.map(i => i.stakeToken)
       const bals = await api.multiCall({  abi: abi.totalStakeTokens, calls: strategies})
       api.add(tokens, bals)
-      blacklistedTokens.forEach(token => api.removeTokenBalances(token))
+      blacklistedTokens.forEach(token => api.removeTokenBalance(token))
       return sumTokens2({ api, resolveLP: true })
     }
   }


### PR DESCRIPTION
Method `removeTokenBalances` does not exist in the definition of `ChainApi` -> `removeTokenBalance`