### PR TITLE
feat: add mtt-network

### DIFF
--- a/projects/helper/chains.json
+++ b/projects/helper/chains.json
@@ -229,6 +229,7 @@
   "moonriver",
   "morph",
   "move",
+  "mtt-network",
   "multivac",
   "muuchain",
   "mvc",

--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -44,6 +44,9 @@ const fixBalancesTokens = {
   ozone: {
     // '0x83048f0bf34feed8ced419455a4320a735a92e9d': { coingeckoId: "ozonechain", decimals: 18 }, // was mapped to wrong chain
   },
+  mtt_network: {
+    '0xecEEEfCEE421D8062EF8d6b4D814efe4dc898265': { coingeckoId: 'usd-coin', decimals: 6 },
+  },
   hemi: {
     '0x6c851f501a3f24e29a8e39a29591cddf09369080': { coingeckoId: 'dai', decimals: 18 },
     '0xad11a8beb98bbf61dbb1aa0f6d6f2ecd87b35afa': { coingeckoId: 'usd-coin', decimals: 6 },

--- a/projects/mtt-dex/index.js
+++ b/projects/mtt-dex/index.js
@@ -1,0 +1,3 @@
+const { uniTvlExport } = require('../helper/unknownTokens')
+
+module.exports = uniTvlExport('mtt-network', '0x6e9400a1501D934771cD9aeD16A3f33A0CE3F9f5')//blockchain, factory address


### PR DESCRIPTION
Add MTT Network chain support.

Name (to be shown on DefiLlama):MTT Network

Twitter Link:https://x.com/MTT_NETWORK

List of audit links if any:
https://github.com/mtt-labs/Audit

Website Link:
https://www.mtt.network/

Logo (High resolution, will be shown with rounded borders):
https://gateway.pinata.cloud/ipfs/bafkreigl72xrnfxf2wbu2l6ul46tmonbmshgfuxmthcax2c6z4sy5bbfga/#x-ipfs-companion-no-redirect

Chain:MTT Network

Short Description (to be shown on DefiLlama): MTT network is built on the Cosmos SDK and compatible with EVM.
Especially designed for E-sports tournaments.