### PR TITLE
Update: Limitless

### DIFF
--- a/projects/limitless/index.js
+++ b/projects/limitless/index.js
@@ -45,6 +45,8 @@ query($lastId: String, $block: Int) {
 }
 `
 
+module.exports.deadFrom = '2025-01-01'
+
 Object.keys(config).forEach(chain => {
   const { postionManager, factory, limWETH, marginContract, graphEndpoint, } = config[chain]
 


### PR DESCRIPTION
> Added a deadFrom for Limitless, the adapter’s frontend is down, the GraphQL endpoint is no longer maintained, and the TVL has been flat and low for months