### PR TITLE
Vest Exchange: adding TVL for the BSC network

### DIFF
--- a/projects/vest/index.js
+++ b/projects/vest/index.js
@@ -41,4 +41,11 @@ module.exports = {
       ADDRESSES.arbitrum.USDC_CIRCLE
     ),
   },
+  bsc: {
+    tvl: staking(
+      "0xef14da66876476C1A75dC057343B97b6Bd372c41",
+      ADDRESSES.bsc.USDC
+    ),
+  },
 }
+


### PR DESCRIPTION
---
##### Name (to be shown on DefiLlama):  Vest Exchange

Updating an existing project, adding TVL for the BSC network

```
--- optimism ---
USDC                      87.24 k
Total: 87.24 k 

--- arbitrum ---
USDC                      333.41 k
Total: 333.41 k 

--- polygon ---
USDC                      102.19 k
Total: 102.19 k 

--- era ---
USDC                      12.13 k
Total: 12.13 k 

--- bsc ---
USDC                      1
Total: 1 

--- ethereum ---
USDC                      300.70 k
Total: 300.70 k 

--- base ---
USDC                      1.15 M
Total: 1.15 M 

--- tvl ---
USDC                      1.99 M
Total: 1.99 M 

------ TVL ------
base                      1.15 M
arbitrum                  333.41 k
ethereum                  300.70 k
polygon                   102.19 k
optimism                  87.24 k
era                       12.13 k
bsc                       1

total                    1.99 M 
```
