### PR TITLE
Update Re Protocol adapter for multi-chain token supply tracking

### DIFF
--- a/projects/re-protocol/index.js
+++ b/projects/re-protocol/index.js
@@ -1,3 +1,5 @@
+const ADDRESSES = require('../helper/coreAssets.json');
+
 const chains = ['ethereum', 'avax', 'arbitrum', 'base'];
 
 // Token addresses per chain
@@ -47,7 +49,8 @@ async function tvl(api) {
       abi: 'function latestAnswer() view returns (int256)',
       target: ORACLE_ADDRESS,
     });
-    api.addUSDValue(Number(latestAnswer) / 1e8);
+    // Oracle has 8 decimals, USDC has 6, so divide by 100
+    api.add(ADDRESSES.avax.USDC, latestAnswer / 100);
   }
 }
 


### PR DESCRIPTION
## Summary

Updates the Re Protocol adapter to properly track TVL across multiple chains using token total supplies.

### Changes
- Track reUSD total supply on Ethereum, Avalanche, Arbitrum, and Base
- Track reUSDe total supply on Ethereum  
- Add off-chain reserves via oracle on Avalanche
- Remove wallet-based tracking to avoid double counting with token supplies

### TVL Methodology
TVL is calculated as the sum of:
1. Total supply of reUSD tokens across all supported chains
2. Total supply of reUSDe tokens on Ethereum
3. Off-chain reserves tracked via oracle contract on Avalanche

### Contract Addresses
**reUSD:**
- Ethereum: `0x5086bf358635B81D8C47C66d1C8b9E567Db70c72`
- Avalanche: `0x180aF87b47Bf272B2df59dccf2D76a6eaFa625Bf`
- Arbitrum: `0x76cE01F0Ef25AA66cC5F1E546a005e4A63B25609`
- Base: `0x7D214438D0F27AfCcC23B3d1e1a53906aCE5CFEa`

**reUSDe:**
- Ethereum: `0xdDC0f880ff6e4e22E4B74632fBb43Ce4DF6cCC5a`

**Oracle (off-chain reserves):**
- Avalanche: `0xc79a363a3f849d8b3F6A1932f748eA9d4fB2f607`

### Test Results
```
ethereum    112.15 M
avax         68.54 M
base        689.79 k
arbitrum     20.96 k
total       181.40 M
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking across multiple blockchains: Ethereum, Avalanche, Arbitrum, and Base.
  * Integrated oracle-based off-chain reserves on Avalanche for more accurate TVL.

* **Updates**
  * API now exposes dynamic per-chain TVL endpoints.
  * Methodology text updated to describe multi-chain and oracle-inclusive TVL calculations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->