### PR TITLE
Add dyorSwap TVL on Plasma chain

### DIFF
--- a/projects/dyorswap/index.js
+++ b/projects/dyorswap/index.js
@@ -12,6 +12,7 @@ const config = {
   sonic: '0xd8863d794520285185197F97215c8B8AD04E8815',
   soneium: '0x4f0c1b4c6FdF983f2d385Cf24DcbC8c68f345E40',
   unichain: '0x6c86ab200661512fDBd27Da4Bb87dF15609A2806',
+  plasma: '0xA9F2c3E18E22F19E6c2ceF49A88c79bcE5b482Ac',
 }
 
 module.exports = {


### PR DESCRIPTION
**Protocol:** dyorSwap (UniV2 fork) on Plasma
  **Factory:** 0xA9F2c3E18E22F19E6c2ceF49A88c79bcE5b482Ac
  **StartBlock (first PairCreated):** 1,871,833

  **Changes:**
  - Add Plasma chain to existing dyorSwap TVL adapter
  - Factory address verified on-chain
  - Follows existing pattern for multi-chain config (getUniTVL helper)

  **Methodology:**
  - TVL from all dyorSwap V2 pools on Plasma via factory enumeration
  - Sum of both token balances held by each pair contract (no double-counting)
  - USD conversion is handled by the Llama price engine (unpriced tokens = $0 until mapped)

  **Notes:**
  - Local validation uses WXPL + stables as anchors → lower-bound vs production
  - No filtering: all pools from the factory are included

  **Validation (local run – example log to illustrate):**
  pairsFound=9348
  pools_with_value=1692/9348
  best_WXPL_USDT0_pool=0x61ce327cf2256690e83d6252de99b000278c5cc6
  WXPL_price_usd=0.865
  tvl_total_usd=~$908,873 (local estimate with limited token mapping)

  (Values may vary depending on mapping at the time of testing.)