### PR TITLE
Update: Beefstake

### DIFF
--- a/projects/beefstake/index.js
+++ b/projects/beefstake/index.js
@@ -11,6 +11,7 @@ async function fetch() {
 }
 
 module.exports = {
+  deadFrom: "2024-06-01",
   timetravel: false,
   misrepresentedTokens: true,
   vite:{


### PR DESCRIPTION
Added a `deadFrom` to the Beefstake protocol, whose TVL has been flat for over a year with very low liquidity. Their API seems to be down, and their frontend no longer displays pools. The Twitter account has shown no real activity since June 2024