### PR TITLE
feat: Add Kinetic Isolated Markets

### DIFF
--- a/projects/kinetic/index.js
+++ b/projects/kinetic/index.js
@@ -1,5 +1,15 @@
 const { compoundExports2 } = require('../helper/compound')
+const sdk = require('@defillama/sdk');
 
 module.exports = {
-  flare: compoundExports2({ comptroller: '0x8041680Fb73E1Fe5F851e76233DCDfA0f2D2D7c8' }),
+    flare: {
+        tvl: sdk.util.sumChainTvls([
+          compoundExports2({ comptroller: '0x8041680Fb73E1Fe5F851e76233DCDfA0f2D2D7c8' }).tvl,
+          compoundExports2({ comptroller: '0xDcce91d46Ecb209645A26B5885500127819BeAdd', cether: '0xd7291D5001693d15b6e4d56d73B5d2cD7eCfE5c6' }).tvl
+        ]),
+        borrowed: sdk.util.sumChainTvls([
+          compoundExports2({ comptroller: '0x8041680Fb73E1Fe5F851e76233DCDfA0f2D2D7c8' }).borrowed,
+          compoundExports2({ comptroller: '0xDcce91d46Ecb209645A26B5885500127819BeAdd', cether: '0xd7291D5001693d15b6e4d56d73B5d2cD7eCfE5c6' }).borrowed
+        ])
+    }
 }

--- a/projects/kinetic/index.js
+++ b/projects/kinetic/index.js
@@ -1,5 +1,5 @@
 const { compoundExports2 } = require('../helper/compound')
 
 module.exports = {
-  flare: compoundExports2({ comptroller: '0x8041680Fb73E1Fe5F851e76233DCDfA0f2D2D7c8' }),
+  flare: compoundExports2({ comptroller: '0x8041680Fb73E1Fe5F851e76233DCDfA0f2D2D7c8', cether: '0x1D80c49BbBCd1C0911346656B529DF9E5c2F783d' }),
 }

--- a/projects/kinetic/index.js
+++ b/projects/kinetic/index.js
@@ -1,5 +1,5 @@
 const { compoundExports2 } = require('../helper/compound')
 
 module.exports = {
-  flare: compoundExports2({ comptroller: '0x8041680Fb73E1Fe5F851e76233DCDfA0f2D2D7c8', cether: '0x1D80c49BbBCd1C0911346656B529DF9E5c2F783d' }),
+  flare: compoundExports2({ comptroller: '0x8041680Fb73E1Fe5F851e76233DCDfA0f2D2D7c8' }),
 }


### PR DESCRIPTION
This PR supports Kinetic's new Isolated Markets for the TVL calculation.

Changes
Added new Unitroller address (0xDcce91d46Ecb209645A26B5885500127819BeAdd) for Kinetic Isolated Markets
Updated TVL and borrowed calculations to sum both Unitrollers (original and new)