### PR TITLE
Fix: Lila-Finance

### DIFF
--- a/projects/lila-finance/index.js
+++ b/projects/lila-finance/index.js
@@ -10,7 +10,7 @@ async function tvl(api) {
   data = data.filter(i => i.strategy !== ADDRESSES.null)
   const aTokens = await api.multiCall({  abi: 'address:aToken', calls: data.map(i => i.strategy)})
   const ownerTokens = data.map((i, idx) => [[i.asset, aTokens[idx]], i.strategy])
-  return api.sumTokens({ ownerTokens })
+  return api.sumTokens({ ownerTokens, blacklistedTokens: ['0x42c248d137512907048021b30d9da17f48b5b7b2'] })
 }
 
 module.exports = {


### PR DESCRIPTION
The TVL of Lila Finance hasn't been updated for nearly 10 days.
Their dApp mainly relied on Radiant pools, but since the hack, most of Radiant's contracts no longer have liquidity on Arbitrum. Lila Finance no longer has collateral in its strategies.
Added a blacklist for the rWSTETH token, which fails on its calls