### PR TITLE
Change Plunderswap to use new api for retreiving tvl, volume, fees

### DIFF
--- a/projects/plunderswap/index.js
+++ b/projects/plunderswap/index.js
@@ -1,3 +1,6 @@
 const { uniTvlExport, } = require('../helper/unknownTokens')
+const { uniV3Export } = require('../helper/uniswapV3')
 
 module.exports = uniTvlExport('zilliqa', '0xf42d1058f233329185A36B04B7f96105afa1adD2')
+module.exports = uniV3Export('zilliqa', '0x000A3ED861B2cC98Cc5f1C0Eb4d1B53904c0c93a')
+

--- a/projects/plunderswap/index.js
+++ b/projects/plunderswap/index.js
@@ -1,8 +1,21 @@
-const { uniTvlExport, } = require('../helper/unknownTokens')
-const { uniV3Export } = require('../helper/uniswapV3')
+const utils = require('../helper/utils')
 
-module.exports = uniTvlExport('zilliqa', '0xf42d1058f233329185A36B04B7f96105afa1adD2')
-module.exports = uniV3Export({
-    zilliqa: { factory: '0x000A3ED861B2cC98Cc5f1C0Eb4d1B53904c0c93a', fromBlock: 3862851, },
-  })
+async function tvl() {
+  const poolPrices = await utils.fetchURL('https://static.plunderswap.com/PlunderswapPoolPrices.json')
+  
+  // Sum up tvlZIL from all pools
+  var totalTvl = poolPrices?.data?.reduce((prev, curr) => prev + (Number(curr?.tvlZIL) ?? 0), 0)
+  
+  return {
+    zilliqa: totalTvl
+  }
+}
 
+module.exports = {
+  zilliqa: {
+    tvl,
+  },
+  timetravel: false,
+  misrepresentedTokens: true,
+  methodology: "Counts the tokens locked in PlunderSwap AMM pools to calculate TVL using pool prices from PlunderSwap API. TVL is calculated in ZIL. the https://static.plunderswap.com/PlunderswapPoolPrices.json is updated every 5 mins"
+}

--- a/projects/plunderswap/index.js
+++ b/projects/plunderswap/index.js
@@ -2,5 +2,7 @@ const { uniTvlExport, } = require('../helper/unknownTokens')
 const { uniV3Export } = require('../helper/uniswapV3')
 
 module.exports = uniTvlExport('zilliqa', '0xf42d1058f233329185A36B04B7f96105afa1adD2')
-module.exports = uniV3Export('zilliqa', '0x000A3ED861B2cC98Cc5f1C0Eb4d1B53904c0c93a')
+module.exports = uniV3Export({
+    zilliqa: { factory: '0x000A3ED861B2cC98Cc5f1C0Eb4d1B53904c0c93a', fromBlock: 3862851, },
+  })
 


### PR DESCRIPTION
Zilliqa EVM blockchain doesnt have logs or traces in the data, so this api reads direct from the factory and pool contracts onchain to display the data out.

Please let me know if I can use utils.fetchURL to an API still.

If not, can I list the v2/v3 pools to track, and track that back to the tokens balances in the pool somehow for an adapter? if you have an example.  

