### PR TITLE
TermMax: third pool TVL

### DIFF
--- a/projects/term-structure/index.js
+++ b/projects/term-structure/index.js
@@ -75,6 +75,10 @@ const ADDRESSES = {
       fromBlock: 50519690,
     },
     FactoryV2: [
+      {
+        address: "0xdffE6De6de1dB8e1B5Ce77D3222eba401C2573b5",
+        fromBlock: 63100000,
+      },
       // Start of TermMax Alpha
       {
         address: "0x96839e9B0482BfFA7e129Ce9FEEFCeb1e895fC2B",
@@ -82,12 +86,6 @@ const ADDRESSES = {
       },
       // End of TermMax Alpha
     ],
-    // MarketV2Factory: [  // it is termMax market v2? https://github.com/DefiLlama/DefiLlama-Adapters/pull/17483 anyway, atm there is only testing with brBTC, excluding it for now
-    //   {
-    //     address: "0x529A60A7aCDBDdf3D71d8cAe72720716BC192106",
-    //     fromBlock: 71136348,
-    //   },
-    // ],
     VaultFactory: [
       {
         address: "0x48bCd27e208dC973C3F56812F762077A90E88Cea",
@@ -97,10 +95,6 @@ const ADDRESSES = {
     VaultFactoryV2: [
       {
         address: "0x1401049368eD6AD8194f8bb7E41732c4620F170b",
-        fromBlock: 63100000,
-      },
-      {
-        address: "0xdffE6De6de1dB8e1B5Ce77D3222eba401C2573b5",
         fromBlock: 63100000,
       },
       // Start of TermMax Alpha


### PR DESCRIPTION
- This PR primarily replaces the `thirdPool.balanceOf(vault)` call with `vault.totalAssets()` (although the term "vault" is used here, in our business logic they refer to "pools"). The reason is that certain Morpho pools, such as kUSDC, do not have price data on DefiLlama, causing these Morpho tokens' values to be excluded from the pool valuation.
- morpho pool: 0x4605593D0aDA76786BEa026e7B62aF1c0619E833
  - holds 435,338.60136068 kUSDC

```
# morpho token (kUSDC)
curl https://coins.llama.fi/prices/current/ethereum:0x6C26793c7F1e2785c09b460676e797b716f0Bc8E
{
  "coins": {}
}
```


- Pool value should be calculated as: underlying asset price (e.g., USDC) multiplied by `vault.totalAssets()`.
- During adapter debugging, we found a discrepancy between our adapter and the DefiLlama dashboard for the period 2025-12-23 to 2025-12-28:

  **Ethereum TVL (in millions):**

  ```
  Date        Adapter    Chart
  2025-12-23  21.08M     24.11M
  2025-12-24  21.02M     23.94M
  2025-12-25  21.01M     16.03M
  2025-12-26  21.23M     15.97M
  2025-12-27  21.26M     20.78M
  2025-12-28  21.27M     20.78M
  ```

- There is a noticeable dip on 12/25–12/26 in the DefiLlama chart, but according to our adapter and internal dashboard, there were no significant fund inflows or outflows during those days. Therefore, we kindly request the DefiLlama team to recalculate TermMax's TVL from scratch.