### PR TITLE
Fix: WhiteWhale-dex (outdated)

### DIFF
--- a/projects/whitewhale-dex/index.js
+++ b/projects/whitewhale-dex/index.js
@@ -4,7 +4,7 @@ const factory = {
   terra2: "terra1f4cr4sr5eulp3f2us8unu6qv8a5rhjltqsg7ujjx6f2mrlqh923sljwhn3",
   juno: "juno14m9rd2trjytvxvu4ldmqvru50ffxsafs8kequmfky7jh97uyqrxqs5xrnx",
   injective: "inj1x22q8lfhz7qcvtzs0dakhgx2th64l79kfye5lk",
-  comdex: "comdex1gurgpv8savnfw66lckwzn4zk7fp394lpe667dhu7aw48u40lj6jswv4mft",
+  // comdex: "comdex1gurgpv8savnfw66lckwzn4zk7fp394lpe667dhu7aw48u40lj6jswv4mft",
   chihuahua: "chihuahua1s8ehad3r9wxyk08ls2nmz8mqh4vlfmaxd2nw0crxwh04t4l5je4s8ljv0j",
   migaloo: "migaloo1z89funaazn4ka8vrmmw4q27csdykz63hep4ay8q2dmlspc6wtdgq92u369",
   sei: "sei1tcx434euh2aszzfsjxqzvjmc4cww54rxvfvv8v7jz353rg779l2st699q0",
@@ -20,7 +20,6 @@ module.exports = {
     [1676300400,"Migaloo Chain Launch"]
   ]
 }
-
 
 Object.keys(factory).forEach(chain => {
   const contract = factory[chain]

--- a/projects/whitewhale-dex/index.js
+++ b/projects/whitewhale-dex/index.js
@@ -4,7 +4,7 @@ const factory = {
   terra2: "terra1f4cr4sr5eulp3f2us8unu6qv8a5rhjltqsg7ujjx6f2mrlqh923sljwhn3",
   juno: "juno14m9rd2trjytvxvu4ldmqvru50ffxsafs8kequmfky7jh97uyqrxqs5xrnx",
   injective: "inj1x22q8lfhz7qcvtzs0dakhgx2th64l79kfye5lk",
-  // comdex: "comdex1gurgpv8savnfw66lckwzn4zk7fp394lpe667dhu7aw48u40lj6jswv4mft",
+  comdex: "comdex1gurgpv8savnfw66lckwzn4zk7fp394lpe667dhu7aw48u40lj6jswv4mft",
   chihuahua: "chihuahua1s8ehad3r9wxyk08ls2nmz8mqh4vlfmaxd2nw0crxwh04t4l5je4s8ljv0j",
   migaloo: "migaloo1z89funaazn4ka8vrmmw4q27csdykz63hep4ay8q2dmlspc6wtdgq92u369",
   sei: "sei1tcx434euh2aszzfsjxqzvjmc4cww54rxvfvv8v7jz353rg779l2st699q0",
@@ -23,5 +23,9 @@ module.exports = {
 
 Object.keys(factory).forEach(chain => {
   const contract = factory[chain]
-  module.exports[chain] = { tvl: getFactoryTvl(contract) }
+  if (chain === 'comdex') {
+    module.exports[chain] = { tvl: () => ({}) }
+  } else {
+    module.exports[chain] = { tvl: getFactoryTvl(contract) }
+  }
 })


### PR DESCRIPTION
> The Comdex network no longer seems to be used by the WhiteWhale-Dex protocol, and the latest update indicates very low liquidity, around $60. Moreover, the Comdex network on the Cosmos Hub appears to be inactive according to recent announcements, and the network endpoint to retrieve data has also been non-functional since yesterday

![image](https://github.com/user-attachments/assets/e5a49602-038b-4802-a6cf-f9cb4b5bcd40)
