### PR TITLE
fix: update MORE-markets

### DIFF
--- a/projects/more-markets/index.js
+++ b/projects/more-markets/index.js
@@ -1,12 +1,5 @@
-const { getLogs2 } = require("../helper/cache/getLogs")
-const { sumTokens2 } = require('../helper/unwrapLPs')
 const { aaveExports } = require('../helper/aave');
 const { mergeExports } = require("../helper/utils");
-
-const abi = {
-  "idToMarketParams": "function idToMarketParams(bytes32 Id) returns (bool isPremiumMarket, address loanToken, address collateralToken, address oracle, address irm, uint256 lltv, address creditAttestationService, uint96 irxMaxLltv, uint256[] categoryLltv)",
-  "market": "function market(bytes32 input) returns (uint128 totalSupplyAssets, uint128 totalSupplyShares, uint128 totalBorrowAssets, uint128 totalBorrowShares, uint128 lastUpdate, uint128 fee, uint256 premiumFee)"
-}
 
 module.exports = {
   methodology: `Collateral (supply minus borrows) in the balance of the MORE Markets contracts`,
@@ -14,48 +7,17 @@ module.exports = {
 
 const config = {
   flow: {
-    moreMarkets: "0x94A2a9202EFf6422ab80B6338d41c89014E5DD72",
-    fromBlock: 2871764,
-    moreAaveForkMarkets: ["0x79e71e3c0EDF2B88b0aB38E9A1eF0F6a230e56bf"],
+    moreAaveForkMarkets: ["0x79e71e3c0EDF2B88b0aB38E9A1eF0F6a230e56bf", "0xF580F6F3A2223Db22294c2241c7e0Cc401d20659"],
   },
 };
 
 Object.keys(config).forEach((chain) => {
-  const { moreMarkets, fromBlock, moreAaveForkMarkets = [] } = config[chain];
+  const { moreAaveForkMarkets = [] } = config[chain];
 
-  const tvl = async (api) => {
-    const marketIds = await getMarkets(api);
-    const tokens = (await api.multiCall({ target: moreMarkets, calls: marketIds, abi: abi.idToMarketParams, }))
-      .map((i) => [i.collateralToken, i.loanToken])
-      .flat();
-    return sumTokens2({ api, owner: moreMarkets, tokens, });
-  }
-
-  const borrowed = async (api) => {
-    const marketIds = await getMarkets(api);
-    const marketInfo = await api.multiCall({ target: moreMarkets, calls: marketIds, abi: abi.idToMarketParams, });
-    const marketData = await api.multiCall({ target: moreMarkets, calls: marketIds, abi: abi.market, });
-    marketData.forEach((i, idx) => {
-      api.add(marketInfo[idx].loanToken, i.totalBorrowAssets);
-    });
-    return sumTokens2({ api })
-  }
-
-  const chainObjects = [{ tvl, borrowed, }]
+  const chainObjects = []
   moreAaveForkMarkets.forEach((i) => {
     chainObjects.push(aaveExports(chain, '', undefined, [i], { v3: true }))
   })
 
   module.exports[chain] = mergeExports(chainObjects.map(i => ({ [chain]: i })))[chain]
-
-  async function getMarkets(api) {
-    const logs = await getLogs2({
-      api,
-      target: moreMarkets,
-      eventAbi: "event CreateMarket(bytes32 indexed id, (bool,address,address,address,address,uint256,address,uint96,uint256[]) marketParams)",
-      fromBlock,
-    });
-    return logs.map((i) => i.id);
-  }
-
 })


### PR DESCRIPTION
## Adapter
We migrated most of the tvl from the deprecated Morpho fork to Aave V3. The adapter has been updated accordingly. Another pool has been added, but for some reason the adapter doesn't take into account the TRUMP Official token it holds.

## forked from

Please change the "Forked from" field to Aave V3

## description changed

Also we would appreciate if You change description of the protocol to:

MORE Markets is a decentralized lending protocol that lets users easily lend and borrow digital assets. It offers features like flash loans, collateral swaps and custom markets offering the ability to manage risk by isolating chosen assets. These tools help users make the most of their digital assets without needing a middleman.

The protocol is designed for permissionless market creation, removing any need for approval or oversight from a central authority. This means anyone can use the factory contract to deploy and update market parameters. The flexibility of market management enables borrowers to design innovative strategies, while offering lenders and asset managers access to sustainable yield

