### PR TITLE
Switch TVL to SKALE Europa

### DIFF
--- a/projects/skale/index.js
+++ b/projects/skale/index.js
@@ -4,7 +4,7 @@ const depositBoxERC20 = '0x8fB1A35bB6fB9c47Fb5065BE5062cB8dC1687669';
 
 module.exports = {
   start: '2021-07-19', // Mon July 19 06:38:20 PM UTC 2021
-  ethereum: {
+  europa: {
     tvl: sumTokensExport({ owners: [depositBoxETH, depositBoxERC20], fetchCoValentTokens: true, permitFailure: true }),
   }
 }


### PR DESCRIPTION
- This is a small change to the SKALE Network Bridge to ensure the TVL is showing up as SKALE TVL and not Ethereum.
- All TVL is currently tagged as Europa TVL since Europa being the primary DeFi + Liquidity Hub today has the ~100% of the native bridge TVL
- In the future, if additional chains use the native SKALE Bridge; we can update the tracking to split TVL by deposit chains