### PR TITLE
Astrovault duplicate export fix

### DIFF
--- a/projects/astrovault/index.js
+++ b/projects/astrovault/index.js
@@ -99,5 +99,3 @@ module.exports = {
     tvl,
   },
 }
-
-module.exports = { nibiru: { tvl } }


### PR DESCRIPTION
The AstroVault adapter accidently had a double export, causing only one chain TVL to be output. 

This simply removes the second export to bring all 3 chains back up. 