### PR TITLE
delete dead project

### DIFF
--- a/projects/shroomy-protocol/index.js
+++ b/projects/shroomy-protocol/index.js
@@ -1,5 +1,0 @@
-const { aaveExports } = require('../helper/aave');
-
-module.exports = {
-  ink: aaveExports('ink', '0xE2fA2C2da2ec22693eb9dE8d95944A54E9FC0D49', undefined, ["0x734A292227aFD525Dc9DC668006Cc264c987959C"], { v3: true})
-};


### PR DESCRIPTION
Gm. Is it possible to remove the project from your website? The owner abandoned the project, sold the tokens, lq, and sent it to a dead address. We are devs who are slowly moving and disabling the infrastructure. The project is also located in your second repo - https://github.com/DefiLlama/dimension-adapters/tree/master/dexs/shroomy-protocol