### PR TITLE
Fix: add block-scoped cache key for SFPM chunks (v1 & v1.1)

### DIFF
--- a/projects/panoptic-v1_1/index.js
+++ b/projects/panoptic-v1_1/index.js
@@ -67,8 +67,8 @@ async function tvl(api) {
     api.addTokens(tokens, balancesRaw)
   }
 
-
-  const chunks = await cachedGraphQuery(`panoptic/v1_1/${chain}/sfpm-chunks`, graphUrl, SFPMChunksQuery, { api, useBlock: true, fetchById: true, safeBlockLimit, })
+  const block = api.block ?? 0
+  const chunks = await cachedGraphQuery(`panoptic/v1_1/${chain}/sfpm-chunks@${block}`, graphUrl, SFPMChunksQuery, { api, useBlock: true, fetchById: true, safeBlockLimit, })
   chunks.forEach(chunk => {
     if (!isV4[chunk.panopticPool.id.toLowerCase()]) return
     addUniV3LikePosition({ api, token0: chunk.pool.token0.id, token1: chunk.pool.token1.id, tick: Number(chunk.pool.tick), liquidity: Number(chunk.netLiquidity), tickUpper: Number(chunk.tickUpper), tickLower: Number(chunk.tickLower), })

--- a/projects/panoptic/index.js
+++ b/projects/panoptic/index.js
@@ -70,7 +70,8 @@ async function tvl(api) {
 
   await api.sumTokens({ ownerTokens })
 
-  const chunks = await cachedGraphQuery(`panoptic/v1/${chain}/sfpm-chunks`, graphUrl, SFPMChunksQuery, { api, useBlock: true, fetchById: true, safeBlockLimit, })
+  const block = api.block ?? 0
+  const chunks = await cachedGraphQuery(`panoptic/v1/${chain}/sfpm-chunks@${block}`, graphUrl, SFPMChunksQuery, { api, useBlock: true, fetchById: true, safeBlockLimit, })
   chunks.forEach(chunk => {
     const { token0, token1, tick, } = poolData[chunk.pool.id.toLowerCase()] ?? {}
     if (!tick) return;


### PR DESCRIPTION
V1 and v1.1 adapters will need to be re-ran for the entire historical period to ensure accuracy of TVL data:
- **For V1: Re-run from Dec 15, 2024**
- **For V1.1: Re-run from Feb 22, 2025**

This PR fixes an issue where cachedGraphQuery reused the same cached SFPM chunk data across multiple days when running TVL over multiple days.

Previously, both the v1 and v1.1 adapters used a static cache key like
`panoptic/v1/${chain}/sfpm-chunks`
even when `useBlock: true` was enabled.

Because the cache key didn’t include the block number, all subsequent days in a multi-day run reused the first day’s cached response, leading to incorrect TVL values in range mode.

This change updates both adapters to include the current block in the cache key:
`panoptic/v1/${chain}/sfpm-chunks@${api.block}`
`panoptic/v1_1/${chain}/sfpm-chunks@${api.block}`

This ensures each day’s subgraph query is cached separately and matches single-day snapshot results.

Impact
* Fixes TVL discrepancies between single-day and multi-day runs
