### PR TITLE
Fix River Omni CDP

### DIFF
--- a/projects/satoshi-protocol/index.js
+++ b/projects/satoshi-protocol/index.js
@@ -212,10 +212,10 @@ module.exports = {
     ],
   }),
   hemi: createExports({
-    safeVaultManagerList: {
+    safeVaultManagerList: [{
       vaultAddress: '0xceBd9461e494Fe3190b4755CFf63815C5cf2605D',
       asset: '0x6A9A65B84843F5fD4aC9a0471C4fc11AFfFBce4a', // enzoBTC
-    },
+    }],
     troveList: [
       '0xb655775C4C7C6e0C2002935133c950FB89974928', // WETH Collateral(V2)
       '0x5EA26D0A1a9aa6731F9BFB93fCd654cd1C3079Ec', // HemiBTC Collateral(V2)


### PR DESCRIPTION
Fix: a push yesterday broke the code with `safeVaultManagerList.forEach`, while `safeVaultManagerList` wasn’t an array, which naturally results in a `is not a function' error`