### PR TITLE
Add IPLR fees & revenue adapter for Solana

### DIFF
--- a/fees/iplr.ts
+++ b/fees/iplr.ts
@@ -1,0 +1,30 @@
+import { FetchResultFees, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+
+const fetch = async (): Promise<FetchResultFees> => {
+  // Placeholder: Replace this with actual revenue logic
+  const dailyFees = 1452.00; // Example: daily fees in USD
+
+  return {
+    dailyFees,
+    dailyRevenue: dailyFees,
+    timestamp: Math.floor(Date.now() / 1000),
+  };
+};
+
+const adapter: SimpleAdapter = {
+  adapter: {
+    [CHAIN.SOLANA]: {
+      fetch,
+      start: async () => 1713139200, // IPLR launch timestamp (April 14, 2024 as placeholder)
+      meta: {
+        methodology: {
+          Fees: "IPLR charges a 10% tax on every buy and sell transaction.",
+          Revenue: "All swap tax collected is considered protocol revenue.",
+        },
+      },
+    },
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

This PR adds IPLR's fees and revenue adapter to the Solana chain.

Fees are based on the 10% tax on all swaps. 
Revenue = total fees (100% retained by protocol).
