### PR TITLE
Add Polymesh staking TVL

### DIFF
--- a/projects/helper/chains.json
+++ b/projects/helper/chains.json
@@ -332,6 +332,7 @@
   "polkadot",
   "polygon",
   "polygon_zkevm",
+  "polymesh",
   "polynomial",
   "pool2",
   "posi",

--- a/projects/polymesh-staking/index.js
+++ b/projects/polymesh-staking/index.js
@@ -1,0 +1,30 @@
+const { ApiPromise, WsProvider } = require("@polkadot/api")
+
+const WS_ENDPOINT = "wss://mainnet-rpc.polymesh.network"
+const POLYX_DECIMALS = 1e6
+
+async function tvl(api) {
+  const provider = new WsProvider(WS_ENDPOINT)
+  const chainApi = await ApiPromise.create({ provider })
+  await chainApi.isReady
+
+  // TVL = total amount bonded in staking (POLYX)
+  // Source: staking pallet → erasTotalStake for the active era
+  const activeEra = await chainApi.query.staking.activeEra()
+  const eraIndex =
+    activeEra.toJSON()?.index ?? activeEra.toHuman()?.index
+
+  const total = await chainApi.query.staking.erasTotalStake(eraIndex)
+  const totalPolyx = Number(total.toString()) / POLYX_DECIMALS
+
+  await chainApi.disconnect()
+
+  api.addCGToken("polymesh", totalPolyx)
+}
+
+module.exports = {
+  timetravel: false,
+  methodology:
+    "Counts total staked POLYX on Polymesh using the staking pallet erasTotalStake for the active era.",
+  polymesh: { tvl },
+}


### PR DESCRIPTION
This PR adds a TVL adapter for Polymesh staking.

TVL is calculated as the total amount of POLYX bonded in staking, using on-chain data from the Polymesh staking pallet (`erasTotalStake`) for the active era via the Polymesh mainnet RPC.

- TVL source: on-chain staking pallet
- Asset: POLYX
- Chain: Polymesh
- Timetravel: disabled (non-EVM chain)

No off-chain APIs are used.