### PR TITLE
Fix: Idex-v4

### DIFF
--- a/projects/idex-v4/index.js
+++ b/projects/idex-v4/index.js
@@ -1,8 +1,26 @@
-const ADDRESSES = require('../helper/coreAssets.json')
-const { sumTokensExport } = require('../helper/unwrapLPs')
+const axios = require('axios')
+
+const USDC = '0xfbda5f676cb37624f28265a144a48b0d6e87d3b6'
+const owner = '0xF0b08bd86f8479a96B78CfACeb619cfFeCc5FBb5'
+
+const tvl = async (api) => {
+  const url = `https://xchain-explorer.idex.io/api/v2/smart-contracts/${USDC}/query-read-method`;
+  const headers = {
+    accept: 'application/json',
+    'Content-Type': 'application/json'
+  };
+
+  const payload = {
+    args: [owner],
+    method_id: "70a08231", // balanceOf method
+    from: USDC,
+    contract_type: "proxy"
+  };
+
+  const { data } = await axios.post(url, payload, { headers })
+  api.addUSDValue(data.result.output[0].value / 1e6)
+}
 
 module.exports = {
-  idex: {
-    tvl: sumTokensExport({ owner: '0xF0b08bd86f8479a96B78CfACeb619cfFeCc5FBb5', tokens: [ADDRESSES.rari.USDC_e]}),
-  }
+  idex: { tvl }
 }


### PR DESCRIPTION
Fix for the Idex-v4 protocol, which hasn’t been updated for 3 weeks. Using the xchain’s REST API (IDEX) to fetch the data directly