### PR TITLE
feat: add beets LP to rings staking

### DIFF
--- a/projects/rings/index.js
+++ b/projects/rings/index.js
@@ -51,6 +51,10 @@ const CONFIG = {
     stakingSupportedAssets: [
       '0xd3DCe716f3eF535C5Ff8d041c1A41C3bd89b97aE',   // scUSD
       '0x3bce5cb273f0f148010bbea2470e7b5df84c7812',   // scETH
+      '0xCd4D2b142235D5650fFA6A38787eD0b7d7A51c0C',   // Stable Beets
+      '0x33B29bcf17e866A35941e07CbAd54f1807B337f5',   // Stable Beets Gauge
+      '0xE54DD58a6d4e04687f2034dd4dDAb49da55F8afF',   // Echoes of the Ether
+      '0x8828a6e3166cac78F3C90A5b5bf17618BDAf1Deb'    // Echoes of the Ether Gauge
     ]
   },
 }


### PR DESCRIPTION
This PR adds beets LP to the staking of rings adapter.

It has an issue as it doesn't recognized the TVL of the gauges and I don't really know if there is an easy way to deal with balancer gauges in defillama.