### PR TITLE
Add adapter for nebula on nibiru

### DIFF
--- a/projects/nebula/index.ts
+++ b/projects/nebula/index.ts
@@ -1,0 +1,3 @@
+const { compoundExports2 } = require('../helper/compound');
+
+module.exports.nibiru = compoundExports2({ comptroller: '0x7bf2f10A061eAA9d12eff11D1c3cBaf402f86C22', cether: '0xFC0De9060D413b60fEE6B735A0291CC7fC2Dc966' })


### PR DESCRIPTION
This PR adds fee & revenue adapter for nebula  deployed on nibiru (an EVM compatible L1).
Revenue is parsed from Trade events emitted by main contract.