### PR TITLE
add (Project) Strata

### DIFF
--- a/projects/strata/index.js
+++ b/projects/strata/index.js
@@ -1,0 +1,12 @@
+const pUSDeVault = "0xA62B204099277762d1669d283732dCc1B3AA96CE";
+
+module.exports = {
+    methodology: "TVL includes USDe/eUSDe tokens locked in Strata’s Season 0 vault on Ethereum.",
+    ethereum: {
+        async tvl (api) {
+            return await api.erc4626Sum2({
+                calls: [ pUSDeVault ],
+            });
+        }
+    },
+};


### PR DESCRIPTION
Hello Team,

the PR adds new project.

##### Name

Strata

##### Twitter Link:

https://x.com/Strata_Money

##### List of audit links:

Season 0 - Pre-deposit Vaults: https://strata-money.gitbook.io/docs/security/audits
- Cyfrin
- Quantstamp

##### Website Link:

https://strata.money

##### Logo:

![strata](https://github.com/user-attachments/assets/8ad99c4d-2041-42f6-a38f-b8c887b74917)

##### Current TVL:

$15M

##### Chain:

Ethereum

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed)

—

##### Coinmarketcap ID

—

##### Short Description (to be shown on DefiLlama):

Users can deposit USDe/eUSDe into the Strata Points Farm on Ethereum Mainnet to mint pUSDe and start accruing Strata Points, unlocking early access, referral rewards, and boosted multipliers.


##### Category:

Farm


##### methodology (what is being counted as tvl, how is tvl being calculated):

In Season 0, the TVL is locked in the pre-deposit vault, which returns `totalAssets` in USDe.

##### Github org:

https://github.com/Strata-Money

