### PR TITLE
Update Peapods Finance adapter to add Berachain support and small fix

### DIFF
--- a/projects/peapods-finance/index.js
+++ b/projects/peapods-finance/index.js
@@ -6,6 +6,7 @@ const config = {
   arbitrum: { indexManagerV3: "0x64511ccE99ab01A6dD136207450eA81263b14FD8", indexManagerV2: "0x0Bb39ba2eE60f825348676f9a87B7CD1e3B4AE6B", leverageManager: "0x3f2257B6f1fd055aEe020027740f266127E8E2B0", peasToken: "0x02f92800F57BCD74066F5709F1Daa1A4302Df875"},
   base: { indexManagerV3: "0x556059e80CB0073D4A9547081Cf0f80cBB94ec30", indexManagerV2: "0x0Bb39ba2eE60f825348676f9a87B7CD1e3B4AE6B", leverageManager: "0x31E35550b15B2DFd267Edfb39Dd9F3CD1c6ab82D", peasToken: "0x02f92800F57BCD74066F5709F1Daa1A4302Df875"},
   sonic: { indexManagerV3: "0x9e054F6C328d8E424a2354af726FDc88cB166060", leverageManager: "0x0C4B19994F466ac4B6bA8F9B220d83beC6118b61", peasToken: "0x02f92800F57BCD74066F5709F1Daa1A4302Df875"},
+  berachain: { indexManagerV3: "0xC9260cE495B5EeC77219Bf4faCCf27EeFD932f01", leverageManager: "0x0ff519EEEc6f1C362A76F87fef3B4a3997bF5a69", peasToken: "0x02f92800F57BCD74066F5709F1Daa1A4302Df875"},
   mode: { indexManagerV2: "0x0Bb39ba2eE60f825348676f9a87B7CD1e3B4AE6B", peasToken: "0x02f92800F57BCD74066F5709F1Daa1A4302Df875"},
 };
 
@@ -50,7 +51,7 @@ const getTvl = async (api, isStaking) => {
 
     PAIRED_LP_TOKEN.forEach((tokens, i) => {
       if(lendingPairArray[i] != ADDRESSES.null){
-        lendingPairsToGetAssets.push([PAIRED_LP_TOKEN[i]]);
+        lendingPairsToGetAssets.push([lendingPairArray[i]]);
       }else{
         includedStakingPools.push([stakingTokensV3[i], PAIRED_LP_TOKEN[i]]);
       }
@@ -76,7 +77,7 @@ const getTvl = async (api, isStaking) => {
 
 module.exports = {
   methodology: "Aggregates TVL in all Peapods Finance indexes created",
-  hallmarks: [[1710444951, "Arbitrum launch"],[1715151225, "Base launch"],[1715214483, "Mode launch"],[1738958400, "LVF launch"],[1742269792, "Sonic launch"]],
+  hallmarks: [[1710444951, "Arbitrum launch"],[1715151225, "Base launch"],[1715214483, "Mode launch"],[1738958400, "LVF launch"],[1742269792, "Sonic launch"],[1744292339, "Berachain launch"]],
 };
 
 Object.keys(config).forEach(chain => {


### PR DESCRIPTION
Adding support for Berachain and adding hallmark.
Small fix to built array lendingPairsToGetAssets with right values.

Request; [please backfill](https://github.com/DefiLlama/DefiLlama-Adapters/pull/14146#issuecomment-2783033385) data since LVF launch hallmark. Should I add code to make this work since contracts don't exist in the past? Please advice.
