### PR TITLE
Add Yield Millionaire adapter (Base, USDC)

### DIFF
--- a/projects/yield-millionaire/index.js
+++ b/projects/yield-millionaire/index.js
@@ -1,0 +1,23 @@
+const BASE_CONTRACT = "0xD4F3Ba2Fe4183c32A498Ad1ecF9Fc55308FcC029";
+const USDC_BASE = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+const AUSDC_BASE = "0x4e65fE4DbA92790696d040ac24Aa414708F5c0AB";
+ 
+
+async function tvl(api) {
+  const balance = await api.call({
+    abi: "erc20:balanceOf",
+    target: AUSDC_BASE,
+    params: [BASE_CONTRACT],
+  });
+
+  // agregamos al TVL
+  api.add(USDC_BASE, balance);
+}
+
+module.exports = {
+  methodology:
+    "Total value of all coins held in the Yield Millionaire contracts",
+  base: {
+    tvl,
+  },
+};


### PR DESCRIPTION
Added TVL adapter for Yield Millionaire.

- Chain: Base
- Token: USDC (via Aave V3)
- Contract: 0xCB513DB80C6C76593770Fc4a1827d5Ab8186b0cD
- TVL methodology: Total value of all coins held in the Yield Millionaire contracts.

## Notes
- Protocol website: https://yieldmillionaire.com
- Logo: https://www.yieldmillionaire.com/logo.webp
