### PR TITLE
Stellar USDY accurate supply

### DIFF
--- a/projects/ondofinance/index.js
+++ b/projects/ondofinance/index.js
@@ -4,7 +4,6 @@ const sui = require("../helper/chain/sui");
 const { aQuery } = require("../helper/chain/aptos");
 const { get } = require("../helper/http");
 const {post} = require("../helper/http");
-const { getAssetSupply } = require("../helper/chain/stellar");
 
 const RIPPLE_ENDPOINT = 'https://s1.ripple.com:51234';
 

--- a/projects/ondofinance/index.js
+++ b/projects/ondofinance/index.js
@@ -116,10 +116,10 @@ Object.keys(config).forEach((chain) => {
         const ousgSupply = (await getXrplTokenBalances(XRPL_OUSG_ISSUER, XRPL_OUSG_CURRENCY)) * Math.pow(10, 6);
         api.addTokens(config.ripple.OUSG, ousgSupply);
       } else if (chain === "stellar") {
-        const usdySupply = await getAssetSupply(config.stellar.USDY);
-        // Stellar represents amounts as integers scaled by 10^7 (7 decimal places)
-        // DefiLlama expects the raw value, so we multiply by 10^7 to get the proper scale
-        api.addTokens(config.stellar.USDY, usdySupply * Math.pow(10, 7));
+        const [code, issuer] = config.stellar.USDY.split('-');
+        const res = await get(`https://api.stellar.expert/explorer/public/asset/${code}-${issuer}`);
+
+        api.addTokens(config.stellar.USDY, res.supply);
       } else {
         supplies = await api.multiCall({ abi: "erc20:totalSupply", calls: fundAddresses, })
         api.addTokens(fundAddresses, supplies);


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---
## Add Stellar Support for USDY to Ondo Finance Adapter
Fixes USDY supply pull - helper function is incorrect

### Changes
Minor fix to the USDY TVL supply pull on Stellar - just a call out that the helper function seems to be busted as it does not include supply held in DEXs

### Testing
✅ Tested with node test.js projects/ondofinance/index.js

Stellar USDY shows correct TVL: ~$608k for 559,811 tokens
All existing chains continue working
