### PR TITLE
Add Etherlink TVL

### DIFF
--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -39,6 +39,10 @@ const ibcMappings = {
 }
 
 const fixBalancesTokens = {
+  etlk: {
+    "0xe4880249745eAc5F1eD9d8F7DF844792D560e750": { coingeckoId: "USTBL", decimals: 5 }, // USTBL
+    "0xa0769f7A8fC65e47dE93797b4e21C073c117Fc80": { coingeckoId: "EUTBL", decimals: 5 }, // EUTBL
+  },
   prom: {
     [ADDRESSES['null']]: { coingeckoId: "prometeus", decimals: 18 }, // Native PROM
     '0x7e942605B5028E3B751dBB5Ef8afC5CF85a5A7eD': { coingeckoId: "tether", decimals: 6 }, // USDT

--- a/projects/spiko/index.js
+++ b/projects/spiko/index.js
@@ -17,6 +17,10 @@ const config = {
   starknet: [
     '0x20ff2f6021ada9edbceaf31b96f9f67b746662a6e6b2bc9d30c0d3e290a71f6',
     '0x4f5e0de717daa6aa8de63b1bf2e8d7823ec5b21a88461b1519d9dbc956fb7f2'
+  ],
+  etlk: [
+    '0xe4880249745eAc5F1eD9d8F7DF844792D560e750',
+    '0xa0769f7A8fC65e47dE93797b4e21C073c117Fc80',
   ]
 }
 
@@ -42,6 +46,7 @@ Object.keys(config).forEach(chain => {
         supplies = await multiCall({ abi: totalSupplyAbi, calls: assets })
       else
         supplies = await api.multiCall({ abi: 'erc20:totalSupply', calls: assets })
+      // console.log(`Chain: ${chain}, Supplies:`, supplies)
       api.add(assets, supplies)
       return sumTokens2({ api })
     }


### PR DESCRIPTION
- Added Etherlink token addresses for EUTBL and USTBL (same as on other listed EVM networks, except Arbitrum)

- Added a manual token mapping for Etherlink in `tokenMapping.js`, since the automatic EVM mapping didn’t work. Open to suggestions if there’s a cleaner way to do this and avoid manually linking tokens with their Coingecko IDs. Last time we did this for Starknet, it caused a token display error — and without historical RPC support on Starknet, we couldn’t backfill the data.

