### PR TITLE
SwissBorg: Add new wallets

### DIFF
--- a/projects/swissborg/index.js
+++ b/projects/swissborg/index.js
@@ -71,6 +71,8 @@ const config = {
       'J6wLEPrT8Jd2NiNSJAQwxdK7FDtDssawsMtLqkZ5E1ZP',
       'EcGfuxwkM3ujBWaty5VW7H9mjJLd7LkY3m7nJZ6Sv7Sy',
       'C57RBagtGDYpTGxwG92gSKQ5ptQr4Wa9qz3yDBB6uu1B',
+      'EbUkjPNjzcbjK3iELhZS6PpNCr62pUsE7VkUvNdQpEYB',
+      'FQxGUUAX3BdFArA2XdvPcRHt4CmRMCw5wLt8F5uDXmwa',
     ],
   },
   polkadot: {


### PR DESCRIPTION
This PR updates the list of wallets owned by SwissBorg. New wallets addition:
https://github.com/SwissBorg/pub/commit/67d014e72ef94eb81aefb28135d65b3a13dbeff9