### PR TITLE
Fix Berachain TVL adapter for Nabla Finance

### DIFF
--- a/projects/nabla/index.js
+++ b/projects/nabla/index.js
@@ -1,51 +1,116 @@
 const { getLogs2 } = require("../helper/cache/getLogs");
 
 const config = {
-    base: {
-        router: "0x791Fee7b66ABeF59630943194aF17B029c6F487B",
-        fromBlock: 19980311,
-    },
     arbitrum: {
         router: "0x7bcFc8b8ff61456ad7C5E2be8517D01df006d18d",
         fromBlock: 240797440,
+        backstopPool: "0x337B03C2a7482c6eb29d8047eA073119dc68a29A",
+    },
+    base: {
+        router: "0x791Fee7b66ABeF59630943194aF17B029c6F487B",
+        fromBlock: 19980311,
+        backstopPool: "0x50841f086891fe57829ee0a809f8B10174892b69",
     },
     berachain: {
         router: "0x8756fd992569E0389bF357EB087f5827F364D2a4",
         fromBlock: 4919561,
+        backstopPool: "0xfa158Cf7cD83F418eBD1326121810466972447F6",
     },
 };
 
-const SwapPoolRegistrationEvent =
-    "event SwapPoolRegistered(address indexed sender, address pool, address asset)";
+const abis = {
+    router: {
+        swapPoolRegistrationEvent:
+            "event SwapPoolRegistered(address indexed sender, address pool, address asset)",
+        poolByAsset:
+            "function poolByAsset(address _asset) external view returns (address swapPool_)",
+    },
+    backstopPool: {
+        getBackedPool:
+            "function getBackedPool(uint256 _index) external view returns (address swapPool_)",
+        getBackedPoolCount:
+            "function getBackedPoolCount() external view returns (uint256 count_)",
+    },
+};
 
 Object.keys(config).forEach((chain) => {
-    const { router, fromBlock } = config[chain];
+    const { router, fromBlock, backstopPool } = config[chain];
 
     module.exports[chain] = {
         tvl: async (api) => {
-            const logs = await getLogs2({
-                api,
-                target: router,
-                eventAbi: SwapPoolRegistrationEvent,
-                fromBlock,
-            });
-            const pools = logs.map((log) => log.pool);
-            const tokensAndOwners = logs.map((i) => [i.asset, i.pool]);
+            if (chain == "berachain") {
+                // Get the asset of the backstop pool
+                const backstopAsset = await api.call({
+                    target: backstopPool,
+                    abi: "address:asset",
+                });
 
-            let backstops = await api.multiCall({
-                abi: "address:backstop",
-                calls: pools,
-            });
-            backstops = [...new Set(backstops)];
-            const bTokens = await api.multiCall({
-                abi: "address:asset",
-                calls: backstops,
-            });
-            backstops.forEach((backstop, i) =>
-                tokensAndOwners.push([bTokens[i], backstop])
-            );
+                // Get all swap pools backed by the backstop pool
+                const backedPoolCount = await api.call({
+                    target: backstopPool,
+                    abi: abis.backstopPool.getBackedPoolCount,
+                });
+                const backedSwapPools = await api.multiCall({
+                    target: backstopPool,
+                    abi: abis.backstopPool.getBackedPool,
+                    calls: [...Array(Number(backedPoolCount)).keys()],
+                });
 
-            return api.sumTokens({ tokensAndOwners });
+                // Get unique assets of all backed swap pools
+                const backedSwapPoolAssets = await api.multiCall({
+                    abi: "address:asset",
+                    calls: backedSwapPools,
+                });
+                const uniqueAssets = [...new Set(backedSwapPoolAssets)];
+
+                // Get all "active" swap pools from router that correspond to the unique assets (might return zero address for removed swap pools)
+                const activeSwapPools = await api.multiCall({
+                    target: router,
+                    abi: abis.router.poolByAsset,
+                    calls: uniqueAssets,
+                });
+
+                // Create tokens and owners for TVL calculation
+                const tokensAndOwners = [];
+
+                tokensAndOwners.push([backstopAsset, backstopPool]);
+
+                uniqueAssets.forEach((asset, i) => {
+                    const swapPool = activeSwapPools[i];
+                    if (
+                        swapPool !==
+                        "0x0000000000000000000000000000000000000000"
+                    ) {
+                        tokensAndOwners.push([asset, swapPool]);
+                    }
+                });
+
+                return api.sumTokens({ tokensAndOwners });
+            } else {
+                const logs = await getLogs2({
+                    api,
+                    target: router,
+                    eventAbi: abis.router.swapPoolRegistrationEvent,
+                    fromBlock,
+                });
+                const pools = logs.map((log) => log.pool);
+                const tokensAndOwners = logs.map((i) => [i.asset, i.pool]);
+
+                let backstops = await api.multiCall({
+                    abi: "address:backstop",
+                    calls: pools,
+                });
+                backstops = [...new Set(backstops)];
+                const bTokens = await api.multiCall({
+                    abi: "address:asset",
+                    calls: backstops,
+                });
+                backstops.forEach((backstop, i) =>
+                    tokensAndOwners.push([bTokens[i], backstop])
+                );
+
+                return api.sumTokens({ tokensAndOwners });
+            }
         },
     };
 });

