### PR TITLE
Fix: StoryHunt

### DIFF
--- a/projects/storyhunt-v3/index.js
+++ b/projects/storyhunt-v3/index.js
@@ -1,4 +1,5 @@
+const { blacklistedTokens_default } = require('../helper/solana')
 const { uniV3Export } = require('../helper/uniswapV3')
 module.exports = uniV3Export({
-  'sty': { factory: '0xa111dDbE973094F949D78Ad755cd560F8737B7e2', fromBlock: 1 }
+  'sty': { factory: '0xa111dDbE973094F949D78Ad755cd560F8737B7e2', fromBlock: 1, blacklistedTokens: ["0x5fbdb2315678afecb367f032d93f642f64180aa3", "0xe7f1725e7734ce288f8367e1bb143e90bb3f0512"] }
 })


### PR DESCRIPTION
> add tokens as blacklisted (EOA tokens)

`0x5FbDB2315678afecb367f032d93F642f64180aa3`
![image](https://github.com/user-attachments/assets/b20d9b96-9176-46ea-a994-cfc502c66c97)

`0xe7f1725e7734ce288f8367e1bb143e90bb3f0512`
![image](https://github.com/user-attachments/assets/664fd3ca-7743-48a5-9fd9-9f6851f9b7c0)
