### PR TITLE
Fix: BadgerDao

### DIFF
--- a/projects/badgerdao.js
+++ b/projects/badgerdao.js
@@ -11,6 +11,7 @@ chains.forEach(chain => {
   module.exports[chain] = {
     tvl: async (api) => {
       const data = await getConfig(`badgerdao/tvl/${chain}`, `https://api.badger.com/v2/vaults?chain=${oChain}&currency=usd`)
+      if (!data || Object.keys(data).length === 0) return;
       const calls = data.map(i => i.vaultToken)
       return api.erc4626Sum({ calls, permitFailure: true, })
     }


### PR DESCRIPTION
BSC has had no TVL since 2022, but it seems to have been breaking the code for the past few days because neither the API nor the cache return any data. Added a return if data is empty to allow the rest of the chains, which are still functional, to continue executing