### PR TITLE
Add missing Spark Liquidity Layer's TVL sources

### DIFF
--- a/projects/spark-liquidity-layer/index.js
+++ b/projects/spark-liquidity-layer/index.js
@@ -210,7 +210,7 @@ async function addMorphoBalances(api) {
 
     const marketsData = await api.multiCall({
       abi: morphoAbi.morphoBlueFunctions.market,
-      calls: activeMarkets.filter((market) => market !== vault.idleMarketId).map((market) => ({
+      calls: activeMarkets.map((market) => ({
         target: vaultConfig.morphoSingleton,
         params: market,
       })),


### PR DESCRIPTION
- adds idle usdc balance on alm proxy on all chains
- stops counting idle market into borrowed and supplied amounts (idle amounts are already in markets)
- adds USDC value supplied to curve pool
- adds morpho spark blue chip market
- adds spark lending markets (pyusd, usdt, usdc) 