### PR TITLE
Add Curvance adapter for Monad

### DIFF
--- a/projects/curvance/index.js
+++ b/projects/curvance/index.js
@@ -1,29 +1,69 @@
-const { sumTokens2 } = require('../helper/unwrapLPs')
-const config = {
-  monad: '0x1310f352f1389969Ece6741671c4B919523912fF'
+const CENTRAL_REGISTRY = "0x1310f352f1389969Ece6741671c4B919523912fF";
+
+const ABI = {
+  marketManagers: "function marketManagers() view returns (address[])",
+  queryTokensListed: "function queryTokensListed() view returns (address[])",
+  asset: "function asset() view returns (address)",
+  totalAssets: "function totalAssets() view returns (uint256)",
+};
+
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+async function tvl(api) {
+  // 1. Get all market managers from the central registry
+  const marketManagers = await api.call({
+    target: CENTRAL_REGISTRY,
+    abi: ABI.marketManagers,
+  });
+
+  if (!marketManagers || !marketManagers.length) return {};
+
+  // 2. Get all cTokens listed in each market manager
+  const tokenLists = await api.multiCall({
+    abi: ABI.queryTokensListed,
+    calls: marketManagers.map((target) => ({ target })),
+    permitFailure: true,
+  });
+
+  // Flatten all cTokens into a single array
+  const allCTokens = tokenLists.flat().filter(Boolean);
+
+  if (!allCTokens.length) return {};
+
+  // 3. For each cToken, get the underlying asset address
+  const underlyings = await api.multiCall({
+    abi: ABI.asset,
+    calls: allCTokens.map((target) => ({ target })),
+    permitFailure: true,
+  });
+
+  // 4. For each cToken, get the totalAssets (total underlying held)
+  const totalAssets = await api.multiCall({
+    abi: ABI.totalAssets,
+    calls: allCTokens.map((target) => ({ target })),
+    permitFailure: true,
+  });
+
+  // 5. Sum up all collateral (skip debt tokens where underlying is zero address)
+  for (let i = 0; i < allCTokens.length; i++) {
+    const underlying = underlyings[i];
+    const amount = totalAssets[i];
+
+    // Skip debt tokens (cAUSD) which have zero address as underlying
+    if (!underlying || underlying === ZERO_ADDRESS) continue;
+    if (!amount || amount === "0") continue;
+
+    api.add(underlying, amount);
+  }
+
+  return api.getBalances();
 }
 
-Object.keys(config).forEach(chain => {
-  const centralRegistry = config[chain]
-
-  async function getMarkets(api) {
-    const managers = await api.call({ abi: 'address[]:marketManagers', target: centralRegistry })
-    const markets = await api.multiCall({ abi: 'address[]:queryTokensListed', calls: managers })
-    return markets.flat()
-  }
-
-  module.exports[chain] = {
-    tvl: async (api) => {
-      const contracts = await getMarkets(api)
-      const tokens = await api.multiCall({ abi: 'address:asset', calls: contracts })
-      return sumTokens2({ api, tokensAndOwners2: [tokens, contracts] })
-    },
-    borrowed: async (api) => {
-      const contracts = await getMarkets(api)
-      const tokens = await api.multiCall({ abi: 'address:asset', calls: contracts })
-      const bals = await api.multiCall({ abi: 'uint256:marketOutstandingDebt', calls: contracts })
-      api.add(tokens, bals)
-      return sumTokens2({ api, })
-    }
-  }
-})
+module.exports = {
+  methodology:
+    "TVL counts all collateral assets supplied inside Curvance markets by summing totalAssets() from each collateral cToken.",
+  timetravel: true,
+  monad: {
+    tvl,
+  },
+};


### PR DESCRIPTION
##### Project Name:
Curvance

##### Chain:
Monad

##### Website:
https://curvance.com/

##### Methodology:
TVL counts all collateral assets supplied inside Curvance markets by summing totalAssets() from each collateral cToken.

##### Is this adapter for a FETCH protocol?
No

##### CoinGecko ID:
curvance (ID: curvance)

##### Oracle Provider(s):
RedStone (RedStone Bolt as primary), DIA Oracles

##### Implementation Details:
The adapter queries Curvance's CentralRegistry contract (0x1310f352f1389969Ece6741671c4B919523912fF) to retrieve all market managers on Monad. For each market manager, it fetches all listed cTokens via queryTokensListed(). Since Curvance cTokens are ERC4626-compliant vaults, the adapter calls totalAssets() on each cToken to get the total underlying collateral deposited, and asset() to identify the underlying token address. Debt tokens (identified by a zero address as their underlying) are filtered out. The adapter sums all collateral assets to calculate TVL.

##### Github org/user:
curvance

##### Documentation/Proof:
- Official Website: https://curvance.com/
- Dashboard: https://app.curvance.com/
- Documentation: https://docs.curvance.com/cve/protocol-overview/contract-addresses
- CentralRegistry on Monad: https://monadscan.io/address/0x1310f352f1389969Ece6741671c4B919523912fF
- GitHub: https://github.com/curvance

##### forkedFrom:
Custom implementation