### PR TITLE
chore: add supervault v2 logic

### DIFF
--- a/projects/superform/index.js
+++ b/projects/superform/index.js
@@ -32,35 +32,57 @@ const CONFIG = {
   linea: {}
 }
 
+
 const DEFAULT_FACTORY = '0xD85ec15A9F814D6173bF1a89273bFB3964aAdaEC'
+const SUPERVAULT_AGGREGATOR = '0x10AC0b33e1C4501CF3ec1cB1AE51ebfdbd2d4698'
+
 
 const previewRedeemFromAbi = "function previewRedeemFrom(uint256) external view returns(uint256)"
 
+
 const tvl = async (api) => {
+  // Superform v1 TVL
   const { factory = DEFAULT_FACTORY, blacklistedVaults = [] } = CONFIG[api.chain]
   const forms = await api.fetchList({ lengthAbi: 'getSuperformCount', itemAbi: "function superforms(uint256) external view returns(uint256)", target: factory })
   const getSuperformRes = await api.multiCall({ abi: "function getSuperform(uint256) external view returns(address, uint32, uint64)", calls: forms, target: factory })
   const super4626 = getSuperformRes.map(v => v[0])
   const vaults = await api.multiCall({ abi: 'address:vault', calls: super4626 })
 
+
   const pairs = vaults
     .map((v, i) => ({ vault: v, s: super4626[i] }))
     .filter(p => p.vault && !blacklistedVaults.includes(p.vault.toLowerCase()))
+
 
   if (pairs.length === 0) return;
   const filteredVaults = pairs.map(p => p.vault);
   const filteredSuper4626 = pairs.map(p => p.s);
 
+
   const assets = await api.multiCall({ abi: 'address:asset', calls: filteredSuper4626 })
   const vBals = await api.multiCall({ abi: "erc20:balanceOf", calls: filteredVaults.map((v, i) => ({ target: v, params: filteredSuper4626[i] })) })
   const bals = await api.multiCall({ abi: previewRedeemFromAbi, calls: filteredSuper4626.map((v, i) => ({ target: v, params: vBals[i] })), permitFailure: true })
+
 
   bals.forEach((bal, i) => {
     const asset = assets[i]
     if (!bal || !asset) return
     api.add(asset, bal)
   })
+
+
+  // SuperVault v2 TVL
+  const superVaults = await api.call({ abi: 'function getAllSuperVaults() view returns (address[])', target: SUPERVAULT_AGGREGATOR, permitFailure: true })
+  if (superVaults && superVaults.length > 0) {
+    const svAssets = await api.multiCall({ abi: 'address:asset', calls: superVaults })
+    const svTotalAssets = await api.multiCall({ abi: 'uint256:totalAssets', calls: superVaults })
+    svTotalAssets.forEach((bal, i) => {
+      if (!bal || !svAssets[i]) return
+      api.add(svAssets[i], bal)
+    })
+  }
 }
+
 
 module.exports = {
   methodology: "counts the TVL of each superform across all the supported networks",
@@ -68,7 +90,9 @@ module.exports = {
     [1707350400, "Early Access"],
     [1715212800, "Open Launch"],
     [1734012000, "SuperVaults Launch"],
+    [1764802000, "SuperVaults v2 Launch"],
   ]
 };
+
 
 Object.keys(CONFIG).forEach(chain => module.exports[chain] = { tvl })


### PR DESCRIPTION
Only changes to existing page https://defillama.com/protocol/superform are shown below

##### List of audit links if any: https://github.com/superform-xyz/superform-core/tree/main/security-review, https://github.com/superform-xyz/v2-core/tree/dev/audits, https://github.com/superform-xyz/v2-periphery/tree/dev/audits

##### Logo (High resolution, will be shown with rounded borders): https://github.com/superform-xyz/brand-kit/blob/main/Social_Logo_Round.svg 

##### Token address and ticker if any: $UP, https://etherscan.io/token/0x1d926bbe67425c9f507b9a0e8030eedc7880bf33

##### methodology (what is being counted as tvl, how is tvl being calculated): SuperVaults v2 are permissionlessly creatable vault products, you can learn more here: https://blog.superform.xyz/2025/11/24/introducing-supervaults-v2/. The adapter is effectively getting all vaults created from the Aggregator (Factory) and then iterating through them to get totalAssets held. 

##### Github org/user (Optional, if your code is open source, we can track activity): https://github.com/superform-xyz/v2-periphery
