### PR TITLE
SwissBorg: Add new wallet

### DIFF
--- a/projects/swissborg/index.js
+++ b/projects/swissborg/index.js
@@ -118,6 +118,11 @@ const config = {
       '0x5509Be53b2dD0CD6fb8473B0EdA94e0a3059b73a',
     ]
   },
+  osmosis: {
+    owners: [
+      'osmo1h9sy6z5hnk5wjf6ds8w4syq0yqs706n9m6qlap',
+    ]
+  }
 }
 
 module.exports = cexExports(config)


### PR DESCRIPTION
This PR updates the list of wallets owned by SwissBorg. New wallets addition: https://github.com/SwissBorg/pub/commit/43f827a6e211b40b8b55062aa2ba54d8214eac96