### PR TITLE
Fix: Xswap-v3

### DIFF
--- a/projects/xspswap-v3/index.js
+++ b/projects/xspswap-v3/index.js
@@ -2,5 +2,5 @@ const { uniV3Export } = require('../helper/uniswapV3')
 const factory = '0x30F317A9EC0f0D06d5de0f8D248Ec3506b7E4a8A'
 
 module.exports = uniV3Export({
-  xdc: { factory, fromBlock: 59782067, methodology: 'TVL accounts for the liquidity on all AMM pools taken from the factory contract', },
+  xdc: { factory, fromBlock: 59782067, methodology: 'TVL accounts for the liquidity on all AMM pools taken from the factory contract', permitFailure: true },
 })


### PR DESCRIPTION
Fix for Xswap-v3, which hasn't updated for a week due to a token: `0x0000000000000000000000000000000000001010` retrieved through the factory that appears to lack any code implementation

