### PR TITLE
Fix: Sushiswap-v3

### DIFF
--- a/projects/sushiswap-v3/index.js
+++ b/projects/sushiswap-v3/index.js
@@ -29,6 +29,7 @@ module.exports = uniV3Export({
   arbitrum: {
     factory: "0x1af415a1EbA07a4986a52B6f2e7dE7003D82231e",
     fromBlock: 75998697,
+    blacklistedTokens: ['0x920675303c7460c86a5b24053db1176a52b85ba6']
   },
   optimism: {
     factory: "0x9c6522117e2ed1fE5bdb72bb0eD5E3f2bdE7DBe0",


### PR DESCRIPTION
> There was an EOA address injected among the tokens, causing an error with the balanceOf method on Arbitrum