### PR TITLE
Add twin-finance TVL adapter for Berachain mainnet

### DIFF
--- a/projects/twin-finance/index.js
+++ b/projects/twin-finance/index.js
@@ -1,25 +1,31 @@
 const erc20Abi = {
-    totalSupply: 'function totalSupply() view returns (uint256)'
+  balanceOf: 'function balanceOf(address) view returns (uint256)',
+  totalSupply: 'function totalSupply() view returns (uint256)' // Kept for reference, but unused now
+};
+
+const usdcAddress = '0x549943e04f40284185054145c6E4e9568C1D3241'; 
+const twinUSDCAddress = '0x1b7678F6991b8dCcf9bB879929e12f1005d80E94';
+// Replace with the actual address of your deposit/staking/vault contract
+const depositContractAddress = '0xF77B36ba4691c5e3e022D9e7b5a8f78103ccC57a'; 
+
+async function tvl(api) {
+  // Get the amount of twinUSDC or USDC held by the deposit contract
+  const depositedAmount = await api.call({
+    abi: erc20Abi.balanceOf,
+    target: twinUSDCAddress, // The token contract
+    params: [depositContractAddress], // The contract holding the deposits
+  });
+  console.log('Deposited Amount:', depositedAmount);
+
+  return {
+    [`berachain:${usdcAddress}`]: depositedAmount.toString()
+  };
+}
+
+module.exports = {
+  misrepresentedTokens: true,
+  methodology: 'TVL is calculated based on the amount of twinUSDC tokens held in the deposit contract, each representing 1 USDC in value.',
+  berachain: {
+    tvl
   }
-  
-  const usdcAddress = '0x549943e04f40284185054145c6E4e9568C1D3241' 
-  const twinUSDCAddress = '0x1b7678F6991b8dCcf9bB879929e12f1005d80E94'
-  
-  async function tvl(api) {
-    const totalSupply = await api.call({
-      abi: erc20Abi.totalSupply,
-      target: twinUSDCAddress,
-    })
-    console.log('Total Supply:', totalSupply)
-    return {
-      [`berachain:${usdcAddress}`]: totalSupply.toString()
-    }
-  }
-  
-  module.exports = {
-    misrepresentedTokens: true,
-    methodology: 'TVL is calculated based on the total supply of twinUSDC tokens, each representing 1 USDC in value.',
-    berachain: {
-      tvl
-    }
-  }
+};

--- a/projects/twin-finance/index.js
+++ b/projects/twin-finance/index.js
@@ -1,0 +1,25 @@
+const erc20Abi = {
+    totalSupply: 'function totalSupply() view returns (uint256)'
+  }
+  
+  const usdcAddress = '0x549943e04f40284185054145c6E4e9568C1D3241' 
+  const twinUSDCAddress = '0x1b7678F6991b8dCcf9bB879929e12f1005d80E94'
+  
+  async function tvl(api) {
+    const totalSupply = await api.call({
+      abi: erc20Abi.totalSupply,
+      target: twinUSDCAddress,
+    })
+    console.log('Total Supply:', totalSupply)
+    return {
+      [`berachain:${usdcAddress}`]: totalSupply.toString()
+    }
+  }
+  
+  module.exports = {
+    misrepresentedTokens: true,
+    methodology: 'TVL is calculated based on the total supply of twinUSDC tokens, each representing 1 USDC in value.',
+    berachain: {
+      tvl
+    }
+  }


### PR DESCRIPTION
##### Name
Twin Finance

##### Twitter Link
https://x.com/TwinFinance

##### List of audit links if any
https://github.com/TWIN-Protocol/Audits/blob/main/TwinFinance%20Audit%20-%20Report.pdf

##### Website Link
www.twinfinance.io

##### Logo (High resolution, preferably in .svg and .png, for coingecko and twitter)
https://github.com/TWIN-Protocol/BrandAssets/blob/main/TWINLogo1.png

##### Current TVL
~676.02k USD (as of April 7, 2025)

##### Chain
Berachain

##### Short Description
Twin Finance is a DeFi protocol on Berachain mainnet, allowing users to deposit USDC.e and mint synthetic assets. Collateral is deposited into a yield farm, which deposits into Dolomite lending protocol. For each 1 USDC.e that is deposited, i twinUSDC is issued.

##### Methodology
TVL is calculated as the total supply of twinUSDC tokens, each representing 1 USDC in value.

##### Coingecko ID (so your TVL can appear on Coingecko)
