### PR TITLE
Add ZealousSwap adapter for Kasplex

### DIFF
--- a/projects/helper/chains.json
+++ b/projects/helper/chains.json
@@ -214,6 +214,7 @@
   "kinto",
   "kintsugi",
   "klaytn",
+  "kasplex",      
   "kopi",
   "kroma",
   "kujira",

--- a/projects/helper/coreAssets.json
+++ b/projects/helper/coreAssets.json
@@ -1,6 +1,9 @@
 {
   "null": "0x0000000000000000000000000000000000000000",
   "GAS_TOKEN_2": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+   "kasplex": {
+    "WKAS": "0x2c2Ae87Ba178F48637acAe54B87c3924F544a83e"
+  },
   "ethereum": {
     "WETH": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
     "WSTETH": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",

--- a/projects/zealousswap/index.js
+++ b/projects/zealousswap/index.js
@@ -5,62 +5,113 @@ const CHAIN   = 'kasplex'
 const FACTORY = '0x98Bb580A77eE329796a79aBd05c6D2F2b3D5E1bD'
 const WKAS    = '0x2c2Ae87Ba178F48637acAe54B87c3924F544a83e'.toLowerCase()
 
-// Standard UniV2 ABIs we need
 const abi = {
   allPairsLength: 'function allPairsLength() view returns (uint256)',
   allPairs:       'function allPairs(uint256) view returns (address)',
   token0:         'function token0() view returns (address)',
   token1:         'function token1() view returns (address)',
   getReserves:    'function getReserves() view returns (uint112,uint112,uint32)',
+  decimals:       'function decimals() view returns (uint8)',
 }
 
+const lower = (x) => (x || '').toLowerCase()
+
 async function tvl(_, _b, _cb, { api }) {
-  // 1) Read # of pairs
   const pairsLen = await api.call({ target: FACTORY, abi: abi.allPairsLength, chain: CHAIN })
   if (!+pairsLen) return {}
 
-  // 2) Fetch pair addresses [0 .. pairsLen-1]
-  const idx = Array.from({ length: Number(pairsLen) }, (_, i) => i)
+  const idx   = Array.from({ length: Number(pairsLen) }, (_, i) => i)
   const pairs = await api.multiCall({
-    abi: abi.allPairs, calls: idx.map(i => ({ target: FACTORY, params: [i] })), chain: CHAIN,
+    abi: abi.allPairs, calls: idx.map(i => ({ target: FACTORY, params: [i] })), chain: CHAIN
   })
 
-  // 3) Fetch token0, token1, reserves for all pairs
   const [t0, t1, res] = await Promise.all([
     api.multiCall({ abi: abi.token0, calls: pairs.map(p => ({ target: p })), chain: CHAIN }),
     api.multiCall({ abi: abi.token1, calls: pairs.map(p => ({ target: p })), chain: CHAIN }),
     api.multiCall({ abi: abi.getReserves, calls: pairs.map(p => ({ target: p })), chain: CHAIN }),
   ])
 
-  // 4) Sum TVL in KAS equivalent for pools that include WKAS
-  // For a WKAS-X pool, pool TVL in KAS ≈ 2 * reserveWKAS (AMM parity).
-  let kasWei = 0n
-  for (let i = 0; i < pairs.length; i++) {
-    const token0 = (t0[i] || '').toLowerCase()
-    const token1 = (t1[i] || '').toLowerCase()
-    const [r0, r1] = res[i] || ['0', '0']
+  const tokens = Array.from(new Set([...t0, ...t1].map(lower)))
+  const decimalsArr = await api.multiCall({
+    abi: abi.decimals,
+    calls: tokens.map(a => ({ target: a })),
+    chain: CHAIN,
+    permitFailure: true,
+  })
+  const dec = new Map(tokens.map((a, i) => [a, BigInt(decimalsArr[i] ?? 18)]))
 
-    if (token0 === WKAS) {
-      kasWei += 2n * BigInt(r0)  // 2 * WKAS side
-    } else if (token1 === WKAS) {
-      kasWei += 2n * BigInt(r1)  // 2 * WKAS side
+  // IMPORTANT: use WKAS real decimals for the unit base
+  const dW = dec.get(WKAS) ?? 18n
+  const ONE = 10n ** dW
+
+  // build edges with decimals-aware pricing
+  const edges = []
+  for (let i = 0; i < pairs.length; i++) {
+    const a0 = lower(t0[i]), a1 = lower(t1[i])
+    const [r0s, r1s] = res[i] || ['0', '0']
+    const r0 = BigInt(r0s), r1 = BigInt(r1s)
+    if (r0 === 0n || r1 === 0n) continue
+    const d0 = dec.get(a0) ?? 18n
+    const d1 = dec.get(a1) ?? 18n
+    // price(a0) in WKAS base-units: p0 = ( (r1 / 10^d1) / (r0 / 10^d0) ) * ONE
+    // => p0 = r1 * 10^(d0) * ONE / (r0 * 10^(d1))
+    edges.push({ a0, a1, r0, r1, d0, d1 })
+  }
+
+  const price = new Map([[WKAS, ONE]])
+  const MIN_ROUTE_WKAS = 500n * ONE // ignore tiny routes
+
+  let improved = true
+  for (let round = 0; improved && round < 8; round++) {
+    improved = false
+    for (const { a0, a1, r0, r1, d0, d1 } of edges) {
+      const p0 = price.get(a0)
+      const p1 = price.get(a1)
+
+      if (!p0 && p1) {
+        const p0e = (r1 * (10n ** d0) * p1) / (r0 * (10n ** d1))
+        // route liquidity in WKAS units on the known side
+        const route = (r1 * p1) / (10n ** d1)
+        if (p0e > 0n && route >= MIN_ROUTE_WKAS) { price.set(a0, p0e); improved = true }
+      } else if (!p1 && p0) {
+        const p1e = (r0 * (10n ** d1) * p0) / (r1 * (10n ** d0))
+        const route = (r0 * p0) / (10n ** d0)
+        if (p1e > 0n && route >= MIN_ROUTE_WKAS) { price.set(a1, p1e); improved = true }
+      }
     }
   }
 
-  // 5) Report as whole KAS tokens (NOT wei) under coingecko:kaspa
-  const DECIMALS = 18n
-  const SCALE = 10n ** DECIMALS
-  const kasTokens = kasWei / SCALE
-
-  if (kasTokens > 0n) {
-    sdk.util.sumSingleBalance(api.getBalances(), 'coingecko:kaspa', kasTokens.toString())
+  // sum TVL in WKAS base units: sum( reserve_i/10^di * price_i )
+  let wkasTotal = 0n
+  for (const { a0, a1, r0, r1, d0, d1 } of edges) {
+    const p0 = price.get(a0), p1 = price.get(a1)
+    if (p0) wkasTotal += (r0 * p0) / (10n ** d0)
+    if (p1) wkasTotal += (r1 * p1) / (10n ** d1)
   }
+
+  // convert to whole KAS for llama balance (divide by WKAS decimals)
+  const kasWhole = wkasTotal / ONE
+
+  // sanity guard to avoid accidental 1e12x reports
+  if (kasWhole > 10_000_000_000n) {
+    // if something goes off the rails, fall back to raw balances to avoid bad PRs
+    for (let i = 0; i < pairs.length; i++) {
+      const a0 = lower(t0[i]), a1 = lower(t1[i])
+      const [R0, R1] = res[i] || ['0','0']
+      sdk.util.sumSingleBalance(api.getBalances(), `${CHAIN}:${a0}`, R0.toString())
+      sdk.util.sumSingleBalance(api.getBalances(), `${CHAIN}:${a1}`, R1.toString())
+    }
+    return api.getBalances()
+  }
+
+  if (kasWhole > 0n)
+    sdk.util.sumSingleBalance(api.getBalances(), 'coingecko:kaspa', kasWhole.toString())
 
   return api.getBalances()
 }
 
 module.exports = {
   misrepresentedTokens: true,
-  methodology: 'TVL = sum of ZealousSwap V2 pools on Kasplex that pair against WKAS, valued via KAS (KASPA).',
+  methodology: 'Prices tokens in WKAS using actual token decimals; TVL = sum(reserve/10^dec * price) in KAS.',
   kasplex: { tvl },
 }

--- a/projects/zealousswap/index.js
+++ b/projects/zealousswap/index.js
@@ -1,0 +1,66 @@
+// projects/zealousswap/index.js
+const sdk = require('@defillama/sdk')
+
+const CHAIN   = 'kasplex'
+const FACTORY = '0x98Bb580A77eE329796a79aBd05c6D2F2b3D5E1bD'
+const WKAS    = '0x2c2Ae87Ba178F48637acAe54B87c3924F544a83e'.toLowerCase()
+
+// Standard UniV2 ABIs we need
+const abi = {
+  allPairsLength: 'function allPairsLength() view returns (uint256)',
+  allPairs:       'function allPairs(uint256) view returns (address)',
+  token0:         'function token0() view returns (address)',
+  token1:         'function token1() view returns (address)',
+  getReserves:    'function getReserves() view returns (uint112,uint112,uint32)',
+}
+
+async function tvl(_, _b, _cb, { api }) {
+  // 1) Read # of pairs
+  const pairsLen = await api.call({ target: FACTORY, abi: abi.allPairsLength, chain: CHAIN })
+  if (!+pairsLen) return {}
+
+  // 2) Fetch pair addresses [0 .. pairsLen-1]
+  const idx = Array.from({ length: Number(pairsLen) }, (_, i) => i)
+  const pairs = await api.multiCall({
+    abi: abi.allPairs, calls: idx.map(i => ({ target: FACTORY, params: [i] })), chain: CHAIN,
+  })
+
+  // 3) Fetch token0, token1, reserves for all pairs
+  const [t0, t1, res] = await Promise.all([
+    api.multiCall({ abi: abi.token0, calls: pairs.map(p => ({ target: p })), chain: CHAIN }),
+    api.multiCall({ abi: abi.token1, calls: pairs.map(p => ({ target: p })), chain: CHAIN }),
+    api.multiCall({ abi: abi.getReserves, calls: pairs.map(p => ({ target: p })), chain: CHAIN }),
+  ])
+
+  // 4) Sum TVL in KAS equivalent for pools that include WKAS
+  // For a WKAS-X pool, pool TVL in KAS ≈ 2 * reserveWKAS (AMM parity).
+  let kasWei = 0n
+  for (let i = 0; i < pairs.length; i++) {
+    const token0 = (t0[i] || '').toLowerCase()
+    const token1 = (t1[i] || '').toLowerCase()
+    const [r0, r1] = res[i] || ['0', '0']
+
+    if (token0 === WKAS) {
+      kasWei += 2n * BigInt(r0)  // 2 * WKAS side
+    } else if (token1 === WKAS) {
+      kasWei += 2n * BigInt(r1)  // 2 * WKAS side
+    }
+  }
+
+  // 5) Report as whole KAS tokens (NOT wei) under coingecko:kaspa
+  const DECIMALS = 18n
+  const SCALE = 10n ** DECIMALS
+  const kasTokens = kasWei / SCALE
+
+  if (kasTokens > 0n) {
+    sdk.util.sumSingleBalance(api.getBalances(), 'coingecko:kaspa', kasTokens.toString())
+  }
+
+  return api.getBalances()
+}
+
+module.exports = {
+  misrepresentedTokens: true,
+  methodology: 'TVL = sum of ZealousSwap V2 pools on Kasplex that pair against WKAS, valued via KAS (KASPA).',
+  kasplex: { tvl },
+}


### PR DESCRIPTION
## ZealousSwap TVL Adapter (Kasplex)

This PR adds a TVL adapter for [ZealousSwap](https://zealousswap.com) on the **Kasplex** chain.

- **Factory:** `0x98Bb580A77eE329796a79aBd05c6D2F2b3D5E1bD`
- **Wrapped KAS (WKAS):** `0x2c2Ae87Ba178F48637acAe54B87c3924F544a83e`
- **Methodology:** TVL is calculated from all pair reserves. Token prices are derived in KAS by routing through WKAS (with decimals support). Pairs with no WKAS route are conservatively excluded.
- **Chain:** kasplex

### Example Output
```bash
node test.js projects/zealousswap
--- kasplex ---
KAS                       576.60 k
Total: 576.60 k
