### PR TITLE
Add Tardigrade staking on Polygon

### DIFF
--- a/projects/tardigrade
+++ b/projects/tardigrade
@@ -1,0 +1,13 @@
+const { staking } = require("../helper/staking");
+
+module.exports = {
+  polygon: {
+    staking: staking(
+      "0xf42d252940f642d27d0f20ab1c661268e4e00d06", // contrato de staking (TardigradeToken)
+      "0xf42d252940f642d27d0f20ab1c661268e4e00d06", // token TARDY (mesmo contrato)
+      "polygon"
+    ),
+    tvl: async () => ({}), // Se tiver pools LP ou outros contratos, adicione aqui
+  },
+  methodology: "TVL includes TARDY tokens staked in the TardigradeToken contract on Polygon.",
+};


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `volume` adapter please submit the PR [here](https://github.com/DefiLlama/adapters).
> - If you would like to add a `liquidations` adapter, please refer to [this readme document](https://github.com/DefiLlama/DefiLlama-Adapters/tree/main/liquidations) for details.

---

##### Name (to be shown on DefiLlama):
Tardigrade Token

##### Twitter Link:
https://twitter.com/TardigradeToken

##### List of audit links if any:
No audits yet. Open source and community-driven.

##### Website Link:
https://tardigradetoken.online

##### Logo (High resolution, will be shown with rounded borders):
https://tardigradetoken.online/img/64x64.png

##### Current TVL:
Staking-based TVL (on-chain)

##### Treasury Addresses (if the protocol has treasury):
N/A

##### Chain:
Polygon

##### Coingecko ID:
(Not yet listed)

##### Coinmarketcap ID:
(Not yet listed)

##### Short Description (to be shown on DefiLlama):
Tardigrade is a deflationary token with on-chain staking and reward mechanisms.

##### Token address and ticker if any:
`0xf42d252940f642d27d0f20ab1c661268e4e00d06` – TARDY

##### Category (full list at https://defillama.com/categories):
Staking

##### Oracle Provider(s):
N/A

##### Implementation Details:
Staking system is computed directly on-chain via smart contract.

##### Documentation/Proof:
https://github.com/TardigradeTokenTardy/DefiLlama-Adapters

##### forkedFrom:
Not forked

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL includes tokens locked in the staking contract. APR is calculated at 15% annualized.

##### Github org/user (Optional):
https://github.com/TardigradeTokenTardy
