### PR TITLE
Include USDS/PYUSD curve pool allocation to Spark's TVL

### DIFF
--- a/projects/spark-liquidity-layer/index.js
+++ b/projects/spark-liquidity-layer/index.js
@@ -253,6 +253,14 @@ const curveConfigs = {
       address: '0x00836Fe54625BE242BcFA286207795405ca4fD10',
       coinIndex: 1,
     },
+    {
+      address: '0xA632D59b9B804a956BfaA9b48Af3A1b74808FC1f',
+      coinIndex: 0,
+    },
+    {
+      address: '0xA632D59b9B804a956BfaA9b48Af3A1b74808FC1f',
+      coinIndex: 1,
+    },
   ],
   base: [],
   arbitrum: [],


### PR DESCRIPTION
Spark Liquidity Layer now supplies funds into [USDS/PYUSD curve pool](https://etherscan.io/address/0xA632D59b9B804a956BfaA9b48Af3A1b74808FC1f) which should be counted into TVL