### PR TITLE
Count idle token balances in SLL

### DIFF
--- a/projects/spark-liquidity-layer/index.js
+++ b/projects/spark-liquidity-layer/index.js
@@ -271,10 +271,6 @@ const curveConfigs = {
       address: '0xA632D59b9B804a956BfaA9b48Af3A1b74808FC1f',
       coinIndex: 0,
     },
-    {
-      address: '0xA632D59b9B804a956BfaA9b48Af3A1b74808FC1f',
-      coinIndex: 1,
-    },
   ],
   base: [],
   arbitrum: [],


### PR DESCRIPTION
SLL now holds some balance of pyUSD on ALM proxy which previously wasn't tracked.
Additionally I removed TVL counting on USDS in USDS/pyUSD curve pool