### PR TITLE
SwissBorg: Add new wallets

### DIFF
--- a/projects/swissborg/index.js
+++ b/projects/swissborg/index.js
@@ -111,11 +111,11 @@ const config = {
       '0x8F0d8b27bF808976Fa94f03e2230b4bca95bf3C4',
     ]
   },
-  injective: {
-    owners: [
-      'inj1wvhk7xhzf9kus9a4tpa6v8vhuqvm265rz7zd6n',
-    ]
-  }
+  // injective: {
+  //   owners: [
+  //     'inj1wvhk7xhzf9kus9a4tpa6v8vhuqvm265rz7zd6n',
+  //   ]
+  // }
 }
 
 module.exports = cexExports(config)

--- a/projects/swissborg/index.js
+++ b/projects/swissborg/index.js
@@ -47,6 +47,7 @@ const config = {
       '9qoUcyhKSWMbk6tqGUYQUpeosPcdUnJszG4eQKwfe4gL',
       'Fe7SEekiKygziaEGKxsDsgLVzrCfNvVBvAYsaJBwFA8s',
       'AR2ecEWY2vfsXmd4fUxc196LhbX5p8TnhvJg8t3fgYUN',
+      '7Sng9GTnkjjb8WTF2kYX8JWqGHHwJGk5Ke9639zREUAR',
     ],
   },
   polkadot: {
@@ -108,6 +109,11 @@ const config = {
   arbitrum: {
     owners: [
       '0x8F0d8b27bF808976Fa94f03e2230b4bca95bf3C4',
+    ]
+  },
+  injective: {
+    owners: [
+      'inj1wvhk7xhzf9kus9a4tpa6v8vhuqvm265rz7zd6n',
     ]
   }
 }


### PR DESCRIPTION
This PR updates the list of wallets owned by SwissBorg. New wallet addition: https://github.com/SwissBorg/pub/commit/41f8b6f960a2f8565cd978820e7c3b032dbc04ab