### PR TITLE
Add hyperEVM support for Nabla Finance TVL

### DIFF
--- a/projects/nabla/index.js
+++ b/projects/nabla/index.js
@@ -8,7 +8,7 @@ const config = {
   berachain: {
     backstopPool: "0xfa158Cf7cD83F418eBD1326121810466972447F6",
   },
-  hyperevm: {
+  hyperliquid: {
     backstopPool: "0x2cD52FF130FD8c4cB1F83c9a179C41FbB06d2363",
   },
   monad: {


### PR DESCRIPTION
Nabla Finance is also deployed to HyperEVM (chain id: 999)


Lets see if we can make this work even if DefiLlama shows
> We don't track any protocols with TVL, Fees, Revenue or Volume on this chain
