### PR TITLE
feat: add Warpx V2 Mainnet adapter

### DIFF
--- a/projects/warpx/index.js
+++ b/projects/warpx/index.js
@@ -1,7 +1,7 @@
 const { getUniTVL } = require('../helper/unknownTokens')
 
 const FACTORY = "0xB3Ae00A68F09E8b8a003B7669e2E84544cC4a385"
-const WMEGA = "0x4200000000000000000000000000000000000006"
+const WETH = "0x4200000000000000000000000000000000000006"
 
 module.exports = {
   misrepresentedTokens: true,
@@ -10,7 +10,7 @@ module.exports = {
       factory: FACTORY, 
       useDefaultCoreAssets: true,
       fetchBalances: true,
-      coreAssets: [WMEGA],
+      coreAssets: [WETH],
     })
   }
 }


### PR DESCRIPTION
**Name**: WarpX
**Twitter**: https://x.com/warpexchange
**Website**: https://warpx.exchange/
**Chain**: MegaETH
**Short Description**: The first and most performant DEX on MegaETH.
**Category**: Dexes
**Forked From**: Uniswap V2
**Methodology**: Counts the tokens locked on AMM pools.