### PR TITLE
Small refacto, ignore btnx atm

### DIFF
--- a/projects/morpho-blue/index.js
+++ b/projects/morpho-blue/index.js
@@ -78,11 +78,11 @@ const config = {
     fromBlock: 3669141,
   },
   */
-  basecamp:{
-    morphoBlue: "0xc7CAd9B1377Eb8103397Cb07Cb5c4f03eb2eBEa8",
-    fromBlock: 4804080,
-    blackList: ['0x68d6024e5168f16d3453a23b36f393a559be7aef'],
-  },
+  // basecamp:{
+  //   morphoBlue: "0xc7CAd9B1377Eb8103397Cb07Cb5c4f03eb2eBEa8",
+  //   fromBlock: 4804080,
+  //   blackList: ['0x68d6024e5168f16d3453a23b36f393a559be7aef'],
+  // },
   hyperliquid: {
     morphoBlue: "0x68e37dE8d93d3496ae143F2E900490f6280C57cD",
     blackList: ['0x66a1e37c9b0eaddca17d3662d6c05f4decf3e110'],


### PR DESCRIPTION
```
------ TVL ------
ethereum                  2.91 B
borrowed                  2.81 B
ethereum-borrowed         1.71 B
base                      1.57 B
base-borrowed             757.33 M
hyperliquid               385.26 M
katana                    218.59 M
hyperliquid-borrowed      158.37 M
unichain                  123.32 M
unichain-borrowed         89.27 M
polygon                   83.68 M
wc                        58.11 M
polygon-borrowed          54.45 M
plume_mainnet             40.54 M
tac                       18.45 M
plume_mainnet-borrowed    17.28 M
katana-borrowed           11.96 M
wc-borrowed               11.68 M
corn                      7.98 M
lisk                      7.89 M
arbitrum-borrowed         3.22 M
optimism                  2.44 M
lisk-borrowed             2.38 M
optimism-borrowed         891.40 k
corn-borrowed             615.16 k
arbitrum                  2.30 k
fraxtal                   1.01 k
fraxtal-borrowed          253
sonic                     66
scroll                    33
sonic-borrowed            12
ink                       2
scroll-borrowed           1
ink-borrowed              1
hemi                      0
hemi-borrowed             0
soneium-borrowed          0
soneium                   0
zircuit                   0
flame-borrowed            0
flame                     0
zircuit-borrowed          0
mode                      0
mode-borrowed             0
tac-borrowed              0

total                    5.43 B
```