### PR TITLE
add resupply hallmark

### DIFF
--- a/projects/crv-usd/index.js
+++ b/projects/crv-usd/index.js
@@ -37,3 +37,7 @@ Object.keys(config).forEach(chain => {
     }
   }
 })
+
+module.exports.hallmarks = [
+  [1742470655, "Resupply Launch"]
+]

--- a/projects/llamalend-curve/index.js
+++ b/projects/llamalend-curve/index.js
@@ -28,3 +28,7 @@ module.exports=Object.keys(chainContracts).reduce((all, chain)=> ({
         }
     }
 }), {})
+
+module.exports.hallmarks = [
+    [1742470655, "Resupply Launch"]
+]


### PR DESCRIPTION
simply added hallmarks for the launch of Resupply for llamalend-curve and crv-usd.