### PR TITLE
Add Polymesh blockchain adapter

### DIFF
--- a/projects/polymesh/index.js
+++ b/projects/polymesh/index.js
@@ -1,0 +1,36 @@
+const { Polymesh } = require("@polymeshassociation/polymesh-sdk");
+
+const POLYX_DECIMALS = 6;
+const RPC_ENDPOINT = "wss://mainnet-rpc.polymesh.network/";
+
+async function tvl() {
+  let polymesh;
+  try {
+    polymesh = await Polymesh.connect({ nodeUrl: RPC_ENDPOINT });
+    const api = polymesh._polkadotApi;
+
+    // Get staking data
+    const activeEra = await api.query.staking.activeEra();
+    if (!activeEra || !activeEra.isSome) return {};
+    
+    const currentEra = activeEra.unwrap().index.toNumber();
+    const totalStake = await api.query.staking.erasTotalStake(currentEra);
+    
+    // Convert to POLYX (DefiLlama will handle USD conversion)
+    const stakedPolyx = Number(totalStake.toString()) / Math.pow(10, POLYX_DECIMALS);
+    
+    // Return with chain identifier (DefiLlama handles pricing)
+    return {
+      'polymesh': stakedPolyx
+    };
+  } finally {
+    if (polymesh) await polymesh.disconnect().catch(() => {});
+  }
+}
+
+module.exports = {
+  timetravel: false,
+  methodology: "Counts staked POLYX tokens in the Proof-of-Stake consensus mechanism",
+  start: 1639612800, // December 16, 2021
+  polymesh: { tvl },
+};


### PR DESCRIPTION
**NOTE**: ✅ "Allow edits by maintainers" is enabled

---

##### Name (to be shown on DefiLlama):
Polymesh

##### Twitter Link:
https://x.com/PolymeshNetwork

##### List of audit links if any:
https://github.com/PolymeshAssociation/Polymesh/tree/develop/audit

##### Website Link:
https://polymesh.network/

##### Logo (High resolution, will be shown with rounded borders):
https://drive.google.com/file/d/1jzGqlKeLqjElCO-zHgEE7QAZYxnkGRtE/view?usp=drive_link
https://polymesh.network/brand-kit

##### Current TVL:
Approximately $29-30M USD (based on staked POLYX)

##### Treasury Addresses (if the protocol has treasury)
N/A (blockchain-level staking tracking)

##### Chain:
Polymesh

##### Coingecko ID:
polymesh

##### Coinmarketcap ID:
9368

##### Short Description:
Polymesh is an institutional-grade permissioned blockchain built specifically for regulated securities and assets, featuring identity verification, compliance automation, and confidential asset management for capital markets.

##### Token address and ticker:
POLYX (Native blockchain token, 6 decimals)

##### Category:
Chain

##### forkedFrom:
N/A (purpose-built blockchain for regulated assets)

##### methodology:
Tracks POLYX tokens staked in the Proof-of-Stake consensus mechanism. The adapter connects to Polymesh mainnet via official SDK and queries staking data directly from the blockchain using Polkadot.js API. DefiLlama handles USD conversion via CoinGecko price feeds.

##### Github org/user:
PolymeshAssociation

---

**Technical Details:**
- Mainnet RPC: wss://mainnet-rpc.polymesh.network/
- SDK: @polymeshassociation/polymesh-sdk v27.7.0
- Mainnet Launch: December 16, 2021
- Documentation: https://developers.polymesh.network/