### PR TITLE
Fix: Kinesis-labs (deadFrom)

### DIFF
--- a/projects/kinesis/index.js
+++ b/projects/kinesis/index.js
@@ -44,12 +44,12 @@ const gravUSDC = ADDRESSES.functionx.PURSE;
 const gravUSDT = ADDRESSES.functionx.USDT;
 
 module.exports = {
+  deadFrom: ['2023-03-01'],
+  methodology: "Counts as TVL all the Assets deposited on EVMOS through different Pool Contracts",
   evmos: {
     tvl: sumTokensExport({
       owners: poolAddresses_evmos, 
       tokens: [madUSDC, madUSDT, axlDAI, axlUSDC, axlUSDT, ceDAI, ceUSDC, ceUSDT, gravDAI, gravUSDC, gravUSDT, FRAX],
     }),
   },
-  methodology:
-    "Counts as TVL all the Assets deposited on EVMOS through different Pool Contracts",
 };


### PR DESCRIPTION
Recently, the adapter stopped updating, it appears that the project has been sunset. The TVL has been flat for over a year, the website is no longer accessible, and the team seems inactive on Twitter.
Add a `deadFrom`