### PR TITLE
Add new SwissBorg wallets

### DIFF
--- a/projects/swissborg/index.js
+++ b/projects/swissborg/index.js
@@ -21,6 +21,7 @@ const config = {
       '0x8F0d8b27bF808976Fa94f03e2230b4bca95bf3C4',
       '0xe2484A7Ac1b9Cb6D8E55fd00e129aB913172bea6',
       '0xdbe15F6573108B6736c70779C683Ca633c18aFe2',
+      '0xa2E07DB4e92F66071Ca68984517972F5625AB325',
     ],
   },
   bitcoin: {
@@ -49,6 +50,7 @@ const config = {
       'Fe7SEekiKygziaEGKxsDsgLVzrCfNvVBvAYsaJBwFA8s',
       'AR2ecEWY2vfsXmd4fUxc196LhbX5p8TnhvJg8t3fgYUN',
       '7Sng9GTnkjjb8WTF2kYX8JWqGHHwJGk5Ke9639zREUAR',
+      '3jvARuePRR6KpNAeYYGRQzs8W4VYsWWxe4BfoTSTZhUr',
     ],
   },
   polkadot: {


### PR DESCRIPTION
This PR updates the list of wallets owned by SwissBorg. New wallets addition: https://github.com/SwissBorg/pub/commit/e72ba1486fd4b2a95f27fe437b0c511e6201ec77