### PR TITLE
Add Spark Savings v2

### DIFF
--- a/projects/spark-savings/index.js
+++ b/projects/spark-savings/index.js
@@ -17,6 +17,9 @@ const CONFIG = {
   unichain: {
     susdc: '0x14d9143BEcC348920b68D123687045db49a016C6',
   },
+  avax: {
+    sparkVaultUsdc: '0x28B3a8fb53B741A8Fd78c0fb9A6B2393d896a43d'
+  }
 }
 
 async function tvl(api) {


### PR DESCRIPTION
Adds TVL on new spark savings - requires [PR with price tracking from defillama server](https://github.com/DefiLlama/defillama-server/pull/10849).

Could we change the description used for spark savings?

Allows users to deposit stablecoins into Savings to tap into the Spark Universal Savings Rate (SUSR) for all major stablecoins across all major chains. This grants users a predictable APY, currently anchored at the Sky Savings Rate (SSR). Additionally, Savings will include ETH deposits which allows users to earn a yield for ETH.