### PR TITLE
Update HashKey Exchange Wallet Address

### DIFF
--- a/projects/hashkey-exchange/index.js
+++ b/projects/hashkey-exchange/index.js
@@ -6,6 +6,7 @@ const config = {
     owners: [
       "0xb016ebc8a1440aff7bf098b8f165af65eb898738",
       "0xa108b99c315c22673f7f5b5ca172a21628cf8334",
+      "0xB7D06ea243337d98C93c11Fd114cDd50768F264e",
     ],
   },
   bitcoin: {
@@ -24,12 +25,48 @@ const config = {
     owners: [
       "ltc1qh6w8epz4ycm2smpmnhfauqach28qr4ge6jffyv",
       "LSNjwQ1RGR5rbVDzCwrWiMQF8rdqVRGcPu",
+      "ltc1q4qexj7a62h9uxkk0wyt55s0v8qkrc2vqdsnv02",
     ],
   },
   polygon: {
     owners: [
       "0xecd094b51bafbd7bffdf1f4fef067c5d197a1b75",
       "0xee4f6df29617f00b12f85ee56c68962cbeac16aa",
+    ],
+  },
+  doge: {
+    owners: [
+      "DEovrjDhPB36kwvbyNtiYVrbWv1ahR1jQv",
+    ],
+  },
+  solana: {
+    owners: [
+      "HwEiRVn4ryKsTq6jECQHepLtUv2GVBfdibC4JjTDj8Su",
+    ],
+  },
+  ton: {
+    owners: [
+      "UQDd4CJlAR48mUvAJpPagHqp3AaZOs8st6Vs3tpRLbFuURT4",
+    ],
+  },
+  arbitrum: {
+    owners: [
+      "0xF04671a9Fd6470aA01C35f713C4ae75458920592",
+    ],
+  },
+  optimism: {
+    owners: [
+      "0x1557601DBA8A9Bbe3a18471A6fdb0416E2db0Ea3",
+    ],
+  },
+  polkadot: {
+    owners: [
+      "16ceMbQrLZgd9mTyxe72s5KZtUcFcLDx4Kr6diijxVU21RoA",
+    ],
+  },
+  aptos: {
+    owners: [
+      "0x846763265925e39951ad4f795cae687f9f22466583332f7c9e3ab1943fdad8b8",
     ],
   },
 };


### PR DESCRIPTION
Updated HashKey Global's wallet address, added more chain addresses.

By the way, how should I add the historical data of these addresses? From the update records of HashKey Exchange, it seems that only the updated data can be displayed, and there is no backtracking.
https://defillama.com/cex/hashkey-exchange