### PR TITLE
Fix: Peapods-Finance

### DIFF
--- a/projects/peapods-finance/index.js
+++ b/projects/peapods-finance/index.js
@@ -3,41 +3,43 @@ const { sumTokens2 } = require("../helper/unwrapLPs");
 const config = {
   ethereum: { indexManager: "0x0Bb39ba2eE60f825348676f9a87B7CD1e3B4AE6B", peasToken: "0x02f92800F57BCD74066F5709F1Daa1A4302Df875" },
   arbitrum: { indexManager: "0x0Bb39ba2eE60f825348676f9a87B7CD1e3B4AE6B", peasToken: "0x02f92800F57BCD74066F5709F1Daa1A4302Df875" },
-  base: { indexManager: "0x0Bb39ba2eE60f825348676f9a87B7CD1e3B4AE6B", peasToken: "0x02f92800F57BCD74066F5709F1Daa1A4302Df875" },
+  base: { indexManager: "0x0Bb39ba2eE60f825348676f9a87B7CD1e3B4AE6B", peasToken: "0x02f92800F57BCD74066F5709F1Daa1A4302Df875", blacklist: ['0xc31389794ffac23331e0d9f611b7953f90aa5fdc'] },
   mode: { indexManager: "0x0Bb39ba2eE60f825348676f9a87B7CD1e3B4AE6B", peasToken: "0x02f92800F57BCD74066F5709F1Daa1A4302Df875" },
 }
 
-const indexManagerABI =
-  "function allIndexes() view returns (tuple(address index, bool verified)[])";
-const indexABI = { lpStakingPool: "address:lpStakingPool" };
-const indexABIassets =
-  "function getAllAssets() view returns (tuple(address token, uint256 weighting, uint256 basePriceUSDX96, address c1, uint256 q1)[])";
-const stakingPoolABI = { stakingToken: "address:stakingToken" };
+const abi = {
+  allIndexes: "function allIndexes() view returns (tuple(address index, bool verified)[])",
+  lpStakingPool: "address:lpStakingPool",
+  getAllAssets: "function getAllAssets() view returns (tuple(address token, uint256 weighting, uint256 basePriceUSDX96, address c1, uint256 q1)[])",
+  stakingToken: "address:stakingToken"
+}
 
 const getTvl = async (api, isStaking) => {
-  const { indexManager, peasToken } = config[api.chain]
-  const ownerTokens = []
-  const indexes = (await api.call({ abi: indexManagerABI, target: indexManager, })).map(i =>i.index);
+  const { indexManager, peasToken, blacklist = [] } = config[api.chain]
+  const indexes = (await api.call({ abi: abi.allIndexes, target: indexManager, })).map(i =>i.index);
 
-  //get staking pool contract for index (spp)
-  const stakingPools = await api.multiCall({ abi: indexABI.lpStakingPool, calls: indexes, });
+  // get staking pool contract for index (spp)
+  const stakingPools = await api.multiCall({ abi: abi.lpStakingPool, calls: indexes, });
 
   //get assets this index consists of
-  const assetsResult = await api.multiCall({ abi: indexABIassets, calls: indexes, });
-  const stakingTokens = await api.multiCall({ abi: stakingPoolABI.stakingToken, calls: stakingPools, });
+  const assetsResult = await api.multiCall({ abi: abi.getAllAssets, calls: indexes, });
+  const stakingTokens = await api.multiCall({ abi: abi.stakingToken, calls: stakingPools, });
 
-  assetsResult.forEach((assets, i) => {
-    ownerTokens.push([assets.map(i => i.token), indexes[i]])
-  })
-  stakingTokens.forEach((stakingToken, i) => ownerTokens.push([[stakingToken], stakingPools[i]]))
-  await sumTokens2({ api, ownerTokens, blacklistedTokens: indexes, resolveLP: true, })
-  indexes.forEach(i => api.removeTokenBalance(i))
-  Object.keys(api.getBalances()).forEach(token => {
+  const ownerTokens = [
+    ...assetsResult.map((assets, i) => [assets.map(asset => asset.token), indexes[i]]),
+    ...stakingTokens.map((stakingToken, i) => [[stakingToken], stakingPools[i]])
+  ];
+
+  await sumTokens2({ api, ownerTokens, blacklistedTokens: [...indexes, ...blacklist], resolveLP: true });
+  [...indexes, ...blacklist].forEach(i => api.removeTokenBalance(i))
+
+    Object.keys(api.getBalances()).forEach(token => {
     let remove = (new RegExp(peasToken, "i")).test(token)
     if (isStaking) remove = !remove
     if (remove)
       api.removeTokenBalance(token)
   })
+
   return api.getBalances()
 };
 

--- a/projects/peapods-finance/index.js
+++ b/projects/peapods-finance/index.js
@@ -22,11 +22,11 @@ const getTvl = async (api, isStaking) => {
   const stakingPools = await api.multiCall({ abi: abi.lpStakingPool, calls: indexes, });
 
   //get assets this index consists of
-  const assetsResult = await api.multiCall({ abi: abi.getAllAssets, calls: indexes, });
+  const assetsResult = await api.multiCall({ abi: abi.getAllAssets, calls: indexes, permitFailure: true });
   const stakingTokens = await api.multiCall({ abi: abi.stakingToken, calls: stakingPools, });
 
   const ownerTokens = [
-    ...assetsResult.map((assets, i) => [assets.map(asset => asset.token), indexes[i]]),
+    ...assetsResult.filter(assets => assets).map((assets, i) => [assets.map(asset => asset.token), indexes[i]]),
     ...stakingTokens.map((stakingToken, i) => [[stakingToken], stakingPools[i]])
   ];
 


### PR DESCRIPTION
Fix for Peapods Finance, which has not received updates for the past 3 days:
Adding a blacklist for tokens that have a different code architecture than the others and are rejected in multicalls, such as: `base:0xc31389794ffac23331e0d9f611b7953f90aa5fdc`