### PR TITLE
SwissBorg: Add new wallets

### DIFF
--- a/projects/swissborg/index.js
+++ b/projects/swissborg/index.js
@@ -88,6 +88,7 @@ const config = {
       '0xcDE4c1b984F3F02f997ECfF9980B06316de2577d',
       '0x7153D2ef9F14a6b1Bb2Ed822745f65E58d836C3F',
       '0xFF4606bd3884554CDbDabd9B6e25E2faD4f6fc54',
+      '0x9531AA9883bF11f2a63d86caD7e826f37Acec3c4',
     ]
   },
   polygon: {
@@ -110,6 +111,7 @@ const config = {
   arbitrum: {
     owners: [
       '0x8F0d8b27bF808976Fa94f03e2230b4bca95bf3C4',
+      '0x5509Be53b2dD0CD6fb8473B0EdA94e0a3059b73a',
     ]
   },
   // injective: {

--- a/projects/swissborg/index.js
+++ b/projects/swissborg/index.js
@@ -114,11 +114,6 @@ const config = {
       '0x5509Be53b2dD0CD6fb8473B0EdA94e0a3059b73a',
     ]
   },
-  // injective: {
-  //   owners: [
-  //     'inj1wvhk7xhzf9kus9a4tpa6v8vhuqvm265rz7zd6n',
-  //   ]
-  // }
 }
 
 module.exports = cexExports(config)


### PR DESCRIPTION
This PR updates the list of wallets owned by SwissBorg. New wallets addition: https://github.com/SwissBorg/pub/commit/bc19152ef55a059c05b77d330865eeac60fcf37f

It also removes Injective wallets as they are not supported.