### PR TITLE
Fix: Furucombo (sunset)

### DIFF
--- a/projects/furucombo/index.js
+++ b/projects/furucombo/index.js
@@ -1,22 +1,23 @@
 const { getLogs } = require('../helper/cache/getLogs')
-const config = {
-  polygon: { factory: '0xFD1353baBf86387FcB6D009C7b74c1aB2178B304', fromBlock:   29080112   },
+
+const factory = '0xFD1353baBf86387FcB6D009C7b74c1aB2178B304'
+const fromBlock = '29080112'
+
+const tvl = async (api) => {
+  const logs = await getLogs({
+    api,
+    target: factory,
+    eventAbi: 'event FundCreated (address indexed newFund, address comptroller, address shareToken, address vault)',
+    onlyArgs: true,
+    fromBlock,
+  })
+
+  const tokens = await api.multiCall({  abi: 'address[]:getAssetList', calls: logs.map(l => l.newFund) })
+  const ownerTokens = tokens.map((t, i) => [t, logs[i].vault])
+  return api.sumTokens({ ownerTokens })
 }
 
-Object.keys(config).forEach(chain => {
-  const { factory, fromBlock} = config[chain]
-  module.exports[chain] = {
-    tvl: async (api) => {
-      const logs = await getLogs({
-        api,
-        target: factory,
-        eventAbi: 'event FundCreated (address indexed newFund, address comptroller, address shareToken, address vault)',
-        onlyArgs: true,
-        fromBlock,
-      })
-      const tokens = await api.multiCall({  abi: 'address[]:getAssetList', calls: logs.map(l => l.newFund) })
-      const ownerTokens = tokens.map((t, i) => [t, logs[i].vault])
-      return api.sumTokens({ ownerTokens })
-    }
-  }
-})
+module.exports = {
+  deadFrom: '2024-12-09',
+  polygon : { tvl : () => ({}) } 
+}


### PR DESCRIPTION
Stopping the tracking of the `Furucombo` adapter:

- There is no more activity on the contracts
- The comptroller was deactivated 28 hours ago, preventing access to data on dependent contracts
- TVL has been flat since summer 2022

https://polygonscan.com/address/0x24fdb881EfAaF200c29c7449fB16845cc081BAB7#events
![image](https://github.com/user-attachments/assets/da79d4f8-4a48-448d-b160-514ff821d3d2)

https://polygonscan.com/address/0x8c3B8122a0983f7ac32A14e9cd7Fc3F92a48dBD2#readProxyContract
![image](https://github.com/user-attachments/assets/a9a40334-94ab-43cf-9557-14d12b2f3ddf)
