### PR TITLE
Add Mining Tycoon adapter - Dual currency mining pool on Solana

### DIFF
--- a/projects/mining-tycoon/index.js
+++ b/projects/mining-tycoon/index.js
@@ -1,5 +1,6 @@
 // Mining Tycoon - Dual Currency Mining Pool on Solana
-// Tracks SOL + GPU token locked in protocol vaults
+// TVL: SOL locked in mining vault
+// Staking: Protocol's own GPU tokens locked in rewards vault
 
 const { sumTokens2 } = require("../helper/solana");
 
@@ -9,13 +10,15 @@ const ADDRESSES = {
 };
 
 async function tvl(api) {
-  // Track SOL in vault
+  // Track SOL TVL (external asset)
   await sumTokens2({
     api,
     solOwners: [ADDRESSES.SOL_VAULT],
   });
-  
-  // Track GPU tokens in ATA
+}
+
+async function staking(api) {
+  // Track GPU tokens (protocol's own token)
   await sumTokens2({
     api,
     tokenAccounts: [ADDRESSES.GPU_VAULT_ATA],
@@ -26,6 +29,7 @@ module.exports = {
   timetravel: false,
   solana: {
     tvl,
+    staking,
   },
-  methodology: 'TVL counts SOL locked in the mining vault plus GPU tokens locked in the GPU vault. Mining Tycoon is a dual-currency mining pool where users buy mining power with SOL or GPU tokens and earn proportional rewards from both vaults.',
+  methodology: 'TVL counts SOL locked in the mining vault. Staking counts the protocol\'s own GPU tokens locked in the GPU vault. Mining Tycoon is a dual-currency mining pool where users buy mining power with SOL or GPU tokens and earn proportional rewards from both vaults.',
 };


### PR DESCRIPTION
## Protocol Description
Mining Tycoon is a dual-currency mining pool on Solana where users:
- Buy mining power with SOL or GPU tokens
- Earn proportional rewards from both SOL and GPU token vaults
- Compound earnings or claim dual rewards

## Adapter Details
- **Chain**: Solana
- **Type**: Mining Pool / Yield Farming
- **TVL Components**: 
  - SOL locked in mining vault
  - GPU tokens (KNT35xCHndUgJRbXccyfYyQEUb64mwwvkWWxG5ppump) locked in GPU vault
- **Program ID**: t6YG88Q2wCsimhQ5gqSeRC8Wm5qVksw62urHAezPGPU

## Testing
✅ Tested locally with `node test.js projects/mining-tycoon/index.js`
✅ Shows $3.13k TVL (SOL priced, GPU tokens tracked but awaiting price oracle)

## Links
- Website: [Add your website]
- Twitter: [Add your Twitter]
- Explorer: https://solscan.io/account/t6YG88Q2wCsimhQ5gqSeRC8Wm5qVksw62urHAezPGPU
