### PR TITLE
Fix: Vectis

### DIFF
--- a/projects/vectis/index.js
+++ b/projects/vectis/index.js
@@ -38,7 +38,7 @@ async function tvl(api) {
 
   // Get all vault accounts first
   const accounts = await getMultipleAccounts(vaultUserAddresses)
-  const deserializedData = accounts.map(deserializeUserPositions)
+  const deserializedData = accounts.filter((accountInfo) => !!accountInfo).map(deserializeUserPositions)
 
   // Collect unique market indices upfront
   const allSpotIndices = new Set()


### PR DESCRIPTION
Added a filter to prevent `null` responses from `const accounts = await getMultipleAccounts(vaultUserAddresses)` from entering the `deserializeUserPositions` logic, which would otherwise throw an error