### PR TITLE
Update: Kleva-farm

### DIFF
--- a/projects/kleva/index.js
+++ b/projects/kleva/index.js
@@ -58,6 +58,8 @@ async function fetchLiquidity() {
 }
 
 module.exports = {
+  deadFrom: '2025-01-01',
+  hallmarks: [[1711929600,'Sunset of Kleva-Farm']],
   klaytn: { tvl: sdk.util.sumChainTvls([fetchLiquidity, kExports.klaytn.tvl]) },
   doublecounted: true,
 }


### PR DESCRIPTION
Adapter update: the protocol was sunset in 2024; added deadFrom and hallmarks

https://kleva.io/

![image](https://github.com/user-attachments/assets/67315c9f-682c-4682-8305-ea5d71b14efd)
