### PR TITLE
Add Fraxtal and Optimism to Curve Llamalend

### DIFF
--- a/projects/llamalend-curve/index.js
+++ b/projects/llamalend-curve/index.js
@@ -1,7 +1,9 @@
 
 const chainContracts = {
     ethereum: "0xeA6876DDE9e3467564acBeE1Ed5bac88783205E0",
-    arbitrum: "0xcaec110c784c9df37240a8ce096d352a75922dea"
+    arbitrum: "0xcaec110c784c9df37240a8ce096d352a75922dea",
+    fraxtal: "0xf3c9bdAB17B7016fBE3B77D17b1602A7db93ac66",
+    optimism: "0x5ea8f3d674c70b020586933a0a5b250734798bef"
 }
 
 const uniq = (arr) => Array.from(new Set(arr))


### PR DESCRIPTION
Added factory addresses for the lending markets on fraxtal and optimism so that the TVL of these chains could be reported in the stats.