### PR TITLE
Add Arbitrum adapter for Balancer V3

### DIFF
--- a/projects/balancer-v3/index.js
+++ b/projects/balancer-v3/index.js
@@ -3,6 +3,7 @@ const { v3Tvl } = require("../helper/balancer")
 const config = {
   xdai: { vault: '0xbA1333333333a1BA1108E8412f11850A5C319bA9', fromBlock: 37360338 },
   ethereum: { vault: '0xbA1333333333a1BA1108E8412f11850A5C319bA9', fromBlock: 21332121 },
+  arbitrum: { vault: '0xbA1333333333a1BA1108E8412f11850A5C319bA9', fromBlock: 297810187 },
 }
 
 Object.keys(config).forEach(chain => {


### PR DESCRIPTION
Add Arbitrum adapter for Balancer V3 (same address as everywhere else).

Announcement link: https://x.com/Balancer/status/1887561984918626606.

Thanks in advance!