### PR TITLE
Add KavaLake TVL adapter

### DIFF
--- a/projects/kavalake/index.js
+++ b/projects/kavalake/index.js
@@ -1,0 +1,13 @@
+const { sumTokensExport } = require('../../helper/unwrapLPs');
+
+module.exports = {
+  timetravel: false,
+  misrepresentedTokens: false,
+  methodology: "TVL is calculated based on the amount of WKAVA held in the KavaLake liquid staking vault on Kava EVM.",
+  kava: {
+    tvl: sumTokensExport({
+      owners: ['0x46ffa1b9a9f027fA958dF9276e3EdCf099A58882'], // KavaLake vault
+      tokens: ['0xc86c7C0eFbd6A49B35E8714C5f59D99De09A225b'], // WKAVA
+    }),
+  },
+};

--- a/projects/kavalake/index.js
+++ b/projects/kavalake/index.js
@@ -1,4 +1,4 @@
-const { sumTokensExport } = require('../../helper/unwrapLPs');
+const { sumTokensExport } = require('../helper/unwrapLPs');
 
 module.exports = {
   timetravel: false,


### PR DESCRIPTION
Name (to be shown on DefiLlama):

KavaLake

Twitter Link:

https://x.com/LakeKava

List of audit links if any:

No audits yet — MVP vault is public and verified.

Website Link:

https://kavalake.xyz

Logo (High resolution, will be shown with rounded borders):
[
![logo1](https://github.com/user-attachments/assets/bb46e7e4-8979-47c8-b97d-994184c0df8e)
](url)

Current TVL:

~$50 (test amount seeded; expecting >$10k in next deposit window)

Treasury Addresses (if the protocol has treasury):

N/A

Chain:

Kava

Coingecko ID:

N/A

Coinmarketcap ID:

N/A

Short Description (to be shown on DefiLlama):

KavaLake is a liquid staking protocol on Kava EVM that mints kKAVA in exchange for WKAVA. It allows users to earn staking rewards while remaining liquid and composable across DeFi. The protocol is expanding to support validator rotation, restaking, and slashing insurance.

Token address and ticker if any:

WKAVA (tracked token):
0xc86c7C0eFbd6A49B35E8714C5f59D99De09A225b
Vault:
0x46ffa1b9a9f027fA958dF9276e3EdCf099A58882
Receipt token: kKAVA (ERC-20 issued by vault)

Category (choose one):

Liquid Staking

Oracle Provider(s):

None (not required for vault TVL tracking)

Implementation Details:

TVL is measured directly on-chain using the WKAVA balance of the vault contract. No oracles are used.

forkedFrom:

Custom implementation (inspired by Lido’s minimal wrapper design)

methodology:

TVL is calculated by summing the WKAVA tokens held in the Kluster vault on Kava EVM. The vault mints kKAVA 1:1 for each deposited WKAVA.

Github org/user:

https://github.com/kavablue