### PR TITLE
Slipstream V2 handler & Arcadia account version upgrade

### DIFF
--- a/projects/arcadia-finance-v2/index.js
+++ b/projects/arcadia-finance-v2/index.js
@@ -7,10 +7,13 @@ const config = {
   uniV4NFT: "0x7C5f5A4bBd8fD63184577525326123B519429bDc",
   alienBaseNFT: "0xb7996d1ecd07fb227e8dca8cd5214bdfb04534e5",
   slipNFT: "0x827922686190790b37229fd06084350e74485b72",
+  slipV2NFT: "0xa990C6a764b73BF43cee5Bb40339c3322FB9D55F",
   wAeroNFT: "0x17B5826382e3a5257b829cF0546A08Bd77409270".toLowerCase(),
   sAeroNFT: "0x9f42361B7602Df1A8Ae28Bf63E6cb1883CD44C27".toLowerCase(),
   sSlipNFT: "0x1Dc7A0f5336F52724B650E39174cfcbbEdD67bF1".toLowerCase(),
+  sSlipV2NFT: "0xBed6C3E35B9B1e044b3Bc71465769EdFDC0FDD4c".toLowerCase(),
   wsSlipNFT: "0xD74339e0F10fcE96894916B93E5Cc7dE89C98272".toLowerCase(),
+  wsSlipV2NFT: "0x147a2ccbaf4521ad209a2875ae0b3c496f4b25a4".toLowerCase(),
   pools: [
     "0x803ea69c7e87D1d6C86adeB40CB636cC0E6B98E2", // wethPool
     "0x3ec4a293Fb906DD2Cd440c20dECB250DeF141dF1", // usdcPool
@@ -19,10 +22,11 @@ const config = {
 };
 
 async function unwrapArcadiaAeroLP({ api, ownerIds }) {
-  const { wAeroNFT, sAeroNFT, sSlipNFT, wsSlipNFT } = config
+  const { wAeroNFT, sAeroNFT, sSlipNFT, sSlipV2NFT, wsSlipNFT, wsSlipV2NFT, slipNFT, slipV2NFT } = config
   const wAERONFTIds = []
   const sAERONFTIds = []
   const sSlipNftIds = []
+  const sSlipV2NftIds = []
 
   // for each asset address owned by an account
   // check if the asset is the wrapped or staked aero asset module
@@ -42,8 +46,14 @@ async function unwrapArcadiaAeroLP({ api, ownerIds }) {
         case sSlipNFT:
           sSlipNftIds.push(ids[i]);
           break;
+        case sSlipV2NFT:
+          sSlipV2NftIds.push(ids[i]);
+          break;
         case wsSlipNFT:
           sSlipNftIds.push(ids[i]);
+          break;
+        case wsSlipV2NFT:
+          sSlipV2NftIds.push(ids[i]);
           break;
       }
     }
@@ -54,96 +64,83 @@ async function unwrapArcadiaAeroLP({ api, ownerIds }) {
   wrappedData.forEach((data) => api.add(data.pool, data.amountWrapped));
   stakedData.forEach((data) => api.add(data.pool, data.amountStaked));
 
-  await uwrapStakedSlipstreamLP({ api, sSlipNftIds });
+  await uwrapStakedSlipstreamLP({ api, sSlipNftIds, nft: slipNFT });
+  await uwrapStakedSlipstreamLP({ api, sSlipV2NftIds, nft: slipV2NFT });
 }
 
-async function uwrapStakedSlipstreamLP({ api, sSlipNftIds, }) {
-  const { slipNFT } = config;
+async function uwrapStakedSlipstreamLP({ api, sSlipNftIds, nft, }) {
 
   // Arcadia's staked slipstream NFT wrapper issues a position with the same ID as the wrapped NFT
   // -> fetch the values of the wrapped IDs by simply fetching the values of those IDs on the native slipstream NFT
-  await unwrapSlipstreamNFT({ api, positionIds: sSlipNftIds, nftAddress: slipNFT, });
+  await unwrapSlipstreamNFT({ api, positionIds: sSlipNftIds, nftAddress: nft, });
 }
 
 async function tvl (api) {
-  const { factory, pools, uniNFT, uniV4NFT,slipNFT, wAeroNFT, sAeroNFT, sSlipNFT, alienBaseNFT, wsSlipNFT } = config;
+  const { factory, pools, uniNFT, uniV4NFT, slipNFT, slipV2NFT, wAeroNFT, sAeroNFT, sSlipNFT, sSlipV2NFT, alienBaseNFT, wsSlipNFT, wsSlipV2NFT } = config;
   const ownerTokens = []
   const ownerIds = []
   const accs = []
   const uniV4Ids = []
 
   const uTokens = await api.multiCall({ abi: "address:asset", calls: pools });
-  await api.sumTokens({ blacklistedTokens: [uniNFT, uniV4NFT, slipNFT, wAeroNFT, sAeroNFT, sSlipNFT, alienBaseNFT, wsSlipNFT], tokensAndOwners2: [uTokens, pools] });
+  await api.sumTokens({ blacklistedTokens: [uniNFT, uniV4NFT, slipNFT, slipV2NFT, wAeroNFT, sAeroNFT, sSlipNFT, sSlipV2NFT, alienBaseNFT, wsSlipNFT, wsSlipV2NFT], tokensAndOwners2: [uTokens, pools] });
 
   const accounts = await api.fetchList({ lengthAbi: 'allAccountsLength', itemAbi: 'allAccounts', target: factory, })
 
   // Account version 1 has a stored state of all assets, and can be fetched using generateAssetData()
   // Account version 2 has no such stored state, and must be fetched with external api calls.
   const versions = await api.multiCall({abi: 'function ACCOUNT_VERSION() view returns (uint256)', calls: accounts,});
-  const v1Accounts = accounts.filter((_, i) => versions[i] === '1');
-  const v2Accounts = accounts.filter((_, i) => versions[i] === '2');
+  const v1Accounts = accounts.filter((_, i) => versions[i] === '1' || versions[i] === '3');
+  const v2Accounts = accounts.filter((_, i) => versions[i] === '2' || versions[i] === '4');
 
   // This endpoint uses the following logic:
   // 1. Uses batches of all v2Accounts (to prevent rate limiting)
   // 2. calls Arcadia's endpoint to fetch the asset data of a V2 account
   // 3. verifies onchain that the ownership of the NFTs is indeed correct
   // 4. Return format is then transformed to be identical to the format of the V1 assetData
-  const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
 
-  const batchSize = 25;
-  for (let i = 0; i < v2Accounts.length; i += batchSize) {
-    const batch = v2Accounts.slice(i, i + batchSize);
-    await Promise.all(batch.map(async (account) => {
+  const addressesPerRequest = 5;
+  const parallelRequests = 25;
+  const accountsPerBatch = addressesPerRequest * parallelRequests;
+
+  for (let i = 0; i < v2Accounts.length; i += accountsPerBatch) {
+    const batchAccounts = v2Accounts.slice(i, i + accountsPerBatch);
+
+    // Create sub-batches of 5 addresses each
+    const requestBatches = [];
+    for (let j = 0; j < batchAccounts.length; j += addressesPerRequest) {
+      requestBatches.push(batchAccounts.slice(j, j + addressesPerRequest));
+    }
+
+    await Promise.all(requestBatches.map(async (accountGroup) => {
       try {
-        const assetDataCall = await utils.fetchURL(`https://api.arcadia.finance/v1/api/accounts/spot_asset_data?chain_id=8453&account_addresses=${account}`);
-        const assetData = assetDataCall.data[0] // call is made for multiple addresses, but may time out if all accounts are requested at once
-        if (!assetData || !assetData[0][0] || assetData[0][0].length < 1) return;
-  
-        // Since the return of the ownership data comes from a "blackbox" backend,
-        // we verify onchain that the ownership of the NFTs is indeed correct
-        // We check this for each asset where ID != 0
-        /* const verificationCalls = assetData[0][1].map((tokenId, index) => {
-          if (tokenId === "0") return null; // Skip if tokenId is 0, just an erc20, balance will be fetched through sdk
-          return {
-            target: assetData[0][0][index],
-            params: [tokenId]
-          }
-        }).filter(call => call !== null); // Remove null entries
-  
-        if (verificationCalls.length > 0) {
-          const owners = await api.multiCall({
-            abi: 'function ownerOf(uint256) view returns (address)',
-            calls: verificationCalls
-          });
-  
-          // Verify all owners match the account
-          const allOwnersMatch = owners.every(owner => owner.toLowerCase() === account.toLowerCase());
-          if (!allOwnersMatch) return; // Skip this account if any ownership verification fails
-        } */
-  
-        ownerTokens.push([assetData[0][0], account])
-        if (!assetData[0][0].length || !assetData[0][1].length || assetData[0][1] == "0") return;
-        ownerIds.push([assetData[0][0], assetData[0][1], account])
-        accs.push(account)
+        const addressParams = accountGroup.map(addr => `account_addresses=${addr}`).join('&');
+        const assetDataCall = await utils.fetchURL(`https://api.arcadia.finance/v1/api/accounts/spot_asset_data?${addressParams}&chain_id=8453`);
 
-        for (let i = 0; i < assetData[0][0].length; i++) {
-          if (assetData[0][0][i] === uniV4NFT) {
-            uniV4Ids.push(assetData[0][1][i]);
+        // Process each account's data from the batched response
+        assetDataCall.data.forEach((assetData, index) => {
+          const account = accountGroup[index];
+          if (!assetData || !assetData[0][0] || assetData[0][0].length < 1) return;
+
+          ownerTokens.push([assetData[0][0], account])
+          if (!assetData[0][0].length || !assetData[0][1].length || assetData[0][1] == "0") return;
+          ownerIds.push([assetData[0][0], assetData[0][1], account])
+          accs.push(account)
+
+          for (let i = 0; i < assetData[0][0].length; i++) {
+            if (assetData[0][0][i] === uniV4NFT) {
+              uniV4Ids.push(assetData[0][1][i]);
+            }
           }
-        }
-        
+        });
       } catch (error) {
-          console.log(`Failed to fetch/process data for account ${account}:`, error);
-          return;
+        console.log(`Failed to fetch/process data for accounts ${accountGroup.join(', ')}:`, error);
+        return;
       }
     }));
 
-    api.log(`[arcadia] Processed batch ${Math.ceil((i + 1) / batchSize)} of ${Math.ceil(v2Accounts.length / batchSize)} for v2 accounts.`);
+    api.log(`[arcadia] Processed batch ${Math.ceil((i + accountsPerBatch) / accountsPerBatch)} of ${Math.ceil(v2Accounts.length / accountsPerBatch)} for v2 accounts.`);
 
-    // Add small delay between batches to prevent rate limiting
-    if (i + batchSize < v2Accounts.length) {  // Only sleep if there are more batches to process
-      await sleep(500);
-    }
   }
 
   const assetDatasV1 = await api.multiCall({ abi: abi.generateAssetData, calls: v1Accounts, permitFailure: true })
@@ -166,7 +163,7 @@ async function tvl (api) {
     await sumTokens2({ api, owners: accs, uniV3ExtraConfig: { nftAddress: alienBaseNFT } })
 
   // add all simple ERC20s
-  await api.sumTokens({ ownerTokens, blacklistedTokens: [uniNFT, uniV4NFT, slipNFT, wAeroNFT, sAeroNFT, sSlipNFT, alienBaseNFT, wsSlipNFT],});
+  await api.sumTokens({ ownerTokens, blacklistedTokens: [uniNFT, uniV4NFT, slipNFT, slipV2NFT, wAeroNFT, sAeroNFT, sSlipNFT, sSlipV2NFT, alienBaseNFT, wsSlipNFT, wsSlipV2NFT],});
 
   // add all Arcadia-wrapped LP positions
   await unwrapArcadiaAeroLP({ api, ownerIds });
@@ -177,7 +174,7 @@ async function tvl (api) {
   if (uniV4Ids.length > 0) {
     await sumTokens2({ api, resolveUniV4: true, uniV4ExtraConfig: {"positionIds":uniV4Ids}})
   }
-  return sumTokens2({ api, owners: accs, resolveUniV3: true, resolveSlipstream: true})
+  return sumTokens2({ api, owners: accs, resolveUniV3: true, resolveSlipstream: true, resolveSlipstreamV2: true})
 }
 
 module.exports = {


### PR DESCRIPTION
Aerodrome Slipstream V2 was recently deployed on Base. Although code is very similar, this can be considered a fully new protocol (new factory, new pool impl, new position manager) -> handle Slipstream V2 positions correctly.

Added resolveSlipstreamV2 with unwrapSlipstreamV2NFTs as to not potentially break any other project's code that depends on the slipstream resolver. It uses the same code for the inner unwrapping logic, only the nft address checks in unwrapSlipstreamV2NFTs are different.

Added Arcadia Account version 3 and 4. Version 3 = margin account and handles the same way as version 1, similar for account version 4 to account version 2. All 4 account versions (can) coexist within the protocol.

Improved performance by batching spot_asset_data calls into batches of 5 and removing the sleep inbetween calls, as there is no rate limit for defillama.