### PR TITLE
feat(projects/silo): adds v2 launch hallmark to v1 chart

### DIFF
--- a/projects/silo/index.js
+++ b/projects/silo/index.js
@@ -114,6 +114,7 @@ module.exports = {
   base: { tvl, borrowed, },
   sonic: { tvl, borrowed, },
   hallmarks: [
-    [1692968400, "Launch CRV market"]
+    [1692968400, "Launch CRV market"],
+    [1736978400, "Launch Silo V2"],
   ]
 }


### PR DESCRIPTION
Adds a hallmark to V1 (and composite) chart for once Silo V2 began proper rollout