### PR TITLE
Update smilee-finance tvl calculation

### DIFF
--- a/projects/smilee-finance/index.js
+++ b/projects/smilee-finance/index.js
@@ -1,21 +1,19 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+
+const GBERA_CONTRACT = '0x3b3dd22625128Ff1548110f9B7Bc702F540668e2';
+
+async function tvl(api) {
+  const totalSupply = await api.call({
+    abi: 'uint256:totalSupply',
+    target: GBERA_CONTRACT,
+  });
+  
+  api.add(ADDRESSES.null, totalSupply)
+}
+
 module.exports = {
-  methodology: 'Sum of balances from vault contracts associated with each DVP retrieved by the registry.',
-}
-
-const config = {
-  arbitrum: { provider: '0x110A3B051397956D69733B6fe947648bB9062cf1' }
-}
-
-Object.keys(config).forEach(chain => {
-  const { provider } = config[chain]
-  module.exports[chain] = {
-    tvl: async (api) => {
-      const registry = await api.call({ abi: 'address:registry', target: provider })
-      const dvps = await api.call({ abi: 'address[]:getDVPs', target: registry })
-      const vaults = await api.multiCall({ abi: 'address:vault', calls: dvps })
-      const sideTokens = await api.multiCall({ abi: 'address:sideToken', calls: dvps })
-      const baseTokens = await api.multiCall({ abi: 'address:baseToken', calls: dvps })
-      return api.sumTokens({ tokensAndOwners2: [sideTokens.concat(baseTokens), vaults.concat(vaults)] })
-    }
+  methodology: 'TVL of all the assets managed by gBERA',
+  berachain: {
+    tvl,
   }
-})
+};


### PR DESCRIPTION
Smilee Finance is now on Berachain and based on gBERA token, the TVL is now calculated differently.

### Changed TVL calculation:

* Removed the previous configuration and methodology that involved multiple API calls to retrieve balances from vault contracts.
* Introduced a new constant `GBERA_CONTRACT` for the contract address.
* Implemented a new `tvl` function that calculates the total supply of the `GBERA_CONTRACT` and adds it to the API.

### Methodology update:

* Updated the `methodology` to reflect the new approach of calculating the TVL of all assets managed by gBERA.
