### PR TITLE
adding base to defi-money adapter

### DIFF
--- a/projects/defi-money/index.js
+++ b/projects/defi-money/index.js
@@ -25,6 +25,17 @@ const config = {
       "0x07aDF588508b923B8eA0389d27b61b9CB8a197Cb", // FRAX/MONEY
     ],
   },
+  base: {
+    controller: "0x1337F001E280420EcCe9E7B934Fa07D67fdb62CD",
+    MONEY: "0xEbE54BEE7A397919C53850bA68E126b0A6b295ed",
+    stakeLPs: [
+      // "0x9F04112af02CE57C10d946481Ea06373719c1E7E", // MONEY - already included in tvl
+      "0xe0f7c023763d782970ab45e9232255a64290cd6a", // crvUSD/MONEY
+      "0xb7698c690752ae034e914a29a0de67339a94982b", // USDC/MONEY
+      "0x45acdee3c9f7e1c7ad6cc10c9cb9f74eb52d0e70", // USDbC/MONEY
+      "0xac786337dde86b768ea3cc90afa03250bccfff28", // DAI/MONEY
+    ],
+  },
 }
 
 const tvl = async (api) => {


### PR DESCRIPTION
  - Adds base contracts
  - Re: Pools
    - Please let us know if there is something we can do on our side in order to fix the "unrecognized tokens" message

Thank You

```bash
arbitrum summing tokens 5
optimism summing tokens 5
arbitrum summing tokens 7
base summing tokens 4
optimism summing tokens 5
base summing tokens 3
Balance table for [base] Unrecognized tokens
┌─────────┬─────────────────────────┬─────────────┬─────────┬───────────────────────────────────────────────────┬──────────┐
│ (index) │ name                    │ symbol      │ balance │ label                                             │ decimals │
├─────────┼─────────────────────────┼─────────────┼─────────┼───────────────────────────────────────────────────┼──────────┤
│ 0       │ 'crvUSD/MONEY Curve LP' │ 'dfmcrvUSD' │ '4981'  │ 'base:0x68446d5f287c5dfaabff932efbecda2dd7e7861b' │ '18'     │
│ 1       │ 'USDC/MONEY Curve LP'   │ 'dfmUSDC'   │ '2'     │ 'base:0x70d410b739da81303a76169cdd406a746bde8b34' │ '18'     │
│ 2       │ 'USDbC/MONEY Curve LP'  │ 'dfmUSDbC'  │ '0'     │ 'base:0x5ecfa6940a33a2dad5c473896452f018c6c04577' │ '18'     │
└─────────┴─────────────────────────┴─────────────┴─────────┴───────────────────────────────────────────────────┴──────────┘
--- arbitrum-pool2 ---
dfmcrvUSD                 283.16 k
dfmUSDC                   109.42 k
dfmUSDT                   101.20 k
dfmDAI                    100.10 k
dfmFRAX                   51.91 k
Total: 645.79 k 

--- optimism-pool2 ---
dfmcrvUSD                 917.54 k
dfmUSDC                   141.32 k
dfmUSDT                   103.60 k
dfmDAI                    100.09 k
dfmFRAX                   69.99 k
Total: 1.33 M 

--- arbitrum ---
weth                      753.58 k
wbtc                      722.11 k
wstETH                    326.40 k
gmx                       228.02 k
pendle                    59.14 k
arb                       52.09 k
Total: 2.14 M 

--- optimism ---
WBTC                      674.58 k
wstETH                    583.85 k
WETH                      315.02 k
op                        144.25 k
velo                      45.03 k
Total: 1.76 M 

--- base-pool2 ---
Total: 0 

--- base ---
cbBTC                     8.25 k
WETH                      16.956824758388677
cbETH                     2.289867452599898
Total: 8.27 k 

--- pool2 ---
dfmcrvUSD                 1.20 M
dfmUSDC                   250.74 k
dfmUSDT                   204.80 k
dfmDAI                    200.19 k
dfmFRAX                   121.91 k
Total: 1.98 M 

--- tvl ---
wstETH                    910.25 k
weth                      753.58 k
wbtc                      722.11 k
WBTC                      674.58 k
WETH                      315.03 k
gmx                       228.02 k
op                        144.25 k
pendle                    59.14 k
arb                       52.09 k
velo                      45.03 k
cbBTC                     8.25 k
cbETH                     2
Total: 3.91 M 

------ TVL ------
arbitrum                  2.14 M
pool2                     1.98 M
optimism                  1.76 M
optimism-pool2            1.33 M
arbitrum-pool2            645.79 k
base                      8.27 k
base-pool2                0

total                    3.91 M 


```