### PR TITLE
feat: update contract addresses and configuration for Clober ecosystem

### DIFF
--- a/projects/clober-liquidity-vault/index.js
+++ b/projects/clober-liquidity-vault/index.js
@@ -7,10 +7,10 @@ const abi = {
 }
 
 const config = {
-  rebalancer: '0xeA0E19fbca0D9D707f3dA10Ef846cC255B0aAdf3',
-  bookManager: '0x382CCccbD3b142D7DA063bF68cd0c89634767F76',
-  blacklistedTokens: ['0x000000000000bb1b11e5ac8099e92e366b64c133'],
-  fromBlock: 21715410
+  rebalancer: '0xB09684f5486d1af80699BbC27f14dd5A905da873',
+  bookManager: '0x6657d192273731C3cAc646cc82D5F28D0CBE8CCC',
+  blacklistedTokens: [],
+  fromBlock: 31662843
 }
 
 async function tvl(api) {
@@ -23,7 +23,6 @@ async function tvl(api) {
 }
 
 module.exports = {
-  // hallmarks: [[1733788800, 'The Clober Liquidity Vault has been hacked']],
   methodology: "TVL includes all assets deposited into the Clober Liquidity Vault contract, specifically allocated for liquidity provision and market-making within the Clober ecosystem",
-  base: { tvl }
+  monad: { tvl }
 }

--- a/projects/clober-v2/index.js
+++ b/projects/clober-v2/index.js
@@ -7,8 +7,7 @@ const abi = {
 }
 
 const config = {
-  base: { factory: '0x382CCccbD3b142D7DA063bF68cd0c89634767F76', fromBlock: 14528050, },
-  era: { factory: '0xAaA0e933e1EcC812fc075A81c116Aa0a82A5bbb8', fromBlock: 34448160, },
+  monad: { factory: '0x6657d192273731C3cAc646cc82D5F28D0CBE8CCC', fromBlock: 31662843, },
 }
 
 function customCacheFunction({ cache, logs }) {


### PR DESCRIPTION
we have deprecated all previously supported chains and migrated our entire deployment to monad mainnet
clober is now officially launched exclusively on monad mainnet, and all legacy deployments on other chains have been fully sunset. 

this pr updates our tvl sources accordingly and aligns defiLlama integration with our new monad-only architecture