### PR TITLE
Fix TVL in Resolved Seer Markets and add TVL tracking support for futarchy markets

### DIFF
--- a/projects/seer/index.js
+++ b/projects/seer/index.js
@@ -3,12 +3,14 @@ const config = {
   'ethereum': {
     marketFactory: ['0x1F728c2fD6a3008935c1446a965a313E657b7904'],
     marketView: '0xAb797C4C6022A401c31543E316D3cd04c67a87fC',
-    collateralToken: ADDRESSES.ethereum.SDAI
+    collateralToken: ADDRESSES.ethereum.SDAI,
+    conditionalTokens: '0xC59b0e4De5F1248C1140964E0fF287B192407E0C'
   },
   'xdai': {
     marketFactory: ['0x83183DA839Ce8228E31Ae41222EaD9EDBb5cDcf1'],
     marketView: '0x995dC9c89B6605a1E8cc028B37cb8e568e27626f',
-    collateralToken: ADDRESSES.xdai.SDAI
+    collateralToken: ADDRESSES.xdai.SDAI,
+    conditionalTokens: '0xCeAfDD6bc0bEF976fdCd1112955828E00543c0Ce'
   },
 }
 
@@ -16,7 +18,7 @@ const MARKET_VIEW_ABI =
   'function getMarket(address marketFactory, address market) public view returns (tuple(address id, string marketName, string[] outcomes, address parentMarket, uint256 parentOutcome, address[] wrappedTokens, uint256 outcomesSupply, uint256 lowerBound, uint256 upperBound, bytes32 parentCollectionId, bytes32 conditionId, bytes32 questionId, uint256 templateId, tuple(bytes32 content_hash, address arbitrator, uint32 opening_ts, uint32 timeout, uint32 finalize_ts, bool is_pending_arbitration, uint256 bounty, bytes32 best_answer, bytes32 history_hash, uint256 bond, uint256 min_bond)[] questions, bytes32[] questionsIds, string[] encodedQuestions,bool payoutReported) memory)'
 
 async function tvl(api) {
-  const { marketFactory, marketView, collateralToken } = config[api.chain]
+  const { marketFactory, marketView, collateralToken, conditionalTokens } = config[api.chain]
   // get all markets
   const markets = await api.multiCall({ abi: 'address[]:allMarkets', calls: marketFactory })
   const dataCalls = markets.map((v, i) => {
@@ -30,6 +32,8 @@ async function tvl(api) {
   *  - parentOutcome
   *  - wrappedTokens
   *  - outcomesSupply
+  *  - conditionId
+  *  - payoutReported
   */
   const marketsData = (await api.multiCall({ abi: MARKET_VIEW_ABI, calls: dataCalls, target: marketView })).map(market => ({
     id: market.id,
@@ -37,22 +41,31 @@ async function tvl(api) {
     parentOutcome: market.parentOutcome,
     wrappedTokens: market.wrappedTokens,
     outcomesSupply: (market.wrappedTokens ?? []).map(_ => 0),
+    conditionId: market.conditionId,
+    payoutReported: market.payoutReported,
   }))
 
-  const idIndexMapping = []
+  // Fetch token supplies for all outcome tokens
   const supplyCalls = []
-  marketsData.forEach((marketData, index) => {
-    marketData.wrappedTokens.forEach((outcomeToken, idx2) => {
-      idIndexMapping.push([index, idx2])
-      supplyCalls.push(outcomeToken)
+  const supplyMapping = [] // Track which supply belongs to which market/outcome
+
+  marketsData.forEach((market, marketIdx) => {
+    market.wrappedTokens.forEach((token, outcomeIdx) => {
+      supplyCalls.push(token)
+      supplyMapping.push({ marketIdx, outcomeIdx })
     })
   })
 
   const supplies = await api.multiCall({ abi: 'erc20:totalSupply', calls: supplyCalls })
+
+  // Map supplies back to markets
   supplies.forEach((supply, i) => {
-    const [marketIndex, outcomeIndex] = idIndexMapping[i]
-    marketsData[marketIndex].outcomesSupply[outcomeIndex] = +supply
+    const { marketIdx, outcomeIdx } = supplyMapping[i]
+    marketsData[marketIdx].outcomesSupply[outcomeIdx] = BigInt(supply)
   })
+
+  // Process resolved markets - fetch payout data from ConditionalTokens
+  await fetchPayoutData(api, marketsData, conditionalTokens)
 
   const totalSupply = calculateTotalSupply(marketsData);
 
@@ -60,53 +73,144 @@ async function tvl(api) {
 }
 
 /**
- * When a child market is created, the parent market's supply is decreased by the amount used to mint the child market.
- * This function calculates the total supply of parent markets by merging child market supplies into parent markets
- * and summing up the unique supplies. These unique supplies represent the TVL of sDAI backing the parent markets.
+ * Fetches payout data for resolved markets from ConditionalTokens
+ */
+async function fetchPayoutData(api, marketsData, conditionalTokens) {
+  // Filter for markets that are reported as resolved
+  const resolvedMarkets = marketsData.filter(m =>
+    m.payoutReported &&
+    m.conditionId !== '0x0000000000000000000000000000000000000000000000000000000000000000'
+  )
+
+  if (resolvedMarkets.length === 0) return
+
+  // Step 1: Check which markets have valid payout denominators
+  const denominatorCalls = resolvedMarkets.map(m => ({
+    target: conditionalTokens,
+    params: [m.conditionId]
+  }))
+
+  const payoutDenominators = await api.multiCall({
+    abi: 'function payoutDenominator(bytes32) view returns (uint256)',
+    calls: denominatorCalls,
+    permitFailure: true
+  })
+
+  // Filter markets with valid denominators
+  const marketsWithPayouts = []
+  resolvedMarkets.forEach((market, i) => {
+    const denominator = payoutDenominators[i]
+    if (denominator && BigInt(denominator) > 0n) {
+      market.payoutDenominatorBig = BigInt(denominator)
+      marketsWithPayouts.push(market)
+    }
+  })
+
+  if (marketsWithPayouts.length === 0) return
+
+  // Step 2: Batch fetch all payout numerators
+  const numeratorCalls = []
+  const callMapping = [] // Maps each call back to market and outcome
+
+  marketsWithPayouts.forEach((market, marketIdx) => {
+    const outcomeCount = market.wrappedTokens?.length || 0
+    for (let outcomeIdx = 0; outcomeIdx < outcomeCount; outcomeIdx++) {
+      numeratorCalls.push({
+        target: conditionalTokens,
+        params: [market.conditionId, outcomeIdx]
+      })
+      callMapping.push({ market, outcomeIdx })
+    }
+  })
+
+  if (numeratorCalls.length === 0) return
+
+  const numeratorResults = await api.multiCall({
+    abi: 'function payoutNumerators(bytes32, uint256) view returns (uint256)',
+    calls: numeratorCalls,
+    permitFailure: true
+  })
+
+  // Step 3: Organize numerators by market
+  marketsWithPayouts.forEach(market => {
+    market.payoutNumeratorsBig = []
+  })
+
+  numeratorResults.forEach((result, i) => {
+    const { market, outcomeIdx } = callMapping[i]
+    market.payoutNumeratorsBig[outcomeIdx] = result ? BigInt(result) : 0n
+  })
+}
+
+/**
+ * Calculates the effective supply for a market based on its resolution status
+ */
+function getEffectiveSupply(market, supplies) {
+  if (!supplies || supplies.length === 0) return 0n
+
+  // For resolved markets with payout data, calculate weighted supply
+  if (market.payoutReported && market.payoutNumeratorsBig && market.payoutDenominatorBig > 0n) {
+    let weightedSupply = 0n
+    const numerators = market.payoutNumeratorsBig
+    const denominator = market.payoutDenominatorBig
+
+    for (let i = 0; i < supplies.length && i < numerators.length; i++) {
+      weightedSupply += (supplies[i] * numerators[i]) / denominator
+    }
+    return weightedSupply
+  }
+
+  // For unresolved markets, use the maximum supply (all outcomes should be equal)
+  return supplies.reduce((max, supply) => supply > max ? supply : max, 0n)
+}
+
+/**
+ * Calculates total TVL by:
+ * 1. Deduplicating token supplies (tokens can appear in multiple markets)
+ * 2. Rolling up child market supplies into parent markets
+ * 3. Summing only parent market supplies (to avoid double counting)
  */
 function calculateTotalSupply(marketsData) {
-  const marketSupplies = new Map();
-  const processedTokens = new Set();
+  // Step 1: Deduplicate token supplies across markets
+  const marketSupplies = new Map()
+  const processedTokens = new Set()
 
-  marketsData.forEach((market, index) => {
-    const supply = market.outcomesSupply
-    const uniqueSupply = []
-    let i = 0
-    for (const token of market.wrappedTokens) {
+  marketsData.forEach(market => {
+    const uniqueSupplies = []
+    market.wrappedTokens.forEach((token, i) => {
       if (!processedTokens.has(token)) {
-        uniqueSupply.push(supply[i])
+        uniqueSupplies.push(market.outcomesSupply[i])
         processedTokens.add(token)
       }
-      i++
-    }
+    })
+    marketSupplies.set(market.id, uniqueSupplies)
+  })
 
-    marketSupplies.set(market.id, uniqueSupply);
-  });
+  // Step 2: Roll up child market supplies into parent markets
+  marketsData.forEach(market => {
+    if (market.parentMarket === ADDRESSES.null) return // Skip parent markets
 
-  // Merge child market supplies into parent markets
-  marketsData.forEach((market) => {
-    if (market.parentMarket !== ADDRESSES.null) {
-      const parentSupply = marketSupplies.get(market.parentMarket);
-      const childSupply = marketSupplies.get(market.id);
+    const parentSupply = marketSupplies.get(market.parentMarket)
+    const childSupply = marketSupplies.get(market.id)
 
-      if (parentSupply && childSupply) {
-        // Add child market supply to the corresponding parent outcome
-        parentSupply[market.parentOutcome] = (parentSupply[market.parentOutcome] || 0) + childSupply.reduce((a, b) => a > b ? a : b, 0);
-        marketSupplies.set(market.parentMarket, parentSupply);
-      }
-    }
-  });
+    if (!parentSupply || !childSupply) return
 
-  // Calculate total supply of parent markets (parent markets are backed by sDAI)
-  let totalSupply = 0;
-  marketsData.forEach((market) => {
-    if (market.parentMarket === ADDRESSES.null) {
-      const marketSupply = marketSupplies.get(market.id);
-      if (marketSupply) {
-        totalSupply += marketSupply.reduce((a, b) => a > b ? a : b, 0);
-      }
-    }
-  });
+    // Calculate child's effective supply and add to parent's outcome
+    const childEffectiveSupply = getEffectiveSupply(market, childSupply)
+    const parentOutcome = market.parentOutcome
+    parentSupply[parentOutcome] = (parentSupply[parentOutcome] || 0n) + childEffectiveSupply
+  })
+
+  // Step 3: Sum up only parent markets (markets with no parent)
+  let totalSupply = 0n
+  marketsData.forEach(market => {
+    if (market.parentMarket !== ADDRESSES.null) return // Skip child markets
+
+    const marketSupply = marketSupplies.get(market.id)
+    if (!marketSupply) return
+
+    totalSupply += getEffectiveSupply(market, marketSupply)
+  })
 
   return totalSupply;
 }


### PR DESCRIPTION
This PR fixes an issue where resolved Seer markets were overcounting TVL and adds support for tracking TVL in Seer's futarchy markets on Gnosis chain. 

Changes: 
- Fixed TVL calculation for resolved markets by weighting them based on payout ratios from ConditionalTokens 
- Added support for futarchy markets which use dual collateral tokens 
- Improved child market supply calculation with recursive bubbling to parent outcomes 
- Added proper deduplication for shared wrapped tokens 

Technical details: 
- Resolved markets now fetch payout numerators/denominators from ConditionalTokens to calculate actual redeemable value 
- Futarchy markets (4 outcomes, 2 collaterals) are handled separately with proper resolution logic 
- Added conditional tokens contract addresses for both Ethereum and Gnosis chains methodology: TVL counts collateral locked in Seer prediction markets. Futarchy markets with dual collaterals are counted separately by token type. Resolved markets are weighted by payout ratios.

Here are the results from the TVL test. 1.37 M instead of the currently [reported](https://defillama.com/protocol/seer) 3.5 M

node test.js projects/seer
Building prices get queries for 1 tokens
Building prices get queries for 4 tokens
--- ethereum ---
sDAI                      30.37 k
Total: 30.37 k 

--- xdai ---
sDAI                      1.23 M
PNK                       99.73 k
gno                       3.88 k
WXDAI                     5.088396017816572
Total: 1.34 M 

--- tvl ---
sDAI                      1.26 M
PNK                       99.73 k
gno                       3.88 k
WXDAI                     5
Total: 1.37 M 

------ TVL ------
xdai                      1.34 M
ethereum                  30.37 k

total                    1.37 M 
