### PR TITLE
Add `almProxy` allocation to Morpho's DAI vault for Spark Liquidity Layer

### DIFF
--- a/projects/spark-liquidity-layer/index.js
+++ b/projects/spark-liquidity-layer/index.js
@@ -150,6 +150,10 @@ const morphoVaultConfigs = {
       {
         allocator: '0x9C259F14E5d9F35A0434cD3C4abbbcaA2f1f7f7E',
         address: '0x73e65DBD630f90604062f6E02fAb9138e713edD9',
+      },
+      {
+        allocator: almProxy.ethereum,
+        address: '0x73e65DBD630f90604062f6E02fAb9138e713edD9',
       }
     ]
   },


### PR DESCRIPTION
We started automatic allocations to Morpho's DAI vault in Spark Liquidity Layer, so I added missing allocator to the config. It discounts idle assets in the same way as for other DAI and USDS allocations