### PR TITLE
Update hydradex listing

### DIFF
--- a/projects/hydradex/index.js
+++ b/projects/hydradex/index.js
@@ -1,0 +1,5 @@
+const { uniV3Export } = require('../helper/uniswapV3')
+
+module.exports = uniV3Export({
+  hydra: { factory: '0xd555277891c118109b8bd066249D541FF4f993A4', fromBlock: 363060, },
+})


### PR DESCRIPTION
Hydra Chain has been upgraded to be fully EVM and we've also redeployed the DEX hence this PR updating the listing integration. The PR removes the `hydradex-v2` and `hydradex-v3` separate listings because we now only have one version, so I did rename it to just `hydradex`.

### **Name (to be shown on DefiLlama):**
Hydradex

### **Chain:**
Hydra Chain (4488)

### **Methodology (what is being counted as tvl, how is tvl being calculated):**
The new adapter uses `uniV3Export` to calculate TVL since our DEX is a direct fork of Uniswap V3.
Factory address - `0xd555277891c118109b8bd066249D541FF4f993A4`
Deploy block - `363060`

### **Notes:**
**IMPORTANT:** While running the test script it always fails with `Timeout reached, exiting...`. I'm 100% sure this happens because Hydra Chain has very fast blocks and its trying to fetch logs for the interval `[363060; 30494518]` which are way too many blocks. However I noticed that pancakeswap-v3 fails with same error so I assumed it might work in real env. 

If it keeps being problematic I could provide a subgraph integration.

Current TVL is: $93.38k