### PR TITLE
added arche-protocol project

### DIFF
--- a/projects/arche-protocol/index.js
+++ b/projects/arche-protocol/index.js
@@ -4,23 +4,19 @@ const ARCHE_CONTRACT_ADDRESS = "0xbcc40f56a3538c9cc25254f485f48e6f150f9acac53a2e
 const MOVE_TOKEN_ADDRESS = "0x1::aptos_coin::AptosCoin";
 
 async function fetchLockedTokens() {
-    try {
-        // Call arche contract to get the total locked move tokens
-        const protocolSummary = await function_view({
-            functionStr: `${ARCHE_CONTRACT_ADDRESS}::router::protocol_summary`,
-            type_arguments: [],
-            args: ["0xa"],
-            chain: 'move'
-        })
 
-        // Returns [0] because the functions returns multiple values
-        // Total deposited move is the first value
-        return protocolSummary[0];
+    // Call arche contract to get the total locked move tokens
+    const lockedTokens = await function_view({
+        functionStr: `${ARCHE_CONTRACT_ADDRESS}::collateral::total_collateral`,
+        type_arguments: [],
+        args: ["0xa"],
+        chain: 'move'
+    })
 
-    } catch (error) {
-        console.error("Error fetching locked tokens:", error);
-        return 0;
-    }
+    // Returns [0] because the functions returns multiple values
+    // Total deposited move is the first value
+    return lockedTokens;
+
 }
 
 module.exports = {

--- a/projects/arche-protocol/index.js
+++ b/projects/arche-protocol/index.js
@@ -13,10 +13,7 @@ async function fetchLockedTokens() {
         chain: 'move'
     })
 
-    // Returns [0] because the functions returns multiple values
-    // Total deposited move is the first value
     return lockedTokens;
-
 }
 
 module.exports = {

--- a/projects/arche-protocol/index.js
+++ b/projects/arche-protocol/index.js
@@ -36,7 +36,3 @@ module.exports = {
         }
     }
 };
-
-let a = fetchLockedTokens().then(resp => {
-    console.log(resp)
-})

--- a/projects/arche-protocol/index.js
+++ b/projects/arche-protocol/index.js
@@ -1,0 +1,42 @@
+const {function_view} = require("../helper/chain/aptos");
+
+const ARCHE_CONTRACT_ADDRESS = "0xbcc40f56a3538c9cc25254f485f48e6f150f9acac53a2e92c6d698a9c1751a0b";
+const MOVE_TOKEN_ADDRESS = "0x1::aptos_coin::AptosCoin";
+
+async function fetchLockedTokens() {
+    try {
+        // Call arche contract to get the total locked move tokens
+        const protocolSummary = await function_view({
+            functionStr: `${ARCHE_CONTRACT_ADDRESS}::router::protocol_summary`,
+            type_arguments: [],
+            args: ["0xa"],
+            chain: 'move'
+        })
+
+        // Returns [0] because the functions returns multiple values
+        // Total deposited move is the first value
+        return protocolSummary[0];
+
+    } catch (error) {
+        console.error("Error fetching locked tokens:", error);
+        return 0;
+    }
+}
+
+module.exports = {
+    timetravel: false,
+    methodology: "Counts the total value of MOVE tokens locked in the MSD protocol",
+    move: {
+        tvl: async (api) => {
+            // Fetch total locked tokens
+            const lockedTokens = await fetchLockedTokens();
+
+            // Add the token to the balances
+            api.add(MOVE_TOKEN_ADDRESS, lockedTokens);
+        }
+    }
+};
+
+let a = fetchLockedTokens().then(resp => {
+    console.log(resp)
+})


### PR DESCRIPTION
##### Name (to be shown on DefiLlama): Arche Protocol


##### Twitter Link: https://x.com/ArcheProtocol


##### List of audit links if any: https://github.com/arche-labs/assets/blob/main/audits/Arche%20Protocol%20Audit%20Report.pdf


##### Website Link: https://www.archeprotocol.xyz/home 


##### Logo (High resolution, will be shown with rounded borders): https://raw.githubusercontent.com/arche-labs/assets/refs/heads/main/icons/Arche.png


##### Current TVL:~155k$


##### Treasury Addresses (if the protocol has treasury): N/A


##### Chain: Movement


##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): 


##### Short Description (to be shown on DefiLlama): Arche Protocol is the leading  CDP protocol within the Movement ecosystem, supporting multiple assets for collateralization while extending stablecoin loans in $MSD. Arche is modular, capital-efficient, and designed for on-chain builders who MOVE fast.


##### Token address and ticker if any: N/A

##### Category (full list at https://defillama.com/categories) *Please choose only one: CDP (https://defillama.com/protocols/cdp)

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.): Pyth

##### Implementation Details: @aladeen_cl can you help on this one?
The adapter calls Arche's smart contract to get the total deposited amount of Move tokens using the function protocol_summary, and returns the first value of the array. Then adds to the tlv balances the amount of deposited Move tokens. 

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage: 

##### forkedFrom (Does your project originate from another project): N/A

##### methodology (what is being counted as tvl, how is tvl being calculated): Counts the total value of MOVE tokens locked in the MSD protocol

##### Github org/user (Optional, if your code is open source, we can track activity): N/A