### PR TITLE
Fix: Oh-finance

### DIFF
--- a/projects/oh-finance/abi.json
+++ b/projects/oh-finance/abi.json
@@ -1,4 +1,0 @@
-{
-  "virtualBalance": "uint256:virtualBalance",
-  "underlying": "address:underlying"
-}

--- a/projects/oh-finance/index.js
+++ b/projects/oh-finance/index.js
@@ -1,39 +1,47 @@
-const sdk = require('@defillama/sdk');
-const abi = require('./abi.json')
+const CONFIG = {
+  ethereum: [
+    "0xa528639aae2e765351dcd1e0c2dd299d6279db52", // usdc
+  ],
+  avax: [
+    "0x8B1Be96dc17875ee01cC1984e389507Bb227CaAB", // usdc.e
+    "0xd96AbEcf6AA022735CFa9CB512d63645b0834720", // usdt.e
+    "0xF74303DD14E511CCD90219594e8069d36Da01DCD", // dai.e
+    "0xe001DeCc1763F8BadBbc1b10c2D6db0900f9B928", // usdc
+    "0xB3ce618F43b53Cdc12077FB937f9fF465BcE1f60", // usdt
+  ],
+  moonriver: [
+    "0x4C211F45876d8EC7bAb54CAc0e32AAD15095358A", // usdc
+    "0xdeA7Ff1D84B7E54587b434C1A585718857CF61d1", // usdt
+  ],
+  metis: [
+    "0x4C211F45876d8EC7bAb54CAc0e32AAD15095358A", // m.usdc
+    "0xc53bC2517Fceff56308b492AFad4A53d96d16ed8", // m.usdt
+  ],
+};
 
-function getBankTvl(bankAddress, chain){
-    return async (time, ethBlock, {[chain]: block})=>{
-        const invested = await sdk.api.abi.call({target: bankAddress, block, chain, abi:abi.virtualBalance})
-        const underlying = await sdk.api.abi.call({target: bankAddress, block, chain, abi:abi.underlying})
-        return {
-            [chain+":"+underlying.output]: invested.output
-        }
-    }
+const abi = {
+  virtualBalance: "uint256:virtualBalance",
+  underlying: "address:underlying",
+};
+
+async function getBankTvl(api, vaults) {
+  const [investeds, underlyings] = await Promise.all([
+    api.multiCall({ calls: vaults, abi: abi.virtualBalance, permitFailure: true }),
+    api.multiCall({ calls: vaults, abi: abi.underlying, permitFailure: true }),
+  ]);
+
+  vaults.forEach((_vault, i) => {
+    const invested = investeds[i]
+    const underlying = underlyings[i]
+    if (!invested || !underlying ) return
+    api.add(underlying, invested)
+  })
+
 }
 
-module.exports={
-    ethereum:{
-        tvl: getBankTvl("0xa528639aae2e765351dcd1e0c2dd299d6279db52", "ethereum"), // usdc
-    },
-    avax:{
-        tvl: sdk.util.sumChainTvls([
-            getBankTvl("0x8B1Be96dc17875ee01cC1984e389507Bb227CaAB", "avax"), // usdc.e
-            getBankTvl("0xd96AbEcf6AA022735CFa9CB512d63645b0834720", "avax"), // usdt.e
-            getBankTvl("0xF74303DD14E511CCD90219594e8069d36Da01DCD", "avax"), // dai.e
-            getBankTvl("0xe001DeCc1763F8BadBbc1b10c2D6db0900f9B928", "avax"), // usdc
-            getBankTvl("0xB3ce618F43b53Cdc12077FB937f9fF465BcE1f60", "avax"), // usdt
-        ])
-    },
-    moonriver: {
-        tvl: sdk.util.sumChainTvls([
-            getBankTvl("0x4C211F45876d8EC7bAb54CAc0e32AAD15095358A","moonriver"), // usdc
-            getBankTvl("0xdeA7Ff1D84B7E54587b434C1A585718857CF61d1","moonriver"), // usdt
-        ])
-    },
-    metis: {
-        tvl: sdk.util.sumChainTvls([
-            getBankTvl("0x4C211F45876d8EC7bAb54CAc0e32AAD15095358A", "metis"), // m.usdc
-            getBankTvl("0xc53bC2517Fceff56308b492AFad4A53d96d16ed8", "metis"), // m.usdt
-        ])
-    }
-}
+Object.keys(CONFIG).forEach((chain) => {
+  const vaults = CONFIG[chain];
+  module.exports[chain] = {
+    tvl: (api) => getBankTvl(api, vaults),
+  };
+});


### PR DESCRIPTION
The TVL of the Oh-finance adapter hasn't been updated for about 20 days. One of the addresses was returning errors during on-chain calls. A small refactor was done to use multicalls instead of single calls, with a permitFailure option in case of failure, and added error handling to eliminate null responses