### PR TITLE
Fix: Clone (sunset)

### DIFF
--- a/projects/clone/index.js
+++ b/projects/clone/index.js
@@ -21,10 +21,9 @@ async function tvl() {
 }
 
 module.exports = {
+  deadFrom: "2024-09-30",
+  hallmarks: [[1727654400, "Clone Sunset"]],
   timetravel: false,
-  solana: {
-    tvl,
-  },
-  methodology:
-    'Return the amount of collateral in the vault.'
+  solana: { tvl : () => ({})},
+  methodology: 'Return the amount of collateral in the vault.'
 }


### PR DESCRIPTION
Stopping the tracking of the Clone adapter: the contract was closed on Solana, and the team had announced a definitive sunset for September 30, 2024

![image](https://github.com/user-attachments/assets/1e6fae25-66e4-4df0-a710-ecda598e220e)

https://x.com/CloneProtocol/status/1823164538218536986

https://cloneprotocol.medium.com/the-deprecation-of-clone-protocol-6ff85310b458