### PR TITLE
Fix: Solv-funds

### DIFF
--- a/projects/solv-protocol-funds/index.js
+++ b/projects/solv-protocol-funds/index.js
@@ -228,23 +228,24 @@ async function vaultBalance(api, graphData) {
     const poolConcretes = await concrete(poolLists, api);
 
     const poolBaseInfos = await api.multiCall({
+      permitFailure: true,
       abi: abi.slotBaseInfo,
       calls: poolLists.map((index) => ({
         target: poolConcretes[index.contractAddress],
-        params: [index.openFundShareSlot]
+        params: [index.openFundShareSlot],
       })),
     })
 
     let vaultAddress = [];
     for (const key in poolLists) {
-      if (solvbtc[network] != undefined && solvbtc[network]['slot'] != undefined && solvbtc[network]['slot'].indexOf(poolLists[key]["openFundShareSlot"]) != -1) {
+      if (poolBaseInfos[key] && solvbtc[network] != undefined && solvbtc[network]['slot'] != undefined && solvbtc[network]['slot'].indexOf(poolLists[key]["openFundShareSlot"]) != -1) {
         vaultAddress.push(`${poolBaseInfos[key][1].toLowerCase()}-${poolLists[key]["vault"].toLowerCase()}`);
       }
     }
 
     let vaults = {};
     for (const key in poolLists) {
-      if (poolBaseInfos[key][1] && poolLists[key]["vault"] && vaultAddress.indexOf(`${poolBaseInfos[key][1].toLowerCase()}-${poolLists[key]["vault"].toLowerCase()}`) == -1) {
+      if (poolBaseInfos[key] && poolBaseInfos[key][1] && poolLists[key]["vault"] && vaultAddress.indexOf(`${poolBaseInfos[key][1].toLowerCase()}-${poolLists[key]["vault"].toLowerCase()}`) == -1) {
         vaults[`${poolBaseInfos[key][1].toLowerCase()}-${poolLists[key]["vault"].toLowerCase()}`] = [poolBaseInfos[key][1], poolLists[key]["vault"]]
       }
     }


### PR DESCRIPTION
Adding a `permitFailure` to the multicall: `slotBaseInfo`. There are addresses introduced with different architectures that do not have the slotBaseInfo methods, causing the multicall to break

`0x5364B54DfAD3D08879C9FFDf488ff7578a855E93`