### PR TITLE
fix: use ton api for token prices

### DIFF
--- a/projects/evaa/index.js
+++ b/projects/evaa/index.js
@@ -14,8 +14,7 @@ async function borrowed(api) {
 
 async function tvl(api) {
   const owners = Object.values(evaaPoolAssets).map(pool => pool.poolAddress);
-  return sumTokens({ owners, api, tokens: [ADDRESSES.null], useTonApiForPrices: false })
-
+  return sumTokens({ owners, api, tokens: [ADDRESSES.null], useTonApiForPrices: true })
 }
 
 module.exports = {


### PR DESCRIPTION
Hi there, EVAA supporting token, which not priced on coingecko, for example: USDT Storm LP, TON Storm LP, DeDust Pool: TON/USDT – because of what EVAA TVL calculated is incorrect. So, let's to use ton api for calc token prices. 


The actual TVL on DeFiLLama: 
<img width="376" alt="Screenshot 2025-02-20 at 4 10 03 PM" src="https://github.com/user-attachments/assets/4f03c000-2c36-49a6-bd17-7c63d2a20251" />

The actual TVL on EVAA Protocol:
<img width="954" alt="Screenshot 2025-02-20 at 4 10 28 PM" src="https://github.com/user-attachments/assets/dd2ce54c-c000-4aa5-9028-abe0c39767db" />
