### PR TITLE
FEAT: Add Graphene TVL on IOTA EVM

### DIFF
--- a/projects/graphene/index.js
+++ b/projects/graphene/index.js
@@ -14,6 +14,10 @@ const config = {
     fromBlock: 18438182,
     controller: "0x7900f766F06e361FDDB4FdeBac5b138c4EEd8d4A",
   },
+  iotaevm: {
+    fromBlock: 1936296,
+    controller: "0x0E4d23092A4a12caAd0E22e0892EcEC7C09DC51c",
+  },
 };
 
 Object.keys(config).forEach((chain) => {


### PR DESCRIPTION
Adds Graphene by Velocimeter (licensed fork of Carbon DeFi by Bancor) TVL on IOTA EVM.

Name (to be shown on DefiLlama):
Graphene by Velocimeter

Twitter Link:
https://twitter.com/VelocimeterDEX

List of audit links if any:
Graphene is a direct licensed fork of Carbon with no contract changes.
[Link to Carbon audits docs page](https://docs.carbondefi.xyz/carbon-defi/security-and-audits)

Website Link:
https://automate.velocimeter.xyz/

Logo (High resolution, will be shown with rounded borders):
https://raw.githubusercontent.com/Velocimeter/carbon-app/93b784fb65be51e9b3494779079f2ee074019ac3/public/logo512.png

Current TVL on IOTA EVM:
$ 1M.

Chain:
Base, Fantom and Mantle are added. This adds IOTA EVM.

Short Description (to be shown on DefiLlama):
Graphene is a licensed fork of Carbon DeFi in the Velocimeter eco-system. This product allow users to create automated on-chain limit orders, range limit orders, re-occurring limit/range orders, overlapping liquidity orders.

Category:
Dexes

forkedFrom (Does your project originate from another project):
Carbon DeFi

methodology (what is being counted as tvl, how is tvl being calculated):
Balance of tokens

Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/Velocimeter/