### PR TITLE
SwissBorg: Add new wallets

### DIFF
--- a/projects/swissborg/index.js
+++ b/projects/swissborg/index.js
@@ -33,6 +33,7 @@ const config = {
       '0x0926a7b610B9Fc2D1E3F09FcBa52Ba3BEDCFfd91',
       '0x49841B9bb1dc499B36C4F618bf8feAC85fDFE889',
       '0xaCA8FB892Ac27d2f84Fa78EDb32F3AD221538c3e',
+      '0xbA87587622a808547Ee16c79Be7f19ba356feD9d',
     ],
   },
   bitcoin: {
@@ -77,6 +78,7 @@ const config = {
       'EbUkjPNjzcbjK3iELhZS6PpNCr62pUsE7VkUvNdQpEYB',
       'FQxGUUAX3BdFArA2XdvPcRHt4CmRMCw5wLt8F5uDXmwa',
       'EKtwdf5gFPb58WJPENcS8qqPRoAkEwDLHfHk2S2nbTnB',
+      'HGqHR9Wm6ETAgQHj7q1qcmywXHfDx48VuVovQpGTgsHU',
     ],
   },
   polkadot: {


### PR DESCRIPTION
This PR updates the list of wallets owned by SwissBorg. New wallets addition:
https://github.com/SwissBorg/pub/commit/491f400e3392ccbed376305223469d67f8d39059