### PR TITLE
Adding Myth Finance dualSTAKE

### DIFF
--- a/projects/helper/chain/algorand.js
+++ b/projects/helper/chain/algorand.js
@@ -224,6 +224,16 @@ async function lookupTransactionsByID(searchParams = {}) {
 
 const limitedGetAccountInfo = withLimiter(getAccountInfo)
 
+async function getApplicationBoxes({ appId, limit = 1000, nexttoken, }) {
+  const response = (await axiosObj.get(`/v2/applications/${appId}/boxes`, {
+    params: {
+      limit,
+      next: nexttoken,
+    }
+  }))
+  return response.data.boxes
+}
+
 module.exports = {
   tokens,
   getAssetInfo: withLimiter(getAssetInfo),
@@ -239,4 +249,5 @@ module.exports = {
   getAppGlobalState: getAppGlobalState,
   getPriceFromAlgoFiLP,
   lookupApplicationsCreatedByAccount: withLimiter(lookupApplicationsCreatedByAccount),
+  getApplicationBoxes,
 }

--- a/projects/myth-dualSTAKE/index.js
+++ b/projects/myth-dualSTAKE/index.js
@@ -1,0 +1,33 @@
+const { getApplicationBoxes, getAppGlobalState } = require("../helper/chain/algorand")
+
+const registryAppId = 2933409454
+
+async function getDualSTAKEAppIDs() {
+    const registryBoxes = await getApplicationBoxes({ appId: registryAppId });
+    const boxKeys = registryBoxes.map(({ name: base64Key }) => Buffer.from(base64Key, 'base64'));
+    const applicationIDs = boxKeys
+        .filter(key => key[0] === 97) // app boxes prefixed with "a"
+        .map(key => parseInt(key.slice(1).toString("hex"), 16))
+
+    return applicationIDs
+}
+
+async function getStake() {
+    const appIds = await getDualSTAKEAppIDs()
+    let tvl = 0;
+    for (const appId of appIds) {
+        const { staked } = await getAppGlobalState(appId)
+        tvl += staked
+    }
+    return { algorand: tvl / 1e6 }
+}
+
+module.exports = {
+    timetravel: false,
+    methodology: 'Returns total amount staked on the Myth Finance dualSTAKE protocol.',
+    algorand: {
+        tvl: async () => {
+            return getStake()
+        },
+    }
+}


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):

Myth Finance dualSTAKE

##### Twitter Link:

https://x.com/Myth_Finance/

##### List of audit links if any:

-

##### Website Link:

https://myth.finance/dualSTAKE

##### Logo (High resolution, will be shown with rounded borders):

![social-dark](https://github.com/user-attachments/assets/456da96b-b294-4d97-b7d2-2e820aa2d7be)

##### Current TVL:

~$735K

##### Treasury Addresses (if the protocol has treasury) 

N/A

##### Chain:

Algorand

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

N/A

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

N/A

##### Short Description (to be shown on DefiLlama):

dualSTAKE is a liquid staking protocol on Algorand that allows users to accrue rewards in Assets. dualSTAKE instances swap staking rewards into a specific asset, e.g. the gobtcALGO dualSTAKE swaps rewards into goBTC. dualSTAKE tokens are backed by ALGO at 1:1 and an increasing amount of the paired rewards asset.

##### Token address and ticker if any:

-

##### Category (full list at https://defillama.com/categories) *Please choose only one:

Liquid Staking

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

No oracle integration

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

No oracle integration

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

No oracle integration

##### forkedFrom (Does your project originate from another project):

N/A

##### methodology (what is being counted as tvl, how is tvl being calculated):

dualSTAKE contracts are fetched from the registry contract on-chain. Their state is then read for the `staked` global state variable, which represents the ALGO staked in each contract. The paired rewards asset is _not_ counted, [as instructed on discord](https://discord.com/channels/823822164956151810/823885412425793587/1387895565144293497)

##### Github org/user (Optional, if your code is open source, we can track activity):

https://github.com/MythFinance/