### PR TITLE
Update Strike Finance adapter

### DIFF
--- a/projects/helper/chain/cardano/blockfrost.js
+++ b/projects/helper/chain/cardano/blockfrost.js
@@ -84,6 +84,11 @@ async function getTokensMinted(tokenId){
   return Number(data.quantity)
 }
 
+async function getAccountAddresses(account) {
+  const { data } = await axiosObj.get(`/accounts/${account}/addresses`)
+  return data
+}
+
 module.exports = {
   getAssets,
   getAddressesUTXOs,
@@ -94,4 +99,5 @@ module.exports = {
   addressesUtxosAssetAll,
   getTokensMinted,
   getScriptsDatum,
+  getAccountAddresses
 }

--- a/projects/strike-finance/index.js
+++ b/projects/strike-finance/index.js
@@ -1,26 +1,19 @@
+const { getAccountAddresses } = require("../helper/chain/cardano/blockfrost");
 const { sumTokens2 } = require("../helper/chain/cardano");
 
+const strikeStakeAccount = "stake1uyd2hj6j4848mdrdln7x8fc6hpunw5ft6yct2rtzafzrt9qh0m28h"
 const strikeStaking =
   "addr1z9yh4zcqs4gh78ysvh8nqp40fsnxg49nn3h6x25az9k8tms6409492020k6xml8uvwn34wrexagjh5fsk5xk96jyxk2qf3a7kj";
-const strikeBatching =
-  "addr1q9mqsgrgdaq9aahjfcrc6f45sgmcut4gu3c774kqzawkjkhujht5h40l2yrm8e7r2vwr2g3tv64pzjgnxwsztwg0yu5s00jz00";
 const strikeTokenAddress =
   "f13ac4d66b3ee19a6aa0f2a22298737bd907cc95121662fc971b5275535452494b45";
-const strikePerpsScript =
-  "addr1wy2gch9ua0700a3dg423wxcwx4p886m4ny5u3aqs66sluqcly9uud";
-const strikePerpsScriptV2 =
-  "addr1z9nsxjyw7xgfw5jtfxcw7fxucte0277ununa4evyxcw3evg6409492020k6xml8uvwn34wrexagjh5fsk5xk96jyxk2q4366ry";
-const strikeSnekPerpsScript =
-  "addr1zy48lqwffvzkahcyrhj8982p3f7c002g098ly4zxzxefnlg6409492020k6xml8uvwn34wrexagjh5fsk5xk96jyxk2qst04fy";
+  
 
 async function tvl() {
+  const addresses = (await getAccountAddresses(strikeStakeAccount))
+    .map(a => a.address)
+    .filter(addr => addr !== strikeStaking);
   return await sumTokens2({
-    owners: [
-      strikePerpsScript,
-      strikeBatching,
-      strikePerpsScriptV2,
-      strikeSnekPerpsScript,
-    ],
+    owners: addresses
   });
 }
 


### PR DESCRIPTION
This PR updates the Strike Finance adapter to fetch all addresses associated with the stake key instead of using hardcoded addresses. To support this, I've added the `getAccountAddresses` helper function to `/helper/chain/cardano/blockfrost.js`. The staked protocol token address is filtered out of the list before TVL is calculated. 
