### PR TITLE
Fix reference from ustake to utoken to fix accounting

### DIFF
--- a/projects/silostake/index.js
+++ b/projects/silostake/index.js
@@ -36,7 +36,7 @@ Object.keys(config).forEach(chain => {
       // Logic for calculating TVL - just get total ustake.
       let state = await getState(chain, hub);
 
-      let total_ustake = state['total_ustake'];
+      let total_ustake = state['total_utoken'];
 
       api.add(coinGeckoId, total_ustake / 10 ** 6, { skipChain: true });
       


### PR DESCRIPTION
Fixing a reference in our adapter. You can see it [here](https://www.seiscan.app/pacific-1/interact-contract?selectedType=query&contract=sei1e3gttzq5e5k49f9f5gzvrl0rltlav65xu6p9xc0aj7e84lantdjqp7cncc&msg=ewogICJleGNoYW5nZV9yYXRlcyI6IHt9Cn0=), querying the state directly. As of 10/2/2024 the state is:

```json
{
  "data": {
    "total_ustake": "156329708588359",
    "total_utoken": "161521021712271",
    "exchange_rate": "1.033207463704685547",
    "unlocked_coins": [
      {
        "denom": "usei",
        "amount": "12828721273"
      }
    ],
    "unbonding": "3425220778859",
    "available": "150481022080",
    "tvl_utoken": "165096723513210"
  }
}
```

The `total_ustake` is the amount of iSEI issued (which because is rewards-bearing the price is diverging from SEI). To get the proper TVL in SEI/dollars, we change this to using `total_utoken`.

Thanks to jas*** for finding and identifying this bug.
