### PR TITLE
feat(myriad-markets): add BSC chain support

### DIFF
--- a/projects/myriad-markets/index.js
+++ b/projects/myriad-markets/index.js
@@ -4,6 +4,8 @@ const { sumTokensExport } = require('../helper/unwrapLPs')
 const config = {
   abstract: { owner: '0x3e0F5F8F5Fb043aBFA475C0308417Bf72c463289', tokens: [ADDRESSES.abstract.USDC] },
   linea: { owner: '0x39e66ee6b2ddaf4defded3038e0162180dbef340', tokens: [ADDRESSES.linea.USDC] },
+  bsc: { owner: '0x39e66ee6b2ddaf4defded3038e0162180dbef340', tokens: [ADDRESSES.bsc.USDT] },
+  
 }
 
 Object.keys(config).forEach(chain => {

--- a/projects/treasury/myriad-markets.js
+++ b/projects/treasury/myriad-markets.js
@@ -4,6 +4,7 @@ const { sumTokensExport } = require('../helper/unwrapLPs')
 const config = {
   abstract: { owner: '0x5E3EbEc100e2294C0EB2264FC96225dF067AAaa3', tokens: [ADDRESSES.abstract.USDC] },
   linea: { owner: '0x5E3EbEc100e2294C0EB2264FC96225dF067AAaa3', tokens: [ADDRESSES.linea.USDC] },
+  bsc: { owner: '0x5E3EbEc100e2294C0EB2264FC96225dF067AAaa3', tokens: [ADDRESSES.bsc.USDT] },
 }
 
 Object.keys(config).forEach(chain => {


### PR DESCRIPTION
## PR Title
feat(myriad-markets): add BSC chain support

## Summary
Myriad Markets deployed on BSC using the same owner contract and TVL structure as Linea.  
This PR adds BSC support to the adapter by adding a new config entry referencing the BSC USDT token.

## Changes
- Added `bsc` config entry to `projects/myriad-markets/index.js`
- Reused Linea owner address (confirmed identical)
- Linked token to `coreAssets.bsc.USDT`
- Added BSC support to the Treasury adapter in projects/treasury/myriad-markets.js.

## Methodology
TVL is computed via `sumTokensExport` using:
- Owner address: `0x39e66ee6b2ddaf4defded3038e0162180dbef340`
- Token list: `[ADDRESSES.bsc.USDT]`

No ABI or contract logic was changed.

## Tests
Tested locally via:
```bash
node test.js projects/myriad-markets/index.js
```

All three chains (abstract, linea, bsc) returned correct token balances and aggregated TVL.