### PR TITLE
Feat: mCap_check

### DIFF
--- a/test.js
+++ b/test.js
@@ -436,7 +436,12 @@ async function computeTVL(balances, timestamp) {
         console.log(`-------------------
   Warning: `);
         console.log(`Token ${address} has more than 100M in value (${usdAmount / 1e6} M), price data: `, data);
-        await checkMarketCap(address, symbol, usdAmount);
+
+        const isWithinMarketCap = await checkMarketCap(address, symbol, usdAmount);
+        if (!isWithinMarketCap) {
+          console.log(`Ignoring token ${address} (${symbol}) due to exceeding market cap.`);
+          continue;
+        }
         console.log(`-------------------`);
       }
   

--- a/test.js
+++ b/test.js
@@ -441,7 +441,7 @@ async function computeTVL(balances, timestamp) {
 
         if (!isWithinMarketCap) {
           if (!newPrice) {
-            console.log(`Token ${address} (${symbol}) exceeds market cap and no valid price was found. Ignoring token.`);
+            console.log(`❌ Token ${address} (${symbol}) exceeds market cap and no valid price was found. Ignoring token.`);
             continue;
           }
         


### PR DESCRIPTION
Added a check to ensure that no token of a protocol exceeds its own market cap during the computeTvl, preventing a token from being counted if an incorrect price is injected while a market cap exists.
If no market cap is found, it is suggested to act cautiously, and the token is included in the TVL

If a market cap is found and CoinGecko provides an updated price, the updated CoinGecko price is used, and the token is counted. However, if the market cap is exceeded and there is no updated price on CoinGecko, the token is ignored

`node test.js .\projects\pendle\index.js`

![image](https://github.com/user-attachments/assets/5edd6001-70ec-4500-aabb-ddafe45ec1fa)

=========================================

`node test.js .\projects\unitrade\index.js`

![image](https://github.com/user-attachments/assets/8a8936cc-1b98-4017-8480-54977970ea2f)

