### PR TITLE
Blast removed from Bitbond

### DIFF
--- a/projects/BitbondLockers/config.json
+++ b/projects/BitbondLockers/config.json
@@ -3,7 +3,6 @@
     "arbitrum": "arbitrum",
     "avax": "avalanche",
     "base": "base",
-    "blast": "blast",
     "bsc": "bsc",
     "ethereum": "ethereum",
     "optimism": "optimism",

--- a/projects/BitbondSales/config.json
+++ b/projects/BitbondSales/config.json
@@ -3,7 +3,6 @@
     "arbitrum": "arbitrum",
     "avax": "avalanche",
     "base": "base",
-    "blast": "blast",
     "bsc": "bsc",
     "ethereum": "ethereum",
     "optimism": "optimism",


### PR DESCRIPTION
Blast is no more supported in our Token Tool dApp.

The historical data for that network is almost entirely negligible, as we've seen very little activity on it since integrating the adapters you provided.