### PR TITLE
Fix predict.fun TVL calculation

### DIFF
--- a/projects/predict-fun/index.js
+++ b/projects/predict-fun/index.js
@@ -2,7 +2,7 @@ const ADDRESSES = require('../helper/coreAssets.json')
 const { sumTokensExport } = require('../helper/unwrapLPs');
 
 module.exports = {
-  polygon: {
+  blast: {
     tvl: sumTokensExport({ owners: [
       '0xE1A2E68C401378050fdba9704FA8BCb1f72b98f4',
       '0x8F9C9f888A4268Ab0E2DDa03A291769479bAc285'

--- a/projects/predict-fun/index.js
+++ b/projects/predict-fun/index.js
@@ -1,5 +1,5 @@
-const ADDRESSES = require('./helper/coreAssets.json')
-const { sumTokensExport } = require('./helper/unwrapLPs');
+const ADDRESSES = require('../helper/coreAssets.json')
+const { sumTokensExport } = require('../helper/unwrapLPs');
 
 module.exports = {
   polygon: {

--- a/projects/predict-fun/index.js
+++ b/projects/predict-fun/index.js
@@ -1,55 +1,12 @@
-const { graphQuery } = require('../helper/http')
-const ADDRESSES = require('../helper/coreAssets.json')
+const ADDRESSES = require('./helper/coreAssets.json')
+const { sumTokensExport } = require('./helper/unwrapLPs');
 
-const config = {
-  blast: 'https://graphql.predict.fun/graphql'
+module.exports = {
+  polygon: {
+    tvl: sumTokensExport({ owners: [
+      '0xE1A2E68C401378050fdba9704FA8BCb1f72b98f4',
+      '0x8F9C9f888A4268Ab0E2DDa03A291769479bAc285'
+    ], tokens: [ADDRESSES.blast.USDB]})
+  },
+  methodology: `TVL is the total quantity of USDB held in the conditional tokens contract as well as USDB collateral submitted to every predict.fun market ever opened - once the markets resolve, participants are able to withdraw their share given the redemption rate and their input stake.`
 }
-
-
-const  query = (after) => `query {
-  categories (pagination: {
-    first: 100
-    ${after ? `after: "${after}"` : ''}
-  }) {
-    totalCount
-    pageInfo {
-      hasNextPage
-      startCursor
-      endCursor
-    }
-    edges {
-      node {
-        id
-        slug
-        title
-        statistics {
-          liquidityValueUsd
-          volume24hUsd
-          volumeTotalUsd
-        }
-      }
-    }
-  }
-}
-`
-
-Object.keys(config).forEach(chain => {
-  const endpoint = config[chain]
-  module.exports[chain] = {
-    tvl: async (api) => {
-      const categories = []
-      let after = null
-      do {
-        const data = await graphQuery(endpoint, query(after))
-        categories.push(...data.categories.edges)
-        if (data.categories.pageInfo.hasNextPage) {
-          after = data.pageInfo.endCursor
-        }
-      } while (after)
-      const usd =  categories.reduce((tvl, category) => tvl + category.node.statistics.liquidityValueUsd, 0)
-      api.add(ADDRESSES.blast.USDB, usd * 1e18)
-    }
-  }
-})
-
-module.exports.timetravel = false


### PR DESCRIPTION
**NOTE**

##### methodology (what is being counted as tvl, how is tvl being calculated):

TVL is computed from on-chain data. The internal API is currently computing TVL via an internal Liquidity statistic which is unforuntately very incorrect.

In order to correct this we are deriving TVL from actual on-chain data.

**Note: I am unclear if the historical TVL will be adjusted correctly? Is there a way to recompute the history of the TVL here or is this going to have to reset the tvl calculations from now forward for example.**

Please let e know if anything else is needed, I didn't fill out other details as this is an adjustment, not adding a new project.