### PR TITLE
perf(uniswap): use Oku pool query for Nibiru since it's accurate and runs locally with test.js

### DIFF
--- a/projects/uniswap/index.js
+++ b/projects/uniswap/index.js
@@ -79,7 +79,6 @@ module.exports = {
     telos: { factory: "0xcb2436774C3e191c85056d248EF4260ce5f27A9D", fromBlock: 386633562 },
     goat: { factory: "0xcb2436774C3e191c85056d248EF4260ce5f27A9D", fromBlock: 848385 },
     hemi: { factory: "0x346239972d1fa486FC4a521031BC81bFB7D6e8a4", fromBlock: 1293598 },
-    nibiru: { factory: "0x346239972d1fa486FC4a521031BC81bFB7D6e8a4", fromBlock: 23658062 },
     sonic: { factory: "0xcb2436774C3e191c85056d248EF4260ce5f27A9D", fromBlock: 322744 },
     unichain: { factory: "0x1F98400000000000000000000000000000000003", fromBlock: 1 },
     lightlink_phoenix: { factory: "0xcb2436774C3e191c85056d248EF4260ce5f27A9D", fromBlock: 131405097 },
@@ -103,6 +102,7 @@ chains.forEach(chain => {
 const okuGraphMap = {
   filecoin: 'https://omni.v2.icarus.tools/filecoin',
   rsk: 'https://omni.v2.icarus.tools/rootstock',
+  nibiru: 'https://omni.v2.icarus.tools/nibiru', // nibiru: { factory: "0x346239972d1fa486FC4a521031BC81bFB7D6e8a4", fromBlock: 23658062 },
   saga: 'https://omni.v2.icarus.tools/saga',
   sei: 'https://omni.v2.icarus.tools/sei',
   // lightlink_phoenix: 'https://omni.v2.icarus.tools/lightlink',


### PR DESCRIPTION
## Purpose

The Uniswap deployment on Nibiru is powered by Oku, meaning we can use the
Oku-based helper function return all of the pools instead of iterating across
thousands of blocks and calling `getLogs`.

### Evidence

Re-running with the Oku pool request shows all of the pools on Nibiru
(2025-09-22): 

Validated these againt the active pool set found on Oku: https://oku.trade/info/nibiru/pools 

<img width="948" height="733" alt="25-09-22__549-chrome" src="https://github.com/user-attachments/assets/a76e9e9d-3e16-410f-b465-6b8f50536896" />


<details>
<summary>

\[Result from `node test.js projects/uniswap/index.js 2>&1`\]

</summary>

*Produced from console logging `ownerTokens` when `chain === "nibiru"`*.

```
  ownerTokens: [
    [
      [
        '0x0829f361a05d993d5ceb035ca6df3446b060970b',
        '0xca0a9fb5fbf692fa12fd13c0a900ec56bb3f0a7b',
        [length]: 2
      ],
      '0x9fe58f1883732931625c281afe2a068fe19183f5',
      [length]: 2
    ],
    [
      [
        '0x0cacf669f8446beca826913a3c6b96acd4b02a97',
        '0xca0a9fb5fbf692fa12fd13c0a900ec56bb3f0a7b',
        [length]: 2
      ],
      '0x0085a09e68468a99c6ec3c0c9c98e17af614c470',
      [length]: 2
    ],
    [
      [
        '0x0829f361a05d993d5ceb035ca6df3446b060970b',
        '0x0cacf669f8446beca826913a3c6b96acd4b02a97',
        [length]: 2
      ],
      '0xd8f82b8d2e82265ac25d8d4ef3ca47917693d3d5',
      [length]: 2
    ],
    [
      [
        '0xca0a9fb5fbf692fa12fd13c0a900ec56bb3f0a7b',
        '0xcda5b77e2e2268d9e09c874c1b9a4c3f07b37555',
        [length]: 2
      ],
      '0x9475b76b7f77791b6147cb989187fecd9b55398a',
      [length]: 2
    ],
    [
      [
        '0x9568f2afd09d845d48cf999244e18b1a9467eadb',
        '0xca0a9fb5fbf692fa12fd13c0a900ec56bb3f0a7b',
        [length]: 2
      ],
      '0xd66ecd109743868c89d7fc07d783224ec4925c25',
      [length]: 2
    ],
    [
      [
        '0x84f682626302ea7bca2a7c338b84863292131319',
        '0xf4e097e36d2064e2bdca96e60439f3a369522003',
        [length]: 2
      ],
      '0x5649dfd613bb0675e1b41cc8f4ba82832e700e0d',
      [length]: 2
    ],
    [
      [
        '0x9568f2afd09d845d48cf999244e18b1a9467eadb',
        '0xd59be1da2e9b30b6f7ab27b2d08f841b39c349fa',
        [length]: 2
      ],
      '0xb4a474d0d93663073ce54fa8f60204b777b3c3a3',
      [length]: 2
    ],
    [
      [
        '0x0cacf669f8446beca826913a3c6b96acd4b02a97',
        '0x43f2376d5d03553ae72f4a8093bbe9de4336eb08',
        [length]: 2
      ],
      '0x43960e914a8e8714b9708971729125a1dcc00308',
      [length]: 2
    ],
    [
      [
        '0xca0a9fb5fbf692fa12fd13c0a900ec56bb3f0a7b',
        '0xd59be1da2e9b30b6f7ab27b2d08f841b39c349fa',
        [length]: 2
      ],
      '0x946f30cddda25bc4523147371ec0be69d5043648',
      [length]: 2
    ],
    [
      [
        '0x0829f361a05d993d5ceb035ca6df3446b060970b',
        '0x84f682626302ea7bca2a7c338b84863292131319',
        [length]: 2
      ],
      '0x5133222db1e9f1b98d16e5fb46d6f398c60998e2',
      [length]: 2
    ],
    [
      [
        '0x0829f361a05d993d5ceb035ca6df3446b060970b',
        '0xf4e097e36d2064e2bdca96e60439f3a369522003',
        [length]: 2
      ],
      '0x8e730a8dfc9fa849130a0b784417ab258b646926',
      [length]: 2
    ],
    [
      [
        '0x1d1715ece22a6ab6349196e7054e61de3ac2ea3d',
        '0xcda5b77e2e2268d9e09c874c1b9a4c3f07b37555',
        [length]: 2
      ],
      '0x9aed04abec56eafaebc536ca89060cc2721934b2',
      [length]: 2
    ],
    [
      [
        '0x1d1715ece22a6ab6349196e7054e61de3ac2ea3d',
        '0xcda5b77e2e2268d9e09c874c1b9a4c3f07b37555',
        [length]: 2
      ],
      '0xe7612e14a05613caf06fad766b484b0a6d146c3a',
      [length]: 2
    ],
    [length]: 13
  ]
```

</details>

## Related

- https://github.com/DefiLlama/defillama-server/pull/10669 - Fixing this one should get rid of the underreported TVL for sUSDa