### PR TITLE
SwissBorg: Add new wallets

### DIFF
--- a/projects/swissborg/index.js
+++ b/projects/swissborg/index.js
@@ -27,6 +27,7 @@ const config = {
       '0x8a1feCFF181dD770206c0892E09B0243A495152b',
       '0x5eD60B7BFba654342C401f853B55B8dd82f90726',
       '0xa9a99C96e9fCCaC00a100e72A2C19eDe79458698',
+      '0x52b37e6dB2Fe5bB2781355Ac397aE49C9Bd29275',
     ],
   },
   bitcoin: {
@@ -89,6 +90,7 @@ const config = {
       '0xcDE4c1b984F3F02f997ECfF9980B06316de2577d',
       '0x7153D2ef9F14a6b1Bb2Ed822745f65E58d836C3F',
       '0xff4606bd3884554cdbdabd9b6e25e2fad4f6fc54',
+      '0xE8322f6234B6F1e6e3489600f8b1297aB3dE22ab',
     ]
   },
   avax: {
@@ -99,6 +101,7 @@ const config = {
       '0xFF4606bd3884554CDbDabd9B6e25E2faD4f6fc54',
       '0x9531AA9883bF11f2a63d86caD7e826f37Acec3c4',
       '0x4DF0BCB425aac41795B40a2B5A563A6a3eC23B41',
+      '0xC6A4e26E07a848F2AB180a455C211d38BF483E3E',
     ]
   },
   polygon: {


### PR DESCRIPTION
This PR updates the list of wallets owned by SwissBorg. New wallets addition: https://github.com/SwissBorg/pub/commit/d8f41c55a9910a959dd85b411791b4bf1f9a93ec