### PR TITLE
Zenrock: more efficient btc tvl calculation for backfilling efficiency

### DIFF
--- a/projects/helper/bitcoin-book/fetchers.js
+++ b/projects/helper/bitcoin-book/fetchers.js
@@ -245,4 +245,71 @@ module.exports = {
     })
     return Array.from(new Set(staticAddresses))
   },
+  zenrock: async () => {
+    const ZRCHAIN_WALLETS_API = 'https://api.diamond.zenrocklabs.io/zrchain/treasury/zenbtc_wallets';
+    const ZENBTC_PARAMS_API = 'https://api.diamond.zenrocklabs.io/zenbtc/params';
+    const ZRCHAIN_KEY_BY_ID_API = 'https://api.diamond.zenrocklabs.io/zrchain/treasury/key_by_id';
+
+    // Always use latest addresses since wallets are only added, never removed.
+    // The balance checker will use the historical timestamp to get correct balances.
+    return getConfig('zenrock/addresses', undefined, {
+      fetcher: async () => {
+        async function getBitcoinAddresses() {
+          const btcAddresses = [];
+          let nextKey = null;
+
+          while (true) {
+            let url = ZRCHAIN_WALLETS_API;
+            if (nextKey) {
+              url += `?pagination.key=${encodeURIComponent(nextKey)}`;
+            }
+            const data = await get(url);
+            if (data.zenbtc_wallets && Array.isArray(data.zenbtc_wallets)) {
+              for (const walletGroup of data.zenbtc_wallets) {
+                if (walletGroup.wallets && Array.isArray(walletGroup.wallets)) {
+                  for (const wallet of walletGroup.wallets) {
+                    if (wallet.type === 'WALLET_TYPE_BTC_MAINNET' && wallet.address) {
+                      btcAddresses.push(wallet.address);
+                    }
+                  }
+                }
+              }
+            }
+            if (data.pagination && data.pagination.next_key) {
+              nextKey = data.pagination.next_key;
+            } else {
+              break;
+            }
+          }
+          return btcAddresses;
+        }
+
+        async function getChangeAddresses() {
+          const paramsData = await get(ZENBTC_PARAMS_API);
+          if (!paramsData?.params?.changeAddressKeyIDs) {
+            return [];
+          }
+          const changeAddresses = [];
+          for (const keyID of paramsData.params.changeAddressKeyIDs) {
+            const keyData = await get(`${ZRCHAIN_KEY_BY_ID_API}/${keyID}/WALLET_TYPE_BTC_MAINNET/`);
+            if (keyData.wallets && Array.isArray(keyData.wallets)) {
+              for (const wallet of keyData.wallets) {
+                if (wallet.type === 'WALLET_TYPE_BTC_MAINNET' && wallet.address) {
+                  changeAddresses.push(wallet.address);
+                }
+              }
+            }
+          }
+          return changeAddresses;
+        }
+
+        const [btcAddresses, changeAddresses] = await Promise.all([
+          getBitcoinAddresses(),
+          getChangeAddresses(),
+        ]);
+        const allAddresses = [...btcAddresses, ...changeAddresses];
+        return allAddresses;
+      }
+    });
+  },
 }


### PR DESCRIPTION
This PR intends to make data backfilling work for Zenrock protocol, by using a simplified supply based method to calculate BTC TVL. When backfilling was last attempted, we appeared to encounter a rate limiting error, likely due to checking 300+ BTC addresses for every datapoint. With this PR there is no BTC address checking, relying on zrchain's supply reporting.