### PR TITLE
add aptos tvl to mirage protocol

### DIFF
--- a/projects/mirage-protocol/index.js
+++ b/projects/mirage-protocol/index.js
@@ -3,19 +3,46 @@ const { function_view } = require("../helper/chain/aptos");
 const MIRAGE_MOVEMENT =
   "0x24d6dcce95555b8e8eeaed7d739ea1036c0b8d4bbc6a01797505295a56d322cc";
 
+const MIRAGE_APTOS = 
+  "0x24d6dcce95555b8e8eeaed7d739ea1036c0b8d4bbc6a01797505295a56d322cc"
+
 const MOVEMENT_MOVE_MUSD_POOL = "0x81821b61b14a7899e6417c9f9b6a2a8871d6d27a2fc66fee97942425185d546f";
 
+const APTOS_APT_MUSD_POOL = "0xe1e13aa968df88dff6ac5227eaa6220c90a0e40e60ce274695a134f43966e2c0";
+const APTOS_USDC_MUSD_POOL = "0x3fb56c8c18ad3f20acf1ac971edfca4dd2bef1144e363aec83a04587675752f5";
+
+const APTOS_USDC_FA = "0xbae207659db88bea0cbead6da0ed00aac12edcdda169e591cd41c94180b46f3b"
+
 async function tvl(api) {
-  const resp = await function_view({
-    functionStr: `${MIRAGE_MOVEMENT}::vault::total_collateral`,
-    args: [MOVEMENT_MOVE_MUSD_POOL],
-    chain: 'move'
-  })
-  api.add("0xa", resp)
+  const chain = api.chain;
+
+  if (chain === 'move') {
+    const moveResponse = await function_view({
+      functionStr: `${MIRAGE_MOVEMENT}::vault::total_collateral`,
+      args: [MOVEMENT_MOVE_MUSD_POOL],
+      chain: 'move'
+    })
+    api.add("0xa", moveResponse)
+  } else if (chain === 'aptos') {
+    const aptResponse = await function_view({
+      functionStr: `${MIRAGE_APTOS}::vault::total_collateral`,
+      args: [APTOS_APT_MUSD_POOL],
+      chain: 'aptos'
+    })
+    api.add("0xa", aptResponse)
+
+    const usdcResponse = await function_view({
+      functionStr: `${MIRAGE_APTOS}::vault::total_collateral`,
+      args: [APTOS_USDC_MUSD_POOL],
+      chain: 'aptos'
+    })
+    api.add(APTOS_USDC_FA, usdcResponse)
+  }
 }
 
 module.exports = {
   timetravel: false,
   move: { tvl },
+  aptos: { tvl }
 };
 


### PR DESCRIPTION
Original PR with protocol description: https://github.com/DefiLlama/DefiLlama-Adapters/pull/14149

This pr adds in our aptos deployment.  On aptos we have 2 vault collections, one with USDC as collateral and one with APT.  This PR adds both of those pools to our aptos tvl metric.

Explanation for why we use a view function as opposed to looking directly at a single asset balance is explained in previous pr, repasting here

"the way our vaults work is that the collateral is stored in each individual vault object, which are owned by users. There isn't a single pool of collateral. so to use sum tokens, we'd need to pass in all the vault object addresses, which can only be achieved using indexing, not data directly available from a node."