### PR TITLE
Update: script DupBtc

### DIFF
--- a/utils/scripts/checkBTCDups.js
+++ b/utils/scripts/checkBTCDups.js
@@ -1,21 +1,22 @@
 const fs = require('fs');
 const path = require('path');
+const axios = require('axios');
+const { getEnv } = require('../../projects/helper/env');
 
-// Regular expression to match Bitcoin addresses
-// const btcAddressRegex = /\b(bc1|[13])[a-zA-HJ-NP-Z0-9]{25,39}\b/g;
+// Regular expressions
+const bitcoinAddressRegex = /\b(1[1-9A-HJ-NP-Za-km-z]{25,34}|3[1-9A-HJ-NP-Za-km-z]{25,34}|bc1[ac-hj-np-z02-9]{39,59})\b/g;
+const bitcoinKeyRegex = /module\.exports\s*=\s*{[^}]*\bbitcoin\b\s*:/s;
+const apiUrlRegex = /['"]https?:\/\/[^\s'"]+['"]/g;
 
-
-// Regular expression to match alphanumeric strings between single or double quotes
-const addressRegex = /['"]([a-zA-Z0-9]{25,99})['"]/g;
-
-// Function to read all files in a directory recursively
+// Function to read files in a directory recursively, ignoring node_modules
 const readFilesInDirectory = (dir) => {
-  let files = [];
+  const files = [];
   const items = fs.readdirSync(dir);
   for (const item of items) {
     const fullPath = path.join(dir, item);
+    if (fullPath.includes('node_modules')) continue;
     if (fs.statSync(fullPath).isDirectory()) {
-      files = files.concat(readFilesInDirectory(fullPath));
+      files.push(...readFilesInDirectory(fullPath));
     } else {
       files.push(fullPath);
     }
@@ -23,61 +24,139 @@ const readFilesInDirectory = (dir) => {
   return files;
 };
 
-// Function to extract Bitcoin addresses from a file
-const extractBtcAddresses = (filePath) => {
-  let content = fs.readFileSync(filePath, 'utf8');
-  if (['solana', 'tezos'].some(i => content.includes(i)) && !content.includes('bitcoin')) return []
-  content = content.replaceAll('modifyEndpoint("', '')
-  content = content.replaceAll('modifyEndpoint(\'', '')
-  return content.match(addressRegex) || [];
+const extractAllBitcoinAddresses = (files, addressMap, folderPath) => {
+  files.forEach(file => {
+    const content = fs.readFileSync(file, 'utf8');
+    
+    // Skip files that likely contain only non-Bitcoin chains
+    if (['solana', 'tezos'].some(chain => content.includes(chain)) && !content.includes('bitcoin')) return;
+
+    // Match Bitcoin-specific addresses
+    const bitcoinAddresses = content.match(bitcoinAddressRegex) || [];
+    const baseFile = file.replace(folderPath, '');
+    
+    bitcoinAddresses.forEach(address => {
+      if (addressMap.has(address)) {
+        addressMap.get(address).add(`File:${baseFile}`);
+      } else {
+        addressMap.set(address, new Set([`File:${baseFile}`]));
+      }
+    });
+  });
 };
 
-// Function to find duplicates between files
-const findDuplicates = (folderPath) => {
-  console.log(folderPath)
-  const files = readFilesInDirectory(folderPath+'/');
+// Function to identify Bitcoin adapters with "bitcoin" as a key in module.exports
+const findBitcoinAdapters = (files, folderPath) => {
+  return files
+    .filter(file => bitcoinKeyRegex.test(fs.readFileSync(file, 'utf8')))
+    .map(file => ({ path: file.replace(folderPath, ''), content: fs.readFileSync(file, 'utf8') }));
+};
+
+// Function to extract API URLs from adapter content
+const extractApiUrlsForAdapters = (adapters) => {
+  return adapters.reduce((map, adapter) => {
+    const apiUrls = adapter.content.match(apiUrlRegex) || [];
+    map.set(adapter.path, apiUrls.map(url => url.replace(/['"]/g, '')));
+    return map;
+  }, new Map());
+};
+
+// Function to fetch Bitcoin addresses from API URLs
+const fetchBitcoinAddressesFromApis = async (apiUrlsMap, addressMap) => {
+  const addressesFromApis = new Map();
+
+  for (const [adapter, urls] of apiUrlsMap.entries()) {
+    if (urls.length === 0) {
+      addressesFromApis.set(adapter, [{ apiUrl: "No API", address: "No data extracted from API" }]);
+      continue;
+    }
+
+    for (const url of urls) {
+      const addresses = await fetchAddressesFromApi(adapter, url, addressMap);
+      addressesFromApis.set(adapter, (addressesFromApis.get(adapter) || []).concat(addresses));
+    }
+  }
+  
+  return addressesFromApis;
+};
+
+// Helper function to fetch addresses from a single API URL
+const fetchAddressesFromApi = async (adapter, url, addressMap) => {
+  try {
+    const response = await axios.get(url, {
+      headers: adapter === "\\fbtc\\index.js" && url.includes("fbtc-reserved-addr")
+        ? { 'access-token': getEnv('FBTC_ACCESS_TOKEN') }
+        : {}
+    });
+
+    const bitcoinAddresses = (JSON.stringify(response.data).match(bitcoinAddressRegex) || [])
+      .map(addr => addr.replace(/['"]/g, ''));
+
+    if (bitcoinAddresses.length === 0) {
+      return [{ apiUrl: url, address: "No data extracted from API" }];
+    }
+
+    bitcoinAddresses.forEach(address => {
+      if (addressMap.has(address)) {
+        addressMap.get(address).add(`API:${adapter}`);
+      } else {
+        addressMap.set(address, new Set([`API:${adapter}`]));
+      }
+    });
+
+    return bitcoinAddresses.map(addr => ({ address: addr, apiUrl: url }));
+
+  } catch (error) {
+    console.error(`Error fetching data from ${url}: ${error.message}`);
+    return [{ apiUrl: url, address: "No data extracted from API" }];
+  }
+};
+
+const createCombinedCsvFile = async (folderPath) => {
+  const files = readFilesInDirectory(folderPath);
   const addressMap = new Map();
 
-  for (let file of files) {
-    const addresses = extractBtcAddresses(file);
-    file = file.replace(folderPath, '')
-    for (let address of addresses) {
-      address = address.replace(/'/g, '').replace(/"/g, '')
-      if (address.startsWith('0x') || !/\d/.test(address)) continue;
-      if (addressMap.has(address)) {
-        const arry = addressMap.get(address)
-        if (!arry.includes(file))
-          arry.push(file);
-      } else {
-        addressMap.set(address, [file]);
+  // Extract Bitcoin addresses from all files in the codebase
+  extractAllBitcoinAddresses(files, addressMap, folderPath);
+
+  // Identify Bitcoin adapters and extract API URLs
+  const bitcoinAdapters = findBitcoinAdapters(files, folderPath);
+  const apiUrlsMap = extractApiUrlsForAdapters(bitcoinAdapters);
+
+  const apiAddresses = await fetchBitcoinAddressesFromApis(apiUrlsMap, addressMap);
+
+  let combinedCsvContent = 'Adapter,API_URL,Address\n';
+  bitcoinAdapters.forEach(adapter => {
+    const adapterPath = adapter.path;
+    const adapterApiData = apiAddresses.get(adapterPath) || [{ apiUrl: "No API", address: "No data extracted from API" }];
+    adapterApiData.forEach(({ apiUrl, address }) => {
+      combinedCsvContent += `"${adapterPath}","${apiUrl}","${address}"\n`;
+    });
+  });
+
+  const combinedCsvPath = path.join(__dirname, 'bitcoin_apiCrawler.csv');
+  fs.writeFileSync(combinedCsvPath, combinedCsvContent, 'utf8');
+  console.log(`Combined Bitcoin adapters CSV file created: ${combinedCsvPath}`);
+
+  let duplicateCsvContent = 'Address,Source1,Source2,Source3,Source4,Source5,Source6\n';
+  addressMap.forEach((sources, address) => {
+    if (sources.size > 1) {
+      const sourceArray = Array.from(sources);
+      duplicateCsvContent += `"${address}"`;
+      for (let i = 0; i < 6; i++) {
+        duplicateCsvContent += i < sourceArray.length ? `,"${sourceArray[i]}"` : ',';
       }
+      duplicateCsvContent += '\n';
     }
-  }
+  });
 
-  // Find duplicates
-  const duplicates = [];
-  for (const [address, fileList] of addressMap.entries()) {
-    if (fileList.length > 1) {
-      duplicates.push({ address, files: fileList });
-    }
-  }
-
-  return duplicates;
+  const duplicateCsvPath = path.join(__dirname, 'duplicate_addresses.csv');
+  fs.writeFileSync(duplicateCsvPath, duplicateCsvContent, 'utf8');
+  console.log(`Duplicate addresses CSV file created: ${duplicateCsvPath}`);
 };
 
-// Main function
-const main = (folderPath) => {
-  const duplicates = findDuplicates(folderPath);
-  if (duplicates.length > 0) {
-    console.log('Duplicate Bitcoin addresses found:');
-    for (const { address, files } of duplicates) {
-      console.log(`Address: ${address}`);
-      console.log(`Files: ${files.join(', ')}`);
-      console.log('---');
-    }
-  } else {
-    console.log('No duplicate Bitcoin addresses found.');
-  }
+const main = async (folderPath) => {
+  await createCombinedCsvFile(folderPath);
 };
 
 main(path.join(__dirname, '../../projects'));


### PR DESCRIPTION
Improvement of the script to check if a Bitcoin address is used across multiple adapters by retrieving addresses from both adapters using the Bitcoin network and their APIs.

**Required:**
`export FBTC_ACCESS_TOKEN=`

**Cmd**
`npm run check-bitcoin-duplicates`

The result is presented in the form of two CSV files: one displaying all the addresses collected from the various adapter APIs (for manual checking), and a final one showing all the duplicates found

**Api Crawler :**
![api_crawler](https://github.com/user-attachments/assets/81272128-a138-48f4-a35b-9137b553bf35)

**Final Result :** 
![result_duplicate](https://github.com/user-attachments/assets/7ca2cd6f-d8ea-49ca-9f85-4c97f6a6304a)

