### PR TITLE
Fix LUKSO chain TVL

### DIFF
--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -22,7 +22,7 @@ const ibcChains = ['ibc', 'terra', 'terra2', 'crescent', 'osmosis', 'kujira', 's
   'celestia', 'dydx', 'carbon', 'milkyway', 'regen', 'sommelier', 'stride', 'prom', 'babylon'
 ]
 const caseSensitiveChains = [...ibcChains, 'solana', 'tezos', 'ton', 'algorand', 'aptos', 'near', 'bitcoin', 'waves', 'tron', 'litecoin', 'polkadot', 'ripple', 'elrond', 'cardano', 'stacks', 'sui', 'ergo', 'mvc', 'renec', 'doge', 'stellar', 'massa',
-  'eclipse', 'acala', 'aelf', 'aeternity', 'alephium', 'bifrost', 'bittensor', 'verus',
+  'eclipse', 'acala', 'aelf', 'aeternity', 'alephium', 'bifrost', 'bittensor', 'verus', 'lukso'
 ]
 
 const transformTokens = {
@@ -31,6 +31,10 @@ const transformTokens = {
   //   "0x065de42e28e42d90c2052a1b49e7f83806af0e1f": "0x123", // CRK token is mispriced
   //   [ADDRESSES.cronos.TUSD]: ADDRESSES.ethereum.TUSD,
   // },
+  lukso: {
+    // Map wrapped LYX variants to the native LYX token
+    "0x2db41674f2b882889e5e1bd09a3f3613952bc472": "0x0000000000000000000000000000000000000000", // WLYX -> LYX
+  }
 }
 const ibcMappings = {
   // Sample Code
@@ -42,6 +46,9 @@ const fixBalancesTokens = {
   ozone: {
     // '0x83048f0bf34feed8ced419455a4320a735a92e9d': { coingeckoId: "ozonechain", decimals: 18 }, // was mapped to wrong chain
   },
+  lukso: {
+    '0x2db41674f2b882889e5e1bd09a3f3613952bc472': { coingeckoId: 'wrapped-lyx-universalswaps-2', decimals: 18 }, // WLYX
+  }
 }
 
 ibcChains.forEach(chain => fixBalancesTokens[chain] = { ...ibcMappings, ...(fixBalancesTokens[chain] || {}) })


### PR DESCRIPTION
The TVL for the LUKSO chain is broken, I did push this fix to restore the TVL calculations for our dex.

It was always working since the chain got added, but because of that LUKSO was removed from the `tokenMappings.js` file, it broke.

I restored this original PR https://github.com/DefiLlama/DefiLlama-Adapters/pull/10492/files