### PR TITLE
add shibaswap v2

### DIFF
--- a/projects/shibaswap-v2/index.js
+++ b/projects/shibaswap-v2/index.js
@@ -1,0 +1,8 @@
+const { uniV3Export } = require('../helper/uniswapV3')
+
+module.exports = uniV3Export({
+    ethereum: { factory: "0xD9CE49caf7299DaF18ffFcB2b84a44fD33412509", fromBlock: 21036458 },
+    shibarium: {
+        factory: "0x2996B636663ddeBaE28742368ed47b57539C9600", fromBlock: 7518119
+    },
+})


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/adapters).
> - If you would like to add a `liquidations` adapter, please refer to [this readme document](https://github.com/DefiLlama/DefiLlama-Adapters/tree/main/liquidations) for details.

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
3. Please fill the form below  **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
4. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can  edit it there and put up a PR
5. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
6. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap

---


Add TVL tracking for [Shibaswap's V2](https://docs.shib.io/shibaswap/shibaswap-v2/overview) contracts, which are forked from Uniswap V3 (While Shibaswap V1 forks Uniswap V2).

Note: The reported TVL on their [frontend](https://shibaswap.com/explore/pools) seems to be broken, but the [largest V2 pool](https://etherscan.io/address/0xaB21798D88EE0854F99F1D148c1e59f238E561Fe) holds ~$921K at the time of this PR's creation.

<img width="931" height="212" alt="image" src="https://github.com/user-attachments/assets/0cbcb530-70c3-4dfe-ac5a-a5f2afd1bbc1" />