### PR TITLE
Update Teller Adapter to include Lender Principal Supplied to Pools 

### DIFF
--- a/projects/teller/index.js
+++ b/projects/teller/index.js
@@ -142,13 +142,20 @@ async function bidCollateralTvl(api) {
     let skip = 0
     const pageSize = 1000
 
-    while (true) {
+    let hasMore = true
+    while (hasMore) {
       const data = await request(tellerGraphUrl, bidCollateralQuery, { skip })
-      if (!data.bidCollaterals || data.bidCollaterals.length === 0) break
+      if (!data.bidCollaterals || data.bidCollaterals.length === 0) {
+        hasMore = false
+        break
+      }
 
       allCollaterals = allCollaterals.concat(data.bidCollaterals)
 
-      if (data.bidCollaterals.length < pageSize) break
+      if (data.bidCollaterals.length < pageSize) {
+        hasMore = false
+        break
+      }
       skip += pageSize
     }
 
@@ -230,13 +237,20 @@ async function bidBorrowed(api){
   let skip = 0
   const pageSize = 1000
 
-  while (true) {
+  let hasMore = true
+  while (hasMore) {
     const data = await request(tellerGraphUrl, activeBidsQuery, { skip })
-    if (!data.bids || data.bids.length === 0) break
+    if (!data.bids || data.bids.length === 0) {
+      hasMore = false
+      break
+    }
 
     allBids = allBids.concat(data.bids)
 
-    if (data.bids.length < pageSize) break
+    if (data.bids.length < pageSize) {
+      hasMore = false
+      break
+    }
     skip += pageSize
   }
 


### PR DESCRIPTION
This PR updates the Teller Protocol adapter to use Subgraphs for scraping data instead of using getLogs.  It computes TVL and Borrowed in the same way, except  for the TVL computation, it now also includes principal that lenders have supplied in to the new Teller Pools.   When this Adapter was originally created, Teller Pools did not exist; Teller only allowed users to create 1:1 OTC loans with one another.  Since Teller Pools now make up a majority of activity on the protocol, it makes sense to track and include lender supplied principal for these pools on DefiLlama now.   