### PR TITLE
feat: use latest subgraphs for Sablier

### DIFF
--- a/projects/helper/cache.js
+++ b/projects/helper/cache.js
@@ -128,7 +128,7 @@ async function cachedGraphQuery(project, endpoint, query, { api, useBlock = fals
       return json
     } catch (e) {
       // sdk.log(e)
-      sdk.log(project, 'tryng to fetch from cache, failed to fetch data from endpoint:', endpoint)
+      sdk.log(project, 'trying to fetch from cache, failed to fetch data from endpoint:', endpoint)
       return getCache(key, project)
     }
   }

--- a/projects/sablier-lockup/index.js
+++ b/projects/sablier-lockup/index.js
@@ -1,34 +1,37 @@
 const { isWhitelistedToken } = require('../helper/streamingHelper')
 const { cachedGraphQuery } = require('../helper/cache')
+const { request } = require("graphql-request");
 
 const config = {
-  arbitrum: { endpoints: ['8BnGPBojHycDxVo83LP468pUo4xDyCQbtTpHGZXR6SiB'], },
-  base: { endpoints: ['3pxjsW9rbDjmZpoQWzc5CAo4vzcyYE9YQyTghntmnb1K'], },
-  blast: { endpoints: ['BXoC2ToMZXnTmCjWftQRPh9zMyM7ysijMN54Nxzb2CEY'], },
-  avax: { endpoints: ['FdVwZuMV43yCb1nPmjnLQwmzS58wvKuLMPzcZ4UWgWAc'], },
-  era: { endpoints: ['GY2fGozmfZiZ3xF2MfevohLR4YGnyxGxAyxzi9zmU5bY'], },
-  bsc: { endpoints: ['BVyi15zcH5eUg5PPKfRDDesezMezh6cAkn8LPvh7MVAF'], },
-  ethereum: { endpoints: ['5EgaXheiBXZBCkepyGUYAu8pN31Dkbh7bpGtnLPqaT5m'], },
-  linea: { endpoints: ['FoJnatzCZKyp9XjZyUBaw1juTb5ydnFvJvWUxS3oRCHZ'], },
-  mode: { endpoints: ['5ezGnVwNucVTW45WCb91VBiKBEdiqT4ceHDhh1KGigYG'], },
-  optimism: { endpoints: ['6e6Dvs1yDpsWDDREZRqxGi54SVdvTNzUdKpKJxniKVrp'], },
-  polygon: { endpoints: ['CsDNYv9XPUMP8vufuwDVKQrVhsxhzzRHezjLFFKZZbrx'], },
-  scroll: { endpoints: ['HVcngokCByfveLwguuafrBC34xB65Ne6tpGrXHmqDSrh'], },
-  xdai: { endpoints: ['EXhNLbhCbsewJPx4jx5tutNXpxwdgng2kmX1J7w1bFyu'], },
-	chz: { endpoints: ['HKvzAuGjrEiza11W48waJy5csbhKpkMLF688arwHhT5f'], },
+  ethereum: { endpoints: ['sablier-lockup-ethereum'] },
+  abstract: { endpoints: ['sablier-lockup-abstract'] },
+  arbitrum: { endpoints: ['sablier-lockup-arbitrum'] },
+  avax: { endpoints: ['sablier-lockup-avalanche'] },
+  base: { endpoints: ['sablier-lockup-base'] },
+  blast: { endpoints: ['sablier-lockup-blast'] },
+  bsc: { endpoints: ['sablier-lockup-bsc'] },
+  chz: { endpoints: ['sablier-lockup-chiliz'] },
+  xdai: { endpoints: ['sablier-lockup-gnosis'] },
+  iotex: { endpoints: ['sablier-lockup-iotex'] },
+  linea: { endpoints: ['sablier-lockup-linea'] },
+  mode: { endpoints: ['sablier-lockup-mode'] },
+  optimism: { endpoints: ['sablier-lockup-optimism'] },
+  polygon: { endpoints: ['sablier-lockup-polygon'] },
+  scroll: { endpoints: ['sablier-lockup-scroll'] },
 }
 
 
 async function getTokensConfig(api, isVesting) {
   const ownerTokens = []
   const { endpoints } = config[api.chain]
-  let i = 0
   for (const endpoint of endpoints) {
-    i++
-    const { contracts, assets } = await cachedGraphQuery('sablier-v2/' + api.chain + '-' + i, endpoint, `{
-      contracts { id address category }
-      assets { id chainId symbol }
-    }`)
+    const { contracts, assets } = await request(
+      'https://api.studio.thegraph.com/query/57079/' + endpoint + '/version/latest', 
+      `{
+        contracts { id address category }
+        assets { id chainId symbol }
+      }`
+    );
     const owners = contracts.map(i => i.address)
     let tokens = assets.map(i => i.id)
     const symbols = assets.map(i => i.symbol)


### PR DESCRIPTION
### Changelog

- Use latest subgraph endpoints for Sablier
- Add new chains

The same approach is not working for zksync, for which it throws the following error:

```bash
TypeError: invalid BytesLike value (argument="value", value=null, code=INVALID_ARGUMENT, version=6.13.1)
```

Any tips on how I can fix it? The subgraph endpoint for zksync is `sablier-lockup-zksync`.