### PR TITLE
Fix: Commodo (outdated)

### DIFF
--- a/projects/commodo/index.js
+++ b/projects/commodo/index.js
@@ -43,6 +43,7 @@ async function getData() {
 
 
 module.exports = {
+  deadFrom: "2024-09-17",
   timetravel: false,
   comdex: {
     tvl: async () => transformBalances('comdex', (await getData()).tvl),


### PR DESCRIPTION
As with the other PRs I've submitted, the Comdex network no longer seems to be maintained.

Commodo is part of a triad of protocols maintained by the Comdex team, including Harbor, Commodo, and cSwap, with cSwap being the most important protocol. The latter was completely shut down on 2024-09-17, and since then, the endpoints to access Comdex data are no longer available