### PR TITLE
Fix Seer TVL in resolved markets and add missing TVL in Seer futarchy markets

### DIFF
--- a/projects/helper/cache/getLogs.js
+++ b/projects/helper/cache/getLogs.js
@@ -80,7 +80,7 @@ async function getLogs({ target,
     const logIndices = new Set()
 
     // remove possible duplicates
-    if (!splitCache || !customCacheFunction)
+     if (!splitCache && !customCacheFunction)
       cache.logs = cache.logs.filter(i => {
         let key = (i.transactionHash ?? i.hash) + (i.logIndex ?? i.index)
         if (!(i.hasOwnProperty('logIndex') || i.hasOwnProperty('index')) || !i.hasOwnProperty('transactionHash')) {

--- a/projects/superReturn/index.js
+++ b/projects/superReturn/index.js
@@ -1,0 +1,112 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+
+// superUSD vault contract address are same in all chains
+const SUPERUSD_CONTRACT = '0x15f3Ee2F609FBAe0bC48E3a071D66DD917C682EB';
+
+const protocols = {
+  ethereum: {
+    euler: '0xe0a80d35bB6618CBA260120b279d357978c42BCE'
+  },
+  soneium: {
+    sake: '0x5D7Af17B88Ad600EAb35957CC99eaa30D6330cFD',
+    sakeProvider: '0x73a35ca19Da0357651296c40805c31585f19F741'
+  },
+  plume: {
+    morpho: ['0x0b14D0bdAf647c541d3887c5b1A4bd64068fCDA7']
+  }
+};
+
+async function ethereumTvl(api) {
+    // Euler Protocol
+    const collateralBalance = await api.call({
+        abi: 'erc20:balanceOf',
+        target: protocols.ethereum.euler,
+        params: [SUPERUSD_CONTRACT],
+    });
+
+    const previewShare = await api.call({
+        abi: 'function convertToAssets(uint256 shares) view returns (uint256 assets)',
+        target: protocols.ethereum.euler,
+        params: [collateralBalance],
+    });
+
+    api.add(ADDRESSES.ethereum.USDC, previewShare);
+
+    // Vault funds
+    const vaultFunds = await api.call({
+        abi: 'erc20:balanceOf',
+        target: ADDRESSES.ethereum.USDC,
+        params: [SUPERUSD_CONTRACT],
+    });
+
+    api.add(ADDRESSES.ethereum.USDC, vaultFunds);
+}
+
+async function soneiumTvl(api) {
+    // Sake Protocol
+    let [userReserves, ] = await api.call({
+        abi: "function getUserReservesData(address provider, address user) view returns (tuple(address underlyingAsset, uint256 scaledATokenBalance, bool usageAsCollateralEnabledOnUser, uint256 stableBorrowRate, uint256 scaledVariableDebt, uint256 principalStableDebt, uint256 stableBorrowLastUpdateTimestamp)[], uint8)",
+        target: protocols.soneium.sake,
+        params: [protocols.soneium.sakeProvider, SUPERUSD_CONTRACT],
+    });
+    userReserves = userReserves.filter(reserve => reserve.scaledATokenBalance != 0);
+
+    for (const reserve of userReserves) {
+        const {
+        underlyingAsset,
+        scaledATokenBalance,
+        } = reserve;
+
+        api.add(ADDRESSES.soneium.USDC, scaledATokenBalance)
+    }
+
+    // Vault funds
+    const vaultFunds = await api.call({
+        abi: 'erc20:balanceOf',
+        target: ADDRESSES.soneium.USDC,
+        params: [SUPERUSD_CONTRACT],
+    });
+
+    api.add(ADDRESSES.soneium.USDC, vaultFunds);
+}
+
+async function plumeTvl(api) {
+    // Morpho Protocol
+    const morphoAddresses = protocols.plume.morpho;
+    
+    const collateralBalances = await api.multiCall({
+        abi: 'erc20:balanceOf',
+        calls: morphoAddresses.map(morphoAddress => ({
+            target: morphoAddress,
+            params: [SUPERUSD_CONTRACT]
+        }))
+    });
+
+    const previewShares = await api.multiCall({
+        abi: 'function convertToAssets(uint256 shares) view returns (uint256 assets)',
+        calls: morphoAddresses.map((morphoAddress, i) => ({
+            target: morphoAddress,
+            params: [collateralBalances[i]]
+        }))
+    });
+
+    previewShares.forEach(share => {
+        api.add(ADDRESSES.plume_mainnet.pUSD, share);
+    });
+
+    // Vault funds
+    const vaultFunds = await api.call({
+        abi: 'erc20:balanceOf',
+        target: ADDRESSES.plume_mainnet.pUSD,
+        params: [SUPERUSD_CONTRACT],
+    });
+
+    api.add(ADDRESSES.plume_mainnet.pUSD, vaultFunds);
+}
+
+module.exports = {
+  methodology: 'Tracks the deposits in yield-generating protocols',
+  ethereum: { tvl: ethereumTvl },
+  soneium: { tvl: soneiumTvl },
+  plume: { tvl: plumeTvl }
+}; 

--- a/projects/superReturn/index.js
+++ b/projects/superReturn/index.js
@@ -11,7 +11,7 @@ const protocols = {
     sake: '0x5D7Af17B88Ad600EAb35957CC99eaa30D6330cFD',
     sakeProvider: '0x73a35ca19Da0357651296c40805c31585f19F741'
   },
-  plume: {
+  plume_mainnet: {
     morpho: ['0x0b14D0bdAf647c541d3887c5b1A4bd64068fCDA7']
   }
 };
@@ -72,7 +72,7 @@ async function soneiumTvl(api) {
 
 async function plumeTvl(api) {
     // Morpho Protocol
-    const morphoAddresses = protocols.plume.morpho;
+    const morphoAddresses = protocols.plume_mainnet.morpho;
     
     const collateralBalances = await api.multiCall({
         abi: 'erc20:balanceOf',
@@ -108,5 +108,5 @@ module.exports = {
   methodology: 'Tracks the deposits in yield-generating protocols',
   ethereum: { tvl: ethereumTvl },
   soneium: { tvl: soneiumTvl },
-  plume: { tvl: plumeTvl }
+  plume_mainnet: { tvl: plumeTvl }
 }; 


### PR DESCRIPTION
This PR fixes an issue where resolved Seer markets were overcounting TVL and adds support for tracking TVL in Seer's futarchy markets on Gnosis chain.

Changes:

Fixed TVL calculation for resolved markets by weighting them based on payout ratios from ConditionalTokens
Added support for futarchy markets which use dual collateral tokens
Improved child market supply calculation with recursive bubbling to parent outcomes
Added proper deduplication for shared wrapped tokens
Technical details:

Resolved markets now fetch payout numerators/denominators from ConditionalTokens to calculate actual redeemable value
Futarchy markets (4 outcomes, 2 collaterals) are handled separately with proper resolution logic
Added conditional tokens contract addresses for both Ethereum and Gnosis chains methodology: TVL counts collateral locked in Seer prediction markets. Futarchy markets with dual collaterals are counted separately by token type. Resolved markets are weighted by payout ratios.
Here are the results from the TVL test. 1.37 M instead of the currently [reported](https://defillama.com/protocol/seer) 3.5 M

node test.js projects/seer
Building prices get queries for 1 tokens
Building prices get queries for 4 tokens
--- ethereum ---
sDAI 30.37 k
Total: 30.37 k

--- xdai ---
sDAI 1.23 M
PNK 99.73 k
gno 3.88 k
WXDAI 5.088396017816572
Total: 1.34 M

--- tvl ---
sDAI 1.26 M
PNK 99.73 k
gno 3.88 k
WXDAI 5
Total: 1.37 M

------ TVL ------
xdai 1.34 M
ethereum 30.37 k

total 1.37 M