### PR TITLE
Update: Claystack (eth+matic)

### DIFF
--- a/projects/claystack-matic/clayABIs/clayMain.json
+++ b/projects/claystack-matic/clayABIs/clayMain.json
@@ -1,3 +1,0 @@
-{
-    "funds": "function funds() view returns (uint256 currentDeposit, uint256 stakedDeposit, uint256 accruedFees)" 
-}

--- a/projects/claystack-matic/index.js
+++ b/projects/claystack-matic/index.js
@@ -1,5 +1,4 @@
 const ADDRESSES = require('../helper/coreAssets.json')
-const abi = require('./clayABIs/clayMain.json');
 
 const abis = {
   "funds": "function funds() view returns (uint256 currentDeposit, uint256 stakedDeposit, uint256 accruedFees)"

--- a/projects/claystack-matic/index.js
+++ b/projects/claystack-matic/index.js
@@ -1,19 +1,21 @@
 const ADDRESSES = require('../helper/coreAssets.json')
 const abi = require('./clayABIs/clayMain.json');
 
+const abis = {
+  "funds": "function funds() view returns (uint256 currentDeposit, uint256 stakedDeposit, uint256 accruedFees)"
+}
+
 const clayAddresses = {
   clayMatic: "0x91730940DCE63a7C0501cEDfc31D9C28bcF5F905",
 };
 
-async function getTvlOnEthereum(api) {
-  const maticDeposits = await api.call({ target: clayAddresses.clayMatic, abi: abi.funds, })
-
+async function tvl(api) {
+  const maticDeposits = await api.call({ target: clayAddresses.clayMatic, abi: abis.funds })
   api.add(ADDRESSES.ethereum.MATIC, maticDeposits.currentDeposit)
 }
 
 module.exports = {
-  ethereum: {
-    tvl: getTvlOnEthereum,
-  },
+  deadFrom: '2025-05-20',
+  ethereum: { tvl },
   methodology: `We get the total MATIC deposited in clay contracts and convert it to USD.`
 }

--- a/projects/claystack/clayABIs/clayMain.json
+++ b/projects/claystack/clayABIs/clayMain.json
@@ -1,3 +1,0 @@
-{
-  "funds": "function funds() view returns (uint256 currentDeposit, uint256 stakedDeposit, uint256 accruedFees)"
-}

--- a/projects/claystack/index.js
+++ b/projects/claystack/index.js
@@ -1,23 +1,22 @@
 const ADDRESSES = require('../helper/coreAssets.json')
-const abi = require('./clayABIs/clayMain.json');
+
+const abis = {
+  "funds": "function funds() view returns (uint256 currentDeposit, uint256 stakedDeposit, uint256 accruedFees)"
+}
 
 const clayAddresses = {
   clayEth: "0x331312DAbaf3d69138c047AaC278c9f9e0E8FFf8"
 };
 
-async function getTvlOnEthereum(api) {
-  const ethDeposits = await api.call({ target: clayAddresses.clayEth, abi: abi.funds, })
-
+async function tvl(api) {
+  const ethDeposits = await api.call({ target: clayAddresses.clayEth, abi: abis.funds, })
   api.add(ADDRESSES.null, ethDeposits.currentDeposit)
 }
 
 module.exports = {
+  deadFrom: '2025-05-20',
   doublecounted: true,
-  hallmarks: [
-    [1707315338,"Split Adapter"]
-  ],
-  ethereum: {
-    tvl: getTvlOnEthereum,
-  },
+  hallmarks: [[1707315338,"Split Adapter"]],
+  ethereum: { tvl },
   methodology: `We get the total ETH deposited in clay contracts and convert it to USD.`
 }


### PR DESCRIPTION
Added a deadFrom field for the Claystack protocol, whose contracts were upgraded two days ago by the protocol deployer.
The protocol had previously announced its shutdown, and the contract methods are no longer callable

https://app.claystack.com/stake/ethereum
![image](https://github.com/user-attachments/assets/7c6e3fa5-9eb1-4a87-9879-e82433a76e47)

![image](https://github.com/user-attachments/assets/275359bf-f798-48e5-9c62-2e20df634b8e)

