### PR TITLE
fix: Maya-protocol (outdated)

### DIFF
--- a/projects/mayachain/index.js
+++ b/projects/mayachain/index.js
@@ -19,6 +19,7 @@ const tokenGeckoMapping = {
   "ETH.PEPE": "pepe",
   "ETH.ETH": "ethereum",
   "ETH.USDC": "usd-coin",
+  "ETH.MOG":"mog-coin",
   "KUJI.USK": "usk",
   "KUJI.KUJI": "kujira",
   "THOR.RUNE": "thorchain",
@@ -47,6 +48,7 @@ const tokenToDecimalMapping = {
   "ETH.PEPE": 18,
   "ETH.ETH": 18,
   "ETH.USDC": 6,
+  "ETH.MOG":18,
   "KUJI.USK": 8,
   "KUJI.KUJI": 8,
   "THOR.RUNE": 8,
@@ -92,9 +94,9 @@ async function tvl(api) {
 
     let [baseToken, address] = token.split("-");
     if (chain === "ethereum" || chain === "arbitrum") {
-      assetDepth =
-        assetDepth *
-        10 ** (+tokenToDecimalMapping[chainStr + "." + baseToken] - 8);
+      let decimal = tokenToDecimalMapping[chainStr + "." + baseToken];
+      if (decimal === undefined || isNaN(decimal)) return
+      assetDepth = assetDepth * 10 ** (+decimal - 8);
 
       // e.g. ETH.USDC-0XA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48
       address = address && address.includes('-') ? address.split("-")[1] : address


### PR DESCRIPTION
> Fix for maya-protocol: the mapping and decimals for a token (MOG) were missing, which was causing NaN issues further in the code. Added the missing token and implemented a filter to prevent the error from happening again