### PR TITLE
Switches term-finance borrowed calculation to use events instead of subgraph.

### DIFF
--- a/projects/term-finance/index.js
+++ b/projects/term-finance/index.js
@@ -1,5 +1,6 @@
 const { cachedGraphQuery } = require('../helper/cache')
 const { sumTokens2 } = require('../helper/unwrapLPs');
+const { getLogs } = require('../helper/cache/getLogs')
 
 const graphs = {
   ethereum:
@@ -23,22 +24,39 @@ query poolQuery($lastId: ID) {
   }
 }`
 
-const borrowedQuery = `
-query borrowedQuery($lastId: ID) {
-  termRepoExposures(
+const purchaseTokensQuery = `
+query purchaseTokensQuery($lastId: ID) {
+  termAuctions(
+    first: 1000,
     where: {
-      repoExposure_gt: 0,
       id_gt: $lastId,
-    },
-    first: 1000
+      term_: { delisted: false },
+      delisted: false
+    }
   ) {
     id
     term {
+      id
       purchaseToken
     }
-    repoExposure
   }
 }`
+
+const startBlocks = {
+  "ethereum": 16380765,
+  "avax": 43162228,
+};
+const emitters = {
+  "ethereum": [
+    "0x9D6a563cf79d47f32cE46CD7b1fb926eCd0f6160",  // 0.2.4
+    "0xf268E547BC77719734e83d0649ffbC25a8Ff4DB3",  // 0.4.1
+    "0xc60e0f5cD9EE7ACd22dB42F7f56A67611ab6429F",  // 0.6.0
+    "0x4C6Aeb4E8dBBAF53c13AF495c847D4eC68994bD4",  // 0.9.0
+  ],
+  "avax": [
+    "0xb81afB6724ba9d19a3572Fb29ed7ef633fD50093",  // 0.6.0
+  ],
+};
 
 module.exports = {
   methodology: `Counts the collateral tokens locked in Term Finance's term repos.`,
@@ -53,10 +71,81 @@ Object.keys(graphs).forEach(chain => {
       return sumTokens2({ api, tokensAndOwners: data.map(i => [i.collateralToken, i.term.termRepoLocker]), permitFailure: true })
     },
     borrowed: async (api) => {
-      const data = await cachedGraphQuery(`term-finance-borrowed-${chain}`, host, borrowedQuery, { fetchById: true })
+      const tokenData = await cachedGraphQuery(`term-finance-purchase-tokens-${chain}`, host, purchaseTokensQuery, { fetchById: true })
 
-      for (const { term: { purchaseToken }, repoExposure } of data) {
-        api.add(purchaseToken, repoExposure)
+      const purchaseTokensByTermId = {};
+      for (const { term: { id, purchaseToken } } of tokenData) {
+        purchaseTokensByTermId[id] = purchaseToken
+      }
+
+      for (const eventEmitter of emitters[chain] ?? []) {
+        // First handle events that add to the balance
+        const bidFulfilledLogs = await getLogs({
+          api,
+          target: eventEmitter,
+          eventAbi: 'event BidFulfilled(bytes32 termRepoId, address bidder, uint256 purchasePrice, uint256 repurchasePrice, uint256 servicingFees)',
+          onlyArgs: true,
+          fromBlock: startBlocks[chain],
+        })
+        for (const { termRepoId, repurchasePrice } of bidFulfilledLogs) {
+          api.add(purchaseTokensByTermId[termRepoId], repurchasePrice)
+        }
+
+        const exposureOpenedOnRolloverNewLogs = await getLogs({
+          api,
+          target: eventEmitter,
+          eventAbi: 'event ExposureOpenedOnRolloverNew(bytes32 termRepoId, address borrower, uint256 purchasePrice, uint256 repurchasePrice, uint256 servicingFees)',
+          onlyArgs: true,
+          fromBlock: startBlocks[chain],
+        })
+        for (const { termRepoId, repurchasePrice } of exposureOpenedOnRolloverNewLogs) {
+          api.add(purchaseTokensByTermId[termRepoId], repurchasePrice)
+        }
+
+        // Then handle events that subtract from the balance
+        const liquidationLogs = await getLogs({
+          api,
+          target: eventEmitter,
+          eventAbi: 'event Liquidation(bytes32 termRepoId, address borrower, address liquidator, uint256 closureAmount, address collateralToken, uint256 amountLiquidated, uint256 protocolSeizureAmount, bool defaultLiquidation)',
+          onlyArgs: true,
+          fromBlock: startBlocks[chain],
+        })
+        for (const { termRepoId, closureAmount } of liquidationLogs) {
+          api.add(purchaseTokensByTermId[termRepoId], -closureAmount)
+        }
+        
+        const repurchasePaymentSubmittedLogs = await getLogs({
+          api,
+          target: eventEmitter,
+          eventAbi: 'event RepurchasePaymentSubmitted(bytes32 termRepoId, address borrower, uint256 repurchaseAmount)',
+          onlyArgs: true,
+          fromBlock: startBlocks[chain],
+        })
+        for (const { termRepoId, repurchaseAmount } of repurchasePaymentSubmittedLogs) {
+          api.add(purchaseTokensByTermId[termRepoId], -repurchaseAmount)
+        }
+
+        const burnCollapseExposureLogs = await getLogs({
+          api,
+          target: eventEmitter,
+          eventAbi: 'event BurnCollapseExposure(bytes32 termRepoId, address borrower, uint256 amountToClose)',
+          onlyArgs: true,
+          fromBlock: startBlocks[chain],
+        })
+        for (const { termRepoId, amountToClose } of burnCollapseExposureLogs) {
+          api.add(purchaseTokensByTermId[termRepoId], -amountToClose)
+        }
+
+        const exposureClosedOnRolloverExistingLogs = await getLogs({
+          api,
+          target: eventEmitter,
+          eventAbi: 'event ExposureClosedOnRolloverExisting(bytes32 termRepoId, address borrower, uint256 amountRolled)',
+          onlyArgs: true,
+          fromBlock: startBlocks[chain],
+        })
+        for (const { termRepoId, amountRolled } of exposureClosedOnRolloverExistingLogs) {
+          api.add(purchaseTokensByTermId[termRepoId], -amountRolled)
+        }
       }
 
       return api.getBalances()


### PR DESCRIPTION
@g1nt0ki This still has an issue where the `getLogs(...)` call for the `BidFulfilled (bytes32 termRepoId, address bidder, uint256 purchasePrice, uint256 repurchasePrice, uint256 servicingFees)` event tries to fetch the wrong topic: `0x550c99f14e2d6b02b095f180d3d23f4c2af030ba6ba708ca4f0902e774a11ce6`. This should be fetching the topic: `0x21d26d59bcce3d9a4ab2914b73dbef7755fbff3d793d77ed1e7fba2e86bccbbe`. See: https://etherscan.io/tx/0x4148489bd060f6a8d854e2295a43c4e794f10a370ee2498164dcb03a1b41625b#eventlog.

I added a few logs to https://github.com/DefiLlama/DefiLlama-Adapters/blob/term-finance/switch-to-event-based-borrowed/projects/helper/cache/getLogs.js#L52 to see that the wrong topic was getting fetched (thus leading to a `null` parsed event log and a crash.

This is the log that's being parsed incorrectly:

```
{
  blockNumber: 17436351,
  blockHash: '0xbd8fdee16df07549f2ea41b8b2b8e85be839b0105974aa63440b29c36d926804',
  transactionIndex: 55,
  removed: false,
  address: '0x9D6a563cf79d47f32cE46CD7b1fb926eCd0f6160',
  data: '0x6c65fca47318d257d994dd7dcdade944cfc82c45bb5322b59dbe8690b0bcbe43a4406e284260e5fbc84d6985d8562155f939059a2abf26e67cd3d19f90c0501100000000000000000000000000000000000000000000000000000002540be400',
  topics: [
    '0x550c99f14e2d6b02b095f180d3d23f4c2af030ba6ba708ca4f0902e774a11ce6'
  ],
  transactionHash: '0x4148489bd060f6a8d854e2295a43c4e794f10a370ee2498164dcb03a1b41625b',
  logIndex: 187
}
```

And the offending crash stacktrace when running the test script on this change:

```
Error in ethereum-borrowed: TypeError: Cannot read properties of null (reading 'args')
    at /Users/robert/src/DefiLlama-Adapters/projects/helper/cache/getLogs.js:56:30
    at Array.map (<anonymous>)
    at getLogs (/Users/robert/src/DefiLlama-Adapters/projects/helper/cache/getLogs.js:50:19)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async borrowed (/Users/robert/src/DefiLlama-Adapters/projects/term-finance/index.js:83:34)
    at async getTvl (/Users/robert/src/DefiLlama-Adapters/test.js:52:23)
    at async /Users/robert/src/DefiLlama-Adapters/test.js:175:9
    at async Promise.all (index 1)
    at async Promise.all (index 1)
    at async /Users/robert/src/DefiLlama-Adapters/test.js:222:3
```