### PR TITLE
Fix: Tezos helper, change API endpoint

### DIFF
--- a/projects/helper/chain/tezos.js
+++ b/projects/helper/chain/tezos.js
@@ -3,7 +3,7 @@ const http = require('../http')
 const sdk = require('@defillama/sdk')
 const { PromisePool } = require('@supercharge/promise-pool')
 
-const RPC_ENDPOINT = 'https://api.tzkt.io'
+const RPC_ENDPOINT = 'https://api.mainnet.tzkt.io'
 
 const usdtAddressTezos = ADDRESSES.tezos.USDt
 const transformAddressDefault = t => t == "tezos" ? "coingecko:tezos" : 'tezos:' + t


### PR DESCRIPTION
Change of endpoint for retrieving data from Tezos. Many Tezos adapters have not been updated for several days:

**Matter-Defi**

![image](https://github.com/user-attachments/assets/a8cf05f0-99e0-4af8-8d6f-30d54f952a53)

**Plenty**

![image](https://github.com/user-attachments/assets/96d81b11-081e-4b2f-9b6e-65b0f3aca392)

**Crunchy**

![image](https://github.com/user-attachments/assets/44773bb2-ca6d-4a5a-b7d6-5111e3b10ac5)

**Youves**

![image](https://github.com/user-attachments/assets/7a7f1cfe-2678-46ec-8f18-74f5950f8b86)


