### PR TITLE
Re-added ankr-staked-flow

### DIFF
--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -43,6 +43,9 @@ const fixBalancesTokens = {
   ozone: {
     // '0x83048f0bf34feed8ced419455a4320a735a92e9d': { coingeckoId: "ozonechain", decimals: 18 }, // was mapped to wrong chain
   },
+  flow: {
+    "0x1b97100ea1d7126c4d60027e231ea4cb25314bdb": { coingeckoId: "ankr-staked-flow", decimals: 18 },
+  },
   camp: {
     [ADDRESSES.camp.WCAMP]: { coingeckoId: "camp-network", decimals: 18 }, // Wrapped CAMP (ERC-20 wrapper of native CAMP)
     [ADDRESSES.camp.ETH]: { coingeckoId: "ethereum", decimals: 18 }, // Wrapped ETH


### PR DESCRIPTION
re-added 'ankr-staked-flow' which had been removed by another PR

Missing balance for the token:
Ankr Staked FLOW EVM: flow:0x1b97100ea1d7126c4d60027e231ea4cb25314bdb

Previous [PR](https://github.com/DefiLlama/DefiLlama-Adapters/pull/16214) had been rejected as the token should be priced via [this](https://coins.llama.fi/prices/current/flow:0x1b97100ea1d7126c4d60027e231ea4cb25314bdb), but that doesn't seem to be the case anymore and ~$20m ANKRFLOWEVM TVL is not being counted in DeFi Llama currently.

Ref: https://coins.llama.fi/prices/current/flow:0x1b97100ea1d7126c4d60027e231ea4cb25314bdb
<img width="783" height="159" alt="Screenshot 2025-09-22 at 09 45 33" src="https://github.com/user-attachments/assets/21d0af6d-f171-46d5-8a50-cded9e475b75" />
