### PR TITLE
Add Arbitrum chain to existing Lockon protocol adapter

### DIFF
--- a/projects/lockon/index.js
+++ b/projects/lockon/index.js
@@ -1,14 +1,26 @@
 const START_TIMESTAMP = 1690340140; // 2023-07-26T02:55:40Z
-const CONTROLLER_ADDRESS = "0x153e739B8823B277844Ad885A30AC5bD9DfB6E83"
-
-async function tvl(api) {
-  const sets = await api.call({ abi: "address[]:getSets", target: CONTROLLER_ADDRESS, })
-  const tokens = await api.multiCall({  abi: 'address[]:getComponents', calls: sets})
-  const ownerTokens = sets.map((set, i) => [tokens[i], set])
-  return api.sumTokens({ ownerTokens })
+const config = {
+  polygon: {
+    controllerAddress: "0x153e739B8823B277844Ad885A30AC5bD9DfB6E83",
+  },
+  arbitrum: {
+    controllerAddress: "0xA36c2B06aFc96Ffd52d148Ed6acbB9fe2Ab864Be",
+  }
 }
 
-module.exports = {
-  start: START_TIMESTAMP,
-  polygon: { tvl }
+function tvlExport({controllerAddress}) {
+  return async function tvl(api) {
+    const sets = await api.call({ abi: "address[]:getSets", target: controllerAddress, })
+    const tokens = await api.multiCall({  abi: 'address[]:getComponents', calls: sets})
+    const ownerTokens = sets.map((set, i) => [tokens[i], set])
+    return api.sumTokens({ ownerTokens })
+  }
+
 }
+
+module.exports.start = START_TIMESTAMP
+Object.keys(config).forEach(chain => {
+  module.exports[chain] = {
+    tvl: tvlExport(config[chain])
+  }
+})


### PR DESCRIPTION
This PR adds Arbitrum chain support to the existing Lockon protocol adapter. No new protocol listing - just extending chain coverage.

Note: This PR is from an organization fork, so "Allow edits by maintainers" option cannot be enabled.