### PR TITLE
feat(morpho): adding mode, corn, sonic, unichain & hemi

### DIFF
--- a/projects/helper/chains.json
+++ b/projects/helper/chains.json
@@ -157,6 +157,7 @@
   "hedera",
   "heiko",
   "hela",
+  "hemi",
   "hoo",
   "hpb",
   "hydra",

--- a/projects/helper/env.js
+++ b/projects/helper/env.js
@@ -21,6 +21,8 @@ const DEFAULTS = {
   LULO_API_KEY: '', 
   HYPERLIQUID_RPC: 'https://hyperliquid.cloud.blockscout.com/api/eth-rpc',
   TRON_RPC: 'https://api.trongrid.io',
+  HEMI_RPC: 'https://rpc.hemi.network/rpc',
+  HEMI_RPC_MULTICALL: '0xca11bde05977b3631167028862be2a173976ca11',
 }
 
 const ENV_KEYS = [

--- a/projects/morpho-blue/index.js
+++ b/projects/morpho-blue/index.js
@@ -43,6 +43,28 @@ const config = {
     morphoBlue: "0xE741BC7c34758b4caE05062794E8Ae24978AF432",
     fromBlock: 9025669,
   },
+  mode: {
+    morphoBlue: "0xd85cE6BD68487E0AaFb0858FDE1Cd18c76840564",
+    fromBlock: 19983370,
+  },
+  corn: {
+    morphoBlue: "0xc2B1E031540e3F3271C5F3819F0cC7479a8DdD90",
+    fromBlock: 25140190,
+  },
+  // Error: Unknown chain(s): hemi
+  // hemi: {
+  //   morphoBlue: "0xa4Ca2c2e25b97DA19879201bA49422bc6f181f42",
+  //   fromBlock: 1188872,
+  // },
+  sonic: {
+    morphoBlue: "0xd6c916eB7542D0Ad3f18AEd0FCBD50C582cfa95f",
+    fromBlock: 9100931,
+  },
+  // Error in unichain: TypeError: Cannot read properties of null (reading 'getBlock')
+  // unichain: {
+  //   morphoBlue: "0x8f5ae9CddB9f68de460C77730b018Ae7E04a140A",
+  //   fromBlock: 9139027,
+  // },
 };
 
 Object.keys(config).forEach((chain) => {

--- a/projects/morpho-blue/index.js
+++ b/projects/morpho-blue/index.js
@@ -51,20 +51,18 @@ const config = {
     morphoBlue: "0xc2B1E031540e3F3271C5F3819F0cC7479a8DdD90",
     fromBlock: 25140190,
   },
-  // Error: Unknown chain(s): hemi
-  // hemi: {
-  //   morphoBlue: "0xa4Ca2c2e25b97DA19879201bA49422bc6f181f42",
-  //   fromBlock: 1188872,
-  // },
+  hemi: {
+    morphoBlue: "0xa4Ca2c2e25b97DA19879201bA49422bc6f181f42",
+    fromBlock: 1188872,
+  },
   sonic: {
     morphoBlue: "0xd6c916eB7542D0Ad3f18AEd0FCBD50C582cfa95f",
     fromBlock: 9100931,
   },
-  // Error in unichain: TypeError: Cannot read properties of null (reading 'getBlock')
-  // unichain: {
-  //   morphoBlue: "0x8f5ae9CddB9f68de460C77730b018Ae7E04a140A",
-  //   fromBlock: 9139027,
-  // },
+  unichain: {
+    morphoBlue: "0x8f5ae9CddB9f68de460C77730b018Ae7E04a140A",
+    fromBlock: 9139027,
+  },
 };
 
 Object.keys(config).forEach((chain) => {


### PR DESCRIPTION
- Adding the batch 2 deployment.

2 Errors: 

- Hemi not supported (yet?)
Contract address link:
https://explorer.hemi.xyz/address/0xa4Ca2c2e25b97DA19879201bA49422bc6f181f42?tab=contract


- Unichain TypeError: Cannot read properties of null (reading 'getBlock')

Contract deployed at block 9139027
Address: https://uniscan.xyz/address/0x8f5ae9cddb9f68de460c77730b018ae7e04a140a#code
Tx creation: https://uniscan.xyz/tx/0x6a3a7a8c0fe34d232bd69eb086ae32f35a57d658a95bdc09e38a303c82b06635