### PR TITLE
Added base pools for maha.xyz

### DIFF
--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -50,6 +50,7 @@ const fixBalancesTokens = {
   },
   base: {
     [ADDRESSES.base.rETH]: { coingeckoId: 'rocket-pool-eth', decimals: 18 },
+    '0x0a27e060c0406f8ab7b64e3bee036a37e5a62853': { coingeckoId: 'zai-stablecoin', decimals: 18 },
   },
   op_bnb: {
     [ADDRESSES.defiverse.USDC]: { coingeckoId: 'binance-bitcoin', decimals: 18 },

--- a/projects/mahaxyz/index.js
+++ b/projects/mahaxyz/index.js
@@ -56,8 +56,9 @@ module.exports = {
     pool2: sumTokensExport({
       tokensAndOwners: [
         [base.zaiMahaAerodrome, base.zaiMahaStaking],
-        [base.zaiUsdcAerodrome, base.zaiUsdcStaking]
-      ]
+        [base.zaiUsdcAerodrome, base.zaiUsdcStaking],
+      ],
+      resolveLP: true,
     }),
   }
 };

--- a/projects/mahaxyz/index.js
+++ b/projects/mahaxyz/index.js
@@ -22,6 +22,21 @@ const eth = {
   zaiUsdcCurveStaking: "0x154F52B347D8E48b8DbD8D8325Fe5bb45AAdCCDa",
 };
 
+
+const base = {
+  usdc: ADDRESSES.base.USDC,
+  maha: '0x554bba833518793056CF105E66aBEA330672c0dE',
+  usdz: '0x0A27E060C0406f8Ab7B64e3BEE036a37e5a62853',
+
+  // pools
+  zaiUsdcAerodrome: "0x72d509aff75753aaad6a10d3eb98f2dbc58c480d",
+  zaiMahaAerodrome: "0x6B22E989E1D74621ac4c8bcb62bcC7EE7c25b45A",
+
+  // staking contracts
+  zaiUsdcStaking: "0x1097dFe9539350cb466dF9CA89A5e61195A520B0",
+  zaiMahaStaking: "0x7D5a39744608A809c850f63CB1A3d3f9b4cAc586",
+}
+
 Object.keys(eth).forEach((k) => (eth[k] = eth[k].toLowerCase()));
 
 const collaterals = [eth.usdc, eth.usdt, eth.dai];
@@ -36,5 +51,13 @@ module.exports = {
       ]
     }),
     tvl: sumTokensExport({ owners: pegStabilityModules, tokens: collaterals }),
+  },
+  base: {
+    pool2: sumTokensExport({
+      tokensAndOwners: [
+        [base.zaiMahaAerodrome, base.zaiMahaStaking],
+        [base.zaiUsdcAerodrome, base.zaiUsdcStaking]
+      ]
+    }),
   }
 };


### PR DESCRIPTION
Currently there's about 170k$ of liquidity in the Aerodrome pools on base but for some reason the MAHA, USDC and USDz TVL does not show up.

Probably because the LP token's price isn't live yet. However we have made the PR adding these pools in.

<img width="1092" alt="image" src="https://github.com/user-attachments/assets/05c8b32c-4d3d-4eec-9ed0-a0faf8d4f109">
