### PR TITLE
feat: shapeshift multichain update

### DIFF
--- a/projects/shapeshift/index.js
+++ b/projects/shapeshift/index.js
@@ -1,38 +1,92 @@
-const { staking } = require("../helper/staking");
-const { pool2 } = require("../helper/pool2");
+const { stakings } = require("../helper/staking");
+const { pool2s } = require("../helper/pool2");
 
-// Contracts
-const stakingUNIv2Contracts = [
-  "0xDd80E21669A664Bce83E3AD9a0d74f8Dad5D9E72", // v1
-  "0xc54b9f82c1c54e9d4d274d633c7523f2299c42a0", // v2
-  "0x212ebf9fd3c10f371557b08e993eaab385c3932b", // v3
-  "0x24FD7FB95dc742e23Dc3829d3e656FEeb5f67fa0", // v4
-  "0xC14eaA8284feFF79EDc118E06caDBf3813a7e555", // v5
-  "0xEbB1761Ad43034Fd7FaA64d84e5BbD8cB5c40b68", // v6
-  "0x5939783dbf3e9f453a69bc9ddc1e492efac1fbcb", // v7
-  "0x662da6c777a258382f08b979d9489c3fbbbd8ac3", // v8
-  "0x721720784b76265aa3e34c1c7ba02a6027bcd3e5", // v9
-];
-const stakingFoxy = "0xee77aa3Fd23BbeBaf94386dD44b548e9a785ea4b";
-
-// Tokens Or LPs
-const ETH_FOX_UNIV2 = "0x470e8de2eBaef52014A47Cb5E6aF86884947F08c";
-const FOX = "0xc770eefad204b5180df6a14ee197d99d808ee52d";
-const tFOX = "0x808D3E6b23516967ceAE4f17a5F9038383ED5311";
-const FOXy = "0xDc49108ce5C57bc3408c3A5E95F3d864eC386Ed3";
-
-module.exports = {
+const chains = {
   ethereum: {
-    pool2: pool2(
-      [...stakingUNIv2Contracts, ],
-      [ETH_FOX_UNIV2, ]
-    ),
-    staking: staking(
-      [stakingFoxy],
-      [FOX, tFOX]
-    ),
-    tvl: async () => ({}),
+    tokens: {
+      FOX: "0xc770eefad204b5180df6a14ee197d99d808ee52d",
+      tFOX: "0x808D3E6b23516967ceAE4f17a5F9038383ED5311",
+      ETH_FOX_UniV2: "0x470e8de2eBaef52014A47Cb5E6aF86884947F08c", // LP token used in staking
+    },
+    pools: {
+      GIV_FOX_UniV3: "0xad0E10Df5dCDF21396b9d64715aaDAf543F8B376",
+    },
+    staking: {
+      stakingFoxy: "0xee77aa3Fd23BbeBaf94386dD44b548e9a785ea4b",
+      FOXy: "0xDc49108ce5C57bc3408c3A5E95F3d864eC386Ed3",
+      stakingUNIv2Contracts: [
+        "0xDd80E21669A664Bce83E3AD9a0d74f8Dad5D9E72", // v1
+        "0xc54b9f82c1c54e9d4d274d633c7523f2299c42a0", // v2
+        "0x212ebf9fd3c10f371557b08e993eaab385c3932b", // v3
+        "0x24FD7FB95dc742e23Dc3829d3e656FEeb5f67fa0", // v4
+        "0xC14eaA8284feFF79EDc118E06caDBf3813a7e555", // v5
+        "0xEbB1761Ad43034Fd7FaA64d84e5BbD8cB5c40b68", // v6
+        "0x5939783dbf3e9f453a69bc9ddc1e492efac1fbcb", // v7
+        "0x662da6c777a258382f08b979d9489c3fbbbd8ac3", // v8
+        "0x721720784b76265aa3e34c1c7ba02a6027bcd3e5", // v9
+        "0xe7e16e2b05440c2e484c5c41ac3e5a4d15da2744", // Evergreen
+      ]
+    }
   },
-  methodology:
-    "We count liquidity of ETH-FOX LP deposited on Uniswap V2 pool through StakingYieldContract contracts; and the staking of native token",
+  arbitrum: {
+    tokens: {
+      FOX: "0xf929de51d91c77e42f5090069e0ad7a09e513c73",
+    },
+    pools: {
+      ETH_FOX_UniV2: "0x5f6ce0ca13b87bd738519545d3e018e70e339c24",
+      ETH_FOX_UniV3: "0x76d4D1EAA0C4b3645E75C46E573c1d4F75E9041e",
+    },
+    staking: {
+      stakingRFOXProxy: "0xac2a4fd70bcd8bab0662960455c363735f0e2b56",
+      stakingRFOX: "0x4f9c6a6cc987de98c8109e121516008906a899c9",
+    }
+  },
+  polygon: {
+    tokens: {
+      FOX: "0x65A05DB8322701724c197AF82C9CaE41195B0aA8",
+    },
+    pools: {
+      ETH_FOX_SushiSwap: "0x93eF615F1DdD27d0E141Ad7192623A5c45e8f200",
+    }
+  },
+  xdai: { // Gnosis
+    tokens: {
+      FOX: "0x21a42669643f45bc0e086b8fc2ed70c23d67509d",
+    },
+    pools: {
+      XDAI_FOX_UniV2: "0xC22313fD39F7d4D73A89558F9E8E444C86464BAc",
+      HNY_FOX_UniV2: "0x8a0Bee989c591142414ad67FB604539d917889dF",
+      GIV_FOX_UniV2: "0x75594f01dA2e4231e16e67f841C307C4Df2313d1",
+    }
+  }
 };
+
+function generateExports() {
+  const exports = {
+    methodology: "We count liquidity of FOX deposited on Uniswap V2 and V3 pools on Ethereum, Arbitrum, Gnosis and a SushiSwap pool on Polygon using on-chain data. For Staking we count the FOX tokens locked in RFOX on Arbitrum and its predecessor FOXy on Ethereum which are single asset staking contracts used for revenue sharing.",
+  };
+
+  for (const [chain, data] of Object.entries(chains)) {
+    exports[chain] = {
+      tvl: async () => ({}),
+    };
+
+    if (data.pools) {
+      exports[chain].pool2 = pool2s(
+        Object.values(data.pools),
+        [data.tokens.FOX]
+      );
+    }
+
+    if (data.staking) {
+      exports[chain].staking = stakings(
+        Object.values(data.staking).flat(),
+        Object.values(data.tokens)
+      );
+    }
+  }
+
+  return exports;
+}
+
+module.exports = generateExports();


### PR DESCRIPTION
Adds the missing data from the various chains where the FOX token, ShapeShift DAO's native token, lives (Ethereum, Aribtrum, Gnosis and Polygon) and where it has locked value (even if none qualifies as our protocol TVL per DefiLlama's methodology):
 
