### PR TITLE
refactor: add `deadFrom` for defi.money

### DIFF
--- a/projects/defi-money/index.js
+++ b/projects/defi-money/index.js
@@ -52,6 +52,7 @@ const pool2 = async (api) => {
 }
 
 module.exports = {
+  deadFrom: '2025-06-01',
   methodology: "TVL corresponds to the collateral deposited in the markets",
 }
 


### PR DESCRIPTION
## Summary

> As of June 1, 2025, the [defi.money](http://defi.money/) protocol, including its user interface, will be taken offline, and all services - borrowing, leverage, and staking will cease to function (at the UI level).

Refs: 
1. https://blog.defi.money/sunsetting-defimoney#h-user-actions
2. https://x.com/defidotmoney/status/1920119197402558536