### PR TITLE
Add RandAO adapter

### DIFF
--- a/projects/randao.net/index.js
+++ b/projects/randao.net/index.js
@@ -1,0 +1,9 @@
+async function tvl() {
+  return {}
+}
+
+module.exports = {
+  ao: {
+    tvl,
+  },
+}


### PR DESCRIPTION
##### Name (to be shown on DefiLlama): randao.net

##### Twitter Link: https://x.com/RandAOToken

##### Website Link: https://randao.net

##### Logo (High resolution, will be shown with rounded borders): 
<img width="341" height="341" alt="favicon png" src="https://github.com/user-attachments/assets/4fd27757-4390-4140-92fc-69973b049933" />

##### Chain: AO

##### Short Description (to be shown on DefiLlama): RandAO is a decentralized randomness protocol built on AO.

##### Category: Oracle

##### Implementation Details: randao.net provides verifiable randomness via AO processes. The current adapter is intentionally minimal as the protocol does not yet have on-chain value locked.

##### Documentation/Proof: https://docs_randao.ar.io/

##### methodology (what is being counted as tvl, how is tvl being calculated): Currently no TVL. The adapter returns 0 as the protocol does not custody funds on-chain yet.

##### Github: https://github.com/RandAOLabs