### PR TITLE
feat(silo-v2): avalanche deployment support

### DIFF
--- a/projects/silo-v2/index.js
+++ b/projects/silo-v2/index.js
@@ -33,6 +33,14 @@ const configV2 = {
       }
     ]
   },
+  avax: {
+    factories: [
+      {
+        START_BLOCK: 64050356,
+        SILO_FACTORY: '0x92cECB67Ed267FF98026F814D813fDF3054C6Ff9', // Silo V2 Avalanche (Main)
+      }
+    ]
+  },
 }
 
 async function tvl(api) {
@@ -114,5 +122,6 @@ module.exports = {
   // optimism: { tvl, borrowed, },
   // base: { tvl, borrowed, },
   sonic: { tvl, borrowed, },
+  avax: { tvl, borrowed, },
   hallmarks: []
 }


### PR DESCRIPTION
Adds support for Silo V2 deployment to Avalanche as per https://github.com/silo-finance/silo-contracts-v2/blob/master/silo-core/deployments/avalanche/SiloFactory.sol.json
