### PR TITLE
Add axlp Adapter

### DIFF
--- a/projects/axlp/config.json
+++ b/projects/axlp/config.json
@@ -1,0 +1,12 @@
+{
+    "arbitrum": {
+        "AMLP": {
+            "token": "0x152f5E6142db867f905a68617dBb6408D7993a4b",
+            "staker": "0x3a66b81be26f2d799C5A96A011e1E3FB2BA50999"
+        },
+        "AHLP": {
+            "token": "0x5fd22dA8315992dbbD82d5AC1087803ff134C2c4",
+            "staker": "0x1ba274EBbB07353657ed8C76A87ACf362E408D85"
+        }
+    }
+}

--- a/projects/axlp/index.js
+++ b/projects/axlp/index.js
@@ -1,16 +1,18 @@
-const sAMLP_arbitrum = '0xbC08F30c18a79a3a18dBbd40931C551F91EDB9dB'
-const sAHLP_arbitrum = '0x50c30f24b957B1ac9e31558e55Bf7dc4ab685eA9'
+const config = require('./config.json')
 
 module.exports = {
-  methodology: 'counts the number of sAMLP and sAHLP tokens in the contract.',
+  methodology: 'counts the number of AMLP and AHLP tokens in the staking contracts.',
   arbitrum: {
     tvl: async (api) => {
-      const [sAMLP_supply, sAHLP_supply] = await api.multiCall({
-        abi: 'erc20:totalSupply',
-        calls: [sAMLP_arbitrum, sAHLP_arbitrum]
+      const [amlp_staker_balance, ahlp_staker_balance] = await api.multiCall({
+        abi: 'erc20:balanceOf',
+        calls: [
+          { target: config.arbitrum.AMLP.token, params: [config.arbitrum.AMLP.staker] },
+          { target: config.arbitrum.AHLP.token, params: [config.arbitrum.AHLP.staker] }
+        ]
       })
-      api.add(sAMLP_arbitrum, sAMLP_supply)
-      api.add(sAHLP_arbitrum, sAHLP_supply)
+      api.add(config.arbitrum.AMLP.token, amlp_staker_balance)
+      api.add(config.arbitrum.AHLP.token, ahlp_staker_balance)
     }
   }
 }


### PR DESCRIPTION
Hi,
We would like to add our dex to the defi-llama.
Name (to be shown on DefiLlama): Antarctic Exchange
Twitter Link: https://x.com/Antarctic_EX
List of audit links if any: https://drive.google.com/file/d/1SwiKK6Wrt55g_-60ccebhV2OuO4kpiZd/view?usp=drive_link
Website Link: https://www.antarctic.exchange/
Logo (High resolution, will be shown with rounded borders):https://drive.google.com/file/d/1kUAZnDZti4ayL5Y-oAPOZDpjAo3b88Y0/view?usp=sharing
Current TVL: AMLP=225190.37489071 ；AHLP=50252.3946052
Chain: Arbitrum One
Short Description (to be shown on DefiLlama): Antarctic Exchange (AX) is a high-performance decentralized perpetual futures DEX delivering CEX-grade trading with deep liquidity, low fees, and a clean, self-custodial UX.
Category (full list at https://defillama.com/categories): Derivatives
forkedFrom (Does your project originate from another project): None
methodology (what is being counted as tvl, how is tvl being calculated):  
AXLP vaults — consisting of AMLP (market-making) and AHLP (hedging) — together with their staking contracts. sAMLP and sAHLP are the corresponding staked receipt tokens representing users’ shares in the AMLP and AHLP vaults respectively.