### PR TITLE
Add DeFive

### DIFF
--- a/projects/defive-v2/index.js
+++ b/projects/defive-v2/index.js
@@ -1,4 +1,31 @@
-const { uniTvlExports } = require('../helper/unknownTokens')
-module.exports = uniTvlExports({
-  'sonic': '0x47524ca6578E172878aBf6fD6f3E1Cd106c551e6'
-})
+const { uniTvlExport } = require('../helper/calculateUniTvl.js');
+const sdk = require('@defillama/sdk');
+
+// Sonic Network Addresses
+const factory = '0x47524ca6578E172878aBf6fD6f3E1Cd106c551e6';  // Replace with DeFive's factory contract
+const fiveToken = '0xb0695ce12c56AAe40894235e2d1888D0b62Dd110';  // FIVE token address
+const masterFarmer = '0x4aDe5608127594CD9eA131f0826AEA02FE517461';  // MasterFarmer contract on Sonic
+
+// Fetch **TVL** (Total Value Locked in liquidity pools)
+const tvl = uniTvlExport(factory, 'sonic', true);
+
+// Fetch **staking** (Governance-locked FIVE tokens)
+async function staking(_, _b, _cb, { api }) {
+  const balances = {};
+  const totalLocked = await api.call({
+    target: masterFarmer,
+    abi: 'uint256:totalLockedAmount',
+  });
+
+  sdk.util.sumSingleBalance(balances, 'sonic:' + fiveToken, totalLocked);
+  return balances;
+}
+
+module.exports = {
+  methodology:
+    'TVL is calculated using the factory contract. "staking" fetches `totalLockedAmount()` from MasterFarmer for governance-locked FIVE tokens.',
+  sonic: {
+    tvl,
+    staking,
+  },
+};


### PR DESCRIPTION
##### Name (to be shown on DefiLlama): DeFive


##### Twitter Link: https://twitter.com/0xdefive


##### List of audit links if any:


##### Website Link: https://defive.com


##### Logo (High resolution, will be shown with rounded borders): 
![logo](https://github.com/user-attachments/assets/9cb0faed-06b5-4ebc-8ef1-00fd3b8e021d)



##### Current TVL: $3.5M


##### Treasury Addresses (if the protocol has treasury)


##### Chain: Sonic


##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)



##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description (to be shown on DefiLlama):
DeFive is a next-gen DeFi platform on Sonic, evolving from WigoSwap. It offers fast, low-cost trading, fair yield farming, and innovative mechanics like Gamified Burning (GBM) and Burn-to-Mint (B2M). The FIVE token powers governance, rewards, and liquidity incentives. veFIVE holders shape emissions and platform decisions through DAO governance.


##### Token address and ticker if any: 0xb0695ce12c56AAe40894235e2d1888D0b62Dd110


##### Category (full list at https://defillama.com/categories) *Please choose only one: Dexs


##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
##### Implementation Details: Briefly describe how the oracle is integrated into your project:
##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

##### forkedFrom (Does your project originate from another project): WigoSwap


##### methodology (what is being counted as tvl, how is tvl being calculated):  TVL is calculated using the factory contract. "Locked" fetches `totalLockedAmount()` from MasterFarmer for governance-locked FIVE tokens.



##### Github org/user (Optional, if your code is open source, we can track activity): 0xdefive
