### PR TITLE
update solera adapter

### DIFF
--- a/projects/solera/index.js
+++ b/projects/solera/index.js
@@ -1,9 +1,33 @@
-const { aaveExports } = require("../helper/aave");
-const methodologies = require("../helper/methodologies");
+const { getMorphoVaultTvl } = require('../helper/morpoho');
+
+const config = {
+  plume_mainnet: {
+    morphoVaults: [
+      '0xc0Df5784f28046D11813356919B869dDA5815B16',
+      '0x0b14D0bdAf647c541d3887c5b1A4bd64068fCDA7',
+      '0xBB748a1346820560875CB7a9cD6B46c203230E07'
+    ],
+  },
+  hemi: {
+    morphoVaults: [
+      '0x05c2e246156d37b39a825a25dd08D5589e3fd883',
+      '0xA7dB73F80a173c31A1241Bf97F4452A07e443c6c'
+    ],
+  },
+}
 
 module.exports = {
-  methodology: methodologies.lendingMarket,
-  plume: { tvl: () => ({  }) },
-  plume_mainnet: aaveExports("plume_mainnet", undefined, undefined, ['0xEE343bd811500ca27995Bc83D7ec2bacb63680d0'], { v3: true }),
-  // hemi: aaveExports("hemi", undefined, undefined, ['0xEE343bd811500ca27995Bc83D7ec2bacb63680d0'], { v3: true }),
+  doublecounted: true,
+  plume_mainnet: { 
+    tvl: getMorphoVaultTvl(undefined, {
+    vaults: config.plume_mainnet.morphoVaults,
+    morphoFactory: "0x2525D453D9BA13921D5aB5D8c12F9202b0e19456",
+    }), 
+  },
+  hemi: { 
+    tvl: getMorphoVaultTvl(undefined, {
+    vaults: config.hemi.morphoVaults,
+    morphoFactory: "0x2525D453D9BA13921D5aB5D8c12F9202b0e19456",
+    }), 
+  },
 }


### PR DESCRIPTION
## Update Solera adapter - add Morpho vaults, remove Aave markets

**Changes:**
- Added Morpho vault tracking for Plume (3 vaults)
- Added Morpho vault tracking for Hemi (2 vaults)

**Tested locally:**
- Plume: $66.26M
- Hemi: $2.91M
- Total: $69.17M

**Vault addresses:**
- Plume: 0xc0Df5784f28046D11813356919B869dDA5815B16, 0x0b14D0bdAf647c541d3887c5b1A4bd64068fCDA7, 0xBB748a1346820560875CB7a9cD6B46c203230E07
- Hemi: 0x05c2e246156d37b39a825a25dd08D5589e3fd883, 0xA7dB73F80a173c31A1241Bf97F4452A07e443c6c
