### PR TITLE
centrifuge: include off‑chain tranche NAVs 

### DIFF
--- a/projects/centrifuge/index.js
+++ b/projects/centrifuge/index.js
@@ -47,11 +47,32 @@ const CONFIG = {
 const abis = {
   getVault: "function vault(address asset) external view returns (address)",
   totalAssets: "function totalAssets() external view returns (uint256)",
+  asset: "function asset() external view returns (address)",
 };
 
 const eventAbis = {
   deployTranches: 'event DeployTranche(uint64 indexed poolId, bytes16 indexed trancheId, address indexed tranche)',
   addShareClass: 'event AddShareClass(uint64 indexed poolId, bytes16 indexed scId, address token)'
+}
+
+const safeGetLogs = async (fn, timeoutMs = 90_000) => {
+  try {
+    return await new Promise((resolve) => {
+      const timer = setTimeout(() => resolve([]), timeoutMs)
+      Promise.resolve()
+        .then(fn)
+        .then((res) => {
+          clearTimeout(timer)
+          resolve(res)
+        })
+        .catch(() => {
+          clearTimeout(timer)
+          resolve([])
+        })
+    })
+  } catch (e) {
+    return []
+  }
 }
 
 const getTokens = async (api, block, factories) => {
@@ -60,12 +81,12 @@ const getTokens = async (api, block, factories) => {
       let allTranches = []
 
       if (factory.TOKEN_FACTORY_V2) {
-        const tranches = await api.getLogs({  target: factory.TOKEN_FACTORY_V2, fromBlock: factory.START_BLOCK, toBlock: block, eventAbi: eventAbis.deployTranches, onlyArgs: true })
+        const tranches = await safeGetLogs(() => api.getLogs({ target: factory.TOKEN_FACTORY_V2, fromBlock: factory.START_BLOCK, toBlock: block, eventAbi: eventAbis.deployTranches, onlyArgs: true }))
         allTranches.push(...tranches.map(({ tranche }) => tranche))
       }
 
       if (factory.TOKEN_FACTORY_V3) {
-        const shareClasses = await api.getLogs({  target: factory.TOKEN_FACTORY_V3, fromBlock: factory.START_BLOCK, toBlock: block, eventAbi: eventAbis.addShareClass, onlyArgs: true })
+        const shareClasses = await safeGetLogs(() => api.getLogs({ target: factory.TOKEN_FACTORY_V3, fromBlock: factory.START_BLOCK, toBlock: block, eventAbi: eventAbis.addShareClass, onlyArgs: true }))
         allTranches.push(...shareClasses.map(({ token }) => token))
       }
 
@@ -81,12 +102,51 @@ const tvl = async (api) => {
   const block = await api.getBlock() - 100
   const { factories, assets: { USDC } } = CONFIG[chain]
   const tokens = await getTokens(api, block, factories)
-  if (!tokens) return;
-  const vaults = (await api.multiCall({ calls: tokens.map((t) => ({ target: t, params: [USDC] })), abi: abis.getVault })).filter(addr => addr.toLowerCase() !== nullAddress)
+  if (!tokens || !tokens.length) return;
+
+  const vaults = (await api.multiCall({ calls: tokens.map((t) => ({ target: t, params: [USDC] })), abi: abis.getVault, permitFailure: true }))
+    .filter(addr => addr && addr.toLowerCase() !== nullAddress)
+
   await api.erc4626Sum({ calls: vaults, tokenAbi: 'address:asset', balanceAbi: 'uint256:totalAssets', permitFailure: true })
+
+  const shareClassAssets = await api.multiCall({ calls: tokens, abi: abis.asset, permitFailure: true })
+
+  const offchainIndexes = []
+  shareClassAssets.forEach((assetAddr, idx) => {
+    if (!assetAddr) return
+    if (assetAddr.toLowerCase() !== nullAddress) return
+    offchainIndexes.push(idx)
+  })
+
+  if (!offchainIndexes.length)
+    return
+
+  const offchainTokens = offchainIndexes.map((idx) => tokens[idx])
+  const [shareClassTotals, shareClassDecimals] = await Promise.all([
+    api.multiCall({ calls: offchainTokens, abi: abis.totalAssets, permitFailure: true }),
+    api.multiCall({ calls: offchainTokens, abi: 'erc20:decimals', permitFailure: true }),
+  ])
+
+  let offchainUsd = 0
+  // Share classes with a null asset hold off-chain exposures and report their NAV directly via totalAssets
+  offchainTokens.forEach((token, idx) => {
+    const total = shareClassTotals[idx]
+    if (!total) return
+
+    const decimals = shareClassDecimals[idx] ?? 18
+    const value = typeof total === 'string' ? BigInt(total) : BigInt(total.toString())
+    const scale = BigInt(10) ** BigInt(decimals)
+    if (!scale) return
+    const usd = Number(value) / Number(scale)
+    if (!Number.isFinite(usd) || usd <= 0) return
+    offchainUsd += usd
+  })
+
+  if (offchainUsd > 0)
+    api.addUSDValue(offchainUsd)
 }
 
-module.exports.methodology = `TVL corresponds to the total USD value of tokens minted on Centrifuge across Ethereum, Base, and Arbitrum.`
+module.exports.methodology = `TVL includes onchain vault deposits (queried via ERC4626 vaults) and offchain tranche net asset values reported by Centrifuge share classes across supported chains.`
 Object.keys(CONFIG).forEach((chain) => {
   module.exports[chain] = { tvl }
 })


### PR DESCRIPTION
Fixes https://github.com/DefiLlama/DefiLlama-Adapters/issues/15483


- Add handling for Centrifuge share classes that report a null underlying asset (off‑chain tranches). Those share classes expose their NAV via totalAssets(); the adapter now sums those NAVs and reports them as USD.
- Update methodology text to reflect on‑chain ERC‑4626 vault deposits and off‑chain tranche NAVs.




