### PR TITLE
Fix: Axelar (outdated not refillable)

### DIFF
--- a/projects/alexar/index.js
+++ b/projects/alexar/index.js
@@ -10,12 +10,17 @@ const chainMapping = {
   bsc: 'binance'
 };
 
-const chainListSupply = ['juno', 'cosmos', /*'comdex',*/ 'carbon', /*'crescent',*/ 'injective', 'kujira', 'osmosis', 'persistence', 'stargaze', 'secret', 'stargaze', 'umee', 'evmos', 'terra2'];
+const blackListChains = ['comdex', 'crescent'];
+const chainListSupply = ['juno', 'cosmos', 'carbon', 'injective', 'kujira', 'osmosis', 'persistence', 'stargaze', 'secret', 'stargaze', 'umee', 'evmos', 'terra2'];
 const chainListTotal = ['avax', 'bsc', 'moonbeam', 'polygon', 'fantom', 'arbitrum', 'aurora', 'celo', 'kava', 'mantle', 'ethereum', 'base'];
 
 
 chainListSupply.concat(chainListTotal).forEach(chain => {
-  module.exports[chain] = { tvl };
+  if (blackListChains.includes(chain)) {
+    module.exports[chain] = { tvl: () => ({}) };
+  } else {
+    module.exports[chain] = { tvl };
+  }
   async function tvl(api) {
     const config = await getConfig('alexar', 'https://api.axelarscan.io/api/getTVL')
     const tokensAndOwners = []

--- a/projects/alexar/index.js
+++ b/projects/alexar/index.js
@@ -10,7 +10,7 @@ const chainMapping = {
   bsc: 'binance'
 };
 
-const chainListSupply = ['juno', 'cosmos', 'comdex', 'carbon', /*'crescent',*/ 'injective', 'kujira', 'osmosis', 'persistence', 'stargaze', 'secret', 'stargaze', 'umee', 'evmos', 'terra2'];
+const chainListSupply = ['juno', 'cosmos', /*'comdex',*/ 'carbon', /*'crescent',*/ 'injective', 'kujira', 'osmosis', 'persistence', 'stargaze', 'secret', 'stargaze', 'umee', 'evmos', 'terra2'];
 const chainListTotal = ['avax', 'bsc', 'moonbeam', 'polygon', 'fantom', 'arbitrum', 'aurora', 'celo', 'kava', 'mantle', 'ethereum', 'base'];
 
 


### PR DESCRIPTION
Comdex network no longer seems to be maintained, and the main endpoint for accessing data is no longer functional. It appears that the team is trying to transition to a new product.

https://x.com/ComdexOfficial/status/1811458704853623087
https://www.mintscan.io/akash/proposals/262

In the meantime, Comdex is being removed from the Axelar adapter since it represents less than $1, and it is important to keep Axelar's TVL up to date as it is not refillable