### PR TITLE
feat: added elix.fi tvl

### DIFF
--- a/projects/elix-fi/index.js
+++ b/projects/elix-fi/index.js
@@ -32,7 +32,7 @@ query DefiLlama {
 
 module.exports = {
   methodology: "TVL is the total value promised on Elix.fi markets in addition to all non promised value that are in the ALM vaults.",
-  start: "2025-04-25",
+  start: "2025-10-20",
   doublecounted: true,
 }
 
@@ -53,7 +53,6 @@ Object.keys(config).forEach(chain => {
     tvl: async (api) => {
       // vault tvl
       const { vaultsV2s: { items: itemsV2 } } = await cachedGraphQuery(`elix-vaults-v2-${configEntry.chainId}`, configEntry.api_url, query(configEntry.chainId))
-      
       const vaultMakers = new Set()
       
       await getBalances(api, itemsV2, vaultMakers, 2)
@@ -83,8 +82,3 @@ Object.keys(config).forEach(chain => {
     }
   }
 })
-
-
-
-
-


### PR DESCRIPTION
Name (to be shown on DefiLlama):
Elix.fi

Twitter Link:
https://x.com/elix_fi

List of audit links if any:

Website Link:
https://www.elix.fi/

Logo (High resolution, will be shown with rounded borders):
https://www.elix.fi/elixfiwhitelarge.png

Current TVL:
around 20k USD

Treasury Addresses (if the protocol has treasury)

Chain:
Somnia (5031)

Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)
Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

Short Description (to be shown on DefiLlama):
Capital-efficient and modular CLOB DEX

Token address and ticker if any:

Category (full list at https://defillama.com/categories) *Please choose only one:
Dexs

Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
Implementation Details: Briefly describe how the oracle is integrated into your project:
Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

forkedFrom (Does your project originate from another project):
Mangrove

methodology (what is being counted as tvl, how is tvl being calculated):
TVL is the total promised value on the order book as well as the managed vaults TVL that is not already on the book.

Github org/user (Optional, if your code is open source, we can track activity):


As a side node:
We are summing up offers value as tvl, even though they are not 'locked' in the contract, though:

For offers in the contract the value is fully promised. Our protocol has a mechanism that will remove all offers that does not deliver the liquidity (like a liquidation bot but for an orderbook).

So the value is bound to Elix.fi without being directly on the main contract.

We cannot ensure that TVL is not higher since strategies can be written by anyone, but we can insure that TVL will be at least the amount we return because of the liquidation bot. Hope this makes sense.