### PR TITLE
feat: added savings module for frankencoin

### DIFF
--- a/projects/frankencoin/index.js
+++ b/projects/frankencoin/index.js
@@ -1,8 +1,12 @@
 const { sumTokens2 } = require('../helper/unwrapLPs');
+const { staking } = require("../helper/staking.js");
 const { cachedGraphQuery } = require('../helper/cache')
 
 // @dev: mapping of XCHF to its Bridge
 const XCHFBridge = ["0xb4272071ecadd69d933adcd19ca99fe80664fc08", "0x7bbe8F18040aF0032f4C2435E7a76db6F1E346DF"];
+const Frankencoin = "0xB58E61C3098d85632Df34EecfB899A1Ed80921cB";
+const SavingsModule = "0x3BF301B0e2003E75A3e86AB82bD1EFF6A9dFB2aE";
+
 
 async function tvl(api) {
   const tokensAndOwners = [XCHFBridge];
@@ -21,6 +25,7 @@ async function tvl(api) {
 module.exports = {
   ethereum: {
     tvl,
+    staking: staking(SavingsModule, Frankencoin)
   },
   start: '2023-10-28',
 };


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):

> unchanged

##### Twitter Link:

> unchanged

##### List of audit links if any:

https://github.com/Frankencoin-ZCHF/FrankenCoin/blob/main/audits/V1/ChainSecurity-audit.pdf
https://github.com/Frankencoin-ZCHF/FrankenCoin/blob/main/audits/V1/blockbite-audit.pdf
https://github.com/Frankencoin-ZCHF/FrankenCoin/blob/main/audits/V1/code4rena-audit.md

https://github.com/Frankencoin-ZCHF/FrankenCoin/blob/main/audits/V2/ChainSecurity_Frankencoin_Frankencoin_v2024.pdf
https://github.com/Frankencoin-ZCHF/FrankenCoin/blob/main/audits/V2/frankencoin-audit-report-2024-1.1.pdf

##### Website Link:

> unchanged

##### Logo (High resolution, will be shown with rounded borders):

> unchanged

##### Current TVL:

```
--- tvl ---
wbtc                      11.18 M
LsETH                     10.57 M
DQTS                      3.57 M
BOSS                      3.45 M
cbBTC                     831.76 k
weth                      784.46 k
CRV                       9.62 k
Total: 30.39 M 
```

### Savings Module

The frankencoin eco system is equip with a savings module, earn a yield on frankencoin (ZCHF). 

`staking: staking(SavingsModule, Frankencoin)`

#### Output:

```
--- ethereum-staking ---
ZCHF                      2.15 M
Total: 2.15 M 
```

Is there a better way to describe the savings module, since its not really staking?

### List totalSupply, market cap of frankencoin 

Collateralized, oracle-free stablecoin that tracks the value of the Swiss franc (peggedCHF). 
Is this PR enough to list the totalSupply and market cap of frankencoin (crypto backed stablecoin)?

https://github.com/DefiLlama/peggedassets-server/pull/436
