### PR TITLE
fix(donut): track burned LP tokens for accurate TVL

### DIFF
--- a/projects/donut/index.js
+++ b/projects/donut/index.js
@@ -7,7 +7,7 @@ const AUCTION_ADDRESS = "0xC23E316705Feef0922F0651488264db90133ED38";
 // Original burn address - always track this even if paymentReceiver changes
 const DEAD_ADDRESS = "0x000000000000000000000000000000000000dEaD";
 
-async function tvl(api) {
+async function pool2(api) {
   // Read current paymentReceiver from Auction contract
   const paymentReceiver = await api.call({
     abi: "address:paymentReceiver",
@@ -31,8 +31,9 @@ async function tvl(api) {
 
 module.exports = {
   methodology:
-    "TVL is the value of permanently burned DONUT/WETH LP tokens. Tracks LP at the dead address plus the current Auction paymentReceiver.",
+    "Pool2 tracks the value of permanently burned DONUT/WETH LP tokens at the dead address plus the current Auction paymentReceiver.",
   base: {
-    tvl,
+    tvl: () => ({}),
+    pool2,
   },
 };


### PR DESCRIPTION
## Summary
- Track LP tokens at burn address for accurate TVL calculation
- Read `paymentReceiver` dynamically from Auction contract
- Remove incorrect staking/pool2 sections (protocol has no staking mechanism)

## Protocol Overview
Donut is a mining protocol where users pay WETH to mine DONUT tokens. The Auction contract collects LP tokens as payment and sends them to a burn address, permanently locking the liquidity.

## Changes
- **TVL**: Now correctly tracks burned DONUT/WETH LP tokens at `0x...dEaD`
- **Dynamic**: Reads burn address from Auction contract's `paymentReceiver`
- **Future-proof**: Always tracks dead address + current paymentReceiver (in case it changes)
- **Removed**: Fake staking/pool2 categories that didn't reflect actual protocol mechanics

## Test Results
```
WETH                      273.58 k
DONUT                     272.62 k
Total: 546.20 k
```

## Contracts
- Auction: `0xC23E316705Feef0922F0651488264db90133ED38`
- LP Token: `0xD1DbB2E56533C55C3A637D13C53aeEf65c5D5703`
- Burn Address: `0x000000000000000000000000000000000000dEaD`