### PR TITLE
projects(silverswap): Nibiru has a SilverSwap deployment on mainnet

### DIFF
--- a/projects/silverswap/index.js
+++ b/projects/silverswap/index.js
@@ -1,5 +1,30 @@
 const { uniV3Export } = require('../helper/uniswapV3')
 
-module.exports = uniV3Export({
-  sonic: { factory: '0xb860200BD68dc39cEAfd6ebb82883f189f4CdA76', fromBlock: 186117, isAlgebra: true, }
-})
+/**
+ * @typedef {Object} SilverSwapInfo
+ * @property {string} factory - Hex address of the factory contract
+ * @property {number} fromBlock - Block to start indexing. Should precede the
+ *   deployment block by at least 1.
+ * @property {boolean} isAlgebra - Defaults to true. SilverSwap is based on
+ *   Algebra's DEX model.
+ */
+
+/**
+ * Config object mapping chain names to SilverSwap deployment information.
+ *
+ * @type {Object.<string, SilverSwapInfo>}
+ */
+const silverswap = {
+  sonic: {
+    factory: '0xb860200BD68dc39cEAfd6ebb82883f189f4CdA76',
+    fromBlock: 186117,
+    isAlgebra: true,
+  },
+  nibiru: {
+    factory: '0xb860200BD68dc39cEAfd6ebb82883f189f4CdA76',
+    fromBlock: 19674297 - 1,
+    isAlgebra: true,
+  },
+}
+
+module.exports = uniV3Export(silverswap)


### PR DESCRIPTION
## Purpose

1. SilverSwap is live on Nibiru mainnet. This pull request seeks to add the factory address and use the Algebra and Uniswap V3 helper.

## Background Context (Less Relevant Now)

2. ✅ Initially blocked by the below issue with a missing chain ID for "nibiru", however this was resolved in `@defillama/sdk v5.0.143`. DeFiLlama correctly shows a chain ID 6900 for "nibiru" now.
   ```bash
   node test.js projects/silverswap/index.js 2>&1
   ```

---

<details>
<summary>[Info on the Prior Blocker with the Missing Chain ID in the DeFiLLama SDK]</summary>

Several TVL Adapters are blocked by chain "nibiru":
1. Missing its `chainId` field on the `ChainApi` (api) object, and
2. Having the default value of 400069 as the `chainId` on the `LlamaProvider`

This can be seen from console logging the `api` object in the downstream repos.
For example, this is from the `uniV3Export` helper in the adapters repo:

```js
// DEBUG uniV3Export forEach 
{
  chain: 'nibiru',
  fromBlock: 19674297,
  api: <ref *1> ChainApi {
    block: undefined,
    chain: 'nibiru',
    timestamp: 1747982188,
    provider: LlamaProvider {
      quorum: 1,
      eventQuorum: 1,
      eventWorkers: 1,
      isCustomLlamaProvider: true,
      rpcs: [
        {
          url: 'https://evm-rpc.nibiru.fi',
          provider: JsonRpcProvider {}
        },
        [length]: 1
      ],
      archivalRPCs: [ [length]: 0 ],
      chainName: 'nibiru',
      chainId: 400069,
      _isReady: Promise { undefined },
      [providerConfigs]: [Getter],
      [pollingInterval]: [Getter],
      [provider]: [Getter],
      [plugins]: [Getter],
      [disableCcipRead]: [Getter/Setter],
      [destroyed]: [Getter],
      [paused]: [Getter/Setter]
    },
    _balances: Balances { chain: 'nibiru', timestamp: 1747982188, _balances: {} },
    chainId: undefined,
    storedKey: 'nibiru',
    api: [Circular *1]
  }
}: 
```

</details>
