### PR TITLE
Revert "Remove self referential Usual TVL"

### DIFF
--- a/projects/usual/index.js
+++ b/projects/usual/index.js
@@ -4,6 +4,7 @@ const { sumTokensExport } = require('../helper/unwrapLPs')
 const tokens = [
   '0x136471a34f6ef19fe571effc1ca711fdb8e49f2b', // USYC
   '0x437cc33344a0B27A429f795ff6B469C72698B291',  // wM
+  '0xd001f0a15D272542687b2677BA627f48A4333b5d', // USL
   '0xC139190F447e929f090Edeb554D95AbB8b18aC1C' // USDtb
   
 ]
@@ -11,6 +12,7 @@ const tokens = [
 const owners = [
   '0xdd82875f0840AAD58a455A70B88eEd9F59ceC7c7', // treasury
   '0x4Cbc25559DbBD1272EC5B64c7b5F48a2405e6470',  // USUALM
+  '0xd001f0a15D272542687b2677BA627f48A4333b5d', // USL
   '0x58073531a2809744D1bF311D30FD76B27D662abB' // USUALUSDtb
 ]
 


### PR DESCRIPTION
Reverts DefiLlama/DefiLlama-Adapters#14428

eUSD0 is backed, as validated in several audits, including economic: 

https://tech.usual.money/security-and-audits/audits

Oak Security Economic Audit USL: https://1503334455-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FpUhQzPJGdJzuLTQ5sCym%2Fuploads%2FJJRRRX0G6wz1CGyDWHI4%2FOAK%20Security%20-%20Usual%20USL%20Economic%20Risk%20Assessment.pdf?alt=media&token=db96beb4-a834-424f-b62c-e7280f00b620

https://usual.money/blog/what-are-the-usual-stability-loans

https://docs.usual.money/usual-products/usual-stability-loans-usl

https://app.euler.finance/vault/0xd001f0a15D272542687b2677BA627f48A4333b5d?network=ethereum&modal=supply&vault=0xd001f0a15D272542687b2677BA627f48A4333b5d