### PR TITLE
Fix Goldsand TVL calculation 

### DIFF
--- a/projects/goldsand/index.js
+++ b/projects/goldsand/index.js
@@ -49,7 +49,7 @@ module.exports = {
 
       // Filter out FundedOnBehalf events where funder is 0x22B35d437b3999F5C357C176adEeC1b8b0F35C13
       const filteredFundedOnBehalfLogs = fundedOnBehalfLogs.filter(log => 
-        log.funder !== '0x22B35d437b3999F5C357C176adEeC1b8b0F35C13'
+        log.funderAccountAddress !== '0x22B35d437b3999F5C357C176adEeC1b8b0F35C13'
       )
 
       // Filter out ETHWithdrawnForUser events where recipient is 0x22B35d437b3999F5C357C176adEeC1b8b0F35C13

--- a/projects/goldsand/index.js
+++ b/projects/goldsand/index.js
@@ -46,10 +46,21 @@ module.exports = {
         fromBlock: 20966151,
         customCacheFunction,
       })
-      api.addGasToken((fundedLogs + fundedOnBehalfLogs - withdrawnForUserLogs).toString())
 
-      // The withdrawl vault holds validator rewards until withdrawn.
-      return api.sumTokens({ owner: '0x22B35d437b3999F5C357C176adEeC1b8b0F35C13', tokens: [nullAddress] })
+      // Filter out FundedOnBehalf events where funder is 0x22B35d437b3999F5C357C176adEeC1b8b0F35C13
+      const filteredFundedOnBehalfLogs = fundedOnBehalfLogs.filter(log => 
+        log.funder !== '0x22B35d437b3999F5C357C176adEeC1b8b0F35C13'
+      )
+
+      // Filter out ETHWithdrawnForUser events where recipient is 0x22B35d437b3999F5C357C176adEeC1b8b0F35C13
+      const filteredWithdrawnForUserLogs = withdrawnForUserLogs.filter(log => 
+        log.recipient !== '0x22B35d437b3999F5C357C176adEeC1b8b0F35C13'
+      )
+
+      api.addGasToken((fundedLogs + filteredFundedOnBehalfLogs - filteredWithdrawnForUserLogs).toString())
+
+      // Return empty object since we're excluding the assets of 0x22B35d437b3999F5C357C176adEeC1b8b0F35C13
+      return {}
     },
   },
 }


### PR DESCRIPTION
## GoldSand TVL Calculation Update

### Summary
Updated the GoldSand TVL calculation to exclude address `0x22B35d437b3999F5C357C176adEeC1b8b0F35C13` from the TVL computation.

### Changes Made
1. **Excluded FundedOnBehalf events**: Filtered out `FundedOnBehalf` events where the funder is `0x22B35d437b3999F5C357C176adEeC1b8b0F35C13`
2. **Excluded withdrawals**: Filtered out `ETHWithdrawnForUser` events where the recipient is `0x22B35d437b3999F5C357C176adEeC1b8b0F35C13`
3. **Removed assets**: Excluded the balance/assets of `0x22B35d437b3999F5C357C176adEeC1b8b0F35C13` from the TVL calculation


### Testing
The changes ensure that the specified address's deposits, withdrawals, and current balance are excluded from the GoldSand protocol's TVL calculation.

---

**Note**: This PR enables "Allow edits by maintainers" for easier collaboration. 