### PR TITLE
LHYPE (HyperEVM) Hyperlend Valuation Request

### DIFF
--- a/projects/looped-hype/index.js
+++ b/projects/looped-hype/index.js
@@ -12,11 +12,11 @@ const LHYPE_VAULT_ADDRESS = ['0x5748ae796AE46A4F1348a1693de4b50560485562'];
 const tvl = async () => {
   const strategies = await getConfig(
     'lhype-tokens',
-    `https://backend.nucleusearn.io/v1/vaults/underlying_strategies?vault_address=${LHYPE_VAULT_ADDRESS}&chain_id=999`
+    `https://backend.nucleusearn.io/v1/vaults/underlying_strategies?vault_address=${LHYPE_VAULT_ADDRESS}`
   );
   const hyperevmStrategies = strategies["999"]
   const tokens = Object.values(hyperevmStrategies).map((strategy) => strategy.tokenAddress);
-  const sanitizedTokens = sanitizeAndValidateEvmAddresses([...tokens, ...LHYPE_VAULT_ADDRESS]);
+  const sanitizedTokens = sanitizeAndValidateEvmAddresses(tokens);
   console.log(sanitizedTokens);
 
   return sumTokens2({


### PR DESCRIPTION
Hi, thanks for fixing the previous issue with the collateral in HypurrFi. Now we deposited into Hyperlend and our collateral and debt tokens are not being tracked. For reference, here are the respective token addresses `0x0Ab8AAE3335Ed4B373A33D9023b6A6585b149D33` and `0x747d0d4Ba0a2083651513cd008deb95075683e82`. Where the collateral token (`0x0Ab...`) is valued the same as the collateral in HypurrFi and debt is just in `WHYPE`.  This is an aave v3 fork so the valuation for these assets are the same as I outlined here https://github.com/DefiLlama/DefiLlama-Adapters/pull/13735#issuecomment-2701672715. 

For future reference, should I open up an issue or another PR next time?