### PR TITLE
LHYPE TVL update using endpoint NAV (valueInBase sum)

### DIFF
--- a/projects/looped-hype/index.js
+++ b/projects/looped-hype/index.js
@@ -1,32 +1,29 @@
-const { getConfig } = require("../helper/cache");
-const { sumTokens2 } = require('../helper/unwrapLPs');
+const { getConfig } = require("../helper/cache")
 
-const sanitizeAndValidateEvmAddresses = (addresses) => {
-  return addresses
-    .map((address) => address.replace(/_$/, ""))
-    .filter((address) => /^0x[a-fA-F0-9]{40}$/.test(address));
-};
-
-const LHYPE_VAULT_ADDRESS = ['0x5748ae796AE46A4F1348a1693de4b50560485562'];
+const LHYPE_VAULT = '0x5748ae796AE46A4F1348a1693de4b50560485562'
+const CHAIN_ID_STR = '999'
+const HYPE_TOKEN = '0x5555555555555555555555555555555555555555'
 
 const tvl = async (api) => {
-  const strategies = await getConfig(
+  const data = await getConfig(
     'lhype-tokens',
-    `https://backend.nucleusearn.io/v1/vaults/underlying_strategies?vault_address=${LHYPE_VAULT_ADDRESS}&chain_id=999`
-  );
-  const hyperevmStrategies = strategies["999"]
-  const tokens = Object.values(hyperevmStrategies).map((strategy) => strategy.tokenAddress);
-  const sanitizedTokens = sanitizeAndValidateEvmAddresses([...tokens, ...LHYPE_VAULT_ADDRESS]);
+    `https://backend.nucleusearn.io/v1/vaults/underlying_strategies?vault_address=${LHYPE_VAULT}&chain_id=${CHAIN_ID_STR}`
+  )
 
-  return sumTokens2({
-    owners: LHYPE_VAULT_ADDRESS,
-    tokens: sanitizedTokens,
-    api,
-    resolveLP: true,
-    permitFailure: true
-  });
-};
+  const strat = data?.[CHAIN_ID_STR]
+  if (!strat) return
+
+  let totalHype = 0
+  for (const pos of Object.values(strat)) {
+    totalHype += Number(pos.valueInBase || 0)
+  }
+
+  const hypeAmount = BigInt(Math.round(totalHype * 1e18))
+  api.add(HYPE_TOKEN, hypeAmount)
+}
 
 module.exports = {
-  hyperliquid: { tvl }
-};
+  hyperliquid: { tvl },
+  methodology: 'The total value of assets deployed across all LHYPE strategies.',
+  misrepresentedTokens: true,
+}


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/adapters).
> - If you would like to add a `liquidations` adapter, please refer to [this readme document](https://github.com/DefiLlama/DefiLlama-Adapters/tree/main/liquidations) for details.

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
3. Please fill the form below  **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
4. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can  edit it there and put up a PR
5. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
6. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap

---
Update reason:

From the beginning, the TVL data for LHYPE has been incorrectly calculated. It pulled tokenAddress values from the Nucleus endpoint and then called balanceOf(vault) for each token via sumTokens2. I went through each tokenAddress using this method and observed several issues with this approach:
1. It counted debt values (negative) as positive values, because the balanceOf call obviously returned the absolute value.
2. It returned incorrect values for Pendle Markets (pendleKhypeNov122025Market, pendleHyperlendHypeDec172025Market), because the balanceOf call returns the amount of LP tokens and not the amount of HYPE tokens deposited.
3. It was skipping tokenAddresses with underscores, e.g., 0x68e37dE8d93d3496ae143F2E900490f6280C57cD_ so almost all Felix-Morpho positions were dropped and not accounted for in the TVL.

So to sum up, I know you ideally prefer fetching data from blockchain, but this approach miscalculated the LHYPE TVL from the start. I guess just fetching the LHYPE totalSupply() from its contract and multiplying it by the LHYPE price wouldn't be sufficient because then we would lose the TVL token breakdown, or am I mistaken there?