### PR TITLE
Zyx swap fix

### DIFF
--- a/projects/zyxswap/index.js
+++ b/projects/zyxswap/index.js
@@ -1,9 +1,8 @@
 const { getUniTVL } = require('../helper/unknownTokens')
 
-module.exports={
-        misrepresentedTokens: true,
+module.exports = {
+    deadFrom: '2024-04-01',
+    misrepresentedTokens: true,
     methodology: "Factory address (0x26e13874ad1cd512b29795dafe3937e1c6f6d507) is used to find the LP pairs. TVL is equal to the liquidity on the AMM.",
-    zyx: {
-        tvl: getUniTVL({ factory: '0x26e13874ad1cd512b29795dafe3937e1c6f6d507', useDefaultCoreAssets: true }),
-    }
+    zyx: { tvl: getUniTVL({ factory: '0x26e13874ad1cd512b29795dafe3937e1c6f6d507', useDefaultCoreAssets: true }) }
 }

--- a/projects/zyxswap/index.js
+++ b/projects/zyxswap/index.js
@@ -1,7 +1,7 @@
 const { getUniTVL } = require('../helper/unknownTokens')
 
 module.exports = {
-    deadFrom: '2024-04-01',
+    deadFrom: '2025-04-01',
     misrepresentedTokens: true,
     methodology: "Factory address (0x26e13874ad1cd512b29795dafe3937e1c6f6d507) is used to find the LP pairs. TVL is equal to the liquidity on the AMM.",
     zyx: { tvl: getUniTVL({ factory: '0x26e13874ad1cd512b29795dafe3937e1c6f6d507', useDefaultCoreAssets: true }) }


### PR DESCRIPTION
Added a deadFrom on the adapter that has had no activity for a year, with a flat TVL, and has stopped updating for the past few days. It is the only adapter on the Zyx chain, which appears to have stopped producing blocks for the last 3 days

https://zyxscan.com/blocks

![image](https://github.com/user-attachments/assets/964b4dcc-0694-416a-b514-48c215f00f15)
