### PR TITLE
fix: incorrect proton loan staking amount

### DIFF
--- a/projects/proton-loan/index.js
+++ b/projects/proton-loan/index.js
@@ -1,5 +1,6 @@
 const { getTableRows, getCurrencyBalance, getAllOracleData, getTokenPriceUsd } = require("../helper/chain/proton");
 const { toUSDTBalances } = require('../helper/balances');
+const { staking } = require('../helper/staking')
 
 const LENDING_CONTRACT = 'lending.loan';
 const LOAN_TOKEN_CONTRACT = 'loan.token';
@@ -65,12 +66,11 @@ function getLendingTvl(returnBorrowed = false) {
   }
 }
 
-async function getTotalStaking() {
-  const loanPrice = await getTokenPriceUsd('LOAN', LOAN_TOKEN_CONTRACT)
+async function getTotalStaking(api) {
   const [staked] = await getCurrencyBalance(LOAN_TOKEN_CONTRACT, STAKING_CONTRACT, 'LOAN')
   const [stakedAmount] = staked.split(' ');
-  let stakingTvl = toUSDTBalances(stakedAmount * loanPrice)
-  return stakingTvl
+  api.addCGToken('proton-loan', BigInt(Math.floor(stakedAmount)))
+  return api.getBalances()
 }
 
 module.exports = {


### PR DESCRIPTION
Even though price of LOAN token is 0.0006 , it was getting rounded to 0.001 and sometimes misbehaving
<img width="1688" height="636" alt="image" src="https://github.com/user-attachments/assets/2442171b-37de-4150-aa1f-80cd8d3a06bf" />
