### PR TITLE
Fix Sonic-ICP

### DIFF
--- a/projects/sonicooo/index.js
+++ b/projects/sonicooo/index.js
@@ -1,7 +1,6 @@
 const { request, gql } = require('graphql-request');
 const { toUSDTBalances } = require('../helper/balances');
 
-const graphUrl = 'https://api.sonic.ooo/graphQl'
 const graphUrl_v3 = 'https://v3.api.sonic.ooo'
 
 const graphQuery = gql`
@@ -9,18 +8,12 @@ query get_tvl($timestamp: Int!) {
    sonicDayData(dateTo: $timestamp, dateFrom: 0) {
       totalLiquidityUSD
    }
-}
-`;
+}`
 
 const tvl = async ({ timestamp }) => {
-   const [{ sonicDayData: data_v1 }, { sonicDayData: data_v3 }] = await Promise.all([
-      request(graphUrl, graphQuery, { timestamp }),
-      request(graphUrl_v3, graphQuery, { timestamp })
-   ])
-
-   const supply_v1 = Number(data_v1[data_v1.length-1].totalLiquidityUSD) || 0 // api return orderBy DESC
-   const supply_v3 = Number(data_v3[0].totalLiquidityUSD) || 0                // api return orderBy ASC
-   return toUSDTBalances(supply_v1+supply_v3);
+   const { sonicDayData: data_v3 } = await request(graphUrl_v3, graphQuery, { timestamp })
+   const supply_v3 = Number(data_v3[data_v3.length-1].totalLiquidityUSD) || 0
+   return toUSDTBalances(supply_v3)
 }
 
 module.exports = {


### PR DESCRIPTION
Adapter updated: removed the logic fetching data from v1, which has been inaccessible for months. The data is no longer available via GraphQL and there has been no liquidity since the transition to v3. Minor change on v3, which has been using an ascending order by clause for the past few weeks