### PR TITLE
Unix timestamp fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ If you have any suggestions, want to contribute or want to chat, please join [ou
 ```bash
 node test.js projects/pangolin/index.js
 # Add a timestamp at the end to run the adapter at a historical timestamp
-node test.js projects/aave/v3.js 1729080692
+node test.js projects/aave-v3/index.js 1729080692
 # or using YYYY-MM-DD
-node test.js projects/aave/v3.js 2024-10-16
+node test.js projects/aave-v3/index.js 2024-10-16
 ```
 
 ## Changing RPC providers

--- a/test.js
+++ b/test.js
@@ -138,7 +138,7 @@ function validateHallmarks(hallmark) {
 
   let unixTimestamp = Math.round(Date.now() / 1000) - 60;
   let chainBlocks = {}
-  const passedTimestamp = process.argv[3] ? Math.floor(new Date(process.argv[3]) / 1000) : undefined
+  const passedTimestamp = process.argv[3] ? (isNaN(process.argv[3]) ? Math.floor(new Date(process.argv[3]) / 1000) : parseInt(process.argv[3])) : undefined
   if (passedTimestamp !== undefined) {
     unixTimestamp = Number(passedTimestamp)
 


### PR DESCRIPTION
Fixed the Unix timestamp issue to get historical data (#16493 )

`node test.js projects/aave-v3/index.js 1729080692`

<img width="272" height="34" alt="image" src="https://github.com/user-attachments/assets/d796a5b2-9cf0-4cec-ac52-fb47c39bc16c" />

Also fixed the path for Aave v3 in the Readme for testing