### PR TITLE
Update plunderswap v2 to use same method as v3, add some more token mappings, include kUSD TVL.

### DIFF
--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -100,6 +100,10 @@ const fixBalancesTokens = {
     '0x03a79429acc808e4261a68b0117acd43cb0fdbfa': { coingeckoId: "governance-zil", decimals: 15 },
     '0xccf3ea256d42aeef0ee0e39bfc94baa9fa14b0ba': { coingeckoId: "xcad-network", decimals: 18 },
     '0xe64ca52ef34fdd7e20c0c7fb2e392cc9b4f6d049': { coingeckoId: "kalijo", decimals: 18 },
+    '0xe9d47623bb2b3c497668b34fcf61e101a7ea4058': { coingeckoId: "lunr-token", decimals: 4 },
+    '0x9c3fe3f471d8380297e4fb222efb313ee94dfa0f': { coingeckoId: "zilpepe", decimals: 18 },
+    '0x7d2ff48c6b59229d448473d267a714d29f078d3e': { coingeckoId: "zilstream", decimals: 8 },
+    '0x241c677d9969419800402521ae87c411897a029f': { coingeckoId: "web3war", decimals: 12 },
   },
 }
 

--- a/projects/plunderswap-v3/index.js
+++ b/projects/plunderswap-v3/index.js
@@ -1,12 +1,32 @@
 const { getConfig } = require('../helper/cache')
 const { sumTokens2 } = require('../helper/unwrapLPs')
 
+const KUSD = '0xE9DF5B4B1134a3AaDf693DB999786699B016239e'
+const zUSDT = '0x2274005778063684FBB1BFa96A2B725Dc37D75F9'
+
 async function tvl(api) {
   const data = await getConfig('plunderswap', 'https://static.plunderswap.com/PlunderswapPoolPrices.json')
   const v3Pairs = data.filter(pair => pair.version === 'V3').map(pair => pair.address)
   const token0s = await api.multiCall({ abi: 'address:token0', calls: v3Pairs })
   const token1s = await api.multiCall({ abi: 'address:token1', calls: v3Pairs })
-  return sumTokens2({ api, tokensAndOwners2: [token0s.concat(token1s), v3Pairs.concat(v3Pairs)] })
+
+  // Get kUSD balance from all v3 pairs - kUSD is represented as zUSDT (1:1 backed stablecoin)
+  const kUsdBalances = await api.multiCall({
+    abi: 'erc20:balanceOf',
+    target: KUSD,
+    calls: v3Pairs
+  })
+
+  // Sum up balances
+  const totalKusd = kUsdBalances.reduce((a, b) => Number(a) + Number(b), 0)
+  
+  // Add kUSD value to api balances as zUSDT
+  api.add(zUSDT, totalKusd)
+
+  return sumTokens2({ 
+    api, 
+    tokensAndOwners2: [token0s.concat(token1s), v3Pairs.concat(v3Pairs)]
+  })
 }
 
 module.exports = {

--- a/projects/plunderswap/index.js
+++ b/projects/plunderswap/index.js
@@ -1,3 +1,34 @@
-const { uniTvlExport, } = require('../helper/unknownTokens')
+const { getConfig } = require('../helper/cache')
+const { sumTokens2 } = require('../helper/unwrapLPs')
 
-module.exports = uniTvlExport('zilliqa', '0xf42d1058f233329185A36B04B7f96105afa1adD2')
+const KUSD = '0xE9DF5B4B1134a3AaDf693DB999786699B016239e'
+const zUSDT = '0x2274005778063684FBB1BFa96A2B725Dc37D75F9'
+
+async function tvl(api) {
+  const data = await getConfig('plunderswap', 'https://static.plunderswap.com/PlunderswapPoolPrices.json')
+  const v2Pairs = data.filter(pair => pair.version === 'V2').map(pair => pair.address)
+  const token0s = await api.multiCall({ abi: 'address:token0', calls: v2Pairs })
+  const token1s = await api.multiCall({ abi: 'address:token1', calls: v2Pairs })
+
+  // Get kUSD balance from all v3 pairs - kUSD is represented as zUSDT (1:1 backed stablecoin)
+  const kUsdBalances = await api.multiCall({
+    abi: 'erc20:balanceOf',
+    target: KUSD,
+    calls: v2Pairs
+  })
+
+  // Sum up balances
+  const totalKusd = kUsdBalances.reduce((a, b) => Number(a) + Number(b), 0)
+  
+  // Add kUSD value to api balances as zUSDT
+  api.add(zUSDT, totalKusd)
+
+  return sumTokens2({ 
+    api, 
+    tokensAndOwners2: [token0s.concat(token1s), v2Pairs.concat(v2Pairs)]
+  })
+}
+
+module.exports = {
+  zilliqa: { tvl }
+}


### PR DESCRIPTION
Update plunderswap v2 to use same method as v3, add some more token mappings, include kUSD TVL.