### PR TITLE
Fix: Small fix Cian yield

### DIFF
--- a/projects/cian-yl/index.js
+++ b/projects/cian-yl/index.js
@@ -18,8 +18,6 @@ module.exports = {
 
 Object.keys(config).forEach((chain) => {
     module.exports[chain] = {
-        tvl: async (_, _b, _cb, { api }) => {
-            return api.erc4626Sum({ calls: config[chain], isOG4626: true });
-        },
+        tvl: async (api) =>  api.erc4626Sum({ calls: config[chain], isOG4626: true, permitFailure: true })
     };
 });


### PR DESCRIPTION
Adapter has not been updated for a week due to an issue with the `totalAssets` method call on the contract `0xd4Cc9b31e9eF33E392FF2f81AD52BE8523e0993b`. From Etherscan, we can see that the contract returns 0 on this method, which is likely blocking subsequent calls. A `permitFailure` has been added to prevent the code from being blocked