### PR TITLE
fix Re7 Euler Plasma vault owner

### DIFF
--- a/projects/re7/index.js
+++ b/projects/re7/index.js
@@ -111,7 +111,7 @@ const configs = {
     },
     plasma: {
       eulerVaultOwners: [
-        '0xddedB1F2d1dd0b0455Fe5277632c84f57f894011',
+        '0xE5EAE3770750dC9E9eA5FB1B1d81A0f9C6c3369c',
       ],
     },
   }


### PR DESCRIPTION
fixing the address of Re7 Euler Vault Owner - address was confirmed from the vault creation transaction https://plasmascan.to/tx/0xc85a8fd0169fee53338772da49eb2a4e3ca049ce502120f151e7e5ddcd0d6a67/eventlog and compared to Linea vault creation transaction https://lineascan.build/tx/0x8e989cb9622655e758f0be206b4c38b3616c2ec7c39306b3e8d7c3de0b65a70f#eventlog
