### PR TITLE
Fix SoSoValue-Indexes TVL

### DIFF
--- a/projects/ssi-protocol/index.js
+++ b/projects/ssi-protocol/index.js
@@ -1,12 +1,11 @@
 const sdk = require('@defillama/sdk')
 const { getBlock } = require('../helper/http');
 
-
 const abi = {
   getBasket: 'function getBasket() view returns ((string chain, string symbol, string addr, uint8 decimals, uint256 amount)[])'
 }
 
-ssi_tokens = [
+const ssi_tokens = [
   // MAG7.ssi
   '0x9E6A46f294bB67c20F1D1E7AfB0bBEf614403B55',
   // DEFI.ssi
@@ -34,6 +33,8 @@ function underlyingExports(chains) {
         baskets.forEach(basket => {
           basket.forEach(token => {
             if (token.chain == chain_name) {
+              let token_addr;
+              let token_amount;
               if (token.addr != '') {
                 token_addr = chain + ':' + token.addr;
                 token_amount = token.amount;

--- a/projects/ssi-protocol/index.js
+++ b/projects/ssi-protocol/index.js
@@ -1,16 +1,66 @@
-const { treasuryExports } = require("../helper/treasury");
-const bitcoinAddressBook = require('../helper/bitcoin-book/index.js')
+const sdk = require('@defillama/sdk')
+const { getBlock } = require('../helper/http');
 
 
-// https://github.com/DefiLlama/DefiLlama-Adapters/pull/12893#issuecomment-2577690389s
-module.exports = treasuryExports({
-  ethereum: { owners: ['0x55ac87E54019fa2e2156a0fAf13176DcdDFA16ce', '0x605b50f07f46251a7a39fa18c2247fb612f7452f', '0x3bc6b3146d48fafcfb6be35284295019fbd645e7'], },
-  bsc: { owners: [ '0x3bc6b3146d48fafcfb6be35284295019fbd645e7'], },
-  doge: { owners: [ 'DPQ3EbacSG6gdakZmXwMu7qS6SbpRUjY4a', 'D5gedqfZm198AyTFVg8NqWFUh8bFTdmKj7'], },
-  solana: { owners: ['CeuKmW1XqgKz4E8JNpZxrysMRsvkEz55qUvm9soqhALY', 'GQkn3fPeCV4pH1MGZVHsWPpRdq5ENYnaB8GVwSubjkCZ', '8yVXip9eFwdmrbTxPqHsuCvVR5ktBdLGz7S1bUpSx7j6'] },
-  bitcoin: { owners: bitcoinAddressBook.ssiProtocol },
-  cardano: { owners: ['addr1v9nkv9p0gz83ha7hx0h6pg6lrte0t0dsj8tyersc8np5gegrwwxpp'] },
-  ripple: { owners: ['rp53vxWXuEe9LL6AHcCtzzAvdtynSL1aVM'] },
-})
+const abi = {
+  getBasket: 'function getBasket() view returns ((string chain, string symbol, string addr, uint8 decimals, uint256 amount)[])'
+}
 
-Object.keys(module.exports).forEach(chain => delete module.exports[chain].ownTokens)
+ssi_tokens = [
+  // MAG7.ssi
+  '0x9E6A46f294bB67c20F1D1E7AfB0bBEf614403B55',
+  // DEFI.ssi
+  '0x164ffdaE2fe3891714bc2968f1875ca4fA1079D0',
+  // MEME.ssi
+  '0xdd3acDBDc7b358Df453a6CB6bCA56C92aA5743aA'
+]
+
+function underlyingExports(chains) {
+  const exportObj = {};
+  Object.entries(chains).forEach(([chain, [chain_name, native_token]]) => {
+    exportObj[chain] = {
+      tvl: async (api, ethBlock, chainBlocks) => {
+        const balances = {};
+        const base_block = await getBlock(api.timestamp, 'base', chainBlocks);
+        const baskets = await Promise.all(ssi_tokens.map(async (ssi_token) => {
+          const res = await sdk.api.abi.call({
+            abi: abi.getBasket,
+            target: ssi_token,
+            chain: 'base',
+            block: base_block,
+          });
+          return res.output;
+        }));
+        baskets.forEach(basket => {
+          basket.forEach(token => {
+            if (token.chain == chain_name) {
+              if (token.addr != '') {
+                token_addr = chain + ':' + token.addr;
+                token_amount = token.amount;
+              } else {
+                token_addr = native_token;
+                token_amount = token.amount / 10 ** token.decimals;
+              }
+              sdk.util.sumSingleBalance(balances, token_addr, token_amount);
+            }
+          });
+        });
+        return balances;
+      }
+    }
+  });
+  return exportObj;
+}
+
+module.exports = {
+  methodology: 'TVL counts the underlying tokens in the baskets of the SSI tokens.',
+  ...underlyingExports({
+    ethereum: ['ETH', 'ethereum'],
+    bsc: ['BSC_BNB', 'binancecoin'],
+    doge: ['DOGE', 'dogecoin'],
+    solana: ['SOL', 'solana'],
+    bitcoin: ['BTC', 'bitcoin'],
+    cardano: ['ADA', 'cardano'],
+    ripple: ['XRP', 'ripple'],
+  })
+};


### PR DESCRIPTION
Since the MAG7's TVL is removed from sosovalue-basis by  https://github.com/DefiLlama/DefiLlama-Adapters/pull/15896, we change the SoSoValue-Indexes TVL methodology from **tracking balances of custody wallets** to **tracking the underlying token balances recorded in the Index Token contracts**, in this way MAG7's TVL can be summed together.