### PR TITLE
[thala] update thalaswap-v3 lens address to latest

### DIFF
--- a/projects/thalaswap-v3/index.js
+++ b/projects/thalaswap-v3/index.js
@@ -3,7 +3,7 @@ const { function_view } = require("../helper/chain/aptos");
 const { get } = require('../helper/http')
 const { PromisePool } = require('@supercharge/promise-pool')
 
-const thalaswapLensAddress = "10e4cef9dd33e192738a33c8529e5c5feeb00d660b08f8d0891b4ceb3ed71dfd";
+const thalaswapLensAddress = "ee8c71b117851371fb180928cd73e4f111b04b0efbebb0054b9b29c8d5fec96c";
 
 async function getPool(lensAddress, lptAddress) {
   const args = [lptAddress];


### PR DESCRIPTION
Updates thalaswap-v3 lens address to latest. Returns pools consistent with https://app.thala.fi/api/liquidity-pools, filtered by:
```
"poolType": "Concentrated"
```

**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/adapters).
> - If you would like to add a `liquidations` adapter, please refer to [this readme document](https://github.com/DefiLlama/DefiLlama-Adapters/tree/main/liquidations) for details.

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
3. Please fill the form below  **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
4. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can  edit it there and put up a PR
5. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
6. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap

---
##### Name (to be shown on DefiLlama):

thalaswap-v3 (already listed: https://defillama.com/protocol/tvl/thalaswap-v3)

##### Chain:
Aptos
