### PR TITLE
feat: add pBERA and stpBERA, add LBGT, clean up staking

### DIFF
--- a/projects/berapaw/index.js
+++ b/projects/berapaw/index.js
@@ -1,4 +1,3 @@
-const { stakings } = require("../helper/staking");
 const { sumTokens2 } = require("../helper/unwrapLPs");
 const ADDRESSES = require("../helper/coreAssets.json");
 
@@ -62,7 +61,6 @@ module.exports = {
     methodology: 'TVL includes staked LBGT and pBERA tokens, plus WBERA-LBGT LP tokens',
     berachain: {
         tvl,
-        // staking: stakingTvl(),
         pool2,
     },
 };


### PR DESCRIPTION
(Cant find the option to allow changes to PR, sorry 🙁)
Added new product pBERA and its staking contract TVL.
pBERA is minted using BERA derivates and effectively pBERA can be redeemed for BERA, so its fully backed by BERA, therefore I defined BERA as lower bound TVL value. (Check infrared/index.ts for reference, similar product).

Added LBGT (before, only staked LBGT was tracked).
Similar situation here: is backed by BGT, which can be redeemed 1:1 for BERA, so BERA used as lower bound TVL.

pBERA and pBERA staking show now TVL currently. Probably price is not tracked yet.
