### PR TITLE
Fix: Prdt

### DIFF
--- a/projects/prdt/index.js
+++ b/projects/prdt/index.js
@@ -55,14 +55,14 @@ const config = {
       ADDRESSES.polygon.WETH,
     ],
   },
-   nibiru: {
-     owners: Object.values({
-       predictionPROV3: "0x062EB9830D1f1f0C64ac598eC7921f0cbD6d4841",
-     }),
-     tokens: [
-       ADDRESSES.null,
-     ],
-   },
+  //  nibiru: {
+  //    owners: Object.values({
+  //      predictionPROV3: "0x062EB9830D1f1f0C64ac598eC7921f0cbD6d4841",
+  //    }),
+  //    tokens: [
+  //      ADDRESSES.null,
+  //    ],
+  //  },
   solana: {},
 };
 


### PR DESCRIPTION
Since adding Nibiru, the adapter has stopped working. The fetch logic for Nibiru is different, and according to the explorer, the TVL appears to be under $1000. For now, it has been commented out to allow the fetch of other chains