### PR TITLE
update index.js of OpenDelta TVL adapter

### DIFF
--- a/projects/opendelta/index.js
+++ b/projects/opendelta/index.js
@@ -18,11 +18,11 @@ async function tvl(api) {
     const timeElapsedSinceLastUpdate = currentTimestamp - lastUpdateTimestamp
     const interestRate = currentRate / 1e4
     const interestRatePre = preUpdateAverageRate / 1e4
-    const ONE_YEAR = 365 * 24 * 60 * 60
-    const interestAccruedCurrent = interestRate * timeElapsedSinceLastUpdate / ONE_YEAR
-    const interestAccruedPre = interestRatePre * timeElapsed / ONE_YEAR
+    const ONE_YEAR = 365.24 * 24 * 60 * 60
+    const interestAccruedCurrent = Math.exp(interestRate * timeElapsedSinceLastUpdate / ONE_YEAR)
+    const interestAccruedPre = Math.exp(interestRatePre * timeElapsed / ONE_YEAR)
 
-    const computedSupply = supply * (1 + interestAccruedCurrent + interestAccruedPre)
+    const computedSupply = supply * (interestAccruedCurrent * interestAccruedPre)
     return computedSupply / Math.pow(10, decimals)
   }
 
@@ -31,7 +31,7 @@ async function tvl(api) {
 module.exports = {
   timetravel: false,
   misrepresentedTokens: true,
-  methodology: "TVL is calculated by multiplying OPB token supply by the current USD value of 1.0 OPB. Initially worth $1.0, 1.0 OPB now reflects its increased value from accrued interest, derived via amountToUiAmount using the Interest Bearing extension.",
+  methodology: "TVL is calculated by multiplying the OPB token supply by the current USD value of 1.0 OPB. Initially worth $1.0, 1.0 OPB now reflects its increased value from accrued interest, derived using amountToUiAmount approach of Solana Token2022 Interest Bearing extension.",
   solana: {
     tvl,
   },


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
OpenDelta Perpetual Bond (OPB)


##### Twitter Link:

[https://x.com/opendelta_](https://x.com/opendelta_)


##### List of audit links if any:


##### Website Link:
https://www.opendelta.com/
https://app.opendelta.com/dashboard/position


##### Logo (High resolution, will be shown with rounded borders):
https://drive.google.com/file/d/1KKVTMjnbsztgCy1xhKQKCu03pXUolkvT/view?usp=sharing


##### Current TVL:
$5.03M


##### Treasury Addresses (if the protocol has treasury):


##### Chain:
Solana


##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): 


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): 


##### Short Description (to be shown on DefiLlama):
OpenDelta's perpetual bond (OPB) is created by hedging Bitcoin collateral across a variety of global derivatives exchanges in a trust-minimized way. This process creates a position that’s stable in dollar terms, protects the holder against downside risk, and earns continuous yield from the derivatives market funding rate.

##### Token address and ticker if any:
Address: opbrKSFxFXRHNg75xjpEAbJ5R6e6GYZ6QKEqdvcBq7c
Ticker: OPB


##### Category (full list at https://defillama.com/categories) *Please choose only one:
Basis Trading

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
##### Implementation Details: Briefly describe how the oracle is integrated into your project:
##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

##### forkedFrom (Does your project originate from another project):


##### methodology (what is being counted as tvl, how is tvl being calculated):
The token contract is from the Solana Token2022 library and is of the type Interest Bearing extension. It carries on-chain information about historic and current yield rates. The TVL is calculated by multiplying OPB token supply with the current USD value of 1.0 OPB. The first ever minted OPB was worth $1.0. Due to this, the Token2022 IB helper function `amountToUiAmount` of 1.0 OPB reflects its increased value since then, which equals the current price in USD. 


##### Github org/user (Optional, if your code is open source, we can track activity):
The code is open source as the token is deployed using official Solana Token2022 library. It can be verified via inspection of the token contract at https://solscan.io/token/opbrKSFxFXRHNg75xjpEAbJ5R6e6GYZ6QKEqdvcBq7c