- A new ETH/FOX LP staking staking farm on Ethereum (`0xe7e16e2b05440c2e484c5c41ac3e5a4d15da2744`). This is an evergreen contract so we shouldn't need to add new ones on Ethereum after that (hopefully).
- RFOX. This is a "FOX on Arbitrum" (`0xf929de51d91c77e42f5090069e0ad7a09e513c73`) staking contract deployed on Arbitrum (Proxy: `0xac2a4fd70bcd8bab0662960455c363735f0e2b56`, Implementation:`0x4f9c6a6cc987de98c8109e121516008906a899c9`). It is single asset staking, 28 days lock minimum, with yield distributed in RUNE on Thorchain. It serves as a way for our DAO to do both revenue sharing with stakers and FOX burning monthly.

Few things of note:
- I've moved the ETH/FOX LP token staking in `ethereum` to `staking` because they are effectively a staking farm and not just a liquidity pool... and since we should not double count them, under `pool2` we have another pool that is not used for  farming/staking.
  - I would like to know the benefits of using `staking` to list these? Aren't we missing out on counting tokens that might be in the Uniswap v2 pool but aren't staked in any of the staking farms? If so, shouldn't we instead just remove all the staking/farms and only list the two pools under `pool2` (Uniswap v2 and v3)?
- I've this PR it and the values appear to be correct for all chains but I would appreciate a sanity check, especially around the RFOX proxy/contract, as it is a custom contract/implementation. It seems to work with `stakings()`, but I do not know all of the details of this functions and maybe the particularities of the RFOX contract.

If that might be useful for the tests, we maintain a dashboard with the LP on these various chains here: https://flipsidecrypto.xyz/Rayyyk/shapeshift-lp-dashboard-ciW_N4 . It isn't live data, it has to be refreshed, and doesn't list USD values for the FOX share of the pools unfortunately, but it could still be of use. For RFOX we maintain a dashboard here with the total FOX locked: https://dune.com/shapeshift/rfox