### PR TITLE
Aggregated tvl for pinto

### DIFF
--- a/projects/pinto/index.js
+++ b/projects/pinto/index.js
@@ -173,11 +173,24 @@ async function pool2(api) {
   return retval;
 }
 
+async function tvl(api) {
+  if (invalidTime(api)) {
+    return {};
+  }
+  const [stakingTvl, pool2Tvl] = await Promise.all([staking(api), pool2(api)]);
+  const tokens = new Set(Object.keys(stakingTvl).concat(Object.keys(pool2Tvl)));
+  const retval = {};
+  for (const token of tokens) {
+    retval[token] = (stakingTvl[token] ?? 0) + (pool2Tvl[token] ?? 0);
+  }
+  return retval;
+}
+
 module.exports = {
   methodology: "Counts the value of deposited Pinto and LP tokens in the Silo.",
   start: '2024-11-19',
   base: {
-    tvl: () => ({}),
+    tvl,
     pool2,
     staking
   },


### PR DESCRIPTION
Updates the Pinto TVL adapter to include user deposits in the overall TVL.

After discussing with @realdealshaman  in our thread (https://discord.com/channels/823822164956151810/1397579870363713537), we propose that Pinto/Beanstalk should be in the same boat as Synthetix, barring the discussion of whether protocol issued tokens should count towards staking (https://github.com/DefiLlama/DefiLlama-Adapters/discussions/438). Given the goal of the protocol is to create endogenous value from the credit worthiness of the model and its ability to maintain the value target, we feel that not including deposits in TVL by default greatly undermines the success the protocol has in gaining adoption and trust.