### PR TITLE
Fix termfinance-lend

### DIFF
--- a/projects/term-finance/index.js
+++ b/projects/term-finance/index.js
@@ -8,10 +8,10 @@ const graphs = {
     "https://api.mainnet.termfinance.io/avalanche/subgraph/term",
   base:
     "https://api.mainnet.termfinance.io/base/subgraph/term",
-  bsc:
-    "https://api.mainnet.termfinance.io/bnb/subgraph/term",
-  arbitrum:
-    "https://api.mainnet.termfinance.io/arbitrum/subgraph/term",
+  // bsc:
+  //   "https://api.mainnet.termfinance.io/bnb/subgraph/term",
+  // arbitrum:
+  //   "https://api.mainnet.termfinance.io/arbitrum/subgraph/term",
 };
 
 const query = `


### PR DESCRIPTION
Fix for termfinance-lend → There’s no data on BSC and Arbitrum, the subgraphs return 502 errors which unnecessarily break the code for now