### PR TITLE
Update: Tulip-Protocol

### DIFF
--- a/projects/solfarm.js
+++ b/projects/solfarm.js
@@ -7,6 +7,7 @@ async function fetch() {
 }
 
 module.exports = {
+  deadFrom: 2024-12-31,
   hallmarks:[
     [1667865600, "FTX collapse"]
 ],

--- a/projects/solfarm.js
+++ b/projects/solfarm.js
@@ -7,7 +7,7 @@ async function fetch() {
 }
 
 module.exports = {
-  deadFrom: 2024-12-31,
+  deadFrom: '2024-12-31',
   hallmarks:[
     [1667865600, "FTX collapse"]
 ],


### PR DESCRIPTION
Tulip-Protocol has not been updated since January 1, 2025. It seems that the protocol is no longer maintained by the team, the API has stopped returning data, the team's last tweet was in 2023, and the TVLhas been flat since the collapse of FTX