### PR TITLE
Fix: SailingProtocol

### DIFF
--- a/projects/sailingprotocol/index.js
+++ b/projects/sailingprotocol/index.js
@@ -69,11 +69,6 @@ const tokens = [
     "sufficientLiquidityForDefiLlamaIndexer": false,
   },
   {
-    "address": "0xBa5c32915e2303EA41d1986f5B3AAd0a98B4Fd80",
-    "ticker": "ETHE",
-    "sufficientLiquidityForDefiLlamaIndexer": false,
-  },
-  {
     "address": "0xA78Fb2b64Ce2Fb8bBe46968cf961C5Be6eB12924",
     "ticker": "AAAU",
     "sufficientLiquidityForDefiLlamaIndexer": false,


### PR DESCRIPTION
Removing the `ETHE` asset that no longer exists in the protocol and therefore returns an error in the API call, which can’t retrieve its price