### PR TITLE
Fix: Pixel-Swap (FIX)

### DIFF
--- a/projects/pixel-swap/index.js
+++ b/projects/pixel-swap/index.js
@@ -4,7 +4,7 @@ async function tvl (api) {
     const res = await get("https://api.pixelswap.io/apis/tokens");
 
     res.data.tokens.forEach(({ address, tokenBalance }) => {
-      if (!tokenBalance) return
+      if (!tokenBalance) return;
       api.addTokens(address, tokenBalance)
     })
   }

--- a/projects/pixel-swap/index.js
+++ b/projects/pixel-swap/index.js
@@ -1,15 +1,14 @@
 const { get } = require('../helper/http')
 
-async function tvl(api) {
+async function tvl (api) {
     const res = await get("https://api.pixelswap.io/apis/tokens");
-    const tokens = res.data.tokens.map(i => i.address);
-    const balances = res.data.tokens.map(i => i.tokenBalance);
-  
-    api.addTokens(tokens, balances);
+
+    res.data.tokens.forEach(({ address, tokenBalance }) => {
+      if (!tokenBalance) return
+      api.addTokens(address, tokenBalance)
+    })
   }
 
   module.exports = {
-    ton: {
-      tvl,
-    }
+    ton: { tvl }
   };


### PR DESCRIPTION
Small fix on `pixel-swap`, which hasn’t been updated for a few days 
> There was a balance returning null, causing an error that prevented the rest from executing

![null](https://github.com/user-attachments/assets/e1bcd782-97b1-4fef-951b-1f2a94dd3c55)
