### PR TITLE
Update OneLedger OCTO adapter with multi-chain staking support

### DIFF
--- a/projects/openLedger/index.js
+++ b/projects/openLedger/index.js
@@ -1,11 +1,19 @@
 const { staking } = require('../helper/staking')
 
-const OCTO = "0xC4B6A514449375eD2208E050540dBDf0dCAdA619";
-const TOKEN = "0xA227Cc36938f0c9E09CE0e64dfab226cad739447";
+const TOKEN = "0xA227Cc36938f0c9E09CE0e64dfab226cad739447"
+const OCTO = "0xC4B6A514449375eD2208E050540dBDf0dCAdA619"
+
+//same hex, different chains
+const ETH_STAKING = "0xaDB85bDF08E492E9B62B0d0F705113d1E379ED85"
+const BNB_STAKING = "0xaDB85bDF08E492E9B62B0d0F705113d1E379ED85"
 
 module.exports = {
   ethereum: {
     tvl: () => ({}),
-    staking: staking(OCTO, TOKEN),
+    staking: staking([OCTO, ETH_STAKING], TOKEN),
   },
-};
+  bsc: {
+    tvl: () => ({}),
+    staking: staking(BNB_STAKING, TOKEN),
+  },
+}


### PR DESCRIPTION
Updates the existing OneLedger OCTO adapter to include staking support on Ethereum and BNB Chain.

Staking TVL is calculated using ERC20 token balances held by the staking contracts on each chain. The existing protocol structure is preserved, and this change extends staking coverage across multiple networks.
