### PR TITLE
added usdt0 to marginpool

### DIFF
--- a/projects/rysk-v12/index.js
+++ b/projects/rysk-v12/index.js
@@ -7,6 +7,7 @@ module.exports = {
       owner: '0x24a44f1dc25540c62c1196FfC297dFC951C91aB4', // marginPool
       tokens: [
         ADDRESSES.hyperliquid.WHYPE,
+        ADDRESSES.hyperliquid.USDT0,
         '0x9FDBdA0A5e284c32744D2f17Ee5c74B284993463', // UBTC
         '0xBe6727B535545C67d5cAa73dEa54865B92CF7907', // UETH
         '0x27eC642013bcB3D80CA3706599D3cdA04F6f4452', // UPUMP


### PR DESCRIPTION
Updated Rysk V12 adapter to include USDT0 as collateral for cash secured puts