### PR TITLE
Add silicon core assets & update ripple/ton vault addresses

### DIFF
--- a/projects/helper/coreAssets.json
+++ b/projects/helper/coreAssets.json
@@ -2266,6 +2266,9 @@
   },
   "silicon_zk": {
     "WETH": "0xe66863b695a392507f5d68b6a7b8aa8218914059",
-    "USDT": "0x1e4a5963abfd975d8c9021ce480b42188849d41d"
+    "USDT": "0x1e4a5963abfd975d8c9021ce480b42188849d41d",
+    "USDC": "0xa8ce8aee21bc2a48a5ef670afcc9274c7bbbc035",
+    "WBTC": "0xea034fb02eb1808c2cc3adbc15f447b93cbe08e1",
+    "DAI": "0xc5015b9d9161dca7e18e32f6f25c4ad850731fd4"
   }
 }

--- a/projects/orbitbridge/index.js
+++ b/projects/orbitbridge/index.js
@@ -22,6 +22,17 @@ const vaults = {
   silicon_zk: '0x5aAAcf28ECDd691b4a657684135d8848d38236Bb'
 }
 
+const SILICON_RECOVERY = '0xac6b4b573df32f31e933c2c8a58d5e334690e0ee'
+
+// tokens on silicon bridged from ethereum
+const SILICON_TOKENS = [
+  ADDRESSES.null,// ETH
+  ADDRESSES.silicon_zk.DAI, // DAI
+  ADDRESSES.silicon_zk.USDC, // USDC
+  ADDRESSES.silicon_zk.USDT, // USDT
+  ADDRESSES.silicon_zk.WBTC // WBTC
+]
+
 const farms = {
   bsc: [
     ADDRESSES.null,// BNB
@@ -72,6 +83,13 @@ async function tvl(api) {
     const farmBalance = await api.multiCall({ abi: ABI.wantLockedTotal, calls: farmData, })
     api.add(farms[chain], farmBalance)
   }
+
+  if (chain === 'silicon_zk') {
+    await sumTokens2({
+      api,
+      owner: SILICON_RECOVERY, tokens: SILICON_TOKENS
+    })
+  }
 }
 
 module.exports = {
@@ -87,9 +105,9 @@ module.exports = {
   wemix: { tvl },
   silicon_zk: { tvl },
   ripple: {
-    tvl: sumTokensExport({ owner: 'rLcxBUrZESqHnruY4fX7GQthRjDCDSAWia' })
+    tvl: sumTokensExport({ owner: 'rJTEBWu7u1NcJAiMQ9iEa1dbsuPyhTiW23' })
   },
   ton: {
-    tvl: tonExport({ owner: "EQAtkbV8ysI75e7faO8Ihu0mFtmsg-osj7gmrTg_mljVRccy", tokens: [ADDRESSES.null], onlyWhitelistedTokens: true }),
+    tvl: tonExport({ owner: "EQDXbWI3jClPS510by25zTA8SUKMa4XSD2K7DbZb0jincPGw", tokens: [ADDRESSES.null], onlyWhitelistedTokens: true }),
   },
 }

--- a/projects/orbitbridge/index.js
+++ b/projects/orbitbridge/index.js
@@ -26,11 +26,11 @@ const SILICON_RECOVERY = '0xac6b4b573df32f31e933c2c8a58d5e334690e0ee'
 
 // tokens on silicon bridged from ethereum
 const SILICON_TOKENS = [
-  ADDRESSES.null,// ETH
-  ADDRESSES.silicon_zk.DAI, // DAI
-  ADDRESSES.silicon_zk.USDC, // USDC
-  ADDRESSES.silicon_zk.USDT, // USDT
-  ADDRESSES.silicon_zk.WBTC // WBTC
+  "0x0000000000000000000000000000000000000000",// ETH
+  "0xc5015b9d9161dca7e18e32f6f25c4ad850731fd4", // DAI
+  "0xa8ce8aee21bc2a48a5ef670afcc9274c7bbbc035", // USDC
+  "0x1e4a5963abfd975d8c9021ce480b42188849d41d", // USDT
+  "0xea034fb02eb1808c2cc3adbc15f447b93cbe08e1" // WBTC
 ]
 
 const farms = {


### PR DESCRIPTION
Hello.
 We’ve updated the addresses for Ripple and TON Vault to facilitate the migration of assets. Additionally, the key assets from Silicon Vault have been moved to the recovery contract. I apologize for overlooking this information in the previous PR, and I’m now including it for your review. I’d greatly appreciate it if you could kindly consider these updates when reviewing the changes.