### PR TITLE
Add Mr Lightspeed Creator Coin adapter

### DIFF
--- a/projects/mr-lightspeed/index.js
+++ b/projects/mr-lightspeed/index.js
@@ -1,6 +1,5 @@
 const { sumTokens2, nullAddress } = require('../helper/unwrapLPs')
 
-const MR_TOKEN = '0xf0cb96a4011a0a6f73d100c7080bf8020d10f87a'
 const POOL_MANAGER = '0x498581ff718922c3f8e6a244956af099b2652b2b'
 const UNI_V4_POSITION_IDS = ['500329', '415619'] // protocol-owned + locked mr_lightspeed/ETH Uniswap v4 positions (NFT IDs)
 const WETH_BASE = '0x4200000000000000000000000000000000000006'
@@ -17,19 +16,12 @@ async function tvl(api) {
   })
 }
 
-async function staking(api) {
-  const locked = await api.call({ abi: 'erc20:balanceOf', target: MR_TOKEN, params: [MR_TOKEN] })
-  api.add(MR_TOKEN, locked)
-  return api.getBalances()
-}
-
 module.exports = {
   timetravel: true,
   start: '2025-10-23',
-  methodology: 'TVL counts ETH collateral locked in protocol-owned Uniswap v4 positions. Staking captures the 500M MR tokens that remain vested inside the CreatorCoin contract.',
+  methodology: 'TVL counts ETH collateral locked in protocol-owned Uniswap v4 positions.',
   doublecounted: false,
   base: {
     tvl,
-    staking,
   },
 }


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
3. Please fill the form below  **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
4. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can  edit it there and put up a PR
5. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
6. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap

---
##### Name (to be shown on DefiLlama):
Mr. Lightspeed Creator Coin

##### Twitter Link:
https://x.com/Mr_Lightspeed

##### List of audit links if any:
https://github.com/ourzora/zora-token/blob/main/audit/Zora%20Token%20-%20Zellic%20Audit%20Report.pdf

##### Website Link:
https://zora.co/mr_lightspeed

##### Logo (High resolution, will be shown with rounded borders):
https://i.ibb.co/KcYqxYdL/MLS-200.png

##### Current TVL:
≈ $7.25k (ETH collateral on Base, as of adapter test run)

##### Treasury Addresses (if the protocol has treasury)
- CreatorCoin vesting (locked MR): `0xf0cb96a4011a0a6f73d100c7080bf8020d10f87a`
- Payout recipient: `0x78bE7E42bC7e131b125178DcC233D54457F456ca`
- Protocol reward recipient: `0x7bf90111Ad7C22bec9E9dFf8A01A44713CC1b1B6`

##### Chain:
Base

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):
mr-lightspeed-creator-coin

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):
38857

##### Short Description (to be shown on DefiLlama):
Creator coin on Base that backs MR_LIGHTSPEED with protocol-owned ETH liquidity and a time-locked MR treasury.

##### Token address and ticker if any:
MRLIGHTSPEED — `0xf0cb96a4011a0a6f73d100c7080bf8020d10f87a` (Base)

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Social

##### Oracle Provider(s):
None (uses spot DEX pricing)

##### Implementation Details / Documentation:
https://docs.zora.co/docs/creator-coins/overview

##### Documentation/Proof:
https://dexscreener.com/base/0x80df5fb4c2b38adaa2fd711a254c38e9a1d7e1bb1a016fbd3cb1bf970f7aee56

##### forkedFrom (Does your project originate from another project):
No

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL counts ETH collateral locked in protocol-owned Uniswap v4 positions (NFT IDs 500329 & 415619) on Base. No MR supply or Zora-controlled liquidity is included.

##### Github org/user (Optional, if your code is open source, we can track activity):

---
### Adapter Summary
- Added `projects/mr-lightspeed/index.js`.
- `base.tvl` unwraps the protocol-owned ETH-side Uni v4 positions using `sumTokens2` with `resolveUniV4`.
- Removed `base.staking` after reviewer feedback so the non-circulating MR treasury is no longer surfaced.

### Tests
- `node test.js projects/mr-lightspeed/index.js`
