### PR TITLE
Scale XRPL OUSG to get raw balance

### DIFF
--- a/projects/ondofinance/index.js
+++ b/projects/ondofinance/index.js
@@ -106,7 +106,9 @@ Object.keys(config).forEach((chain) => {
         const split = config.ripple.OUSG.split('.');
         const XRPL_OUSG_CURRENCY = split[0];
         const XRPL_OUSG_ISSUER = split[1];
-        const ousgSupply = await getXrplTokenBalances(XRPL_OUSG_ISSUER, XRPL_OUSG_CURRENCY);
+        // XRPL RPCs automatically adjust for the currency's decimal places, but DefiLlama expects the raw value
+        // so we convert to a raw balance by multiplying by 10^6
+        const ousgSupply = (await getXrplTokenBalances(XRPL_OUSG_ISSUER, XRPL_OUSG_CURRENCY)) * Math.pow(10, 6);
         api.addTokens(config.ripple.OUSG, ousgSupply);
       } else {
         supplies = await api.multiCall({ abi: "erc20:totalSupply", calls: fundAddresses, })


### PR DESCRIPTION
Defi Llama expects index.js to return raw balances, but the XRPL RPC automatically makes the precision adjustment. This PR simply scales the OUSG supply by 10^6 so the raw balance is returned as expected

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `volume` adapter please submit the PR [here](https://github.com/DefiLlama/adapters).
> - If you would like to add a `liquidations` adapter, please refer to [this readme document](https://github.com/DefiLlama/DefiLlama-Adapters/tree/main/liquidations) for details.

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
3. Please fill the form below  **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
4. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can  edit it there and put up a PR
5. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
6. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap
