### PR TITLE
Feat/add zs farms and inifnity pools

### DIFF
--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -111,9 +111,6 @@ const fixBalancesTokens = {
   },
   kasplex: {
     '0x2c2Ae87Ba178F48637acAe54B87c3924F544a83e': { coingeckoId: 'kaspa', decimals: 18 },
-    '0xb7a95035618354D9ADFC49Eca49F38586B624040': { coingeckoId: 'zeal', decimals: 18 },
-    '0x9a5a144290dffA24C6c7Aa8cA9A62319E60973D8': { coingeckoId: 'nacho-the-kat', decimals: 18 },
-    '0x1F3Ce97f8118035dba7FBCd5398005491Cf45603': { coingeckoId: 'kasper', decimals: 18 },
   },
   '0g': {
     '0x1cd0690ff9a693f5ef2dd976660a8dafc81a109c': { coingeckoId: 'zero-gravity', decimals: 18 }, // W0G (Wrapped 0G)


### PR DESCRIPTION
This is a PR to add TVL tracking for both the Infinity Pools and the Farms on Zealous Swap
https://defillama.com/protocol/zealousswap

Infinity Pools are independent pools (no LPs) and should be counted towards the total TVL since users stake assets in them - Think of them as Liquid staking pools.

Farms on the other hand allows users to lock LP tokens and shouldn't be counted towards the total TVL to avoid double liquidity counting.

Infinity Pools docs:
https://zealous-swap.gitbook.io/zealous-swap/protocol/staking/infinity-pool-zeal-staking
https://zealous-swap.gitbook.io/zealous-swap/protocol/staking/infinity-pool-nacho-staking
https://zealous-swap.gitbook.io/zealous-swap/protocol/staking/infinity-pool-kasper-staking

Farms docs:
https://zealous-swap.gitbook.io/zealous-swap/protocol/farms