### PR TITLE
Fix BlazeStake treasury adapter

### DIFF
--- a/projects/treasury/blazestake.js
+++ b/projects/treasury/blazestake.js
@@ -2,7 +2,12 @@ const { treasuryExports } = require("../helper/treasury");
 
 module.exports = treasuryExports({
     solana: {
-        owners: ["7zND8YAtCYehNoa1JrfDLQZi44xJkEuPWK5b4CkiuFpo"],
+        owners: [
+            "5sGFdNkBfbMxipRxBo28ZjTC9cEFmQPdC3Smk2gM8DVM",
+            "4y86xvbDuyiJaxSYuMUNB5NzRYGfY4knvZJXmmAYTNmJ",
+            "DfeAPX17JhfVpz5i2BiSaVhSereFQ8GoWABDw2v8p74j",
+            "3SUtLuJVqaTVPnN38bQm6tc6v9kAMXg6Gg4SLuctMxK6"
+        ],
         ownTokens: ["BLZEEuZUBVqFhj8adcCFPJvPVCiCyVmh3hkJMrU8KuJA"]
     },
 })


### PR DESCRIPTION
This PR updates the treasury adapter to include the addresses associated with the DAO treasury ([rewards.solblaze.org/governance](https://rewards.solblaze.org/governance))