### PR TITLE
add Morpheus adapter with V1 + V2 support

### DIFF
--- a/projects/MorpheusAI/index.js
+++ b/projects/MorpheusAI/index.js
@@ -1,26 +1,88 @@
+// DefiLlama SDK adapter — Morpheus (Capital V1 + V2 combined)
+//
+// Logic:
+// • Before MIGRATION_TS: TVL = stETH balance on the legacy V1 contract
+// • From MIGRATION_TS onwards: TVL = Distributor balances (V2):
+//    - direct balances (stETH + any idle USDC/USDT/WETH/WBTC)
+//    - aTokens held by Distributor (for AAVE strategies)
+
+const { sumTokens2 } = require('../helper/unwrapLPs')
 const ADDRESSES = require('../helper/coreAssets.json')
-const STETH_CONTRACT = ADDRESSES.ethereum.STETH;
-const PROJECT_CONTRACT = '0x47176B2Af9885dC6C4575d4eFd63895f7Aaa4790';
 
-async function tvl(_, __, ___, { api }) {
-  const stEthBalance = await api.call({
-    abi: 'erc20:balanceOf',
-    target: STETH_CONTRACT,
-    params: [PROJECT_CONTRACT],
-  });
+// ---------- Constants ----------
 
-  api.add(STETH_CONTRACT, stEthBalance);
+// V1 (legacy contract that held stETH)
+const V1_STETH_HOLDER = '0x47176B2Af9885dC6C4575d4eFd63895f7Aaa4790'
+
+// V2
+// Source of truth: https://gitbook.mor.org/smart-contracts/documentation/distribution-protocol/deployed-contracts
+const DISTRIBUTOR = '0xDf1AC1AC255d91F5f4B1E3B4Aef57c5350F64C7A'
+
+// Supported deposit tokens in Capital V2
+const TOKENS = {
+  STETH: ADDRESSES.ethereum.STETH, // strategy: NONE
+  USDC:  ADDRESSES.ethereum.USDC,  // strategy: AAVE
+  USDT:  ADDRESSES.ethereum.USDT,  // strategy: AAVE
+  WETH:  ADDRESSES.ethereum.WETH,  // strategy: AAVE
+  WBTC:  ADDRESSES.ethereum.WBTC,  // strategy: AAVE
+}
+
+// Migration timestamp: "stETH was moved from V1 to V2"
+const MIGRATION_TS = 1758210107
+
+// Minimal ABIs
+const abi = {
+  // Distributor -> Aave v3 data provider
+  aavePoolDataProvider: 'function aavePoolDataProvider() view returns (address)',
+  // Aave v3 data provider
+  getReserveTokensAddresses:
+    'function getReserveTokensAddresses(address asset) view returns (address aToken, address stableDebtToken, address variableDebtToken)',
+}
+
+async function tvl(timestamp, _ethBlock, _chainBlocks, { api }) {
+  // Historical branch: before migration, only count V1 stETH
+  if (timestamp && timestamp < MIGRATION_TS) {
+    return sumTokens2({
+      api,
+      tokensAndOwners: [[TOKENS.STETH, V1_STETH_HOLDER]],
+    })
+  }
+
+  // Active branch (>= MIGRATION_TS): count Distributor balances (V2)
+  const tokensAndOwners = []
+
+  // 1) Direct balances on Distributor
+  //    (covers stETH with NONE strategy and any temporary idle balances of other tokens)
+  const direct = [TOKENS.STETH, TOKENS.USDC, TOKENS.USDT, TOKENS.WETH, TOKENS.WBTC]
+  direct.forEach(token => tokensAndOwners.push([token, DISTRIBUTOR]))
+
+  // 2) AAVE positions: fetch aToken addresses for each underlying and count Distributor’s balances
+  const dataProvider = await api.call({ abi: abi.aavePoolDataProvider, target: DISTRIBUTOR })
+  const aaveUnderlyings = [TOKENS.USDC, TOKENS.USDT, TOKENS.WETH, TOKENS.WBTC]
+  const reserves = await api.multiCall({
+    abi: abi.getReserveTokensAddresses,
+    calls: aaveUnderlyings.map(asset => ({ target: dataProvider, params: [asset] })),
+  })
+  reserves.forEach(([aToken]) => { if (aToken) tokensAndOwners.push([aToken, DISTRIBUTOR]) })
+
+  // 3) Sum balances; DefiLlama will handle pricing and mapping aTokens to their underlyings
+  return sumTokens2({ api, tokensAndOwners })
 }
 
 module.exports = {
   timetravel: true,
   misrepresentedTokens: false,
-  methodology: 'Calculates TVL based on stETH deposits in the project contract.',
-  start: '2024-02-08',  // Feb-08-2024 07:33:35 AM UTC in Unix timestamp
-  ethereum: {
-    tvl
-  },
+  methodology:
+    'TVL =\n' +
+    ' • before migration: stETH balance on the V1 contract;\n' +
+    ' • after migration: direct balances on the Distributor (stETH + idle USDC/USDT/WETH/WBTC) + aTokens held by Distributor for AAVE strategies.\n' +
+    'In Capital V2, deposits are not stored in DepositPool — they are routed to the Distributor and then into strategies (e.g., Aave).',
+  // Full project history starting from Fair Launch (V1)
+  start: 1707350400, // 2024-02-08 00:00:00 UTC — start of TVL history (Fair Launch)
   hallmarks: [
-    [1712400000, "MOR token launch"],  // May-08-2024 12:00:00 AM UTC in Unix timestamp
+    [1707350400, 'MOR token launch (Feb-08-2024)'],
+    [1758107291, 'Capital V2 contracts deployed'],
+    [1758210107, 'stETH migrated from V1 to V2'],
   ],
-};
+  ethereum: { tvl },
+}


### PR DESCRIPTION
**Description**
Adds a new Morpheus adapter that supports both Capital V1 (stETH-only) and Capital V2 (multi-asset).
Before migration (Feb 2024 → Sep 2025): TVL = stETH balance on the legacy V1 contract.
After migration (Sep-17-2025, 08:28 UTC): TVL = balances held by the V2 Distributor contract, including:
Direct stETH (NONE strategy)
aTokens (USDC, USDT, WETH, WBTC) held by Distributor for AAVE strategies

**Notes**
Uses sumTokens2 and SDK helpers.
Correct start date set to Feb-08-2024 (Fair Launch).
Includes hallmarks for MOR token launch, V2 deployment, and stETH migration.