### PR TITLE
add Linea deployment to Morpho Markets V1

### DIFF
--- a/projects/morpho-blue/index.js
+++ b/projects/morpho-blue/index.js
@@ -147,6 +147,10 @@ const config = {
     morphoBlue: "0xa40103088A899514E3fe474cD3cc5bf811b1102e",
     fromBlock: 2348260,
   },
+  linea: {
+    morphoBlue: "0x6B0D716aC0A45536172308e08fC2C40387262c9F",
+    fromBlock: 25072608,
+  }
 }
 
 const eventAbis = {


### PR DESCRIPTION
I double checked the new chain addition with:
https://unpkg.com/@defillama/sdk@5.0.170/build/providers.json

Addresses are accessible here:

https://docs.morpho.org/get-started/resources/addresses/#morpho-v1-contracts
And available in our tg chat