### PR TITLE
Fix: Astherus

### DIFF
--- a/projects/astherus/index.js
+++ b/projects/astherus/index.js
@@ -10,12 +10,16 @@ module.exports = {
   start: '2024-01-31', // 02/01/2024 @ 00:00:00pm (UTC)
 }
 
+function checkEvmAddress(addr) {
+  return /^0x[a-fA-F0-9]{40}$/.test(addr)
+}
+
 Object.keys(config).forEach(chain => {
   const vault = config[chain]
   module.exports[chain] = {
     tvl: async (api) => {
       const { data } = await getConfig(`astherus/${api.chain}`, `https://astherus.finance/bapi/futures/v1/public/future/web3/ae-deposit-asset?chainId=${api.chainId}`)
-      const tokens = data.map(i => i.contractAddress)
+      const tokens = data.map(i => i.contractAddress).filter(checkEvmAddress)
       return api.sumTokens({ owner: vault, tokens })
     }
   }


### PR DESCRIPTION
The Astherus API was returning an empty token `''`, which was preventing `sumTokens` from executing:

```
[
  '0xa2E3356610840701BDf5611a53974510Ae27E2e1',
  '0x4aae823a6a0b376De6A78e74eCC5b079d38cBCf7',
  '0xC96dE26018A54D51c097160568752c4E3BD6C364',
  '0x0782b6d8c4551b9760e74c0545a9bcd90bdc41e5',
  '0xB0b84D294e0C75A6abe60171b70edEb2EFd14A1B',
  '0x55d398326f99059ff775485246999027b3197955',
  '0x7130d2a12b9bcbfae4f2634d864a1ee1ce3ead9c',
  '0x2170ed0880ac9a755fd29b2688956bd959f933f8',
  '0x0000000000000000000000000000000000000000',
  '0x80137510979822322193FC997d400D5A6C747bf7',
  '0x5A110fC00474038f6c02E89C707D638602EA44B5',
  '0x715465bD8405587169C5C63e78351EbD7cABD6fB',
  '0xFceB31A79F71AC9CBDCF853519c1b12D379EdC46',
  '0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82',
  '0x8d0D000Ee44948FC98c9B98A4FA4921476f08B0d',
  ''
]
```