### PR TITLE
SwissBorg: Add new wallet

### DIFF
--- a/projects/swissborg/index.js
+++ b/projects/swissborg/index.js
@@ -32,6 +32,7 @@ const config = {
       '0x85AC393adDd65bcf6Ab0999F2a5c064E867F255f',
       '0x0926a7b610B9Fc2D1E3F09FcBa52Ba3BEDCFfd91',
       '0x49841B9bb1dc499B36C4F618bf8feAC85fDFE889',
+      '0xaCA8FB892Ac27d2f84Fa78EDb32F3AD221538c3e',
     ],
   },
   bitcoin: {


### PR DESCRIPTION
This PR updates the list of wallets owned by SwissBorg. New wallets addition:
https://github.com/SwissBorg/pub/commit/de5cc5de1c9cffe14f97d06b2c7e94b5d34bd152