### PR TITLE
Fix: Rebalance

### DIFF
--- a/projects/rebalance/index.js
+++ b/projects/rebalance/index.js
@@ -28,5 +28,5 @@ const tvl = async (api, vaults) => {
   ]);
 
   const balances = await api.multiCall({ calls: vaults.map((vault, i) => ({ target: providers[i], params: [vault, vault] })), abi })
-  assets.forEach((asset, i) => { api.add(asset, balances[i]) })
+  api.add(assets, balances)
 };

--- a/projects/rebalance/index.js
+++ b/projects/rebalance/index.js
@@ -1,24 +1,36 @@
-const { sumERC4626VaultsExport } = require('../helper/erc4626');
 const config = {
   arbitrum: [
-    '0xCF86c768E5b8bcc823aC1D825F56f37c533d32F9', // rUSDT
-    '0x6eAFd6Ae0B766BAd90e9226627285685b2d702aB', // rUSDC
-    '0xa8aae282ab2e57B8E39ad2e70DA3566d315348A9', // rUSDC.e
-    '0xcd5357A4F48823ebC86D17205C12B0B268d292a7', // rWETH
-    '0x5A0F7b7Ea13eDee7AD76744c5A6b92163e51a99a', // rDAI
-    '0x3BCa6513BF284026b4237880b4e4D60cC94F686c', // rFRAX
+    "0xCF86c768E5b8bcc823aC1D825F56f37c533d32F9", // rUSDT
+    "0x6eAFd6Ae0B766BAd90e9226627285685b2d702aB", // rUSDC
+    "0xa8aae282ab2e57B8E39ad2e70DA3566d315348A9", // rUSDC.e
+    "0xcd5357A4F48823ebC86D17205C12B0B268d292a7", // rWETH
+    "0x5A0F7b7Ea13eDee7AD76744c5A6b92163e51a99a", // rDAI
+    "0x3BCa6513BF284026b4237880b4e4D60cC94F686c", // rFRAX
   ],
 };
 
+const abi =
+  "function getDepositBalance(address user, address vault) view returns (uint256 balance)";
+
 module.exports = {
-  methodology:
-    'TVL displays the total amount of assets stored in the REBALANCE vault contracts.',
+  methodology: "TVL displays the total amount of assets stored in the REBALANCE vault contracts.",
   start: 1712143874,
-  hallmarks: [[1712143874, 'Profitable vaults deployment']],
+  hallmarks: [[1712143874, "Profitable vaults deployment"]],
 };
 
 Object.keys(config).forEach((chain) => {
-  module.exports[chain] = {
-    tvl: sumERC4626VaultsExport({ vaults: config[chain], isOG4626: true }),
-  };
+  module.exports[chain] = { tvl: (api) => tvl(api, config[chain]) };
 });
+
+const tvl = async (api, vaults) => {
+  const [providers, assets] = await Promise.all([
+    api.multiCall({ calls: vaults, abi: "address:activeProvider" }),
+    api.multiCall({ calls: vaults, abi: "address:asset" }),
+  ]);
+
+  const balances = await api.multiCall({ calls: vaults.map((vault, i) => ({ target: providers[i], params: [vault, vault] })), abi })
+  
+  assets.forEach((asset, i) => {
+    api.add(asset, balances[i])
+  })
+};

--- a/projects/rebalance/index.js
+++ b/projects/rebalance/index.js
@@ -9,8 +9,7 @@ const config = {
   ],
 };
 
-const abi =
-  "function getDepositBalance(address user, address vault) view returns (uint256 balance)";
+const abi = "function getDepositBalance(address user, address vault) view returns (uint256 balance)";
 
 module.exports = {
   methodology: "TVL displays the total amount of assets stored in the REBALANCE vault contracts.",
@@ -29,8 +28,5 @@ const tvl = async (api, vaults) => {
   ]);
 
   const balances = await api.multiCall({ calls: vaults.map((vault, i) => ({ target: providers[i], params: [vault, vault] })), abi })
-  
-  assets.forEach((asset, i) => {
-    api.add(asset, balances[i])
-  })
+  assets.forEach((asset, i) => { api.add(asset, balances[i]) })
 };


### PR DESCRIPTION
The TVL of the Rebalance adapter hasn’t been updated for 13 days, as it seems all contracts are returning errors.
It appears the contracts were recently modified, with changes to the vault strategy providers.
Adjustments to the logic were made to align with balances and allow our code to adapt to future changes.
Additional calls were added to retrieve the latest active provider used, and balance calls were made on it.
The resulting TVL matches the TVL displayed on the Rebalance frontend, which is entirely based on deposits on Compound v3

![image](https://github.com/user-attachments/assets/22b2b953-8dea-46bf-827e-5cdb8bdaadc5)
