### PR TITLE
fix: Openeden xrpl

### DIFF
--- a/projects/openeden-tbill/index.js
+++ b/projects/openeden-tbill/index.js
@@ -1,12 +1,14 @@
 const { getCache, } = require("../helper/cache");
 const ADDRESSES = require('../helper/coreAssets.json')
 
+const tbill = "0xdd50C053C096CB04A3e3362E2b622529EC5f2e8a"
+
 function getTimeNow() {
   return Math.floor(Date.now() / 1000);
 }
 
 async function tvl(api) {
-  let contract = '0xdd50C053C096CB04A3e3362E2b622529EC5f2e8a'
+  let contract = tbill
   if (api.chain === 'arbitrum') contract = '0xF84D28A8D28292842dD73D1c5F99476A80b6666A'
   const [bal, token] = await api.batchCall([
     { abi: 'uint256:totalAssets', target: contract },
@@ -23,7 +25,7 @@ async function ripplTvl (api) {
   let { lastDataUpdate, tvl } = await getCache(projectKey, cacheKey)
   if (!lastDataUpdate || timeNow - lastDataUpdate > aDayInSeconds || !tvl) 
     throw new Error("stale/missing tvl data");
-  api.add(ADDRESSES.ethereum.USDC, tvl * 10 ** 6, { skipChain: true })
+  api.add(tbill, tvl * 10 ** 6, { skipChain: true })
 }
 
 module.exports = {

--- a/projects/xrpl-dex/app.js
+++ b/projects/xrpl-dex/app.js
@@ -196,10 +196,8 @@ async function openedenRippleTvl() {
 }
 
 async function main() {
-  await openedenRippleTvl()
-  await xrplDex()
+  return  Promise.allSettled([
+    openedenRippleTvl(),
+    xrplDex()
+  ])
 }
-
-
-
-


### PR DESCRIPTION
Fix for openeden xrpl using the share price of tbill xrpl
TVL is now exactly the same as the one returned by the Open Eden frontend.
![ripple](https://github.com/user-attachments/assets/12ead815-4677-4f44-ba05-6534a5b64e9c)
![image](https://github.com/user-attachments/assets/299758e6-6d82-4a18-9cf8-c8e873248bbd)
