### PR TITLE
Fix: AlienBase-v3

### DIFF
--- a/projects/alienbase-v3/index.js
+++ b/projects/alienbase-v3/index.js
@@ -2,5 +2,5 @@ const { uniV3Export } = require('../helper/uniswapV3')
 const factory = '0x0Fd83557b2be93617c9C1C1B6fd549401C74558C'
 
 module.exports = uniV3Export({
-  base: { factory, fromBlock: 7150708, },
+  base: { factory, fromBlock: 7150708, permitFailure: true },
 })


### PR DESCRIPTION
The adapter hasn’t received an update for nearly 24 days. Adding a permitFailure due to a failed call on multiCall: the contract `0x7c19e26660e5004bd7e9b77bc02039d6467876a4` was recently self-destructed, preventing the rest of the calls from functioning

![image](https://github.com/user-attachments/assets/6bdaf24c-7f28-4581-a105-4829434a793c)

![image](https://github.com/user-attachments/assets/1176205c-8994-4248-a8c7-0ecebf52be54)