### PR TITLE
[TermMax] hard-code vault addresses for accurate TVL

### DIFF
--- a/projects/term-structure/index.js
+++ b/projects/term-structure/index.js
@@ -13,10 +13,16 @@ const ABIS = {
 };
 
 const Events = {
-  CreateMarket:
-    "event CreateMarket(address indexed market, address indexed collateral, address indexed debtToken)",
-  CreateVault:
-    "event CreateVault(address indexed vault, address indexed creator, (address,address,uint256,address,uint256,string,string,uint64) initialParams)",
+  CreateMarket: {
+    eventAbi:
+      "event CreateMarket(address indexed market, address indexed collateral, address indexed debtToken)",
+    topic: "0x3f53d2c2743b2b162c0aa5d678be4058d3ae2043700424be52c04105df3e2411",
+  },
+  CreateVault: {
+    eventAbi:
+      "event CreateVault(address indexed vault, address indexed creator, tuple(address,address,uint256,address,uint256,string,string,uint64) indexed initialParams)",
+    topic: "0x8d49b14f2b628cc0c1a7ad5e098155260cd1881003c9d3107c728be96f706b33",
+  },
 };
 
 const ADDRESSES = {
@@ -25,30 +31,64 @@ const ADDRESSES = {
   // TermMax
   arbitrum: {
     Factory: {
-      address: "0x14920eb11b71873d01c93b589b40585dacfca096",
+      address: "0x14920Eb11b71873d01c93B589b40585dacfCA096",
       fromBlock: 322193553,
     },
     VaultFactory: [
       {
-        address: "0x929cbcb8150ad59db63c92a7daec07b30d38ba79",
+        address: "0x929CBcb8150aD59DB63c92A7dAEc07b30d38bA79",
         fromBlock: 322193571,
       },
+    ],
+    Vaults: [
+      // TermMax WETH Vault
+      [
+        [CORE_ASSETS.arbitrum.WETH],
+        "0x8c5161f287Cbc9Afa48bC8972eE8CC0a755fcAdC",
+      ],
+      // TermMax USDC Vault
+      [
+        [CORE_ASSETS.arbitrum.USDC],
+        "0xc94b752839a22d2c44e99e298671dd4b2add11b3",
+      ],
     ],
   },
   ethereum: {
     Factory: {
-      address: "0x37ba9934aaba7a49cc29d0952c6a91d7c7043dbc",
+      address: "0x37Ba9934aAbA7a49cC29d0952C6a91d7c7043dbc",
       fromBlock: 22174761,
     },
     VaultFactory: [
       {
-        address: "0x01d8c1e0584751085a876892151bf8490e862e3e",
+        address: "0x01D8C1e0584751085a876892151Bf8490e862E3E",
         fromBlock: 22174789,
       },
       {
-        address: "0x4778cbf91d8369843281c8f5a2d7b56d1420dff5",
+        address: "0x4778CBf91d8369843281c8f5a2D7b56d1420dFF5",
         fromBlock: 22283092,
       },
+    ],
+    Vaults: [
+      // TermMax wstETH Vault
+      [
+        [CORE_ASSETS.ethereum.WSTETH],
+        "0xDAdeAcC03a59639C0ecE5ec4fF3BC0d9920A47eC",
+      ],
+      // TermMax USDC Vault
+      [
+        [CORE_ASSETS.ethereum.USDC],
+        "0x984408C88a9B042BF3e2ddf921Cd1fAFB4b735D1",
+      ],
+      // TermMax USDC Prime
+      [
+        [CORE_ASSETS.ethereum.USDC],
+        "0x13e361dC94459a01bc4991F9e681033Dc2b0fA5A",
+      ],
+      // TermMax WETH Vault
+      [
+        [CORE_ASSETS.ethereum.WETH],
+        "0xDEB8a9C0546A01b7e5CeE8e44Fd0C8D8B96a1f6e",
+      ],
     ],
   },
 };
@@ -56,7 +96,8 @@ const ADDRESSES = {
 async function getTermMaxMarketAddresses(api) {
   const logs = await getLogs2({
     api,
-    eventAbi: Events.CreateMarket,
+    eventAbi: Events.CreateMarket.eventAbi,
+    topic: Events.CreateMarket.topic,
     fromBlock: ADDRESSES[api.chain].Factory.fromBlock,
     target: ADDRESSES[api.chain].Factory.address,
   });
@@ -86,7 +127,8 @@ async function getTermMaxVaultAddresses(api) {
     const promise = async () => {
       const logs = await getLogs2({
         api,
-        eventAbi: Events.CreateVault,
+        eventAbi: Events.CreateVault.eventAbi,
+        topic: Events.CreateVault.topic,
         fromBlock: vaultFactory.fromBlock,
         target: vaultFactory.address,
       });
@@ -107,7 +149,12 @@ async function getTermMaxVaultOwnerTokens(api) {
     abi: ABIS.Vault.asset,
     calls: vaultAddresses,
   });
-  return assets.map(([asset], idx) => [[asset], vaultAddresses[idx]]); // TVL factor: idle fund in the vault
+  // TVL factor: idle fund in the vault
+  return assets
+    .map(([asset], idx) => [[asset], vaultAddresses[idx]])
+    // Hard-code vault addresses here since
+    // CreateVault events are not returned by RPC used by DefiLlama
+    .concat(ADDRESSES[api.chain].Vaults);
 }
 
 async function getTermMaxOwnerTokens(api) {


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `volume` adapter please submit the PR [here](https://github.com/DefiLlama/adapters).
> - If you would like to add a `liquidations` adapter, please refer to [this readme document](https://github.com/DefiLlama/DefiLlama-Adapters/tree/main/liquidations) for details.

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
3. Please fill the form below  **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
4. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can  edit it there and put up a PR
5. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
6. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap

---

We observed that TermMax's TVL surpassed 10 million this morning according to other data sources. However, on DefiLlama, the TVL remains around 9 million. After running the adapter locally and adding some ```console.log``` statements, I found that the ```CreateVault``` events are not returned by the DefiLlama SDK. As a result, the adapter misses some vaults and the funds within them, causing the TVL to be lower than expected. According to the [Discord thread](https://discord.com/channels/823822164956151810/830747708410429440/1368939216137879562), the DefiLlama team recommended hardcoding the vault addresses for now. Therefore, I am submitting this pull request to hardcode the vault addresses and improve the TVL accuracy.

Additionally, we would like to update the logo to the following version, as requested by our designer:

![image](https://github.com/user-attachments/assets/55fedb65-f4fb-497c-b3d7-69e627d73d58)
