### PR TITLE
Fix: BSX-exchange, blacklist

### DIFF
--- a/projects/bsx-exchange/index.js
+++ b/projects/bsx-exchange/index.js
@@ -7,7 +7,7 @@ Object.keys(config).forEach(chain => {
   module.exports[chain] = {
     tvl: async (api) => {
       const tokens = await api.call({ abi: 'address[]:getSupportedTokenList', target: exchange })
-      return api.sumTokens({ owner: exchange, tokens })
+      return api.sumTokens({ owner: exchange, tokens, blacklistedTokens: ['0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'] })
     }
   }
 })


### PR DESCRIPTION
The adapter's TVL has not received an update for about 20 days: The adapter's methodology is a simple sumTokens; however, there was a token (0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE) among the supported tokens to sum that returned a failure. A blacklist has been added

The amount on the contract is indeed identical to the one we now see

![image](https://github.com/user-attachments/assets/b94b0d1c-877b-4582-9f68-78cda7055330)
