### PR TITLE
add hallmark to TermMax

### DIFF
--- a/projects/term-structure/index.js
+++ b/projects/term-structure/index.js
@@ -134,6 +134,12 @@ async function getTermStructureOwnerTokens(api) {
 }
 
 module.exports = {
+  hallmarks: [
+    [
+      Math.floor(new Date("2025-04-15") / 1000),
+      "Sunset Term Structure and launch TermMax",
+    ],
+  ],
   arbitrum: {
     tvl: async (api) => {
       const ownerTokens = await getTermMaxOwnerTokens(api);


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `volume` adapter please submit the PR [here](https://github.com/DefiLlama/adapters).
> - If you would like to add a `liquidations` adapter, please refer to [this readme document](https://github.com/DefiLlama/DefiLlama-Adapters/tree/main/liquidations) for details.

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
3. Please fill the form below  **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
4. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can  edit it there and put up a PR
5. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
6. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap

---

This pull request does not add a new protocol to DefiLlama but instead adds a hallmark to the existing protocol, TermMax. TermMax is our new product, launched on April 15, 2025. It may confuse viewers to see that TermMax already has TVL data before its launch date. Since DefiLlama aims to preserve historical data from Term Structure, we propose adding a hallmark to the TVL chart to clarify that the current TVL originates from TermMax starting from the launch date, rather than from Term Structure.

ref #14365 