### PR TITLE
fix:💥breaking change on the API - update symbol

### DIFF
--- a/projects/liqwid/index.js
+++ b/projects/liqwid/index.js
@@ -40,11 +40,9 @@ const query = `query($input: MarketsInput)  {
         page
         pagesCount
         results {
+          id
           asset {
             id
-            symbol
-            qTokenName
-            qTokenCurrencySymbol
             currencySymbol
             name
             decimals
@@ -61,13 +59,13 @@ const query = `query($input: MarketsInput)  {
 `
 
 const tokenMapping = {
-  ADA: 'lovelace',
+  Ada: 'lovelace',
   DJED: '8db269c3ec630e06ae29f74bc39edd1f87c819f1056206e879a1cd61446a65644d6963726f555344',
   DAI: 'dai',
 
 }
 
-const getToken = (market) => tokenMapping[market.asset.symbol] ?? market.asset.currencySymbol + toHex(market.asset.name)
+const getToken = (market) => tokenMapping[market.id] ?? market.asset.currencySymbol + toHex(market.asset.name)
 
 const getOptimBondTVL = async () => {
   const getLoans = async (pageIndex = 0, collectedLoans = []) => {


### PR DESCRIPTION
We are going to support multiple markets for a single asset, so the symbol for an asset might be incorrect for some case

I've also deleted those variables since we aren't using them, and we are going to delete those fields from the assets query in the next API release
```
qTokenName
qTokenCurrencySymbol
```