### PR TITLE
feat: added the qubic-monero-mining tvl

### DIFF
--- a/projects/qubic-monero-mining/index.js
+++ b/projects/qubic-monero-mining/index.js
@@ -1,0 +1,11 @@
+const RPC_ENDPOINT = "https://rpc.qubic.org"
+
+module.exports = {
+    timetravel: false, 
+    qubic: { 
+      tvl: async () => {
+        const res = await fetch(`${RPC_ENDPOINT}/v1/latest-stats/`).then(r => r.json());
+        return {'coingecko:qubic-network': res.data.burnedQus}
+      }
+    },
+  };


### PR DESCRIPTION
##### Name (to be shown on DefiLlama): 
Qubic-Monero-Mining-Profit

##### Twitter Link:
There is no at the moment.

##### List of audit links if any:

##### Website Link:
https://qpools.qubicdisciple.info/

##### Logo (High resolution, will be shown with rounded borders):
https://qubic.org/brand-kit

##### Current TVL:
252.8M USD

##### Treasury Addresses (if the protocol has treasury)
There is no treasury.

##### Chain:
Qubic

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): qubic-network


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): 29169

##### Short Description (to be shown on DefiLlama):
This is the total amount burnt by mining the monero
