### PR TITLE
Fix: hpdex (outdated)

### DIFF
--- a/projects/hpdex/index.js
+++ b/projects/hpdex/index.js
@@ -1,6 +1,7 @@
 const { getUniTVL } = require('../helper/unknownTokens')
 
 module.exports = {
+  deadFrom: '2024-09-22',
   misrepresentedTokens: true,
   methodology: "Factory address (0xE1d563BcFD4E2a5A9ce355CC8631421186521aAA) is used to find the LP pairs. TVL is equal to the liquidity on the AMM.",
   hpb: {


### PR DESCRIPTION
Added a deadFrom on the hpdex adapter which hasn't been updated for a few days. The HPB chain no longer seems active, the RPCs are down, the block explorer is no longer maintained, and the team's GitHub has had no activity for several years

![image](https://github.com/user-attachments/assets/81a762d0-04b4-4571-9b73-eabba9e01d23)

![image](https://github.com/user-attachments/assets/9d7ef81f-5e6b-4244-9ed8-e196d9be35fa)

![image](https://github.com/user-attachments/assets/f60ae230-ddae-4680-b3a0-6923328c2ae5)
