### PR TITLE
Update Kinetix AMM V3 adapter to use uniV3GraphExport helper. (uniV3Export missed cache)

### DIFF
--- a/projects/kinetix-v3/index.js
+++ b/projects/kinetix-v3/index.js
@@ -1,12 +1,16 @@
-const { uniV3Export } = require("../helper/uniswapV3");
+const { uniV3GraphExport } = require('../helper/uniswapV3')
 
-module.exports = uniV3Export({
+module.exports = {
   kava: {
-    factory: "0x2dBB6254231C5569B6A4313c6C1F5Fe1340b35C2",
-    fromBlock: 6069472,
+    tvl: uniV3GraphExport({
+      graphURL: 'https://kava-graph-node.metavault.trade/subgraphs/name/kinetixfi/v3-subgraph',
+      name: 'kinetixfi/kava-v3',
+  })
   },
   base: {
-    factory: "0xdDF5a3259a88Ab79D5530eB3eB14c1C92CD97FCf",
-    fromBlock: 14195510,
-  },
-});
+    tvl: uniV3GraphExport({
+      graphURL: 'https://api.studio.thegraph.com/query/55804/kinetixfi-base-v3/version/latest',
+      name: 'kinetixfi/base-v3',
+  })
+  }
+}


### PR DESCRIPTION
Hello, although we set the starting block of the adapter to 6069472 using `uniV3Export`, it is only able to retrieve pools from blocks after 8000000. As a result, it is missing data from some of our largest pools. Therefore, we are switching the adapter to use the `uniV3GraphExport` helper instead.