### PR TITLE
feat(varlamore-capital): adds support for Varlamore Capital

### DIFF
--- a/projects/helper/curators/configs.js
+++ b/projects/helper/curators/configs.js
@@ -174,7 +174,35 @@ const SiloConfigs = {
         address: '0x7867f2b584e91d7c3798f4659b6fffa3631ea06a',
         fromBlock: 21718349,
       },
+      {
+        address: '0x02BbB86731EC6aA81B52961e14dD1AebE5171b1d',
+        fromBlock: 32865457,
+      }
     ],
+  },
+  ethereum: {
+    vaultFactories: [
+      {
+        address: '0xe7Ed54e4e432Cf85024f8D4434cB3756338469B0',
+        fromBlock: 22666249,
+      }
+    ]
+  },
+  arbitrum: {
+    vaultFactories: [
+      {
+        address: '0x451b35b2dF223a7Ef71c4ecb451C1C15019e28A5',
+        fromBlock: 345527587,
+      }
+    ]
+  },
+  avax: {
+    vaultFactories: [
+      {
+        address: '0x77cbCB96fFFe44d344c54A5868C49ad1C5AaAC6A',
+        fromBlock: 64052773,
+      }
+    ]
   }
 }
 

--- a/projects/varlamore-capital/index.js
+++ b/projects/varlamore-capital/index.js
@@ -1,0 +1,29 @@
+const { getCuratorExport } = require("../helper/curators");
+
+const configs = {
+  methodology: 'Count all assets are deposited in all vaults curated by Varlamore Capital.',
+  blockchains: {
+    ethereum: {
+      siloVaultOwners: [
+        '0xd8454B3787c6Aab1cf2846AF7882f8c440C3903d',
+      ],
+    },
+    arbitrum: {
+      siloVaultOwners: [
+        '0xd8454B3787c6Aab1cf2846AF7882f8c440C3903d',
+      ],
+    },
+    sonic: {
+      siloVaultOwners: [
+        '0xd8454B3787c6Aab1cf2846AF7882f8c440C3903d',
+      ],
+    },
+    avax: {
+      siloVaultOwners: [
+        '0xd8454B3787c6Aab1cf2846AF7882f8c440C3903d',
+      ]
+    }
+  }
+}
+
+module.exports = getCuratorExport(configs)


### PR DESCRIPTION
##### Name (to be shown on DefiLlama): Varlamore Capital


##### Twitter Link: https://x.com/VarlamoreCap


##### List of audit links if any: https://docs.silo.finance/docs/audits

##### Website Link: https://varlamore.capital/

##### Logo (High resolution, will be shown with rounded borders):


<img width="300" height="300" alt="varlamore-capital" src="https://github.com/user-attachments/assets/1edfdd81-c33b-48f2-941a-4547f8265e81" />


##### Treasury Addresses (if the protocol has treasury): 0xd8454B3787c6Aab1cf2846AF7882f8c440C3903d


##### Chain: Sonic, Arbitrum, Ethereum, Avax


##### Short Description (to be shown on DefiLlama): Varlamore Capital is a DeFi risk manager that provides catered yield opportunities for different risk profiles while enhancing liquidity for protocols.


##### Category (full list at https://defillama.com/categories): Risk Curators


##### methodology (what is being counted as tvl, how is tvl being calculated): We count all TVL according to how much value has been allocated to Varlamore Capital vaults on silo.finance


