### PR TITLE
Add Bonzo Protocol Treasury Adapter

### DIFF
--- a/projects/treasury/bonzo.js
+++ b/projects/treasury/bonzo.js
@@ -1,0 +1,19 @@
+const BigNumber = require("bignumber.js");
+const axios = require("axios");
+
+const fetch = async () => {
+    const res = await axios.get("https://data.bonzo.finance/market");
+    const result = {};
+    for (const reserve of res.data.reserves) {
+        result[`hedera:${reserve.evm_address}`] = new BigNumber(reserve.total_reserve.tiny_token).toString();
+    }
+    return result;
+};
+
+module.exports = {
+    misrepresentedTokens: true,
+    methodology: "The Treasury holds aToken balances, but reports using corresponding HTS token addresses to facilitate proper USD value calculations by DeFi Llama's pricing API.",
+    hedera: {
+        tvl: fetch
+    }
+};


### PR DESCRIPTION
Please accept our PR to add protocol treasury balances adapter for Bonzo Finance, a Aave protocol deployed on the Hedera Network.

##### methodology (what is being counted as tvl, how is tvl being calculated):

This addition adds a TVL adapter enumerating the aToken balances for the treasury protocol accounts receiving protocol reserve payments.  Note: to utilize DeFi Llama's built in pricing, it reports these token addresses as the underlying native Hedera HTS token, `misrepresentedTokens` is set to true.

If there is a better way to facilitate automated loading of the reserve token lists so `treasuryExports` could be utilized natively, I suspect that would be preferred, but we couldn't quite figure that part out.

Thankyou for your time.