### PR TITLE
feat: read total vet staked on stargate

### DIFF
--- a/projects/stargate/index.js
+++ b/projects/stargate/index.js
@@ -1,0 +1,24 @@
+const axios = require('axios');
+
+const STARGATE_CONTRACT = '0x1856c533ac2d94340aaa8544d35a5c1d4a21dee7';
+const VET_ADDRESS = '0x0000000000000000000000000000000000000000';
+const NODE_URL = 'https://mainnet.vechain.org';
+
+async function getTotalVetStaked() {
+  const resp = await axios.get(`${NODE_URL}/accounts/${STARGATE_CONTRACT}`);
+  const balance = resp.data.balance;
+  return BigInt(balance);
+}
+
+async function tvl(api) {
+  const totalVetStaked = await getTotalVetStaked();
+
+  api.add(VET_ADDRESS, totalVetStaked)
+}
+
+module.exports = {
+  timetravel: false, 
+  misrepresentedTokens: false,
+  methodology: 'Reads the total VET staked in the Stargate contract',
+  vechain: { tvl },
+};


### PR DESCRIPTION
---
##### Name (to be shown on DefiLlama): 
StarGate


##### Twitter Link:
https://x.com/vechainofficial


##### List of audit links if any:
https://hacken.io/audits/vechain-foundation/sca-vechain-stargate-may2025/

##### Website Link:
https://stargate.vechain.org/

##### Logo (High resolution, will be shown with rounded borders):

<img width="488" height="489" alt="stargate-icon" src="https://github.com/user-attachments/assets/7145f4da-ca60-48b8-a02e-99cc8ef62a9e" />

##### Current TVL:
123.21 M


##### Chain:
VeChain

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): https://www.coingecko.com/en/coins/vechain


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): 
https://coinmarketcap.com/currencies/vechain/


##### Short Description (to be shown on DefiLlama):
VeChain’s next-generation staking platform, designed to transform how users participate in the VeChainThor network.


##### Category (full list at https://defillama.com/categories) *Please choose only one:
[Liquid Staking](https://defillama.com/protocols/liquid-staking)


##### Methodology (what is being counted as tvl, how is tvl being calculated):
Users stake their VET and start accumulating rewards. To know the total amount of VET staked it is enough to check the balance of the StarGate contract.

Once Hayabusa will go live at the end of 2025, users will be able to use the staked VET to participate in protocol's native staking and delegation. When this will happen VET will be moved from the contract to the protocol itself, allowing thus to automatically scale down tvl of the stargate project and increase the tvl of the native staking, without counting 2 times the same amounts.


##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/vechain/stargate-contracts
