### PR TITLE
feat: Add Forgeyields tvl adapter

### DIFF
--- a/projects/forgeyields/index.js
+++ b/projects/forgeyields/index.js
@@ -1,7 +1,7 @@
 const { getConfig } = require('../helper/cache')
 const { get } = require('../helper/http')
 const ADDRESSES = require('../helper/coreAssets.json');
-const { call } = require('../helper/chain/starknet');
+const { multiCall } = require('../helper/chain/starknet');
 
 const totalAssetsABI = {
   "type": "function",
@@ -32,18 +32,33 @@ const totalAssetsProvider = "0x2d0ee5bf4445712c414d58544c9d522a537e4292fa3c3ad36
 
 async function tvl(api) {
   const strategies = await getConfig('forgeyields', undefined, { fetcher })
-  for (let index = 0; index < strategies.length; index++) {
-    const strategyInfo = strategies[index];
+  
+  const calls = strategies
+    .map(strategyInfo => {
+      const tokenGateway = strategyInfo.token_gateway_per_domain
+        .find(domain => domain.domain === 'starknet')
+        ?.token_gateway;
+      return {
+        abi: totalAssetsABI,
+        target: totalAssetsProvider,
+        params: [tokenGateway]
+      }
+    })
+    .filter(call => call.params[0])
+
+  const totalAssets = await multiCall({ calls })
+  
+  let callIndex = 0
+  for (const strategyInfo of strategies) {
     const tokenGateway = strategyInfo.token_gateway_per_domain
-    .find(domain => domain.domain === 'starknet')
-    ?.token_gateway;
-    const totalAssets = await call({
-      abi: totalAssetsABI,
-      target: totalAssetsProvider,
-      params: [tokenGateway]
-    });
-    const underlying = ADDRESSES.starknet[strategyInfo.underlyingSymbol]
-    api.add(underlying, totalAssets)
+      .find(domain => domain.domain === 'starknet')
+      ?.token_gateway;
+    
+    if (tokenGateway) {
+      const underlying = ADDRESSES.starknet[strategyInfo.underlyingSymbol]
+      api.add(underlying, totalAssets[callIndex])
+      callIndex++
+    }
   }
 }
 module.exports = {

--- a/projects/forgeyields/index.js
+++ b/projects/forgeyields/index.js
@@ -1,6 +1,26 @@
 const { getConfig } = require('../helper/cache')
 const { get } = require('../helper/http')
 const ADDRESSES = require('../helper/coreAssets.json');
+const { call } = require('../helper/chain/starknet');
+
+const totalAssetsABI = {
+  "type": "function",
+  "name": "total_assets",
+  "inputs": [
+      {
+          "name": "token_gateway",
+          "type": "core::starknet::contract_address::ContractAddress"
+      }
+  ],
+  "outputs": [
+      {
+          "type": "core::integer::u256"
+      }
+  ],
+  "state_mutability": "view",
+  "customInput": "address"
+
+}
 
 
 async function fetcher() {
@@ -8,13 +28,22 @@ async function fetcher() {
   return get(apiUrl)
 }
 
+const totalAssetsProvider = "0x2d0ee5bf4445712c414d58544c9d522a537e4292fa3c3ad36e68bd177a378b8"
+
 async function tvl(api) {
   const strategies = await getConfig('forgeyields', undefined, { fetcher })
   for (let index = 0; index < strategies.length; index++) {
     const strategyInfo = strategies[index];
-    console.log(strategyInfo.tvl)
+    const tokenGateway = strategyInfo.token_gateway_per_domain
+    .find(domain => domain.domain === 'starknet')
+    ?.token_gateway;
+    const totalAssets = await call({
+      abi: totalAssetsABI,
+      target: totalAssetsProvider,
+      params: [tokenGateway]
+    });
     const underlying = ADDRESSES.starknet[strategyInfo.underlyingSymbol]
-    api.add(underlying, strategyInfo.tvl * 10 ** strategyInfo.decimals)
+    api.add(underlying, totalAssets)
   }
 }
 module.exports = {

--- a/projects/forgeyields/index.js
+++ b/projects/forgeyields/index.js
@@ -1,0 +1,25 @@
+const { getConfig } = require('../helper/cache')
+const { get } = require('../helper/http')
+const ADDRESSES = require('../helper/coreAssets.json');
+
+
+async function fetcher() {
+  const apiUrl = 'https://api.forgeyields.com/strategies'
+  return get(apiUrl)
+}
+
+async function tvl(api) {
+  const strategies = await getConfig('forgeyields', undefined, { fetcher })
+  for (let index = 0; index < strategies.length; index++) {
+    const strategyInfo = strategies[index];
+    console.log(strategyInfo.tvl)
+    const underlying = ADDRESSES.starknet[strategyInfo.underlyingSymbol]
+    api.add(underlying, strategyInfo.tvl * 10 ** strategyInfo.decimals)
+  }
+}
+module.exports = {
+  methodology: 'Compute the total assets under management for each strategy.',
+  starknet: {
+    tvl
+  },
+}


### PR DESCRIPTION
##### Name (to be shown on DefiLlama): 
ForgeYields

##### Twitter Link:
https://x.com/ForgeYields

##### List of audit links if any:
https://forge-labs.gitbook.io/forge-docs/audits

##### Website Link:
https://app.forgeyields.com

##### Logo (High resolution, will be shown with rounded borders):
https://pink-implicit-dormouse-609.mypinata.cloud/ipfs/bafkreiaq5ytqwofdzfiaknbqheb2ihkukbtxsn3xztcwwf473hw3veoyey

##### Current TVL:
119099.46

##### Treasury Addresses (if the protocol has treasury)
Not yet

##### Chain:
Starknet

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): 

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): 

##### Short Description (to be shown on DefiLlama):
ForgeYields is a cross-chain yield aggregator. Users deposit into token gateways across multiple chains, and assets are netted and allocated into yield strategies (Curve, Convex, lending protocols, etc.) on Ethereum L1 and L2s.

##### Token address and ticker if any:

##### Category (full list at https://defillama.com/categories) *Please choose only one:
11 - Onchain Capital Allocator

##### Oracle Provider(s): 
##### Implementation Details: 
##### Documentation/Proof: 
##### forkedFrom: 

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL = total user deposits held across Starknet entry buffers + liquidity allocated in cross-chain strategies.  

Because deposits can originate from multiple token gateways across several chains, TVL is currently fetched via our API for accuracy. We understand this is not the standard approach, but given the complexity we would like to request an exception. We are happy to provide proofs (on-chain data and allocation reports) to validate TVL.  

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/ForgeYields
