### PR TITLE
Remove ADX Token from Ambire Wallet TVL Calculation

### DIFF
--- a/projects/ambire-wallet/index.js
+++ b/projects/ambire-wallet/index.js
@@ -3,8 +3,6 @@ const sdk = require('@defillama/sdk')
 
 const WALLET = '0x88800092ff476844f74dc2fc427974bbee2794ae'
 const WALLET_staking = '0x47cd7e91c3cbaaf266369fe8518345fc4fc12935'
-const ADX = '0xADE00C28244d5CE17D72E40330B1c318cD12B7c3'
-const ADX_staking = '0xB6456b57f03352bE48Bf101B46c1752a0813491a'
 
 module.exports = {
   methodology: `TVL for Ambire Wallet consists of the staking of WALLET.`, 
@@ -12,7 +10,6 @@ module.exports = {
     tvl: () => ({}),
     staking: sdk.util.sumChainTvls([
       staking(WALLET_staking, WALLET), 
-      staking(ADX_staking, ADX)
     ]), 
   }
 }


### PR DESCRIPTION
## Summary
This PR removes the ADX token and its staking contract from the Ambire Wallet DefiLlama adapter. While considering TVL improvements, I thought about including LP pools (Uniswap, SushiSwap), but ultimately decided against it after reviewing [DefiLlama’s TVL guidelines](https://docs.llama.fi/list-your-project/what-to-include-as-tvl).

## Visual Comparison

**Before:**  
![Screenshot 2025-06-19 at 19 51 57](https://github.com/user-attachments/assets/3f4663d5-9673-46fb-be20-78e7b3caf14e)

**After:**  
![Screenshot 2025-06-19 at 20 30 18](https://github.com/user-attachments/assets/8bcf9f99-f563-405e-82ab-7c738849d2e9)

## Rationale
- **ADX is a separate project** and should not be included in Ambire Wallet’s TVL.
- LP pools were not included in the codebase. After reviewing the guidelines, only protocol-owned LP tokens (not user-owned public pools) should count toward TVL.  
- See:  
  > “Do NOT count as TVL: Liquidity that is merely user-deposited into external AMM pools (e.g., Uniswap, SushiSwap, etc.), if those LP tokens are not protocol-controlled.”  
  > — [DefiLlama TVL documentation](https://docs.llama.fi/list-your-project/what-to-include-as-tvl)

## Changes
- Removed all references to the ADX token and its staking contract.
- Confirmed TVL now includes only protocol-owned WALLET staking.

## Testing
```bash
node test.js projects/ambire-wallet/index.js
