### PR TITLE
Fix: Origami (multicall failed)

### DIFF
--- a/projects/origami/index.js
+++ b/projects/origami/index.js
@@ -21,16 +21,29 @@ async function tvl(api) {
   const levVaults = investmentVaults.filter(isLeveraged).map(v => v.id)
   const nonLevVaults = investmentVaults.filter(v => !isLeveraged(v)).map(v => v.id)
 
-  let nonLevTokens = await api.multiCall({ abi: 'address:reserveToken', calls: nonLevVaults })
-  nonLevTokens = await api.multiCall({ abi: 'address:baseToken', calls: nonLevTokens })
-  const decimals = await api.multiCall({ abi: 'uint8:decimals', calls: nonLevVaults })
-  const supplies = await api.multiCall({ abi: 'uint256:totalSupply', calls: nonLevVaults })
-  const reserves = await api.multiCall({ abi: 'uint256:reservesPerShare', calls: nonLevVaults })
-  const bals = supplies.map((supply, idx) => reserves[idx] * supply / 10 ** decimals[idx])
-  api.add(nonLevTokens, bals)
+  const [decimals, supplies, reserves, rawNonLevTokens] = await Promise.all([
+    api.multiCall({ abi: 'uint8:decimals', calls: nonLevVaults, permitFailure: true }),
+    api.multiCall({ abi: 'uint256:totalSupply', calls: nonLevVaults, permitFailure: true }),
+    api.multiCall({ abi: 'uint256:reservesPerShare', calls: nonLevVaults, permitFailure: true }),
+    api.multiCall({ abi: 'address:reserveToken', calls: nonLevVaults, permitFailure: true })
+  ])
 
-  const levReserveTokens = await api.multiCall({ calls: levVaults, abi: 'address:reserveToken' })
-  const assetsAndLiabilities = await api.multiCall({ abi: 'function assetsAndLiabilities() external view returns (uint256 assets,uint256 liabilities,uint256 ratio)', calls: levVaults })
+  await Promise.all(nonLevVaults.map(async (_vault, i) => {
+    const decimal = decimals[i]
+    const supply = supplies[i]
+    const reserve = reserves[i]
+    const rawNonLevToken = rawNonLevTokens[i]
+    if (!decimals || !supply || !reserve || !rawNonLevToken) return
+    const nonLevToken = await api.call({ abi: 'address:baseToken', target: rawNonLevToken })
+    const bal = reserve * supply / 10 ** decimal
+    api.add(nonLevToken, bal)
+  }))
+
+  const [levReserveTokens, assetsAndLiabilities] = await Promise.all([
+    api.multiCall({ calls: levVaults, abi: 'address:reserveToken' }),
+    api.multiCall({ abi: 'function assetsAndLiabilities() external view returns (uint256 assets,uint256 liabilities,uint256 ratio)', calls: levVaults })
+  ])
+
   const levBals = assetsAndLiabilities.map(({ assets, liabilities }) => assets - liabilities)
   api.add(levReserveTokens, levBals)
 }


### PR DESCRIPTION
Fix for Origami, which hasn't been updated for about 15 days => multicall was returning an error on the Ethereum chain. Added permitFailure and error handling