### PR TITLE
Added oxium vaults v2 TVL

### DIFF
--- a/projects/oxium/index.js
+++ b/projects/oxium/index.js
@@ -13,6 +13,7 @@ const abi = {
   openMarkets: "function openMarkets() view returns ((address,address,uint256)[])",
   offerList: "function offerList((address,address,uint256),uint256,uint256) view returns (uint256,uint256[],(uint256,uint256,int256,uint256)[],(address,uint256,uint256,uint256)[])",
   getUnderlyingBalances: "function getUnderlyingBalances() public view returns (uint256 baseAmount, uint256 quoteAmount)",
+  totalBalances: "function totalBalances() public view returns (uint256 baseAmount, uint256 quoteAmount)",
 }
 
 
@@ -20,6 +21,14 @@ const query = (chainId) => `
 query DefiLlama {
 	mangroveVaults (where:{chainId:${chainId}}) {
     items {
+      address
+      baseAddress
+      quoteAddress
+      kandelAddress
+    }
+  }
+  vaultsV2s (where:{chainId:${chainId}}) {
+    items{
       address
       baseAddress
       quoteAddress
@@ -35,23 +44,30 @@ module.exports = {
   doublecounted: true,  // tokens are kept in yei vault to get the yield
 }
 
+async function getBalances(api, items, vaultMakers, version) {
+  const balances = await api.multiCall({ abi: version === 1 ? abi.getUnderlyingBalances : abi.totalBalances, calls: items.map(vault => vault.address) })
+  balances.forEach((bals, i) => {
+    const { baseAddress, quoteAddress, kandelAddress } = items[i]
+    vaultMakers.add(kandelAddress.toLowerCase())
+
+    api.add(baseAddress.toLowerCase(), bals.baseAmount)
+    api.add(quoteAddress.toLowerCase(), bals.quoteAmount)
+  })
+}
+
 Object.keys(config).forEach(chain => {
   const configEntry = config[chain]
   module.exports[chain] = {
     tvl: async (api) => {
-
       // vault tvl
-      const { mangroveVaults: { items } } = await cachedGraphQuery(`oxium-vaults-${configEntry.chainId}`, configEntry.api_url, query(configEntry.chainId))
+      const { mangroveVaults: { items: itemsV1 }, vaultsV2s: { items: itemsV2 } } = await cachedGraphQuery(`oxium-vaults-v2-${configEntry.chainId}`, configEntry.api_url, query(configEntry.chainId))
+      
       const vaultMakers = new Set()
-      const vaultBals = await api.multiCall({ abi: abi.getUnderlyingBalances, calls: items.map(vault => vault.address) })
-      vaultBals.forEach((bals, i) => {
-        const { baseAddress, quoteAddress, kandelAddress } = items[i]
-        vaultMakers.add(kandelAddress.toLowerCase())
-
-        api.add(baseAddress.toLowerCase(), bals.baseAmount)
-        api.add(quoteAddress.toLowerCase(), bals.quoteAmount)
-      })
-
+      
+      await Promise.all([
+        getBalances(api, itemsV1, vaultMakers, 1),
+        getBalances(api, itemsV2, vaultMakers, 2)
+      ])
 
       // book tvl
       const openMarkets = await api.call({ target: configEntry.reader, abi: abi.openMarkets, })


### PR DESCRIPTION
## Updated Oxium: added vaults V2 TVL

Oxium recently created Vaults V2, and we need to index these new vaults TVL. The integration is mostly the same as on vaults V1 for the adapter, So I created a function to avoid code repetition.

The same way as before, our indexer is only used here to gather the list of vaults, but the TVL is then queried on-chain.