### PR TITLE
Update: Vaulty-finance

### DIFF
--- a/projects/vaulty/index.js
+++ b/projects/vaulty/index.js
@@ -1,6 +1,6 @@
 const { get } = require('../helper/http')
-const {staking} = require("../helper/staking");
-const {toUSDTBalances} = require("../helper/balances");
+const { staking } = require("../helper/staking");
+const { toUSDTBalances } = require("../helper/balances");
 
 async function getPlatformData() {
   return get("https://55vvs1ddm4.execute-api.eu-central-1.amazonaws.com/default/tvl")
@@ -15,9 +15,10 @@ async function tvl() {
 }
 
 module.exports = {
+  deadFrom: '2025-01-01',
   misrepresentedTokens: true,
   methodology: 'TVL counts the tokens deposited to all vaults',
-  bsc:{
+  bsc: {
     staking: staking(stakingContract, vlty),
     tvl
   }


### PR DESCRIPTION
Added a `deadFrom` field to the adapter, which hasn't been updated for around 15 days. The adapter depends on an external API, shows a flat TVL for nearly two years, has low liquidity, and both its Twitter and website are down