### PR TITLE
Use string timestamps for start fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "useTokenLabels": "node utils/scripts/useTokenLabels.js",
     "biggest-files": "find ./projects -name '*.js' -not -path './projects/helper/*' -not -path './projects/curve/*' -not -path './projects/sigmao/*' -exec du -sh {} \\; | sort -rh | head -n 100",
     "check-bitcoin-duplicates": "node utils/scripts/checkBTCDupsv2.js",
+    "string-timestamp": "node utils/scripts/stringTimestamp.js",
     "postinstall": "echo 'run \"npm update @defillama/sdk\" if you want lastest sdk changes' "
   },
   "author": "",

--- a/projects/0x0dex/index.js
+++ b/projects/0x0dex/index.js
@@ -2,6 +2,6 @@ const { sumTokensExport, nullAddress } = require('../helper/unwrapLPs');
 const ETH_POOL_ADDRESS = "0x3d18AD735f949fEbD59BBfcB5864ee0157607616";
 
 module.exports = {
-    start: 1685386800, // 19/05/2023 @ 07:00pm UTC
+    start: '2023-05-29', // 19/05/2023 @ 07:00pm UTC
     ethereum: { tvl: sumTokensExport({ owner: ETH_POOL_ADDRESS, tokens: [nullAddress]}) },
 };

--- a/projects/0x_nodes/index.js
+++ b/projects/0x_nodes/index.js
@@ -50,7 +50,7 @@ module.exports = {
     ],
   methodology: ` Counts the number of wrapped native tokens in all yield strategies across all the chains the protocol is deployed on
   + staking counts the number of BIOS tokens staked in the kernels across all the chains (PFA: Protocol Fee Accruals by staking assets)`,
-  start: 1633046400, // Friday 1. October 2021 00:00:00 GMT
+  start: '2021-10-01', // Friday 1. October 2021 00:00:00 GMT
   ...tvlExports,
   deadFrom: 1659527340,
 }

