### PR TITLE
Fix Nolus TVL

### DIFF
--- a/projects/nolus/index.js
+++ b/projects/nolus/index.js
@@ -1,4 +1,5 @@
 const sdk = require('@defillama/sdk')
+const { transformBalances } = require('../helper/portedTokens')
 const { queryContract, queryManyContracts, queryContracts } = require('../helper/chain/cosmos')
 const { sleep } = require('../helper/utils')
 
@@ -100,9 +101,9 @@ function sumAssests(balances, leases, currencies) {
       const currencyData = find(currencies, (n) => n.ticker == ticker)
       if (currencyData) { 
         if (nativeTokens.hasOwnProperty(currencyData.dex_symbol)) {
-          sdk.util.sumSingleBalance(balances, nativeTokens[currencyData.dex_symbol], amount, 'nolus')
+          sdk.util.sumSingleBalance(balances, nativeTokens[currencyData.dex_symbol], amount)
         }
-        sdk.util.sumSingleBalance(balances, currencyData.dex_symbol, amount, 'nolus')
+        sdk.util.sumSingleBalance(balances, currencyData.dex_symbol, amount)
       }
     }
   })
@@ -129,6 +130,7 @@ async function tvl(protocols) {
     const leases = await getLeases(leaseContracts)
     sumAssests(balances, leases, oracleData)
   }
+  return transformBalances('nolus', balances)
 }
 
 module.exports = {


### PR DESCRIPTION
@g1nt0ki it seems like this commit: https://github.com/DefiLlama/DefiLlama-Adapters/commit/fdf5ff305d5a24ddba7dd549c4b2f6d83dba2060 has broken the TVL calculation of the leverage positions on Nolus. It is working fine with the original code so I pushed it back. You had removed this transformBalances function entirely so the tvl(protocols) function was not returning a thing, hence the 0 TVL for the positions. 
