### PR TITLE
Update nucleus adapter with new vaults and chains

### DIFF
--- a/projects/nucleus/index.js
+++ b/projects/nucleus/index.js
@@ -56,7 +56,7 @@ const tvl = async (api, chainId) => {
 
 module.exports = {
   ethereum: { tvl: (api) => tvl(api, 1) },
-  plume: { tvl: (api) => tvl(api, 98866) },
+  plume_mainnet: { tvl: (api) => tvl(api, 98866) },
   arbitrum: { tvl: (api) => tvl(api, 42161) },
   swellchain: { tvl: (api) => tvl(api, 1923) },
 }


### PR DESCRIPTION
### Changes
- Added chains `plume`, `arbitrum`, and `swellchain`.
- Modified the underlying token query approach to allow for chain by chain fetching.

### Notes:
1. A lot of our underlying tokens on Plume chain are not being caught by your implementation of `api.sumTokens`. It would be much appreciated if the team could add support; however, for these RWA assets, fetching their valuation in a common denomination (USDC) is not always straightforward. I can outline the valuation process to fetch on-chain prices for each of these assets if that would speed up the process. 
2. There is a similar issue with tokens on arbitrum as well, specifically `wM` ,`M`, and `JTRSY`. I can provide the steps to fetch these prices on-chain as well.


Please let me know if you have any questions or if anything is unclear! 