### PR TITLE
fix StakeStone BeraVault TVL calculation: add Boyco deployed amount

### DIFF
--- a/projects/stakestone-berastone/index.js
+++ b/projects/stakestone-berastone/index.js
@@ -1,10 +1,16 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+
 const vaultABI = {
-  "getUnderlyings": "function getUnderlyings() external view returns (address[])"
+  "getUnderlyings": "function getUnderlyings() external view returns (address[])",
+  "assetsBorrowed": "function assetsBorrowed() external view returns (uint256)"
 }
 
 const Vault = '0x8f88aE3798E8fF3D0e0DE7465A0863C9bbB577f0';
 
 const Tvl = async (api) => {
+  const usedTVL = await api.call({ abi: vaultABI.assetsBorrowed, target: Vault })
+  api.add(ADDRESSES.ethereum.WETH, usedTVL);
+
   const underlyings = await api.call({ abi: vaultABI.getUnderlyings, target: Vault })
   return api.sumTokens({ owner: Vault, tokens: underlyings })
 }

--- a/projects/stakestone-berastone/index.js
+++ b/projects/stakestone-berastone/index.js
@@ -16,6 +16,7 @@ const Tvl = async (api) => {
 }
 
 module.exports = {
+  doublecounted: true,
   ethereum: {
     tvl: Tvl,
   }


### PR DESCRIPTION
The funds(STONE, WETH) in StakeStone BeraVault will be withdrawn and deposited into Berachain Boyco after its launch. The contract uses `assetsBorrowed` to record the amount withdrawn. Therefore, the correct TVL calculation should be the value of STONE and WETH in the contract, plus `assetsBorrowed`.