### PR TITLE
Add Base support for DeFi Saver Automation TVL

### DIFF
--- a/projects/defisaver.js
+++ b/projects/defisaver.js
@@ -26,4 +26,5 @@ module.exports = {
   ethereum: { tvl },
   arbitrum: { tvl },
   optimism: { tvl },
+  base: { tvl },
 };


### PR DESCRIPTION
Updating DeFi Saver adapter to add newly supported network. The network has been supported on Automation since the start of December 2024. A backfill would be appreciated. We're in touch on Discord already so let me know if this works. 