### PR TITLE
Fix: Sobal

### DIFF
--- a/projects/sobal/index.js
+++ b/projects/sobal/index.js
@@ -10,6 +10,6 @@ const config = {
 Object.keys(config).forEach(chain => {
   const { fromBlock } = config[chain]
   module.exports[chain] = {
-    tvl: onChainTvl(V2_ADDRESS, fromBlock)
+    tvl: onChainTvl(V2_ADDRESS, fromBlock, { blacklistedTokens: ['0x4440000000000000000000000000000000000002'] })
   }
 })


### PR DESCRIPTION
Fixed the Sobal adapter. An EOA was mistakenly included in the `onChain()` function for the Base chain, which broke its functionality → added the token to `blacklistedTokens`