### PR TITLE
Fix: Ottopia

### DIFF
--- a/projects/ottopia/index.js
+++ b/projects/ottopia/index.js
@@ -26,6 +26,7 @@ async function tvl(api) {
 }
 
 module.exports = {
+  deadFrom: '2024-08-14',
   methodology: "This adapter uses otterclam's subgraph to fetch tvl data.",
   polygon: {
     tvl,

--- a/projects/ottopia/index.js
+++ b/projects/ottopia/index.js
@@ -1,37 +1,32 @@
 const sdk = require("@defillama/sdk");
-const { GraphQLClient, gql } = require("graphql-request");
+const { request, gql } = require("graphql-request");
 const { staking } = require("../helper/staking");
 
 const CLAM = "0xC250e9987A032ACAC293d838726C511E6E1C029d";
 const PearlBank = "0x845EB7730a8D37e8D190Fb8bb9c582038331B48a";
 
-async function tvl({timestamp}, block, chainBlocks) {
-  let endpoint = sdk.graph.modifyEndpoint('CejrrsnSQAxHJBpkgiBrLHQZ7h2MkK9QArM8bJvN9GuQ');
-  let graphQLClient = new GraphQLClient(endpoint);
-  let query = gql`
-    query tvl($start: BigInt!, $end: BigInt!) {
-      protocolMetrics(
-        where: { timestamp_gte: $start, timestamp_lt: $end }
-        orderBy: timestamp
-        orderDirection: desc
-        first: 1
-      ) {
-        treasuryMarketValue
-        timestamp
-      }
+const endpoint = sdk.graph.modifyEndpoint('CejrrsnSQAxHJBpkgiBrLHQZ7h2MkK9QArM8bJvN9GuQ')
+
+const query = gql`
+  query tvl {
+    protocolMetrics(
+      first: 1
+      orderBy: timestamp
+      orderDirection: desc
+    ) {
+      treasuryMarketValue
+      timestamp
     }
-  `;
-  const results = await  graphQLClient.request(query, {
-        start: timestamp - 2 * 60 * 60 * 1000,
-        end: timestamp,
-      })
-  return {
-    usd: parseFloat(results.protocolMetrics[0].treasuryMarketValue),
-  };
+  }
+`;
+
+async function tvl(api) {
+  const results = await request(endpoint, query)
+  return api.addUSDValue(parseFloat(results.protocolMetrics[0].treasuryMarketValue))
 }
 
 module.exports = {
-    methodology: "This adapter uses otterclam's subgraph to fetch tvl data.",
+  methodology: "This adapter uses otterclam's subgraph to fetch tvl data.",
   polygon: {
     tvl,
     staking: staking(PearlBank, CLAM),


### PR DESCRIPTION
The project seems to have been inactive since March 2023. The TVL is flat. I fixed the GraphQL endpoint. The last accessible value from the endpoint dates back to August 2024. With the addition of a deadFrom parameter, there’s no point in continuing to update the project

![image](https://github.com/user-attachments/assets/a2ce37f2-34ff-46b7-87d5-b0e2c4da5daa)
