### PR TITLE
feat: add luckystake adapter

### DIFF
--- a/projects/luckystake/index.js
+++ b/projects/luckystake/index.js
@@ -1,0 +1,15 @@
+const { queryContract } = require('../helper/chain/cosmos')
+
+const ADDRESSES = {
+    LS_CONTRACT: 'mantra1ua04lz6ztuuhpjt4lfvg4e52rd806hhmajzvjjxrhh70zy3fmvlqppkygu',
+}
+
+async function tvl(api) {
+    const data = await queryContract({ chain: 'mantra', contract: ADDRESSES.LS_CONTRACT, data: { get_prize_pool: {} } })
+    api.add('uom', data.total_staked)
+}
+
+module.exports = {
+    methodology: "Returns total amount staked in the LuckyStake No Loss Lottery.",
+    mantra: { tvl },
+};


### PR DESCRIPTION
##### Name (to be shown on DefiLlama): LuckyStake.app


##### Twitter Link: https://x.com/LuckyStakeApp


##### List of audit links if any:

##### Website Link: https://luckystake.app/


##### Logo (High resolution, will be shown with rounded borders):
![logo](https://github.com/user-attachments/assets/0e85292a-552f-464a-a24a-6c2465d18d48)


##### Current TVL: 870


##### Treasury Addresses (if the protocol has treasury): mantra1g628v9vsww8h5xs8qdau49xlcm4uxsy9vtky2w


##### Chain: MANTRA Chain


##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): N/A (https://api.coingecko.com/api/v3/coins/list)


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): N/A (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description (to be shown on DefiLlama): LuckyStake is a no-loss, principal-protected lottery built on MANTRA Chain. Users deposit OM, which is staked to earn rewards. Every Wednesday, staking rewards are distributed to random winners - bigger deposits mean better odds. The more you stake, the luckier you get.


##### Token address and ticker if any: N/A


##### Category (full list at https://defillama.com/categories) *Please choose only one: Yield Lottery


##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.): N/A
##### Implementation Details: Briefly describe how the oracle is integrated into your project: N/A
##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage: N/A

##### forkedFrom (Does your project originate from another project): N/A


##### methodology (what is being counted as tvl, how is tvl being calculated): TVL (Total Value Locked) for LuckyStake represents the total amount of OM tokens currently deposited into the LuckyStake smart contract by users.


##### Github org/user (Optional, if your code is open source, we can track activity): N/A
