### PR TITLE
feat: add TVL of Goat Network Main Market

### DIFF
--- a/projects/avalon-finance/index.js
+++ b/projects/avalon-finance/index.js
@@ -18,6 +18,7 @@ const mainMarket = {
 	corn: aaveExports('', '', undefined, ['0x56552f4407113894Bfce34b5b88C57b941AFc519'], { v3: true }), // Corn V3 Main
 	duckchain: aaveExports('', '', undefined, ['0x100AC26ad2c253B18375f1dC4BC0EeeB66DEBc88'], { v3: true }), // Duckchain V3 Main
 	taiko: aaveExports('', '', undefined, ['0x43248dF19B9B55f7b488CF68A1224308Af2D81eC'], { v3: true }), // Taiko - Main
+	goat: aaveExports('', '', undefined, ['0x2c4aEB7C9f0D196a51136B3c7bec49cB2DBD1966'], { v3: true }), // Goat - Main
 }
 
 const innovativeMarket = {


### PR DESCRIPTION
Tracking TVL of Goat Network Main Market.

Looks like Goat Network is not in the Defillama chain list yet.  

![CleanShot 2025-03-09 at 13 59 01@2x](https://github.com/user-attachments/assets/ec111162-d3a6-47f0-a83b-0519790912ea)


| Parameter             | Value                                         |
|-----------------------|-----------------------------------------------|
| Network Name      | GOAT Network                                |
| Chain ID          | 0x929 (2345)                               |
| Currency Symbol   | BTC                                         |
| Currency Decimals | 18                                          |
| RPC URL           | https://rpc.goat.network                    |
| Explorer        | https://explorer.goat.network               |