### PR TITLE
numbers-protocol: add core TVL from exogenous side of staked LPs

### DIFF
--- a/projects/numbers/index.js
+++ b/projects/numbers/index.js
@@ -1,24 +1,53 @@
 const { staking } = require("../helper/staking");
 const { pool2 } = require("../helper/pool2");
+const { sumTokens2 } = require("../helper/unwrapLPs");
 
-const farmContract = "0x0cc111738b9627F6f518D746d8Ca9493E9074ABe";
-const USDC_NUM_UNIV2 = "0x22527f92f43Dc8bEa6387CE40B87EbAa21f51Df3";
-const NUM = "0x3496b523e5c00a4b4150d6721320cddb234c3079";
-
-const farmContract_bsc = "0xc0bE417Db06c4Ec2bDdD7432780AB1d47ae816Fe";
-const BUSD_NUM_CakeLP = "0x3b17F6682E8205239B5d4773CE3c1d9632743e88";
-const NUM_bsc = "0xeceb87cf00dcbf2d4e2880223743ff087a995ad9";
-
-module.exports = {
-  misrepresentedTokens: true,
+// -------- Addresses --------
+const config = {
   ethereum: {
-    tvl: (async) => ({}),
-    staking: staking(farmContract, NUM),
-    pool2: pool2(farmContract, USDC_NUM_UNIV2),   
+    farm: "0x0cc111738b9627F6f518D746d8Ca9493E9074ABe",
+    lp:   "0x22527f92f43Dc8bEa6387CE40B87EbAa21f51Df3", // USDC-NUM UniswapV2 LP
+    num:  "0x3496b523e5c00a4b4150d6721320cddb234c3079", // NUM
   },
   bsc: {
-    staking: staking(farmContract_bsc, NUM_bsc),
-    pool2: pool2(farmContract_bsc, BUSD_NUM_CakeLP),
+    farm: "0xc0bE417Db06c4Ec2bDdD7432780AB1d47ae816Fe",
+    lp:   "0x3b17F6682E8205239B5d4773CE3c1d9632743e88", // BUSD-NUM Pancake LP
+    num:  "0xeceb87cf00dcbf2d4e2880223743ff087a995ad9", // NUM on BSC
   },
-  methodology: "Counts liquidty on the staking and pool2 only",
+};
+
+// -------- Core TVL helpers --------
+// Count only the exogenous side of the LPs (exclude NUM)
+function makeChainTVL(chain) {
+  const { farm, lp, num } = config[chain];
+  return async (_, _b, _c, { api }) =>
+    sumTokens2({
+      api,
+      owners: [farm],          // farm contract holds the staked LPs
+      tokens: [lp],            // unwrap this LP
+      resolveLP: true,         // get underlying tokens
+      blacklistedTokens: [num] // exclude NUM so only USDC/BUSD are counted
+    });
+}
+
+// -------- Export --------
+module.exports = {
+  misrepresentedTokens: true,
+
+  ethereum: {
+    tvl: makeChainTVL("ethereum"),
+    staking: staking(config.ethereum.farm, config.ethereum.num),
+    pool2: pool2(config.ethereum.farm, config.ethereum.lp),
+  },
+
+  bsc: {
+    tvl: makeChainTVL("bsc"),
+    staking: staking(config.bsc.farm, config.bsc.num),
+    pool2: pool2(config.bsc.farm, config.bsc.lp),
+  },
+
+  methodology:
+    "Core TVL = non‑NUM assets (USDC on Ethereum, BUSD on BSC) derived from unwrapping the LP " +
+    "tokens staked in the farm contracts. 'staking' tracks single‑asset NUM staking and 'pool2' " +
+    "tracks full NUM‑LP staking. NUM itself is excluded from core TVL to avoid double counting.",
 };


### PR DESCRIPTION
This PR reports a positive core TVL for Numbers Protocol by summing non‑NUM assets locked in our farming contracts via staked LP tokens (USDC‑NUM on Ethereum, BUSD‑NUM on BSC). We exclude NUM itself from core TVL to avoid double counting. staking (single‑asset NUM) and pool2 (full LP value) are unchanged.

Contracts / tokens:

Ethereum

Farm: 0x0cc111738b9627F6f518D746d8Ca9493E9074ABe

LP (USDC‑NUM, UniswapV2): 0x22527f92f43Dc8bEa6387CE40B87EbAa21f51Df3

NUM: 0x3496b523e5c00a4b4150d6721320cddb234c3079

BSC

Farm: 0xc0bE417Db06c4Ec2bDdD7432780AB1d47ae816Fe

LP (BUSD‑NUM, Pancake LP): 0x3b17F6682E8205239B5d4773CE3c1d9632743e88

NUM (BSC): 0xeceb87cf00dcbf2d4e2880223743ff087a995ad9

Methodology:
Core TVL = USDC (ETH) + BUSD (BSC) balances derived from unwrapping the staked LP tokens held by the farm contracts. sumTokens2 with resolveLP: true and blacklistedTokens: [NUM] ensures only exogenous assets are counted. NUM staking remains in staking and full LP value in pool2.

**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/adapters).
> - If you would like to add a `liquidations` adapter, please refer to [this readme document](https://github.com/DefiLlama/DefiLlama-Adapters/tree/main/liquidations) for details.

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
3. Please fill the form below  **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
4. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can  edit it there and put up a PR
5. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
6. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap

---
##### Name (to be shown on DefiLlama): 


##### Twitter Link:


##### List of audit links if any:

##### Website Link:


##### Logo (High resolution, will be shown with rounded borders):


##### Current TVL:


##### Treasury Addresses (if the protocol has treasury)


##### Chain:


##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description (to be shown on DefiLlama):


##### Token address and ticker if any:


##### Category (full list at https://defillama.com/categories) *Please choose only one:


##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
##### Implementation Details: Briefly describe how the oracle is integrated into your project:
##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

##### forkedFrom (Does your project originate from another project):


##### methodology (what is being counted as tvl, how is tvl being calculated):


##### Github org/user (Optional, if your code is open source, we can track activity):