--- a/projects/nabla/index.js
+++ b/projects/nabla/index.js
@@ -1,30 +1,16 @@
-const { getLogs2 } = require("../helper/cache/getLogs");
-
 const config = {
     arbitrum: {
-        router: "0x7bcFc8b8ff61456ad7C5E2be8517D01df006d18d",
-        fromBlock: 240797440,
         backstopPool: "0x337B03C2a7482c6eb29d8047eA073119dc68a29A",
     },
     base: {
-        router: "0x791Fee7b66ABeF59630943194aF17B029c6F487B",
-        fromBlock: 19980311,
         backstopPool: "0x50841f086891fe57829ee0a809f8B10174892b69",
     },
     berachain: {
-        router: "0x8756fd992569E0389bF357EB087f5827F364D2a4",
-        fromBlock: 4919561,
         backstopPool: "0xfa158Cf7cD83F418eBD1326121810466972447F6",
     },
 };
 
 const abis = {
-    router: {
-        swapPoolRegistrationEvent:
-            "event SwapPoolRegistered(address indexed sender, address pool, address asset)",
-        poolByAsset:
-            "function poolByAsset(address _asset) external view returns (address swapPool_)",
-    },
     backstopPool: {
         getBackedPool:
             "function getBackedPool(uint256 _index) external view returns (address swapPool_)",
@@ -34,83 +20,42 @@ const abis = {
 };
 
 Object.keys(config).forEach((chain) => {
-    const { router, fromBlock, backstopPool } = config[chain];
+    const { backstopPool } = config[chain];
 
     module.exports[chain] = {
         tvl: async (api) => {
-            if (chain == "berachain") {
-                // Get the asset of the backstop pool
-                const backstopAsset = await api.call({
-                    target: backstopPool,
-                    abi: "address:asset",
-                });
+            // Get the asset of the backstop pool
+            const backstopAsset = await api.call({
+                target: backstopPool,
+                abi: "address:asset",
+            });
 
-                // Get all swap pools backed by the backstop pool
-                const backedPoolCount = await api.call({
-                    target: backstopPool,
-                    abi: abis.backstopPool.getBackedPoolCount,
-                });
-                const backedSwapPools = await api.multiCall({
-                    target: backstopPool,
-                    abi: abis.backstopPool.getBackedPool,
-                    calls: [...Array(Number(backedPoolCount)).keys()],
-                });
+            // Get all swap pools backed by the backstop pool
+            const backedPoolCount = await api.call({
+                target: backstopPool,
+                abi: abis.backstopPool.getBackedPoolCount,
+            });
+            const backedSwapPools = await api.multiCall({
+                target: backstopPool,
+                abi: abis.backstopPool.getBackedPool,
+                calls: [...Array(Number(backedPoolCount)).keys()],
+            });
 
-                // Get unique assets of all backed swap pools
-                const backedSwapPoolAssets = await api.multiCall({
-                    abi: "address:asset",
-                    calls: backedSwapPools,
-                });
-                const uniqueAssets = [...new Set(backedSwapPoolAssets)];
+            // Get the assets of all backed swap pools
+            const backedSwapPoolAssets = await api.multiCall({
+                abi: "address:asset",
+                calls: backedSwapPools,
+            });
 
-                // Get all "active" swap pools from router that correspond to the unique assets (might return zero address for removed swap pools)
-                const activeSwapPools = await api.multiCall({
-                    target: router,
-                    abi: abis.router.poolByAsset,
-                    calls: uniqueAssets,
-                });
+            // Create 'tokens and owners' for TVL calculation
+            const tokensAndOwners = [[backstopAsset, backstopPool]];
 
-                // Create tokens and owners for TVL calculation
-                const tokensAndOwners = [];
+            backedSwapPools.forEach((swapPool, i) => {
+                const swapPoolAsset = backedSwapPoolAssets[i];
+                tokensAndOwners.push([swapPoolAsset, swapPool]);
+            });
 
-                tokensAndOwners.push([backstopAsset, backstopPool]);
-
-                uniqueAssets.forEach((asset, i) => {
-                    const swapPool = activeSwapPools[i];
-                    if (
-                        swapPool !==
-                        "0x0000000000000000000000000000000000000000"
-                    ) {
-                        tokensAndOwners.push([asset, swapPool]);
-                    }
-                });
-
-                return api.sumTokens({ tokensAndOwners });
-            } else {
-                const logs = await getLogs2({
-                    api,
-                    target: router,
-                    eventAbi: abis.router.swapPoolRegistrationEvent,
-                    fromBlock,
-                });
-                const pools = logs.map((log) => log.pool);
-                const tokensAndOwners = logs.map((i) => [i.asset, i.pool]);
-
-                let backstops = await api.multiCall({
-                    abi: "address:backstop",
-                    calls: pools,
-                });
-                backstops = [...new Set(backstops)];
-                const bTokens = await api.multiCall({
-                    abi: "address:asset",
-                    calls: backstops,
-                });
-                backstops.forEach((backstop, i) =>
-                    tokensAndOwners.push([bTokens[i], backstop])
-                );
-
-                return api.sumTokens({ tokensAndOwners });
-            }
+            return api.sumTokens({ tokensAndOwners });
         },
     };
 });

--- a/projects/nabla/index.js
+++ b/projects/nabla/index.js
@@ -1,28 +1,51 @@
-const { getLogs2 } = require('../helper/cache/getLogs')
+const { getLogs2 } = require("../helper/cache/getLogs");
 
 const config = {
-  base: { router: '0x791Fee7b66ABeF59630943194aF17B029c6F487B', fromBlock: 19980311 },
-  arbitrum: { router: '0x7bcFc8b8ff61456ad7C5E2be8517D01df006d18d', fromBlock: 240797440 },
-  berachain: { router: '0x8756fd992569E0389bF357EB087f5827F364D2a4', fromBlock: 4919561 },
-}
+    base: {
+        router: "0x791Fee7b66ABeF59630943194aF17B029c6F487B",
+        fromBlock: 19980311,
+    },
+    arbitrum: {
+        router: "0x7bcFc8b8ff61456ad7C5E2be8517D01df006d18d",
+        fromBlock: 240797440,
+    },
+    berachain: {
+        router: "0x8756fd992569E0389bF357EB087f5827F364D2a4",
+        fromBlock: 4919561,
+    },
+};
 
-const SwapPoolRegistrationEvent = 'event SwapPoolRegistered(address indexed sender, address pool, address asset)'
+const SwapPoolRegistrationEvent =
+    "event SwapPoolRegistered(address indexed sender, address pool, address asset)";
 
-Object.keys(config).forEach(chain => {
-  const { router, fromBlock } = config[chain]
+Object.keys(config).forEach((chain) => {
+    const { router, fromBlock } = config[chain];
 
-  module.exports[chain] = {
-    tvl: async (api) => {
-      const logs = await getLogs2({ api, target: router, eventAbi: SwapPoolRegistrationEvent, fromBlock, })
-      const pools = logs.map(log => log.pool)
-      const tokensAndOwners = logs.map(i => [i.asset, i.pool])
+    module.exports[chain] = {
+        tvl: async (api) => {
+            const logs = await getLogs2({
+                api,
+                target: router,
+                eventAbi: SwapPoolRegistrationEvent,
+                fromBlock,
+            });
+            const pools = logs.map((log) => log.pool);
+            const tokensAndOwners = logs.map((i) => [i.asset, i.pool]);
 
-      let backstops = await api.multiCall({ abi: 'address:backstop', calls: pools })
-      backstops = [...new Set(backstops)]
-      const bTokens = await api.multiCall({ abi: 'address:asset', calls: backstops })
-      backstops.forEach((backstop, i) => tokensAndOwners.push([bTokens[i], backstop]))
+            let backstops = await api.multiCall({
+                abi: "address:backstop",
+                calls: pools,
+            });
+            backstops = [...new Set(backstops)];
+            const bTokens = await api.multiCall({
+                abi: "address:asset",
+                calls: backstops,
+            });
+            backstops.forEach((backstop, i) =>
+                tokensAndOwners.push([bTokens[i], backstop])
+            );
 
-      return api.sumTokens({ tokensAndOwners })
-    }
-  }
-})
+            return api.sumTokens({ tokensAndOwners });
+        },
+    };
+});


### PR DESCRIPTION
#### Objective
Fix for adding support for Berachain to the Nabla Finance TVL adapters.  
Preserves the existing methodology of including all pools ever backed by the backstop pool / included in the pool hub (even if later inactive, since users can still withdraw), matching the current logic used on Arbitrum and Base.

#### Why fix?
TVL did not show for Berachain. From discord:

> the berachain fromBlock is too old and there are RPC limitation that prevent us from fetching logs from too far back, we might have to use a subgraph to solve it or possible a different rpc. Could you update it to use a subgraph instead?

#### Approach
Use on-chain calls instead of event listeners to generate the swap pool list and fetch assets for TVL calculation.

Previous PR: https://github.com/DefiLlama/DefiLlama-Adapters/pull/15995