### PR TITLE
feat: add Seamless Morpho vaults to TVL

### DIFF
--- a/projects/seamless/index.js
+++ b/projects/seamless/index.js
@@ -5,7 +5,7 @@ const abi = require("./abis.json");
 const { mergeExports } = require("../helper/utils");
 const methodologies = require("../helper/methodologies");
 
-const SEAMLESS_GOVERNOR_SHORT_TIMELOCK = "0x8768c789C6df8AF1a92d96dE823b4F80010Db294";
+const SEAMLESS_GOVERNOR_SHORT_TIMELOCK = "0x639d2dD24304aC2e6A691d8c1cFf4a2665925fee";
 const MORPHO_VAULTS_FACTORY_v1_1 = "0xFf62A7c278C62eD665133147129245053Bbf5918";
 
 const AAVE_ADDRESSES_PROVIDER_REGISTRY = "0x90C5055530C0465AbB077FA016a3699A3F53Ef99";

--- a/projects/seamless/index.js
+++ b/projects/seamless/index.js
@@ -1,8 +1,12 @@
 const { aaveExports } = require("../helper/aave");
+const { getLogs2 } = require("../helper/cache/getLogs");
 const { sumTokens2 } = require("../helper/unwrapLPs");
 const abi = require("./abis.json");
 const { mergeExports } = require("../helper/utils");
 const methodologies = require("../helper/methodologies");
+
+const SEAMLESS_GOVERNOR_SHORT_TIMELOCK = "0x8768c789C6df8AF1a92d96dE823b4F80010Db294";
+const MORPHO_VAULTS_FACTORY_v1_1 = "0xFf62A7c278C62eD665133147129245053Bbf5918";
 
 const AAVE_ADDRESSES_PROVIDER_REGISTRY = "0x90C5055530C0465AbB077FA016a3699A3F53Ef99";
 const AAVE_POOL_DATA_PROVIDER = "0x2A0979257105834789bC6b9E1B00446DFbA8dFBa";
@@ -44,7 +48,54 @@ async function geyserTvl(api) {
 
 const baseAAVE = aaveExports("base", AAVE_ADDRESSES_PROVIDER_REGISTRY, undefined, [AAVE_POOL_DATA_PROVIDER], { v3: true });
 
-module.exports = mergeExports([{
-  methodology: methodologies.lendingMarket,
-  base: baseAAVE,
-}, { base: { tvl: geyserTvl } }]);
+const SeamlesMorphoVaultsTVL = async (api) => {
+  const allVaults = (
+    await getLogs2({
+      api,
+      factory: MORPHO_VAULTS_FACTORY_v1_1,
+      eventAbi:
+        "event CreateMetaMorpho(address indexed metaMorpho, address indexed caller, address initialOwner, uint256 initialTimelock, address indexed asset, string name, string symbol, bytes32 salt)",
+      fromBlock: 24831748,
+    })
+  ).map((log) => log.metaMorpho);
+
+  const allVaultOwners = await api.multiCall({
+    calls: allVaults,
+    abi: "function owner() public view returns (address)",
+  });
+
+  const seamlessMorphoVaults = allVaults.filter(
+    (_, i) =>
+      allVaultOwners[i].toLowerCase() ===
+      SEAMLESS_GOVERNOR_SHORT_TIMELOCK.toLowerCase()
+  );
+
+  const underlyingAssets = await api.multiCall({
+    calls: seamlessMorphoVaults,
+    abi: "function asset() public view returns (address)",
+  });
+  const totalAssets = await api.multiCall({
+    calls: seamlessMorphoVaults,
+    abi: "function totalAssets() public view returns (uint256)",
+  });
+
+  underlyingAssets.forEach((asset, i) => {
+    api.add(asset, totalAssets[i]);
+  });
+
+  return api.getBalances();
+};
+
+const methodology = `Counts the tokens deposited in Seamless Protocol owned vaults even when those vaults exist on other protocols (this is marked as double counted). Other sources of TVL are not double counted such as lending market TVL which follows uses the following methodology: ${methodologies.lendingMarket}`;
+
+module.exports = mergeExports([
+  {
+    base: baseAAVE,
+  },
+  { base: { tvl: geyserTvl } },
+  {
+    doublecounted: true,
+    base: { tvl: SeamlesMorphoVaultsTVL },
+  },
+  { methodology },
+]);


### PR DESCRIPTION
Seamless protocol is launching new vaults on Morpho and would like to include this in the protocols TVL numbers with the double counted flag set to true. This would include all current and future Morpho vaults on Base that are owned onchain by Seamless Protocol governance.