### PR TITLE
Fix: Sommelier

### DIFF
--- a/projects/sommelier/cellar-constants.js
+++ b/projects/sommelier/cellar-constants.js
@@ -44,7 +44,7 @@ const cellarsV2 = [
 ];
 
 // v2.5 Cellars
-const TURBO_SWETH = "0xd33dad974b938744dac81fe00ac67cb5aa13958e";
+// const TURBO_SWETH = "0xd33dad974b938744dac81fe00ac67cb5aa13958e";
 const TURBO_GHO = "0x0c190ded9be5f512bd72827bdad4003e9cc7975c";
 const ETH_GROWTH = "0x6c51041a91c91c86f3f08a72cb4d3f67f1208897";
 const TURBO_STETH = "0xfd6db5011b171b05e1ea3b92f9eacaeeb055e971";
@@ -59,7 +59,7 @@ const TURBO_RSETH = "0x1dffb366b5c5A37A12af2C127F31e8e0ED86BDbe";
 const TURBO_EZETH = "0x27500De405a3212D57177A789E30bb88b0AdbeC5";
 
 const cellarsV2p5 = [
-  { id: TURBO_SWETH, startBlock: 17910374 },
+  // { id: TURBO_SWETH, startBlock: 17910374 },
   { id: TURBO_GHO, startBlock: 18118614 },
   { id: ETH_GROWTH, startBlock: 18144591 },
   { id: TURBO_STETH, startBlock: 18330620 },


### PR DESCRIPTION
The `totalAssets` method is throwing an error. It seems that the vault's oracle (`0x7AcDB8096E51b2730387977Bad340B9EFDE61342`) is no longer able to return the asset price via the `getLatest` method, which now indicates `notSafeToUse` as `true`

I'm commenting out the vault for now to prevent a potential break in the code. Also, commenting out the vault doesn't seem to impact the TVL (no drop observed)