### PR TITLE
Fix: Lachain adapters

### DIFF
--- a/projects/lachain-yield-market.js
+++ b/projects/lachain-yield-market.js
@@ -1,4 +1,5 @@
 const utils = require('./helper/utils');
+const { deadFrom } = require('./ladex-exchange');
 
 async function fetch() {
     const response = await utils.fetchURL(`https://farms-info.lachain.io/farms/beefy`); 
@@ -20,6 +21,7 @@ async function fetch() {
 }
 
 module.exports = {
+  deadFrom: '2024-01-01',
   lachain: { fetch },
   fetch,
 }

--- a/projects/ladex-exchange/index.js
+++ b/projects/ladex-exchange/index.js
@@ -2,6 +2,7 @@ const { getUniTVL } = require('../helper/unknownTokens')
 const factory_contract = "0xD707d9038C1d976d3a01c770f01CB73a1fd305Cd"
 
 module.exports = {
+  deadFrom: '2024-01-01',
   lachain: {
     tvl: getUniTVL({ factory: factory_contract, useDefaultCoreAssets: true }),
   }


### PR DESCRIPTION
Added a deadFrom to the protocols Lachain Yield Market and Ladex Exchange, which have not been maintained for several years on the Lachain chain. The TVLs are no longer changing, the websites are down, and it seems the last listed public RPC has stopped. Lachain’s Twitter has not been active since September 2022.

A new network called LaChain-network has recently emerged. Could Lachain (classic) now be completely shut down to make way for the new LaChain-network product ?