### PR TITLE
Add sum of all LP tokens deposited on Stride to Stride TVL

### DIFF
--- a/projects/stride/index.js
+++ b/projects/stride/index.js
@@ -103,10 +103,7 @@ function getCoinDenimals(denom) {
 function makeTvlFn(chain) {
   return async () => {
     // Define the URL for host_zone based on chainId
-    const hostZoneUrl =
-      chain.chainId === "celestia"
-        ? "https://stride-fleet.main.stridenet.co/api/Stride-Labs/stride/staketia/host_zone"
-        : chain.chainId === "dymension_1100-1"
+    const hostZoneUrl = chain.chainId === "dymension_1100-1"
         ? "https://stride-fleet.main.stridenet.co/api/Stride-Labs/stride/stakedym/host_zone"
         : `https://stride-fleet.main.stridenet.co/api/Stride-Labs/stride/stakeibc/host_zone/${chain.chainId}`;
 

--- a/projects/stride/index.js
+++ b/projects/stride/index.js
@@ -141,19 +141,13 @@ function makeLPTokensTvlFn() {
 
     const balances = {};
 
-    // const amount = Math.round(Number(2904155.048717085) * 100) / 100;
-    // @todo use token amount, not token price
-    const amount = Math.round(Number(stats.total_deposits_usd) * 100) / 100;
-
     sdk.util.sumSingleBalance(
       balances,
-      // @todo replace with bgt once it has value on coingecko
-      // https://www.coingecko.com/en/coins/berachain-governance-token
-      "wrapped-bera",
-      amount
+      "berachain",
+      Math.floor(stats.tvl_usd)
     );
 
-    return balances;
+    return balances
   };
 }
 

--- a/projects/stride/index.js
+++ b/projects/stride/index.js
@@ -139,15 +139,9 @@ function makeLPTokensTvlFn() {
       "https://berachain.main.stridenet.co/stats"
     );
 
-    const balances = {};
-
-    sdk.util.sumSingleBalance(
-      balances,
-      "berachain",
-      Math.floor(stats.tvl_usd)
-    );
-
-    return balances
+    return {
+      "berachain-bera": Math.floor(stats.tvl_usd)
+    };
   };
 }
 

--- a/projects/stride/index.js
+++ b/projects/stride/index.js
@@ -133,6 +133,30 @@ function makeTvlFn(chain) {
   };
 }
 
+function makeLPTokensTvlFn() {
+  return async () => {
+    const stats = await get(
+      "https://berachain.main.stridenet.co/stats"
+    );
+
+    const balances = {};
+
+    // const amount = Math.round(Number(2904155.048717085) * 100) / 100;
+    // @todo use token amount, not token price
+    const amount = Math.round(Number(stats.total_deposits_usd) * 100) / 100;
+
+    sdk.util.sumSingleBalance(
+      balances,
+      // @todo replace with bgt once it has value on coingecko
+      // https://www.coingecko.com/en/coins/berachain-governance-token
+      "wrapped-bera",
+      amount
+    );
+
+    return balances;
+  };
+}
+
 module.exports = {
   timetravel: false,
   methodology: "Sum of all the tokens that are liquid staked on Stride",
@@ -144,3 +168,7 @@ module.exports = {
 for (const chainName of Object.keys(chains)) {
   module.exports[chainName] = { tvl: makeTvlFn(chains[chainName]) };
 }
+
+module.exports["berachain"] = {
+  tvl: makeLPTokensTvlFn(),
+};


### PR DESCRIPTION
Hey guys, we wanted to add the sum of all LP tokens deposited on Stride to our TVL. We already have the value for this but we're having some trouble showing the correct amount when running the script `node test.js projects/stride/index.js`.

For example: Let's say we have `421270.9992` total deposits in usd, when we run the script, it still shows 0 for Berachain: 
```
--- stride ---
Total: 0

--- berachain ---
Total: 0

--- umee ---
UX                        21.81 k
Total: 21.81 k

--- islm ---
ISLM                      2.74 M
Total: 2.74 M

--- juno ---
JUNO                      501.79 k
Total: 501.79 k

--- dymension ---
DYM                       228.18 k
Total: 228.18 k

--- injective ---
INJ                       414.25 k
Total: 414.25 k

--- band ---
BAND                      1.05 M
Total: 1.05 M

--- sommelier ---
SOMM                      13.08 k
Total: 13.08 k

--- terra2 ---
LUNA                      28.28 k
Total: 28.28 k

--- dydx ---
DYDX                      18.48 M
Total: 18.48 M

--- evmos ---
EVMOS                     308.58 k
Total: 308.58 k

--- comdex ---
CMDX                      7.28 k
Total: 7.28 k

--- celestia ---
TIA                       4.65 M
Total: 4.65 M

--- osmosis ---
OSMO                      5.80 M
Total: 5.80 M

--- stargaze ---
STARS                     90.84 k
Total: 90.84 k

--- cosmos ---
ATOM                      20.72 M
Total: 20.72 M

--- tvl ---
ATOM                      20.72 M
DYDX                      18.48 M
OSMO                      5.80 M
TIA                       4.65 M
ISLM                      2.74 M
BAND                      1.05 M
JUNO                      501.79 k
INJ                       414.25 k
EVMOS                     308.58 k
DYM                       228.18 k
STARS                     90.84 k
LUNA                      28.27 k
UX                        21.81 k
SOMM                      13.08 k
CMDX                      7.28 k
Total: 55.05 M

------ TVL ------
cosmos                    20.72 M
dydx                      18.48 M
osmosis                   5.80 M
celestia                  4.65 M
islm                      2.74 M
band                      1.05 M
juno                      501.79 k
injective                 414.25 k
evmos                     308.58 k
dymension                 228.18 k
stargaze                  90.84 k
terra2                    28.27 k
umee                      21.81 k
sommelier                 13.08 k
comdex                    7.28 k
stride                    0
berachain                 0

total                    55.05 M
```

Can someone point out what we're doing wrong? Happy to make some adjustments to this