### PR TITLE
add (Strata) tranches

### DIFF
--- a/projects/strata-tranches/index.js
+++ b/projects/strata-tranches/index.js
@@ -1,0 +1,13 @@
+const srUSDeVault = "0x3d7d6fdf07EE548B939A80edbc9B2256d0cdc003";
+const jrUSDeVault = "0xC58D044404d8B14e953C115E67823784dEA53d8F";
+
+module.exports = {
+    methodology: "Total value of all coins held in the smart contracts of the protocol.",
+    ethereum: {
+        async tvl (api) {
+            return await api.erc4626Sum2({
+                calls: [ srUSDeVault, jrUSDeVault ],
+            });
+        }
+    },
+};


### PR DESCRIPTION
Hello Team,

I’m adding here the recently launched product of the Strata Protocol - the Tranches.
It currently consists of two ERC-4626 vaults.

The logos, description, and organizational structure (to group Season 0 and Tranches) are being added in a separate PR to defillama-server: https://github.com/DefiLlama/defillama-server/pull/10816

Thank you,
Alex