### PR TITLE
Update sparkdex-perps adapter with correct token addresses and owner

### DIFF
--- a/projects/sparkdex-perps/index.js
+++ b/projects/sparkdex-perps/index.js
@@ -1,13 +1,11 @@
-const ADDRESSES = require('../helper/coreAssets.json')
-const { nullAddress } = require("../helper/unwrapLPs");
-
-const FlareUSDCe=ADDRESSES.rari.USDC_e;
 const FlareSFLR="0x12e605bc104e93B45e1aD99F9e555f659051c2BB";
 const FlareUSDT0="0xe7cd86e13AC4309349F30B3435a9d337750fC82D"
+const FlareWFLR='0x1d80c49bbbcd1c0911346656b529df9e5c2f783d';
+const FlareFXRP='0xad552a648c74d49e10027ab8a618a3ad4901c5be'
 
 async function FlareTvl(api) {
-  const tokens = [nullAddress, FlareUSDCe, FlareSFLR, FlareUSDT0];
-  const owners = ["0xF59b51cB430736E0F344b0101b23981DEaE10968"];
+  const tokens = [FlareWFLR, FlareSFLR, FlareUSDT0, FlareFXRP];
+  const owners = ["0x74DA11B3Bb05277CF1cd3572a74d626949183e58"];
   return api.sumTokens({ owners, tokens });
 }
 


### PR DESCRIPTION
## Summary

Updated sparkdex-perps adapter on Flare network with:
- Added WFLR and FXRP token addresses
- Updated token list to include: WFLR, sFLR, USDT0, and FXRP
- Updated owner address to correct contract address: 0x74DA11B3Bb05277CF1cd3572a74d626949183e58

## Testing

✅ Test passed successfully
- Command: `node test.js projects/sparkdex-perps/index.js`
- Current TVL: ~$998k on Flare network
- Tokens tracked: WFLR, sFLR, USDT0, FXRP

## Changes
- Updated token list: [WFLR, sFLR, USDT0, FXRP]
- Updated owner address for sumTokens call
- Removed unused imports (ADDRESSES, nullAddress)