### PR TITLE
add stellar + spiko cash & carry

### DIFF
--- a/projects/spiko/index.js
+++ b/projects/spiko/index.js
@@ -1,57 +1,119 @@
-const { multiCall } = require('../helper/chain/starknet')
-const { sumTokens2 } = require('../helper/unwrapLPs')
+const { multiCall } = require("../helper/chain/starknet");
+const { sumTokens2 } = require("../helper/unwrapLPs");
+const { get } = require("../helper/http");
+const { stellar } = require("../helper/chain/rpcProxy");
 
 const config = {
   polygon: [
-    '0xe4880249745eAc5F1eD9d8F7DF844792D560e750',
-    '0xa0769f7A8fC65e47dE93797b4e21C073c117Fc80'
+    "0xe4880249745eAc5F1eD9d8F7DF844792D560e750", //USTBL
+    "0xa0769f7A8fC65e47dE93797b4e21C073c117Fc80", //EUTBL
+    "0x903d5990119bc799423e9c25c56518ba7dd19474", //SPKCC
+    "0x99F70A0e1786402a6796c6B0AA997ef340a5c6da", //eurSPKCC
+    "0x970E2aDC2fdF53AEa6B5fa73ca6dc30eAFEDfe3D", //UKTBL
   ],
   ethereum: [
-    '0xe4880249745eAc5F1eD9d8F7DF844792D560e750',
-    '0xa0769f7A8fC65e47dE93797b4e21C073c117Fc80'
+    "0xe4880249745eAc5F1eD9d8F7DF844792D560e750", //USTBL
+    "0xa0769f7A8fC65e47dE93797b4e21C073c117Fc80", //EUTBL
+    "0x4f33acf823e6eeb697180d553ce0c710124c8d59", //SPKCC
+    "0x3868D4e336d14D38031cf680329d31e4712e11cC", //eurSPKCC
+    "0xf695Df6c0f3bB45918A7A82e83348FC59517734E", //UKTBL
   ],
   arbitrum: [
-    '0x021289588cd81dC1AC87ea91e91607eEF68303F5',
-    '0xcbeb19549054cc0a6257a77736fc78c367216ce7'
+    "0x021289588cd81dC1AC87ea91e91607eEF68303F5", //USTBL
+    "0xcbeb19549054cc0a6257a77736fc78c367216ce7", //EUTBL
+    "0x99f70a0e1786402a6796c6b0aa997ef340a5c6da", //SPKCC
+    "0x0e389C83Bc1d16d86412476F6103027555C03265", //eurSPKCC
+    "0x903d5990119bC799423e9C25c56518Ba7DD19474", //UKTBL
   ],
   base: [
-    '0xe4880249745eAc5F1eD9d8F7DF844792D560e750',
-    '0xa0769f7A8fC65e47dE93797b4e21C073c117Fc80'
+    "0xe4880249745eAc5F1eD9d8F7DF844792D560e750", //USTBL
+    "0xa0769f7A8fC65e47dE93797b4e21C073c117Fc80", //EUTBL
+    "0xf695df6c0f3bb45918a7a82e83348fc59517734e", //SPKCC
+    "0x4f33aCf823E6eEb697180d553cE0c710124C8D59", //eurSPKCC
+    "0xA8De1f55Aa0E381cb456e1DcC9ff781eA0079068", //UKTBL
   ],
   starknet: [
-    '0x20ff2f6021ada9edbceaf31b96f9f67b746662a6e6b2bc9d30c0d3e290a71f6',
-    '0x4f5e0de717daa6aa8de63b1bf2e8d7823ec5b21a88461b1519d9dbc956fb7f2'
+    "0x20ff2f6021ada9edbceaf31b96f9f67b746662a6e6b2bc9d30c0d3e290a71f6", //USTBL
+    "0x4f5e0de717daa6aa8de63b1bf2e8d7823ec5b21a88461b1519d9dbc956fb7f2", //EUTBL
+    "0x04bade88e79a6120f893d64e51006ac6853eceeefa1a50868d19601b1f0a567d", //SPKCC
+    "0x06472cabc51a3805975b9c60c7dec63897c9a287f2db173a1d6c589d18dd1e07", //eurSPKCC
+    "0x0153d6e0462080bb2842109e9b64f589ef5aa06bb32b26bbdb894aca92674395", //UKTBL
   ],
   etlk: [
-    '0xe4880249745eAc5F1eD9d8F7DF844792D560e750',
-    '0xa0769f7A8fC65e47dE93797b4e21C073c117Fc80',
-  ]
+    "0xe4880249745eAc5F1eD9d8F7DF844792D560e750", //USTBL
+    "0xa0769f7A8fC65e47dE93797b4e21C073c117Fc80", //EUTBL
+    "0x4f33aCf823E6eEb697180d553cE0c710124C8D59", //SPKCC
+    "0x3868D4e336d14D38031cf680329d31e4712e11cC", //eurSPKCC
+    "0x970E2aDC2fdF53AEa6B5fa73ca6dc30eAFEDfe3D", //UKTBL
+  ],
+  stellar: [
+    {
+      contract: "CARUUX2FZNPH6DGJOEUFSIUQWYHNL5AVDV7PMVSHWL7OBYIBFC76F4TO",
+      target: "0xe4880249745eAc5F1eD9d8F7DF844792D560e750",
+    }, // USTBL
+    {
+      contract: "CBGV2QFQBBGEQRUKUMCPO3SZOHDDYO6SCP5CH6TW7EALKVHCXTMWDDOF",
+      target: "0xa0769f7A8fC65e47dE93797b4e21C073c117Fc80",
+    }, // EUTBL
+    // {
+    //   contract: "CDWOB6T7SVSMMQN5V3P2OPTBAXOP7DAZHGVW3PYTZIKHVFKN6TBSXR6A",
+    //   target: "0x3868D4e336d14D38031cf680329d31e4712e11cC",
+    // }, // eurSPKCC
+    // {
+    //   contract: "CDS2GCAQTNQINSCJUJIVBJXILKBWP5PU7LOBGHMP3X47QCQBFKPMTCNT",
+    //   target: "0x4f33acf823e6eeb697180d553ce0c710124c8d59",
+    // }, // SPKCC
+    {
+      contract: "CDT3KU6TQZNOHKNOHNAFFDQZDURVC3MSTL4ML7TUTZGNOPBZCLABP4FR",
+      target: "0xf695Df6c0f3bB45918A7A82e83348FC59517734",
+    }, // UKTBL
+  ],
+};
+
+async function fetchStellarSupply(contract) {
+  const { supply } = await get(
+    `https://api.stellar.expert/explorer/public/asset/${contract}`
+  );
+  return supply;
 }
 
 const totalSupplyAbi = {
-  "name": "totalSupply",
-  "type": "function",
-  "inputs": [],
-  "outputs": [
+  name: "totalSupply",
+  type: "function",
+  inputs: [],
+  outputs: [
     {
-      "name": "totalSupply",
-      "type": "uint256"
-    }
+      name: "totalSupply",
+      type: "uint256",
+    },
   ],
-  "stateMutability": "view",
-}
+  stateMutability: "view",
+};
 
