### PR TITLE
integrations Create PR to update DefiLlama [sc-19751]

### DIFF
--- a/projects/maple-rwa/index.js
+++ b/projects/maple-rwa/index.js
@@ -16,8 +16,15 @@ const ENDPOINT = 'https://api.maple.finance/v2/graphql';
 const LOANS_QUERY = `
     query getNativeLoansSnapshot($timestamp: Float!) {
       nativeLoansSnapshot(timestamp: $timestamp) {
-        loanValueUsd
+        loanId
+        loanAsset
+        loanAmount
+        collateralAsset
+        collateralAmount
+        collateralPrice
         collateralValueUsd
+        loanAssetPrice
+        loanValueUsd
       }
     }
   `;
@@ -25,7 +32,7 @@ const LOANS_QUERY = `
 /**
  * Fetches raw loan data from Maple Finance's GraphQL API
  * @param {number} timestamp Unix timestamp in seconds
- * @returns {Promise<Array<{loanValueUsd: string, collateralValueUsd: string}>>} Array of loan objects containing USD values
+ * @returns {Promise<Array<{loanId: string, loanAsset: string, loanAmount: string, collateralAsset: string, collateralAmount: string, collateralPrice: string, collateralValueUsd: string, loanAssetPrice: string, loanValueUsd: string}>>} Array of loan objects
  */
 const fetchLoans = async (timestamp) => {
   const timestampMs = timestamp * 1000;

--- a/projects/maple-rwa/index.js
+++ b/projects/maple-rwa/index.js
@@ -1,57 +1,61 @@
+/**
+ * Maple Finance TVL & Borrowed Amounts Adapter
+ * 
+ * This adapter fetches data from Maple Finance's GraphQL API to calculate:
+ * - Total Value Locked (TVL): Sum of all collateral values
+ * - Total Borrowed: Sum of all loan values
+ * 
+ * References:
+ * - Maple Finance API Docs: https://studio.apollographql.com/public/maple-api/variant/mainnet/home
+ * 
+ */
+
 const axios = require('axios');
 
-const query_url = "https://api.maple.finance/v2/graphql";
-
-const coingeckoMapping = {
-  'BTC': { name: 'bitcoin', decimals: 8 },
-  'ETH': { name: 'ethereum', decimals: 18 },
-  'SOL': { name: 'solana', decimals: 18 },
-  'INJ': { name: 'injective-protocol', decimals: 18 }
-}
-
-const query = `
-  query {
-    nativeLoans {
-      liquidityAsset {
-        symbol
-        decimals
+const ENDPOINT = 'https://api.maple.finance/v2/graphql';
+const LOANS_QUERY = `
+    query getNativeLoansSnapshot($timestamp: Float!) {
+      nativeLoansSnapshot(timestamp: $timestamp) {
+        loanValueUsd
+        collateralValueUsd
       }
-      createdAt
-      principalOwed
-      collateralAsset
-      collateralAssetAmount
     }
-  }
-`;
+  `;
 
-const getLoans = async (api) => {
+/**
+ * Fetches raw loan data from Maple Finance's GraphQL API
+ * @param {number} timestamp Unix timestamp in seconds
+ * @returns {Promise<Array<{loanValueUsd: string, collateralValueUsd: string}>>} Array of loan objects containing USD values
+ */
+const fetchLoans = async (timestamp) => {
+  const timestampMs = timestamp * 1000;
+
   const payload = {
-    query,
+    query: LOANS_QUERY,
+    variables: { timestamp: timestampMs },
     headers: { "Content-Type": "application/json" }
   };
 
-  const { data } = await axios.post(query_url, payload);
-  return data.data.nativeLoans.filter(({ createdAt }) => createdAt < api.timestamp * 1000);
-};
+  const response = await axios.post(ENDPOINT, payload);
 
-const processLoans = async (api, key) => {
-  const loans = await getLoans(api)
-  const isCollateral = key === "collateralValue";
-
-  loans.forEach(({ liquidityAsset: { symbol, decimals }, principalOwed, collateralAssetAmount, collateralAsset }) => {
-    const assetKey = isCollateral ? collateralAsset : symbol;
-    const balance = Number(isCollateral ? collateralAssetAmount : principalOwed);
-    const token = coingeckoMapping[assetKey]?.name;
-    const parseDecimals = coingeckoMapping[assetKey]?.decimals ?? decimals;
-    if (!token) return;
-    api.addCGToken(token, balance / 10 ** parseDecimals);
-  })
+  return response.data.data.nativeLoansSnapshot;
 }
 
+/**
+ * Calculates total value based on specified property and returns API response format
+ * @param {number} timestamp Unix timestamp in seconds
+ * @param {string} propertyName Property to sum ('loanValueUsd' or 'collateralValueUsd')
+ * @returns {Promise<{usd: number}>} Total value in USD
+ */
+const getTotal = async (timestamp, propertyName) => {
+  const loans = await fetchLoans(timestamp);
+  const total = loans.reduce((sum, loan) => sum + Number(loan[propertyName]), 0);
+  return { usd: total };
+}
 
 module.exports = {
-  ethereum: { 
-    tvl: async (api) => processLoans(api, "collateralValue"),
-    borrowed: async (api) => processLoans(api),
-  }
+  ethereum: {
+    tvl: async (api) => await getTotal(api.timestamp, 'collateralValueUsd'),
+    borrowed: async (api) => await getTotal(api.timestamp, 'loanValueUsd'),
+  },
 };

--- a/projects/maple/index.js
+++ b/projects/maple/index.js
@@ -2,7 +2,7 @@
  * Maple Finance TVL & Borrowed Amounts Adapter
  * 
  * This adapter fetches data from Maple Finance's GraphQL API to calculate:
- * - Total Value Locked (TVL): Sum of all pool TVL and strategies deployed
+ * - Total Value Locked (TVL): Sum of all pool cash, cash in DeFi strategies, and collateral
  * - Total Borrowed: Sum of all principal out (active loans)
  * - Total Staking: Sum of all staked assets in stSYRUP ERC-4626 vault
  * 
@@ -24,12 +24,23 @@ const ENDPOINT = "https://api.maple.finance/v2/graphql";
 const POOLS_QUERY = `
   query example($block: Block_height) {
     poolV2S(block: $block) {
+      id
+      name
       collateralValue
       principalOut
       strategiesDeployed
       tvl
+      assets
       asset {
         symbol
+      }
+      poolMeta {
+        state
+        asset
+        poolCollaterals {
+          addresses
+          assetAmount
+        }
       }
     }
   }
@@ -38,7 +49,7 @@ const POOLS_QUERY = `
 /**
  * Fetches pool data from Maple Finance's GraphQL API
  * @param {number} block Ethereum block number
- * @returns {Promise<Array<{collateralValue: string, principalOut: string, tvl: string, asset: {symbol: string}}>>} Array of pool objects containing values and asset info
+ * @returns {Promise<Array<{id: string, name: string, collateralValue: string, principalOut: string, strategiesDeployed: string, tvl: string, assets: string[], asset: {symbol: string}, poolMeta: {state: string, asset: string, poolCollaterals: Array<{addresses: string[], assetAmount: string}>}}>>} Array of pool objects
  */
 const getPools = async (block) => {
   const payload = {
@@ -54,22 +65,20 @@ const getPools = async (block) => {
 /**
  * Calculates total value based on specified property and returns API response format
  * @param {Object} api DefiLlama SDK api object
- * @param {string} propertyName Property to sum ('tvl' or 'principalOut')
+ * @param {string} key Property to sum
  * @returns {Promise<{usd: number}>} Total value in USD
  */
-const processPools = async (api, propertyName) => {
+const processPools = async (api, key) => {
   const block = await api.getBlock();
   
   if (block < POOL_V2_START_BLOCK) return console.error('Error: Impossible to backfill - The queried block is earlier than the deployment block of poolsV2');
-
   const pools = await getPools(block);
 
   pools.forEach((pool) => {
-    const token = ADDRESSES.ethereum[pool.asset.symbol] ?? null
-    const balance = propertyName === 'tvl' ? Number(pool.tvl) + Number(pool.strategiesDeployed) : Number(pool.principalOut) ?? null
-
-    if (!token || !balance) return;
-
+    const { id, name, asset: { symbol }, assets, collateralValue, principalOut, strategiesDeployed, poolMeta } = pool
+    const token = ADDRESSES.ethereum[symbol] ?? null
+    if (!token) return;
+    const balance = key === "collateralValue" ? Number(collateralValue) + Number(assets) + Number(strategiesDeployed) : Number(principalOut)
     api.add(token, balance)
   })
 };
@@ -80,10 +89,9 @@ const processPools = async (api, propertyName) => {
  * @returns {Promise<Object>} Total staked value in USD
  */
 const staking = async (api) => {
+  const START_BLOCK = 20735662
   const block = await api.getBlock()
-
-  if (block < STAKING_START_BLOCK) return;
-  
+  if (block < START_BLOCK) return;
   return api.erc4626Sum({ calls: [stSYRUP], tokenAbi: 'address:asset', balanceAbi: 'uint256:totalAssets' })
 }
 
@@ -91,8 +99,8 @@ module.exports = {
   hallmarks: [[1670976000, 'V2 Deployment']],
   solana: { tvl: () => ({})},
   ethereum: { 
-    tvl: async (api) => await processPools(api, 'tvl'),
-    borrowed: async (api) => await processPools(api, 'principalOut'),
+    tvl: async (api) => processPools(api, "collateralValue"),
+    borrowed: async (api) => processPools(api),
     staking
   }
 };

--- a/projects/maple/index.js
+++ b/projects/maple/index.js
@@ -89,9 +89,8 @@ const processPools = async (api, key) => {
  * @returns {Promise<Object>} Total staked value in USD
  */
 const staking = async (api) => {
-  const START_BLOCK = 20735662
   const block = await api.getBlock()
-  if (block < START_BLOCK) return;
+  if (block < STAKING_START_BLOCK) return;
   return api.erc4626Sum({ calls: [stSYRUP], tokenAbi: 'address:asset', balanceAbi: 'uint256:totalAssets' })
 }
 

--- a/projects/maple/index.js
+++ b/projects/maple/index.js
@@ -1,63 +1,89 @@
+/**
+ * Maple Finance TVL & Borrowed Amounts Adapter
+ * 
+ * This adapter fetches data from Maple Finance's GraphQL API to calculate:
+ * - Total Value Locked (TVL): Sum of all pool TVL and strategies deployed
+ * - Total Borrowed: Sum of all principal out (active loans)
+ * - Total Staking: Sum of all staked assets in stSYRUP ERC-4626 vault
+ * 
+ * 
+ * References:
+ * - Maple Finance API Docs: https://studio.apollographql.com/public/maple-api/variant/mainnet/home
+ * 
+ */
+
 const ADDRESSES = require('../helper/coreAssets.json');
 const axios = require('axios');
 
-const query_url = "https://api.maple.finance/v2/graphql";
-const stSYRUP = "0xc7E8b36E0766D9B04c93De68A9D47dD11f260B45"
+const stSYRUP = "0xc7E8b36E0766D9B04c93De68A9D47dD11f260B45";
 
-const query = `
+const POOL_V2_START_BLOCK = 16186377;
+const STAKING_START_BLOCK = 20735662;
+
+const ENDPOINT = "https://api.maple.finance/v2/graphql";
+const POOLS_QUERY = `
   query example($block: Block_height) {
     poolV2S(block: $block) {
-      id
-      name
       collateralValue
       principalOut
+      strategiesDeployed
       tvl
-      assets
       asset {
         symbol
-      }
-      poolMeta {
-        state
-        asset
-        poolCollaterals {
-          addresses
-          assetAmount
-        }
       }
     }
   }
 `;
 
+/**
+ * Fetches pool data from Maple Finance's GraphQL API
+ * @param {number} block Ethereum block number
+ * @returns {Promise<Array<{collateralValue: string, principalOut: string, tvl: string, asset: {symbol: string}}>>} Array of pool objects containing values and asset info
+ */
 const getPools = async (block) => {
   const payload = {
-    query,
+    query: POOLS_QUERY,
     variables: { block: { number: block - 10 } },
     headers: { "Content-Type": "application/json" }
   };
 
-  const { data } = await axios.post(query_url, payload);
+  const { data } = await axios.post(ENDPOINT, payload);
   return data.data.poolV2S;
 };
 
-const processPools = async (api, key) => {
+/**
+ * Calculates total value based on specified property and returns API response format
+ * @param {Object} api DefiLlama SDK api object
+ * @param {string} propertyName Property to sum ('tvl' or 'principalOut')
+ * @returns {Promise<{usd: number}>} Total value in USD
+ */
+const processPools = async (api, propertyName) => {
   const block = await api.getBlock();
-  // This is the deployment block of the first poolV2
-  if (block < 16186377) return console.error('Error: Impossible to backfill - The queried block is earlier than the deployment block of poolsV2');
+  
+  if (block < POOL_V2_START_BLOCK) return console.error('Error: Impossible to backfill - The queried block is earlier than the deployment block of poolsV2');
+
   const pools = await getPools(block);
 
   pools.forEach((pool) => {
-    const { id, name, asset: { symbol }, assets, collateralValue, principalOut, poolMeta } = pool
-    const token = ADDRESSES.ethereum[symbol] ?? null
-    if (!token) return;
-    const balance = key === "collateralValue" ? Number(collateralValue) + Number(assets) : Number(principalOut)
+    const token = ADDRESSES.ethereum[pool.asset.symbol] ?? null
+    const balance = propertyName === 'tvl' ? Number(pool.tvl) + Number(pool.strategiesDeployed) : Number(pool.principalOut) ?? null
+
+    if (!token || !balance) return;
+
     api.add(token, balance)
   })
 };
 
+/**
+ * Calculates total staked value in Maple's stSYRUP ERC-4626 vault
+ * @param {Object} api DefiLlama SDK api object
+ * @returns {Promise<Object>} Total staked value in USD
+ */
 const staking = async (api) => {
-  const START_BLOCK = 20735662
   const block = await api.getBlock()
-  if (block < START_BLOCK) return;
+
+  if (block < STAKING_START_BLOCK) return;
+  
   return api.erc4626Sum({ calls: [stSYRUP], tokenAbi: 'address:asset', balanceAbi: 'uint256:totalAssets' })
 }
 
@@ -65,8 +91,8 @@ module.exports = {
   hallmarks: [[1670976000, 'V2 Deployment']],
   solana: { tvl: () => ({})},
   ethereum: { 
-    tvl: async (api) => processPools(api, "collateralValue"),
-    borrowed: async (api) => processPools(api),
+    tvl: async (api) => await processPools(api, 'tvl'),
+    borrowed: async (api) => await processPools(api, 'principalOut'),
     staking
   }
 };


### PR DESCRIPTION
This PR updates the Maple Finance adapter implementation:

1. Splits the adapter into two versions:
   - `maple-rwa/index.js`: New adapter specifically for Real World Assets (RWA) using native loans data
   - `maple/index.js`: Original adapter for pool TVL, borrowed amounts, and staking

### Key changes:
- Added new GraphQL query for native loans snapshot in maple-rwa adapter
- Implemented separate TVL and borrowed calculations for RWA based on collateral and loan values
- Maintained existing pool-based calculations in the original maple adapter
- Both adapters use the official Maple Finance GraphQL API

### Methodology:
- maple-rwa:
  - TVL: Sum of all collateral values from native loans
  - Borrowed: Sum of all loan values from native loans
- maple (original):
  - TVL: Sum of pool TVL and strategies deployed
  - Borrowed: Sum of all principal out (active loans)
  - Staking: Sum of staked assets in stSYRUP ERC-4626 vault
  
### Note
Previously, the `maple-rwa` adapter calculated asset prices manually using the DeFiLlama SDK.
With this update, that step is no longer necessary since the new endpoint already returns the values in USD.
This simplifies the logic and removes an unnecessary dependency.  