### PR TITLE
✨ add Arcadia V2 accounts

### DIFF
--- a/projects/arcadia-finance-v2/index.js
+++ b/projects/arcadia-finance-v2/index.js
@@ -1,4 +1,5 @@
 const { sumTokens2, unwrapSlipstreamNFT } = require("../helper/unwrapLPs");
+const utils = require('../helper/utils')
 
 const config = {
   factory: "0xDa14Fdd72345c4d2511357214c5B89A919768e59",
@@ -8,6 +9,7 @@ const config = {
   wAeroNFT: "0x17B5826382e3a5257b829cF0546A08Bd77409270".toLowerCase(),
   sAeroNFT: "0x9f42361B7602Df1A8Ae28Bf63E6cb1883CD44C27".toLowerCase(),
   sSlipNFT: "0x1Dc7A0f5336F52724B650E39174cfcbbEdD67bF1".toLowerCase(),
+  wsSlipNFT: "0xD74339e0F10fcE96894916B93E5Cc7dE89C98272".toLowerCase(),
   pools: [
     "0x803ea69c7e87D1d6C86adeB40CB636cC0E6B98E2", // wethPool
     "0x3ec4a293Fb906DD2Cd440c20dECB250DeF141dF1", // usdcPool
@@ -16,7 +18,7 @@ const config = {
 };
 
 async function unwrapArcadiaAeroLP({ api, ownerIds }) {
-  const { wAeroNFT, sAeroNFT, sSlipNFT } = config
+  const { wAeroNFT, sAeroNFT, sSlipNFT, wsSlipNFT } = config
   const wAERONFTIds = []
   const sAERONFTIds = []
   const sSlipNftIds = []
@@ -37,6 +39,9 @@ async function unwrapArcadiaAeroLP({ api, ownerIds }) {
           sAERONFTIds.push(ids[i]);
           break;
         case sSlipNFT:
+          sSlipNftIds.push(ids[i]);
+          break;
+        case wsSlipNFT:
           sSlipNftIds.push(ids[i]);
           break;
       }
@@ -60,19 +65,79 @@ async function uwrapStakedSlipstreamLP({ api, sSlipNftIds, }) {
 }
 
 async function tvl (api) {
-  const { factory, pools, uniNFT, slipNFT, wAeroNFT, sAeroNFT, sSlipNFT, alienBaseNFT } = config;
+  const { factory, pools, uniNFT, slipNFT, wAeroNFT, sAeroNFT, sSlipNFT, alienBaseNFT, wsSlipNFT } = config;
   const ownerTokens = []
   const ownerIds = []
   const accs = []
 
   const uTokens = await api.multiCall({ abi: "address:asset", calls: pools });
-  await api.sumTokens({ blacklistedTokens: [uniNFT, slipNFT, wAeroNFT, sAeroNFT, sSlipNFT, alienBaseNFT], tokensAndOwners2: [uTokens, pools] });
+  await api.sumTokens({ blacklistedTokens: [uniNFT, slipNFT, wAeroNFT, sAeroNFT, sSlipNFT, alienBaseNFT, wsSlipNFT], tokensAndOwners2: [uTokens, pools] });
   
   const accounts = await api.fetchList({ lengthAbi: 'allAccountsLength', itemAbi: 'allAccounts', target: factory, })
-  const assetDatas = await api.multiCall({ abi: abi.generateAssetData, calls: accounts, permitFailure: true })
 
-  accounts.forEach((account, i) => {
-    const assetData = assetDatas[i];
+    // Account version 1 has a stored state of all assets, and can be fetched using generateAssetData()
+  // Account version 2 has no such stored state, and must be fetched with external api calls.
+  const versions = await api.multiCall({abi: 'function ACCOUNT_VERSION() view returns (uint256)', calls: accounts,});
+  const v1Accounts = accounts.filter((_, i) => versions[i] === '1');
+  const v2Accounts = accounts.filter((_, i) => versions[i] === '2');
+
+  // This endpoint uses the following logic:
+  // 1. Uses batches of all v2Accounts (to prevent rate limiting)
+  // 2. calls Arcadia's endpoint to fetch the asset data of a V2 account
+  // 3. verifies onchain that the ownership of the NFTs is indeed correct
+  // 4. Return format is then transformed to be identical to the format of the V1 assetData
+  const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+
+  const batchSize = 10;
+  for (let i = 0; i < v2Accounts.length; i += batchSize) {
+    const batch = v2Accounts.slice(i, i + batchSize);
+    await Promise.all(batch.map(async (account) => {
+      try {
+        const assetDataCall = await utils.fetchURL(`https://api.arcadia.finance/v1/api/accounts/spot_asset_data?chain_id=8453&account_addresses=${account}`);
+        const assetData = assetDataCall.data[0] // call is made for multiple addresses, but may time out if all accounts are requested at once
+        if (!assetData || !assetData[0][0] || assetData[0][0].length < 1) return;
+  
+        // Since the return of the ownership data comes from a "blackbox" backend,
+        // we verify onchain that the ownership of the NFTs is indeed correct
+        // We check this for each asset where ID != 0
+        const verificationCalls = assetData[0][1].map((tokenId, index) => {
+          if (tokenId === "0") return null; // Skip if tokenId is 0, just an erc20, balance will be fetched through sdk
+          return {
+            target: assetData[0][0][index],
+            params: [tokenId]
+          }
+        }).filter(call => call !== null); // Remove null entries
+  
+        if (verificationCalls.length > 0) {
+          const owners = await api.multiCall({
+            abi: 'function ownerOf(uint256) view returns (address)',
+            calls: verificationCalls
+          });
+  
+          // Verify all owners match the account
+          const allOwnersMatch = owners.every(owner => owner.toLowerCase() === account.toLowerCase());
+          if (!allOwnersMatch) return; // Skip this account if any ownership verification fails
+        }
+  
+        ownerTokens.push([assetData[0][0], account])
+        if (!assetData[0][0].length || !assetData[0][1].length || assetData[0][1] == "0") return;
+        ownerIds.push([assetData[0][0], assetData[0][1], account])
+        accs.push(account)
+      } catch (error) {
+          console.log(`Failed to fetch/process data for account ${account}:`, error);
+          return;
+      }
+    }));
+    
+    // Add small delay between batches to prevent rate limiting
+    if (i + batchSize < v2Accounts.length) {  // Only sleep if there are more batches to process
+      await sleep(1000);
+    }
+  }
+
+  const assetDatasV1 = await api.multiCall({ abi: abi.generateAssetData, calls: v1Accounts, permitFailure: true })
+  v1Accounts.forEach((account, i) => {
+    const assetData = assetDatasV1[i];
     if (!assetData || !assetData.assets || !assetData.assets.length ) return;
     ownerTokens.push([assetData.assets, account])
     if (!assetData[0].length || !assetData[1].length) return;
@@ -84,7 +149,7 @@ async function tvl (api) {
     await sumTokens2({ api, owners: accs, uniV3ExtraConfig: { nftAddress: alienBaseNFT } })
 
   // add all simple ERC20s
-  await api.sumTokens({ ownerTokens, blacklistedTokens: [uniNFT, slipNFT, wAeroNFT, sAeroNFT, sSlipNFT, alienBaseNFT],});
+  await api.sumTokens({ ownerTokens, blacklistedTokens: [uniNFT, slipNFT, wAeroNFT, sAeroNFT, sSlipNFT, alienBaseNFT, wsSlipNFT],});
 
   // add all Arcadia-wrapped LP positions
   await unwrapArcadiaAeroLP({ api, ownerIds });


### PR DESCRIPTION
Adds Arcadia V2 Accounts.

Arcadia V1 Accounts have the "generateAssetData" function to fetch which assets are stored on the account.
Arcadia V2 Accounts do not have such a function.

As discussed with the team on Discord (mostly with ulysses), the following method is used to fetch the contents of an V2 Account:
* For all V2 Accounts, fetch the assets of the Account through Arcadia's api endpoint.
The logic in this endpoint is quite simple, it requests Alchemy's 1) getNFTsForOwner for ERC721s and 2) a alchemy_getTokenBalances for ERC20s.
This API call is done in batches of 10, arbitrary number to prevent any overload or rate limiting.
* For each ERC721 found in a V2 Account, verify onchain (through the SDK) that the V2 Account is the actual owner. If so, the information from the endpoint was valid. If this is not the case, disregard the Account completely.
* ERC20s are not checked, however ERC20 balances are disregarded and fetched separately through the SDK.
-> Although "blackbox" data is fetched through an offchain endpoint, all data is verified and priced onchain.

Arcadia V2 Accounts use a new Wrapper around Staked Slipstream positions. Like the other wrappers, this wrapper mints the same positionID as the native NFT Position Manager. To value it, it simply feeds it into an "unwrapSlipstreamNFT" for that position ID.