### PR TITLE
Smardex: Liquidation adapter for leveraged positions on USDN

### DIFF
--- a/liquidations/smardex/index.ts
+++ b/liquidations/smardex/index.ts
@@ -1,0 +1,118 @@
+import { ethers } from "ethers";
+import { Liq } from "../utils/types";
+import axios from "axios";
+interface PositionHistory {
+  transactionHash: string;
+}
+
+interface PositionMainOwner {
+  address: string;
+}
+
+interface PositionMain {
+  lastOwner: PositionMainOwner;
+}
+
+interface Position {
+  tick: number;
+  tickVersion: string;
+  index: string;
+  validator: string;
+  recipient: string;
+  amount: string;
+  startPrice: string;
+  liquidationPenalty: number;
+  totalExpo: string;
+  amountReceived: string;
+  amountRemaining: string;
+  profit: string;
+  liquidationPrice: string | null;
+  effectiveTickPrice: string | null;
+  type: string;
+  status: string;
+  history: PositionHistory[];
+  mainPosition: PositionMain;
+}
+
+interface ApiResponse {
+  serverTimestamp: number;
+  positions: Position[];
+}
+
+if(!process.env.SMARDEX_SUBGRAPH_API_KEY) {
+  throw new Error("Missing SMARDEX_SUBGRAPH_API_KEY environment variable");
+}
+
+const WSTETH_KEY = "ethereum:0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0";
+const API_URL = "https://usdn-public.api.smardex.io/usdn/positions/open";
+const API_KEY = process.env.SMARDEX_SUBGRAPH_API_KEY
+const EXPLORER_BASE_URL = "https://smardex.io/usdn/explorer?search=";
+
+const fetchOpenPositions = async (): Promise<Position[]> => {
+  try {
+    const response = await axios.get<ApiResponse>(API_URL, {
+      headers: { "x-api-key": API_KEY },
+    });
+    
+    if (response.data && response.data.positions && Array.isArray(response.data.positions)) {
+      return response.data.positions;
+    } else {
+      return [];
+    }
+  } catch (error) {
+    console.error(`Failed to fetch USDN positions: ${error}`);
+    return [];
+  }
+};
+
+const calculateLiquidationPrice = (position: Position): number => {
+  if (!position.startPrice || !position.totalExpo || !position.amountRemaining) {
+    return 0;
+  }
+  const startPrice = parseFloat(position.startPrice) / 1e18;
+  const totalExpo = parseFloat(position.totalExpo) / 1e18;
+  const collateral = parseFloat(position.amountRemaining) / 1e18;
+  const leverage = totalExpo / collateral;
+  return startPrice - (startPrice / leverage);
+};
+
+const formatPosition = (position: Position): Liq => {
+  const owner =
+    position.mainPosition?.lastOwner?.address || ethers.constants.AddressZero;
+    
+  const searchParam = position.history && position.history.length > 0 ? 
+    position.history[position.history.length - 1].transactionHash : position.index;
+    
+  const liquidationPrice = calculateLiquidationPrice(position);
+
+  return {
+    owner,
+    liqPrice: liquidationPrice,
+    collateral: WSTETH_KEY,
+    collateralAmount: position.amountRemaining,
+    extra: {
+      url: `${EXPLORER_BASE_URL}${searchParam}`,
+    },
+  };
+};
+
+const positions = async (): Promise<Liq[]> => {
+  try {
+    const positionsData = await fetchOpenPositions();
+    
+    if (!positionsData || positionsData.length === 0) {
+      return [];
+    }
+    
+    return positionsData.map(formatPosition);
+  } catch (error) {
+    console.error(`Error retrieving USDN positions: ${error}`);
+    return [];
+  }
+};
+
+module.exports = {
+  ethereum: {
+    liquidations: positions,
+  },
+};

--- a/liquidations/smardex/index.ts
+++ b/liquidations/smardex/index.ts
@@ -49,7 +49,6 @@ const API_KEY = process.env.SMARDEX_SUBGRAPH_API_KEY
 const EXPLORER_BASE_URL = "https://smardex.io/usdn/explorer?search=";
 
 const fetchOpenPositions = async (): Promise<Position[]> => {
-  try {
     const response = await axios.get<ApiResponse>(API_URL, {
       headers: { "x-api-key": API_KEY },
     });
@@ -59,10 +58,6 @@ const fetchOpenPositions = async (): Promise<Position[]> => {
     } else {
       return [];
     }
-  } catch (error) {
-    console.error(`Failed to fetch USDN positions: ${error}`);
-    return [];
-  }
 };
 
 const calculateLiquidationPrice = (position: Position): number => {
@@ -97,7 +92,6 @@ const formatPosition = (position: Position): Liq => {
 };
 
 const positions = async (): Promise<Liq[]> => {
-  try {
     const positionsData = await fetchOpenPositions();
     
     if (!positionsData || positionsData.length === 0) {
@@ -105,10 +99,6 @@ const positions = async (): Promise<Liq[]> => {
     }
     
     return positionsData.map(formatPosition);
-  } catch (error) {
-    console.error(`Error retrieving USDN positions: ${error}`);
-    return [];
-  }
 };
 
 module.exports = {


### PR DESCRIPTION
Here is our liquidation adapter for the decentralized perpetual protocol USDN by Smardex.

Few links:
https://smardex.io/usdn/long
https://smardex.io/analytics

USDN has leveraged positions that are liquidable.

As discussed on Discord, this adapter is a version based on our internal API, we will migrate this adapter when we have subgraphs on the protocol.

**API Key**
Would it be possible to provide you with an API key privately on Discord to access our API? I'm currently using the `SMARDEX_USDN_API_KEY` environment variable; let me know if that doesn't work.
This is an API used only for Defillama so we would like to not expose it publicly.

We've already provided an API key to access the subgraphs of the DEX portion of Smardex in the past, so I assume this is possible for our USDN API 

Thank you !