### PR TITLE
feat(balancer-v3): add Plasma chain support

### DIFF
--- a/projects/balancer-v3/index.js
+++ b/projects/balancer-v3/index.js
@@ -8,6 +8,7 @@ const config = {
   optimism: { vault: '0xbA1333333333a1BA1108E8412f11850A5C319bA9', fromBlock: 133969439 },
   avax: { vault: '0xbA1333333333a1BA1108E8412f11850A5C319bA9', fromBlock: 59955604 },
   hyperliquid: { vault: '0xbA1333333333a1BA1108E8412f11850A5C319bA9', fromBlock: 6132445 },
+  plasma: { vault: '0xbA1333333333a1BA1108E8412f11850A5C319bA9', fromBlock: 782595 },
 }
 
 Object.keys(config).forEach(chain => {

--- a/projects/helper/chains.json
+++ b/projects/helper/chains.json
@@ -306,6 +306,7 @@
   "pg",
   "pgn",
   "planq",
+  "plasma",
   "plume",
   "plume_mainnet",
   "pokt",


### PR DESCRIPTION
## Description

This PR adds **Plasma chain support** to the existing Balancer V3 adapter.

- Added `"plasma"` to `projects/helper/chains.json`
- Extended `balancer/v3` config with Plasma vault and `fromBlock`
- Vault address: `0xbA1333333333a1BA1108E8412f11850A5C319bA9`
- `fromBlock`: `782595`

This enables DefiLlama to track Balancer V3 TVL on the Plasma chain.

---

## Type of change
- [x] Add new chain
- [x] Extend existing adapter (Balancer V3)

---

## Checklist
- [x] Added Plasma slug to `projects/helper/chains.json`
- [x] Verified Balancer V3 Vault contract on Plasma
- [x] Included correct `fromBlock`
- [x] No changes to `package-lock.json`

---

## Additional context
- Plasma explorer: [https://plasmascan.to](https://plasmascan.to)
- Chain ID: 9745
- Currency: XPL
- Balancer V3 canonical vault is deployed with the same CREATE2 address across chains.

---

## Not a new protocol listing
This PR is **not** adding a new protocol — just extending an existing adapter.  
Therefore, fields such as Twitter, audits, logo, etc. are not applicable.
