### PR TITLE
Update: DaoVentures

### DIFF
--- a/projects/daoventures/index.js
+++ b/projects/daoventures/index.js
@@ -18,6 +18,7 @@ async function tvl(api) {
 }
 
 module.exports = {
+  deadFrom: '2025-06-01',
   misrepresentedTokens: true,
   ethereum: {
     tvl,


### PR DESCRIPTION
> Update on DaoVentures: the adapter hasn't been up-to-date for about two weeks. The contract ownership has changed, and new strategies were created to transfer funds to new treasury addresses. The team hasn't tweeted in over 3 years, the front end is down, and the TVL has been flat since 2023, staying below $10k. A deadFrom field has been added, as it's unclear whether users can still access their funds (~$10k)