### PR TITLE
feat: add Kerne Protocol V2 adapter

### DIFF
--- a/projects/kerne-protocol-v2/index.js
+++ b/projects/kerne-protocol-v2/index.js
@@ -1,0 +1,25 @@
+const sdk = require('@defillama/sdk');
+
+// Kerne Protocol TVL Adapter
+// ERC-4626 Vault on Base
+
+const VAULT_ADDRESS = "0x5FD0F7eA40984a6a8E9c6f6BDfd297e7dB4448Bd";
+const WETH_ADDRESS = "0x4200000000000000000000000000000000000006";
+
+async function tvl(api) {
+  // Call totalAssets() on the ERC-4626 vault
+  const totalAssets = await api.call({
+    target: VAULT_ADDRESS,
+    abi: 'function totalAssets() view returns (uint256)',
+  });
+  
+  // Add the totalAssets value as the underlying WETH
+  api.add(WETH_ADDRESS, totalAssets);
+}
+
+module.exports = {
+  methodology: "TVL is calculated by calling totalAssets() on the KerneVault ERC-4626 contract. This reflects the net asset value of the vault, including on-chain collateral and verified hedging reserves.",
+  base: {
+    tvl,
+  },
+};


### PR DESCRIPTION
This PR adds the TVL adapter for Kerne Protocol V2 on Base. Kerne is a delta-neutral synthetic dollar protocol leveraging LST collateral and CEX-based hedging. The adapter calculates TVL by calling totalAssets() on the KerneVault ERC-4626 contract.