### PR TITLE
Add SparkDEX AMM V3.1 adapter.

### DIFF
--- a/projects/sparkdex-v3.1/index.js
+++ b/projects/sparkdex-v3.1/index.js
@@ -1,0 +1,6 @@
+const { uniV3Export } = require("../helper/uniswapV3");
+
+module.exports = uniV3Export({
+  flare: { factory: '0x8A2578d23d4C532cC9A98FaD91C0523f5efDE652', fromBlock: 
+    30717263, },
+})


### PR DESCRIPTION
The Flare ecosystem continues to grow stronger with FlareDrops.  https://flare.network/flaredrop-guide/

**SparkDEX V3.1** is a version of Uniswap AMM V3 that allows SparkDEX V3 users to receive FlareDrop rewards.
