### PR TITLE
Add new chain for rabbitx tvl adapter

### DIFF
--- a/projects/rabbitx/index.js
+++ b/projects/rabbitx/index.js
@@ -11,4 +11,13 @@ module.exports = {
     tvl: sumTokensExport({ owners: ['0x3Ba925fdeAe6B46d0BB4d424D829982Cb2F7309e', '0x212f3a03b0e67f2d0afc7bca138707cf9fd6a0e6'], tokens: [ADDRESSES.blast.USDB, ADDRESSES.blast.WETH]}),
     staking: staking('0x67dBA61709D78806395acDBa3EF9Df686aF5dc24', '0x236bb48fcF61ce996B2C8C196a9258c176100c7d'),
   },
+  sonic: {
+    tvl: sumTokensExport({ owners: ['0xaC63e55a9D6B331987072f98beDf216F51370E28'], tokens: [ADDRESSES.sonic.USDC_e]}),
+  },
+  base: {
+    tvl: sumTokensExport({ owners: ['0x07607d79Bc28669bbF7ec6cfC7Ae68AA6964C762'], tokens: [ADDRESSES.base.USDC]}),
+  },
+  arbitrum: {
+    tvl: sumTokensExport({ owners: ['0x2E89ECF3945fcBdA70770f59F3833aC7D08b83c0'], tokens: ["0xaf88d065e77c8cC2239327C5EDb3A432268e5831"]}),
+  },
 }


### PR DESCRIPTION
Devs from rabbitx to update exchange contract for the new chain we recently supported. So that TVL is reflected correctly.