### PR TITLE
feat(mimswap): add support for nibiru

### DIFF
--- a/projects/mimswap/index.js
+++ b/projects/mimswap/index.js
@@ -2,17 +2,27 @@ const { getLogs2 } = require('../helper/cache/getLogs')
 
 const config = {
   arbitrum: { factory: '0x8D0Cd3eEf1794F59F2B3a664Ef07fCAD401FEc73', fromBlock: 205217727 },
-  ethereum: { factory: '0xDF46F6b1a5F794F21eaD4008C7De4E02Dc045297', fromBlock: 20537337 },
   blast: { factory: '0x7E05363E225c1c8096b1cd233B59457104B84908', fromBlock: 1067907 },
+  ethereum: { factory: '0xDF46F6b1a5F794F21eaD4008C7De4E02Dc045297', fromBlock: 20537337 },
+  nibiru: {
+    pools: [{
+      pool: "0xF63fCFcd000af6401dc1848E7e147AeDf56f9355",
+      baseToken: "0xfCfc58685101e2914cBCf7551B432500db84eAa8",
+      quoteToken: "0x0829F361A05D993d5CEb035cA6DF3446b060970b",
+    }]
+  },
   kava: { factory: '0x7Ad0e580d8458BbeF71EC6A1755c59651E1EAaa7', fromBlock: 10023543 },
 }
 
 Object.keys(config).forEach(chain => {
-  const { factory, fromBlock } = config[chain]
+  const { factory, fromBlock, pools = [] } = config[chain]
   module.exports[chain] = {
     tvl: async (api) => {
-      const logs = await getLogs2({ api, factory, eventAbi: 'event LogPoolAdded (address baseToken, address quoteToken, address creator, address pool)', fromBlock, })
-      const ownerTokens = logs.map(log => [[log.baseToken, log.quoteToken], log.pool])
+      let logs = []
+      if (factory) {
+        logs = await getLogs2({ api, factory, eventAbi: 'event LogPoolAdded (address baseToken, address quoteToken, address creator, address pool)', fromBlock, })
+      }
+      const ownerTokens = [...pools, ...logs].map(pool => [[pool.baseToken, pool.quoteToken], pool.pool])
       return api.sumTokens({ ownerTokens })
     }
   }


### PR DESCRIPTION
The pool for Nibiru has been hardcoded for now as there's currently only one pool, and because getLogs doesn't work on Nibiru. I suspect it attempts to fetch block 1, but it doesn't exist.