### PR TITLE
feat: add USDe and WETH TVL support for terminal-fi-predeposit

### DIFF
--- a/projects/terminal-fi-predeposit/index.js
+++ b/projects/terminal-fi-predeposit/index.js
@@ -6,7 +6,9 @@ module.exports = {
     tvl: sumTokensExport({
       tokensAndOwners: [
         [ADDRESSES.ethereum.sUSDe, '0xFaAE52c6A6d477f859a740a76B29c33559ace18c'],
+        [ADDRESSES.ethereum.USDe, '0xFaAE52c6A6d477f859a740a76B29c33559ace18c'],
         [ADDRESSES.ethereum.WEETH, '0xe042678e6c6871fa279e037c11e390f31334ba0b'],
+        [ADDRESSES.ethereum.WETH, '0xe042678e6c6871fa279e037c11e390f31334ba0b'],
         [ADDRESSES.ethereum.WBTC, '0x2db1ec186acdeaf7d0fc78bffe335560b0fe0085'],
       ]
     }),


### PR DESCRIPTION
- add USDe TVL for tUSDe redemption vault
- add WETH TVL for tETH redemption vault

As part of Terminal Finance preparations for launch, which will require unstaking part of sUSDe & weETH to setup the sUSDe/USDe & WETH/weETH liquidity pools, we need to update the TVL methodology to account for the unstaked version of those assets.