### PR TITLE
add quokkalend

### DIFF
--- a/projects/quokkalend/index.js
+++ b/projects/quokkalend/index.js
@@ -1,0 +1,5 @@
+const { aaveExports } = require("../helper/aave");
+
+module.exports = {
+    "morph": aaveExports("morph", "0x8C28AAA6c07c6c4e3E68B2e426C847614A9c0Dea", undefined, ["0x367ab6F3e883617f8385Eb5eA9d6e41A6e5c0D35"])
+};


### PR DESCRIPTION
Hello! We are Quokkalend, an Aave v3 fork on Morph.
This is an adapter for Quokkalend. Thanks!
---
##### Name (to be shown on DefiLlama):
QuokkaLend

##### Twitter Link:
https://x.com/QuokkaLend



##### List of audit links if any:


##### Website Link:
https://app.quokkalend.xyz/

##### Logo (High resolution, will be shown with rounded borders):
![quokka_X_Profile](https://github.com/user-attachments/assets/48c93b5f-0b9f-4a48-b9bc-6cb9209ec7ac)

##### Current TVL:
$5

##### Treasury Addresses (if the protocol has treasury)
none

##### Chain:
morph

##### Short Description (to be shown on DefiLlama):
Quokkalend is the lending market of Morph chain

##### Token address and ticker if any:
none

##### Category (full list at https://defillama.com/categories) *Please choose only one:
lending

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
Pyth

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
We use Pyth to calculate the price of assets

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
This is our oracle contract

https://explorer.morphl2.io/address/0x36DD706E3ca705A63d4281831B351b6f7B568319?tab=txs

##### forkedFrom (Does your project originate from another project):
Aave V3

##### methodology (what is being counted as tvl, how is tvl being calculated):
same as Aave V3:
TVL: Counts the tokens locked in the contracts to be used as collateral to borrow or to earn yield. Borrowed coins are not counted towards the TVL, so only the coins actually locked in the contracts are counted. There's multiple reasons behind this but one of the main ones is to avoid inflating the TVL through cycled lending

##### Github org/user (Optional, if your code is open source, we can track activity):
