### PR TITLE
Update Kaspa Finance V3 (KFC) adapter for Kasplex

### DIFF
--- a/projects/kfc.js
+++ b/projects/kfc.js
@@ -4,4 +4,4 @@ const factory = '0x09df701f1f5df83a3bbef7da4e74bb075199d6a4' // same on all chai
 
 module.exports = uniV3Export({
   kasplex: { factory, fromBlock: 484634, }
-})
+})// test change


### PR DESCRIPTION
Name (to be shown on DefiLlama): Kaspa Finance V3 (KFC)
Twitter Link: https://x.com/KaspaFinance
List of audit links if any:
Website Link: https://app.kaspafinance.io/swap
Logo (High resolution): https://app.kaspafinance.io/images/chains/0xf87e587ab945f7b111329a6ace6dc497d34f098b.png
Current TVL: $499
Treasury Addresses:
Chain: Kasplex
Coingecko ID:
Coinmarketcap ID:
Short Description: Discover the most used AMM on KASPLEX and IGRA Caravel! Farm KFC tokens, take part in innovative token launches through Initial Farm Offerings by Kaspa Finance, collect unique NFTs, and enjoy a reliable, community-driven platform.
Token address and ticker:
Category: DEX
Oracle Provider(s): None (TVL is computed directly from blockchain)
Github org/user:

My Tvl is wrong please add these tokens support and then my Tvl will be correct, and also update my DEX name from kfx dex to "Kaspa Finance V3 (KFC)"

NOTE FOR MAINTAINERS
These Kasplex ecosystem tokens currently lack Coingecko price mappings:
0xb7a95035618354d9adfc49eca49f38586b624040 -> zeal
0x9a5a144290dffa24c6c7aa8ca9a62319e60973d8 -> nacho-the-kat
0x1f3ce97f8118035dba7fbcd5398005491cf45603 -> kasper
0x98508da68180e3c23bee5685f14ad2da5195da12 -> keiro
0x0fd8d408ce707f4e4f8e54193c4c55a3b969834b -> krex
0xc47c03309c1c5e17b4a0b542dec2e47c99f16a5d -> mambo

Please add these mappings to the DefiLlama pricing registry
so the helper can display the correct TVL.