### PR TITLE
add granite

### DIFF
--- a/projects/granite/index.js
+++ b/projects/granite/index.js
@@ -1,0 +1,16 @@
+const { sumTokens } = require('../helper/chain/stacks')
+
+async function tvl() {
+  return sumTokens({
+    owners: [
+      'SP35E2BBMDT2Y1HB0NTK139YBGYV3PAPK3WA8BRNA.state-v1',
+    ]
+  })
+}
+
+module.exports = {
+  methodology: 'aeUSDC and sBTC currently in the Vault',
+  stacks: {
+    tvl,
+  },
+}


### PR DESCRIPTION
##### Name (to be shown on DefiLlama): 
Granite

##### Twitter Link:
[@GraniteBTC](https://x.com/GraniteBTC)

##### List of audit links if any:
[Granite audits](https://github.com/GraniteProtocol/audits)

##### Website Link:
[Landing page](https://granite.world)
[Frontend](https://app.granite.world)
[Docs](https://docs.granite.world)

##### Logo (High resolution, will be shown with rounded borders):
[Logo](https://drive.google.com/file/d/1CdhopjwY1mKFS4YM3Gey9F7GfnklEy6H/view?usp=sharing)

##### Current TVL:
5.17m

##### Chain:
Stacks

##### Short Description (to be shown on DefiLlama):
Granite Protocol is an autonomous Bitcoin Liquidity Protocol on the Stacks blockchain. The protocol allows borrowers to take stablecoin loans using Stacks’ sBTC as collateral while eliminating rehypothecation risk. Liquidity providers can earn yield on stablecoins by providing liquidity to the pool, which is then lent to borrowers. Granite is a project incubated by Trust Machines. For more information about Granite, please visit granite.world

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Lending - 1

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
Pyth

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
Users provide market asset and collateral asset price attestations as part of the contract call to update Pyth on-chain price, in a pull method.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
[Pyth module](https://github.com/GraniteProtocol/core-v1/blob/master/contracts/modules/pyth-adapter-v1.clar)

##### methodology (what is being counted as tvl, how is tvl being calculated):
aeUSDC and sBTC currently in the Vault

##### Github org/user (Optional, if your code is open source, we can track activity):
[https://github.com/GraniteProtocol/core-v1](https://github.com/GraniteProtocol/core-v1)
