### PR TITLE
Update: Neemo (Calculate TVL before CCIP)

### DIFF
--- a/projects/neemo-finance/index.js
+++ b/projects/neemo-finance/index.js
@@ -1,36 +1,41 @@
 const ADDRESSES = require('../helper/coreAssets.json');
 
-// ABI for fetching the conversion rate
 const abis = {
-    getRate: "function getRate() view returns (uint256)"
-};
+  getAssetState: "function getAssetState() view returns (uint256 totalAstarDeposit, uint256 totalAstarStaked, uint256 totalAstarPendingToStake, uint256 totalAstarPendingBonus, uint256 totalAstarRedeemable, uint256 totalLstSupply)"
+}
 
-// Contract configurations
-const configs = {
-    nsASTRToken: '0xc67476893C166c537afd9bc6bc87b3f228b44337',
-    nsASTRManager: '0x85031E58C66BA47A16Eef7A69514cd33EC16559c',
-    nrETHToken: '0x2fc9a87b1ef46dCDdF4801C36d752E0d5F243E4b',
-    nrETHManager: '0xf5AeA1089D075C8f16095aa11be4114350383a9B'
-};
+const CONFIG = {
+  ethereum: {
+    vault: '0x54Cd23460DF45559Fd5feEaaDA7ba25f89c13525',
+    tokens: [
+      ADDRESSES.null,
+      ADDRESSES.ethereum.WETH,
+      ADDRESSES.ethereum.STETH,
+      ADDRESSES.ethereum.WSTETH,
+      ADDRESSES.ethereum.WEETH,
+      ADDRESSES.ethereum.EETH,
+    ]
+  },
+  astar: {
+    vault: '0x85031E58C66BA47A16Eef7A69514cd33EC16559c',
+    token: ADDRESSES.astar.ASTR
+  }
+}
 
-// Fetches TVL for nsASTR and nrETH and adds their value to the API.
-async function getNeemoTvl(api) {
-    // Fetch and calculate TVL for nsASTR
-    const nsASTRSupply = await api.call({ target: configs.nsASTRToken, abi: 'erc20:totalSupply' });
-    const nsASTRRate = await api.call({ target: configs.nsASTRManager, abi: abis.getRate });
-    const stakedAmountInASTR = (nsASTRSupply * nsASTRRate) / 1e18;
-    api.add(ADDRESSES.soneium.ASTAR, stakedAmountInASTR);
+const eth_tvl = async (api) => {
+  const { vault, tokens } = CONFIG[api.chain]
+  return api.sumTokens({ tokens, owner: vault })
+}
 
-    // Fetch and calculate TVL for nrETH
-    const nrETHSupply = await api.call({ target: configs.nrETHToken, abi: 'erc20:totalSupply' });
-    const nrETHRate = await api.call({ target: configs.nrETHManager, abi: abis.getRate });
-    const stakedAmountInETH = (nrETHSupply * nrETHRate) / 1e18;
-    api.add(ADDRESSES.soneium.WETH, stakedAmountInETH);
+const astar_tvl = async (api) => {
+  const { vault, token } = CONFIG[api.chain]
+  const { totalAstarDeposit } = await api.call({ abi: abis.getAssetState, target: vault })
+  return api.add(token, totalAstarDeposit)
+
 }
 
 module.exports = {
-    soneium: {
-        tvl: getNeemoTvl
-    },
-    methodology: `TVL is calculated by fetching the total supply of nsASTR and nrETH tokens and converting their values into the underlying tokens (ASTR and WETH) using the current conversion rate provided by the respective managers.`
-};
+  methodology: 'TVL is calculated by retrieving all collaterals deposited on the chains before using CCIP',
+  ethereum: { tvl: eth_tvl },
+  astar: { tvl: astar_tvl }
+}


### PR DESCRIPTION
We strive to remain as fair as possible between adapters to prevent any unfair or unjust competition among DeFi protocols. We always prefer to count TVL on the chain where the collaterals are actually held.

I have rewritten the adapter to calculate Neemo Finance's TVL based on the deposit chains before the use of CCIP