### PR TITLE
RockSolid Network

### DIFF
--- a/projects/RockSolid/index.js
+++ b/projects/RockSolid/index.js
@@ -1,29 +1,14 @@
 const vault = '0x936facdf10c8c36294e7b9d28345255539d81bc7' // RockSolid rock.rETH
-const rETH = '0xae78736Cd615f374D3085123A210448E74Fc6393'
 
-const totalAssetsABI = {
-  "inputs": [],
-  "name": "totalAssets",
-  "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
-  "stateMutability": "view",
-  "type": "function"
-}
-
-// Works across all DefiLlama SDK versions
 async function tvl(_, _b, _cb, { api }) {
-  // Call totalAssets() method to get total rETH managed by the vault
-  const totalAssets = await api.call({
-    abi: totalAssetsABI,
-    target: vault,
-  })
-
-  api.add(rETH, totalAssets)
+  // Use erc4626Sum helper to automatically get underlying asset and totalAssets
+  return api.erc4626Sum({ calls: [vault], tokenAbi: 'asset', balanceAbi: 'totalAssets' })
 }
 
 module.exports = {
   methodology:
     'Calls totalAssets() on the RockSolid rock.rETH vault to get the total amount of rETH managed by the vault.',
-  start: 1756339201, // vault launch timestamp
+  start: 1756339201, //  vault launch timestamp
   ethereum: { tvl },
   timetravel: true,
   misrepresentedTokens: false,


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/adapters).
> - If you would like to add a `liquidations` adapter, please refer to [this readme document](https://github.com/DefiLlama/DefiLlama-Adapters/tree/main/liquidations) for details.

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
3. Please fill the form below  **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
4. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can  edit it there and put up a PR
5. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
6. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap

---
##### Name (to be shown on DefiLlama): RockSolid Network


##### Twitter Link: https://x.com/rocksolidhq


##### List of audit links if any:

##### Website Link: https://rocksolid.network/


##### Logo (High resolution, will be shown with rounded borders): https://drive.google.com/file/d/1xUoKW4dsh-iTA3s7HIihByqUlDrt8XuP/view?usp=sharing


##### Current TVL: $23.27M


##### Treasury Addresses (if the protocol has treasury): N/A


##### Chain: ETH


##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list) {"id":"rocksolid-reth","symbol":"rock.reth","name":"RockSolid rETH"}


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description (to be shown on DefiLlama): RockSolid is a single-click integrated DeFi Vault platform that makes it simple for users to access the best DeFi rewards.

##### Token address and ticker if any:


##### Category (full list at https://defillama.com/categories) *Please choose only one: Yield


##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
The TVL is reported by the vault using totalAssets(). It's an ERC4626-compatible vault. There isn't an "official" oracle but the TVL number can be verified using debank or similar by looking at the vault's wallet https://debank.com/profile/0x9Ca1d6E730Eb9fbfD45c9FF5F0AC4E3d172d8F4d

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
The TVL is reported by the vault using totalAssets(). It's an ERC4626-compatible vault. There isn't an "official" oracle but the TVL number can be verified using debank or similar by looking at the vault's wallet https://debank.com/profile/0x9Ca1d6E730Eb9fbfD45c9FF5F0AC4E3d172d8F4d

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
The TVL is reported by the vault using totalAssets(). It's an ERC4626-compatible vault. There isn't an "official" oracle but the TVL number can be verified using debank or similar by looking at the vault's wallet https://debank.com/profile/0x9Ca1d6E730Eb9fbfD45c9FF5F0AC4E3d172d8F4d

##### forkedFrom (Does your project originate from another project): The vault is deployed from the Lagoon vault factory. See https://docs.lagoon.finance/ and https://etherscan.io/address/0x8D6f5479B14348186faE9BC7E636e947c260f9B1#writeProxyContract#F1


##### methodology (what is being counted as tvl, how is tvl being calculated): The totalAssets() returns the NAV which is set by the external curator (Tulipa Capital).


##### Github org/user (Optional, if your code is open source, we can track activity):