### PR TITLE
Add JPMorgan MONY TVL adapter

### DIFF
--- a/projects/jpmorgan-mony/index.js
+++ b/projects/jpmorgan-mony/index.js
@@ -1,0 +1,22 @@
+const sdk = require("@defillama/sdk");
+
+const MONY = "0x6a7c6aa2b8b8a6A891dE552bDEFFa87c3F53bD46";
+
+async function tvl() {
+  const supply = await sdk.api.erc20.totalSupply({
+    target: MONY,
+    chain: "ethereum",
+  });
+
+  return {
+    [MONY.toLowerCase()]: supply.output,
+  };
+}
+
+module.exports = {
+  methodology:
+    "TVL equals the total supply of the MONY token on Ethereum. Token address is published by J.P. Morgan Asset Management in the MONY launch press release.",
+  misrepresentedTokens: true,
+  ethereum: { tvl },
+};
+


### PR DESCRIPTION
**Summary**
Adds a TVL adapter for **JPMorgan MONY**, a tokenized money market fund issued by J.P. Morgan Asset Management, on Ethereum.

**Methodology**
TVL is calculated as the total on-chain ERC20 supply of the MONY token on Ethereum.

This protocol represents a **real-world asset (RWA)**. As with other RWA protocols on DefiLlama, TVL is tracked at the **protocol level only** and is **not intended to be counted toward chain-level TVL**.

The adapter is marked with `misrepresentedTokens: true` because MONY currently does not have a public USD price feed on DefiLlama or CoinGecko. Once pricing becomes available, USD TVL will be reflected automatically without requiring adapter changes.

**Implementation**
* Reads `totalSupply` directly from the MONY ERC20 contract
* On-chain only
* No external APIs or subgraphs
* Ethereum only

**Contract**
* MONY token (Ethereum):
  `0x6a7c6aa2b8b8a6A891dE552bDEFFa87c3F53bD46`

**Verification**
The adapter output can be verified locally using the DefiLlama test runner:
```bash
node test.js projects/jpmorgan-mony/index.js
```
This prints the same total supply value used by the adapter.

**Issue**
Closes #17540
