### PR TITLE
Add Altai Exchange

### DIFF
--- a/projects/altai-exchange/index.js
+++ b/projects/altai-exchange/index.js
@@ -1,0 +1,34 @@
+const TOKEN_LIST = [ 
+  "0x99EBb9BFa6AF26E483fD55F92715321EB4C93aa9",
+  "0x544ff249Be54bEaba1a80b4716D576222d41236d",
+  "0x1f22a92AdcD346B0a4EAB1672F51584f15487c91",
+  "0x5270A13CeA56f15AcfA8A58378cc8a643DFfDbFa",
+  "0xf1E087d98928B99D02c2b72412608089688A979f"
+];
+const STAKE_CONTRACT = "0x4bB93E518b17ec37a00D0f8940cafbc65184BB99";
+
+async function tvl(_, __, ___, { api }) {
+  const balances = await api.multiCall({
+    abi: "erc20:balanceOf",
+    calls: TOKEN_LIST.map(token => ({
+      target: token,
+      params: STAKE_CONTRACT
+    }))
+  });
+
+  balances.forEach((balance, i) => {
+    if (+balance > 0) api.add(TOKEN_LIST[i], balance);
+  });
+}
+
+module.exports = {
+  timetravel: true,
+  doublecounted: false,
+  misrepresentedTokens: false,
+  methodology: "Altai Exchange is a Real World Assets (RWA) protocol on BNB Chain that tokenizes physical precious metals (gold, silver, platinum, palladium, etc.). TVL represents the total USD value of all RWA-backed tokens and stablecoins currently staked/locked in the official staking contract. Token prices are supplied directly on-chain via Pyth Network oracles, with some metal tokens using troy ounce (31.1 g) denomination that is automatically normalized by the protocol.",
+  start: 1730287364,
+  bsc: { tvl },
+  hallmarks: [
+    [1730287364, "Altai Exchange Mainnet Launch"]
+  ]
+};


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
Altai Exchange

##### Twitter Link:
https://x.com/altaiexchange

##### List of audit links if any:

##### Website Link:
https://altai.exchange

##### Logo (High resolution, will be shown with rounded borders):
https://altai.exchange/logos/altai.svg

##### Current TVL:


##### Treasury Addresses (if the protocol has treasury)


##### Chain:
BSC (56)

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):[](https://api.coingecko.com/api/v3/coins/list)


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):[](https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description (to be shown on DefiLlama):
Altai Exchange – RWA protocol on BNB Chain tokenizing physical gold, silver, platinum & palladium with on-chain Pyth Network pricing.

##### Token address and ticker if any:

**Pyth Price Feed IDs – please add these + apply /31.1 divisor to metal tokens (AXAU, AXAG, AXPT, AXPD)**

| Token             | Ticker | Address                                    | Pyth Price ID (BSC)                                                  | Note                  |
|-------------------|--------|--------------------------------------------|----------------------------------------------------------------------|-----------------------|
| Altai USD         | AUSD   | 0x99EBb9BFa6AF26E483fD55F92715321EB4C93aa9 | 0x2b89b9dc8fdf9f34709a5b106b472f0f39bb6ca9ce04b0fd7f2e971688e2e53b | Stablecoin, $1 peg    |
| Altai Gold        | AXAU   | 0x544ff249Be54bEaba1a80b4716D576222d41236d | 0x765d2ba906dbc32ca17cc11f5310a89e9ee1f6420508c63861f2f8ba4ee34bb2 | divide by 31.1        |
| Altai Silver      | AXAG   | 0x1f22a92AdcD346B0a4EAB1672F51584f15487c91 | 0xf2fb02c32b055c805e7238d628e5e9dadef274376114eb1f012337cabe93871e | divide by 31.1        |
| Altai Palladium   | AXPD   | 0x5270A13CeA56f15AcfA8A58378cc8a643DFfDbFa | 0x80367e9664197f37d89a07a804dffd2101c479c7c4e8490501bc9d9e1e7f9021 | divide by 31.1        |
| Altai Platinum    | AXPT   | 0xf1E087d98928B99D02c2b72412608089688A979f | 0x398e4bbc7cbf89d6648c21e08019d878967677753b3096799595c78f805a34e5 | divide by 31.1        |

@price-team – all pricing via Pyth Network.  
Please add the above Price IDs and apply /31.1 divisor to AXAU, AXAG, AXPT, AXPD (troy ounce → 1 gram conversion, same as Tangible).  
AUSD is the $1 pegged stablecoin – no divisor needed.

Thank you so much!

##### Category (full list at https://defillama.com/categories) *Please choose only one:
RWA (Commodities)

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
Pyth Network

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
Prices are fetched directly on-chain from Pyth Network oracles in the token contracts. Some metal tokens are priced per troy ounce and divided by 31.1 to represent 1 gram denomination.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
- Swap contract (Pyth integration visible in `getPriceNoOlderThan()` function):  
  https://github.com/AltaiExchange/altai-swap/blob/main/contracts/Swap.sol

##### forkedFrom (Does your project originate from another project):

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL is the total USD value of Altai USD (AUSD) stablecoin and the four physical metal RWA tokens (AXAU, AXAG, AXPT, AXPD) currently staked in the official staking contract. All token prices are supplied directly on-chain via Pyth Network oracles. The four metal tokens represent 1 gram of the respective physical asset, with the on-chain Pyth price (per troy ounce) internally divided by 31.1 for correct gram-based valuation.

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/AltaiExchange