### PR TITLE
chore(ci): upgrade checkout to v5

### DIFF
--- a/.github/workflows/alert.yml
+++ b/.github/workflows/alert.yml
@@ -8,7 +8,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
     - name: Update unlisted
       run: curl https://born-to-llama.herokuapp.com/refresh
     # - name: Deploy to server

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
           output: 'json'
           fileOutput: 'json'
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
       - name: Run changes files through test script
         env:
           LLAMA_DEBUG_MODE: "true"


### PR DESCRIPTION
Bumps checkout to v5 for future-proofing against Node 24 runner updates.
Requires runner v2.327.1+. Workflows compile the same.

ref: https://github.com/actions/checkout/releases/tag/v5.0.0