### PR TITLE
Fix: Ampleswap

### DIFF
--- a/projects/ampleswap/index.js
+++ b/projects/ampleswap/index.js
@@ -12,5 +12,5 @@ module.exports = {
     staking: staking(MasterChefContract, AMPLE),
   },
   alv: { tvl: getUniTVL({ factory: '0x01dC97C89DF7d3C616a696dD53F600aB3FF12983', useDefaultCoreAssets: true }), },
-  dsc: { tvl: getUniTVL({ factory: '0x232Ba9f3B3643ab28d28ED7ee18600708D60E5fe', useDefaultCoreAssets: true, }), },
+  // dsc: { tvl: getUniTVL({ factory: '0x232Ba9f3B3643ab28d28ED7ee18600708D60E5fe', useDefaultCoreAssets: true, }), },
 };

--- a/projects/ampleswap/index.js
+++ b/projects/ampleswap/index.js
@@ -12,5 +12,6 @@ module.exports = {
     staking: staking(MasterChefContract, AMPLE),
   },
   alv: { tvl: getUniTVL({ factory: '0x01dC97C89DF7d3C616a696dD53F600aB3FF12983', useDefaultCoreAssets: true }), },
+  dsc: { tvl: () => ({}) }
   // dsc: { tvl: getUniTVL({ factory: '0x232Ba9f3B3643ab28d28ED7ee18600708D60E5fe', useDefaultCoreAssets: true, }), },
 };


### PR DESCRIPTION
Ampleswap is the only protocol using DSC (Decimal Smart Chain). Currently, there appears to be only 1 dollar of TVL on the chain for nearly 6 months. According to our Chainlist RPCs, all RPCs are non-functional, and the last block is from 5 days ago.

![image](https://github.com/user-attachments/assets/db1bc8c4-ad6b-4653-bbfe-183ad1120bb4)

![image](https://github.com/user-attachments/assets/3e341670-473e-4c41-87af-6a384ded22f7)

![image](https://github.com/user-attachments/assets/7ea6c5d9-77dd-4afb-9db5-c41e97143473)

https://explorer.decimalchain.com/blocks/?page=1


Comment out the DSC-related code to allow the rest of the code to execute