### PR TITLE
feat: update treehouse adapters

### DIFF
--- a/projects/treehouse/index.js
+++ b/projects/treehouse/index.js
@@ -1,9 +1,21 @@
-const ADDRESSES = require('../helper/coreAssets.json');
-const { sumTokensExport } = require('../helper/unwrapLPs');
+const ADDRESSES = require('../helper/coreAssets.json')
+
+const IAU_tETH = '0x1B6238E95bBCABEE58997c99BaDD4154ad68BA92'
+
+async function ethTvl(api) {
+    const iauSupply = await api.call({
+      abi: 'erc20:totalSupply',
+      target:IAU_tETH,
+    });
+  
+    api.add(ADDRESSES.ethereum.WSTETH, iauSupply)
+  }
+  
 
 module.exports = {
-  start: 1725926400, // Tuesday, September 10, 2024 12:00:00 AM
-  ethereum: {
-    tvl: sumTokensExport({ owner: '0x551d155760ae96050439AD24Ae98A96c765d761B', tokens: [ADDRESSES.ethereum.WSTETH], }),
-  }
-} 
+    methodology: 'Staked tokens are counted as TVL based on the chain that they are staked on and where the liquidity tokens are issued.',
+    start: 1725926400, // Tuesday, September 10, 2024 12:00:00 AM
+    ethereum: {
+      tvl: ethTvl,
+    }
+  }; 


### PR DESCRIPTION
Methodology updated because the IAU ERC20 is backed 1:1 by wstETH, but the wstETH may not necessarily be in the vault address.