### PR TITLE
Add HyperEVM in Giza / Arma

### DIFF
--- a/projects/giza/index.js
+++ b/projects/giza/index.js
@@ -12,5 +12,6 @@ module.exports = {
     methodology: 'TVL is calculated by querying onchain balances of Giza smart wallet accounts across DeFi lending protocols for the Arma product, and Pendle PT token holdings for the Pulse product.',
     base: arma.base,
     plasma: arma.plasma,
+    hyperliquid: arma.hyperliquid,
     arbitrum: { tvl: combinedArbitrumTvl },
 }


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/adapters).
> - If you would like to add a `liquidations` adapter, please refer to [this readme document](https://github.com/DefiLlama/DefiLlama-Adapters/tree/main/liquidations) for details.

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
3. Please fill the form below  **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR

This PR adds HyperEVM support for Arma inside Giza protocol to track its TVL.