### PR TITLE
update plume mainnet

### DIFF
--- a/projects/multichainz/index.js
+++ b/projects/multichainz/index.js
@@ -1,11 +1,11 @@
 const abi = {
-  "getTokensForBorrowingArray": "function getTokensForBorrowingArray() view returns ((address tokenAddress, uint256 LTV, uint256 stableRate, string name, uint256 liquidationThreshold)[])",
-  "getTokensForLendingArray": "function getTokensForLendingArray() view returns ((address tokenAddress, uint256 LTV, uint256 stableRate, string name, uint256 liquidationThreshold)[])",
+  "getTokensForBorrowingArray": "function getTokensForBorrowingArray() view returns ((address tokenAddress, uint256 LTV, uint256 rate, string name, uint256 liquidationThreshold)[])",
+  "getTokensForLendingArray": "function getTokensForLendingArray() view returns ((address tokenAddress, uint256 LTV, uint256 rate, string name, uint256 liquidationThreshold)[])",
   "getTotalTokenBorrowed": "function getTotalTokenBorrowed(address tokenAddress) view returns (uint256)",
 }
 
 const config = {
-  plume: { pool: '0x8bd47bC14f38840820d1DC7eD5Eb57b85d2c7808', },
+  plume_mainnet: { pool: '0x3AF7D19aAeCf142C91FF1A8575A316807a0f611A', },
 }
 
 Object.keys(config).forEach(chain => {


### PR DESCRIPTION
**Update:** Change contract address for Multichainz

**Details:**  
- **Old Address:** `0x8bd...7808`  
- **New Address:** `0x3AF....611A`  
- **Chain:** Plume ( 
- **Reason for Update:**  
  - Plume deployed a new chain so we had to deploy a new contract on the new chain 

**Verification:**  
- New contract is verified 
- TVL calculation remains accurate 

**Additional Notes:**  
- The adapter has been tested locally.  
- The new contract uses the same ABI/interface.  