### PR TITLE
Track Lighter FastCCTP bridge deposits for spot trades

### DIFF
--- a/projects/lighter-v2/index.js
+++ b/projects/lighter-v2/index.js
@@ -4,14 +4,20 @@ const { sumTokensExport } = require("../helper/unwrapLPs");
 const config = {
   arbitrum: {
     owners: ["0x3b4d794a66304f130a4db8f2551b0070dfcf5ca7"],
-    tokens: [ADDRESSES.arbitrum.USDC_CIRCLE],
+    tokens: [
+      ADDRESSES.arbitrum.USDC_CIRCLE,
+      ADDRESSES.null, // native ETH
+    ],
   },
   ethereum: {
     owners: [
       "0x3b4d794a66304f130a4db8f2551b0070dfcf5ca7", // system wallet
-      "0x57e9e78a627baa30b71793885b952a9006298af6", // FastCCTP
+      "0x57e9e78a627baa30b71793885b952a9006298af6", // FastCCTP (USDC-only)
     ],
-    tokens: [ADDRESSES.ethereum.USDC],
+    tokens: [
+      ADDRESSES.ethereum.USDC,
+      ADDRESSES.null, // native ETH
+    ],
   },
 };
 
@@ -22,4 +28,4 @@ Object.keys(config).forEach((chain) => {
 });
 
 module.exports.methodology =
-  "Counts USDC held in the Lighter system wallet and FastCCTP bridge custody for spot trade deposits on Ethereum and Arbitrum.";
+  "Counts assets held in Lighter custody wallets for spot trade deposits, including native ETH (ADDRESSES.null) and USDC in the system wallet, plus USDC held in the FastCCTP bridge custody wallet, on Ethereum and Arbitrum.";


### PR DESCRIPTION
**Summary**
Adds tracking for Lighter spot trade deposits held in the FastCCTP bridge custody wallet.

**Context**
Issue #17314 requested tracking deposits bridged into Lighter for spot trading. These funds are held in custody contracts and were not previously included in TVL.

**Methodology**
TVL is calculated as USDC balances held by:
- The existing Lighter system wallet
- The FastCCTP bridge custody address used for spot trade deposits

Only on-chain balances are counted. No derivatives, leverage, or perps exposure is included.

**Implementation**
- Extends the existing lighter-v2 adapter
- Uses `sumTokensExport` for direct on-chain accounting
- Ethereum and Arbitrum only
- No external APIs or subgraphs

Verification
Run locally:
```bash
node test.js projects/lighter-v2/index.js
```

Closes #17314
