### PR TITLE
feat: added qx adapter in Qubic chain

### DIFF
--- a/projects/qx/index.js
+++ b/projects/qx/index.js
@@ -1,0 +1,12 @@
+const RPC_ENDPOINT = "https://rpc.qubic.org"
+const QearnAddress = "BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARMID";
+
+module.exports = {
+    timetravel: false, 
+    qubic: { 
+      tvl: async () => {
+        const res = await fetch(`${RPC_ENDPOINT}/v1/balances/${QearnAddress}`).then(r => r.json());
+        return {'coingecko:qubic-network': res.balance.balance }
+      }
+    },
+  };


### PR DESCRIPTION
Name (to be shown on DefiLlama): QX

Website Link:      https://qx.qubic.org/
Logo (High resolution, will be shown with rounded borders):   https://qubic.org/brand-kit
Current TVL:  145.44 k USD
Chain: Qubic
Short Description (to be shown on DefiLlama): This is a Dex in Qubic blockchain.
methodology (what is being counted as tvl, how is tvl being calculated): The users can trade all the assets, tokens using QX DEX. assets or tokens -> $qubic, $qubic -> assets or tokens.
Github org/user (Optional, if your code is open source, we can track activity): https://github.com/qubic/core/blob/main/src/contracts/Qx.h
