### PR TITLE
Rename Makina Finance to Makina

### DIFF
--- a/projects/makina/index.js
+++ b/projects/makina/index.js
@@ -1,7 +1,7 @@
 // https://docs.makina.finance/
 // https://app.makina.finance/
 
-// Makina Finance TVL Adapter - External Pricing Version
+// Makina TVL Adapter - External Pricing Version
 const DUSD_TOKEN = '0x1e33e98af620f1d563fcd3cfd3c75ace841204ef';
 const DETH_TOKEN = '0x871ab8e36cae9af35c6a3488b049965233deb7ed';
 const DBIT_TOKEN = '0x972966bcc17f7d818de4f27dc146ef539c231bdf';


### PR DESCRIPTION
Follow up of: https://github.com/DefiLlama/DefiLlama-Adapters/pull/16912

This PR is to rename "Makina Finance" to "Makina", the true project name.

If this could change:

`https://defillama.com/protocol/makina-finance`

to

`https://defillama.com/protocol/makina`

it would be amazing. Thanks and sorry for the double PR here.