### PR TITLE
fix: update Starknet RPC endpoint from Blast to Lava

### DIFF
--- a/projects/helper/env.js
+++ b/projects/helper/env.js
@@ -10,7 +10,7 @@ const _yek = "b523cf66-7a5a-4fe8-8d67-f604fd0492c2"  // bifrost
 
 const DEFAULTS = {
   EVMOS_MULTICALL_CHUNK_SIZE: "3", // evmos reduced gas limit, this is a workaround to make multicall work
-  STARKNET_RPC: 'https://starknet-mainnet.public.blastapi.io',
+  STARKNET_RPC: 'https://rpc.starknet.lava.build/',
   COVALENT_KEY: 'ckey_72cd3b74b4a048c9bc671f7c5a6',
   // SOLANA_RPC: 'https://mainnet.helius-rpc.com/?api-key=0109717a-77b4-498a-bc3c-a0b31aa1b3bf',
   SOLANA_RPC: "https://api.mainnet-beta.solana.com",


### PR DESCRIPTION
- Confirming Blast RPC Endpoint is not working anymore
```bash
curl -X POST https://starknet-mainnet.public.blastapi.io \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","id":1,"method":"starknet_blockNumber"}' 

{
  "jsonrpc": "2.0",
  "id": null,
  "error": {
    "code": -32000,
    "message": "Blast API is no longer available. Please update your integration to use Alchemy's API instead: https://alchemy.com"
  }
}
```
- Lava works
```bash
curl -X POST https://rpc.starknet.lava.build/ \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","id":1,"method":"starknet_blockNumber"}' 

{"jsonrpc":"2.0","id":1,"result":3470961}%
```

- Test new RPC endpoint:
```bash
node test.js projects/10kswap/api.js

Building prices get queries for 6 tokens
--- starknet ---
ETH                       411.07 k
USDC                      332.45 k
USDT                      87.70 k
DAI                       35.62 k
WBTC                      23.78 k
STRK                      10.57 k
Total: 901.19 k 

--- tvl ---
ETH                       411.07 k
USDC                      332.45 k
USDT                      87.70 k
DAI                       35.62 k
WBTC                      23.78 k
STRK                      10.57 k
Total: 901.19 k 

------ TVL ------
starknet                  901.18 k

total                    901.19 k
```

- Other test for new RPC endpoint
```bash
node test.js projects/myswap-cl/index.js

Building prices get queries for 10 tokens
--- starknet ---
USDC                      233.84 k
ETH                       231.88 k
USDT                      52.03 k
STRK                      36.67 k
DAI                       18.86 k
wstETH(legacy)            2.70 k
LORDS                     642.6844852350187
LUSD                      345.90226368565567
WBTC                      303.4874495305242
RETH                      20.61712113472187
Total: 577.30 k 

--- tvl ---
USDC                      233.84 k
ETH                       231.88 k
USDT                      52.03 k
STRK                      36.67 k
DAI                       18.86 k
wstETH(legacy)            2.70 k
LORDS                     643
LUSD                      346
WBTC                      303
RETH                      21
Total: 577.30 k 

------ TVL ------
starknet                  577.30 k

total                    577.30 k
```
