### PR TITLE
fix: filter pools by hook type

### DIFF
--- a/projects/tapp-exchange/index.js
+++ b/projects/tapp-exchange/index.js
@@ -35,10 +35,9 @@ module.exports = {
     timetravel: false,
     aptos: {
         tvl: async (api) => {
-            const pools = (await getPools()).filter(pool=> pool.hook_type == 2 || pool.hook_type == 3 || pool.hook_type == 4);
+            const hookTypes = [2,3,4]
 
-            // The first element is not considered a pool reserve.
-            pools.shift();
+            const pools = (await getPools()).filter(pool=> hookTypes.includes(pool.hook_type));
 
             for (const pool of pools) {
                 const coinA = await getPairedCoin(pool.assets[0]) || pool.assets[0];

--- a/projects/tapp-exchange/index.js
+++ b/projects/tapp-exchange/index.js
@@ -35,7 +35,7 @@ module.exports = {
     timetravel: false,
     aptos: {
         tvl: async (api) => {
-            const pools = await getPools();
+            const pools = (await getPools()).filter(pool=> pool.hook_type == 2 || pool.hook_type == 3 || pool.hook_type == 4);
 
             // The first element is not considered a pool reserve.
             pools.shift();

--- a/projects/tapp-exchange/index.js
+++ b/projects/tapp-exchange/index.js
@@ -1,0 +1,73 @@
+const {GraphQLClient} = require("graphql-request");
+const {function_view} = require("../helper/chain/aptos");
+
+const graphQLClient = new GraphQLClient("https://api.mainnet.aptoslabs.com/v1/graphql");
+
+const ACCOUNT_ADDRESS = "0x57edaae7ac6e3813b057a675c05f155c0296f6757050e213dda7d8941b79609d"
+
+
+const APT_COIN_ADDRESS = '0x1::aptos_coin::AptosCoin';
+
+const getFungibleAssetQuery = `query GetFungibleAssetBalances($address: String, $offset: Int, $limit: Int) {
+  current_fungible_asset_balances(
+    where: {owner_address: {_eq: $address}}
+    offset: $offset
+    limit: $limit
+    order_by: {amount: desc}
+  ) {
+    asset_type
+    amount
+    __typename
+  }
+}`;
+
+async function getAssets(skip, limit) {
+    return await graphQLClient.request(getFungibleAssetQuery, {
+        address: ACCOUNT_ADDRESS,
+        offset: skip,
+        limit: limit,
+    }).then(r => r.current_fungible_asset_balances);
+}
+
+async function getPairedCoin(address) {
+    const result = await function_view({
+        functionStr: "0x1::coin::paired_coin",
+        args: [address],
+        type_arguments: [],
+    });
+
+    const [coinInfo] = result.vec || [];
+
+    if (!coinInfo) return null;
+
+    const { account_address, module_name, struct_name } = coinInfo;
+
+    const module = Buffer.from(module_name.replace(/^0x/, ""), "hex").toString("utf-8");
+    const struct = Buffer.from(struct_name.replace(/^0x/, ""), "hex").toString("utf-8");
+
+    return `${account_address}::${module}::${struct}`;
+}
+
+
+module.exports = {
+    methodology: "Measures the total liquidity across all pools on TAPP Exchange.",
+    timetravel: false,
+    aptos: {
+        tvl: async (api) => {
+            let offset = 0;
+            let limit = 100;
+            const assets = await getAssets(offset, limit);
+
+
+            for (const asset of assets) {
+                let coin = asset.asset_type;
+                if (coin !== APT_COIN_ADDRESS) {
+                 coin = await getPairedCoin(asset.asset_type) || asset.asset_type;
+                }
+
+                api.add(coin, asset.amount);
+            }
+        },
+    },
+};
+

--- a/projects/tapp-exchange/index.js
+++ b/projects/tapp-exchange/index.js
@@ -36,6 +36,8 @@ module.exports = {
     aptos: {
         tvl: async (api) => {
             const pools = await getPools();
+
+            // The first element is not considered a pool reserve.
             pools.shift();
 
             for (const pool of pools) {

--- a/projects/tapp-exchange/index.js
+++ b/projects/tapp-exchange/index.js
@@ -36,19 +36,14 @@ module.exports = {
     aptos: {
         tvl: async (api) => {
             const pools = await getPools();
-            let index = 0
+            pools.shift();
 
             for (const pool of pools) {
-                if (index === 0) {
-                    index += 1;
-                    continue
-                }
                 const coinA = await getPairedCoin(pool.assets[0]) || pool.assets[0];
                 const coinB = await getPairedCoin(pool.assets[1]) || pool.assets[1];
 
                 api.add(coinA, pool.reserves[0]);
                 api.add(coinB, pool.reserves[1]);
-                index += 1;
             }
         },
     },

--- a/projects/tapp-exchange/index.js
+++ b/projects/tapp-exchange/index.js
@@ -30,6 +30,9 @@ async function getAssets(skip, limit) {
 }
 
 async function getPairedCoin(address) {
+    if (address.split("::").length > 1) {
+        return address;
+    }
     const result = await function_view({
         functionStr: "0x1::coin::paired_coin",
         args: [address],
@@ -40,7 +43,7 @@ async function getPairedCoin(address) {
 
     if (!coinInfo) return null;
 
-    const { account_address, module_name, struct_name } = coinInfo;
+    const {account_address, module_name, struct_name} = coinInfo;
 
     const module = Buffer.from(module_name.replace(/^0x/, ""), "hex").toString("utf-8");
     const struct = Buffer.from(struct_name.replace(/^0x/, ""), "hex").toString("utf-8");
@@ -64,13 +67,8 @@ module.exports = {
                 offset += limit;
             } while (limit <= data.length);
 
-
-
             for (const asset of assets) {
-                let coin = asset.asset_type;
-                if (coin !== APT_COIN_ADDRESS) {
-                 coin = await getPairedCoin(asset.asset_type) || asset.asset_type;
-                }
+                const coin = await getPairedCoin(asset.asset_type) || asset.asset_type;
 
                 api.add(coin, asset.amount);
             }

--- a/projects/tapp-exchange/index.js
+++ b/projects/tapp-exchange/index.js
@@ -56,7 +56,14 @@ module.exports = {
         tvl: async (api) => {
             let offset = 0;
             let limit = 100;
-            const assets = await getAssets(offset, limit);
+            let assets = []
+            let data = []
+            do {
+                data = await getAssets(offset, limit);
+                assets = [...assets, ...data];
+                offset += limit;
+            } while (limit <= data.length);
+
 
 
             for (const asset of assets) {


### PR DESCRIPTION
## Summary

This PR fixes an issue where TVL stopped updating due to the presence of a new hook type (type 5), which is not associated with any liquidity pool.

## Details

- We previously assumed all hooks were pool-related, but a new `hookType = 5` was introduced.
- Hook type 5 does not represent a pool and should be excluded from TVL calculation.
- This fix updates the adapter to only include hook types:
  - `2`, `3`, and `4` — valid pool hooks
- Additionally, we continue to ignore:
  - `hookType = 1` which is used for platform fees
  - `hookType = 5` (new) which is non-pool logic

## Outcome

- TVL will now accurately reflect only active pools
- This resolves the issue where TVL updates stopped after July 21 due to invalid data structures