### PR TITLE
feat(silo-v2): ethereum deployment support

### DIFF
--- a/projects/silo-v2/index.js
+++ b/projects/silo-v2/index.js
@@ -20,8 +20,8 @@ const configV2 = {
   arbitrum: {
     factories: [
       {
-        START_BLOCK: 291201890,
-        SILO_FACTORY: '0xf7dc975C96B434D436b9bF45E7a45c95F0521442', // Silo V2 Arbitrum (Main)
+        START_BLOCK: 334531851,
+        SILO_FACTORY: '0x384DC7759d35313F0b567D42bf2f611B285B657C', // Silo V2 Arbitrum (Main)
       }
     ]
   }

--- a/projects/silo-v2/index.js
+++ b/projects/silo-v2/index.js
@@ -24,7 +24,15 @@ const configV2 = {
         SILO_FACTORY: '0x384DC7759d35313F0b567D42bf2f611B285B657C', // Silo V2 Arbitrum (Main)
       }
     ]
-  }
+  },
+  ethereum: {
+    factories: [
+      {
+        START_BLOCK: 22616413,
+        SILO_FACTORY: '0x22a3cF6149bFa611bAFc89Fd721918EC3Cf7b581', // Silo V2 Ethereum (Main)
+      }
+    ]
+  },
 }
 
 async function tvl(api) {
@@ -101,8 +109,8 @@ async function getSilosV2(api) {
 
 module.exports = {
   methodology: `We calculate TVL by interacting with Silo Factory smart contracts on Ethereum, Arbitrum, Base & Optimism. For Ethereum, it queries Silo(Main-V2)(0xa42001d6d2237d2c74108fe360403c4b796b7170). On Arbitrum, we query the Silo Arbitrum factory (Main-V2)(0xf7dc975C96B434D436b9bF45E7a45c95F0521442), we query the factories to obtain the addresses of Silos, retrieve the assets of each Silo, and then calculate the sum of the deposited tokens, borrowed amounts are calculated separately from TVL.`,
-  // ethereum: { tvl, borrowed, },
   arbitrum: { tvl, borrowed, },
+  ethereum: { tvl, borrowed, },
   // optimism: { tvl, borrowed, },
   // base: { tvl, borrowed, },
   sonic: { tvl, borrowed, },


### PR DESCRIPTION
Adds support for the Ethereum deployment for Silo V2 as per reference: https://github.com/silo-finance/silo-contracts-v2/blob/master/silo-core/deployments/mainnet/SiloFactory.sol.json
