### PR TITLE
Added EOS xSat EVM adapter

### DIFF
--- a/projects/eos-exsat-evm/index.js
+++ b/projects/eos-exsat-evm/index.js
@@ -1,23 +1,13 @@
 const { post } = require('../helper/http')
+const {sumTokens} = require("../helper/chain/bitcoin");
+const bitcoinBook = require("../helper/bitcoin-book");
 
 async function tvl() {
-    return post('https://eos.greymass.com/v1/chain/get_table_rows', {
-        json: true,
-        code: "btc.xsat",
-        scope: "BTC",
-        table: "stat",
-        limit: "1",
-        reverse: false,
-        show_payer: false
-    }).then(response => {
-        return {
-            bitcoin: parseFloat(response.rows[0].supply.split(" ")[0])
-        }
-    })
+    return sumTokens({ owners: await bitcoinBook.exsatBridge() });
 }
 
 module.exports = {
-    methodology: `EOS ExSAT EVM TVL is achieved by querying the total available supply from the [btc.xsat] account. This supply fluctuates as users deposit and withdraw funds from the ExSAT EVM.`,
+    methodology: `EOS ExSAT EVM TVL is achieved by querying the total balance held in custody addresses on the BTC network that are bridged to the EOS ExSAT EVM network.`,
     eos: {
         tvl
     },

--- a/projects/eos-exsat-evm/index.js
+++ b/projects/eos-exsat-evm/index.js
@@ -1,0 +1,24 @@
+const { post } = require('../helper/http')
+
+async function tvl() {
+    return post('https://eos.greymass.com/v1/chain/get_table_rows', {
+        json: true,
+        code: "btc.xsat",
+        scope: "BTC",
+        table: "stat",
+        limit: "1",
+        reverse: false,
+        show_payer: false
+    }).then(response => {
+        return {
+            bitcoin: parseFloat(response.rows[0].supply.split(" ")[0])
+        }
+    })
+}
+
+module.exports = {
+    methodology: `EOS ExSAT EVM TVL is achieved by querying the total available supply from the [btc.xsat] account. This supply fluctuates as users deposit and withdraw funds from the ExSAT EVM.`,
+    eos: {
+        tvl
+    },
+}


### PR DESCRIPTION

##### Name (to be shown on DefiLlama):
EOS XSAT EVM

##### Twitter Link:
https://x.com/exsatnetwork

##### Website Link:
https://exsat.network/


##### Logo (High resolution, will be shown with rounded borders):
![ep6sQ44w_400x400](https://github.com/user-attachments/assets/308ae45b-3950-4b63-b61d-96830377fc4d)


##### Current TVL:
$27.45m

##### Chain:
EOS


##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): 
`eos`


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): 
1765


##### Short Description (to be shown on DefiLlama):
The amount of BTC that has been bridged over to the EOS network via the xSat BTC EVM. 

##### Token address and ticker if any:
`btc.xsat`
`BTC`


##### Category (full list at https://defillama.com/categories) *Please choose only one:
15 [Cross Chain](https://defillama.com/protocols/Cross%20Chain)

##### methodology (what is being counted as tvl, how is tvl being calculated):
EOS ExSAT EVM TVL is achieved by querying the total available supply from the [btc.xsat] account. This supply fluctuates as users deposit and withdraw funds from the ExSAT EVM.

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/exsat-network/contract-of-consensus
