### PR TITLE
🐛 accommodate for new unwrapUniV4

### DIFF
--- a/projects/arcadia-finance-v2/index.js
+++ b/projects/arcadia-finance-v2/index.js
@@ -171,8 +171,13 @@ async function tvl (api) {
   // add all Arcadia-wrapped LP positions
   await unwrapArcadiaAeroLP({ api, ownerIds });
 
-  //add all native LP positions
-  return sumTokens2({ api, owners: accs, resolveUniV3: true, resolveSlipstream: true, resolveUniV4: true, uniV4ExtraConfig: {"positionIds":uniV4Ids}})
+  // add all native LP positions
+  // first add all uniswap v4 positions, without the owner(s) param
+  // only call sumTokens2 if any uniswapv4 position is found, otherwise it will throw an error
+  if (uniV4Ids.length > 0) {
+    await sumTokens2({ api, resolveUniV4: true, uniV4ExtraConfig: {"positionIds":uniV4Ids}})
+  }
+  return sumTokens2({ api, owners: accs, resolveUniV3: true, resolveSlipstream: true})
 }
 
 module.exports = {


### PR DESCRIPTION
Some changes were made in how the unwrapping of Uniswap V4 is done
https://github.com/DefiLlama/DefiLlama-Adapters/blob/e2bb738d5121d9a2964d9f6c7fa758ed7cd57d25/projects/helper/unwrapLPs.js#L116

This caused 2 issues for the Arcadia adaptor:

- By providing the 'owners' param, the function would revert
- In case an empty uniV4ExtraConfig.positionIds is given, and 'owner' isn't provided

```ts
if (!commonConfig.uniV4ExtraConfig.positionIds?.length) { // -> returns true on length == 0
    if (!owner)
```

would both return True, falling into another error.

In the adaptor, a check is now done to not do the unwrapping of UniV4 is no positions are found, and if there are, do a separate sumTokens2 without owners and only for UniV4.