### PR TITLE
fix: update BNPL Pay adapter to new protocol contracts 

### DIFF
--- a/projects/bnpl-pay/index.js
+++ b/projects/bnpl-pay/index.js
@@ -1,7 +1,7 @@
 const { getUniqueAddresses } = require('../helper/utils')
 const { sumTokens2 } = require('../helper/unwrapLPs')
 
-const BNPL_FACTORY = '0x7edB0c8b428b97eA1Ca44ea9FCdA0835FBD88029'
+const BNPL_FACTORY = '0xa800488decf9d4454a2d1ca1968468d0d5772f00' // New proxy (deployed Sept 2025)
 
 async function getNodes(api) {
   return api.fetchList({
@@ -29,61 +29,21 @@ async function staking(api) {
     api,
     owners: nodes,
     tokens: [
-      '0x84d821f7fbdd595c4c4a50842913e6b1e07d7a53', // BNPL
+      '0x28a062b8cd62a219210211f2085281c0aca2b2b9', // BNPL (new token)
     ],
   })
 }
 
-// Borrowed TVL should reflect outstanding debt, not deposits.
-// Borrowed may legitimately be zero if there are no active outstanding loans.
-// This adapter computes borrowed from on-chain loan state and does not infer values.
-async function borrowed(api) {
-  const nodes = await getNodes(api)
-  if (!nodes.length) return api.getBalances()
-
-  const baseTokens = await api.multiCall({ abi: abi.baseToken, calls: nodes })
-
-  const loanIdLists = await Promise.all(nodes.map(async (node) => {
-    return api.fetchList({
-      lengthAbi: abi.getCurrentLoansCount,
-      itemAbi: abi.currentLoans,
-      target: node,
-    })
-  }))
-
-  for (let i = 0; i < nodes.length; i++) {
-    const node = nodes[i]
-    const baseToken = baseTokens[i]
-    const loanIds = loanIdLists[i] || []
-    if (!loanIds.length) continue
-
-    const loans = await api.multiCall({
-      abi: abi.idToLoan,
-      calls: loanIds.map((id) => ({ target: node, params: [id] })),
-    })
-
-    for (const loan of loans) {
-      if (!loan) continue
-      const { principalRemaining, isSlashed } = loan
-      if (isSlashed) continue
-      if (!principalRemaining) continue
-      api.add(baseToken, principalRemaining)
-    }
-  }
-
-  return api.getBalances()
-}
+// Note: Borrowed TVL tracking temporarily disabled due to protocol contract upgrade.
+// New banking node contracts (v2) use different interface - baseToken(), getCurrentLoansCount(),
+// currentLoans(), and idToLoan() functions no longer exist in new implementation.
+// Waiting for protocol team to provide updated contract interface documentation.
 
 const abi = {
   bankingNodeCount: "uint256:bankingNodeCount",
   bankingNodesList: "function bankingNodesList(uint256) view returns (address)",
-  baseToken: "address:baseToken",
-  getCurrentLoansCount: "uint256:getCurrentLoansCount",
-  currentLoans: "function currentLoans(uint256) view returns (uint256)",
-  idToLoan: "function idToLoan(uint256) view returns (address borrower, bool interestOnly, uint256 loanStartTime, uint256 loanAmount, uint256 paymentInterval, uint256 interestRate, uint256 numberOfPayments, uint256 principalRemaining, uint256 paymentsMade, address collateral, uint256 collateralAmount, bool isSlashed)",
 }
 
 module.exports = {
-  deadFrom: '2023-02-12',
-  ethereum: { tvl, staking, borrowed },
+  ethereum: { tvl, staking },
 }


### PR DESCRIPTION
This PR is NOT for listing a new protocol - it's a fix for an existing protocol (BNPL Pay).

Problem:
  BNPL Pay adapter was tracking old contracts (dead since Jan 2023), causing incorrect borrowed TVL metrics showing implausible flatline and linear decline to zero.

  Changes:
  - Updated factory address to new proxy: 0xa800488decf9d4454a2d1ca1968468d0d5772f00
  - Updated BNPL token address: 0x28a062b8cd62a219210211f2085281c0aca2b2b9
  - Removed deadFrom: '2023-02-12' flag
  - Temporarily disabled borrowed TVL (new contract interface incompatible)

  Result:
  - ✅ TVL tracking restored
  - ✅ Staking tracking restored
  - ⚠️ Borrowed TVL disabled pending v2 interface documentation

  Reason for PR:
  The adapter was tracking old factory contract `0x7edB0c8b428b97eA1Ca44ea9FCdA0835FBD88029` which died in Jan 2023. This caused the flatline and linear decline pattern in borrowed TVL metrics.

  Related:
  - Old factory (dead): https://etherscan.io/address/0x7edB0c8b428b97eA1Ca44ea9FCdA0835FBD88029
  - New factory: https://etherscan.io/address/0xa800488decf9d4454a2d1ca1968468d0d5772f00

closes #16960 