### PR TITLE
Fix: Aave-v1

### DIFF
--- a/projects/aave/v1.js
+++ b/projects/aave/v1.js
@@ -39,7 +39,7 @@ async function multiMarketV1TvlBorrowed(balances, lendingPoolCore, block, chain,
 }
 
 async function depositMultiMarketV1Tvl(balances, lendingPoolCore, block, chain, eth) {
-    const reserves = (await getV1Assets(lendingPoolCore, block, chain)).filter(reserve => reserve !== ethReplacement);
+    const reserves = (await getV1Assets(lendingPoolCore, block, chain)).filter(reserve => reserve.toLowerCase() !== ethReplacement.toLowerCase());
 
     sdk.util.sumSingleBalance(balances, eth, (await sdk.api.eth.getBalance({ target: lendingPoolCore, block, chain })).output)
 


### PR DESCRIPTION
Small fix: since the change to "GAS_TOKEN_2": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", the ETH address was no longer correctly replaced because the input was 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE and there was no lowercase normalization