### PR TITLE
Fix: Curve (Corn issue)

### DIFF
--- a/projects/curve/index.js
+++ b/projects/curve/index.js
@@ -240,7 +240,7 @@ function tvl(chain) {
     if (blacklists[chain])
       blacklistedTokens.push(...blacklists[chain])
     await addPlainFactoryConfig({ api, tokensAndOwners, plainFactoryConfig })
-    await sumTokens2({ balances, chain, block, tokensAndOwners, transformAddress: transform, blacklistedTokens })
+    await sumTokens2({ balances, chain, block, tokensAndOwners, transformAddress: transform, blacklistedTokens, ...(chain === "corn" && { permitFailure: true }) })
     await handleUnlistedFxTokens(balances, chain);
     return balances;
   };


### PR DESCRIPTION
Added a minor fix for the Curve adapter, which is encountering issues with the Corn chain. There are significantly more RPC errors than usual on Corn. Added a permitFailure option exclusively for this chain to ensure it does not disrupt the proper functioning of other chains. Apparently, according to Curve's frontend, they are also facing issues with displaying balances on Corn (likely related to RPC issues as well)

![image](https://github.com/user-attachments/assets/bb8a3282-7572-4a05-a65e-ec8ab6de980f)

![image](https://github.com/user-attachments/assets/6c7ad268-6872-4e0b-a3b4-cc8d8bd3de74)
