### PR TITLE
Fix: Stargate

### DIFF
--- a/projects/stargatefinance/index.js
+++ b/projects/stargatefinance/index.js
@@ -62,13 +62,14 @@ const CONFIG = {
 }
 
 module.exports = {
-  // goerli: {
-  //   tvl: async (api) => {
-  //     return {
-  //       [ADDRESSES.ethereum.WETH]: await api.call({ abi: 'erc20:balanceOf', target: '0xdD69DB25F6D620A7baD3023c5d32761D353D3De9', params: ['0x88124ef4a9ec47e691f254f2e8e348fd1e341e9b'], }),
-  //     }
-  //   },
-  // },
+  goerli: {
+    tvl: () => ({})
+    // tvl: async (api) => {
+    //   return {
+    //     [ADDRESSES.ethereum.WETH]: await api.call({ abi: 'erc20:balanceOf', target: '0xdD69DB25F6D620A7baD3023c5d32761D353D3De9', params: ['0x88124ef4a9ec47e691f254f2e8e348fd1e341e9b'], }),
+    //   }
+    // },
+  },
 }
 
 Object.keys(CONFIG).forEach((chain) => {

--- a/projects/stargatefinance/index.js
+++ b/projects/stargatefinance/index.js
@@ -62,13 +62,13 @@ const CONFIG = {
 }
 
 module.exports = {
-  goerli: {
-    tvl: async (api) => {
-      return {
-        [ADDRESSES.ethereum.WETH]: await api.call({ abi: 'erc20:balanceOf', target: '0xdD69DB25F6D620A7baD3023c5d32761D353D3De9', params: ['0x88124ef4a9ec47e691f254f2e8e348fd1e341e9b'], }),
-      }
-    },
-  },
+  // goerli: {
+  //   tvl: async (api) => {
+  //     return {
+  //       [ADDRESSES.ethereum.WETH]: await api.call({ abi: 'erc20:balanceOf', target: '0xdD69DB25F6D620A7baD3023c5d32761D353D3De9', params: ['0x88124ef4a9ec47e691f254f2e8e348fd1e341e9b'], }),
+  //     }
+  //   },
+  // },
 }
 
 Object.keys(CONFIG).forEach((chain) => {


### PR DESCRIPTION
Stargate is the only adapter we display on the Goerli testnet, which is now deprecated in favor of Sepolia. All RPCs from Chainlist are no longer functional.
Comment out the Goerli-related code to allow the rest of the code to execute

![image](https://github.com/user-attachments/assets/2a6a8dd1-973d-4154-9cf1-e3c5601ebd49)
