### PR TITLE
Add Umoja's UMJA TVL.

### DIFF
--- a/projects/umoja-umja/index.js
+++ b/projects/umoja-umja/index.js
@@ -5,7 +5,8 @@ const Arbitrum = {
 
 module.exports = {
   arbitrum: {
-      tvl: async (api) => {
+      tvl: () => ({}),
+      staking: async (api) => {
           const lockedUmoGov = await api.call({ abi: 'erc20:balanceOf', target: Arbitrum.token, params: Arbitrum.umo_governance })
           api.add(Arbitrum.token, lockedUmoGov)
       },


### PR DESCRIPTION
$UMJA is our protocol's utility token that is and will be attached to existing and new products released by Umoja.

For example, if you mint any smartcoin (like Umoja's yBTC), you'd be credited with $UMJA, and the reverse is also true, if you burn some smartcoin, you'll need to burn UMJA too.

You may also stake $UMJA to accrue $UMO which is our governance token and it is not tradeable.

$UMJA is already listed in

Coingecko: https://www.coingecko.com/en/coins/umoja
CMC: https://coinmarketcap.com/currencies/umoja/