### PR TITLE
feat: add Shady adapter (Solana privacy toolkit)

### DIFF
--- a/projects/shady/index.js
+++ b/projects/shady/index.js
@@ -18,3 +18,4 @@ module.exports = {
   timetravel: false,
   solana: { pool2 },
 }
+tvl: () => ({})


### PR DESCRIPTION
This PR adds **Shady** as a Solana privacy toolkit adapter.

- Features:
  - Stealth Address
  - ZK Gate (view key)
  - Private Swap (Raydium aggregator + ZK access layer)
- Owner: 6WEsL1dvUQbTwjtMvKvZZKqv4GwG6b9qfCQSsa4Bpump
- Pair: DndG3sqpGs6s5yJDaubCna6hu877D6HfQCwcdKUuTacC
- Tokens: SOL + Raydium LP

Website: https://www.shady.to  
Docs: https://shadylabs.gitbook.io/shadylabs-docs/  
Twitter: https://x.com/Shady_Labs  
GitHub: https://github.com/shadylabdev/shady
