### PR TITLE
add partner vault

### DIFF
--- a/projects/doppler-finance/index.js
+++ b/projects/doppler-finance/index.js
@@ -2,6 +2,7 @@ const ADDRESSES = require('../helper/coreAssets.json');
 const axios = require('axios');
 
 const DOPPLER_API_URL = "https://api.doppler.finance/v2/staking-info";
+const DOPPLER_PARTNER_API_URL = "https://partner.doppler.finance";
 const XRPL = "xrpl";
 const ETHEREUM = "ethereum";
 const XRPL_RLUSD_ADDRESS = "524C555344000000000000000000000000000000.rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De";
@@ -12,7 +13,12 @@ const ETHEREUM_RLUSD_ADDRESS = "0x8292Bb45bf1Ee4d140127049757C2E0fF06317eD";
 // rp53vxWXuEe9LL6AHcCtzzAvdtynSL1aVM: Ceffu, Under Ceffu custody, the assets in this wallet can be delegated to Binance. Once the delegation is complete, the balance is no longer recorded on-chain for this wallet.
 // Ceffu is similar to CEX wallets, making it impossible to track Doppler's balance on-chain
 // Our api response is sum of fireblocks and ceffu balances
+
+// Partner Vault
+// rDkfnysh6MmpitowwYm3cEyYKzLG2zEWEX: Fireblocks, Partner Vault 1
+// rHsvjnyYoAZFajhti4mb5bhcXTxLebqpKK: Fireblocks, Partner Vault 2
 const xrplTvl = async (api) => {
+    // ### Main Vault ###
     // XRP
     const { data } = await axios.get(`${DOPPLER_API_URL}/token/XRP`);
     if (!data) {
@@ -40,6 +46,14 @@ const xrplTvl = async (api) => {
             api.add(XRPL_RLUSD_ADDRESS, total * 1e6);
         }
     }
+
+    // ### Partner Vault ###
+    const { data: partnerData } = await axios.get(`${DOPPLER_PARTNER_API_URL}/v1/bridge/vaults/balance/XRP`);
+    if (!partnerData) {
+        throw new Error('Invalid API response');
+    }
+    const { totalBalance } = partnerData;
+    api.add(XRPL_RLUSD_ADDRESS, totalBalance * 1e6);
 }
 
 const ethereumTvl = async (api) => {


### PR DESCRIPTION
We have launched a vault for institutional users in addition to the regular user vault, and its TVL will also be tracked.
We are using Fireblocks and Ceffu for this vault as well, and will submit a PR with updated addresses as they become available.

Currently, the following two vaults are in use:
- rDkfnysh6MmpitowwYm3cEyYKzLG2zEWEX: Fireblocks, Partner Vault 1
- rHsvjnyYoAZFajhti4mb5bhcXTxLebqpKK: Fireblocks, Partner Vault 2