### PR TITLE
Fix: Vaultka (outdated)

### DIFF
--- a/projects/vaultka/index.js
+++ b/projects/vaultka/index.js
@@ -63,8 +63,9 @@ module.exports = {
       const bals = await api.multiCall({
         abi: "int256:getVaultMarketValue",
         calls: vaults,
+        permitFailure: true
       });
-      bals.forEach((i) => api.add(ADDRESSES.arbitrum.USDC, i));
+      bals.filter((bal) => bal !== null).forEach((i) => api.add(ADDRESSES.arbitrum.USDC, i));
 
       const addresses = {
         wSol: "0x2bcC6D6CdBbDC0a4071e48bb3B969b06B3330c07",


### PR DESCRIPTION
> Fix for vaultka: the multicall was sometimes returning errors, preventing the execution of the rest of the code. Added a permitFailure with null handling

**Fixed:** 
Error: Multicall failed! 
 [chain: arbitrum] [fail count: 1] [abi: int256:getVaultMarketValue]
    target: 0x6df0018b0449bB4468BfAE8507E13021a7aa0583
    
    