### PR TITLE
Add USP TVL calculation for Ethereum (#1)

### DIFF
--- a/projects/piku-dao/index.js
+++ b/projects/piku-dao/index.js
@@ -1,0 +1,32 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+
+const USP_TOKEN = '0x098697bA3Fee4eA76294C5d6A466a4e3b3E95FE6'
+const ORACLE = '0x433471901bA1A8BDE764E8421790C7D9bAB33552'
+
+async function tvl(api) {
+  // Get USP total supply and oracle price in parallel
+  const [totalSupply, decimals, pricePerToken] = await Promise.all([
+    api.call({ target: USP_TOKEN, abi: 'erc20:totalSupply' }),
+    api.call({ target: USP_TOKEN, abi: 'uint256:decimals' }),
+    api.call({ target: ORACLE, abi: 'function getPriceForIssuance() view returns (uint256)' })
+  ])
+
+  // Calculate TVL in USDC
+  // totalSupply is in 18 decimals, pricePerToken is in 6 decimals (USDC format)
+  // Result should be in USDC's 6 decimals
+  // Formula: (totalSupply * price) / 10^18 = TVL in USDC (6 decimals)
+  const tvlInUsdc = (totalSupply * pricePerToken) / (10 ** decimals)
+
+  // Report as USDC for proper USD valuation
+  api.add(ADDRESSES.ethereum.USDC, tvlInUsdc)
+}
+
+module.exports = {
+  methodology: "TVL is calculated by multiplying USP stablecoin's total supply with its oracle price (getPriceForIssuance). The oracle price is manually updated and reflects the yield-bearing value of USP backed by USDC.",
+  start: 23081800,
+  timetravel: true,
+  misrepresentedTokens: false,
+  ethereum: {
+    tvl,
+  }
+}


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/adapters).
> - If you would like to add a `liquidations` adapter, please refer to [this readme document](https://github.com/DefiLlama/DefiLlama-Adapters/tree/main/liquidations) for details.

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
3. Please fill the form below  **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
4. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can  edit it there and put up a PR
5. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
6. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap

---

##### Name (to be shown on DefiLlama): Piku

##### Twitter Link: https://x.com/piku_dao 

##### List of audit links if any: 
We have four audits in total:
Omega Security – July 2025
 Scope: Token, Oracle, Funding, and Payment Processor Upgrades
 Report:[ Google Drive link](https://drive.google.com/file/d/1qXOajYt-r68EWirW8K2PKKSNVzEZTx38/view)


0xMacro – April 15 – May 24, 2024
 Scope: Full modular contract suite — governance, staking, bonding curve, rewards, payments
 Report:[ GitHub PDF](https://github.com/InverterNetwork/contracts/blob/main/audits/2024-06-19-macro.pdf)


Hats Finance – June 2024
 Scope: Full Inverter V1 contract suite powering Piku
 Report:[ GitHub Report](https://github.com/hats-finance/Inverter-Network-0xe47e52c4fea05e555920f1dcdcc6fb8eca103eeb/blob/main/report.md)


Audit33 (33Audits & Co.) – May 2025
 Scope: Oracle-integrated Funding Manager & queue-based payment logic
 Report:[ PDF link](https://1348667451-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2F0bjHfif1xj95cheaAKP7%2Fuploads%2Fj2MGBiI7ljolQKmn1pKY%2Faudit-report-fm-oracle-redeeming-.pdf?alt=media&token=1040dd51-3d68-4aeb-8458-538c46b0053c)
For further and detailed information please visit : https://docs.piku.co/piku/piku/security-and-risks/audits 

##### Website Link: https://piku.co/ 

##### Logo (High resolution, will be shown with rounded borders):
https://continuous-steed-202.notion.site/Piku-Logo-29d1e6685f3d80a19985db11a47d1782?source=copy_link 

##### Current TVL: $4,955,712 = 4.95M$

##### Treasury Addresses (if the protocol has treasury)
We have one treasury, one hot and one cold wallets. 

Piku Backing Hot Wallet:  0xb7f15d1122c0F91eE77C1172B9EFa4C061952E3C
Piku Backing Cold Wallet: 0x16c4150e22c53eCE02bB70763625DD3d61f1E7E9
Piku Treasury Wallet: 0x32a605E91Ecc3ab972697E58712f6c9c37cabC1D
Also, here are the trackable links of the dedicated wallets’ on different chains. https://docs.piku.co/piku/piku-platform/treasury-wallet-addresses 


##### Chain:
For now, chain is Ethereum. Soon will be multichain on Plasma, Base and more.

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

{"id":"piku-utility-token","symbol":"piku","name":"Piku Utility Token"}
{"id":"staked-piku","symbol":"spiku","name":"Staked PIKU"}


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): 

(https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama):
The USP token is classified as a yield-optimized stablecoin that uniquely combines the stability of a traditional stablecoin with the growth potential of yield-generating assets. Governed by PikuDAO, USP is initially fully backed by USD Stables at 1:1 ratio, ensuring a stable launch value of $1.00 USD. PikuDAO then diversifies and enhances this backing with a carefully selected basket of on-chain and off-chain assets that generate yield.
As these additional assets contribute yield, they inherently increase the underlying value of USP, increasing its value beyond the initial peg while reflecting the generated yield directly within the token's value.  USP is a savings tool with a simple access.


##### Token address and ticker if any: 
Contract Address: 0x098697bA3Fee4eA76294C5d6A466a4e3b3E95FE6
Ticker: USP

##### Category (full list at[ https://defillama.com/categories](https://defillama.com/categories)) *Please choose only one:
Yield
##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

Source: Price Oracle for USP
Contract Address: 0x433471901bA1A8BDE764E8421790C7D9bAB33552
Description
The Oracle Logic Module fetches approved on-chain price feeds for both the yield optimized stablecoin and the accounting asset, normalizes them to USDC (6 decimals), and exposes the current exchange rates through:
getPriceForIssuance()
getPriceForRedemption()
These rates form the basis for all minting, redemption, and yield calculations in the protocol.


##### Implementation Details: Briefly describe how the oracle is integrated into your project:
Each morning at 11.00 am GMT+3 our finance team calculate the latest USP price and finalized through internal data processes. Once the daily price is verified, it is submitted to the blockchain through the Piku Backoffice interface by invoking the following oracle update functions:
setPriceForIssuance()


setPriceForRedemption()


The transaction is executed via the Fireblocks-controlled multisig wallet, ensuring full custody security and auditability. This mechanism guarantees that the on-chain price feed remains synchronized with verified off-chain market data, forming the reference point for all minting, redemption, and yield distribution operations within the protocol.



##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

https://docs.piku.co/piku/piku/minting-and-redemption/how-to-get-usp-price

##### forkedFrom (Does your project originate from another project):
No.

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL is calculated by multiplying the current issuance price as returned by the oracle via getPriceForIssuance() with the total circulating supply of the USP token retrieved from the token contract.
TVL=Issuance Price×Total Supply of USP
This approach ensures that the reported TVL accurately reflects the real-time value of all minted assets within the system, normalized to USD, and automatically adjusts with any changes in price or supply on-chain.

##### Github org/user (Optional, if your code is open source, we can track activity):

https://github.com/piku-co