### PR TITLE
Add Dexodus TVL adapter

### DIFF
--- a/projects/dexodus/index.js
+++ b/projects/dexodus/index.js
@@ -1,0 +1,18 @@
+const { sumTokens2 } = require('../helper/unwrapLPs');
+
+async function tvl(_, _b, _cb, { api, }) {
+    const owner = '0x1A84d7E27e7f0e93Da74b93095e342b6e8dBd50A'; // Dexodus liquidity pool address
+    const tokens = [
+      '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913', // USDC on Base
+      '0x4200000000000000000000000000000000000006', // WETH on Base
+    ];
+    return sumTokens2({ api, owner, tokens });
+  }
+  
+  module.exports = {
+    methodology: 'Counts the USDC and WETH tokens in the Dexodus liquidity pool on Base.',
+    base: {
+      tvl,
+    },
+  };
+  


### PR DESCRIPTION
### Add Dexodus TVL Adapter for Base Mainnet

This pull request adds the TVL adapter for Dexodus. The adapter calculates the TVL of the Dexodus liquidity pool deployed on Base Mainnet. The liquidity pool contains USDC and WETH tokens, and the TVL is calculated using the sumTokens2 helper function.

#### Methodology
- The adapter uses `sumTokens2` to fetch the balances of USDC and WETH in the Dexodus liquidity pool on Base Mainnet.

#### Key Details
- **Owner Address**: 0x1A84d7E27e7f0e93Da74b93095e342b6e8dBd50A
- **Supported Tokens**: USDC, WETH

---

### Dexodus Project Information
- **Website**: [https://dexodus.finance](https://dexodus.finance)
- **Twitter**: [@dexodusfinance](https://twitter.com/dexodusfinance)
- **Documentation**: [https://docs.dexodus.finance](https://docs.dexodus.finance)

Dexodus is an innovative oracle-based perpetual DEX designed to empower traders with advanced financial tools and access to diverse markets. We are excited to integrate with DefiLlama to provide accurate TVL data for the community.
