### PR TITLE
Fix Noble TVL calculations

### DIFF
--- a/projects/noble-points-vault.js
+++ b/projects/noble-points-vault.js
@@ -4,14 +4,15 @@ const ENDPOINT = 'https://api.noble.xyz/noble/dollar/vaults/v1/stats';
 
 async function tvl() {
   const data = await get(ENDPOINT);
-  const tvlUsd = Number(data.staked_total_principal) / 1e6;
-  return { tether: tvlUsd };
+  const usdnAmount = Number(data.staked_total_principal) / 1e6;
+  return { 'noble-dollar-usdn': usdnAmount };
 }
 
 module.exports = {
   timetravel: false,
-  methodology: 'TVL is the total principal deposited in the Noble USDN points vault.',
+  methodology: 'TVL is the total USDN deposited in the Noble points vault.',
   noble: {
     tvl,
   },
-}
+};
+


### PR DESCRIPTION
updates the Noble adapter to stop using total chain token supply as TVL and instead use the Noble points vault as the TVL source (the only TVL on Noble currently).