### PR TITLE
Fix: Hyperion

### DIFF
--- a/projects/hyperion/index.js
+++ b/projects/hyperion/index.js
@@ -1,51 +1,67 @@
 const { function_view } = require("../helper/chain/aptos");
 const { sleep } = require("../helper/utils");
 
+const coinInfoCache = new Map();
+const PAIRED_COIN_DELAY_MS = 1000;
+const MAX_RETRIES = 3;
+const BASE_BACKOFF_MS = 1000;
+
+const hexToUtf8 = (hexStr) => Buffer.from(String(hexStr).replace(/^0x/, ''), 'hex').toString('utf-8');
+
+const backoffMs = (i) => BASE_BACKOFF_MS * (i + 1) * (i + 1);
+
+async function callWithRetry(fn) {
+  let lastErr;
+  for (let i = 0; i <= MAX_RETRIES; i++) {
+    const sentinel = Symbol('ERR');
+    const res = await fn().catch((e) => { lastErr = e; return sentinel; });
+    if (res !== sentinel) return res;
+    if (i === MAX_RETRIES) throw lastErr;
+    await sleep(backoffMs(i));
+  }
+}
+
 async function _getPoolInfo(offset, limit) {
-  const poolInfo = await function_view({
+  return function_view({
     functionStr: "0x8b4a2c4bb53857c718a04c020b98f8c2e1f99a68b0f57389a8bf5434cd22e05c::pool_v3::all_pools_with_info",
     args: [String(offset), String(limit)],
     type_arguments: [],
   });
-
-  return poolInfo;
 }
 
 async function _getCoinInfo(faType) {
-  const coinInfo = await function_view({
-    functionStr: "0x1::coin::paired_coin",
-    args: [faType],
-    type_arguments: [],
-  });
+  if (coinInfoCache.has(faType)) return coinInfoCache.get(faType);
 
-  if (coinInfo.vec.length > 0) {
-    const address = coinInfo.vec[0].account_address;
-    const module = Buffer.from(coinInfo.vec[0].module_name.replace('0x', ''), 'hex').toString('utf-8');
-    const struct = Buffer.from(coinInfo.vec[0].struct_name.replace('0x', ''), 'hex').toString('utf-8');
+  await sleep(PAIRED_COIN_DELAY_MS);
 
-    return (address + "::" + module + "::" + struct);
-  } else {
+  const coinInfo = await callWithRetry(() =>
+    function_view({ functionStr: "0x1::coin::paired_coin", args: [faType], type_arguments: [] })
+  );
+
+  if (!coinInfo || !coinInfo.vec || coinInfo.vec.length === 0) {
+    coinInfoCache.set(faType, null);
     return null;
   }
+
+  const v = coinInfo.vec[0];
+  const out = `${v.account_address}::${hexToUtf8(v.module_name)}::${hexToUtf8(v.struct_name)}`;
+  coinInfoCache.set(faType, out);
+  return out;
 }
 
 async function getPoolInfo() {
   let offset = 0;
-  let limit = 100;
-  let poolInfo = [];
+  const limit = 100;
+  let pools = [];
   let [data, pager] = await _getPoolInfo(offset, limit);
-
-  if (data.length !== 0) {
-    poolInfo = poolInfo.concat(data);
-  }
+  if (data.length) pools = pools.concat(data);
 
   while (offset + limit < pager.total) {
     offset += limit;
     [data, pager] = await _getPoolInfo(offset, limit);
-    poolInfo = poolInfo.concat(data);
+    if (data.length) pools = pools.concat(data);
   }
-
-  return poolInfo;
+  return pools;
 }
 
 module.exports = {
@@ -54,18 +70,16 @@ module.exports = {
   methodology: "Counts the total liquidity in all pools on Hyperion.",
   aptos: {
     tvl: async (api) => {
-      const poolInfo = await getPoolInfo();
-      api.log(`Hyperion Number of pools: ${poolInfo.length}`);
+      const pools = await getPoolInfo();
+      api.log(`Hyperion Number of pools: ${pools.length}`);
 
-      for (const pool of poolInfo) {
-        const coin1 = await _getCoinInfo(pool.token_a.inner) || pool.token_a.inner;
-        const coin2 = await _getCoinInfo(pool.token_b.inner) || pool.token_b.inner;
+      for (const pool of pools) {
+        const coin1 = (await _getCoinInfo(pool.token_a.inner)) || pool.token_a.inner;
+        const coin2 = (await _getCoinInfo(pool.token_b.inner)) || pool.token_b.inner;
 
         api.add(coin1, pool.token_a_reserve);
         api.add(coin2, pool.token_b_reserve);
-        await sleep(2000); // to avoid rate limit
       }
     },
   },
 };
-


### PR DESCRIPTION
- Added a cache to avoid fetching the same token info multiple times (→ prevents rate limiting)
- Added a retry mechanism with backoff in case of rate limiting

```
--- tvl ---
APT                       34.14 M
USDC                      32.59 M
USDt                      14.29 M
amAPT                     7.84 M
xBTC                      5.73 M
kAPT                      5.13 M
TruAPT                    3.93 M
uniBTC                    3.83 M
sthAPT                    3.33 M
aBTC                      2.85 M
USD1                      1.60 M
stAPT                     1.09 M
thAPT                     927.25 k
AMI                       301.30 k
USDA                      113.48 k
MKL                       46.43 k
AURO                      3.84 k
tAPT                      13
WETH                      3
THL                       1
Total: 117.80 M

------ TVL ------
aptos                     117.80 M

total                    117.80 M
```