### PR TITLE
Update: brewlabs

### DIFF
--- a/projects/brewlabs/index.js
+++ b/projects/brewlabs/index.js
@@ -23,6 +23,7 @@ const blacklist = [
 ];
 
 module.exports = {
+  deadFrom: "2025-04-01",
   timetravel: false,
   misrepresentedTokens: true,
 };


### PR DESCRIPTION
Added a `deadFrom` to prevent future updates. Currently, the adapter hasn’t been updated for a few days. The TVL has been flat for nearly two years with less than $5k in USD value, and the API used to fetch the pools has been down for a few days