### PR TITLE
SwissBorg: Add new wallets

### DIFF
--- a/projects/swissborg/index.js
+++ b/projects/swissborg/index.js
@@ -234,6 +234,11 @@ const config = {
       '2BNEJ7ZV2SDGRZ2JGXTSVWVIBK5FYKAERAWXXGYZ66TSWWGHWAPXJ52HAE',
     ]
   },
+  chz: {
+    owners: [
+      '0x762DA64958BbF03bB206BF33C520a3846b6Cc93D',
+    ]
+  },
 }
 
 module.exports = cexExports(config)


### PR DESCRIPTION
This PR updates the list of wallets owned by SwissBorg. New wallets addition:
https://github.com/SwissBorg/pub/commit/6cdaed598f1027547ddc11d8794cc347b551d07f
