### PR TITLE
Genius Yield Adapter - Update: added v2.0 address

### DIFF
--- a/projects/genius-yield/index.js
+++ b/projects/genius-yield/index.js
@@ -9,8 +9,9 @@ const gensx = 'fbae99b8679369079a7f6f0da14a2cf1c2d6bfd3afdf3a96a64ab67a0014df104
 const staking = 'addr1w8r99sv75y9tqfdzkzyqdqhedgnef47w4x7y0qnyts8pznq87e4wh'
 
 const orders = [
-  'addr_vkh1ahllvc7n0lzljafmcs3zurdzhlsg4fydkzph6tpjnt0tx0asedu', // v1.0
-  'addr_vkh14rtl7h85cytjwq5gxuhe4j8peedhtzhptfu9r3qkvxjgcz7xfs0'  // v1.1
+  'addr_vkh1ahllvc7n0lzljafmcs3zurdzhlsg4fydkzph6tpjnt0tx0asedu',        // v1.0
+  'addr_vkh14rtl7h85cytjwq5gxuhe4j8peedhtzhptfu9r3qkvxjgcz7xfs0',        // v1.1
+  'addr_shared_vkh12xfk70yc5p9kvzd2ndwgx2aprqk0gwjcu560eszakzwkj6ry36s'  // v2.0
 ]
 
 module.exports = {


### PR DESCRIPTION
# Genius Yield Adapter Update: Added v2.0 address

Recently the v2.0 of the smart contracts had been deployed.

The assets locked into Smart Liquidity Vaults or Two Way Orders are available under a new shared payment address.

This address had been added as part of this PR.

With this change the assets locked into Smart Liquidity Vaults (Two Way Orders) should show up in the TVL of Genius yield.