### PR TITLE
fix: venofinance tvl

### DIFF
--- a/projects/venofinance/index.js
+++ b/projects/venofinance/index.js
@@ -1,13 +1,13 @@
 const { staking } = require("../helper/staking.js");
+const sdk = require('@defillama/sdk')
 
 const fountain_contract_address = "0xb4be51216f4926ab09ddf4e64bc20f499fd6ca95";
 const reservoir_contract_address = "0x21179329c1dcfd36ffe0862cca2c7e85538cca07";
 const vno_contract_address = "0xdb7d0a1ec37de1de924f8e8adac6ed338d4404e9";
 const zkCRO_contract_address = "0x28Ff2E4dD1B58efEB0fC138602A28D5aE81e44e2";
-const ybETH_contract_address = "0x76bf2D1e6dFda645c0c17440B17Eccc181dfC351";
-const ybUSD_contract_address = "0xFA59075DfCE274E028b58BdDFcC3D709960F594a";
 const vETH_contract_address = "0x271602A97027ee1dd03b1E6e5dB153eB659A80b1";
 const vUSD_contract_address = "0x5b91e29Ae5A71d9052620Acb813d5aC25eC7a4A2";
+const lcro_contract_address = "0x9fae23a2700feecd5b93e43fdbc03c76aa7c08a6"
 
 
 async function tvlCronos(api) {
@@ -30,24 +30,24 @@ async function tvlEra(api) {
   return api.getBalances()
 }
 
-async function tvlEthereum(api) {
-  const cro_pooled = await api.call({ abi: "uint256:totalPooledCro", target: zkCRO_contract_address });
-  api.addCGToken('crypto-com-chain', cro_pooled / 1e8);
-  const eth_pooled = await api.call({ abi: "uint256:totalPooledEth", target: ybETH_contract_address });
-  api.addCGToken('ethereum', eth_pooled / 1e18);  
-  const usd_pooled = await api.call({ abi: "uint256:totalUsdValue", target: ybUSD_contract_address });
-  api.addCGToken('dai', usd_pooled / 1e18); 
 
-  return api.getBalances();
-}
+async function tvlCronosZkEVM(zkEvmApi) {
+  const totalVEth = await zkEvmApi.call({ abi: "uint256:ybEthValue", target: vETH_contract_address });
+  zkEvmApi.addCGToken('ethereum', totalVEth / 1e18); 
+  const totalVUsd = await zkEvmApi.call({ abi: "uint256:ybUsdValue", target: vUSD_contract_address });
+  zkEvmApi.addCGToken('dai', totalVUsd / 1e18);
 
-async function tvlCronosZkEVM(api) {
-  const totalVEth = await api.call({ abi: "uint256:ybEthValue", target: vETH_contract_address });
-  api.addCGToken('ethereum', totalVEth / 1e18); 
-  const totalVUsd = await api.call({ abi: "uint256:ybUsdValue", target: vUSD_contract_address });
-  api.addCGToken('dai', totalVUsd / 1e18);
+  const ethApi = new sdk.ChainApi({ chain: 'ethereum' });
+  const cro_pooled = await ethApi.call({ abi: "uint256:totalPooledCro", target: zkCRO_contract_address });
+  const cronosApi = new sdk.ChainApi({ chain: 'cronos' });
+  const totalLcro = await cronosApi.call({
+    abi: 'function convertToShare(uint256 assets) view returns (uint256 shares)',
+    target: lcro_contract_address,
+    params: [cro_pooled]
+  });
 
-  return api.getBalances();
+  zkEvmApi.addCGToken('liquid-cro', totalLcro / 1e8);
+  return zkEvmApi.getBalances();
 }
 
 module.exports = {
@@ -62,10 +62,5 @@ module.exports = {
   era: {
     tvl: tvlEra,
   },
-  ethereum: {
-    tvl: tvlEthereum, 
-  },
-  cronos_zkevm: {
-    tvl: tvlCronosZkEVM, 
-  },
+  cronos_zkevm: {tvl: tvlCronosZkEVM}
 };


### PR DESCRIPTION
Hello,

this PR will fix the following issues in the venofinance adapter:

* TVL from YbEth/YbUsd will no longer be tracked, as these numbers are already tracked by getting them via the vETH and vUSD contracts respectively. So the reported TVL will be lower after merging this PR.
* The zkCRO contract locks LCRO, so we report the underlying LCRO value instead of CRO now. zkCRO is the native token of the Cronos zkEVM chain. To get the required numbers, however, we have to make calls on the Cronos EVM and Ethereum chain (see code).

Thank you

**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.
