### PR TITLE
Fix: Deflex

### DIFF
--- a/projects/deflex/index.js
+++ b/projects/deflex/index.js
@@ -16,7 +16,7 @@ async function tvl(api) {
 				limitOrderState[keyValue['key']] = keyValue['value']
 			}
 			const assetInId = limitOrderState[assetInIdKey]['uint']
-			api.add(assetInId > 0 ? assetInId : 1, limitOrderState[amountInKey]['uint'])
+			api.add((assetInId > 0 ? assetInId : 1).toString(), limitOrderState[amountInKey]['uint'])
 		})
 	})
 }


### PR DESCRIPTION
use .toString() to prevent `Error in algorand: Error: token must be a string`