### PR TITLE
Add Lazy Protocol (LazyUSD)

### DIFF
--- a/projects/lazyusd/index.js
+++ b/projects/lazyusd/index.js
@@ -3,15 +3,8 @@ const ADDRESSES = require('../helper/coreAssets.json')
 const VAULT = '0xd53B68fB4eb907c3c1E348CD7d7bEDE34f763805'
 
 async function tvl(api) {
-  try {
-    const totalAssets = await api.call({
-      abi: 'function totalAssets() view returns (uint256)',
-      target: VAULT
-    })
-    api.add(ADDRESSES.ethereum.USDC, totalAssets)
-  } catch (error) {
-    console.error('LazyUSD TVL adapter error:', error.message)
-  }
+  const totalAssets = await api.call({ target: VAULT, abi: 'uint256:totalAssets' })
+  api.add(ADDRESSES.ethereum.USDC, totalAssets)
 }
 
 module.exports = {


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
Lazy

##### Twitter Link:
https://x.com/lazydotxyz

##### List of audit links if any:
Internal whitehat security analysis - formal verification using Halmos symbolic execution

##### Website Link:
https://getlazy.xyz

##### Logo (High resolution, will be shown with rounded borders):
https://raw.githubusercontent.com/sirmoremoney/AYP/main/frontend/public/favicon.svg

##### Current TVL:
~$500,000

##### Treasury Addresses (if the protocol has treasury):
0x0FBCe7F3678467f7F7313fcB2C9D1603431Ad666

##### Chain:
Ethereum

##### Coingecko ID:


##### Coinmarketcap ID:


##### Short Description (to be shown on DefiLlama):
Patient capital, rewarded. Deposit USDC, earn yield. No staking. No claiming.

##### Token address and ticker if any:
lazyUSD: 0xd53B68fB4eb907c3c1E348CD7d7bEDE34f763805

##### Category:
Yield

##### Oracle Provider(s):
None - yield calculated off-chain and reported by protocol multisig

##### Implementation Details:
Yield accrues from delta-neutral strategies across Ethereum, Solana, and Hyperliquid. NAV is reported on-chain via reportYieldAndCollectFees() by the protocol multisig. Share price grows automatically - no claiming required.

##### Documentation/Proof:
https://github.com/sirmoremoney/AYP

##### forkedFrom:
No

##### methodology:
TVL equals total assets under management via the vault's totalAssets() function, denominated in USDC. Marked as doublecounted since capital is deployed to other protocols (Hyperliquid, Jupiter, Pendle).

##### Github org/user:
sirmoremoney

##### Does this project have a referral program?
No