### PR TITLE
Fix Moar TVL Calculations

### DIFF
--- a/projects/moar/index.js
+++ b/projects/moar/index.js
@@ -6,6 +6,7 @@ const addresses = {
         'moar': "0xa3afc59243afb6deeac965d40b25d509bb3aebc12f502b8592c283070abc2e07",
         'moar_lens': "0xfa3d17dfdf5037ed9b68c2c85976f899155048fdf96bc77b57ef1ad206c5b007",
         'moar_package_owner': "0x37e9ce6910ceadd16b0048250a33dac6342549acf31387278ea0f95c9057f110",
+        'goblin': "0x19bcbcf8e688fd5ddf52725807bc8bf455a76d4b5a6021cfdc4b5b2652e5cd55",
     },
 }
 
@@ -30,14 +31,45 @@ async function tvl(api, chain) {
     })
 
     for (const creditAccount of creditAccounts) {
-        const assetData = await function_view({
-            functionStr: `${addresses[chain]['moar_lens']}::lens::get_credit_account_combined_asset_amounts`,
-            args: [creditAccount],
+        try {
+            const assetData = await function_view({
+                functionStr: `${addresses[chain]['moar_lens']}::lens::get_credit_account_combined_asset_amounts`,
+                args: [creditAccount],
+                chain: chain
+            })
+            for (const asset of assetData) {
+                sdk.util.sumSingleBalance(balances, asset['asset']['inner'], asset['amount'], chain);
+            }
+        } catch (error) {
+            console.error('Failed to fetch balances for credit account', creditAccount)
+        }
+    }
+
+    // convert goblin LP tokens to their underlying tokens
+    for (const asset in balances) {
+        const metadataAddress = asset.split(":")[1]
+        let getVaultTokenResponse
+        try {
+            getVaultTokenResponse = await function_view({
+                functionStr: `0x19bcbcf8e688fd5ddf52725807bc8bf455a76d4b5a6021cfdc4b5b2652e5cd55::vaults::get_vault_token_ab`,
+                args: [metadataAddress],
+                chain: chain
+            })
+        } catch (error) {
+            // not goblin LP token; ignore
+            continue;
+        }
+        const tokenA = getVaultTokenResponse[0].inner
+        const tokenB = getVaultTokenResponse[1].inner
+
+        const [tokenABalance, tokenBBalance] = await function_view({
+            functionStr: `${addresses[chain]['goblin']}::vaults::get_token_amount_by_share`,
+            args: [metadataAddress, balances[asset]],
             chain: chain
         })
-        for (const asset of assetData) {
-            sdk.util.sumSingleBalance(balances, asset['asset']['inner'], asset['amount'], chain);
-        }
+
+        sdk.util.sumSingleBalance(balances, tokenA, tokenABalance, chain);
+        sdk.util.sumSingleBalance(balances, tokenB, tokenBBalance, chain);
     }
 
     return balances;


### PR DESCRIPTION
Updated the logic to calculate TVL. Some credit accounts held Goblin Vaults' LP tokens which cannot be priced directly. This change converts the LP tokens into the underlying tokens with their balances.