### PR TITLE
Fix AVAX for Balancer V3

### DIFF
--- a/projects/balancer-v3/index.js
+++ b/projects/balancer-v3/index.js
@@ -6,7 +6,7 @@ const config = {
   arbitrum: { vault: '0xbA1333333333a1BA1108E8412f11850A5C319bA9', fromBlock: 297810187 },
   base: { vault: '0xbA1333333333a1BA1108E8412f11850A5C319bA9', fromBlock: 25343854 },
   optimism: { vault: '0xbA1333333333a1BA1108E8412f11850A5C319bA9', fromBlock: 133969439 },
-  avax: { vault: '0xba1333333333cbcdB5D83c2e5d1D898E07eD00Dc', fromBlock: 59388625 },
+  avax: { vault: '0xbA1333333333a1BA1108E8412f11850A5C319bA9', fromBlock: 59955604 },
 }
 
 Object.keys(config).forEach(chain => {


### PR DESCRIPTION
A recent upgrade in the AVAX chain (particularly the gas limit for the blocks) allowed us to deploy the Vault to the usual address.

This is the address that will have official support.

Thanks in advance!