### PR TITLE
Updated TVL For Satoshi Protocol on Bob chain

### DIFF
--- a/projects/satoshi-protocol/index.js
+++ b/projects/satoshi-protocol/index.js
@@ -55,12 +55,18 @@ module.exports = {
       '0xf1A7b474440702BC32F622291B3A01B80247835E', // BITLAYER WBTC Collateral
       '0xe9897fe6C8bf96D5ef8B0ECC7cBfEdef9818232c', // BITLAYER stBTC Collateral
     ],
+    nymInformation: {
+      address: '0xC562321a494290bE5FeDF9092cee35DE6f884D50',
+      fromBlock: 3442163,
+    }
   }),
   bob: createExports({
     troveList: [
       '0xc50D117C21054455aE9602237d3d17ca5Fa91288', // BOB WETH Collateral
       '0xBDFedF992128CbF10974DC935976116e10665Cc9', // BOB WBTC Collateral
       '0x8FAE9D3dBeE1c66b84E90df21A1DbdBab9262843', // BOB tBTC Collateral
+      '0xFFFE50D535aaA9B16499D2fDb3BbD94144ca5336', // BOB SolvBTC Collateral
+      '0xa0B2325BB635679cCFbf50570edd0C6F3D7dA81e', // BOB SolvBTC.BBN Collateral
     ],
     nymInformation: {
       address: '0x7253493c3259137431a120752e410b38d0c715C2',


### PR DESCRIPTION
Satoshi Protocol has deployed new contract on Bob chain to support new collaterals:
- [solvBTC](https://explorer.gobob.xyz/address/0x541FD749419CA806a8bc7da8ac23D346f2dF8B77)
- [solvBTC.BBN](https://explorer.gobob.xyz/address/0xCC0966D8418d412c599A6421b760a847eB169A8c)

If need further adjustments or have additional data to include, let me know thanks!