### PR TITLE
feat: add mtt-network

### DIFF
--- a/projects/helper/chains.json
+++ b/projects/helper/chains.json
@@ -229,6 +229,7 @@
   "moonriver",
   "morph",
   "move",
+  "mtt-network",
   "multivac",
   "muuchain",
   "mvc",


### PR DESCRIPTION

Add MTT Network chain support.

##### Name (to be shown on DefiLlama):MTT Network


##### Twitter Link:https://x.com/MTT_NETWORK


##### List of audit links if any:
https://github.com/mtt-labs/Audit

##### Website Link:
https://www.mtt.network/

##### Logo (High resolution, will be shown with rounded borders):
https://gateway.pinata.cloud/ipfs/bafkreigl72xrnfxf2wbu2l6ul46tmonbmshgfuxmthcax2c6z4sy5bbfga/#x-ipfs-companion-no-redirect


##### Chain:MTT Network


##### Short Description (to be shown on DefiLlama): MTT network is built on the  Cosmos SDK and compatible with  EVM.
Especially designed for E-sports tournaments.
