### PR TITLE
chore: update CU url

### DIFF
--- a/projects/LiquidOps/index.js
+++ b/projects/LiquidOps/index.js
@@ -2,7 +2,7 @@ const { post } = require("../helper/http.js")
 const methodologies = require('../helper/methodologies');
 
 
-const endpoint = 'https://cu.ao-testnet.xyz'
+const endpoint = 'https://cu.ardrive.io'
 const controllerId = 'SmmMv0rJwfIDVM3RvY2-P729JFYwhdGSeGo2deynbfY'
 const geckoTickerTransformations = {
     'wAR': 'arweave',


### PR DESCRIPTION
The updated Compute Unit node at cu.ardrive.io is much faster and stable than the testnet Compute Unit route at cu.ao-testnet.xyz, which would soon be deprecated