### PR TITLE
Add getTxUtxos helper function

### DIFF
--- a/projects/helper/chain/cardano/blockfrost.js
+++ b/projects/helper/chain/cardano/blockfrost.js
@@ -59,6 +59,10 @@ async function addressesUtxosAssetAll(address, asset) {
   return addresses
 }
 
+async function getTxUtxos(tx_hash) {
+  const { data } = await axiosObj.get(`txs/${tx_hash}/utxos`)
+  return data
+}
 
 async function getTxsRedeemers(utxo) {
   const { data } = await axiosObj.get(`txs/${utxo}/redeemers`)
@@ -83,6 +87,7 @@ async function getTokensMinted(tokenId){
 module.exports = {
   getAssets,
   getAddressesUTXOs,
+  getTxUtxos,
   getTxsRedeemers,
   getTxsMetadata,
   assetsAddresses,


### PR DESCRIPTION
Helper function to get UTXOs of a transaction hash. Will be used by Strike Finance and can be useful to other protocols. 