### PR TITLE
Add OpenDelta Perpetual Bond Token OPB

### DIFF
--- a/projects/OpenDeltaOPB.js
+++ b/projects/OpenDeltaOPB.js
@@ -1,0 +1,43 @@
+const { PublicKey } = require("@solana/web3.js");
+const { TOKEN_2022_PROGRAM_ID, getMint, amountToUiAmount } = require("@solana/spl-token");
+const { getConnection } = require("../helper/solana"); 
+
+const OPB_MINT_ADDRESS = new PublicKey("opbrKSFxFXRHNg75xjpEAbJ5R6e6GYZ6QKEqdvcBq7c");
+
+async function tvl() {
+  const connection = getConnection();
+
+  // Placeholder for a signing-account which need to be setup by DeFiLlama team
+  const payer = null; // Replace `null` with the account configured by DeFiLlama to allow access for `amountToUiAmount`, ref. line 19
+
+  // Fetch OPB token mint information
+  const mintInfo = await getMint(connection, OPB_MINT_ADDRESS, undefined, TOKEN_2022_PROGRAM_ID);
+  const supply = Number(mintInfo.supply);
+  const decimals = mintInfo.decimals;
+
+  // Retrieve the UI amount for 1 OPB in USD terms
+  const uiAmount = await amountToUiAmount(
+    connection,
+    payer,
+    OPB_MINT_ADDRESS,
+    1_000_000_000n,
+    TOKEN_2022_PROGRAM_ID
+  );
+  const OPBPrice = Number(uiAmount);
+
+  // Calculate TVL in USD
+  const tvl = (supply * OPBPrice) / Math.pow(10, decimals);
+
+  // Return TVL as USD
+  return {
+    usd: tvl,
+  };
+}
+
+module.exports = {
+  timetravel: false,
+  methodology: "TVL is calculated by multiplying OPB token supply by the current USD value of 1.0 OPB. Initially worth $1.0, 1.0 OPB now reflects its increased value from accrued interest, derived via amountToUiAmount using the Interest Bearing extension.",
+  solana: {
+    tvl,
+  },
+};


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
OpenDelta Perpetual Bond (OPB)


##### Twitter Link:

[https://x.com/opendelta_](https://x.com/opendelta_)


##### List of audit links if any:


##### Website Link:
https://www.opendelta.com/
https://app.opendelta.com/dashboard/position


##### Logo (High resolution, will be shown with rounded borders):
https://drive.google.com/file/d/1KKVTMjnbsztgCy1xhKQKCu03pXUolkvT/view?usp=sharing


##### Current TVL:
$5.03M


##### Treasury Addresses (if the protocol has treasury):


##### Chain:
Solana


##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): 


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): 


##### Short Description (to be shown on DefiLlama):
OpenDelta's perpetual bond (OPB) is created by hedging Bitcoin collateral across a variety of global derivatives exchanges in a trust-minimized way. This process creates a position that’s stable in dollar terms, protects the holder against downside risk, and earns continuous yield from the derivatives market funding rate.

##### Token address and ticker if any:
Address: opbrKSFxFXRHNg75xjpEAbJ5R6e6GYZ6QKEqdvcBq7c
Ticker: OPB


##### Category (full list at https://defillama.com/categories) *Please choose only one:
Basis Trading

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
##### Implementation Details: Briefly describe how the oracle is integrated into your project:
##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

##### forkedFrom (Does your project originate from another project):


##### methodology (what is being counted as tvl, how is tvl being calculated):
The token contract is from the Solana Token2022 library and is of the type Interest Bearing extension. It carries on-chain information about historic and current yield rates. The TVL is calculated by multiplying OPB token supply with the current USD value of 1.0 OPB. The first ever minted OPB was worth $1.0. Due to this, the Token2022 IB helper function `amountToUiAmount` of 1.0 OPB reflects its increased value since the, which is the actual price in USD. 


##### Github org/user (Optional, if your code is open source, we can track activity):
The code is open source as the token is deployed using official Solana Token2022 library. It can be verified via inspection of the token contract at https://solscan.io/token/opbrKSFxFXRHNg75xjpEAbJ5R6e6GYZ6QKEqdvcBq7c

