### PR TITLE
Fix Harbor (outdated)

### DIFF
--- a/projects/harbor-protocol.js
+++ b/projects/harbor-protocol.js
@@ -10,5 +10,7 @@ async function tvl({ chain }) {
 }
 
 module.exports = {
+  deadFrom: "2024-09-17",
+  hallmarks: [[1692403200, "Exploit on Harbor Protocol"]],
   comdex: { tvl }
 }


### PR DESCRIPTION
> Add of a deadFrom + hallmarks. The protocol has not been maintained since an exploit in 2023, and the TVL has remained flat for months