### PR TITLE
Doppler TVL from tx 

### DIFF
--- a/projects/doppler-finance/index.js
+++ b/projects/doppler-finance/index.js
@@ -1,105 +1,31 @@
 const ADDRESSES = require('../helper/coreAssets.json');
 const axios = require('axios');
 
-const NODE_URL = "https://xrplcluster.com";
+const DOPPLER_API_URL = "https://api.doppler.finance/v1/xrpfi/staking-info";
 // ref: https://docs.doppler.finance/xrpfi/cedefi-yields#what-makes-doppler-finance-different-from-other-cedefi
 // rEPQxsSVER2r4HeVR4APrVCB45K68rqgp2: Fireblocks, A wallet which filters out abnormal deposits
 // rprFy94qJB5riJpMmnPDp3ttmVKfcrFiuq: Fireblocks, A wallet which receives and stores properly deposited funds from the deposit wallet. The funds accumulated in this wallet are transferred to ceffu once a week.
 // rp53vxWXuEe9LL6AHcCtzzAvdtynSL1aVM: Ceffu, Under Ceffu custody, the assets in this wallet can be delegated to Binance. Once the delegation is complete, the balance is no longer recorded on-chain for this wallet.
-
-async function getAccountBalance(address) {
-    const payload = {
-        method: "account_info",
-        params: [{
-            account: address,
-            ledger_index: "validated"
-        }]
-    };
-
+// Ceffu is similar to CEX wallets, making it impossible to track Doppler's balance on-chain
+// Our api response is sum of fireblocks and ceffu balances
+const tvl = async (api) => {
     try {
-        const { data } = await axios.post(NODE_URL, payload);
-        if (data.result && data.result.account_data) {
-            return data.result.account_data.Balance;
+        const { data } = await axios.get(DOPPLER_API_URL);
+        if (!data || !data[0]) {
+            throw new Error('Invalid API response');
         }
-        return 0; 
+
+        const stakingInfo = data[0];
+        const { totalStaked } = stakingInfo;
+
+        api.add(ADDRESSES.ripple.XRP, totalStaked * 1e6); // Convert to drops (1 XRP = 1,000,000 drops)
     } catch (error) {
+        console.error('Error fetching Doppler Finance staking info:', error);
         return 0;
     }
 }
 
-async function fetchAccountTransactions(address, marker = null, transactions = []) {
-    const payload = {
-        method: "account_tx",
-        params: [{
-            account: address,
-            ledger_index_min: -1,
-            ledger_index_max: -1,
-            binary: false,
-            limit: 5000,
-            marker: marker
-        }]
-    };
-    
-    if (marker === null) {
-        delete payload.params[0].marker;
-    }
-
-    try {
-        const { data } = await axios.post(NODE_URL, payload);
-        
-        if (data.result && data.result.transactions) {
-            transactions = transactions.concat(data.result.transactions);
-        }
-        
-        if (data.result && data.result.marker) {
-            return await fetchAccountTransactions(address, data.result.marker, transactions);
-        }
-        
-        return transactions;
-    } catch (error) {
-        return transactions;
-    }
-}
-
-// Calculate net flow of Treasury wallet excluding transactions with Ceffu
-async function calculateTreasuryNetFlow(treasuryAddress, ceffuAddress) {
-    const transactions = await fetchAccountTransactions(treasuryAddress);
-    let netFlow = 0;
-    
-    transactions.forEach(tx => {
-        const transaction = tx.tx || {};
-
-        if (transaction.TransactionType === 'Payment') {
-            // Inflows to Treasury (excluding from Ceffu)
-            if (transaction.Destination === treasuryAddress && transaction.Account !== ceffuAddress) {
-                netFlow += parseInt(transaction.Amount);
-            }
-            
-            // Outflows from Treasury (excluding to Ceffu)
-            if (transaction.Account === treasuryAddress && transaction.Destination !== ceffuAddress) {
-                netFlow -= parseInt(transaction.Amount);
-            }
-        }
-    });
-    
-    return netFlow;
-}
-
-const tvl = async (api) => {
-    const fbTreasuryAddress = "rprFy94qJB5riJpMmnPDp3ttmVKfcrFiuq";
-    const ceffuAddress = "rp53vxWXuEe9LL6AHcCtzzAvdtynSL1aVM";
-    
-    // Calculate Treasury's net flow excluding Ceffu transactions
-    const treasuryNetFlow = await calculateTreasuryNetFlow(fbTreasuryAddress, ceffuAddress);
-    const netFlowToAdd = treasuryNetFlow > 0 ? treasuryNetFlow : 0;
-
-    // Add to TVL
-    api.add(ADDRESSES.ripple.XRP, netFlowToAdd);
-}
-
 module.exports = {
-    timetravel: false,
-    methodology: "Counts the XRP in Doppler Finance's deposit wallet, treasury wallet, and the net inflow to the Treasury wallet (excluding transactions with Ceffu).",
     ripple: {
         tvl
     }

--- a/projects/doppler-finance/index.js
+++ b/projects/doppler-finance/index.js
@@ -2,10 +2,12 @@ const ADDRESSES = require('../helper/coreAssets.json');
 const axios = require('axios');
 
 const NODE_URL = "https://xrplcluster.com";
+// ref: https://docs.doppler.finance/xrpfi/cedefi-yields#what-makes-doppler-finance-different-from-other-cedefi
+// rEPQxsSVER2r4HeVR4APrVCB45K68rqgp2: Fireblocks, A wallet which filters out abnormal deposits
+// rprFy94qJB5riJpMmnPDp3ttmVKfcrFiuq: Fireblocks, A wallet which receives and stores properly deposited funds from the deposit wallet. The funds accumulated in this wallet are transferred to ceffu once a week.
+// rp53vxWXuEe9LL6AHcCtzzAvdtynSL1aVM: Ceffu, Under Ceffu custody, the assets in this wallet can be delegated to Binance. Once the delegation is complete, the balance is no longer recorded on-chain for this wallet.
 
-const tvl = async (api) => {
-    const address = "rprFy94qJB5riJpMmnPDp3ttmVKfcrFiuq";
-    
+async function getAccountBalance(address) {
     const payload = {
         method: "account_info",
         params: [{
@@ -14,11 +16,91 @@ const tvl = async (api) => {
         }]
     };
 
-    const { data } = await axios.post(NODE_URL, payload);
-    const balanceInDrops = data.result.account_data.Balance;
-    api.add(ADDRESSES.ripple.XRP, balanceInDrops)
+    try {
+        const { data } = await axios.post(NODE_URL, payload);
+        if (data.result && data.result.account_data) {
+            return data.result.account_data.Balance;
+        }
+        return 0; 
+    } catch (error) {
+        return 0;
+    }
+}
+
+async function fetchAccountTransactions(address, marker = null, transactions = []) {
+    const payload = {
+        method: "account_tx",
+        params: [{
+            account: address,
+            ledger_index_min: -1,
+            ledger_index_max: -1,
+            binary: false,
+            limit: 5000,
+            marker: marker
+        }]
+    };
+    
+    if (marker === null) {
+        delete payload.params[0].marker;
+    }
+
+    try {
+        const { data } = await axios.post(NODE_URL, payload);
+        
+        if (data.result && data.result.transactions) {
+            transactions = transactions.concat(data.result.transactions);
+        }
+        
+        if (data.result && data.result.marker) {
+            return await fetchAccountTransactions(address, data.result.marker, transactions);
+        }
+        
+        return transactions;
+    } catch (error) {
+        return transactions;
+    }
+}
+
+// Calculate net flow of Treasury wallet excluding transactions with Ceffu
+async function calculateTreasuryNetFlow(treasuryAddress, ceffuAddress) {
+    const transactions = await fetchAccountTransactions(treasuryAddress);
+    let netFlow = 0;
+    
+    transactions.forEach(tx => {
+        const transaction = tx.tx || {};
+
+        if (transaction.TransactionType === 'Payment') {
+            // Inflows to Treasury (excluding from Ceffu)
+            if (transaction.Destination === treasuryAddress && transaction.Account !== ceffuAddress) {
+                netFlow += parseInt(transaction.Amount);
+            }
+            
+            // Outflows from Treasury (excluding to Ceffu)
+            if (transaction.Account === treasuryAddress && transaction.Destination !== ceffuAddress) {
+                netFlow -= parseInt(transaction.Amount);
+            }
+        }
+    });
+    
+    return netFlow;
+}
+
+const tvl = async (api) => {
+    const fbTreasuryAddress = "rprFy94qJB5riJpMmnPDp3ttmVKfcrFiuq";
+    const ceffuAddress = "rp53vxWXuEe9LL6AHcCtzzAvdtynSL1aVM";
+    
+    // Calculate Treasury's net flow excluding Ceffu transactions
+    const treasuryNetFlow = await calculateTreasuryNetFlow(fbTreasuryAddress, ceffuAddress);
+    const netFlowToAdd = treasuryNetFlow > 0 ? treasuryNetFlow : 0;
+
+    // Add to TVL
+    api.add(ADDRESSES.ripple.XRP, netFlowToAdd);
 }
 
 module.exports = {
-    ripple: { tvl }
-}
+    timetravel: false,
+    methodology: "Counts the XRP in Doppler Finance's deposit wallet, treasury wallet, and the net inflow to the Treasury wallet (excluding transactions with Ceffu).",
+    ripple: {
+        tvl
+    }
+};

--- a/projects/doppler-finance/index.js
+++ b/projects/doppler-finance/index.js
@@ -9,20 +9,15 @@ const DOPPLER_API_URL = "https://api.doppler.finance/v1/xrpfi/staking-info";
 // Ceffu is similar to CEX wallets, making it impossible to track Doppler's balance on-chain
 // Our api response is sum of fireblocks and ceffu balances
 const tvl = async (api) => {
-    try {
-        const { data } = await axios.get(DOPPLER_API_URL);
-        if (!data || !data[0]) {
-            throw new Error('Invalid API response');
-        }
-
-        const stakingInfo = data[0];
-        const { totalStaked } = stakingInfo;
-
-        api.add(ADDRESSES.ripple.XRP, totalStaked * 1e6); // Convert to drops (1 XRP = 1,000,000 drops)
-    } catch (error) {
-        console.error('Error fetching Doppler Finance staking info:', error);
-        return 0;
+    const { data } = await axios.get(DOPPLER_API_URL);
+    if (!data || !data[0]) {
+        throw new Error('Invalid API response');
     }
+
+    const stakingInfo = data[0];
+    const { totalStaked } = stakingInfo;
+
+    api.add(ADDRESSES.ripple.XRP, totalStaked * 1e6); // Convert to drops (1 XRP = 1,000,000 drops)
 }
 
 module.exports = {


### PR DESCRIPTION
We have decided to close the PR that uses a custom API ([PR #13978](https://github.com/DefiLlama/DefiLlama-Adapters/pull/13978)) and switch entirely to using on-chain RPC.

To explain once again:

Doppler Finance operates as a CeDeFi service on XRPL, where XRP is sent to exchanges for management and then returned to users. For more details, please refer to the documentation and the official website.
	•	Website: https://doppler.finance/
	•	Docs: https://docs.doppler.finance/

Doppler Finance utilizes services like Ceffu and Copper, similar to Bouncebit, to send and manage users’ assets on exchanges. As a result, TVL cannot be accurately calculated based solely on on-chain address information, so we use an API to determine TVL instead.

Our on-chain addresses and descriptions can be found here:
https://docs.doppler.finance/xrpfi/cedefi-yields#what-makes-doppler-finance-different-from-other-cedefi

The TVL data displayed will be the same as the information shown on the website: https://app.doppler.finance/xrpfi

The calculation is as follows:
![image](https://github.com/user-attachments/assets/b7a3870f-cd20-48a5-ad99-8f5f4c13236e)
![image](https://github.com/user-attachments/assets/2c047b39-d14e-4d24-aeb5-d8bd4faf0ec3)

**We track the assets of the Ceffu wallet using the following approach:**
- **We calculate the net flow of the Fireblocks Treasury wallet.**
- **During this process, transactions between the Fireblocks Treasury wallet and the Ceffu wallet are excluded from the net flow calculation.**

**This decision was made because Ceffu functions as a shared wallet that categorizes assets by destination, similar to a CEX wallet, making precise on-chain tracking impossible.**