### PR TITLE
Fix: Sablier Flow

### DIFF
--- a/projects/sablier-flow/index.js
+++ b/projects/sablier-flow/index.js
@@ -37,7 +37,7 @@ const CHAIN_IDS_ENVIO = {
 // Chains using graph endpoints
 const SUBGRAPH_ENDPOINTS = {
   sei: '41ZGYcFgL2N7L5ng78S4sD6NHDNYEYcNFxnz4T8Zh3iU',
-  iotex: '6No3QmRiC8HXLEerDFoBpF47jUPRjhntmv28HHEMxcA2',
+  // iotex: '6No3QmRiC8HXLEerDFoBpF47jUPRjhntmv28HHEMxcA2',
 };
 
 


### PR DESCRIPTION
> The Iotex GraphQL endpoint has not been working since an update 5 days ago, and there doesn’t appear to be any functional subgraph deployed on that endpoint