### PR TITLE
pingu exchange : remove arbitrum

### DIFF
--- a/projects/pingu/index.js
+++ b/projects/pingu/index.js
@@ -1,9 +1,4 @@
-const ADDRESSES = require('../helper/coreAssets.json')
 const { sumTokensExport, nullAddress } = require('../helper/unwrapLPs')
-
-const fundStore_arb = "0x7Cc41ee3Cba9a1D2C978c37A18A0d6b59c340224"; // fundStore_arb
-const PINGU_arb = "0x83E60B9F7f4DB5cDb0877659b1740E73c662c55B"; // PINGU_arb
-const assets_ARB = [nullAddress, ADDRESSES.arbitrum.USDC_CIRCLE] // ETH, USDC
 
 const fundStore_monad = "0x576d51fB872065DC4Af6f83902fd4078eBCc2f03"; // fundStore_monad
 const PINGU_monad = "0xA2426cD97583939E79Cfc12aC6E9121e37D0904d"; // PINGU_monad
@@ -11,11 +6,7 @@ const USDC_monad = "0x754704Bc059F8C67012fEd69BC8A327a5aafb603"; // USDC_monad
 const assets_MONAD = [nullAddress, USDC_monad] // MON, USDC
 
 module.exports = {
-	arbitrum: {
-		start: '2024-01-10',
-		tvl: sumTokensExport({ owners: [fundStore_arb], tokens: assets_ARB }),
-		staking: sumTokensExport({ owners: [fundStore_arb], tokens: [PINGU_arb] }),
-	},
+	start: '2025-11-24',
 	monad: {
 		start: '2025-11-24',
 		tvl: sumTokensExport({ owners: [fundStore_monad], tokens: assets_MONAD }),


### PR DESCRIPTION
We have finally decided to delete the Arbitrum data because we have sunset and the protocol is no longer active on the chain.