### PR TITLE
Add Capitare adapter for RWA tokenization

### DIFF
--- a/projects/capitare/index.js
+++ b/projects/capitare/index.js
@@ -1,0 +1,39 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+
+const CONTRACT = "0xBf39404960eD6BFB4d782Ab04D232F240aA5B6Bc";
+const ABI = {
+  getRaised: "function getAllTenantsActiveRaisedAmount() view returns (string[] tenantNames, uint256[] tenantActiveRaisedAmounts, uint256[] tenantActiveProjectsCount, uint256 totalActiveRaisedAmount, uint256 totalActiveProjectsCount)",
+  toUSD: "function convertBRLtoUSD(uint256) view returns (uint256)",
+};
+
+async function tvl(api) {
+  // 1. Take the total BRL raised
+  const fundingResult = await api.call({ 
+    abi: ABI.getRaised, 
+    target: CONTRACT
+  });
+  const brlRaisedAmount = fundingResult.totalActiveRaisedAmount;
+  
+  // 2. Convert to USD (returns in 18 decimals)
+  const usdFundingGoal18Decimals = await api.call({ 
+    abi: ABI.toUSD, 
+    target: CONTRACT, 
+    params: [brlRaisedAmount] 
+  });
+  
+  // 3. Convert from 18 decimals to 6 decimals (USDT on Polygon)
+  // Divide by 10^12 (difference between 18 and 6 decimals)
+  const usdFundingGoal6Decimals = BigInt(usdFundingGoal18Decimals) / BigInt(10 ** 12);
+  
+  // Return the correct value in 6 decimals for USDT
+  api.add(ADDRESSES.polygon.USDT, usdFundingGoal6Decimals.toString());
+}
+
+module.exports = {
+  timetravel: false,
+  methodology:
+    "TVL equals the total BRL raised across all active Capitare tenants, converted on-chain to USD via `convertBRLtoUSD`, which itself pulls Chainlink's BRL/USD feed.",
+  polygon: {
+    tvl,
+  },
+};


### PR DESCRIPTION
- Implements TVL calculation using getAllTenantsActiveRaisedAmount()
- Uses on-chain BRL to USD conversion via Chainlink
- Fetches total raised amount across all active tenants
- Converts from 18 to 6 decimals for proper USDT display

**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `volume` adapter please submit the PR [here](https://github.com/DefiLlama/adapters).
> - If you would like to add a `liquidations` adapter, please refer to [this readme document](https://github.com/DefiLlama/DefiLlama-Adapters/tree/main/liquidations) for details.

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
3. Please fill the form below  **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
4. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can  edit it there and put up a PR
5. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
6. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap

---
##### Name (to be shown on DefiLlama): 
Capitare

##### Twitter Link:
https://x.com/Capitare_

##### List of audit links if any:
TODO – add link or write "N/A"

##### Website Link:
https://capitare.io/

##### Logo (High resolution, will be shown with rounded borders):
https://raw.githubusercontent.com/Afonsodalvi/prTVL/main/assets/capitare_logo_512x512.png

##### Current TVL:
Calculated dynamically by adapter

##### Treasury Addresses (if the protocol has treasury)
N/A

##### Chain:
Polygon

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):
*(leave empty if not listed)*

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):
*(leave empty if not listed)*

##### Short Description (to be shown on DefiLlama):
Capitare enables the tokenization of real-world asset (RWA) portfolios through project-specific, white-label tokens, rather than a single unified ticker. The getAllTenantsActiveRaisedAmount endpoint returns the total capital raised across all onboarded projects, denominated in BRL. Each token unit represents a share of audited, off-chain assets and is redeemable through regulated trustees.

##### Token address and ticker if any:
Polygon: 0xBf39404960eD6BFB4d782Ab04D232F240aA5B6Bc [PolygonScan](https://polygonscan.com/address/0xBf39404960eD6BFB4d782Ab04D232F240aA5B6Bc#readProxyContract)

##### Category (full list at https://defillama.com/categories):
Real World Assets (RWA)

##### Oracle Provider(s):
Chainlink (accessed on-chain via `convertBRLtoUSD`)

##### Implementation Details:
The aggregator contract exposes `getAllTenantsActiveRaisedAmount()` (total raised in BRL, 18 decimals) and `convertBRLtoUSD(uint256)` (BRL → USD via Chainlink). The adapter calls both, delegating FX conversion to audited on-chain logic.

##### forkedFrom (Does your project originate from another project):
N/A

##### methodology (what is being counted as tvl, how is tvl being calculated):
• Fetch `totalActiveRaisedAmount` (BRL) 
• Pass value to `convertBRLtoUSD` 
• TVL (USD) = result returned

##### Github org/user (Optional, if your code is open source, we can track activity):
N/A
