### PR TITLE
update astrovault adapter to include nibiru chain

### DIFF
--- a/projects/astrovault/index.js
+++ b/projects/astrovault/index.js
@@ -19,6 +19,15 @@ const data = {
     hybridFactory:
       "neutron16yn2gcz24s9qwpuxvrhl3xed0pmhrgwx2mz40zrazfc0pt5kq0psucs6xl",
   },
+  
+  nibiru: {
+    stableFactory:
+      "nibi143hmeallpaasdyull3gjcmasrcg63yl8f4cumah7xmcmjnqewa9s5jkan2",
+    standardFactory:
+      "nibi1gmw5eqnergfdx5qp4w53vwaywg63dwnvqeus3g6a2926pz2axyqshrlh2m",
+    hybridFactory:
+      "nibi1gwsrmpkkcl82aqs3vk4vy2lt0dm3kr3sshmruzhxhsqh8xglxrtsglzpqj",
+  },
 };
 
 async function tvl(api) {
@@ -84,6 +93,9 @@ module.exports = {
     tvl,
   },
   neutron: {
+    tvl,
+  },
+  nibiru: {
     tvl,
   },
 }


### PR DESCRIPTION
This PR updates the Astrovault adapter to include the Nibiru chain deployment that was done recently.

Now this adapter gets the tvl for the chains:

Archway
Neutron
Nibiru