-Object.keys(config).forEach(chain => {
-  const assets = config[chain]
+Object.keys(config).forEach((chain) => {
+  const assets = config[chain];
   module.exports[chain] = {
     tvl: async (api) => {
-      let supplies
-      if (chain === 'starknet')
-        supplies = await multiCall({ abi: totalSupplyAbi, calls: assets })
+      if (chain === "stellar") {
+        const supplies = await Promise.all(
+          assets.map(({ contract }) => fetchStellarSupply(contract))
+        );
+        supplies.forEach((supply, i) => {
+          const { target } = assets[i];
+          api.add(`ethereum:${target}`, supply, { skipChain: true });
+        });
+        return api.getBalances();
+      }
+      let supplies;
+      if (chain === "starknet")
+        supplies = await multiCall({ abi: totalSupplyAbi, calls: assets });
       else
-        supplies = await api.multiCall({ abi: 'erc20:totalSupply', calls: assets })
-      api.add(assets, supplies)
-      return sumTokens2({ api })
-    }
-  }
-})
+        supplies = await api.multiCall({
+          abi: "erc20:totalSupply",
+          calls: assets,
+        });
+      api.add(assets, supplies);
+      return sumTokens2({ api });
+    },
+  };
+});


### PR DESCRIPTION
**SPIKO NEW PRODUCTS**
- Spiko launched 3 new tokens in the past few months: Spiko C&C (https://www.spiko.io/spiko-cash-and-carry) and Spiko Pound (https://www.spiko.io/spiko-pound)
- The 3 tokens are: SPKCC, eurSPKCC, UKTBL
- They're deployed on all Spiko supported networks

**STELLAR**
- Spiko assets are now available on Stellar: https://x.com/Spiko_finance/status/1991506200312312211
- You can verify the token addresses in both funds prospectus: https://docs.spiko.io/documentation/legal_documentation/prospectus/
- I've commented the SPKCC and eurSPKCC addresses on Stellar since there's an issue with these contracts (currently investigating with the SDF). We'll resubmit a PR once the issue is fixed.

**QUESTION / ISSUE**
- In the DeFiLlama UI, there is an issue with the token displays. There is no token breakdown for the TVL on Starknet. Everything is summed under an empty "()" ticker. 
- How can we fix this?