### PR TITLE
SwissBorg: Add new wallets

### DIFF
--- a/projects/helper/bitcoin-book/swissborg.js
+++ b/projects/helper/bitcoin-book/swissborg.js
@@ -5,4 +5,5 @@ module.exports = [
   '1Mgs8zLJ7JyngcNRUscayyPHnnYJpJS5x2',
   'bc1qc8ee9860cdnkyej0ag5hf49pcx7uvz89lkwpr9',
   '1JgXCkk3gjmgfgjT2vvnjpvqfvNNTFCRpM',
+  'bc1qkgrz5mgsvze06mkexdqghw8udkcv88mmuvaxzz'
 ]

--- a/projects/swissborg/index.js
+++ b/projects/swissborg/index.js
@@ -22,6 +22,7 @@ const config = {
       '0xe2484A7Ac1b9Cb6D8E55fd00e129aB913172bea6',
       '0xdbe15F6573108B6736c70779C683Ca633c18aFe2',
       '0xa2E07DB4e92F66071Ca68984517972F5625AB325',
+      '0xBb6CaCfCeA26e45D0ac8019e1Eb606440736b53e'
     ],
   },
   bitcoin: {


### PR DESCRIPTION
This PR updates the list of wallets owned by SwissBorg. New wallets addition: https://github.com/SwissBorg/pub/commit/b6ccd31648cebcf96f38130a95db697bc5337a30