### PR TITLE
Decouple Injective Helix adapter into spot and derivatives

### DIFF
--- a/projects/injective-helix-derivative/index.js
+++ b/projects/injective-helix-derivative/index.js
@@ -1,0 +1,39 @@
+const { getMarkets, getOrders, TYPES } = require('../helper/chain/injective')
+const { transformBalances } = require('../helper/portedTokens')
+const sdk = require('@defillama/sdk')
+const { default: BigNumber } = require('bignumber.js')
+
+function getOrderBookTvl(typeStr) {
+  return async () => {
+    const balances = {}
+    const markets = await getMarkets({ type: typeStr })
+    const orders = await getOrders({ type: typeStr, marketIds: markets.map(i => i.marketId) })
+    const marketObj = {}
+    for (const market of markets)
+      marketObj[market.marketId] = market
+
+    for (const order of orders) marketObj[order.marketId].orderbook = order.orderbook
+    for (const { quoteDenom, baseDenom, orderbook: { buys, sells, } } of markets) {
+      for (const { price, quantity } of buys)
+        sdk.util.sumSingleBalance(balances, quoteDenom, BigNumber(quantity * price).toFixed(0))
+
+      for (const { quantity } of sells) {
+
+      if (typeStr === TYPES.DERIVATIVES) {
+          const price = buys.length ? buys[0].price : 0
+          sdk.util.sumSingleBalance(balances, quoteDenom, BigNumber(quantity * price).toFixed(0))
+        }
+      }
+    }
+    return transformBalances('injective', balances)
+  }
+}
+
+module.exports = {
+  timetravel: false,
+  injective: {
+    tvl: sdk.util.sumChainTvls([
+      getOrderBookTvl(TYPES.DERIVATIVES),
+    ])
+  }
+}

--- a/projects/injective-orderbook-spot/index.js
+++ b/projects/injective-orderbook-spot/index.js
@@ -36,7 +36,6 @@ module.exports = {
   injective: {
     tvl: sdk.util.sumChainTvls([
       getOrderBookTvl(TYPES.SPOT),
-      getOrderBookTvl(TYPES.DERIVATIVES),
     ])
   }
 }

--- a/projects/injective-orderbook/index.js
+++ b/projects/injective-orderbook/index.js
@@ -1,6 +1,0 @@
-const { getExports } = require('../helper/heroku-api')
-
-module.exports = {
-  timetravel: false,
-  ...getExports("injective-orderbook", ['injective']),
-}


### PR DESCRIPTION
As agreed in the previous discussion, the PR decouples Injective Helix data scraping into two types of adapters: spot trading tvl and derivatives (perpetuals) trading tvl.