### PR TITLE
Fix: Radiant-v2

### DIFF
--- a/projects/radiant-v2/index.js
+++ b/projects/radiant-v2/index.js
@@ -3,14 +3,12 @@ const { staking } = require("../helper/staking");
 const { sumTokensExport } = require("../helper/unwrapLPs");
 const { aaveExports, methodology, } = require("../helper/aave");
 
-
 module.exports = {
+  methodology,
   hallmarks: [
     [1704178500, "flash loan exploit"],
     [Math.floor(new Date('2024-10-16') / 1e3), 'Multisig was compromised'],
-
   ],
-  methodology,
   arbitrum: {
     ...aaveExports('arbitrum', '0xdba0fa00c0691852dbe8b008180f8837f187378c'),
     // balancer pool is not unwrapped properly, so we use staking and rely on price api instead
@@ -33,11 +31,7 @@ module.exports = {
   },
 };
 
-
-
-
 const config = {
-  
   arbitrum: {
     aTokens: [
       '0x727354712BDFcd8596a3852Fd2065b3C34F4F770',
@@ -67,35 +61,44 @@ const config = {
       ADDRESSES.arbitrum.USDe
     ]
   },
-  
   base: {
     aTokens: [
-
+      '0xC2dDb87Da8F16f1c3983Fa7112419A1381919b14',
+      '0x47CeFa4f2170e6CbA87452E9053540e05182A556',
+      '0x43095e6e52A603FA571DDE18a7A123ec407433fE',
+      '0x20508bA938fEdaE646FCAd48416bC9B6a448786E',
+      '0x223A4066bd6A30477Ead12a7AF52125390C735dA',
+      '0x633eBD78E0eBE2ff2e2E169a4010B9Ca4f7bCAa1'
     ], tokens: [
-      ADDRESSES.base.WETH,
-      ADDRESSES.base.weETH,
-      ADDRESSES.base.cbETH,
-      ADDRESSES.base.cbBTC,
-      ADDRESSES.base.USDC,
-      ADDRESSES.base.wstETH
-
+      '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+      '0x4200000000000000000000000000000000000006',
+      '0xc1CBa3fCea344f92D9239c08C0568f6F2F0ee452',
+      '0x2Ae3F1Ec7F1F5012CFEab0185bfc7aa3cf0DEc22',
+      '0x04C0599Ae5A44757c0af6F9eC3b93da8976c150A',
+      '0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf',
     ]
   },
-  
   ethereum: {
     aTokens: [
-
+      '0x3c19d9F2Df0E25C077A637692DA2337D51daf8B7',
+      '0x9E85DF2B42b2aE5e666D7263ED81a744a534BF1f',
+      '0xd10c315293872851184F484E9431dAf4dE6AA992',
+      '0xE57538e4075446e42907Ea48ABFa83B864F518e4',
+      '0x83B3896EC36cB20cFB430fCFE8Da23D450Dd09B5',
+      '0x473693EcDAd05f5002ff5F63880CFA5901FB50E8',
+      '0x03AB03DA2c5012855c743bc318c19EF3dE5Bc906',
+      '0x1d25Bd8AbfEb1D6517Cc21BeCA20b5cd2df8247c'
     ], tokens: [
-      ADDRESSES.ethereum.WETH,
-      ADDRESSES.ethereum.WEETH,
-      ADDRESSES.ethereum.USDC,
-      ADDRESSES.ethereum.USDT,
-      ADDRESSES.ethereum.SDAI,
-      ADDRESSES.ethereum.WSTETH,
-      ADDRESSES.ethereum.RETH,
+      '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+      '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+      '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+      '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599',
+      '0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0',
+      '0x83F20F44975D03b1b09e64809B757c47f942BEeA',
+      '0xae78736Cd615f374D3085123A210448E74Fc6393',
+      '0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee'
     ]
   },
-
   bsc: {
     aTokens: [
       '0x34d4F4459c1b529BEbE1c426F1e584151BE2C1e5',


### PR DESCRIPTION
A previous PR broke the adapter by leaving some tokens unmapped with their corresponding aTokens, which are required to work with `tokensAndOwners2` → Manually added the missing aTokens