### PR TITLE
Stride: Add stBGT, update stTIA redemption rate

### DIFF
--- a/projects/stride/index.js
+++ b/projects/stride/index.js
@@ -103,10 +103,7 @@ function getCoinDenimals(denom) {
 function makeTvlFn(chain) {
   return async () => {
     // Define the URL for host_zone based on chainId
-    const hostZoneUrl =
-      chain.chainId === "celestia"
-        ? "https://stride-fleet.main.stridenet.co/api/Stride-Labs/stride/staketia/host_zone"
-        : chain.chainId === "dymension_1100-1"
+    const hostZoneUrl = chain.chainId === "dymension_1100-1"
         ? "https://stride-fleet.main.stridenet.co/api/Stride-Labs/stride/stakedym/host_zone"
         : `https://stride-fleet.main.stridenet.co/api/Stride-Labs/stride/stakeibc/host_zone/${chain.chainId}`;
 

--- a/projects/stride/index.js
+++ b/projects/stride/index.js
@@ -154,13 +154,14 @@ function makeBerachainTvlFn() {
     // Get all whitelisted receipt tokens (vaults)
     const receipts = await api.call({
       target: MANAGER_CONTRACT_ADDRESS,
-      abi: "receipts",
+      abi: 'function receipts() view returns (address[])',
     });
 
     // For each vault, get the total staked amount
     const stakedAmounts = await api.multiCall({
-      abi: "totalStakedByReceipt",
-      calls: receipts,
+      target: MANAGER_CONTRACT_ADDRESS,
+      abi: "function totalStakedByReceipt(address receipt) view returns (uint256)",
+      calls: receipts.map(receipt => ({ params: [receipt] })),
     });
 
     // Count each receipt’s staked tokens in TVL
@@ -171,5 +172,6 @@ function makeBerachainTvlFn() {
 }
 
 module.exports["berachain"] = {
+  doublecounted: true,
   tvl: makeBerachainTvlFn(),
 };


### PR DESCRIPTION
**Summary**
Add stBGT to Stride's TVL calculation. The methodology is as follows
1. Get all receipt (LP) token vaults that the stBGT manager contract has whitelisted
2. Sum all deposits in those vaults

Also, update stTIA to pull the redemption rate from `x/stakeibc`. stTIA is in the process of migrating from a multisig implementation to an ICA (interchain account) implementation, and the new URL has the correct redemption rate.

**Test plan**
Run locally. $11.4M is roughly in line with our expectations.

```
--- stride ---
Total: 0 

--- dymension ---
DYM                       198.21 k
Total: 198.21 k 

--- sommelier ---
SOMM                      12.40 k
Total: 12.40 k 

--- evmos ---
EVMOS                     318.48 k
Total: 318.48 k 

--- umee ---
UX                        19.84 k
Total: 19.84 k 

--- terra2 ---
LUNA                      28.14 k
Total: 28.14 k 

--- injective ---
INJ                       408.95 k
Total: 408.95 k 

--- celestia ---
TIA                       3.92 M
Total: 3.92 M 

--- osmosis ---
OSMO                      5.71 M
Total: 5.71 M 

--- berachain ---
BYUSD-HONEY-STABLE        7.54 M
50WETH-50WBERA-WEIGHTED   2.07 M
USDC.e-HONEY-STABLE       629.56 k
50WBERA-50HONEY-WEIGHTED  446.20 k
50WBTC-50WBERA-WEIGHTED   350.94 k
Total: 11.04 M 

--- comdex ---
CMDX                      7.41 k
Total: 7.41 k 

--- islm ---
ISLM                      3.44 M
Total: 3.44 M 

--- stargaze ---
STARS                     98.35 k
Total: 98.35 k 

--- juno ---
JUNO                      436.15 k
Total: 436.15 k 

--- cosmos ---
ATOM                      20.75 M
Total: 20.75 M 

--- dydx ---
DYDX                      18.30 M
Total: 18.30 M 

--- band ---
BAND                      1.03 M
Total: 1.03 M 

--- tvl ---
ATOM                      20.75 M
DYDX                      18.30 M
BYUSD-HONEY-STABLE        7.54 M
OSMO                      5.71 M
TIA                       3.92 M
ISLM                      3.44 M
50WETH-50WBERA-WEIGHTED   2.07 M
BAND                      1.03 M
USDC.e-HONEY-STABLE       629.56 k
50WBERA-50HONEY-WEIGHTED  446.20 k
JUNO                      436.15 k
INJ                       408.95 k
50WBTC-50WBERA-WEIGHTED   350.94 k
EVMOS                     318.48 k
DYM                       198.21 k
STARS                     98.35 k
LUNA                      28.14 k
UX                        19.84 k
SOMM                      12.40 k
CMDX                      7.41 k
Total: 65.72 M 

------ TVL ------
cosmos                    20.75 M
dydx                      18.30 M
berachain                 11.04 M
osmosis                   5.71 M
celestia                  3.92 M
islm                      3.44 M
band                      1.03 M
juno                      436.15 k
injective                 408.95 k
evmos                     318.48 k
dymension                 198.21 k
stargaze                  98.35 k
terra2                    28.14 k
umee                      19.84 k
sommelier                 12.40 k
comdex                    7.41 k
stride                    0

total                    65.72 M 
```