### PR TITLE
new Bitlayer USDC address

### DIFF
--- a/projects/bitparty/index.js
+++ b/projects/bitparty/index.js
@@ -9,7 +9,7 @@ module.exports = {
         nullAddress,
         ADDRESSES.btr.ETH,
         '0xfe9f969faf8ad72a83b761138bf25de87eff9dd2',
-        '0x9827431e8b77e87c9894bd50b055d6be56be0030',
+        '0xf8c374ce88a3be3d374e8888349c7768b607c755',
         ADDRESSES.btr.WBTC,
         '0x07373d112edc4570b46996ad1187bc4ac9fb5ed0',
         '0x2729868df87d062020e4a4867ff507fb52ee697c',

--- a/projects/predx/index.js
+++ b/projects/predx/index.js
@@ -41,7 +41,7 @@ module.exports = {
   btr: {
     tvl: sumTokensExport({
       owners: ["0x92CdC3a149A6bc3f39136eF4A94292cDC2Cc4b9b"],
-      tokens: ["0x9827431e8b77e87c9894bd50b055d6be56be0030"]
+      tokens: ["0xf8c374ce88a3be3d374e8888349c7768b607c755"]
     }),
   },
 }


### PR DESCRIPTION
This PR was created to update the USDC Token contract address on the Bitlayer chain.

To comply with Circle's protocol requirements and ensure the stability and compliance of the Bitlayer ecosystem, Bitlayer has renamed the USDC Token. For details, please refer to: https://blog.bitlayer.org/USDC_._e_to_USDC_Conversion_Guide

As a result, we have updated the code to modify the contract address of the USDC Token. Please review and merge the changes. Thank you!