### PR TITLE
projects(uniswap): add Uniswap deployment on Nibiru

### DIFF
--- a/projects/uniswap/index.js
+++ b/projects/uniswap/index.js
@@ -79,6 +79,7 @@ module.exports = {
     telos: { factory: "0xcb2436774C3e191c85056d248EF4260ce5f27A9D", fromBlock: 386633562 },
     goat: { factory: "0xcb2436774C3e191c85056d248EF4260ce5f27A9D", fromBlock: 848385 },
     hemi: { factory: "0x346239972d1fa486FC4a521031BC81bFB7D6e8a4", fromBlock: 1293598 },
+    nibiru: { factory: "0x346239972d1fa486FC4a521031BC81bFB7D6e8a4", fromBlock: 23658062 },
     sonic: { factory: "0xcb2436774C3e191c85056d248EF4260ce5f27A9D", fromBlock: 322744 },
     unichain: { factory: "0x1F98400000000000000000000000000000000003", fromBlock: 1 },
     lightlink_phoenix: { factory: "0xcb2436774C3e191c85056d248EF4260ce5f27A9D", fromBlock: 131405097 },


### PR DESCRIPTION
## Purpose

Adds the Uniswap V3 factory address and deployment block on Nibiru

## Strange Bug

Seeing this coming from the DeFiLlama SDK, resulting in blank balances. Any
advice on how to resolve this would be appreciated. 
```
- host: https://evm-rpc.nibiru.fi error: Cannot read properties of null (reading 'number')
- host: https://evm-rpc.nibiru.fi error: Cannot read properties of null (reading 'number')] {
  _underlyingError: '[object Object]',
  _isCustomError: true
}
```
