### PR TITLE
fix: combine staking and TVL values for Clutch Market

### DIFF
--- a/projects/clutch-market/index.js
+++ b/projects/clutch-market/index.js
@@ -4,29 +4,59 @@ const { sumTokens2 } = require("../helper/unwrapLPs");
 const config = {
     arbitrum: {
         staking: {
-            token: "0xF4AcDE4D938844751f34659C67056f7e69dBE85a", // CLUTCH token
-            contract: "0x2F849Bf926E457CE57dF4f8C24eEA0d33Fa04672" // CLUTCH staking contract
+            token: "0x05905af7933f89280aB258919F0dFA056CeD8e43", // CLUTCH token
+            contract: "0x52070c2f7527822ccaea77e46fb23754151e2793" // CLUTCH staking contract
         },
         tvlTokens: [
             {
                 token: ADDRESSES.arbitrum.USDC_CIRCLE, // USDC
-                contract: "0x9797dA129eaFA143E8A50028563b69Cc02ea6444" // USDC TVL contract
+                contract: "0xbBEa81aBd42e8804de0f7d167Cf8123206d55039" // USDC TVL contract
+            }
+        ]
+    },
+    apechain: {
+        staking: null, // No platform token staking on APE chain
+        tvlTokens: [
+            {
+                token: "0x0000000000000000000000000000000000000000", // Native APE token
+                contract: "0x7F66d16A488Eae9e2B61BfB186fD94bBA3611416" // APE contract
+            },
+            {
+                token: "0xa2235d059f80e176d931ef76b6c51953eb3fbef4", // ApeUSD stablecoin
+                contract: "0x812D9ed73aC36626CA893D99847E9978905b33C6" // ApeUSD contract
             }
         ]
     }
 };
 
 async function stakingTvl(_, _1, _2, { api }) {
-    const { token, contract } = config.arbitrum.staking;
-    return sumTokens2({ api, tokens: [token], owners: [contract] });
+    const chain = api.chain
+    const stakingConfig = config[chain].staking;
+    if (!stakingConfig) return {}; // Return empty TVL if no staking on chain
+    return sumTokens2({ api, tokens: [stakingConfig.token], owners: [stakingConfig.contract] });
 }
 
 async function tvl(_, _1, _2, { api }) {
-    const tokensAndOwners = config.arbitrum.tvlTokens.map(({ token, contract }) => [token, contract]);
-    return sumTokens2({ api, tokensAndOwners });
+    const chain = api.chain
+    const tokensAndOwners = config[chain].tvlTokens.map(({ token, contract }) => [token, contract]);
+    const tvlValue = await sumTokens2({ api, tokensAndOwners });
+    
+    // Add staking value if it exists
+    const stakingConfig = config[chain].staking;
+    if (stakingConfig) {
+        const stakingValue = await sumTokens2({ api, tokens: [stakingConfig.token], owners: [stakingConfig.contract] });
+        return { ...tvlValue, ...stakingValue };
+    }
+    
+    return tvlValue;
 }
 
 module.exports = {
-    methodology: "TVL includes staking for the project's own token (CLUTCH) and total value locked (TVL) for USDC in separate contracts.",
-    arbitrum: { staking: stakingTvl, tvl },
+    methodology: "TVL on Arbitrum includes CLUTCH token staking and USDC in lending pools. On APE Chain, TVL includes native APE token and ApeUSD stablecoin in lending pools. Values are calculated separately for staking and lending pools.",
+    arbitrum: { 
+        tvl  // Combined TVL and staking
+    },
+    apechain: { 
+        tvl  // Track APE and ApeUSD lending
+    },
 };

--- a/projects/clutch-market/index.js
+++ b/projects/clutch-market/index.js
@@ -41,20 +41,13 @@ async function tvl(_, _1, _2, { api }) {
     const tokensAndOwners = config[chain].tvlTokens.map(({ token, contract }) => [token, contract]);
     const tvlValue = await sumTokens2({ api, tokensAndOwners });
     
-    // Add staking value if it exists
-    const stakingConfig = config[chain].staking;
-    if (stakingConfig) {
-        const stakingValue = await sumTokens2({ api, tokens: [stakingConfig.token], owners: [stakingConfig.contract] });
-        return { ...tvlValue, ...stakingValue };
-    }
-    
     return tvlValue;
 }
 
 module.exports = {
     methodology: "TVL on Arbitrum includes CLUTCH token staking and USDC in lending pools. On APE Chain, TVL includes native APE token and ApeUSD stablecoin in lending pools. Values are calculated separately for staking and lending pools.",
     arbitrum: { 
-        tvl  // Combined TVL and staking
+       staking: stakingTvl, tvl  // Combined TVL and staking
     },
     apechain: { 
         tvl  // Track APE and ApeUSD lending


### PR DESCRIPTION
     This PR fixes the TVL calculation for Clutch Market by combining staking and TVL values.
     
     Changes:
     - Modified the TVL function to include staking values
     - Removed separate staking export
     - Combined values are now properly reflected in the total TVL