### PR TITLE
feat: use doppler api

### DIFF
--- a/projects/doppler-finance/index.js
+++ b/projects/doppler-finance/index.js
@@ -2,10 +2,12 @@ const ADDRESSES = require('../helper/coreAssets.json');
 const axios = require('axios');
 
 const NODE_URL = "https://xrplcluster.com";
+// ref: https://docs.doppler.finance/xrpfi/cedefi-yields#what-makes-doppler-finance-different-from-other-cedefi
+// rEPQxsSVER2r4HeVR4APrVCB45K68rqgp2: Fireblocks, A wallet which filters out abnormal deposits
+// rprFy94qJB5riJpMmnPDp3ttmVKfcrFiuq: Fireblocks, A wallet which receives and stores properly deposited funds from the deposit wallet. The funds accumulated in this wallet are transferred to ceffu once a week.
+// rp53vxWXuEe9LL6AHcCtzzAvdtynSL1aVM: Ceffu, Under Ceffu custody, the assets in this wallet can be delegated to Binance. Once the delegation is complete, the balance is no longer recorded on-chain for this wallet.
 
-const tvl = async (api) => {
-    const address = "rprFy94qJB5riJpMmnPDp3ttmVKfcrFiuq";
-    
+async function getAccountBalance(address) {
     const payload = {
         method: "account_info",
         params: [{
@@ -14,11 +16,95 @@ const tvl = async (api) => {
         }]
     };
 
-    const { data } = await axios.post(NODE_URL, payload);
-    const balanceInDrops = data.result.account_data.Balance;
-    api.add(ADDRESSES.ripple.XRP, balanceInDrops)
+    try {
+        const { data } = await axios.post(NODE_URL, payload);
+        if (data.result && data.result.account_data) {
+            return data.result.account_data.Balance;
+        }
+        return 0; 
+    } catch (error) {
+        return 0;
+    }
+}
+
+async function fetchAccountTransactions(address, marker = null, transactions = []) {
+    const payload = {
+        method: "account_tx",
+        params: [{
+            account: address,
+            ledger_index_min: -1,
+            ledger_index_max: -1,
+            binary: false,
+            limit: 5000,
+            marker: marker
+        }]
+    };
+    
+    if (marker === null) {
+        delete payload.params[0].marker;
+    }
+
+    try {
+        const { data } = await axios.post(NODE_URL, payload);
+        
+        if (data.result && data.result.transactions) {
+            transactions = transactions.concat(data.result.transactions);
+        }
+        
+        if (data.result && data.result.marker) {
+            return await fetchAccountTransactions(address, data.result.marker, transactions);
+        }
+        
+        return transactions;
+    } catch (error) {
+        return transactions;
+    }
+}
+
+async function calculateNetTransfersToCeffu(treasuryAddress, ceffuAddress) {
+    // Treasury 계정의 모든 트랜잭션 가져오기
+    const transactions = await fetchAccountTransactions(treasuryAddress);
+    let netTransfer = 0;
+    
+    // 트랜잭션 분석
+    transactions.forEach(tx => {
+        const transaction = tx.tx || {};
+        
+        // FB Treasury -> Ceffu
+        if (transaction.TransactionType === 'Payment' && 
+            transaction.Account === treasuryAddress && 
+            transaction.Destination === ceffuAddress) {
+            netTransfer += parseInt(transaction.Amount);
+        }
+        
+        // Ceffu -> FB Treasury
+        if (transaction.TransactionType === 'Payment' && 
+            transaction.Account === ceffuAddress && 
+            transaction.Destination === treasuryAddress) {
+            netTransfer -= parseInt(transaction.Amount);
+        }
+    });
+    
+    return netTransfer > 0 ? netTransfer : 0;
+}
+
+const tvl = async (api) => {
+    const fbDepositAddress = "rEPQxsSVER2r4HeVR4APrVCB45K68rqgp2";
+    const fbTreasuryAddress = "rprFy94qJB5riJpMmnPDp3ttmVKfcrFiuq";
+    const ceffuAddress = "rp53vxWXuEe9LL6AHcCtzzAvdtynSL1aVM";
+
+    const fbDepositBalance = await getAccountBalance(fbDepositAddress);
+    const fbTreasuryBalance = await getAccountBalance(fbTreasuryAddress);
+    // Calculate net transfers to Ceffu
+    const netTransfersToCeffu = await calculateNetTransfersToCeffu(fbTreasuryAddress, ceffuAddress);
+
+    api.add(ADDRESSES.ripple.XRP, fbDepositBalance);
+    api.add(ADDRESSES.ripple.XRP, fbTreasuryBalance);
+    api.add(ADDRESSES.ripple.XRP, netTransfersToCeffu);
 }
 
 module.exports = {
-    ripple: { tvl }
-}
+    ripple: {
+        tvl
+    }
+};


### PR DESCRIPTION
Doppler Finance operates as a CeDeFi service on XRPL, where XRP is sent to exchanges for management and then returned to users. For more details, please refer to the documentation and the official website.
- Website: https://doppler.finance/
- Docs: https://docs.doppler.finance/

Doppler Finance utilizes services like Ceffu and Copper, similar to Bouncebit, to send and manage users’ assets on exchanges. As a result, TVL cannot be accurately calculated based solely on on-chain address information, so we use an API to determine TVL instead.

Our onchain addresses and description : https://docs.doppler.finance/xrpfi/cedefi-yields#what-makes-doppler-finance-different-from-other-cedefi

The TVL data displayed will be the same as the information shown on the website: https://app.doppler.finance/xrpfi

The calculation is as follows:
<img width="867" alt="image" src="https://github.com/user-attachments/assets/20c2c7ec-6fa2-47e5-b3cf-9654cce62494" />

<img width="381" alt="image" src="https://github.com/user-attachments/assets/c8c5e190-38ea-485b-8798-46b716e8363d" />

~~The external API for this is not yet implemented. I am submitting a PR first to get feedback on whether this approach is reasonable. Please share your thoughts, and if it is deemed appropriate, I will update the implementation accordingly and resubmit.~~

The API implementation is complete, so I have updated it and resubmitted the PR.