--- a/projects/0xacid/index.js
+++ b/projects/0xacid/index.js
@@ -4,7 +4,7 @@ const ACID_STAKING = "0x00a842038a674616f6a97e62f80111a536778282";
 const ACID_TOKEN = "0x29C1EA5ED7af53094b1a79eF60d20641987c867e";
 
 module.exports = {
-  start: 1678417200,
+  start: '2023-03-10',
   arbitrum: {
     tvl: () => ({}),
     staking: stakingUnknownPricedLP(ACID_STAKING, ACID_TOKEN, "arbitrum", "0x73474183a94956cd304c6c5a504923d8150bd9ce")

--- a/projects/1155Tech/index.js
+++ b/projects/1155Tech/index.js
@@ -4,7 +4,6 @@ const MARKET_1155TECH_CONTRACT = '0x33b77fAf955Ed3eDAf939ae66C4D7a2D78bc30C6';
 
 module.exports = {
   methodology: 'Value of all Keys across all art markets is TVL in the protocol',
-  start: 7280880,
   canto: {
     tvl: sumTokensExport({ owner: MARKET_1155TECH_CONTRACT, tokens: [ADDRESSES.canto.NOTE] })
   }

--- a/projects/3xcalibur/index.js
+++ b/projects/3xcalibur/index.js
@@ -2,7 +2,7 @@ const { uniTvlExport } = require("../helper/calculateUniTvl.js");
 
 module.exports = {
   misrepresentedTokens: true,
-    start: 1667689200,
+    start: '2022-11-06',
   arbitrum: {
     tvl: uniTvlExport("0xD158bd9E8b6efd3ca76830B66715Aa2b7Bad2218", "arbitrum", undefined, undefined, { hasStablePools: true, useDefaultCoreAssets: true, }),
   },

--- a/projects/88mph/index.js
+++ b/projects/88mph/index.js
@@ -135,6 +135,6 @@ tvlExports.ethereum.staking = staking("0x1702F18c1173b791900F81EbaE59B908Da8F689
 
 module.exports = {
   methodology: `Using the addresses for the fixed interest rate bonds we are able to find the underlying tokens held in each address. Once we have the underlying token we then get the balances of each of the tokens. For the CRV tokens used "CRV:STETH" for example, the address is replaced with the address of one of the tokens. In the example at hand the address is replaced with the "WETH" address so that the price can be calculated.`,
-  start: 1606109629, // Monday, November 23, 2020 5:33:49 AM GMT
+  start: '2020-11-23', // Monday, November 23, 2020 5:33:49 AM GMT
   ...tvlExports
 }

--- a/projects/BankOfCronos/index.js
+++ b/projects/BankOfCronos/index.js
@@ -1,14 +1,5 @@
-const ADDRESSES = require('../helper/coreAssets.json')
-const { sumTokensExport } = require("../helper/unwrapLPs");
-
-const BOC_TREASURY_ADDRESS = "0xBacF28BF21B374459C738289559EF89978D08102";
-const CUSD_ADDRESS = "0x26043Aaa4D982BeEd7750e2D424547F5D76951d4";
-const USDC_ADDRESS = ADDRESSES.cronos.USDC;
-
 module.exports = {
-  start: 6949784,
   cronos: {
-    // tvl: sumTokensExport({ owner: BOC_TREASURY_ADDRESS, tokens: [CUSD_ADDRESS, USDC_ADDRESS]}),
     tvl: () => 0
   },
   methodology:

--- a/projects/BankofCronos-Loans/index.js
+++ b/projects/BankofCronos-Loans/index.js
@@ -9,7 +9,6 @@ async function tvl(api) {
 }
 
 module.exports = {
-  start: 6949784,
   cronos: {
     tvl,
   },

--- a/projects/DeNet/index.js
+++ b/projects/DeNet/index.js
@@ -7,7 +7,7 @@ const owners = [
 ]
 
 module.exports = {
-  start: 1691761595, // Friday, 11-Aug-23 13:46:35 UTC	
+  start: '2023-08-11', // Friday, 11-Aug-23 13:46:35 UTC	
   methodology: "Total amount of DE tokens used for DeNet storage payments",
     
   polygon: {

--- a/projects/FeeFree/index.js
+++ b/projects/FeeFree/index.js
@@ -17,7 +17,7 @@ const config = {
 }
 
 module.exports = {
-  start: 1714060800, // Apr 26 2024
+  start: '2024-04-25', // Apr 26 2024
 }
 
 Object.keys(config).forEach(chain => {

--- a/projects/LamaMiner/index.js
+++ b/projects/LamaMiner/index.js
@@ -9,7 +9,7 @@ const LP_LQDX_LAMA = "0x3a74922803415Dfc43c0030d47707b20f4c1b05d"
 module.exports = {
   misrepresentedTokens: true,
   methodology: 'counts the number of LAMA tokens in the Lama Miner contract.',
-  start: 1711962980,
+  start: '2024-04-01',
   avax: {
     tvl: sumTokensExport({ owner: LAMA_MINER_CONTRACT, tokens: [LAMA_TOKEN_CONTRACT], lps: [LP_LAMA_WAVAX], useDefaultCoreAssets: true, }),
     staking: sumTokensExport({ owner: LAMA_STAKING_CONTRACT, tokens: [LAMA_TOKEN_CONTRACT], lps: [LP_LAMA_WAVAX, LP_LQDX_LAMA], useDefaultCoreAssets: true, }) 

--- a/projects/MantaTimeLockContract/index.js
+++ b/projects/MantaTimeLockContract/index.js
@@ -6,7 +6,6 @@ const TIME_LOCK_CONTRACT = '0x8Bb6CaE3f1CADA07Dd14bA951e02886ea6bBA183';
 
 module.exports = {
   methodology: 'counts the number of (MANTA OR STONE) in the time lock contract.',
-  start: 1497066,
   manta: {
     tvl: sumTokensExport({ owner: TIME_LOCK_CONTRACT, tokens: [MANTA, STONE] }),
   }

--- a/projects/MeowMiner/index.js
+++ b/projects/MeowMiner/index.js
@@ -5,7 +5,7 @@ const LP_MEOW_WAVAX = "0xbbf8e4b9AD041edE1F5270CAf5b7B41F0e55f719"
 
 module.exports = {
   methodology: 'counts the number of MEOW tokens in the Meow Miner contract.',
-  start: 1710293916,
+  start: '2024-03-13',
   avax: {
     tvl: sumTokensExport({ owner: MEOW_MINER_CONTRACT, tokens: [MEOW_TOKEN_CONTRACT], lps: [LP_MEOW_WAVAX], useDefaultCoreAssets: true, }),
   }

--- a/projects/MorpheusAI/index.js
+++ b/projects/MorpheusAI/index.js
@@ -16,7 +16,7 @@ module.exports = {
   timetravel: true,
   misrepresentedTokens: false,
   methodology: 'Calculates TVL based on stETH deposits in the project contract.',
-  start: 1707378815,  // Feb-08-2024 07:33:35 AM UTC in Unix timestamp
+  start: '2024-02-08',  // Feb-08-2024 07:33:35 AM UTC in Unix timestamp
   ethereum: {
     tvl
   },

--- a/projects/aboard-exchange/index.js
+++ b/projects/aboard-exchange/index.js
@@ -6,7 +6,7 @@ const { sumTokensExport } = require('../helper/unwrapLPs');
 
 module.exports = {
   methodology: "TVL is equal to users' deposits minus withdrawals",
-  start: 1641625200, // Jan-08-2022 07:00:00 AM +UTC
+  start: '2022-01-08', // Jan-08-2022 07:00:00 AM +UTC
 }
 
 const config = {

--- a/projects/acala-euphrates/index.js
+++ b/projects/acala-euphrates/index.js
@@ -16,7 +16,7 @@ async function tvl(api) {
 
 module.exports = {
   misrepresentedTokens: true,
-  start: 1695657600,
+  start: '2023-09-25',
   methodology: 'total ldot and tdot locked in the euphrates contract',
   acala: {
     tvl,

--- a/projects/acoconut/index.js
+++ b/projects/acoconut/index.js
@@ -32,5 +32,5 @@ module.exports = {
   bsc:{
     tvl: bsc
   },
-  start: 1600185600,    // 09/16/2020 @ 12:00am (UTC+8)
+  start: '2020-09-15',    // 09/16/2020 @ 12:00am (UTC+8)
 };

--- a/projects/algem/index.js
+++ b/projects/algem/index.js
@@ -13,7 +13,6 @@ async function tvl(timestamp, block, chainBlocks) {
 
 module.exports = {
             methodology: 'counts the number of ASTR tokens locked in Liquid Staking contract',
-    start: 1502025,
     astar: {
       tvl,
     }

--- a/projects/alien-finance/index.js
+++ b/projects/alien-finance/index.js
@@ -6,7 +6,7 @@ module.exports = {
   blast: {
     tvl, borrowed,
   },
-  start: 1709630412,
+  start: '2024-03-05',
 };
 
 async function tvl(api) {

--- a/projects/alkemi/index.js
+++ b/projects/alkemi/index.js
@@ -71,6 +71,6 @@ async function tvl(timestamp, block) {
 
 module.exports = {
   methodology: "TVL consists of Assets (ETH, WBTC, Stablecoins) deposited in Alkemi Earn, Assets (ETH, WBTC, Stablecoins) deposited in Alkemi Earn Open, and does NOT currently consider assets borrowed",
-  start: 1609380306,        // unix timestamp (utc 0) specifying when the project began, or where live data begins
+  start: '2020-12-31',        // unix timestamp (utc 0) specifying when the project began, or where live data begins
   ethereum: { tvl }                       // tvl adapter
 };

--- a/projects/allspark/index.js
+++ b/projects/allspark/index.js
@@ -3,7 +3,6 @@ const {staking} = require("../helper/staking");
 
 module.exports = {
     methodology: 'allspark counts the staking values as tvl',
-    start: 1690371,
     zklink:{
         tvl: staking(
             ["0xD06B5A208b736656A8F9cD04ed43744C738BD8A9"],

--- a/projects/alpaca-finance-lend/index.js
+++ b/projects/alpaca-finance-lend/index.js
@@ -2,7 +2,7 @@ const { tvl, borrowed } = require("./lend");
 
 // node test.js projects/alpaca-finance-lend/index.js
 module.exports = {
-  start: 1602054167,
+  start: '2020-10-07',
   methodology: "Sum floating balance and vaultDebtValue in each vault",
   bsc: { tvl, borrowed, },
   fantom: { tvl, borrowed, },

--- a/projects/alpaca-finance-v2/index.js
+++ b/projects/alpaca-finance-v2/index.js
@@ -1,7 +1,7 @@
 const { lendingTvl, borrowTvl } = require("./moneyMarket");
 
 module.exports = {
-  start: 1602054167,
+  start: '2020-10-07',
   methodology: "Sum floating balance and borrow for each token",
   bsc: {
     tvl: lendingTvl,

--- a/projects/alpaca-finance/index.js
+++ b/projects/alpaca-finance/index.js
@@ -5,7 +5,7 @@ const { calxALPACAtvl } = require('./xalpaca');
 const aExports = require('../alpaca-finance-lend');
 
 module.exports = {
-  start: 1602054167,
+  start: '2020-10-07',
   bsc: {
     tvl: sdk.util.sumChainTvls([calLyfTvl, calAusdTvl, aExports.bsc.tvl]),
     staking: calxALPACAtvl,

--- a/projects/alpha-homora/index.js
+++ b/projects/alpha-homora/index.js
@@ -26,7 +26,7 @@ module.exports = {
   optimism:{
     tvl: tvlV2Onchain
   },
-  start: 1602054167, // unix timestamp (utc 0) specifying when the project began, or where live data begins
+  start: '2020-10-07', // unix timestamp (utc 0) specifying when the project began, or where live data begins
   hallmarks: [
     [1613178000, "37M exploit"], // Feb 13, 2021
     [1626220800, "Upgrade to V2 on ETH"], // July 14, 2021 00:00 UTC

--- a/projects/alternity/index.js
+++ b/projects/alternity/index.js
@@ -6,7 +6,7 @@ const STAKING_ADDRESS = "0x424891f1D6D4De5c07B6E3F74B3709D6BD9E77ea";
 const ALTR_ADDRESS = "0xD1ffCacFc630CE68d3cd3369F5db829a3ed01fE2"
 
 module.exports = {
-  start: 1692423851,
+  start: '2023-08-19',
   ethereum: {
     tvl: getLiquityTvl('0x51c014510A5AdA43408b40D49eF52094014ef3A7'),
     staking: staking(STAKING_ADDRESS, ALTR_ADDRESS)

--- a/projects/altr-lend/index.js
+++ b/projects/altr-lend/index.js
@@ -17,7 +17,7 @@ async function borrowed(api) {
 
 module.exports = {
   methodology: "Determined by querying from our public TheGraph the total USD value of all active loans",
-  start: 1707874007,
+  start: '2024-02-14',
   polygon: {
     tvl: () => ({}),
     borrowed,

--- a/projects/amped/index.js
+++ b/projects/amped/index.js
@@ -6,7 +6,7 @@ const phoenixStakingAddress = '0x3c9586567a429BA0467Bc63FD38ea71bB6B912E0';
 const phoenixAmpAddress = '0xca7F14F14d975bEFfEe190Cd3cD232a3a988Ab9C';
 
 module.exports = {
-  start: 1717674114,
+  start: '2024-06-06',
   lightlink_phoenix: {
     staking: staking(phoenixStakingAddress, phoenixAmpAddress),
     tvl: gmxExports({ vault: phoenixVaultAddress, })

--- a/projects/anyhedge/index.js
+++ b/projects/anyhedge/index.js
@@ -48,7 +48,7 @@ async function tvl({timestamp}) {
 
 module.exports = {
   methodology: "Scrape the blockchain and filter for spent transaction outputs that match the contract's input script template. Aggregate them to compute TVL. The TVL data lags by contract duration since contracts are secret until settled. So, TVL at the current time will always be 0 and can only be calculated in retrospect and stats back-filled when contracts are revealed. For this reason, the code cuts-off the data at 91 days ago. See here for more details: https://gitlab.com/0353F40E/anyhedge-stats/-/blob/master/readme.md",
-  start: 1654787405,
+  start: '2022-06-09',
   bitcoincash: { tvl },
   hallmarks: [
     [1681725240, "BCH Bull public release (AnyHedge v0.11 contract)"],

--- a/projects/ape-fi/index.js
+++ b/projects/ape-fi/index.js
@@ -42,7 +42,6 @@ module.exports = {
     tvl,
     staking: staking(apeAPE, APE),
   },
-  start: 15688276,
   methodology:
     "Counts liquidity as the Collateral APE and USDC & FRAX on all AMOs through their contracts",
 };

--- a/projects/apollox/index.js
+++ b/projects/apollox/index.js
@@ -65,7 +65,7 @@ async function bscTVL(timestamp, _block, { bsc: block }) {
 }
 
 module.exports = {
-  start: 1640100600, // 12/21/2021 @ 15:30pm (UTC)
+  start: '2021-12-21', // 12/21/2021 @ 15:30pm (UTC)
   bsc: {
     tvl: bscTVL,
     staking: stakings([stakingContract_APX, daoContract], TOKEN_APX),

--- a/projects/applepie/index.js
+++ b/projects/applepie/index.js
@@ -6,7 +6,6 @@ const TOKENS = ["0x574f75bc522CB42ec2365dc54485D471f2eFb4B6"]
 module.exports = {
   methodology:
     "First Crosschain Pool as a Service Miner. Twist to generate 10%/daily reward.",
-  start: 35011373,
   bsc: {
     tvl: sumTokensExport({
       tokensAndOwners: [

--- a/projects/aqua-network/index.js
+++ b/projects/aqua-network/index.js
@@ -32,7 +32,7 @@ async function tvl(api) {
 }
 
 module.exports = {
-  start: 1719792000,
+  start: '2024-07-01',
   misrepresentedTokens: true,
   methodology:
     'counts the liquidity of the Pools on AMM, data is pulled from the Aquarius API.',

--- a/projects/aqua-patina/index.js
+++ b/projects/aqua-patina/index.js
@@ -9,7 +9,6 @@ async function tvl(api) {
 module.exports = {
   doublecounted: true,
   methodology: 'Returns the ETH equivalent value of the total supply of apETH tokens on Ethereum. This is calculated by the multiplier used in the contract to determine the ETH value of each token when minting apETH.',
-  start: 20937454,
   ethereum: {
     tvl,
   }

--- a/projects/aquaprotocol/index.js
+++ b/projects/aquaprotocol/index.js
@@ -5,7 +5,7 @@ const AQUA_ADDRESS = 'EQAWDyxARSl3ol2G1RMLMwepr3v6Ter5ls3jiAlheKshgg0K'
 
 module.exports = {
   methodology: 'Total amount of collateral locked in the Aqua Protocol (EQAWDyxARSl3ol2G1RMLMwepr3v6Ter5ls3jiAlheKshgg0K)',
-  start: 1726506000,
+  start: '2024-09-16',
   ton: {
     tvl: sumTokensExport({ owner: AQUA_ADDRESS, tokens: [ADDRESSES.null]}),
   }

--- a/projects/arbor-finance/index.js
+++ b/projects/arbor-finance/index.js
@@ -18,7 +18,6 @@ async function tvl(api) {
 
 module.exports = {
   methodology: "Sum the collateral value of active Arbor Finance bonds.",
-  start: 14906553,
   ethereum: {
     tvl,
   },

--- a/projects/arcadia-finance-v2/index.js
+++ b/projects/arcadia-finance-v2/index.js
@@ -91,7 +91,7 @@ module.exports = {
   methodology:
     "TVL is calculated as the sum of all Account values and the available balance in the liquidity pools. Assets are not double counted.",
   base: { tvl },
-  start: 1711389600, // Mon Mar 25 2024 18:00:00 GMT+0000
+  start: '2024-03-25', // Mon Mar 25 2024 18:00:00 GMT+0000
   hallmarks: [
     [Math.floor(new Date("2024-04-03") / 1e3), "Points program announced."],
   ],

--- a/projects/arcadia-finance/index.js
+++ b/projects/arcadia-finance/index.js
@@ -5,7 +5,7 @@ module.exports = {
     "TVL includes ERC-20 tokens that have been supplied as collateral as well as ERC-20 tokens that are supplied by liquidity providers.",
   optimism: { tvl },
   ethereum: { tvl },
-  start: 1686391200, // Jun 10 2023 10:00:00 GMT+0000
+  start: '2023-06-10', // Jun 10 2023 10:00:00 GMT+0000
   hallmarks: [
     [Math.floor(new Date('2023-07-10')/1e3), 'Protocol was exploited.'],
   ],

--- a/projects/arcanum/index.js
+++ b/projects/arcanum/index.js
@@ -20,7 +20,6 @@ const SPI_ASSETS_CONTRACTS = [
 
 module.exports = {
     methodology: 'counts the quantities of all tokens in all multipool contracts.',
-    start: 1000235,
     arbitrum: {
         tvl: sumTokensExport({ ownerTokens: [[ARBI_ASSETS_CONTRACTS, ARBI_CONTRACT], [SPI_ASSETS_CONTRACTS, SPI_CONTRACT]] })
     }

--- a/projects/astherus/index.js
+++ b/projects/astherus/index.js
@@ -7,7 +7,7 @@ const config = {
 }
 
 module.exports = {
-  start: 1706716800, // 02/01/2024 @ 00:00:00pm (UTC)
+  start: '2024-01-31', // 02/01/2024 @ 00:00:00pm (UTC)
 }
 
 Object.keys(config).forEach(chain => {

--- a/projects/astra-dao/index.js
+++ b/projects/astra-dao/index.js
@@ -24,7 +24,6 @@ async function tvl(api) {
 }
 
 module.exports = {
-  start: 17243078,
   ethereum: {
     tvl,
   },

--- a/projects/astriddao/index.js
+++ b/projects/astriddao/index.js
@@ -199,7 +199,6 @@ async function tvl(ts, _block, chainBlocks ) {
 }
 
 module.exports = {
-    start: 915830,
   methodology: "Total locked collateral assets (in ERC-20 form) in ActivePool and DefaultPool, plus total staked BAI in StabilityPool",
   astar: {
     tvl,

--- a/projects/atlendis-v2/index.js
+++ b/projects/atlendis-v2/index.js
@@ -63,7 +63,7 @@ async function borrowed(api) {
 }
 
 module.exports = {
-  start: 1686642643,
+  start: '2023-06-13',
   hallmarks: [
     [1702367571, "Launch of Fluna V2 Pool on Polygon"],
     [1713855195, "Launch of Arjan pool on Mode Network"],

--- a/projects/auctus/index.js
+++ b/projects/auctus/index.js
@@ -94,6 +94,6 @@ async function tvl(api) {
 }
 
 module.exports = {
-  start: 1590014400,   // 05/20/2020 @ 08:10:40pm (UTC)
+  start: '2020-05-21',   // 05/20/2020 @ 08:10:40pm (UTC)
   ethereum: { tvl }
 }

--- a/projects/autotronic/index.js
+++ b/projects/autotronic/index.js
@@ -1,6 +1,6 @@
 const { getUniTVL } = require('../helper/unknownTokens')
 module.exports = {
-  start: 1692842880,
+  start: '2023-08-24',
   base: {
     tvl: getUniTVL({ factory: '0x55b3409335B81E7A8B7C085Bbb4047DDc23f7257', useDefaultCoreAssets: true, }),
   },

--- a/projects/awaken/index.js
+++ b/projects/awaken/index.js
@@ -38,7 +38,7 @@ const v2graph = getChainTvl({
 module.exports = {
   misrepresentedTokens: true,
   methodology: `Counts the tokens locked on AMM pools, pulling the data from the 'AElfIndexer_Swap' subgraph`,
-  start: 1706745600,
+  start: '2024-02-01',
   aelf: {
     tvl: v2graph("aelf"),
   },

--- a/projects/axe/index.js
+++ b/projects/axe/index.js
@@ -3,7 +3,7 @@ module.exports = {
     [1648765747, "Rug Pull"]
   ],
     deadFrom: 1648765747,
-    start: 1637036516, // 16 Nov 2021
+    start: '2021-11-16', // 16 Nov 2021
     ethereum: {
       tvl: () => ({}),
       staking: () => ({}),

--- a/projects/babylon/index.js
+++ b/projects/babylon/index.js
@@ -13,7 +13,7 @@ async function tvl(api) {
 
 module.exports = {
   methodology: 'TVL is fetched from Babylon’s Staking API and represents the total Bitcoin locked in the Babylon staking protocol.',
-  start: 1724351485,
+  start: '2024-08-22',
   timetravel: false,
   bitcoin: {
     tvl,

--- a/projects/bagel-finance/index.js
+++ b/projects/bagel-finance/index.js
@@ -221,6 +221,6 @@ async function tvl(timestamp, ethBlock, chainBlocks) {
 }
 
 module.exports = {
-  start: 1602054167,
+  start: '2020-10-07',
   bsc: { tvl },
 };

--- a/projects/bancor/index.js
+++ b/projects/bancor/index.js
@@ -42,7 +42,7 @@ async function generateCallsByBlockchain(api) {
 }
 
 module.exports = {
-  start: 1501632000,  // 08/02/2017 @ 12:00am (UTC)
+  start: '2017-08-02',  // 08/02/2017 @ 12:00am (UTC)
   ethereum: {
     tvl: generateCallsByBlockchain,
   },

--- a/projects/bancor/v3.js
+++ b/projects/bancor/v3.js
@@ -12,7 +12,7 @@ async function addV3Balance(api) {
 }
 
 module.exports = {
-  start: 1650283200,  // 18/04/2022 @ 1:00pm (UTC)
+  start: '2022-04-18',  // 18/04/2022 @ 1:00pm (UTC)
   methodology: `Counts the tokens in the Master Vault Contract.`,
   ethereum: {
     tvl: addV3Balance,

--- a/projects/bao-baskets/index.js
+++ b/projects/bao-baskets/index.js
@@ -20,7 +20,7 @@ const basketTvl = async (api) => {
 }
 
 module.exports = {
-  start: 1640995200, // Jan 1 2022 00:00:00 GMT+0000
+  start: '2022-01-01', // Jan 1 2022 00:00:00 GMT+0000
   ethereum: {
     tvl: basketTvl,
     pool2: sumTokensExport({

--- a/projects/base3d/index.js
+++ b/projects/base3d/index.js
@@ -10,5 +10,4 @@ module.exports = {
     tvl,
   },
   methodology: 'Calculates TVL by checking the ETH balance of the main contract via the totalEthereumBalance function.',
-  start: 3331748,
 };

--- a/projects/basemax-finance/index.js
+++ b/projects/basemax-finance/index.js
@@ -5,7 +5,6 @@ const LP = '0xd2eb1de935fe66501aece023b0437fa7b9c40a25'
 
 module.exports = {
   methodology: "Counts USDC deposited to trade and to mint BLP. Staking counts BSM and esBSM deposited to earn esBSM",
-  start: 1700488,
   base: {
     tvl: staking("0xEDFFF5d0C68cFBd44FA12659Fd9AD55F04748874", ADDRESSES.base.USDbC),
     pool2: sumTokensExport({ owner: "0xe2cb504d51fd16d8bdf533c58553ed3f4f755f00", tokens: [LP], useDefaultCoreAssets: true, }),

--- a/projects/basin/index.js
+++ b/projects/basin/index.js
@@ -23,7 +23,7 @@ async function tvl(api) {
 
 module.exports = {
   methodology: "Counts the value of token reserves inside all deployed Wells.",
-  start: 1692797303,
+  start: '2023-08-23',
   ethereum: { tvl },
   arbitrum: { tvl }
 };

--- a/projects/baton/index.js
+++ b/projects/baton/index.js
@@ -36,7 +36,6 @@ module.exports = {
   misrepresentedTokens: true,
   methodology:
     "Sums the total staked in baton farms and the total amount of tokens deposited as yield farming rewards.",
-  start: 17411300,
   ethereum: {
     tvl
   }

--- a/projects/bean/index.js
+++ b/projects/bean/index.js
@@ -314,7 +314,7 @@ async function pool2(api) {
 
 module.exports = {
   methodology: "Counts the value of deposited Beans and LP tokens in the silo.",
-  start: 1628287657,
+  start: '2021-08-07',
   ethereum: {
     tvl: () => ({}),
     pool2,

--- a/projects/bepro/index.js
+++ b/projects/bepro/index.js
@@ -20,7 +20,6 @@ const config = {
 
 module.exports = {
     methodology: 'counts the number of BEPRO tokens on Moonbeam Network contracts',
-    start: 1000235,
 };
 
 Object.keys(config).forEach(chain => {

--- a/projects/betswirl/index.js
+++ b/projects/betswirl/index.js
@@ -3,7 +3,7 @@ const { sumTokens2 } = require("../helper/unwrapLPs.js")
 
 module.exports = {
   methodology: "TVL counts BETS tokens or 8020 LP deposited on the Staking contracts.",
-  start: 1687715559,
+  start: '2023-06-25',
   bsc: {
     staking: staking('0x20Df34eBe5dCB1082297A18BA8d387B55fB975a0', '0x94025780a1aB58868D9B2dBBB775f44b32e8E6e5'),
   },

--- a/projects/bit-reserve/index.js
+++ b/projects/bit-reserve/index.js
@@ -7,7 +7,7 @@ async function tvl(api) {
 
 module.exports = {
   methodology: 'The total value of BTC in the rBTC contract on the BIT-RESERVE platform.',
-  start: 1715917267,
+  start: '2024-05-17',
   core: {
     tvl
   }

--- a/projects/bitlend/index.js
+++ b/projects/bitlend/index.js
@@ -15,7 +15,6 @@ const bTRX = '0xE73fb086C7Aa48b83372b028f0f35B06E77C7511'
 
 module.exports = {
   methodology: 'Total staked tokens in Bitlend protocol.',
-  start: 14069919,
   bittorrent: {
     tvl: sumTokensExport({
       chain: CHAIN,

--- a/projects/blex/index.js
+++ b/projects/blex/index.js
@@ -12,7 +12,7 @@ const contracts = [
 const tokens = [ADDRESSES.arbitrum.USDT];
 
 module.exports = {
-  start: 1691240820,
+  start: '2023-08-05',
   arbitrum: { tvl: sumTokensExport({ tokens, owners: contracts }) },
   hallmarks: [[1691240820, "Blex Protocol Deployed on Arbitrum"]],
 };

--- a/projects/bluebit/index.js
+++ b/projects/bluebit/index.js
@@ -29,7 +29,6 @@ const tvl = async (timestamp, block, chainBlocks) => {
 
 module.exports = {
   methodology: "The vaults on https://bluebit.fi are included in TVL.",
-      start: 62936418,
   aurora: {
     tvl: tvl,
     staking: staking(veToken, token),

--- a/projects/bonqdao/index.js
+++ b/projects/bonqdao/index.js
@@ -69,7 +69,6 @@ module.exports = {
   ],
   deadFrom: '2023-02-01',
   methodology: 'Summation of the collateral deposited in BonqDAO Troves (personal lending vaults)',
-  start: 36884903,
   polygon: {
     tvl,
     staking: stakings([BNQ_STAKING_CONTRACT], BNQ),

--- a/projects/bracketX/index.js
+++ b/projects/bracketX/index.js
@@ -14,7 +14,7 @@ async function tvl(api) {
 
 module.exports = {
       methodology: 'Count the number of WETH tokens locked in the protocol contract.',
-  start: 1704412800,
+  start: '2024-01-05',
   arbitrum: {
     tvl,
   }

--- a/projects/bril-finance/index.js
+++ b/projects/bril-finance/index.js
@@ -7,7 +7,6 @@ const config = {
 module.exports = {
   doublecounted: true,
   methodology: 'Count tokens managed by Bril automated liquidity management stratagies',
-  start: 30131926,
 };
 
 Object.keys(config).forEach(chain => {

--- a/projects/brine/index.js
+++ b/projects/brine/index.js
@@ -63,7 +63,7 @@ const scrollTokens = [
 ]
 
 module.exports = {
-  start: 1685817000,
+  start: '2023-06-03',
   ethereum: { tvl: sumTokensExport({ owners: ethereumContracts, tokens: ethereumTokens, }) },
   polygon: { tvl: sumTokensExport({ owners: polygonContracts, tokens: polygonTokens}) },
   optimism: { tvl: sumTokensExport({ owners: optimismContracts, tokens: optimismTokens}) },

--- a/projects/brokkr/index.js
+++ b/projects/brokkr/index.js
@@ -66,7 +66,7 @@ async function addEquityValuationToBalances(address, api) {
 
 
 module.exports = {
-  start: 1554848955,  // 04/09/2019 @ 10:29pm (UTC)
+  start: '2019-04-10',  // 04/09/2019 @ 10:29pm (UTC)
   doublecounted: true,
   avax: {
     tvl,

--- a/projects/burve-protocol/index.js
+++ b/projects/burve-protocol/index.js
@@ -6,7 +6,7 @@ const config = {
 }
 
 module.exports = {
-  start: 1707300000,
+  start: '2024-02-07',
   methodology: "The TVL including total values of assets locked in the tokens which are deployed by BurveProtocol",
 }
 

--- a/projects/cache-gold/index.js
+++ b/projects/cache-gold/index.js
@@ -27,5 +27,5 @@ module.exports = {
   ethereum: {
     tvl,
   },
-  start: 1617235200
+  start: '2021-04-01'
 }; 

--- a/projects/cake-monster/index.js
+++ b/projects/cake-monster/index.js
@@ -5,7 +5,6 @@ const CM_STAKING_CONTRACT = "0xF7CDDF60CD076d4d64c613489aA00dCCf1E518F6";
 module.exports = {
   methodology:
     "counts the number of $MONSTA tokens in the Cake Monster Staking contract, excluding the amount reserved for the staking rewards.",
-  start: 15765654,
   bsc: {
     tvl: () => ({}),
     staking: staking(CM_STAKING_CONTRACT, CM_TOKEN_CONTRACT),

--- a/projects/camelot/index.js
+++ b/projects/camelot/index.js
@@ -2,7 +2,7 @@ const { getUniTVL } = require("../helper/unknownTokens");
 
 module.exports = {
   misrepresentedTokens: true,
-  start: 1669075200,
+  start: '2022-11-22',
   arbitrum: {
     tvl: getUniTVL({ factory: '0x6EcCab422D763aC031210895C81787E87B43A652', useDefaultCoreAssets: true,}),
   },

--- a/projects/capy-finance/index.js
+++ b/projects/capy-finance/index.js
@@ -10,7 +10,6 @@ async function tvl(api) {
 
 module.exports = {
   methodology: 'The TVL of the Capy Finance project in USD.',
-  start: 1000235,
   bsquared: {
     tvl,
   },

--- a/projects/cauldron/index.js
+++ b/projects/cauldron/index.js
@@ -23,7 +23,7 @@ async function tvl({ timestamp }) {
 
 module.exports = {
   methodology: "Scrape the blockchain and filter for spent transaction outputs that match the cauldron contract's redeem script. Check if the transaction has an output with a locking script that matches the redeem script in the input. A match on locking script means the funds are still locked in the DEX contract. Aggregate the value of funds in contract utxos.",
-  start: 1688198180,
+  start: '2023-07-01',
   bitcoincash: { tvl },
   hallmarks: [
     [1688198180, "First cauldron contract deployed (SOCK)"],

--- a/projects/chainflip/index.js
+++ b/projects/chainflip/index.js
@@ -59,7 +59,7 @@ async function tvl(api) {
 
 module.exports = {
   methodology: 'The number of FLIP tokens in the Chainflip State Chain Gateway Contract, as well as the total liquidity.',
-  start: 1700740800, // FLIP went live on 2023-11-23 12:00 UTC
+  start: '2023-11-23', // FLIP went live on 2023-11-23 12:00 UTC
   ethereum: {
     tvl: () => ({}),
     staking: staking(FLIP_TOKEN, STATE_CHAIN_GATEWAY_CONTRACT),

--- a/projects/clip-finance/index.js
+++ b/projects/clip-finance/index.js
@@ -140,7 +140,7 @@ module.exports = {
   methodology:
     "Clip Finance TVL is achieved by summing total values of assets deposited in other protocols through our vaults and vaults balances.",
   doublecounted: true,
-  start: 1697627757, // (Oct-18-2023 11:15:57 AM +UTC) deployed on the BSC network
+  start: '2023-10-18', // (Oct-18-2023 11:15:57 AM +UTC) deployed on the BSC network
 };
 
 Object.keys(config).forEach((chain) => {

--- a/projects/collectionxyz/index.js
+++ b/projects/collectionxyz/index.js
@@ -35,7 +35,6 @@ async function getTotalValueLocked(api) {
 }
 
 module.exports = {
-  start: 16945809,
   ethereum: {
     tvl: getTotalValueLocked,
   },

--- a/projects/colony/index.js
+++ b/projects/colony/index.js
@@ -46,7 +46,7 @@ module.exports = {
     "TVL also includes rewards in various tokens distributed in the staking contract, " +
     "actual fundraised stablecoins in projects (Nests), and liquidity from Colony Dex.",
   avax: {
-    start: 1638367059, // CLY Token deployment
+    start: '2021-12-01', // CLY Token deployment
     tvl: _tvl(),
     staking: _staking,
     // vesting: clyVesting(colonyGovernanceToken, vestingContract),

--- a/projects/connext/old.js
+++ b/projects/connext/old.js
@@ -136,7 +136,7 @@ async function xdai(timestamp, ethBlock, {xdai: block}) {
 }
 
 module.exports = {
-  start: 1552065900,  // 03/08/2019 @ 5:25pm (UTC)
+  start: '2019-03-08',  // 03/08/2019 @ 5:25pm (UTC)
   ethereum: {
     tvl: ethereum
   },

--- a/projects/convergence/index.js
+++ b/projects/convergence/index.js
@@ -3,7 +3,7 @@ const MOONBEAM_FACTORY = '0x9504d0d43189d208459e15c7f643aac1abe3735d';
 const { getUniTVL } = require('../helper/unknownTokens')
 
 module.exports = {
-  start: 1621220505, //2021-05-17 00:00:00 +UTC
+  start: '2021-05-17', //2021-05-17 00:00:00 +UTC
   misrepresentedTokens: true,
     ethereum: {
     tvl: getUniTVL({

--- a/projects/core-powercity-io/index.js
+++ b/projects/core-powercity-io/index.js
@@ -5,7 +5,7 @@ const WATT_TOKEN = "0xDfdc2836FD2E63Bba9f0eE07901aD465Bff4DE71";
 const WATT_PLS_LP = "0x956f097E055Fa16Aad35c339E17ACcbF42782DE6";
 
 module.exports = {
-    start: 1702377175,
+    start: '2023-12-12',
     methodology: "No external tokens/coins staked/locked. Only protocol token WATT and WATT-PLS-LP staked within protocol.",
     pulse: {
         tvl: async () => ({}),

--- a/projects/core/index.js
+++ b/projects/core/index.js
@@ -82,7 +82,7 @@ async function staking(_, block){
 module.exports = {
   ethereum: 
   {
-      start: 1601142406, // 2020-09-26 17:46:46 (UTC),
+      start: '2020-09-26', // 2020-09-26 17:46:46 (UTC),
       tvl, 
       treasury, 
       staking,

--- a/projects/coupon-finance/index.js
+++ b/projects/coupon-finance/index.js
@@ -69,7 +69,6 @@ module.exports = {
   misrepresentedTokens: true,
   doublecounted: true,
   methodology: "TVL consists of deposit and collateral in the Coupon Finance contract",
-  start: 150536505,
   arbitrum: {
     tvl,
   },

--- a/projects/cream/index.js
+++ b/projects/cream/index.js
@@ -4,7 +4,7 @@ const { compoundExports } = require("../helper/compound");
 module.exports = {
   hallmarks: [[1635292800, "Flashloan exploit"]],
   timetravel: false, // bsc and fantom api's for staked coins can't be queried at historical points
-  start: 1599552000, // 09/08/2020 @ 8:00am (UTC)
+  start: '2020-09-08', // 09/08/2020 @ 8:00am (UTC)
   ethereum: compoundExports("0xbdC857eae1D15ad171E11af6FC3e99413Ed57Ec4"),
   bsc: compoundExports(
     "0x589DE0F0Ccf905477646599bb3E5C622C84cC0BA",

--- a/projects/creamswap/index.js
+++ b/projects/creamswap/index.js
@@ -16,6 +16,6 @@ async function tvl(api) {
 }
 
 module.exports = {
-  start: 1599552000, // 09/08/2020 @ 8:00am (UTC)
+  start: '2020-09-08', // 09/08/2020 @ 8:00am (UTC)
   ethereum: { tvl }
 }

--- a/projects/cryptoswap/index.js
+++ b/projects/cryptoswap/index.js
@@ -6,5 +6,5 @@ module.exports = {
   bsc: {
     tvl: getUniTVL({ factory: '0x4136A450861f5CFE7E860Ce93e678Ad12158695C', useDefaultCoreAssets: true }),
   },
-  start: 1651494114, // Mon May 02 2022 12:21:54
+  start: '2022-05-02', // Mon May 02 2022 12:21:54
 };

--- a/projects/csix/index.js
+++ b/projects/csix/index.js
@@ -22,6 +22,5 @@ module.exports = {
     tvl: () => ({}),
     staking,
   },
-  start: 25647232,
   methodology: "Counts as TVL the CSIX deposited through Staking Contract",
 };

--- a/projects/cybro/index.js
+++ b/projects/cybro/index.js
@@ -27,6 +27,5 @@ async function tvl(api) {
 module.exports = {
   doublecounted: true,
   methodology: "We calculate TVL based on the Total Supply of our proxy contracts through which users interact with vault's contracts",
-  start: 1000235,
   blast: { tvl },
 };

--- a/projects/dam-finance/index.js
+++ b/projects/dam-finance/index.js
@@ -4,7 +4,6 @@ const ethCollateralJoins = ["0xB1fbcD7415F9177F5EBD3d9700eD5F15B476a5Fe"]
 
 module.exports = {
     methodology: 'Currently counting the USDC that DAM Finance has locked up, but will add more collateral types and multiple chains in the future',
-    start: 16375673, // LMCV Deployment Block
     ethereum: {
         tvl: sumTokensExport({
             tokens: [ADDRESSES.ethereum.USDC],

--- a/projects/ddex/index.js
+++ b/projects/ddex/index.js
@@ -26,7 +26,7 @@ async function tvl(timestamp, block) {
 }
 
 module.exports = {
-  start: 1566470505, // 2019-08-22T18:41:45+08:00
+  start: '2019-08-22', // 2019-08-22T18:41:45+08:00
   ethereum: { tvl }
 }
 

--- a/projects/deepbook-v3/index.js
+++ b/projects/deepbook-v3/index.js
@@ -25,7 +25,7 @@ const tvl = async (api) => {
 
 module.exports = {
   methodology: "All deposits into all BalanceManagers minutes all withdrawals from all BalanceManagers",
-  start: 1728858752,
+  start: '2024-10-14',
   sui: {
     tvl,
   }

--- a/projects/deepp/index.js
+++ b/projects/deepp/index.js
@@ -3,7 +3,7 @@ const ADDRESSES = require("../helper/coreAssets.json");
 
 module.exports = {
   methodology: 'Lists the number of owned USDC tokens in the Deepp LP and BetLock contracts.',
-  start: 1696118400,
+  start: '2023-10-01',
   arbitrum: {
     tvl: sumTokensExport({
       owners: Object.values({

--- a/projects/defi-swap/index.js
+++ b/projects/defi-swap/index.js
@@ -2,7 +2,7 @@ const { getUniTVL } = require('../helper/unknownTokens')
 
 module.exports = {
   misrepresentedTokens: true,
-  start: 1599523200, // Tuesday, 8 September 2020 00:00:00
+  start: '2020-09-08', // Tuesday, 8 September 2020 00:00:00
   ethereum: {
     tvl: getUniTVL({ factory: '0x9DEB29c9a4c7A88a3C0257393b7f3335338D9A9D', useDefaultCoreAssets: true }),
   },

--- a/projects/defifranc/index.js
+++ b/projects/defifranc/index.js
@@ -34,7 +34,7 @@ module.exports = {
     tvl,
     staking: staking(MON_STAKING_POOL, MON_TOKEN),
   },
-  start: 1664074800,
+  start: '2022-09-25',
     methodology:
     "Total deposits of ETH and wBTC for borrowed DCHF.",
 };

--- a/projects/defiyieldprotocol/index.js
+++ b/projects/defiyieldprotocol/index.js
@@ -83,7 +83,7 @@ const lps = {
 }
 
 module.exports = {
-	start: 1619654324,        // Apr-28-2021 23:58:44 PM +UTC
+	start: '2021-04-29',        // Apr-28-2021 23:58:44 PM +UTC
 	ethereum: {
 		tvl: sumTokensExport({
 			tokens: [

--- a/projects/defrost/index.js
+++ b/projects/defrost/index.js
@@ -60,7 +60,6 @@ async function staking(api) {
 
 module.exports = {
   doublecounted: true,
-  start: 6965653,
   avax: {
     tvl,
     staking

--- a/projects/degate/index.js
+++ b/projects/degate/index.js
@@ -17,6 +17,6 @@ async function tvl(api) {
 }
 
 module.exports = {
-  start: 1699746983, // Nov-11-2023 11:56:23 PM +UTC
+  start: '2023-11-12', // Nov-11-2023 11:56:23 PM +UTC
   ethereum: { tvl }
 }

--- a/projects/deltaprime/index.js
+++ b/projects/deltaprime/index.js
@@ -178,8 +178,6 @@ async function addTraderJoeLPs({ api, accounts }) {
 
 module.exports = {
   methodology: 'Counts TVL of DeltaPrime\'s lending pools and individual PrimeAccount contracts\'',
-  start:
-    24753316,
   avax: {
     tvl: tvlAvalanche,
   },

--- a/projects/derivadex/index.js
+++ b/projects/derivadex/index.js
@@ -58,6 +58,6 @@ async function tvl(timestamp, block) {
     ==================================================*/
 
 module.exports = {
-  start: 1607126400, // 12/5/2020 00:00:00 utc
+  start: '2020-12-05', // 12/5/2020 00:00:00 utc
   ethereum: { tvl }
 };

--- a/projects/dexilla/index.js
+++ b/projects/dexilla/index.js
@@ -51,7 +51,7 @@ const config = {
 
 module.exports = {
   methodology: 'TVL counts the ERC20 tokens on the exchange contracts.',
-  start: 1685610580, // June 1, 2023 @ 9:09:40 (UTC +0)
+  start: '2023-06-01', // June 1, 2023 @ 9:09:40 (UTC +0)
 }
 
 Object.keys(config).forEach(chain => {

--- a/projects/dexter/index.js
+++ b/projects/dexter/index.js
@@ -29,7 +29,7 @@ module.exports = {
   timetravel: false,
   // misrepresentedTokens: true,
   methodology: `Counts the liquidity on all AMM pools`,
-  start: 1679788800, // "2023-03-26" UTC
+  start: '2023-03-26', // "2023-03-26" UTC
   persistence: {
     tvl
   }

--- a/projects/dextf/index.js
+++ b/projects/dextf/index.js
@@ -3,7 +3,7 @@ const tvlV2 = require('./v2');
 const sdk = require('@defillama/sdk');
 
 module.exports = {
-  start: 1595853825, // 27/07/2020 @ 12:43:45am (UTC)
+  start: '2020-07-27', // 27/07/2020 @ 12:43:45am (UTC)
   ethereum: { tvl: sdk.util.sumChainTvls([TVLV1, tvlV2]) },
   avax: { tvl: tvlV2 },
   era: { tvl: tvlV2 }

--- a/projects/dforce/index.js
+++ b/projects/dforce/index.js
@@ -196,7 +196,7 @@ async function staking(timestamp, ethBlock, chainBlocks) {
 
 module.exports = {
   ...generalizedChainExports(chainTvl, ['ethereum', "bsc", "arbitrum", "optimism", "polygon", "avax", "kava", "conflux"]),
-  start: 1564165044, // Jul-27-2019 02:17:24 AM +UTC
+  start: '2019-07-26', // Jul-27-2019 02:17:24 AM +UTC
   hallmarks: [
     [Math.floor(new Date('2023-12-19')/1e3), 'Unitus spin-off'],
   ],

--- a/projects/dirac-finance/index.js
+++ b/projects/dirac-finance/index.js
@@ -35,7 +35,6 @@ module.exports = {
     timetravel: true,
     misrepresentedTokens: false,
     methodology: 'counts the number of MINT tokens in the Club Bonding contract.',
-    start: 11251616,
     polygon_zkevm: {
         tvl,
     }

--- a/projects/dogedollar/index.js
+++ b/projects/dogedollar/index.js
@@ -4,7 +4,6 @@ const DJED_ADDR = '0xA99ef299CdA10AC4Ec974370778fbd27Cfb5CF61'
 
 module.exports = {
   methodology: 'finds the DOGE balance of the DJED instance backing the stablecoin, aswell as the fallback stablecoin balance',
-  start: 14576300,
   dogechain: {
     tvl: sumTokensExport({
       tokensAndOwners: [

--- a/projects/dolomite/index.js
+++ b/projects/dolomite/index.js
@@ -34,7 +34,7 @@ async function borrowed(api) {
 }
 
 module.exports = {
-  start: 1664856000,  // 10/4/2022 @ 00:00am (UTC)
+  start: '2022-10-04',  // 10/4/2022 @ 00:00am (UTC)
 };
 
 const config = {

--- a/projects/dvol/index.js
+++ b/projects/dvol/index.js
@@ -58,7 +58,6 @@ async function borrowed(api) {
 }
 
 module.exports = {
-  start: 33674950,
   timetravel: false,
   bsc: {
     tvl, borrowed,

--- a/projects/dydx/index.js
+++ b/projects/dydx/index.js
@@ -40,7 +40,7 @@ const ADDRESSES = require('../helper/coreAssets.json')
   }
 
   module.exports = {
-    start: 1538179200,  // 09/29/2018 @ 12:00am (UTC)
+    start: '2018-09-29',  // 09/29/2018 @ 12:00am (UTC)
     ethereum: { tvl },
    hallmarks:[
     [1611630974, "Series B $10M"],

--- a/projects/earn-powercity-io/index.js
+++ b/projects/earn-powercity-io/index.js
@@ -18,7 +18,7 @@ const LP_EARN_PLSX_ADDRESS = "0xed77CbbB80e5a5C3A1FE664419d6F690766b5913";
 const lps = [LP_PXDC_PLSX_ADDRESS, LP_EARN_PLSX_ADDRESS]
 
 module.exports = {
-    start: 1708418955,
+    start: '2024-02-20',
     methodology: "Total Value Locked includes all Troves, Stability Pool, Staking Pool and LP Farming Pools",
     pulse: {
         tvl: getLiquityTvl(TROVE_MANAGER_ADDRESS, { collateralToken: PLSX_ADDRESS }),

--- a/projects/ebtc/index.js
+++ b/projects/ebtc/index.js
@@ -13,7 +13,7 @@ async function tvl(api) {
     timetravel: true,
     misrepresentedTokens: false,
     methodology: 'Adds the total amount of collateral in the active pool and the collateral surplus pool of the eBTC protocol.',
-    start: 1710492719,
+    start: '2024-03-15',
     ethereum: {
       tvl,
     }

--- a/projects/ecodefi/index.js
+++ b/projects/ecodefi/index.js
@@ -8,7 +8,6 @@ module.exports = {
     ...compoundExports2({ comptroller: '0xfd1f241ba25b8966a14865cb22a4ea3d24c92451'}),
     staking: staking('0x55839fe60742c7789DaBcA85Fd693f1cAbaeDd69', '0x0985205D53D575CB07Dd4Fba216034dc614eab55'),
   },
-  start: 15307794, // Feb-16-2022 01:49:31 PM +UTC
 }
 
 module.exports.bsc.borrowed = () => ({}) // bad debt

--- a/projects/ensuro/index.js
+++ b/projects/ensuro/index.js
@@ -65,7 +65,7 @@ module.exports = {
   polygon: {
     tvl
   },
-  start: 1643673600,
+  start: '2022-02-01',
   hallmarks: [
     [1669852800, "Ensuro V2 Launch"]
   ]

--- a/projects/epoch-island/index.js
+++ b/projects/epoch-island/index.js
@@ -11,7 +11,7 @@ const config = {
 }
 
 module.exports = {
-  start: 1700179200,
+  start: '2023-11-17',
   hallmarks: [
     [1700179200, "vEPOCH Launch"],
     [1704240000, "ITO Launch"]

--- a/projects/erasure/index.js
+++ b/projects/erasure/index.js
@@ -121,6 +121,6 @@ const ADDRESSES = require('../helper/coreAssets.json')
   ==================================================*/
 
   module.exports = {
-    start: 1566518400, // 08/23/2019 @ 12:00am (UTC)
+    start: '2019-08-23', // 08/23/2019 @ 12:00am (UTC)
     ethereum: { tvl }
   };

--- a/projects/esper-finance/index.js
+++ b/projects/esper-finance/index.js
@@ -2,7 +2,6 @@ const { getUniTVL } = require("../helper/unknownTokens");
 
 module.exports = {
   misrepresentedTokens: true,
-  start: 4781359,
   mantle: {
     tvl: getUniTVL({ factory: '0x69C4515C926ac3db7A547044145495240961a7B5', useDefaultCoreAssets: true,  }),
   },

--- a/projects/ethichub/index.js
+++ b/projects/ethichub/index.js
@@ -15,7 +15,7 @@ const STAKED_ETHIX_CELO = '0xCb16E29d0B667BaD7266E5d0Cd59b711b6273C6B';
 
 module.exports = {
       methodology: 'Count of the tokens in pools, reserves...',
-  start: 1608640693,
+  start: '2020-12-22',
   ethereum: {
     tvl: () => ({}),
     pool2: pool2(STAKED_UETHIX_MAINNET, ETHIX_WETH_UNIV2),

--- a/projects/ethosx/index.js
+++ b/projects/ethosx/index.js
@@ -27,7 +27,7 @@ const USDC_BSC_ADDRESS = ADDRESSES.bsc.USDC;
 
 module.exports = {
   methodology: "TVL counts the USDC held in the controller contracts.",
-  start: 1715693000,
+  start: '2024-05-14',
   arbitrum: {
     tvl: sumTokensExport({
       owners: [

--- a/projects/everdex/index.js
+++ b/projects/everdex/index.js
@@ -26,7 +26,7 @@ const uniTVL = getUniTVL({ factory: '0x19f21b0AB98EC10d734E314356Ad562ae349177d'
 
 module.exports = {
   misrepresentedTokens: true,
-  start: 1674864000,
+  start: '2023-01-28',
   bfc: {
     tvl: sdk.util.sumChainTvls([tvl, uniTVL])
   },

--- a/projects/exsat-credit-staking/index.js
+++ b/projects/exsat-credit-staking/index.js
@@ -7,6 +7,6 @@ async function tvl() {
 
 module.exports = {
     methodology: 'TVL is based on Bitcoin addresses in the exSat credit staking contract, summing their associated Bitcoin balances.',
-    start: 1729684800,
+    start: '2024-10-23',
     bitcoin: { tvl },
 };

--- a/projects/ezkalibur/index.js
+++ b/projects/ezkalibur/index.js
@@ -7,7 +7,7 @@ const SWORD_WETH_LP = '0xc8b6b3a4d2d8428ef3a940eac1e32a7ddadcb0f1'
 
 module.exports = {
   misrepresentedTokens: true,
-  start: 1686309181,
+  start: '2023-06-09',
   era: {
     tvl: getUniTVL({ factory: '0x15C664A62086c06D43E75BB3fddED93008B8cE63', useDefaultCoreAssets: true,  }),
     staking: stakingPricedLP(xSWORD,SWORD_TOKEN,'era',SWORD_WETH_LP,'weth')

--- a/projects/ferdyflip/index.js
+++ b/projects/ferdyflip/index.js
@@ -16,7 +16,7 @@ const config = {
 
 Object.keys(config).forEach((chain) => {
   module.exports[chain] = {
-    start: 1675962000, //Fri Feb 10 2023
+    start: '2023-02-09', //Fri Feb 10 2023
     tvl: sumTokensExport(config[chain]),
   };
 });

--- a/projects/ferro/index.js
+++ b/projects/ferro/index.js
@@ -41,7 +41,7 @@ async function tvl(api) {
 
 module.exports = {
   methodology: 'sum of ferro stablecoin pool contracts balance',
-  start: 1651218360,
+  start: '2022-04-29',
   cronos: {
     tvl,
   }

--- a/projects/flashstake/index.js
+++ b/projects/flashstake/index.js
@@ -18,7 +18,7 @@ async function getData() {
 
 module.exports = {
   doublecounted: true,
-  start: 1659312000,
+  start: '2022-08-01',
   hallmarks: [
     [1659312000, "Protocol Launch"],
     [1666641600, "Optimism Launch"],

--- a/projects/flex-powercity-io/index.js
+++ b/projects/flex-powercity-io/index.js
@@ -18,7 +18,7 @@ const LP_FLEX_HEX_ADDRESS = "0x476d63aB94B4E86614Df0C3D5A27E9e22631D062";
 const lps = [LP_HEXDC_HEX_ADDRESS, LP_FLEX_HEX_ADDRESS]
 
 module.exports = {
-    start: 1714534195,
+    start: '2024-05-01',
     methodology: "Total Value Locked includes all Troves, Stability Pool, Staking Pool and LP Farming Pools",
     pulse: {
         tvl: getLiquityTvl(TROVE_MANAGER_ADDRESS, { collateralToken: HEX_ADDRESS }),

--- a/projects/flexdao/index.js
+++ b/projects/flexdao/index.js
@@ -11,7 +11,6 @@ const decimals = 18
 
 module.exports = {
       methodology: 'Counting all FLEX tokens staked in the DAO',
-  start: 2153800,
   [chain]: {
     tvl: ()=>({}),
     staking: staking(veFLEX, FLEX, chain, coingeckoId, decimals)

--- a/projects/florence-finance/index.js
+++ b/projects/florence-finance/index.js
@@ -41,7 +41,7 @@ async function getBorrowedOnBase(api) {
 module.exports = {
   methodology:
     "The Florin token (FLR) is minted whenever a new loan is funded and burned when a loan matures and is repaid. Since the Florin token is 1:1 redeemable for EUR the borrowed amount is denominated in the protocols treasuries EUR stablecoin of the respective chain. Consequently the total supply of Florin equals the amount borrowed through the protocol. To avoid double counting, the amount of FLR held in the bridge contract is subtracted from the total supply. ",
-  ethereum: { start: 16077400, borrowed: getBorrowedOnEthereum, tvl: () => ({}) },
-  arbitrum: { start: 126183369, borrowed: getBorrowedOnArbitrum, tvl: () => ({}) },
-  base: { start: 18941407, borrowed: getBorrowedOnBase, tvl: () => ({}) },
+  ethereum: { borrowed: getBorrowedOnEthereum, tvl: () => ({}) },
+  arbitrum: {  borrowed: getBorrowedOnArbitrum, tvl: () => ({}) },
+  base: { borrowed: getBorrowedOnBase, tvl: () => ({}) },
 };

--- a/projects/forgesx/index.js
+++ b/projects/forgesx/index.js
@@ -5,7 +5,7 @@ const USDC_TOKEN = ADDRESSES.arbitrum.USDC
 
 module.exports = {
   methodology: 'counts the number of USDC tokens deposited as collateral in the Forge.sol contract.',
-  start: 1680643295,
+  start: '2023-04-04',
   arbitrum: {
     tvl: sumTokensExport({ owner: FORGE_SOL, tokens: [USDC_TOKEN]}),
   }

--- a/projects/frankencoin/index.js
+++ b/projects/frankencoin/index.js
@@ -15,5 +15,5 @@ module.exports = {
   ethereum: {
     tvl,
   },
-  start: 1698487043,
+  start: '2023-10-28',
 };

--- a/projects/freestyle/index.js
+++ b/projects/freestyle/index.js
@@ -4,7 +4,7 @@ const { request, } = require("graphql-request");
 const freestyleConfig = {
   base: {
       token: ADDRESSES.base.USDC,
-      start: 1700006400,
+      start: '2023-11-15',
       graphUrl: "https://api-v2.morphex.trade/subgraph/3KhmYXgsM3CM1bbUCX8ejhcxQCtWwpUGhP7p9aDKZ94Z",
       accountSource: '0x6D63921D8203044f6AbaD8F346d3AEa9A2719dDD'
   },

--- a/projects/frigg-eco/index.js
+++ b/projects/frigg-eco/index.js
@@ -36,7 +36,6 @@ async function tvl(_, block) {
 module.exports = {
   misrepresentedTokens: true,
   methodology: 'Gets the value of all tokens managed through frigg.eco universe',
-  start: 15575809,
   ethereum: {
     tvl
   },

--- a/projects/future-swap/index.js
+++ b/projects/future-swap/index.js
@@ -24,7 +24,7 @@ async function farmStakings(api) {
 
 module.exports = {
   findora: {
-    start: 1677029212, // 2023-02-22 01:26:52 UTC
+    start: '2023-02-22', // 2023-02-22 01:26:52 UTC
     methodology: `Sum of liqudities backed USDF; and tokens values staked in the FutureSwap Farm.`,
     tvl: sumTokensExport({
       owner: FutureSwapContracts.USDF,

--- a/projects/futureswap/index.js
+++ b/projects/futureswap/index.js
@@ -47,7 +47,7 @@ async function avax(timestamp, _, { avax: block }) {
 }
 
 module.exports = {
-  start: 1609459200, // unix timestamp (utc 0) specifying when the project began, or where live data begins
+  start: '2021-01-01', // unix timestamp (utc 0) specifying when the project began, or where live data begins
   ethereum: { tvl },
   arbitrum: { tvl: arbitrum },
   avax: { tvl: avax },

--- a/projects/geode/index.js
+++ b/projects/geode/index.js
@@ -84,7 +84,6 @@ async function avax(timestamp, ethBlock, chainBlocks) {
 }
 
 module.exports = {
-  start: 16328353,
     methodology:
     "All Staking Derivatives are included to the TVL with relative underlying price. Also counted the Avax within the Dynamic Withdrawal Pools.",
     doublecounted: true,

--- a/projects/glif/index.js
+++ b/projects/glif/index.js
@@ -20,7 +20,7 @@ module.exports = {
     },
   },
   timetravel: true,
-  start: 1677628800, // 2023-03-01
+  start: '2023-03-01', // 2023-03-01
   hallmarks: [
     // timestamp, event
     [1680206490, "Early deposits open"], // 2023-03-30

--- a/projects/gnosis/index.js
+++ b/projects/gnosis/index.js
@@ -4,7 +4,7 @@ const { sumTokensExport } = require('../helper/unwrapLPs')
 const sdk = require('@defillama/sdk')
 
 module.exports = {
-  start: 1579811423, // Thu, 23 Jan 2020 20:30:23 GMT
+  start: '2020-01-23', // Thu, 23 Jan 2020 20:30:23 GMT
   ethereum: { tvl: sdk.util.sumChainTvls([
     '0xc59b0e4de5f1248c1140964e0ff287b192407e0c',
     '0x6f400810b62df8e13fded51be75ff5393eaa841f',

--- a/projects/goat-tech/index.js
+++ b/projects/goat-tech/index.js
@@ -11,7 +11,6 @@ const configs = {
 
 module.exports = {
   methodology: "Total staking",
-  start: 210487219,
   arbitrum: {
     tvl: sumTokensExport({
       tokensAndOwners: [

--- a/projects/gogocoin/index.js
+++ b/projects/gogocoin/index.js
@@ -49,7 +49,7 @@ async function pool2X(...args) {
 }
 
 module.exports = {
-        start: 1638388550,
+        start: '2021-12-01',
     polygon: {
         staking: stakingX,
         pool2: pool2X,

--- a/projects/goku-money/index.js
+++ b/projects/goku-money/index.js
@@ -48,7 +48,7 @@ function getCollateralOwnersAndToken() {
 
 
 module.exports = {
-  start: 1698768000, // 01 Nov 2023
+  start: '2023-10-31', // 01 Nov 2023
   methodology: "Total locked collateral assets (in ERC-20 form) in ActivePool and DefaultPool, plus total staked GAI in StabilityPool",
   manta: {
     tvl: sumTokensExport({

--- a/projects/goldlink/index.js
+++ b/projects/goldlink/index.js
@@ -2,7 +2,7 @@ const { sumERC4626VaultsExport } = require('../helper/erc4626')
 
 module.exports = {
   methodology: 'Delta neutral farming in GMX Vault',
-  start: 1716638498,
+  start: '2024-05-25',
   doublecounted: true,
   arbitrum: {
     tvl: sumERC4626VaultsExport({ vaults: ['0xd8dd54df1a7d2ea022b983756d8a481eea2a382a',], isOG4626: true, }),

--- a/projects/goober/index.js
+++ b/projects/goober/index.js
@@ -1,7 +1,7 @@
 const abis = require("./abis");
 
 module.exports = {
-  start: 1668410449,
+  start: '2022-11-14',
   methodology:
     "Counts GOO balance of the vault then sums it with the total multiplier reserve based on the vaults pricing of a multiplier in GOO",
 }

--- a/projects/grace/index.js
+++ b/projects/grace/index.js
@@ -20,7 +20,6 @@ async function borrowed(api) {
 
 module.exports = {
   methodology: 'Fetches the list of pools and collaterals from the Core and sums up their balances',
-  start: 14684731,
   base: {
     tvl, borrowed
   },

--- a/projects/grafun/index.js
+++ b/projects/grafun/index.js
@@ -1,7 +1,6 @@
 const { sumTokensExport, nullAddress } = require('../helper/unwrapLPs')
 module.exports = {
   methodology: "TVL is calculated by aggregating the market value of BNB tokens held within the Token Sale Factory smart contract.",
-  start: 42593135,
   bsc: {
     tvl: sumTokensExport({ owner: '0x8341b19a2A602eAE0f22633b6da12E1B016E6451', token: nullAddress })
   }

--- a/projects/grappa-finance/index.js
+++ b/projects/grappa-finance/index.js
@@ -2,7 +2,7 @@ const ethereumTvl = require('./grappa-ethereum');
 
 module.exports = {
   ethereum: {
-    start: 1675468800,
+    start: '2023-02-04',
     tvl: ethereumTvl,
   },
   hallmarks: [

--- a/projects/gravita-protocol/index.js
+++ b/projects/gravita-protocol/index.js
@@ -30,7 +30,7 @@ async function tvl(api) {
 module.exports = {
   methodology:
     "Adds up the total value locked as collateral on the Gravita platform",
-  start: 1684256400, // Tuesday, May 15, 2023 17:00 GMT
+  start: '2023-05-16', // Tuesday, May 15, 2023 17:00 GMT
 };
 
 Object.keys(ADMIN_ADDRESSES).forEach((chain) => {

--- a/projects/gravity-bridge/index.js
+++ b/projects/gravity-bridge/index.js
@@ -58,7 +58,6 @@ const GRAVITY_BRIDGE_CONTRACT = "0xa4108aa1ec4967f8b52220a4f7e94a8201f2d906";
 
 module.exports = {
   methodology: 'Counts the tokens locked in the Gravity Bridge contract on Ethereum chain.',
-  start: 13798211,
   ethereum: {
     tvl: sumTokensExport({ owner: GRAVITY_BRIDGE_CONTRACT, tokens: erc20Contracts, }),
   },

--- a/projects/groprotocol/index.js
+++ b/projects/groprotocol/index.js
@@ -115,7 +115,7 @@ module.exports = {
   avax: {
     tvl: avaxTvl,
   },
-  start: 1622204347, // 28-05-2021 12:19:07 (UTC)
+  start: '2021-05-28', // 28-05-2021 12:19:07 (UTC)
   methodology:
     "Assets held within the GRO Protocol - either within the PWRD or Vault (GVT) products, or staked in the Gro Protocol pools. Avax TVL is the sum of tokens locked in Gro Labs.",
 };

--- a/projects/gudchain/index.js
+++ b/projects/gudchain/index.js
@@ -7,7 +7,6 @@ module.exports = {
   ethereum: {
     tvl: sumTokensExport({
       owner: launchBridge,
-      start: 20203960,
       tokens: [
         ADDRESSES.null,
         ADDRESSES.ethereum.STETH,

--- a/projects/gullnetwork/index.js
+++ b/projects/gullnetwork/index.js
@@ -25,7 +25,7 @@ const tvl = async (api) => {
 }
 
 module.exports = {
-  start: 1710844331, // May-17-2024 12:45:31 PM +UTC
+  start: '2024-03-19', // May-17-2024 12:45:31 PM +UTC
   methodology: 'GullNetwork TVL including total values of assets staked in our staking vaults, and assets in the liquidity pool.',
 }
 

--- a/projects/hai/index.js
+++ b/projects/hai/index.js
@@ -4,7 +4,7 @@ const config = {
 }
 
 module.exports = {
-  start: 1709780769, // globalDebtCeiling raised > 0
+  start: '2024-03-07', // globalDebtCeiling raised > 0
 };
 
 Object.keys(config).forEach(chain => {

--- a/projects/harmonix/index.js
+++ b/projects/harmonix/index.js
@@ -1,6 +1,6 @@
 module.exports = {
   misrepresentedTokens: true,
-  start: 1709251200, // Friday, March 1, 2024 12:00:00 AM
+  start: '2024-03-01', // Friday, March 1, 2024 12:00:00 AM
   methodology: "Aggregates total value of each Harmonix vault"
 }
 

--- a/projects/hectagon/index.js
+++ b/projects/hectagon/index.js
@@ -12,7 +12,6 @@ const HECTA_BUSD_ADDRESS = "0xc7cee4cea7c76e11e9f5e5e5cbc5e3b798a1c4d0";
 module.exports = {
     methodology:
     "Total Value Lock in Hectagon protocol is calculated by sum of: Treasury locked value",
-  start: 20195418,
   bsc: {
     tvl: (_, _b, {[chain]: block}) => sumTokens2({ chain, block, owner: TREASURY_ADDRESS, tokens: [HECTA_BUSD_ADDRESS, BUSD_ADDRESS,]}),
     staking: staking(gHECTA, HECTA_ADDRESS, chain),

--- a/projects/hedgefarm/index.js
+++ b/projects/hedgefarm/index.js
@@ -27,7 +27,6 @@ async function tvl(api) {
 
 module.exports = {
   methodology: 'Gets the total balance in the Alpha #1 contract from IOU total supply and price per share and in the Smart Farmooor (Alpha #2) from the total balance.',
-  start: 21220270,
   avax: {
     tvl,
   }

--- a/projects/hodlify/index.js
+++ b/projects/hodlify/index.js
@@ -51,7 +51,7 @@ const tvl = async (api) => {
 
 module.exports = {
   doublecounted: true,
-  start: 1693929600, // Tue Sep 05 2023 16:00:00 GMT+0000
+  start: '2023-09-05', // Tue Sep 05 2023 16:00:00 GMT+0000
   methodology: 'Hodlify TVL including total values of assets deposited in other protocols, and the petty cash in our earning vaults.',
   arbitrum: { tvl },
   optimism: { tvl },

--- a/projects/huma/index.js
+++ b/projects/huma/index.js
@@ -14,7 +14,7 @@ const config = {
 
 module.exports = {
   methodology: 'sum all tvls from all pools',
-  start: 1716248276, //2023-05-01
+  start: '2024-05-21', //2023-05-01
 }
 
 Object.keys(config).forEach(chain => {

--- a/projects/hydt/index.js
+++ b/projects/hydt/index.js
@@ -42,7 +42,7 @@ async function staking(api) {
 module.exports = {
     misrepresentedTokens: true,
     methodology: "Retrieving the reserve BNB balance for TVL. Retrieving the staked amounts for HYDT from the earn (HYDT staking) contract and the LP Tokens from the farm contract for staking.",
-    start: 1693763345,
+    start: '2023-09-03',
     bsc: {
         tvl,
         staking,

--- a/projects/illuminex/index.js
+++ b/projects/illuminex/index.js
@@ -7,7 +7,7 @@ const ixToken = "0x08Fe02Da45720f754e6FCA338eC1286e860d2d2f";
 module.exports = {
   methodology: "Counts liquidity on illumineX Exchange, as well as IX token single staking together with liquidity mining locked LP",
   misrepresentedTokens: true,
-  start: 1706475600,
+  start: '2024-01-28',
   sapphire: {
     tvl: getUniTVL({  factory: '0x045551B6A4066db850A1160B8bB7bD9Ce3A2B5A5',  useDefaultCoreAssets: true,}),
     staking: stakingPricedLP(stakingFarmingContractAddress, ixToken, "sapphire", "0xf0f7c4e8edb9edcbe200a4eaec384e8a48fc7815", "oasis-network", true),

--- a/projects/increment-protocol/index.js
+++ b/projects/increment-protocol/index.js
@@ -4,5 +4,5 @@ const { sumTokensExport } = require('../helper/unwrapLPs')
 module.exports = {
   methodology: "Counting the value of all tokens locked in the contracts to be used as collateral to trade or provide liquidity.",
   era: { tvl: sumTokensExport({ owner: '0xfc840c55b791a1dbaf5c588116a8fc0b4859d227', tokens: [ADDRESSES.era.USDC] }) },
-  start: 1710004200 // 2024-03-09 09:10
+  start: '2024-03-09' // 2024-03-09 09:10
 }

--- a/projects/insuredefi/index.js
+++ b/projects/insuredefi/index.js
@@ -36,7 +36,7 @@ async function tvl(timestamp, block) {
 
 
 module.exports = {
-  start: 1513566671, // 2020/10/21 6:34:47 (+UTC)
+  start: '2017-12-18', // 2020/10/21 6:34:47 (+UTC)
   ethereum: { tvl }
 };
 

--- a/projects/invar-finance/index.js
+++ b/projects/invar-finance/index.js
@@ -10,5 +10,4 @@ module.exports = {
     tvl: sumTokensExport({ owner:INVARIA2222, token: ADDRESSES.ethereum.USDC}),
   },
   deadFrom: '2023-11-12',
-  start: 15389792,
 };

--- a/projects/inverse-finance-firm/index.js
+++ b/projects/inverse-finance-firm/index.js
@@ -50,6 +50,6 @@ module.exports = {
     [1707177600, "Launch of sDOLA"],
     [1718236800, "CRV liquidation"]    
   ],
-  start: 1670701200, // Dec 10 2022
+  start: '2022-12-10', // Dec 10 2022
   ethereum: { tvl }
 };

--- a/projects/inverse/index.js
+++ b/projects/inverse/index.js
@@ -51,6 +51,6 @@ module.exports = {
     [1648771200, "INV price hack"],
     [1655380800, "Inverse Frontier Deprecated"]
   ],
-  start: 1607731200, // Dec 12 2020 00:00:00 GMT+0000
+  start: '2020-12-12', // Dec 12 2020 00:00:00 GMT+0000
   ethereum: { tvl }
 };

--- a/projects/ion-dao/index.js
+++ b/projects/ion-dao/index.js
@@ -11,7 +11,6 @@ async function tvl() {
 
 module.exports = {
   timetravel: false, // need to add code to fetch osmosis block
-  start: 5887991,
   osmosis: {
     tvl,
   },

--- a/projects/ip/index.js
+++ b/projects/ip/index.js
@@ -83,7 +83,6 @@ async function op_tvl(api) {
 }
 
 module.exports = {
-  start: 14962974,
   ethereum: {
     tvl: eth_tvl
   },

--- a/projects/ironbank/index.js
+++ b/projects/ironbank/index.js
@@ -1,7 +1,7 @@
 const { compoundExports2 } = require("../helper/compound");
 
 module.exports = {
-  start: 1599552000, // 09/08/2020 @ 8:00am (UTC)
+  start: '2020-09-08', // 09/08/2020 @ 8:00am (UTC)
   ethereum: compoundExports2({
     comptroller: '0xAB1c342C7bf5Ec5F02ADEA1c2270670bCa144CbB',
     blacklistedTokens: [

--- a/projects/ithaca/index.js
+++ b/projects/ithaca/index.js
@@ -13,7 +13,6 @@ module.exports = {
   timetravel: true,
   misrepresentedTokens: false,
   methodology: 'counts the number of WETH and USDC in Ithaca Fundlock contract',
-  start: 176036233,
   arbitrum: {
     tvl: sumTokensExport({
       tokensAndOwners: [

--- a/projects/ithil/index.js
+++ b/projects/ithil/index.js
@@ -19,7 +19,6 @@ const config = {
 }
 module.exports = {
   methodology: 'We calculate the TVL as the sum of (deposits + loans + locked profits - losses) for each vault available',
-  start: 171730567,
   hallmarks: [
     [1691649008, "private mainnet launch"]
   ],

--- a/projects/juicebox-v1/index.js
+++ b/projects/juicebox-v1/index.js
@@ -11,7 +11,7 @@ module.exports = {
         methodology: "Count the value of the Ether in the Juicebox V1 terminals",
     ethereum:
     {
-        start: 1626369243, // 2021-06-15 17:14:03 (UTC)
+        start: '2021-07-15', // 2021-06-15 17:14:03 (UTC)
         tvl: async (_, block) => sumTokens2({
             block,
             tokensAndOwners: [

--- a/projects/juicebox-v2/index.js
+++ b/projects/juicebox-v2/index.js
@@ -10,7 +10,7 @@ module.exports = {
     methodology: "Count the value of the Ether in the Juicebox V2 terminal",
   ethereum:
   {
-    start: 1653853643, // 2022-05-29 19:47:23 (UTC)
+    start: '2022-05-29', // 2022-05-29 19:47:23 (UTC)
     tvl: async (_, block) => sumTokens2({
       block,
       tokensAndOwners: [

--- a/projects/juicebox-v3/index.js
+++ b/projects/juicebox-v3/index.js
@@ -13,7 +13,7 @@ module.exports = {
     methodology: "Count the value of the Ether in the Juicebox V3 terminals",
   ethereum:
   {
-    start: 1663679075, // 2022-10-20 15:04:35(UTC)
+    start: '2022-09-20', // 2022-10-20 15:04:35(UTC)
     tvl: async (_, block) => sumTokens2({
       block,
       tokensAndOwners: [

--- a/projects/kaiafun/index.js
+++ b/projects/kaiafun/index.js
@@ -4,7 +4,6 @@ const { sumTokensExport } = require('../helper/unwrapLPs');
 const WKLAY = '0x19aac5f612f524b754ca7e7c41cbfa2e981a4432';
 
 module.exports.klaytn = {
-  start: 165171284,
   methodology: 'TVL counts Canonical WKLAY coins in KaiaFun\'s Core Contract.',
   tvl: sumTokensExport({
     owners: ["0x080f8b793fe69fe9e65b5ae17b10f987c95530bf"],

--- a/projects/keeper-dao/index.js
+++ b/projects/keeper-dao/index.js
@@ -142,7 +142,7 @@ async function tvl(api) {
 }
 
 module.exports = {
-  start: 1611991703, // 01/30/2021 @ 07:28:23 AM +UTC
+  start: '2021-01-30', // 01/30/2021 @ 07:28:23 AM +UTC
   ethereum: {
     tvl
   }

--- a/projects/kewl/index.js
+++ b/projects/kewl/index.js
@@ -2,7 +2,7 @@ const { getUniTVL } = require("../helper/unknownTokens");
 module.exports = {
   methodology:
     "We count liquidity of all paris through Factory Contract and Pools (single tokens) seccions through Factory Contract.",
-    start: 1701478462, //Dec-2-2023 3:54:26 PM +UTC
+    start: '2023-12-02', //Dec-2-2023 3:54:26 PM +UTC
 
   misrepresentedTokens: true,
   chz: {

--- a/projects/kiloex/index.js
+++ b/projects/kiloex/index.js
@@ -11,7 +11,7 @@ const bsquared_owners = ["0xA2E2F3726DF754C1848C8fd1CbeA6aAFF84FC5B2", "0x1EbEd4
 const base_owners = ["0x43E3E6FFb2E363E64cD480Cbb7cd0CF47bc6b477", "0x7BC8D56cC78cF467C7230B77De0fcBDea9ac44cE","0xdf5ACC616cD3ea9556EC340a11B54859a393ebBB"];
 
 module.exports = {
-  start: 1690971144,
+  start: '2023-08-02',
   bsc: { tvl: sumTokensExport({ owners, tokens: [
     ADDRESSES.bsc.USDT, ADDRESSES.ethereum.FDUSD, ADDRESSES.scroll.STONE,
     ADDRESSES.bsc.WBNB, //WBNB

--- a/projects/lavarage/index.js
+++ b/projects/lavarage/index.js
@@ -10,8 +10,8 @@ const TOKEN_PROGRAM_ID = new PublicKey("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ
 const SPL_ASSOCIATED_TOKEN_PROGRAM_ID = new PublicKey("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL");
 
 const edgeCaseTimestamps = [
-  { start: 1713880000, end: 1713885480 }, // 10:32 AM - 10:58 AM ET on April 23, 2024
-  { start: 1713874500, end: 1713876060 }, // 8:15 AM - 8:41 AM ET on April 23, 2024
+  { start: '2024-04-23', end: 1713885480 }, // 10:32 AM - 10:58 AM ET on April 23, 2024
+  { start: '2024-04-23', end: 1713876060 }, // 8:15 AM - 8:41 AM ET on April 23, 2024
 ];
 
 const idleAccount = new PublicKey("bkhAyULeiXwju7Zmy4t3paDHtVZjNaofVQ4VgEdTWiE");

--- a/projects/lien/index.js
+++ b/projects/lien/index.js
@@ -27,6 +27,6 @@ async function tvl(timestamp, block) {
 }
 
 module.exports = {
-  start: 1619798400, // 30/4/2021 @ 04:00PM (UTC)
+  start: '2021-04-30', // 30/4/2021 @ 04:00PM (UTC)
   ethereum: { tvl }
 };

--- a/projects/lightning-network/index.js
+++ b/projects/lightning-network/index.js
@@ -53,7 +53,7 @@ async function tvl({ timestamp }) {
 }
 
 module.exports = {
-  start: 1516406400,
+  start: '2018-01-20',
   bitcoin: { tvl },
 };
 

--- a/projects/liqee/index.js
+++ b/projects/liqee/index.js
@@ -127,5 +127,5 @@ module.exports = {
   bsc: {
     tvl: bsc
   },
-  start: 1629776276, // Aug-24-2021 11:37:56 AM +UTC
+  start: '2021-08-24', // Aug-24-2021 11:37:56 AM +UTC
 }

--- a/projects/liquidity-slicing/index.js
+++ b/projects/liquidity-slicing/index.js
@@ -50,7 +50,6 @@ async function tvl(api) {
 
 module.exports = {
   arbitrum: {
-    start: 224198345,
     tvl,
   }
 }

--- a/projects/liquity/index.js
+++ b/projects/liquity/index.js
@@ -7,7 +7,7 @@ const STAKING_ADDRESS = "0x4f9Fbb3f1E99B56e0Fe2892e623Ed36A76Fc605d";
 const LQTY_ADDRESS = "0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D"
 
 module.exports = {
-  start: 1617607296,
+  start: '2021-04-05',
   ethereum: {
     tvl: getLiquityTvl(TROVE_MANAGER_ADDRESS),
     staking: staking(STAKING_ADDRESS, LQTY_ADDRESS)

--- a/projects/llamalend/index.js
+++ b/projects/llamalend/index.js
@@ -37,7 +37,7 @@ async function tvl(api) {
 }
 
 module.exports = {
-    start: 1666638251,
+    start: '2022-10-24',
   methodology: 'TVL is calculated by adding up all the ETH in the pools and the totalBorrowed of every pool',
   ethereum: {
     tvl: tvl,

--- a/projects/lobster-protocol/index.js
+++ b/projects/lobster-protocol/index.js
@@ -18,7 +18,7 @@ async function tvl(api) {
 
 module.exports = {
   misrepresentedTokens: true,
-  start: 1704067199, // Sunday 31 December 2023 23:59:59
+  start: '2024-01-01', // Sunday 31 December 2023 23:59:59
   methodology:
     "Aggregates total value of Lobster protocol vaults on Arbitrum",
   arbitrum: {

--- a/projects/loopfi/index.js
+++ b/projects/loopfi/index.js
@@ -36,7 +36,7 @@ const tokensYieldnest = {
 module.exports = {
   methodology:
     "Counts the number of WETH, WBTC and LRT tokens in the LoopFi Prelaunch Contracts in Ethereum and Scroll networks.",
-  start: 1718390875,
+  start: '2024-06-14',
   ethereum: {
     tvl: sumTokensExport({
       ownerTokens: [[Object.values(tokens), LOOP_PRELAUNCH], [Object.values(tokensBtc), LOOP_PRELAUNCH_BTC], [Object.values(tokensYieldnest), LOOP_PRELAUNCH_YNETH]],

--- a/projects/louverture/index.js
+++ b/projects/louverture/index.js
@@ -21,7 +21,7 @@ async function staking(timestamp, ethBlock, chainBlocks) {
 
 
 module.exports = {
-  start: 1639872000,            // 19/12/2021 @ 00:00am (UTC)
+  start: '2021-12-19',            // 19/12/2021 @ 00:00am (UTC)
   avax:{
       staking,
       tvl: async()=>({})

--- a/projects/love/index.js
+++ b/projects/love/index.js
@@ -2,7 +2,6 @@
 module.exports = {
   methodology:
     "The liquidity on these three pools + the tokens staked on all three chains (PulseChain, Ethereum, and Binance Smart Chain)",
-  start: 1000235,
 };
 
 const config = {

--- a/projects/lsdx/index.js
+++ b/projects/lsdx/index.js
@@ -24,7 +24,6 @@ async function tvl(api) {
 }
 
 module.exports = {
-  start: 16831303,
   ethereum: {
     tvl,
     pool2: staking(['0x1D31755E03119311c7F00ae107874dddEC7573f3', '0xE05630Da82604591F002b61F7116429CfDC4B542'], LSD_LPs),

--- a/projects/lucidly/index.js
+++ b/projects/lucidly/index.js
@@ -13,6 +13,6 @@ async function tvl(api) {
 
 
 module.exports = {
-    start: 1693971707,
+    start: '2023-09-06',
     ethereum: { tvl }
 };

--- a/projects/lumin-finance/index.js
+++ b/projects/lumin-finance/index.js
@@ -41,7 +41,6 @@ async function staking(api) {
 
 module.exports = {
   methodology: 'Gets v1 total deposits, and v2 staking statistics on-chain.',
-  start: 194344665,
   arbitrum: {
     staking,
     tvl, borrowed,

--- a/projects/lusd-chickenbonds/index.js
+++ b/projects/lusd-chickenbonds/index.js
@@ -23,7 +23,6 @@ async function tvl(_, block) {
 
 module.exports = {
       methodology: 'counts the amount of LUSD tokens in the 3 buckets of the LUSD ChickenBonds protocol.',
-  start: 15674057,
   ethereum: {
     tvl,
   },

--- a/projects/lybra-v2/index.js
+++ b/projects/lybra-v2/index.js
@@ -8,7 +8,6 @@ const wbETHvault = "0xB72dA4A9866B0993b9a7d842E5060716F74BF262";
 const rETHvault = "0x090B2787D6798000710a8e821EC6111d254bb958"
 
 module.exports = {
-  start: 17990141,
   ethereum: {
     tvl: sumTokensExport({ tokensAndOwners2: [[ADDRESSES.ethereum.STETH, ADDRESSES.ethereum.WSTETH, "0xa2e3356610840701bdf5611a53974510ae27e2e1", ADDRESSES.ethereum.RETH], [stETHvault, wstETHvault, wbETHvault, rETHvault]] }),
   }

--- a/projects/lybra/index.js
+++ b/projects/lybra/index.js
@@ -5,7 +5,7 @@ const { sumTokensExport } = require("../helper/unwrapLPs");
 const LYBRA_CONTRACT = "0x97de57eC338AB5d51557DA3434828C5DbFaDA371";
 
 module.exports = {
-  start: 1682265600,
+  start: '2023-04-23',
   ethereum: {
     tvl: sumTokensExport({ owner: LYBRA_CONTRACT, tokens: [ADDRESSES.ethereum.STETH]}),
   }

--- a/projects/lyve/index.js
+++ b/projects/lyve/index.js
@@ -15,7 +15,7 @@ async function tvl(api) {
 module.exports = {
   methodology:
     "Adds up the total value locked as collateral on the Lyve platform",
-  start: 1699459200, 
+  start: '2023-11-08', 
 };
 
 Object.keys(ADMIN_ADDRESSES).forEach(chain => {

--- a/projects/maker-rwa/index.js
+++ b/projects/maker-rwa/index.js
@@ -72,7 +72,7 @@ const tvl = async (api) => {
 
 module.exports = {
   methodology: `Counts all the tokens being used as collateral of CDPs. On the technical level, we get all the collateral tokens by fetching events, get the amounts locked by calling balanceOf() directly, unwrap any uniswap LP tokens and then get the price of each token from coingecko`,
-  start: 1513566671, // 12/18/2017 @ 12:00am (UTC)
+  start: '2017-12-18', // 12/18/2017 @ 12:00am (UTC)
   ethereum: {
     tvl
   },

--- a/projects/maker/index.js
+++ b/projects/maker/index.js
@@ -93,7 +93,7 @@ async function unwrapGunis({ api, toa, }) {
 
 module.exports = {
   methodology: `Counts all the tokens being used as collateral of CDPs. On the technical level, we get all the collateral tokens by fetching events, get the amounts locked by calling balanceOf() directly, unwrap any uniswap LP tokens and then get the price of each token from coingecko`,
-  start: 1513566671, // 12/18/2017 @ 12:00am (UTC)
+  start: '2017-12-18', // 12/18/2017 @ 12:00am (UTC)
   ethereum: {
     tvl
   },

--- a/projects/mangrove/index.js
+++ b/projects/mangrove/index.js
@@ -55,7 +55,7 @@ module.exports = {
   misrepresentedTokens: false,
   methodology:
     "TVL is calculated by getting the total promised liquidity on the orderbook on a specific block.",
-  start: 1708992000,
+  start: '2024-02-27',
 };
 
 for (const chain in mgvReaders) {

--- a/projects/meme-dollar/index.js
+++ b/projects/meme-dollar/index.js
@@ -10,7 +10,7 @@ const PINA_MEME_LP_CONTRACT = "0x713afa49478f1a33c3194ff65dbf3c8058406670";
 
 module.exports = {
   methodology: "counts the number of tokens in Pina pool",
-  start: 1673928000,
+  start: '2023-01-17',
   ethereum: {
     tvl: () => 0,
     staking: staking(

--- a/projects/merlin/index.js
+++ b/projects/merlin/index.js
@@ -1,5 +1,5 @@
 module.exports = {
-  start: 1682899200,
+  start: '2023-05-01',
   era: {
     tvl: () => 0,
   },

--- a/projects/metastreet-v2/index.js
+++ b/projects/metastreet-v2/index.js
@@ -70,5 +70,4 @@ module.exports = {
   },
   methodology:
     "TVL is calculated by summing the value of token balances and NFTs across all MetaStreet pools. Total borrowed is calculated by subtracting the tokens available from the total value of all liquidity nodes across all pools.",
-  start: 17497132, // Block number of PoolFactory creation
 };

--- a/projects/metastreet/index.js
+++ b/projects/metastreet/index.js
@@ -90,5 +90,4 @@ module.exports = {
         borrowed: getMetaStreetTVL(true),
     },
             methodology: 'TVL is calculated by getting the ERC20 balance of each vault, which counts tokens deposited into contracts for earning yield but not the value of any NFT loan note collateral the vault has purchased. Borrowed tokens are also not counted towards TVL.',
-    start: 14878205
 };

--- a/projects/metronome/index.js
+++ b/projects/metronome/index.js
@@ -5,7 +5,7 @@ const met = '0x2Ebd53d035150f328bd754D6DC66B99B0eDB89aa';
 const proceeds = '0x68c4b7d05fae45bcb6192bb93e246c77e98360e1';
 
 module.exports = {
-  start: 1527076766,        // block 5659904
+  start: '2018-05-23',        // block 5659904
   hallmarks: [
     [1661257318,"Metronome V1 Sunset"]
   ],

--- a/projects/milkomeda-djed/index.js
+++ b/projects/milkomeda-djed/index.js
@@ -9,7 +9,6 @@ async function tvl(api) {
 module.exports = {
   methodology: 'The TVL of each Djed deployment on Milkomeda C1.',
   milkomeda: {
-    start: 10440400,
     tvl,
   },
 };

--- a/projects/milkyway/index.js
+++ b/projects/milkyway/index.js
@@ -3,7 +3,7 @@ const { compoundExports } = require("../helper/compound");
 module.exports = {
   deadFrom: '2023-12-15',
   timetravel: false, // milkomeda api's for staked coins can't be queried at historical points
-  start: 1599552000, // 09/08/2020 @ 8:00am (UTC)
+  start: '2020-09-08', // 09/08/2020 @ 8:00am (UTC)
   milkomeda: compoundExports("0x0Dd4E2B7E0E8a2Cd1258a9023D3a5062381554Cf"),
 };
 

--- a/projects/minerPepe/index.js
+++ b/projects/minerPepe/index.js
@@ -6,7 +6,6 @@ const TOKENS = ["0x6d306C2C9CD931160763D99376a68C14D33DC954"]
 module.exports = {
   methodology:
     "MinerPepe  the first mining PEPE Meme Coin on Binance Smart Chain. Miners enjoy 12% daily returns in BNB and MPEPE tokens",
-  start: 35011373,
   bsc: {
     tvl: sumTokensExport({
       tokensAndOwners: [

--- a/projects/mobius/index.js
+++ b/projects/mobius/index.js
@@ -230,6 +230,5 @@ async function tvl(_, _b, {[chain]: block }) {
 }
 
 module.exports = {
-  start: 8606077, // January 19, 2021 11:51:30 AM
   celo: { tvl }
 };

--- a/projects/mojitoswap/index.js
+++ b/projects/mojitoswap/index.js
@@ -13,5 +13,4 @@ module.exports = {
     tvl: getUniTVL({ useDefaultCoreAssets: true, factory: '0x79855a03426e15ad120df77efa623af87bd54ef3', }),
     staking: stakings([masterchefAddress, masterchefV2Address], mjtAddress),
   },
-  start: 3000000,
 };

--- a/projects/mole/index.js
+++ b/projects/mole/index.js
@@ -24,7 +24,7 @@ async function suiTvl() {
 // run command： node test.js projects/mole/index.js
 module.exports = {
   timetravel: false,
-  start: 1653840000,
+  start: '2022-05-29',
   // avax: {
   //   tvl: avaxTvl,
   //   staking: avaxStaking,

--- a/projects/monroeprotocol/index.js
+++ b/projects/monroeprotocol/index.js
@@ -59,7 +59,7 @@ async function tvl(api) {
 module.exports = {
   methodology:
     "Adds up the total value locked as collateral in Monroe vaults",
-  start: 1710288000, // March 13, 2024 00:00 GMT
+  start: '2024-03-13', // March 13, 2024 00:00 GMT
   hallmarks: [
     [1722000000, "V2 Launch"]
   ],

--- a/projects/monster/index.js
+++ b/projects/monster/index.js
@@ -10,7 +10,6 @@ const LP_STAKING_2 = "0xc13926C5CB2636a29381Da874b1e2686163DC226";
 module.exports = {
       methodology:
     "counts the number of MST tokens in the ve contract and the pairs in the staking pool",
-  start: 22569995,
   fantom: {
     tvl: async () => ({}),
     pool2: pool2([LP_STAKING_1, LP_STAKING_2], [LP_POOL_1, LP_POOL_2]),

--- a/projects/moret/index.js
+++ b/projects/moret/index.js
@@ -13,7 +13,7 @@ const tvlTokens = [ADDRESSES.polygon.WETH_1, // WETH
 
 module.exports = {
     methodology: 'counts all USDC/WBTC/WETH/GHST balances of market contracts.',
-    start: 1677225600, // 24 Feb 2023 08:00:00 UTC
+    start: '2023-02-24', // 24 Feb 2023 08:00:00 UTC
     polygon: {
         tvl: sumTokensExport({ owners: markets, tokens: tvlTokens, }),
     }

--- a/projects/mountain-protocol/index.js
+++ b/projects/mountain-protocol/index.js
@@ -20,7 +20,6 @@ async function tvl(api) {
 module.exports = {
   misrepresentedTokens: true,
   methodology: "Calculates the total USDM Supply",
-  start: 16685700,
   ethereum: {
     tvl,
   },

--- a/projects/mstable/index.js
+++ b/projects/mstable/index.js
@@ -127,7 +127,7 @@ const ethereumTvl = tvlForChain('ethereum')
 const polygonTvl = tvlForChain('polygon')
 
 module.exports = {
-  start: 1590624000, // May-28-2020 00:00:00
+  start: '2020-05-28', // May-28-2020 00:00:00
   polygon: {
     tvl: polygonTvl,
   },

--- a/projects/nayms/index.js
+++ b/projects/nayms/index.js
@@ -21,7 +21,7 @@ const ownerBase = "0x546Fb1621CF8C0e8e3ED8E3508b7c5100ADdBc03";
 
 module.exports = {
   methodology: "Sum assets on Nayms",
-  start: 1681990619, // Thu Apr 20 13:36:59 2023 GMT
+  start: '2023-04-20', // Thu Apr 20 13:36:59 2023 GMT
   hallmarks: [[1681990619, "Nayms V3 Launch"]],
   ethereum: {
     tvl: sumTokensExport({ owner, tokens }),

--- a/projects/neptune-mutual/index.js
+++ b/projects/neptune-mutual/index.js
@@ -39,7 +39,7 @@ async function tvl(api) {
 
 module.exports = {
   methodology: "TVL consists of the total liquidity available in the cover pools",
-  start: 1667260800, // Nov 01 2022 @ 12:00am (UTC)
+  start: '2022-11-01', // Nov 01 2022 @ 12:00am (UTC)
   ethereum: { tvl },
   arbitrum: { tvl },
   bsc: { tvl },

--- a/projects/nerve/index.js
+++ b/projects/nerve/index.js
@@ -24,7 +24,7 @@ const ownerTokens = [
 
 module.exports = {
   misrepresentedTokens: true,
-  start: 1614556800, // March 1, 2021 00:00 AM (UTC)
+  start: '2021-03-01', // March 1, 2021 00:00 AM (UTC)
   bsc:{
     tvl: sumTokensExport({ ownerTokens }),
     staking:staking(xnrvAddress, nrv)

--- a/projects/nexus/index.js
+++ b/projects/nexus/index.js
@@ -9,6 +9,6 @@ async function tvl(api) {
 
 module.exports = {
   misrepresentedTokens: true,
-  start: 1558569600, // 05/23/2019 @ 12:00am (UTC)
+  start: '2019-05-23', // 05/23/2019 @ 12:00am (UTC)
   ethereum: { tvl }
 }

--- a/projects/nomad/index.js
+++ b/projects/nomad/index.js
@@ -87,6 +87,5 @@ module.exports = {
     [1659312000,"trusted root exploit"]
   ],
       methodology: 'counts the total amount of assets locked in the Nomad token bridge.',
-  start: 13983843,
   ...chainExports(tvl, Object.keys(HOME_CHAINS))
 }; 

--- a/projects/nsure/index.js
+++ b/projects/nsure/index.js
@@ -101,7 +101,7 @@ async function tvl(timestamp, block) {
 }
 
 module.exports = {
-  start: 1619081169, // Thu Apr 22 2021 16:46:35
+  start: '2021-04-22', // Thu Apr 22 2021 16:46:35
   ethereum: { tvl }
 };
 

--- a/projects/olympus/index.js
+++ b/projects/olympus/index.js
@@ -176,7 +176,7 @@ async function ownTokens(api) {
 }
 
 module.exports = {
-  start: 1616569200, // March 24th, 2021
+  start: '2021-03-24', // March 24th, 2021
   timetravel: false,
   methodology:
     "TVL is the sum of the value of all assets held by the treasury (excluding pTokens). Please visit https://app.olympusdao.finance/#/dashboard for more info.",

--- a/projects/onsenswap/index.js
+++ b/projects/onsenswap/index.js
@@ -2,7 +2,7 @@ const { getUniTVL } = require("../helper/unknownTokens");
 
 module.exports = {
   misrepresentedTokens: true,
-  start: 1682168400,
+  start: '2023-04-22',
   era: {
     tvl: getUniTVL({
       factory: "0x0E15a1a03bD356B17F576c50d23BF7FC00305590",

--- a/projects/optionBlitz/index.js
+++ b/projects/optionBlitz/index.js
@@ -6,7 +6,6 @@ const BLX = "0x220251092F8B63efD0341F69f6ca907Bd6f271Bf"; // BLX
 const assets = [nullAddress, ADDRESSES.arbitrum.USDC_CIRCLE] // ETH, USDC
 
 module.exports = {
-	start: 194784191,
 	arbitrum: {
 		tvl: sumTokensExport({ owners: [treasury], tokens: assets }),
 		staking: sumTokensExport({ owners: [treasury], tokens: [BLX] }),

--- a/projects/opulous/index.js
+++ b/projects/opulous/index.js
@@ -33,7 +33,7 @@ const arbitrumTVL = async (api) => {
 }
 
 module.exports = {
-    //     // start: 1660827158,
+    //     // start: '2022-08-18',
     methodology: `Counts the number of OPUL tokens locked in the staking pool.`,
     algorand: {
         tvl: () => ({}),

--- a/projects/orange-finance/index.js
+++ b/projects/orange-finance/index.js
@@ -23,7 +23,6 @@ async function tvl(api) {
 
 module.exports = {
   doublecounted: true,
-  start: 154577707,
   arbitrum: {
     tvl,
   },

--- a/projects/ottopia/index.js
+++ b/projects/ottopia/index.js
@@ -32,7 +32,6 @@ async function tvl({timestamp}, block, chainBlocks) {
 
 module.exports = {
     methodology: "This adapter uses otterclam's subgraph to fetch tvl data.",
-  start: 30711580,
   polygon: {
     tvl,
     staking: staking(PearlBank, CLAM),

--- a/projects/pairex/index.js
+++ b/projects/pairex/index.js
@@ -16,7 +16,7 @@ const tokens = [
 ]
 
 module.exports = {
-    start: 1678852800,  //  15/03/2023 @ 04:00am (UTC)
+    start: '2023-03-15',  //  15/03/2023 @ 04:00am (UTC)
     arbitrum: {
         tvl: sumTokensExport({ tokens, owners: contracts }),
     },

--- a/projects/paladinfinance-dullahan/index.js
+++ b/projects/paladinfinance-dullahan/index.js
@@ -12,5 +12,4 @@ module.exports = {
   ethereum: {
     tvl,
   },
-  start: 17824291
 };

--- a/projects/paladinfinance-warlord/index.js
+++ b/projects/paladinfinance-warlord/index.js
@@ -40,5 +40,4 @@ module.exports = {
   ethereum: {
     tvl: ethTvl,
   },
-  start: 17368026
 };

--- a/projects/pangolin/index.js
+++ b/projects/pangolin/index.js
@@ -56,5 +56,5 @@ module.exports = {
       return toUSDTBalances(data.pangolinFactory.totalLiquidityUSD)
     }
   },
-  start: 1612715300, // 7th-Feb-2021
+  start: '2021-02-07', // 7th-Feb-2021
 };

--- a/projects/papparico-finance/index.js
+++ b/projects/papparico-finance/index.js
@@ -14,7 +14,6 @@ const LP_MINING_CONTRACT_V2 = "0x2490AFBf1609119bB76E5e936f4ce4cBed815947";
 const lps = [PPFT_MAIN_LP, XPPFT_LP];
 
 module.exports = {
-  start: 13406569,
   cronos: {
     tvl: () => ({}),
     staking: sumTokensExport({

--- a/projects/peakdefi/index.js
+++ b/projects/peakdefi/index.js
@@ -23,7 +23,7 @@ async function tvl(api) {
   return sumTokens2({ api, owners: Object.values(funds), tokens })
 }
 module.exports = {
-  start: 1607405152,        // Dec-08-2020 05:25:52 PM +UTC
+  start: '2020-12-08',        // Dec-08-2020 05:25:52 PM +UTC
   bsc: {
     staking: staking(stakingContracts.bsc, peakAddress, "bsc", peakAddress),
   },

--- a/projects/peardao/index.js
+++ b/projects/peardao/index.js
@@ -22,7 +22,6 @@ const tokens =  [
 
 module.exports = {
   methodology: 'Counts the value of LP tokens and PEX tokens in the staking contracts, assets locked in the P2P escrow contract, and assets in the treasury contract.',
-  start: 15966251, // Mar-11-2022 01:00:01 PM +UTC
   bsc: {
     tvl: sumTokensExport({ tokens, owner: DOTC_CONTRACT, }),
     staking: stakings([TREASURY_ADDRESS, PEX_STAKING_POOL_CONTRACT], PEX_TOKEN_CONTRACT),

--- a/projects/perfect-pool/index.js
+++ b/projects/perfect-pool/index.js
@@ -5,7 +5,7 @@ const NFT_ACE8 = '0x21F3ea812734b6492D88D268622CF068e9E6D596'
 const NFT_ACE16 = '0x70A254c8201adbD88d88D17937d5e8aBb8B8095F'
 
 module.exports = {
-  start: 1725311445,
+  start: '2024-09-02',
   base: {
     tvl: sumTokensExport(
       { owners: [NFT_ACE8, NFT_ACE16], token: ADDRESSES.base.USDC },

--- a/projects/perlinx/index.js
+++ b/projects/perlinx/index.js
@@ -97,6 +97,6 @@ async function tvl(timestamp, block) {
   ==================================================*/
 
 module.exports = {
-    start: 1600905600,
+    start: '2020-09-24',
     ethereum: { tvl }
 }

--- a/projects/perp88/index.js
+++ b/projects/perp88/index.js
@@ -20,7 +20,7 @@ async function blastTvl(api) {
 }
 
 module.exports = {
-  start: 1668684025,
+  start: '2022-11-17',
   polygon: {
     tvl: sumTokensExport({
       owner: POOL_DIAMOND_CONTRACT,

--- a/projects/phission-finance/index.js
+++ b/projects/phission-finance/index.js
@@ -8,7 +8,7 @@ const STAKING_CONTRACT = '0x569a157eac744b87a42314e8fc03a2e648ea33a2'
 
 module.exports = {
     methodology: 'Total amount of WETH split, plus the value of Pool2',
-    start: 1661851416,
+    start: '2022-08-30',
     ethereum: {
         tvl: sumTokensExport({ owner: SPLIT_CONTRACT, tokens: [WETH] }),
         pool2: sumTokensExport({ owner: STAKING_CONTRACT, tokens: [GOV_POOL], useDefaultCoreAssets: true }),

--- a/projects/phoenix/index.js
+++ b/projects/phoenix/index.js
@@ -1,7 +1,7 @@
 
 const tvl = () => ({})
 module.exports = {
-  start: 1631376000,  // beijing time 2021-9-11 0:0:
+  start: '2021-09-11',  // beijing time 2021-9-11 0:0:
   deadFrom: '2022-09-15',
   hallmarks: [
     [Math.floor(new Date('2022-09-15')/1e3), 'Project is dead: https://twitter.com/Phoenix__PHX/status/1570389804734640129'],

--- a/projects/piggy/index.js
+++ b/projects/piggy/index.js
@@ -4,7 +4,7 @@ const TROVE_MANAGER_ADDRESS = "0xb283466d09177c5C6507785d600caFDFa538C65C";
 
 module.exports = {
   deadFrom: 1648765747,
-  start: 1623145388,
+  start: '2021-06-08',
   bsc: {
     tvl: getLiquityTvl(TROVE_MANAGER_ADDRESS)
   },

--- a/projects/pingu/index.js
+++ b/projects/pingu/index.js
@@ -6,7 +6,7 @@ const PINGU = "0x83E60B9F7f4DB5cDb0877659b1740E73c662c55B"; // PINGU
 const assets = [nullAddress, ADDRESSES.arbitrum.USDC_CIRCLE] // ETH, USDC
 
 module.exports = {
-	start: 1704844800,
+	start: '2024-01-10',
 	arbitrum: {
 		tvl: sumTokensExport({ owners: [fundStore], tokens: assets }),
 		staking: sumTokensExport({ owners: [fundStore], tokens: [PINGU] }),

--- a/projects/pizzax/index.js
+++ b/projects/pizzax/index.js
@@ -6,7 +6,6 @@ const TOKENS = ["0x488739D593DC2BC13Fd738CBaa35498bad5F8556"]
 module.exports = {
   methodology:
     "PizzaX is a Defi Miners. A fun platform to generate 15%/Day ROI for Lifetime — Pool as a Service (PAAS)",
-  start: 35011373,
   bsc: {
     tvl: sumTokensExport({
       tokensAndOwners: [

--- a/projects/planar-finance/index.js
+++ b/projects/planar-finance/index.js
@@ -2,7 +2,7 @@ const { getUniTVL } = require("../helper/unknownTokens");
 
 module.exports = {
   misrepresentedTokens: true,
-  start: 1715328951,
+  start: '2024-05-10',
   blast: {
     tvl: getUniTVL({ factory: '0xdC401B87Ee940F5050f6a17f49763635653eb496', useDefaultCoreAssets: true,}),
   }

--- a/projects/plenty/index.js
+++ b/projects/plenty/index.js
@@ -13,7 +13,7 @@ async function getDexes() {
 module.exports = {
   timetravel: false,
   misrepresentedTokens: true,
-  start: 1672531200,
+  start: '2023-01-01',
   tezos: {
     tvl,
   },

--- a/projects/polygon/index.js
+++ b/projects/polygon/index.js
@@ -90,7 +90,7 @@ async function tvl(_, block, _c) {
 }
 
 module.exports = {
-    start: 1590824836, // Sat May 30 13:17:16 2020
+    start: '2020-05-30', // Sat May 30 13:17:16 2020
     polygon: {
         tvl
     }

--- a/projects/polytrade/index.js
+++ b/projects/polytrade/index.js
@@ -5,7 +5,7 @@ const chain = 'polygon'
 
 module.exports = {
   methodology: 'gets the amount in liquidity pool',
-  start: 1657074185,
+  start: '2022-07-06',
   polygon: {
     tvl: async (_,_b , {polygon: block}) => {
       const strategy = await sdk.api2.abi.call({

--- a/projects/ponyswap/index.js
+++ b/projects/ponyswap/index.js
@@ -1,6 +1,6 @@
 const { uniTvlExport } = require("../helper/calculateUniTvl");
 module.exports = {
-      start: 1678790700,
+      start: '2023-03-14',
   arbitrum: {
     tvl: uniTvlExport("0x66020547Ce3c861dec7632495D86e1b93dA6542c", "arbitrum", true),
   },

--- a/projects/popcorn/index.js
+++ b/projects/popcorn/index.js
@@ -41,7 +41,6 @@ const VCX = "0xce246eea10988c495b4a90a905ee9237a0f91543";
 
 module.exports = {
   ethereum: {
-    start: 12237585,
     staking: stakings([stVCX, veVCX], [VCX, WETH_VCX_BAL_LP_TOKEN]),
     tvl,
   },

--- a/projects/powerindex/index.js
+++ b/projects/powerindex/index.js
@@ -45,7 +45,7 @@ async function eth(api) {
 }
 
 module.exports = {
-  start: 1606768668, // 11/30/2021 @ 08:37am (UTC)
+  start: '2020-11-30', // 11/30/2021 @ 08:37am (UTC)
   bsc:{
     tvl: getBscTvl,
   },

--- a/projects/prime-staked/index.js
+++ b/projects/prime-staked/index.js
@@ -12,7 +12,6 @@ module.exports = {
   doublecounted: true,
   methodology:
     "Returns the total assets owned by primeETH",
-  start: 19128047,
   ethereum: {
     tvl,
   },

--- a/projects/primitive/index.js
+++ b/projects/primitive/index.js
@@ -4,7 +4,7 @@ const v1TVL = require('./v1')
 
 module.exports = {
   ethereum: {
-    start: 1647932400, // unix timestamp (utc 0) specifying when the project began, or where live data begins
+    start: '2022-03-22', // unix timestamp (utc 0) specifying when the project began, or where live data begins
     tvl: sdk.util.sumChainTvls([rmmTVL, v1TVL, ]), // 
   },
 }

--- a/projects/promethium/index.js
+++ b/projects/promethium/index.js
@@ -25,7 +25,7 @@ async function tvl(api) {
 module.exports = {
   methodology:
     "TVL displays the total amount of assets stored in the Promethium contracts, excluding not claimed fees.",
-  start: 1696164866,
+  start: '2023-10-01',
   arbitrum: { tvl },
   hallmarks: [[1696164866, "Profitable pools deployment"]],
 };

--- a/projects/psy/index.js
+++ b/projects/psy/index.js
@@ -13,7 +13,7 @@ async function tvl(api) {
 module.exports = {
   methodology:
     "Adds up the total value locked as collateral on the Gravita platform",
-  start: 1689519600, // Sun Jul 16 2023 15:00:00 GMT+0000
+  start: '2023-07-16', // Sun Jul 16 2023 15:00:00 GMT+0000
   arbitrum: {
     tvl,
   },

--- a/projects/puffer/index.js
+++ b/projects/puffer/index.js
@@ -7,7 +7,6 @@ async function tvl(api) {
 module.exports = {
   doublecounted: true,
   methodology: 'Returns the total assets owned by the Puffer Vault on Ethereum.',
-  start: 19128047,
   ethereum: {
     tvl,
   }

--- a/projects/pumpxy/index.js
+++ b/projects/pumpxy/index.js
@@ -2,7 +2,7 @@ const { sumTokens2, nullAddress } = require('../helper/unwrapLPs')
 
 module.exports = {
   methodology: "TVL is calculated by retrieving the ETH balance of all meme coin contracts deployed by the Zircuit factory contract. The factory contract dynamically manages meme coins, and their ETH holdings are summed up to calculate the total TVL.",
-  start: 1726030293,
+  start: '2024-09-11',
   zircuit: {
     tvl,
   },

--- a/projects/pv01/index.js
+++ b/projects/pv01/index.js
@@ -14,7 +14,6 @@ async function tvl(api) {
 module.exports = {
   methodology:
     "Counts the total supply of rTBL (Rolling T-bill) tokens across all PV01 perpetual bond vaults.",
-  start: 20377028,
   ethereum: {
     tvl,
   },

--- a/projects/qian/index.js
+++ b/projects/qian/index.js
@@ -9,6 +9,6 @@ async function tvl(api) {
 }
 
 module.exports = {
-  start: 1513566671, // 2020/10/21 6:34:47 (+UTC)
+  start: '2017-12-18', // 2020/10/21 6:34:47 (+UTC)
   ethereum: { tvl },
 };

--- a/projects/quadrat/index.js
+++ b/projects/quadrat/index.js
@@ -4,7 +4,7 @@ const sdk = require('@defillama/sdk')
 module.exports = {
   doublecounted: true,
   methodology: 'Counts the tokens locked in Strategy Vaults in Uniswap v3 Pools.',
-  start: 1667197843, // Mon Oct 31 2022 06:30:43 GMT+0000
+  start: '2022-10-31', // Mon Oct 31 2022 06:30:43 GMT+0000
 };
 
 const config = {

--- a/projects/range/index.js
+++ b/projects/range/index.js
@@ -51,7 +51,7 @@ const config ={
 module.exports = {
   methodology: 'assets deployed on DEX as LP + asset balance of vaults',
   doublecounted: true,
-  start: 1683965157,
+  start: '2023-05-13',
 };
 
 // vaults that were deployed through factory but are uninitialized and unused

--- a/projects/rari/index.js
+++ b/projects/rari/index.js
@@ -60,7 +60,7 @@ async function fuseTvl(api) {
 
 module.exports = {
   doublecounted: true,
-  start: 1596236058,        // July 14, 2020
+  start: '2020-08-01',        // July 14, 2020
   ethereum: {
     tvl,
     pool2: pool2(rariGovernanceTokenUniswapDistributorAddress, RGTETHSushiLPTokenAddress),

--- a/projects/ray/index.js
+++ b/projects/ray/index.js
@@ -51,7 +51,7 @@ const allPortfolioManagers = [
 owners.push(allPortfolioManagers[0].address)
 
 module.exports = {
-  start: 1568274392,  // 09/12/2019 @ 7:46am (UTC)
+  start: '2019-09-12',  // 09/12/2019 @ 7:46am (UTC)
   ethereum: {
     tvl: sumTokensExport({
       owners,

--- a/projects/rebalance/index.js
+++ b/projects/rebalance/index.js
@@ -13,7 +13,7 @@ const abi = "function getDepositBalance(address user, address vault) view return
 
 module.exports = {
   methodology: "TVL displays the total amount of assets stored in the REBALANCE vault contracts.",
-  start: 1712143874,
+  start: '2024-04-03',
   hallmarks: [[1712143874, "Profitable vaults deployment"]],
 };
 

--- a/projects/reflexer/index.js
+++ b/projects/reflexer/index.js
@@ -32,6 +32,6 @@ async function tvl(timestamp, block) {
   ==================================================*/
 
 module.exports = {
-  start: 1613520000,
+  start: '2021-02-17',
   ethereum: { tvl },
 };

--- a/projects/revault/index.js
+++ b/projects/revault/index.js
@@ -10,7 +10,7 @@ async function tvl(api) {
 }
 
 module.exports = {
-  start: 1634150000,        // 13th of October, 2021
+  start: '2021-10-13',        // 13th of October, 2021
 	bsc: {
 		tvl,
   },

--- a/projects/reyield-finance/index.js
+++ b/projects/reyield-finance/index.js
@@ -41,7 +41,7 @@ const chains = [
 ]
 
 module.exports = {
-  start: 1695873578, // Sep-28-2023 03:59:38 AM +UTC
+  start: '2023-09-28', // Sep-28-2023 03:59:38 AM +UTC
   doublecounted: true,
   methodology: "TVL is equal to users' running positions' liquidity value plus uncollected fees.",
 };

--- a/projects/risq.js
+++ b/projects/risq.js
@@ -32,7 +32,6 @@ async function tvl(api) {
 }
 
 module.exports = {
-  start: 10340221, // Aug-25-2021 03:12:42 PM +UTC
   bsc: {
     tvl,
   }

--- a/projects/rize/index.js
+++ b/projects/rize/index.js
@@ -104,7 +104,7 @@ async function naviSui(coinSymbol) {
 }
 
 module.exports = {
-  start: 1716599207,
+  start: '2024-05-25',
   timetravel: false,
   ethereum: {
     tvl

--- a/projects/rosy-burnt-steak/index.js
+++ b/projects/rosy-burnt-steak/index.js
@@ -5,7 +5,7 @@ const STEAK_CONTRACT = '0x3e7ab819878bEcaC57Bd655Ab547C8e128e5b208';
 
 module.exports = {
   methodology: 'counts the number of ROSY tokens in the Steak contract.',
-  start: 1711020000,
+  start: '2024-03-21',
   sapphire: {
     tvl: () => ({}),
     staking: staking(STEAK_CONTRACT, ROSY_TOKEN_CONTRACT)

--- a/projects/rumi/index.js
+++ b/projects/rumi/index.js
@@ -16,7 +16,6 @@ async function tvl(api) {
 
 module.exports = {
   methodology: 'Total asset value held in the Rumi lend vault and Rumi strategies',
-  start: 143884813,
   arbitrum: {
     tvl: () => ({}),
   },

--- a/projects/sablier/index.js
+++ b/projects/sablier/index.js
@@ -40,7 +40,7 @@ module.exports = {
   hallmarks: [
     [Math.floor(new Date('2022-10-03') / 1e3), 'Vesting tokens are not included in tvl'],
   ],
-  start: 1573582731,
+  start: '2019-11-12',
   timetravel: false,
   ronin: {
     tvl: sumTokensExport({

--- a/projects/saltyio/index.js
+++ b/projects/saltyio/index.js
@@ -10,7 +10,7 @@ const SALT_CONTRACT = '0x0110B0c3391584Ba24Dbf8017Bf462e9f78A6d9F'
 const STAKING_CONTRACT = '0x7c6f5E73210080b093E724fbdB3EF7bcdd6D468b'
 
 module.exports = {
-  start: 1713700739,
+  start: '2024-04-21',
 }
 
 Object.keys(config).forEach(chain => {

--- a/projects/salvor/index.js
+++ b/projects/salvor/index.js
@@ -3,7 +3,7 @@ const { sumTokensExport, nullAddress } = require("../helper/unwrapLPs");
 const { staking } = require("../helper/staking");
 
 module.exports.avax = {
-  start: 1683411200,
+  start: '2023-05-07',
   hallmarks: [
     [1702501200, "Salvor Lending Launch"]
   ],

--- a/projects/sandclock/index.js
+++ b/projects/sandclock/index.js
@@ -62,7 +62,6 @@ async function tvl(api) {
 module.exports = {
     methodology: 'add underlying asset balances in all the vaults together.',
   doublecounted: true,
-  start: 15308000, // The first vault YEARN_VAULT was deployed
   ethereum: {
     tvl,
     staking: staking("0x0a36f9565c6fb862509ad8d148941968344a55d8", "0xba8a621b4a54e61c442f5ec623687e2a942225ef")

--- a/projects/scientixfinance/index.js
+++ b/projects/scientixfinance/index.js
@@ -15,7 +15,6 @@ const ScixBusd = "0xe8Efb51E051B08614DF535EE192B0672627BDbF9";
 const scUsdBusd = "0x53085B02955CFD2F884c58D19B8a35ef5095E8aE";
 
 module.exports = {
-  start: 10880500,    // 09/16/2020 @ 12:00am (UTC+8)
   bsc: {
     tvl,
     staking: staking(VotingEscrow, SCIX),

--- a/projects/scoreplay/index.js
+++ b/projects/scoreplay/index.js
@@ -2,6 +2,6 @@ const ADDRESSES = require('../helper/coreAssets.json')
 const { sumTokensExport } = require('../helper/unwrapLPs')
 
 module.exports = {
-  start: 1717958404,
+  start: '2024-06-09',
   base: { tvl: sumTokensExport({ owner: '0xFcab8B765FB0BCB05407d16173941e2d1F09DE12', tokens: [ADDRESSES.base.WETH] }) },
 }

--- a/projects/seashell/index.js
+++ b/projects/seashell/index.js
@@ -6,7 +6,6 @@ const BLUEBERRY_GLP_COMPOUNDER_CONTRACT =
 
 module.exports = {
   methodology: "Total assets in Seashell's Blueberry GLP Compounder contract",
-  start: 66190371,
   arbitrum: {
     tvl: sumTokensExport({ owner: BLUEBERRY_GLP_COMPOUNDER_CONTRACT, tokens: [SGLP_TOKEN]}),
   },

--- a/projects/set-protocol/index.js
+++ b/projects/set-protocol/index.js
@@ -25,6 +25,6 @@
   }
 
   module.exports = {
-    start: 1554848955,  // 04/09/2019 @ 10:29pm (UTC)
+    start: '2019-04-10',  // 04/09/2019 @ 10:29pm (UTC)
     ethereum: { tvl }
   }

--- a/projects/sfinance/index.js
+++ b/projects/sfinance/index.js
@@ -109,10 +109,10 @@
 
   module.exports = {
     // #1 susdv2 pool started
-    // start: 1600758000, // 09/22/2020 @ 03:00:00pm +UTC
+    // start: '2020-09-22', // 09/22/2020 @ 03:00:00pm +UTC
     // #2 dfi pool started
-    // start: 1602345600, // 10/10/2020 @ 04:00:00pm +UTC
-    start: 1602374400, // 10/11/2020 @ 00:00:00am +UTC
+    // start: '2020-10-10', // 10/10/2020 @ 04:00:00pm +UTC
+    start: '2020-10-11', // 10/11/2020 @ 00:00:00am +UTC
     ethereum: {
       tvl
     }

--- a/projects/shell/index.js
+++ b/projects/shell/index.js
@@ -21,7 +21,6 @@ const TOKEN_CONTRACTS = [
 
 module.exports = {
   methodology: 'Sums up the value of all tokens wrapped into Shell v2',
-  start: 24142587,
   arbitrum: {
     tvl: sumTokensExport({ owner: OCEAN_CONTRACT, tokens: TOKEN_CONTRACTS})
   },

--- a/projects/sherlock/index.js
+++ b/projects/sherlock/index.js
@@ -34,6 +34,6 @@ async function tvl(timestamp, block) {
 
 module.exports = {
   methodology: 'We count USDC that has been staked into the contracts (staking pool). Periodically USDC is swept into Aave, so we also count the aUSDC that is held (in a separate contract from the main contract).',
-  start: 1632861292,            // 9/28/2020 @ 8:00pm (UTC)
+  start: '2021-09-28',            // 9/28/2020 @ 8:00pm (UTC)
   ethereum: { tvl }                           // tvl adapter
 }

--- a/projects/shibui/index.js
+++ b/projects/shibui/index.js
@@ -9,8 +9,6 @@ const Boba_SHIBUI_USDT = "0x3f714fe1380ee2204ca499d1d8a171cbdfc39eaa";
 
 
 module.exports = {
-  start: 394825,
-
   boba: {
     tvl: () => ({}),
     pool2: pool2s([

--- a/projects/shield/index.js
+++ b/projects/shield/index.js
@@ -1,19 +1,13 @@
 const ADDRESSES = require('../helper/coreAssets.json')
-const { sumTokens2 } = require('../helper/unwrapLPs')
-const USDT = ADDRESSES.bsc.USDT;
+const { sumTokensExport } = require('../helper/unwrapLPs')
 
 const publicPool = "0x65081C21228dc943f47b1Cdb394Eb8db022bc744";
 const privatePool = "0xFa4e13EfAf2C90D6Eaf5033A4f3cB189ee4eF189";
 const pools = [publicPool, privatePool];
 
-async function tvl(timestamp, _, { bsc: block }) {
-  return sumTokens2({ chain: 'bsc', block, owners: pools, tokens: [USDT]})
-}
-
 module.exports = {
   methodology: 'Dual liquidity pool is an innovation by Shield that allows the private pool to hedge the market making risk, while the low-risk public pool can accommodate liquidity to guarantee abundant liquidity on the market. TVL on Shield should combine liquidity from both public pool and private pool.',
-  start: 11160281, // Sep-23-2021 08:37:45 AM +UTC
   bsc: {
-    tvl,
+    tvl: sumTokensExport({ owners: pools, token: ADDRESSES.bsc.USDT}),
   },
 }

--- a/projects/shprd/index.js
+++ b/projects/shprd/index.js
@@ -21,7 +21,7 @@ async function tvl(api) {
 
 
 module.exports = {
-  start: 1688162400,
+  start: '2023-07-01',
   hallmarks: [
     [1695396647, "Fees distribution #1"],
     [1705582439, "Fees distribution #2"],

--- a/projects/single/index.js
+++ b/projects/single/index.js
@@ -101,7 +101,7 @@ const getHelpers = (chain) => {
 }
 
 module.exports = {
-  start: 1643186078,
+  start: '2022-01-26',
   // if we can backfill data with your adapter. Most SDK adapters will allow this, but not all. For example, if you fetch a list of live contracts from an API before querying data on-chain, timetravel should be 'false'.
   //if you have used token substitutions at any point in the adapter this should be 'true'.
   misrepresentedTokens: true,

--- a/projects/singularx/index.js
+++ b/projects/singularx/index.js
@@ -17,6 +17,6 @@ const ethereumTokens = [
 ];
 
 module.exports = {
-  start: 1685817000,
+  start: '2023-06-03',
   ethereum: { tvl: sumTokensExport({ owners: ethereumContracts, tokens: ethereumTokens, }) },
 };

--- a/projects/sirius-finance/index.js
+++ b/projects/sirius-finance/index.js
@@ -26,7 +26,7 @@ module.exports = {
     misrepresentedTokens: true,
         methodology: "All locked tokens includes stable and crypto assets in Sirius's pools.",
     astar: {
-        start: 1650117600, // 2022/04/16 14:00 UTC
+        start: '2022-04-16', // 2022/04/16 14:00 UTC
         tvl, // tvl adapter
         staking: staking(VotingEscrow, SRS, Chain, CoinGeckoID, 18),
     },

--- a/projects/skale/index.js
+++ b/projects/skale/index.js
@@ -3,7 +3,7 @@ const depositBoxETH = '0x49F583d263e4Ef938b9E09772D3394c71605Df94';
 const depositBoxERC20 = '0x8fB1A35bB6fB9c47Fb5065BE5062cB8dC1687669';
 
 module.exports = {
-  start: 1626697290, // Mon July 19 06:38:20 PM UTC 2021
+  start: '2021-07-19', // Mon July 19 06:38:20 PM UTC 2021
   ethereum: {
     tvl: sumTokensExport({ owners: [depositBoxETH, depositBoxERC20], fetchCoValentTokens: true, permitFailure: true }),
   }

--- a/projects/skcs/index.js
+++ b/projects/skcs/index.js
@@ -16,7 +16,6 @@ async function tvl(timestamp, ethBlock, {kcc: block}) {
 
 module.exports = {
       methodology: 'Staked token and staking rewards are counted as TVL',
-  start: 12145436,
   kcc:{
     tvl:tvl,
   }

--- a/projects/slsd/index.js
+++ b/projects/slsd/index.js
@@ -24,7 +24,6 @@ async function tvl(api) {
 }
 
 module.exports = {
-  start: 17142918,
   ethereum: {
     tvl,
     pool2: staking('0xBE13DC5235a64d090E9c62952654DBF3c65199d9', SLSD_LP)

--- a/projects/smbswap/index.js
+++ b/projects/smbswap/index.js
@@ -6,5 +6,5 @@ module.exports = {
   bsc: {
     tvl: getUniTVL({ factory: '0x2Af5c23798FEc8E433E11cce4A8822d95cD90565', useDefaultCoreAssets: true }),
   },
-  start: 1645285089, // Sat Feb 19 2022 15:38:09
+  start: '2022-02-19', // Sat Feb 19 2022 15:38:09
 };

--- a/projects/smilee-finance/index.js
+++ b/projects/smilee-finance/index.js
@@ -1,6 +1,5 @@
 module.exports = {
   methodology: 'Sum of balances from vault contracts associated with each DVP retrieved by the registry.',
-  start: 190367425,
 }
 
 const config = {

--- a/projects/solid-world/index.js
+++ b/projects/solid-world/index.js
@@ -47,7 +47,7 @@ async function pool2(api) {
 }
 
 module.exports = {
-  start: 1684477800, // Fri May 19 2023 06:30:00 GMT+0000
+  start: '2023-05-19', // Fri May 19 2023 06:30:00 GMT+0000
   methodology: `TVL is a measure of the health of the Solid World ecosystem. The TVL can be looked at from 2 perspectives. The 1st perspective, "RWA" valuation, represents the total value of the tokenized forward carbon credits, and is computed as the present value of the on-chain forward credits (ERC1155), based on their exchange rate to CRISP tokens (ERC20) and subsequent USDC value, summed-up.The 2nd perspective, "pool2", represents the total value locked up in our staking contract, and it's calculated by adding up the value of all the LP tokens that are staked. The LP tokens represent the amount of liquidity that has been provided to the Solid World platform.`,
   polygon: {
     tvl,

--- a/projects/sommelier/index.js
+++ b/projects/sommelier/index.js
@@ -65,7 +65,7 @@ function filterActiveCellars(cellars, block) {
 module.exports = {
       methodology:
     "TVL is calculated as the sum of deposits invested into the strategy, deposits waiting to be invested, and yield waiting to be reinvested or redistributed across all Cellars.",
-  start: 1656652494,
+  start: '2022-07-01',
   ["ethereum"]: { tvl: ethereum_tvl },
   ["arbitrum"]: { tvl: arbitrum_tvl },
   ["optimism"]: { tvl: optimism_tvl },

--- a/projects/spacewhale/index.js
+++ b/projects/spacewhale/index.js
@@ -6,7 +6,7 @@ const SPACEWHALE = "0xf5961a2441fC68E38300cd8ae8d6a172b12D7E7A"; // SPACEWHALE
 const assets = [nullAddress, ADDRESSES.arbitrum.USDC_CIRCLE] // ETH, USDC
 
 module.exports = {
-	start: 1712109600,
+	start: '2024-04-03',
 	arbitrum: {
 		tvl: sumTokensExport({ owners: [fundStore], tokens: assets }),
 		staking: sumTokensExport({ owners: [fundStore], tokens: [SPACEWHALE] }),

--- a/projects/spiral-dao/index.js
+++ b/projects/spiral-dao/index.js
@@ -19,7 +19,6 @@ async function tvl(api) {
 
 module.exports = {
   methodology: 'Information is retrieved from both the blockchain and the SpiralDAO API. "https://api.spiral.farm".',
-  start: 16991020,
   ethereum: {
     tvl,
     staking: staking(STAKING, COIL),

--- a/projects/stCelo/index.js
+++ b/projects/stCelo/index.js
@@ -31,7 +31,6 @@ async function tvl(timestamp, ethBlock, chainBlocks) {
 
 module.exports = {
             methodology: 'TVL counts Celo staked by the protocol.',
-    start: 14330000,
     celo: {
         tvl 
     }

--- a/projects/stake-ly/index.js
+++ b/projects/stake-ly/index.js
@@ -7,7 +7,7 @@ async function tvl(api) {
 module.exports = {
   methodology:
     "TVL is KLAY staked by the users and rewards accrued from node staking",
-  start: 1663585837,
+  start: '2022-09-19',
   klaytn: {
     tvl,
   },

--- a/projects/stakedotlink/index.js
+++ b/projects/stakedotlink/index.js
@@ -24,7 +24,7 @@ async function staking(api) {
 module.exports = {
       methodology:
     "Queries LINK staking/priority pools and SDL staking pool for the total amount of tokens staked",
-  start: 1670337984,
+  start: '2022-12-06',
   ethereum: {
     tvl,
     staking,

--- a/projects/stakestone-btc/index.js
+++ b/projects/stakestone-btc/index.js
@@ -16,7 +16,6 @@ const ethTvl = async (api) => {
 }
 
 module.exports = {
-  start: 42326440,
   bsc: {
     tvl: bscTvl,
   },

--- a/projects/stakestone/index.js
+++ b/projects/stakestone/index.js
@@ -18,7 +18,6 @@ const mantaTvl = async (api) => {
 }
 
 module.exports = {
-    start: 18182242,
     ethereum: {
         tvl: ethTvl
     },

--- a/projects/steakHut/index.js
+++ b/projects/steakHut/index.js
@@ -12,7 +12,6 @@ async function tvl(api) {
 const steakToken = "0xb279f8DD152B99Ec1D84A489D32c35bC0C7F5674"
 
 module.exports = {
-  start: 14003811,
   methodology: 'Counts the value of JLP tokens staked into SteakMasterChef.',
   avax: {
     tvl,

--- a/projects/stealthpad/index.js
+++ b/projects/stealthpad/index.js
@@ -3,7 +3,6 @@ const abi = require('./abi.js')
 
 module.exports = {
   misrepresentedTokens: true,
-  start: 17996063,
   methodology: `Counts liquidity in lp lock contracts`,
 }
 

--- a/projects/stream/index.js
+++ b/projects/stream/index.js
@@ -31,7 +31,6 @@ async function tvl(api) {
 module.exports = {
   misrepresentedTokens: true,
   methodology: "Calculates the TVL of all Stream vaults",
-  start: 16685700,
   ethereum: {
     tvl,
   },

--- a/projects/suzaku/index.js
+++ b/projects/suzaku/index.js
@@ -8,7 +8,7 @@ async function tvl(api) {
 }
 
 module.exports = {
-  start: 1727654400,
+  start: '2024-09-30',
   avax: {
     tvl,
   },

--- a/projects/swaap-earn/index.js
+++ b/projects/swaap-earn/index.js
@@ -3,7 +3,7 @@ const { cachedGraphQuery } = require('../helper/cache')
 const query = `query FundsTVL{ funds { id  } }`
 
 module.exports = {
-  start: 1713312000, //  Apr 17 2024 00:00:00 GMT+0000
+  start: '2024-04-17', //  Apr 17 2024 00:00:00 GMT+0000
 }
 
 const config = {

--- a/projects/swaap/index.js
+++ b/projects/swaap/index.js
@@ -29,7 +29,7 @@ async function tvl(api) {
 }
 
 module.exports = {
-  start: 1655130642, // Jun-13-2022 02:30:42 PM +UTC
+  start: '2022-06-13', // Jun-13-2022 02:30:42 PM +UTC
   polygon: {
     tvl,
   },

--- a/projects/swapsicle/index.js
+++ b/projects/swapsicle/index.js
@@ -157,5 +157,4 @@ module.exports = {
       stakedTLOSIceBox
    ])
   },
-  //start: 15434772,
 }

--- a/projects/symbiotic/index.js
+++ b/projects/symbiotic/index.js
@@ -8,7 +8,7 @@ async function tvl(api) {
 }
 
 module.exports = {
-  start: 1718088924,
+  start: '2024-06-11',
   ethereum: {
     tvl,
   },

--- a/projects/symmetry-trade/index.js
+++ b/projects/symmetry-trade/index.js
@@ -12,7 +12,6 @@ const TOKENS = [
 
 module.exports = {
     methodology: 'counts the token deposited in market contract',
-    start: 923000,
     scroll: {
         tvl: sumTokensExport({ owner: MARKET_CONTRACT, tokens: TOKENS}),
     }

--- a/projects/synthetix/api.js
+++ b/projects/synthetix/api.js
@@ -136,7 +136,7 @@ async function SNXHolders(snxGraphEndpoint, block, chain) {
 }
 
 module.exports = {
-  start: 1565287200,  // Fri Aug 09 2019 00:00:00
+  start: '2019-08-08',  // Fri Aug 09 2019 00:00:00
   optimism: {
     tvl: chainTvl("optimism")
   },

--- a/projects/synthetix/apiCache.js
+++ b/projects/synthetix/apiCache.js
@@ -149,7 +149,7 @@ async function SNXHolders(snxGraphEndpoint, block, chain) {
 }
 
 module.exports = {
-  start: 1565287200,  // Fri Aug 09 2019 00:00:00
+  start: '2019-08-08',  // Fri Aug 09 2019 00:00:00
   optimism: {
     tvl: chainTvl("optimism")
   },

--- a/projects/synthex/index.js
+++ b/projects/synthex/index.js
@@ -14,7 +14,6 @@ const DAI = ADDRESSES.optimism.DAI;
 
 module.exports = {
     methodology: "counts value of assets in the PoolC and PoolF",
-    start: 82762407,
     arbitrum: {
         tvl: sumTokensExport({
             ownerTokens: [

--- a/projects/t-protocol-v2/index.js
+++ b/projects/t-protocol-v2/index.js
@@ -8,7 +8,7 @@ const USTP = '0xed4d84225273c867d269f967cc696e0877068f8a'
 
 module.exports = {
   methodology: "counts value of assets in the Treasury",
-  start: 1677913260,
+  start: '2023-03-04',
   ethereum: {
     tvl,
   },

--- a/projects/t-protocol/index.js
+++ b/projects/t-protocol/index.js
@@ -7,7 +7,7 @@ const STBT = '0x530824DA86689C9C17CdC2871Ff29B058345b44a'
 
 module.exports = {
   methodology: "counts value of assets in the Treasury",
-  start: 1677913260,
+  start: '2023-03-04',
   ethereum: {
     tvl: sumTokensExport({ owner: TREASURY_CONTRACT, tokens: [USDC_TOKEN_CONTRACT, STBT] }),
   },

--- a/projects/taidog/index.js
+++ b/projects/taidog/index.js
@@ -79,7 +79,6 @@ module.exports = {
   misrepresentedTokens: true,
   methodology:
     "TVL counts user deposits of assets like (ETH, USDC, TAIKO) into protocol, counts pool2 (lp tokens) in staking contract 0xD664c3b22c60b4927ab1e0035b99F157bc2d8F1B, and counts the number of TAIDOG tokens in the staking contract 0x9b4484D5A2665930702d09f74086CAD86d96b25E",
-  start: 84000,
   taiko: {
     tvl: sumTokensExport({
       tokensAndOwners: [

--- a/projects/tcv_platform/index.js
+++ b/projects/tcv_platform/index.js
@@ -11,7 +11,7 @@ async function tvl(api) {
 
 module.exports = {
   methodology: "Calculates total liquidity from all NFT ranges in the given pools.",
-  start: 1717239410,
+  start: '2024-06-01',
   arbitrum: {
     tvl,
   },

--- a/projects/tetu/index.js
+++ b/projects/tetu/index.js
@@ -17,7 +17,7 @@ const EXCLUDED_VAULTS = {
 }
 
 module.exports = {
-  start: 1628024400,  //Tue Aug 03 2021 21:00:00 GMT+0000
+  start: '2021-08-03',  //Tue Aug 03 2021 21:00:00 GMT+0000
   misrepresentedTokens: true,
 };
 

--- a/projects/thala-vethl/index.js
+++ b/projects/thala-vethl/index.js
@@ -8,7 +8,7 @@ const thlDecimals = 8;
 
 module.exports = {
   timetravel: false,
-  start: 1692598825,
+  start: '2023-08-21',
   methodology:
     `TVL data is pulled from the Thala's API "https://app.thala.fi/api/vethl-tvl".`,
   aptos: {

--- a/projects/tholgar/index.js
+++ b/projects/tholgar/index.js
@@ -60,5 +60,4 @@ module.exports = {
   ethereum: {
     tvl: ethTvl,
   },
-  start: 17368026
 };

--- a/projects/thorn-protocol/index.js
+++ b/projects/thorn-protocol/index.js
@@ -11,7 +11,7 @@ async function tvl(api) {
 module.exports = {
   methodology:
     "Uses factory(0x888099De8EA8068D92bB04b47A743B82195c4aD2) address and whitelisted tokens address to find and price Liquidity Pool pairs",
-  start: 1729159200,
+  start: '2024-10-17',
   sapphire: {
     tvl,
   },

--- a/projects/tlx/index.js
+++ b/projects/tlx/index.js
@@ -41,7 +41,7 @@ async function tvl(api) {
 }
 
 module.exports = {
-  start: 1712731500,
+  start: '2024-04-10',
   methodology:
     "Total TLX locked in the genesis locker contract and total TLX staked in the staking contract. TVL is computed as the total margin deposited across the protocol's leveraged tokens.",
   optimism: {

--- a/projects/toros/index.js
+++ b/projects/toros/index.js
@@ -31,7 +31,7 @@ async function tvl(api) {
 
 module.exports = {
     misrepresentedTokens: true,
-  start: 1627776000, // Sunday, August 1, 2021 12:00:00 AM
+  start: '2021-08-01', // Sunday, August 1, 2021 12:00:00 AM
   methodology:
     "Aggregates total value of each Toros vault both on Polygon and Optimism",
   polygon: {

--- a/projects/toucan-protocol/index.js
+++ b/projects/toucan-protocol/index.js
@@ -54,7 +54,7 @@ const getRegenCredits = () => {
 };
 
 module.exports = {
-  start: 1634842800,
+  start: '2021-10-21',
   base: {
     tvl: getCalculationMethod("base")
   },

--- a/projects/tranche/index.js
+++ b/projects/tranche/index.js
@@ -93,7 +93,7 @@ function tvl(chain) {
 }
 
 module.exports = {
-  start: 1621340071,
+  start: '2021-05-18',
   ethereum: tvl('ethereum'),
   fantom: tvl('fantom'),
   avax: tvl('avax'),

--- a/projects/treasury/betswirl.js
+++ b/projects/treasury/betswirl.js
@@ -74,7 +74,7 @@ module.exports = {
   methodology:
     "BetSwirl has no users TVL yet. However, it includes the bankrolls amounts (each tokens amount in the bank allowing players to bet).",
   // The first Bank was deployed on Polygon at tx 0x6b99f617946d2f8c23adcd440cd3309d2da750e52d135853f38a0da11cdc3233
-  start: 1648344312, // new Date(Date.UTC(2022, 2, 27, 1, 25, 12)).getTime() / 1e3,
+  start: '2022-03-27', // new Date(Date.UTC(2022, 2, 27, 1, 25, 12)).getTime() / 1e3,
   bsc: {
     tvl: treasury("bsc"),
     ownTokens: staking('0xa475f643aa480a3df3e9872b6e80e75ae99b19db', '0x3e0a7C7dB7bB21bDA290A80c9811DE6d47781671'),

--- a/projects/treasury/perfect-pool.js
+++ b/projects/treasury/perfect-pool.js
@@ -4,7 +4,7 @@ const ADDRESSES = require('../helper/coreAssets.json')
 const TREASURY = '0xFe4559392aF0E6988F2d7A4E6447a2E702Ff215d'
 
 module.exports = {
-  start: 1725311445,
+  start: '2024-09-02',
   base: {
     tvl: sumTokensExport({ owner: TREASURY, token: ADDRESSES.base.USDC }),
   }

--- a/projects/treasury/shibui.js
+++ b/projects/treasury/shibui.js
@@ -6,8 +6,6 @@ const Boba_SHIBUI_WETH = "0xcE9F38532B3d1e00a88e1f3347601dBC632E7a82";
 const Boba_SHIBUI_USDT = "0x3f714fe1380ee2204ca499d1d8a171cbdfc39eaa";
 
 module.exports = {
-  start: 394825,
-
   boba: {
     tvl: async (api) => {
       return api.sumTokens({ owners: [

--- a/projects/treehouse/index.js
+++ b/projects/treehouse/index.js
@@ -49,7 +49,7 @@ async function tvlMantle(api) {
 
 module.exports = {
   methodology: 'Token balance in vault and strategy contracts',
-  start: 1725926400, // Tuesday, September 10, 2024 12:00:00 AM,
+  start: '2024-09-10', // Tuesday, September 10, 2024 12:00:00 AM,
   hallmarks: [[1727218691, "TVL Cap Raise 1"],[1729045223, "TVL Cap Raise 2"]],
   ethereum: {
     tvl,

--- a/projects/truefi/index.js
+++ b/projects/truefi/index.js
@@ -81,7 +81,7 @@ async function tvlArbitrum(api) {
 }
 
 module.exports = {
-  start: 1605830400,            // 11/20/2020 @ 12:00am (UTC)
+  start: '2020-11-20',            // 11/20/2020 @ 12:00am (UTC)
   ethereum: {
     tvl,
     staking: staking(stkTRU, TRU),

--- a/projects/twtstake/index.js
+++ b/projects/twtstake/index.js
@@ -7,7 +7,6 @@ module.exports = {
     [1681948800, "TWTStake Flagged on Twitter"]
   ],
       methodology: 'Counts the number of TWT tokens in the TWT Stake contract.',
-  start: 1000235,
   bsc: {
     tvl: () => 0,
     staking: staking(TWT_STAKE_CONTRACT,TWT_TOKEN_CONTRACT)

--- a/projects/umamifinance/index.js
+++ b/projects/umamifinance/index.js
@@ -32,7 +32,7 @@ const gmVaultsAvax = [
 
 module.exports = {
   doublecounted: true,
-  start: 1657027865, // UMAMI deployment block ts
+  start: '2022-07-05', // UMAMI deployment block ts
   arbitrum: {
     staking: stakings([mUMAMI, OHM_STAKING_sUMAMI], UMAMI),
     tvl: sumERC4626VaultsExport({ vaults: glpVaults.concat(gmVaultsArbitrum), isOG4626: true }),

--- a/projects/unbk/index.js
+++ b/projects/unbk/index.js
@@ -46,7 +46,6 @@ async function tvl(timestamp, block, chainBlocks) {
 module.exports = {
       methodology:
     "Accross different vaults, counts the total number of assets accumulated on each of them",
-  start: 33000000,
   fantom: {
     tvl,
   },

--- a/projects/unitus/index.js
+++ b/projects/unitus/index.js
@@ -64,5 +64,5 @@ function chainTvl(chain) {
 
 module.exports = {
   ...generalizedChainExports(chainTvl, Object.keys(allControllers)),
-  start: 1564165044, // Jul-27-2019 02:17:24 AM +UTC
+  start: '2019-07-26', // Jul-27-2019 02:17:24 AM +UTC
 }

--- a/projects/universe/index.js
+++ b/projects/universe/index.js
@@ -97,5 +97,5 @@ module.exports = {
         tvl,
         pool2,
     },
-    start: 1621939189, // May-25-2021 10:39:49 AM +UTC
+    start: '2021-05-25', // May-25-2021 10:39:49 AM +UTC
 };

--- a/projects/uniwhale/index.js
+++ b/projects/uniwhale/index.js
@@ -5,7 +5,7 @@ const UNIWHALE_MARGIN_POOL = "0xBB1B941aB76fAE4e9F552B860eFaC1F367AC9bCc";
 const { sumTokensExport } = require('../helper/unwrapLPs')
 
 module.exports = {
-  start: 1677833673,
+  start: '2023-03-03',
   bsc: {
     tvl: sumTokensExport({ owners: [UNIWHALE_LIQUIDITY_POOL, UNIWHALE_MARGIN_POOL, ], tokens: [USDT]}),
   },

--- a/projects/uno-farm/index.js
+++ b/projects/uno-farm/index.js
@@ -90,7 +90,7 @@ async function tvl(api) {
 }
 
 module.exports = {
-  start: 1656018000,
+  start: '2022-06-23',
     polygon: {
     tvl,
   },

--- a/projects/unore/index.js
+++ b/projects/unore/index.js
@@ -43,7 +43,7 @@ const config = {
 }
 
 module.exports = {
-  start: 1626100000,  // Sep-20-2021 07:27:47 AM +UTC
+  start: '2021-07-12',  // Sep-20-2021 07:27:47 AM +UTC
   kava: { tvl: async () => ({})},
 };
 

--- a/projects/uplift/index.js
+++ b/projects/uplift/index.js
@@ -28,7 +28,7 @@ async function tvl(timestamp, block, chainBlocks) {
 
 module.exports = {
       methodology: "Counts the number of LIFT tokens in the Staking contract",
-  start: 1637191200,
+  start: '2021-11-18',
   bsc: {
     tvl: () => ({}),
     staking: tvl,

--- a/projects/valleyswap/index.js
+++ b/projects/valleyswap/index.js
@@ -1,7 +1,6 @@
 const { getUniTVL } = require('../helper/unknownTokens')
 
 module.exports = {
-  start: 411656,
   oasis: {
     tvl: getUniTVL({
       factory: '0xa25464822b505968eEc9A45C43765228c701d35f',

--- a/projects/valueliquid/index.js
+++ b/projects/valueliquid/index.js
@@ -2,6 +2,6 @@
 const { v1Tvl } = require('../helper/balancer')
 
 module.exports = {
-  start: 1601440616,  // 09/30/2020 @ 4:36am (UTC)
+  start: '2020-09-30',  // 09/30/2020 @ 4:36am (UTC)
   ethereum: { tvl: v1Tvl('0xebc44681c125d63210a33d30c55fd3d37762675b', 10961776) }
 };

--- a/projects/varen/index.js
+++ b/projects/varen/index.js
@@ -4,7 +4,7 @@ const { getUniTVL } = require('../helper/unknownTokens')
 
 const stakingRewards = "0x25a25e2f0d2c211a96fa35e8c670ef6f5b3aba57"
 module.exports = {
-  start: 1606392528, // 11/26/2020 @ 12:08:48am (UTC)
+  start: '2020-11-26', // 11/26/2020 @ 12:08:48am (UTC)
   ethereum:{
     staking: staking(stakingRewards, "0x72377f31e30a405282b522d588aebbea202b4f23"),
     pool2: pool2(stakingRewards, "0x88024deacdc2e9eda02a3051377ed635381faa54"),

--- a/projects/vectorreserve/index.js
+++ b/projects/vectorreserve/index.js
@@ -10,7 +10,6 @@ async function tvl(api) {
 
 module.exports = {
   methodology: 'Value of ETH and LSD tokens in VETH contract',
-  start: 19067821,
   ethereum: {
     tvl,
     pool2: staking(['0x2dd568028682ff2961cc341a4849f1b32f371064'], ['0xB6B0C651C37EC4ca81C0a128420e02001A57Fac2', '0x6685fcFCe05e7502bf9f0AA03B36025b09374726']),

--- a/projects/vela-exchange/index.js
+++ b/projects/vela-exchange/index.js
@@ -32,7 +32,6 @@ module.exports = {
     staking: async (api) => velaStaking(api,arbitrumEndpoint)
   },
   base: {
-    start: 3566528,
     tvl: staking("0xC4ABADE3a15064F9E3596943c699032748b13352", ADDRESSES.base.USDbC),
     staking: async (api) => velaStaking(api,baseEndpoint)
   },

--- a/projects/vendor-finance-v2/index.js
+++ b/projects/vendor-finance-v2/index.js
@@ -45,7 +45,6 @@ const config = {
 module.exports = {
   doublecounted: true,
   methodology: 'The sum of the balance of all listed collateral and lend tokens in all deployed pools.',
-  start: 88774917,
 };
 
 Object.keys(config).forEach(chain => {

--- a/projects/vendor-finance/index.js
+++ b/projects/vendor-finance/index.js
@@ -30,7 +30,6 @@ const config = {
 
 module.exports = {
   methodology: 'The sum of the balance of all listed collateral and lend tokens in all deployed pools.',
-  start: 20274088,
   deadFrom: '2024-08-30'
 };
 

--- a/projects/vesper/index.js
+++ b/projects/vesper/index.js
@@ -54,6 +54,6 @@ function getChainExports(chain) {
 }
 
 module.exports = {
-  start: 1608667205, // December 22 2020 at 8:00 PM UTC
+  start: '2020-12-22', // December 22 2020 at 8:00 PM UTC
   ...['ethereum', 'avax', 'polygon', 'optimism', 'base'].reduce((acc, chain) => ({ ...acc, ...getChainExports(chain) }), {})
 };

--- a/projects/vest/index.js
+++ b/projects/vest/index.js
@@ -3,7 +3,7 @@ const ADDRESSES = require('../helper/coreAssets.json')
 
 module.exports = {
   methodology: "Total USDC locked in the Vest Exchange.",
-  start: 1710709200,
+  start: '2024-03-17',
   era: {
     tvl: staking([
         "0xf7483A1464DeF6b8d5A6Caca4A8ce7E5be8F1F68",

--- a/projects/vesta/index.js
+++ b/projects/vesta/index.js
@@ -57,7 +57,7 @@ module.exports = {
     tvl,
     pool2,
   },
-  start: 1644339600,
+  start: '2022-02-08',
     methodology:
     "Total Value Locked includes all stability pools, troves, and vst pairs",
 };

--- a/projects/vine/index.js
+++ b/projects/vine/index.js
@@ -1,7 +1,7 @@
 const { sumTokensExport, nullAddress } = require('../helper/unwrapLPs')
 
 module.exports = {
-  start: 1706475600,
+  start: '2024-01-28',
   sapphire: {
     tvl: sumTokensExport({ owner: '0x1882560361578F2687ddfa2F4CEcca7ae2e614FD', tokens: [nullAddress] }),
   },

--- a/projects/visor/index.js
+++ b/projects/visor/index.js
@@ -9,7 +9,7 @@ const { sumTokens2 } = require('../helper/unwrapLPs')
 
 module.exports = {
   doublecounted: true,
-  start: 1616679762, // (Mar-25-2021 01:42:42 PM +UTC)
+  start: '2021-03-25', // (Mar-25-2021 01:42:42 PM +UTC)
 };
 
 Object.keys(config).forEach(chain => {

--- a/projects/w3bank/index.js
+++ b/projects/w3bank/index.js
@@ -2,7 +2,7 @@ const { lendingMarket } = require("../helper/methodologies");
 const { compoundExports2 } = require("../helper/compound");
 
 module.exports = {
-  start: 1693843200,
+  start: '2023-09-04',
   pg: compoundExports2({ comptroller: '0x697bc9fd98ddafd1979c3e079033698ca93af451'}),
   methodology: `${lendingMarket}`,
 };

--- a/projects/warp/index.js
+++ b/projects/warp/index.js
@@ -27,7 +27,7 @@ async function tvl(api) {
 }
 
 module.exports = {
-  start: 1610650220,
+  start: '2021-01-14',
   ethereum: { tvl },
 }
 

--- a/projects/waterfalldefi/index.js
+++ b/projects/waterfalldefi/index.js
@@ -135,7 +135,6 @@ async function tvl(chain, block) {
 
 module.exports = {
   methodology: 'Counts Waterfall DeFi tranche products TVL and staking TVL',
-  start: 16343128,
   bsc: {
     tvl: bscTVL,
     staking: bscStaking

--- a/projects/weave/index.js
+++ b/projects/weave/index.js
@@ -15,7 +15,6 @@ async function tvl(api) {
 
 module.exports = {
       methodology: 'gets the balance of the strategy contract',
-  start: 5793963,
   kava: {
     tvl,
   }

--- a/projects/winr-protocol/index.js
+++ b/projects/winr-protocol/index.js
@@ -2,7 +2,6 @@ const { gmxExports } = require('../helper/gmx')
 const WINR_VAULT_CONTRACT = "0x8c50528F4624551Aad1e7A265d6242C3b06c9Fca";
 
 module.exports = {
-  start: 67057671,
   arbitrum: {
     tvl: gmxExports({ vault: WINR_VAULT_CONTRACT }),
   },

--- a/projects/wowswap/index.js
+++ b/projects/wowswap/index.js
@@ -40,7 +40,7 @@ function tvl(chain) {
 }
 
 module.exports = {
-  start: 1618218000,            // Mon Apr 12 2021 09:00:00
+  start: '2021-04-12',            // Mon Apr 12 2021 09:00:00
   misrepresentedTokens: true,
 };
 

--- a/projects/xdai/index.js
+++ b/projects/xdai/index.js
@@ -27,5 +27,5 @@ module.exports = {
   ethereum: {
     tvl: eth,
   },
-  start: 1539028166,
+  start: '2018-10-08',
 };

--- a/projects/xfai/index.js
+++ b/projects/xfai/index.js
@@ -3,7 +3,7 @@ const FACTORY_ADDRESS = "0xa5136eAd459F0E61C99Cec70fe8F5C24cF3ecA26";
 
 module.exports = {
   methodology: `Sums on-chain tvl by getting pools using xfai factory`,
-  start: 1692347965 , // Aug-18-2023 08:39:25 AM +UTC
+  start: '2023-08-18' , // Aug-18-2023 08:39:25 AM +UTC
   linea: {
     tvl: async (api) => {
       const pools = await api.fetchList({  lengthAbi: "uint256:allPoolsLength", itemAbi: "function allPools(uint256) external view returns (address)", target: FACTORY_ADDRESS})

--- a/projects/y24/index.js
+++ b/projects/y24/index.js
@@ -6,7 +6,6 @@ const StakingContract2 = '0xe0Ceee33e1CE1EF4EA322B50D55d99E714B7BB6d';
 
 module.exports = {
   methodology: 'This is the total value locked in y24 staking',
-  start: 35011373,
   bsc: {
     tvl: () => ({}),
     staking: sumTokensExport({owners: [StakingContract1, StakingContract2], tokens: [TOKEN_ADDRESS], lps: ['0x44628669C0F888b2884d20b94C22af465AA11f05'], useDefaultCoreAssets: true,})

--- a/projects/yamato/index.js
+++ b/projects/yamato/index.js
@@ -21,7 +21,7 @@ async function tvl(_, block) {
 }
 
 module.exports = {
-    start: 1690387200,
+    start: '2023-07-26',
   ethereum: {
     tvl,
   }

--- a/projects/yamfore/index.js
+++ b/projects/yamfore/index.js
@@ -19,6 +19,6 @@ module.exports = {
   cardano: {
     tvl
   },
-  start: 1728878400,
+  start: '2024-10-14',
   methodology: "TVL is equal to all ADA, CBLP and USDM (USDM by Moneta) held in the treasury and unlent funds, collected fees and loan collateral held by the V1 script.",
 };

--- a/projects/yaxis/index.js
+++ b/projects/yaxis/index.js
@@ -26,5 +26,5 @@ module.exports = {
     staking: staking_,
     pool2: staking(constants.UNISWAP_LPS.map(i => i.staking), constants.UNISWAP_LPS.map(i => i.address))
   },
-  start: 1600185600, // 09/16/2020 @ 12:00am (UTC+8)
+  start: '2020-09-15', // 09/16/2020 @ 12:00am (UTC+8)
 };

--- a/projects/yay-staking/index.js
+++ b/projects/yay-staking/index.js
@@ -11,6 +11,6 @@ const tvl = async (api) => {
 }
 
 module.exports = {
-  start: 1722488340,
+  start: '2024-08-01',
   ethereum: { tvl },
 }

--- a/projects/yearn-ether/index.js
+++ b/projects/yearn-ether/index.js
@@ -7,6 +7,6 @@ async function tvl(api) {
 
 module.exports = {
   methodology: 'counts the total amount of ETH underlying the LSTs deposited into the yETH pool.',
-  start: 1693971707,
+  start: '2023-09-06',
   ethereum: { tvl }
 };

--- a/projects/yetiFinance/index.js
+++ b/projects/yetiFinance/index.js
@@ -1,7 +1,7 @@
 // https://yetifinance.medium.com/yeti-finance-wind-down-55913bbf6aed
 module.exports = {
   misrepresentedTokens: true,
-  start: 1650027587,
+  start: '2022-04-15',
   deadFrom: '2324-02-10',
   hallmarks: [
     [Math.floor(new Date('2023-12-28')/1e3), 'Protocol decides to wind down'],

--- a/projects/yfii/index.js
+++ b/projects/yfii/index.js
@@ -105,6 +105,6 @@ async function tvl(timestamp, block) {
 
 module.exports = {
   doublecounted: true,
-  start: 1600185600,    // 09/16/2020 @ 12:00am (UTC+8)
+  start: '2020-09-15',    // 09/16/2020 @ 12:00am (UTC+8)
   ethereum: { tvl }
 };

--- a/projects/yiedl-vaults/index.js
+++ b/projects/yiedl-vaults/index.js
@@ -90,6 +90,6 @@ module.exports = {
     optimism: {
     tvl,
   },
-  start: 1703073600, // 2023-12-20 12:00:00 UTC
+  start: '2023-12-20', // 2023-12-20 12:00:00 UTC
   methodology: 'Calculates the total value of positions held by the YIEDL Vaults in Synthetix Perpetuals.'
 };

--- a/projects/yieldfields/index.js
+++ b/projects/yieldfields/index.js
@@ -6,5 +6,5 @@ module.exports = {
   bsc: {
     tvl: getUniTVL({ factory: '0x0A376eE063184B444ff66a9a22AD91525285FE1C', useDefaultCoreAssets: true }),
   },
-  start: 1621263282, // May-17-2021 03:54:42 PM
+  start: '2021-05-17', // May-17-2021 03:54:42 PM
 };

--- a/projects/yieldyak-staked-avax/index.js
+++ b/projects/yieldyak-staked-avax/index.js
@@ -22,7 +22,7 @@ async function avax(api) {
 }
 
 module.exports = {
-    start: 1658869201,
+    start: '2022-07-26',
     methodology: "Total Supply and Underlying Price of the derivative is multiplied, resulting in number of staked Avax tokens.",
     doublecounted: true,
     avax: {

--- a/projects/yldr/index.js
+++ b/projects/yldr/index.js
@@ -3,7 +3,7 @@ const { getLogs } = require('../helper/cache/getLogs')
 
 module.exports = {
   methodology: 'Get available liquidity for all reserves and include Uniswap V3 positions',
-  start: 1702931986,
+  start: '2023-12-18',
 };
 
 const config = {

--- a/projects/zeno/index.js
+++ b/projects/zeno/index.js
@@ -16,7 +16,7 @@ async function metisTvl(api) {
 }
 
 module.exports = {
-  start: 1710294153,
+  start: '2024-03-13',
   metis: {
     tvl: metisTvl,
   },

--- a/projects/zeroswap/index.js
+++ b/projects/zeroswap/index.js
@@ -10,7 +10,6 @@ const AVAX_STAKING_ADDRESS = '0xa4751EAa89C5D6ff61384766268cabf25aCD1011'
 
 module.exports = {
   methodology: 'Counts tvl of all the tokens staked through Staking Contracts',
-  start: 1000235,
   ethereum: {
     tvl:() => ({}),
     staking: staking(ETH_STAKING_ADDRESS, ETH_TOKEN_ADDRESS),

--- a/projects/zkUSD/index.js
+++ b/projects/zkUSD/index.js
@@ -6,7 +6,7 @@ const TROVE_MANAGER_ADDRESS = {
 }
 
 module.exports = {
-  start: 1700000000, // Tuesday, November 14, 2023 10:13:20 PM
+  start: '2023-11-14', // Tuesday, November 14, 2023 10:13:20 PM
 };
 
 Object.keys(TROVE_MANAGER_ADDRESS).forEach(chain => {

--- a/projects/zkdx/index.js
+++ b/projects/zkdx/index.js
@@ -3,7 +3,6 @@ const {staking} = require("../helper/staking");
 
 module.exports = {
     methodology: 'zkDX counts the staking values as tvl',
-    start: 3744214,
     era: {
         tvl: staking(
             ["0x79033C597B7d8e752a7511cF24512f4A7217C0B8", "0xd6cce119B45Efcb378a4735a96aE08826A37ca1c",

--- a/projects/zkswap/index.js
+++ b/projects/zkswap/index.js
@@ -8,7 +8,7 @@ const configs = [
 ]
 
 module.exports = {
-  start: 1613135160, // 02/12/2021 @ 01:06pm UTC
+  start: '2021-02-12', // 02/12/2021 @ 01:06pm UTC
   ethereum: {
     tvl: sdk.util.sumChainTvls(configs.map(i => {
       return async function tvl(api) {

--- a/utils/scripts/stringTimestamp.js
+++ b/utils/scripts/stringTimestamp.js
@@ -1,0 +1,96 @@
+const fs = require('fs');
+const path = require('path');
+
+// Function to convert Unix timestamp to 'YYYY-MM-DD' format
+function convertTimestamp(unixTimestamp) {
+  const date = new Date(unixTimestamp * 1000);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+// Function to process files in the given directory
+function processFiles(dir) {
+  if (['node_modules', 'raindex', 'helper', 'exactly'].some(name => dir.includes(name))) {
+    return;
+  }
+  fs.readdir(dir, (err, files) => {
+    if (err) {
+      console.error(`Error reading directory ${dir}:`, err);
+      return;
+    }
+
+    files.forEach(file => {
+      const filePath = path.join(dir, file);
+      fs.stat(filePath, (err, stats) => {
+        if (err) {
+          console.error(`Error stating file ${filePath}:`, err);
+          return;
+        }
+
+        if (stats.isFile()) {
+          fs.readFile(filePath, 'utf8', (err, data) => {
+            if (err) {
+              console.error(`Error reading file ${filePath}:`, err);
+              return;
+            }
+
+            const regex = /start:\s*(\d+)/g;
+            const newData = data.replace(regex, (match, p1) => {
+              if (!/^\d{10}$/.test(p1)) {
+                console.error(`Invalid Unix timestamp ${p1} in file ${filePath}`);
+                return match;
+              }
+
+              const year = new Date(parseInt(p1, 10) * 1000).getFullYear();
+              if (year < 2005 || year > 2055) {
+                console.error(`Year ${year} out of range for timestamp ${p1} in file ${filePath}`);
+                return match;
+              }
+              const newTimestamp = convertTimestamp(parseInt(p1, 10));
+              return `start: '${newTimestamp}'`;
+            });
+
+            if (newData !== data) {
+              fs.writeFile(filePath, newData, 'utf8', err => {
+                if (err) {
+                  console.error(`Error writing file ${filePath}:`, err);
+                } else {
+                  console.log(`Updated file ${filePath}`);
+                }
+              });
+            }
+          });
+        } else if (stats.isDirectory()) {
+          processFiles(filePath);
+        }
+      });
+    });
+  });
+}
+
+// Get the directory two levels up
+const baseDir = path.resolve(__dirname, '../../projects');
+
+// Process all directories two levels up
+fs.readdir(baseDir, (err, dirs) => {
+  if (err) {
+    console.error(`Error reading base directory ${baseDir}:`, err);
+    return;
+  }
+
+  dirs.forEach(dir => {
+    const dirPath = path.join(baseDir, dir);
+    fs.stat(dirPath, (err, stats) => {
+      if (err) {
+        console.error(`Error stating directory ${dirPath}:`, err);
+        return;
+      }
+
+      if (stats.isDirectory()) {
+        processFiles(dirPath);
+      }
+    });
+  });
+});


### PR DESCRIPTION
Convert all `start` fields to string format for consistency and improved readability.