### PR TITLE
Fix: Eigenlayer skipCache

### DIFF
--- a/projects/eigenlayer/index.js
+++ b/projects/eigenlayer/index.js
@@ -48,6 +48,7 @@ const fetchLogs = async (api, eventAbi) => getLogs2({
   target: "0x858646372cc42e1a627fce94aa7a7033e7cf075a",
   eventAbi,
   fromBlock: 17445564,
+  skipCacheRead: true
 });
 
 const tvl = async ({ timestamp }, _b, _cb, { api }) => {


### PR DESCRIPTION
It seems that Eigenlayer hasn't been updated since my last change to the logs. I added the skipCacheRead property to allow the log fetches to work again