### PR TITLE
fix: Correct price scaling from 10e18 to 1e18(10e17) in Gravita Protocol 

### DIFF
--- a/liquidations/gravita-protocol/index.ts
+++ b/liquidations/gravita-protocol/index.ts
@@ -57,7 +57,7 @@ const positions = async () => {
   const prices = {}
   for (const c of collAddresses) {
     const info = await getTokenInfo(`ethereum:${c}`)
-    prices[c] = BigNumber(info.price).times(10e18).toFixed()
+    prices[c] = BigNumber(info.price).times(10e17).toFixed()
   }
 
   const vesselCounts = (


### PR DESCRIPTION

The price passed to `checkRecoveryMode()` is incorrectly multiplied by `10e18` (10^19) instead of `1e18` (10^18), causing a 10x inflation of collateral prices used in recovery mode calculations.
