### PR TITLE
Fix: 21co

### DIFF
--- a/projects/21-co/index.js
+++ b/projects/21-co/index.js
@@ -1,7 +1,6 @@
 const { cexExports } = require('../helper/cex')
 const bitcoinAddressBook = require('../helper/bitcoin-book/index.js')
 
-
 const config = {
   bitcoin: {
     owners: bitcoinAddressBook.twentyOneCo
@@ -37,9 +36,7 @@ const config = {
     ],
   },
  bep2: {
-    owners: [
-      'bnb1k3ulpgw4wzl0e8qx80u87aq9w7ekfygruzs4dg'
-    ],
+    // owners: ['bnb1k3ulpgw4wzl0e8qx80u87aq9w7ekfygruzs4dg'],
   },
  /* bitcoin_cash: {
     owners: [


### PR DESCRIPTION
Since the definitive sunset of BNB on December 3, it is no longer possible to retrieve balances on BEP2

![image](https://github.com/user-attachments/assets/41198868-ed8c-4b6d-9a55-9accb589fdb6)

![image](https://github.com/user-attachments/assets/dd4b3409-4254-408b-940b-a09a73812e6d)
