### PR TITLE
feat: add Spectra on HyperEVM

### DIFF
--- a/projects/spectra/config.json
+++ b/projects/spectra/config.json
@@ -70,5 +70,11 @@
       "factory": "0x64FCC3A02eeEba05Ef701b7eed066c6ebD5d4E51",
       "fromBlock": 50421500
     }
+  ],
+  "hyperliquid": [
+    {
+      "factory": "0xd187cb71fe8201935e6676ff872239fff552d4a5",
+      "fromBlock": 6375000
+    }
   ]
 }


### PR DESCRIPTION
This PR adds support for TVL computation on HyperEVM for Spectra (https://app.spectra.finance/)