### PR TITLE
Fix: Knit-finance (outdated)

### DIFF
--- a/projects/knitfinance/index.js
+++ b/projects/knitfinance/index.js
@@ -52,6 +52,7 @@ module.exports = {
 
 function addChain(chain) {
   module.exports[chain] = {
+    deadFrom: "2023-02-01",
     tvl: async () => {
       const balances = {}
       const key = chainConfig[chain];


### PR DESCRIPTION
The TVL of Knit Finance has been flat for almost 2 years, the Knit Finance API is down, the team hasn't tweeted since March 2024, and there is no more activity on Github. Adding a `deadFrom`

https://github.com/KnitFinance