### PR TITLE
Add STAB Protocol adapter

### DIFF
--- a/projects/stab-protocol/index.js
+++ b/projects/stab-protocol/index.js
@@ -25,8 +25,8 @@ async function tvl(api) {
     const stabXrdPoolXrdVault = await queryAddresses({ addresses: [STAB_XRD_POOL_XRD_VAULT] });
     const xrdAmountPool = stabXrdPoolXrdVault[0].details.balance.amount;
 
-    //add twice XRD value of pool to tvl (once for actual XRD side, and once to represent the STAB side which we can't properly get the value of otherwise)
-    api.add('resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd', xrdAmountPool * 2)
+    //add only XRD value of pool to tvl (STAB value is excluded as backing of STAB tokens are already included in tvl)
+    api.add('resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd', xrdAmountPool)
 }
 
 module.exports = {

--- a/projects/stab-protocol/index.js
+++ b/projects/stab-protocol/index.js
@@ -1,0 +1,36 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+
+const { queryAddresses, sumTokens } = require('../helper/chain/radixdlt');
+
+const STAB_COMPONENT = "component_rdx1cq70cjajtvllgk9z9wm9l8v6w8hsgtlw530cdgpraxprn4yevg89kf";
+const STAB_XRD_POOL_XRD_VAULT = "internal_vault_rdx1trk04c3sxffatj5h78w3266c8q07cvjlgq0zx44sask8wsam4q8rup";
+const ORACLE_COMPONENT = "component_rdx1cq7zsdqfh0mcwnutrevkz6wtml0vnav5fcmtf7rksmhk48urkyjg9c";
+
+async function tvl(api) {
+    //get the token amounts of collaterals used in the STAB Protocol
+    const stabComponentTokens = await sumTokens({ owners: [STAB_COMPONENT], api })
+    const xrdAmount = stabComponentTokens['radixdlt:resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd']
+    const lsuLpAmount = stabComponentTokens['radixdlt:resource_rdx1thksg5ng70g9mmy9ne7wz0sc7auzrrwy7fmgcxzel2gvp8pj0xxfmf']
+
+    //calculate value of LSULP against XRD to get accurate price data
+    const [{ details: { state } }] = await queryAddresses({ addresses: [ORACLE_COMPONENT] } )
+    const xrdPrice = state.fields[0].elements[0].fields[1].value
+    const lsuLpPrice = state.fields[0].elements[1].fields[1].value
+    const lsuLpMultiplier = lsuLpPrice / xrdPrice
+
+    //add XRD and LSULP values to tvl
+    api.add('resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd', xrdAmount + lsuLpAmount * lsuLpMultiplier)
+
+    //get the amount of XRD in the protocol native STAB/XRD pool (with 50/50 weights)
+    const stabXrdPoolXrdVault = await queryAddresses({ addresses: [STAB_XRD_POOL_XRD_VAULT] });
+    const xrdAmountPool = stabXrdPoolXrdVault[0].details.balance.amount;
+
+    //add twice XRD value of pool to tvl (once for actual XRD side, and once to represent the STAB side which we can't properly get the value of otherwise)
+    api.add('resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd', xrdAmountPool * 2)
+}
+
+module.exports = {
+  radixdlt: { tvl },
+  misrepresentedTokens: true,
+  timetravel: false,
+};

--- a/projects/stab-protocol/index.js
+++ b/projects/stab-protocol/index.js
@@ -30,6 +30,7 @@ async function tvl(api) {
 }
 
 module.exports = {
+  methodology: 'Calculates TVL using the amount of collateral locked to borrow STAB using CDPs, and amount of STAB and XRD locked in the protocol-native STAB/XRD pool.',
   radixdlt: { tvl },
   misrepresentedTokens: true,
   timetravel: false,


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `volume` adapter please submit the PR [here](https://github.com/DefiLlama/adapters).
> - If you would like to add a `liquidations` adapter, please refer to [this readme document](https://github.com/DefiLlama/DefiLlama-Adapters/tree/main/liquidations) for details.

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
3. Please fill the form below  **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
4. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can  edit it there and put up a PR
5. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
6. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap

---
##### Name (to be shown on DefiLlama): STAB Protocol


##### Twitter Link: https://x.com/StabilisLabs


##### List of audit links if any: n/a


##### Website Link: https://ilikeitstable.com


##### Logo (High resolution, will be shown with rounded borders): https://ilikeitstable.com/images/stablogo.png


##### Current TVL: 228k USD


##### Treasury Addresses (if the protocol has treasury): n/a


##### Chain: Radix DLT


##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list): n/a


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed)(https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000): n/a


##### Short Description (to be shown on DefiLlama): The STAB Protocol allows for the overcollateralized borrowing of a stable asset called STAB. STAB's peg is not fixed, but variable, as an interest rate mechanism influences the peg to balance supply and demand.


##### Token address and ticker if any: resource_rdx1t40lchq8k38eu4ztgve5svdpt0uxqmkvpy4a2ghnjcxjtdxttj9uam ticker: STAB


##### Category (full list at https://defillama.com/categories) *Please choose only one: CDP


##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.): Morpher (and on-chain data to price assets that can always be redeemed for a certain amount of underlying assets)

##### Implementation Details: Briefly describe how the oracle is integrated into your project: Being a CDP protocol, collateral prices are obviously crucial. We store all prices of accepted collaterals in an oracle adapter and the protocol itself. The oracle adapter prices are updatable by anyone that has a Morpher subscription. It is updated by me personally whenever 1 hour passes without any updates OR the stored XRD price (only accepted collateral at the moment) deviates more than 1% from the actual price. After updating the prices in the oracle adapter they are pushable to the protocol.

We also accept LSULP, an asset that represents a user's stake in a pool of staked XRD (LSUs). This asset is always redeemable against an x amount of XRD, which can be easily fetched from ledger. This is done every time the XRD price is updated and this is how we price that asset.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
link to oracle adapter source code: https://github.com/Stabilis-Labs/STAB-oracle
link to oracle adapter on-ledger component: https://dashboard.radixdlt.com/component/component_rdx1cq7zsdqfh0mcwnutrevkz6wtml0vnav5fcmtf7rksmhk48urkyjg9c/summary

##### forkedFrom (Does your project originate from another project): n/a


##### methodology (what is being counted as tvl, how is tvl being calculated):
The STAB Protocol is a CDP type protocol where users can borrow STAB in return for locking up collateral. This collateral is the first source of TVL. The second source of TVL is the protocol-native STAB/XRD pool, which users can provide liquidity to.

The current accepted collaterals are XRD and LSULP (a token proving ownership of a pool of staked XRD tokens). We fetch the amount of collaterals and add these to the TVL. The amount of LSULP is substituted by its XRD equivalent as the LSULP price didn't seem to be fetched correctly yet. We get the XRD valuation of LSULP from our oracle adapter, which fetches from the on-ledger LSULP component. As said previously: LSULP is always redeemable against an x amount of XRD, which can be easily fetched from ledger, and this is where the data in our oracle adapter comes from.

The TVL contribution of the STAB/XRD pool is calculated by fetching the amount of XRD in the pool and assuming the other side is worth equally as much (it's a 50/50 pool). So, we add twice the amount of XRD in the pool to the TVL (to substitute for the STAB, which is not priced yet). Please change this if this is not appropriate, I'm not entirely sure of the TVL calculation etiquette ;).

##### Github org/user (Optional, if your code is open source, we can track activity):
org: https://github.com/Stabilis-Labs

and the STAB Protocol's repo specifically: https://github.com/Stabilis-Labs/STAB-Protocol