### PR TITLE
Add Prophet.fun

### DIFF
--- a/projects/prophet-fun/index.js
+++ b/projects/prophet-fun/index.js
@@ -1,10 +1,46 @@
 const axios = require('axios');
+const { PublicKey } = require("@solana/web3.js");
+const { sumTokens2, ASSOCIATED_TOKEN_PROGRAM_ID, TOKEN_PROGRAM_ID } = require('../helper/solana');
+const BN = require("bn.js");
+
+const programId = new PublicKey('ProPh6ruVL41JR3XXPuy6hN6TPH1ERqpWkZ9dp9YSEe')
+const globalState = new PublicKey('6PZKJowZMUAgxLxAJmHsrvzEL8PdXNymqYSJDwPRgh6V')
+const token = new PublicKey('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v')
+
+const getAta = (owner) => {
+  const [ata] = PublicKey.findProgramAddressSync(
+    [
+      owner.toBuffer(),
+      TOKEN_PROGRAM_ID.toBuffer(),
+      token.toBuffer(),
+    ],
+    ASSOCIATED_TOKEN_PROGRAM_ID, 
+  );
+  return ata;
+}
+
+function getPredictionMarketAddress(marketId) {
+  const [predictionState] = PublicKey.findProgramAddressSync(
+    [
+      Buffer.from('pred_market_state'),
+      new BN(marketId.toString()).toBuffer('le', 8),
+      globalState.toBuffer(),
+    ],
+    programId,
+  );
+  return predictionState;
+}
 
 async function tvl(api) {
-  const response = await axios.get('https://backend.prophet.fun/business-metrics/tvl?timestamp=' + api.timestamp);
-  const data = response.data;
+  const lastRoundId = await axios.get("https://backend.prophet.fun/business-metrics/last-round-id")
+  const tokenAccounts = []
 
-  api.add('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', data);
+  Array.from({ length: lastRoundId.data.roundId }, (_, i) => i + 1).forEach((roundId) => {
+    const marketAddress = getPredictionMarketAddress(roundId)
+    const marketAta = getAta(marketAddress)
+    tokenAccounts.push(marketAta)
+  })
+  await sumTokens2({ tokenAccounts, api, allowError: true })
 }
 
 

--- a/projects/prophet-fun/index.js
+++ b/projects/prophet-fun/index.js
@@ -1,0 +1,17 @@
+const axios = require('axios');
+
+async function tvl(api) {
+  const response = await axios.get('https://backend.prophet.fun/business-metrics/tvl?timestamp=' + api.timestamp);
+  const data = response.data;
+
+  api.add('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', data);
+}
+
+
+module.exports = {
+  methodology: 'TVL is total quantity of USDC held in the predictions token accounts',
+  start: 1753365600,
+  solana: {
+    tvl,
+  }
+}; 


### PR DESCRIPTION
Hey guys!

Name: Prophet.fun
Twitter: https://x.com/Prophet_fun
Website: https://prophet.fun/
Chain: Solana
Description: Prophet.fun is a fast, on-chain prediction platform built on Solana. Bet on crypto price swings, whale wallet moves, narrative shifts on Crypto Twitter, and degen roulette-style markets.
Category: DEX
<img width="400" height="400" alt="prophet-fun" src="https://github.com/user-attachments/assets/08ea7428-088c-41ef-8e87-cd03beb24912" />

Related to https://github.com/DefiLlama/dimension-adapters/pull/3854