### PR TITLE
Update: Stakehouse (Blockswap)

### DIFF
--- a/projects/blockswap/index.js
+++ b/projects/blockswap/index.js
@@ -81,8 +81,7 @@ async function tvl(api) {
 }
 
 module.exports = {
+  deadFrom: '2025-01-01',
   timetravel: false,
-  ethereum: {
-    tvl
-  }
+  ethereum: { tvl }
 };


### PR DESCRIPTION
Added a deadFrom on the adapter which hasn’t been updated in nearly 3 months. The TVL has been flat at around $100k for about a year. The APIs used to fetch data are no longer up to date, and the team hasn’t tweeted or updated their website in a year