### PR TITLE
Add second Almanak vault

### DIFF
--- a/projects/almanak/index.js
+++ b/projects/almanak/index.js
@@ -5,6 +5,7 @@ const config = {
     vaults:
       [
         "0xDCD0f5ab30856F28385F641580Bbd85f88349124", // alUSD
+        "0x5a97B0B97197299456Af841F8605543b13b12eE3", // alpUSD
       ],
   },
 };

--- a/projects/almanak/index.js
+++ b/projects/almanak/index.js
@@ -1,0 +1,23 @@
+const { getLogs } = require("../helper/cache/getLogs");
+
+const config = {
+  ethereum: {
+    vaults:
+      [
+        "0xDCD0f5ab30856F28385F641580Bbd85f88349124", // alUSD
+      ],
+  },
+};
+
+
+Object.keys(config).forEach((chain) => {
+  const {vaults} = config[chain];
+  module.exports[chain] = { 
+    tvl: async (api) =>  {
+
+      return await api.erc4626Sum2({
+        calls: [...vaults],
+      })
+    }
+}}
+)


### PR DESCRIPTION
On August 21st, [Almanak](https://app.almanak.co/) contributors opened [a second vault](https://app.almanak.co/vaults/0x5a97b0b97197299456af841f8605543b13b12ee3) on the platform.

This PR adds the second vault to the list to be taken into account for the TVL.