### PR TITLE
add beets v3

### DIFF
--- a/projects/beethovenx-v3/index.js
+++ b/projects/beethovenx-v3/index.js
@@ -1,0 +1,12 @@
+const { v3Tvl } = require("../helper/balancer")
+
+const config = {
+  sonic: { vault: '0xbA1333333333a1BA1108E8412f11850A5C319bA9', fromBlock: 368312 },
+}
+
+Object.keys(config).forEach(chain => {
+  const {vault, fromBlock,} = config[chain]
+  module.exports[chain] = {
+    tvl: v3Tvl(vault, fromBlock)
+  }
+})

--- a/projects/beethovenx-v3/index.js
+++ b/projects/beethovenx-v3/index.js
@@ -1,7 +1,7 @@
 const { v3Tvl } = require("../helper/balancer")
 
 const config = {
-  sonic: { vault: '0xbA1333333333a1BA1108E8412f11850A5C319bA9', fromBlock: 368312 },
+  sonic: { vault: '0xbA1333333333a1BA1108E8412f11850A5C319bA9', fromBlock: 368135 },
 }
 
 Object.keys(config).forEach(chain => {


### PR DESCRIPTION
balancer v3 fork on sonic

Can you advise how we can make sure boosted pools are accounted for? 

e.g. https://beets.fi/pools/sonic/v3/0xd5ab187442998f1a62ea58133a03050691a0c280 where we rehypothecate the BTC into avalon? I assume we'll need to make sure the stataTokens from Avalon are priced within the defillama eco?