### PR TITLE
enosys: add songbird governance stake

### DIFF
--- a/projects/enosys-governance/index.js
+++ b/projects/enosys-governance/index.js
@@ -8,7 +8,8 @@ const EnosysGovernanceStakeManagerSfin =
 
 module.exports = {
   songbird: {
-    tvl: sumTokensExport({
+    tvl: () => ({}),
+    staking: sumTokensExport({
       tokensAndOwners: [
         [ADDRESSES.songbird.EXFI, EnosysGovernanceStakeManagerExfi],
         [ADDRESSES.songbird.SFIN, EnosysGovernanceStakeManagerSfin],


### PR DESCRIPTION
adds the new Enosys governance protocol stake for SFIN and EXFI on songbird
at the moment EXFI liquidity is mainly in the added pool and afaik liquidity/volume is too low to be tracked by coingecko.
Adding it regardless in case it is tracked once again