### PR TITLE
Fix: Luchadores (treasury)

### DIFF
--- a/projects/treasury/luchadores.js
+++ b/projects/treasury/luchadores.js
@@ -1,4 +1,5 @@
-const ADDRESSES = require('../helper/coreAssets.json')
+const ADDRESSES = require('../helper/coreAssets.json');
+const { blacklistedTokens_default } = require('../helper/solana');
 const { nullAddress, treasuryExports } = require("../helper/treasury");
 
 module.exports = treasuryExports({
@@ -19,6 +20,7 @@ module.exports = treasuryExports({
     ],
     owners: ['0xa715c8b17268f140D76494c12ec07B48218549C4'],
     ownTokens: ['0xF4435cC8b478d54313F04c956882BE3D9aCf9F6F'],
+    blacklistedTokens: ['0x3a94201a0b6c3593ad3b3e17e3dfce33da183514'],
     resolveLP: true,
   }
 })

--- a/projects/treasury/luchadores.js
+++ b/projects/treasury/luchadores.js
@@ -1,5 +1,4 @@
 const ADDRESSES = require('../helper/coreAssets.json');
-const { blacklistedTokens_default } = require('../helper/solana');
 const { nullAddress, treasuryExports } = require("../helper/treasury");
 
 module.exports = treasuryExports({


### PR DESCRIPTION
Added a blacklist: this token `0x3a94201a0b6c3593ad3b3e17e3dfce33da183514` on Base is a scam token that prevents the normal execution of Luchadores' adapter

[https://basescan.org/token/0x3a94201a0b6c3593ad3b3e17e3dfce33da183514](url)

![image](https://github.com/user-attachments/assets/ee3a4e87-7e12-4090-a41d-d66b753d05c6)

