### PR TITLE
Add KaspaCom dex adapter

### DIFF
--- a/projects/kaspacom-dex/index.js
+++ b/projects/kaspacom-dex/index.js
@@ -1,0 +1,6 @@
+const { uniTvlExports } = require("../helper/unknownTokens")
+
+
+module.exports = uniTvlExports({
+  'kasplex': '0xa9CBa43A407c9Eb30933EA21f7b9D74A128D613c'
+})


### PR DESCRIPTION
Hi, 
We would like to add our dex to the defi-llama.

Name (to be shown on DefiLlama): **KaspaCom Dex**
Twitter Link: https://x.com/KaspaCom
List of audit links if any: https://drive.google.com/file/d/1et35wfvZXSblkG1tF9OPwmdZ9ix7Jxp8/view
Website Link:  https://defi.kaspa.com/swap
Logo (High resolution, will be shown with rounded borders):  https://erc20-logo-dev.s3.eu-central-1.amazonaws.com/0x9b9e99f875f2c03051546d494e3f49cc1d878acc.png
Current TVL:  **66K**
Chain: **Kasplex**
Short Description (to be shown on DefiLlama): **KaspaCom, The Leading Kaspa DEX & Token Launchpad for the Community, by the Community.**
Category (full list at https://defillama.com/categories): **Dexs**
forkedFrom (Does your project originate from another project): **Uniswap V2**
methodology (what is being counted as tvl, how is tvl being calculated):  **Total value of all coins held in the smart contracts of the protocol**
Github org/user (Optional, if your code is open source, we can track activity): https://github.com/KASPACOM