### PR TITLE
Fix: Jarvis

### DIFF
--- a/projects/jarvis/index.js
+++ b/projects/jarvis/index.js
@@ -75,9 +75,11 @@ async function tvl(api) {
     ].map(i => i.toLowerCase())
     const calls = liquidityPools.filter(i => !blacklistedPools.includes(i.toLowerCase()))
     const collateralTokens = await api.multiCall({ abi: abi.collateralToken, calls })
-    const totalCollateralAmounts = await api.multiCall({ abi: abi.totalCollateralAmount, calls })
+    const totalCollateralAmounts = await api.multiCall({ abi: abi.totalCollateralAmount, calls, permitFailure: true })
     collateralTokens.forEach((data, i) => {
-      api.add(data, totalCollateralAmounts[i].totalCollateral)
+      const totalCollateralAmount = totalCollateralAmounts[i]
+      if (!totalCollateralAmount) return
+      api.add(data, totalCollateralAmount.totalCollateral)
     })
   } else if (version === 5) {
     // Get balances of every LiquidityPool and SynthToken Contracts


### PR DESCRIPTION
Fix for Jarvis, which hasn’t been updated for a few days. There was an error in the multiCall for this contract: `0x7a75624f051041baA74aE4E47724216307c7401D` on polygon, which returned an error in the `totalCollateralAmount` method due to `an arithmetic underflow or overflow`

![image](https://github.com/user-attachments/assets/7db29fea-daca-4965-b03a-71017614ea95)