### PR TITLE
Add CreateMyToken Adapter

### DIFF
--- a/projects/createmytoken/index.js
+++ b/projects/createmytoken/index.js
@@ -1,0 +1,53 @@
+const { sumTokens2 } = require('../helper/unwrapLPs');
+
+const factories = ["0xCBD7080c6735E01bc375883DfBC9073e2e587620","0xEB3D17c23e33d908ed80e5CEC419e5f36A5d0F9A"]
+
+const config = {
+  ethereum: {
+    reserves: factories,
+    nftAddress: "0xC36442b4a4522E871399CD717aBDD847Ab11FE88"
+  },
+  arbitrum: {
+    reserves: factories,
+    nftAddress: "0xC36442b4a4522E871399CD717aBDD847Ab11FE88"
+  },
+  bsc: {
+    reserves: factories,
+    nftAddress: "0x46A15B0b27311cedF172AB29E4f4766fbE7F4364"
+  },
+  polygon: {
+    reserves: factories,
+    nftAddress: "0xC36442b4a4522E871399CD717aBDD847Ab11FE88"
+  },
+  base: {
+    reserves: factories,
+    nftAddress: "0x03a520b32C04BF3bEEf7BEb72E919cf822Ed34f1"
+  },
+  optimism: {
+    reserves: factories,
+    nftAddress: "0xC36442b4a4522E871399CD717aBDD847Ab11FE88"
+  },
+  avax: {
+    reserves: factories,
+    nftAddress: "0x655C406EBFa14EE2006250925e54ec43AD184f8B"
+  },
+  blast: {
+    reserves: factories,
+    nftAddress: "0xB218e4f7cF0533d4696fDfC419A0023D33345F28"
+  },
+};
+
+module.exports = {
+  methodology: "Only counts assets paired with the created token, and only when using tracked Fair Launch. Does not include other tokens or ejected tokens."
+}
+
+Object.keys(config).forEach(chain => {
+  const { reserves, nftAddress } = config[chain];
+
+  module.exports[chain] = {
+    tvl: async (api) => {
+      await sumTokens2({ api, owners: reserves, resolveUniV3: true, uniV3ExtraConfig: { nftAddress } });
+      return api.getBalancesV2().getBalances() // Only counting paired assets (like ETH), not the token itself.
+    },
+  };
+});


### PR DESCRIPTION
Adding adapter for [CreateMyToken](https://www.createmytoken.com) specifically noting that this only tracks TVL for Fair Launch tokens, and only for when the token agrees to use public factory. Additionally the adapter only counts paired native token and does not include the created token itself (otherwise the TVL would technically be inflated)

---
##### Name (to be shown on DefiLlama): CreateMyToken
##### Twitter Link: CreateMyToken
##### Website Link: https://www.createmytoken.com/
##### Logo (High resolution, will be shown with rounded borders): https://www.createmytoken.com/logo-sq.png
##### Current TVL: ~$200k* (see above)
##### Chains: A lot, see website.
##### Short Description (to be shown on DefiLlama): Create your own token in just 1 minute and deploy it on Solana, Ethereum, Base, BNB Smart Chain and more! No code, no setup, no login, and free!
##### Category (full list at https://defillama.com/categories) *Please choose only one: Launchpads
##### Methodology (what is being counted as tvl, how is tvl being calculated): Added in code.

