### PR TITLE
Add LinkDeFi TVL adapter on Base

### DIFF
--- a/projects/linkdefi/index.js
+++ b/projects/linkdefi/index.js
@@ -1,47 +1,22 @@
-// projects/linkdefi/index.js
 
-// Base 체인 Split4626 Vault 하나만 TVL로 잡는 간단 어댑터
 
 const VAULT = '0x806Ea0e218d24410e24533fB68810440E3b618e1';
 
-// 우리가 필요한 view 함수 2개만 미니 ABI로 정의
-const VAULT_ABI = {
-  asset: {
-    name: 'asset',
-    inputs: [],
-    outputs: [{ internalType: 'address', name: '', type: 'address' }],
-    stateMutability: 'view',
-    type: 'function',
-  },
-  totalAssets: {
-    name: 'totalAssets',
-    inputs: [],
-    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
-    stateMutability: 'view',
-    type: 'function',
-  },
-};
-
-// tvl(api) 함수: DefiLlama SDK가 api를 넣어줌
 async function tvl(api) {
-  // 1) 볼트 컨트랙트에서 underlying 토큰 주소 + totalAssets 읽기
+ 
   const [asset, totalAssets] = await Promise.all([
-    api.call({ target: VAULT, abi: VAULT_ABI.asset }),
-    api.call({ target: VAULT, abi: VAULT_ABI.totalAssets }),
+    api.call({ target: VAULT, abi: "address:asset" }),
+    api.call({ target: VAULT, abi: "uint256:totalAssets" }),
   ]);
 
-  // 2) TVL에 "asset 토큰을 totalAssets 만큼 보유"로 추가
-  //    decimals 처리는 라마 쪽에서 알아서 해줌
+
   api.add(asset, totalAssets);
 }
 
-// DefiLlama가 읽어가는 export 형식
+
 module.exports = {
   methodology:
-    'Base 체인의 Split4626 Vault(0x806E...)에 예치된 underlying 자산 수량을 TVL로 카운트합니다.',
-  // start 블록은 대충 대략적인 시작 블록 넣어도 되고, 모르면 생략해도 돌아감
-  // start: 12345678,
-
+    'Base Chain Split4626 Vault(0x806E...) TVL Count.',
   base: {
     tvl,
   },


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/adapters).
> - If you would like to add a `liquidations` adapter, please refer to [this readme document](https://github.com/DefiLlama/DefiLlama-Adapters/tree/main/liquidations) for details.

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
3. Please fill the form below  **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
4. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can  edit it there and put up a PR
5. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
6. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap

---
##### Name (to be shown on DefiLlama): LinkDeFi


##### Twitter Link:  N/A


##### List of audit links if any: N/A (no formal audits yet)

##### Website Link: https://linkdefi.xyz


##### Logo (High resolution, will be shown with rounded borders): [add logo URL here, e.g. https://linkdefi.xyz/logo.png]


##### Current TVL: ≈ $50 (Base USDC Split vault at time of listing, dynamic on-chain)


##### Treasury Addresses (if the protocol has treasury) N/A


##### Chain: Base


##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)
(leave empty)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
(leave empty)

##### Short Description (to be shown on DefiLlama):
LinkDeFi is a yield protocol that routes USDC on Base into a Split ERC-4626 vault, allocating deposits across multiple underlying strategies to optimize yield.

##### Token address and ticker if any:
No protocol token yet (vault uses USDC as the underlying asset).

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Yield Aggregator

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
N/A – TVL is computed directly from on-chain balances without using an external oracle.

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
N/A

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
N/A

##### forkedFrom (Does your project originate from another project):
None (custom Split ERC-4626 vault implementation).

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL is calculated as the `totalAssets()` value of the Split4626 vault on Base (`0x806Ea0e218d24410e24533fB68810440E3b618e1`), counting the underlying USDC returned by `asset()` as TVL. Unclaimed rewards or protocol-owned liquidity are not double-counted.

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/AES-256-2