### PR TITLE
Fix Gimo TVL calculation to use st0G exchange rate

### DIFF
--- a/projects/gimo/index.js
+++ b/projects/gimo/index.js
@@ -1,12 +1,14 @@
-const { staking } = require("../helper/staking");
+const ADDRESSES = require('../helper/coreAssets.json');
 
 const st0gAddress = "0x7bBC63D01CA42491c3E084C941c3E86e55951404"; // st0G - Liquid Staking 0G
-const stakingAddress = "0xAc06d1Df23a4Fa00981aFAC0f33A5936Bd2135aF"; // Gimo Staking Vault
 
 module.exports = {
-  methodology: "TVL counts st0G tokens locked in Gimo's staking vault for liquid staking on 0G Chain.",
+  methodology: "TVL counts total st0G supply converted to 0G using the st0G exchange rate.",
   "0g": {
-    tvl: () => ({}),
-    staking: staking(stakingAddress, st0gAddress, "0g"),
+    tvl: async (api) => {
+      const totalSupply = await api.call({ target: st0gAddress, abi: 'uint256:totalSupply' });
+      const rate = await api.call({ target: st0gAddress, abi: 'uint256:getRate' });
+      api.add(ADDRESSES.null, (totalSupply * rate) / 1e18);
+    },
   },
 };


### PR DESCRIPTION
 ## Summary
  - Fixed TVL calculation to use total st0G supply multiplied by the exchange rate (`getRate()`)
  - Previously the adapter was tracking a staking vault with minimal balance (~2,267 st0G)
  - Now correctly reports ~17.5M 0G equivalent (14.3M st0G × 1.2277 rate)