### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Also, don't hesitate to send a message on [our discord](https://discord.defillam
 > If you would like to add a `volume` adapter please submit the PR [here](https://github.com/DefiLlama/adapters)
 > - If you would like to add a `liquidations` adapter, please refer to [this readme document](https://github.com/DefiLlama/DefiLlama-Adapters/tree/main/liquidations) for details.
 
-1. PLEASE PLEASE **enable "Allow edits by maintainers" while putting up the PR.**
+1. PLEASE **enable "Allow edits by maintainers" while putting up the PR.**
 2. Once your adapter has been merged, it takes time to show on the UI. No need to notify us on Discord.
 3. TVL must be computed from blockchain data (reason: https://github.com/DefiLlama/DefiLlama-Adapters/discussions/432), if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
 4. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can  edit it there and put up a PR

--- a/liquidations/README.md
+++ b/liquidations/README.md
@@ -36,7 +36,7 @@ For a hybrid approach using both onchain and indexer data, you may refer to the 
 
 ## Caveat
 
-Since all adapter are run in AWS Lambdas, it is essential to make sure your adapter does not take more than 15min to return the result as it's the hard limit set by AWS.
+Since all adapters are run in AWS Lambdas, it is essential to make sure your adapter does not take more than 15min to return the result as it's the hard limit set by AWS.
 
 ## Test an adapter
 

--- a/liquidations/README.md
+++ b/liquidations/README.md
@@ -28,7 +28,7 @@ interface Liq {
 
 ## Examples and references
 
-You may refer to the Aave V2 and Angle Protocol adapter for examples of how multi-chain protocols are handled.
+You may refer to the Aave V2 and Angle Protocol adapter for examples of how multichain protocols are handled.
 
 For a complete onchain (non-subgraph) adapter, you may refer to the MakerDAO adapter.
 

--- a/liquidations/euler/index.ts
+++ b/liquidations/euler/index.ts
@@ -11,7 +11,7 @@ const accountsQuery = gql`
     # subgraph bug - balances_: {amount_not: "0"} filter doesn't work
     accounts(first: $pageSize, where: { id_gt: $lastId }) {
       id
-      # if account_id != topLevelAccount_id then it's a sub-account, needs to be remapped for "owner" in the end
+      # if account_id != topLevelAccount_id then it's a subaccount, needs to be remapped for "owner" in the end
       topLevelAccount {
         id
       }


### PR DESCRIPTION
- Corrected repeated word "PLEASE PLEASE" in the `README.md` file.
- Fixed the phrase "multi-chain" to "multichain" for consistency.
- Improved clarity in the description of the AWS Lambda constraints for adapter execution time.
- Corrected "sub-account" to "subaccount" in `liquidations/euler/index.ts`.
