### PR TITLE
add incentives calculus to Balancer V2 and V3

### DIFF
--- a/projects/balancer-v3/index.js
+++ b/projects/balancer-v3/index.js
@@ -1,19 +1,44 @@
-const { v3Tvl } = require("../helper/balancer")
+const { v3Tvl, calculateBALIncentives } = require("../helper/balancer");
 
 const config = {
-  xdai: { vault: '0xbA1333333333a1BA1108E8412f11850A5C319bA9', fromBlock: 37360338 },
-  ethereum: { vault: '0xbA1333333333a1BA1108E8412f11850A5C319bA9', fromBlock: 21332121 },
-  arbitrum: { vault: '0xbA1333333333a1BA1108E8412f11850A5C319bA9', fromBlock: 297810187 },
-  base: { vault: '0xbA1333333333a1BA1108E8412f11850A5C319bA9', fromBlock: 25343854 },
-  optimism: { vault: '0xbA1333333333a1BA1108E8412f11850A5C319bA9', fromBlock: 133969439 },
-  avax: { vault: '0xbA1333333333a1BA1108E8412f11850A5C319bA9', fromBlock: 59955604 },
-  hyperliquid: { vault: '0xbA1333333333a1BA1108E8412f11850A5C319bA9', fromBlock: 6132445 },
-  plasma: { vault: '0xbA1333333333a1BA1108E8412f11850A5C319bA9', fromBlock: 782595 },
-}
+  xdai: {
+    vault: "0xbA1333333333a1BA1108E8412f11850A5C319bA9",
+    fromBlock: 37360338,
+  },
+  ethereum: {
+    vault: "0xbA1333333333a1BA1108E8412f11850A5C319bA9",
+    fromBlock: 21332121,
+  },
+  arbitrum: {
+    vault: "0xbA1333333333a1BA1108E8412f11850A5C319bA9",
+    fromBlock: 297810187,
+  },
+  base: {
+    vault: "0xbA1333333333a1BA1108E8412f11850A5C319bA9",
+    fromBlock: 25343854,
+  },
+  optimism: {
+    vault: "0xbA1333333333a1BA1108E8412f11850A5C319bA9",
+    fromBlock: 133969439,
+  },
+  avax: {
+    vault: "0xbA1333333333a1BA1108E8412f11850A5C319bA9",
+    fromBlock: 59955604,
+  },
+  hyperliquid: {
+    vault: "0xbA1333333333a1BA1108E8412f11850A5C319bA9",
+    fromBlock: 6132445,
+  },
+  plasma: {
+    vault: "0xbA1333333333a1BA1108E8412f11850A5C319bA9",
+    fromBlock: 782595,
+  },
+};
 
-Object.keys(config).forEach(chain => {
-  const {vault, fromBlock,} = config[chain]
+Object.keys(config).forEach((chain) => {
+  const { vault, fromBlock } = config[chain];
   module.exports[chain] = {
-    tvl: v3Tvl(vault, fromBlock)
-  }
-})
+    tvl: v3Tvl(vault, fromBlock),
+    incentives: calculateBALIncentives(),
+  };
+});

--- a/projects/balancer/onchain.js
+++ b/projects/balancer/onchain.js
@@ -1,37 +1,43 @@
-const ADDRESSES = require('../helper/coreAssets.json')
-const { onChainTvl } = require('../helper/balancer')
-const { eulerTokens } = require('../helper/tokenMapping')
+const ADDRESSES = require("../helper/coreAssets.json");
+const { onChainTvl, calculateBALIncentives } = require("../helper/balancer");
+const { eulerTokens } = require("../helper/tokenMapping");
 
 const blacklistedTokens = [
   "0xC011A72400E58ecD99Ee497CF89E3775d4bd732F",
   ADDRESSES.ethereum.sUSD_OLD,
   //self destructed
-  "0x00f109f744B5C918b13d4e6a834887Eb7d651535", "0x645F7dd67479663EE7a42feFEC2E55A857cb1833", "0x4922a015c4407F87432B179bb209e125432E4a2A",
-  "0xdA16D6F08F20249376d01a09FEBbAd395a246b2C", "0x9be4f6a2558f88A82b46947e3703528919CE6414", "0xa7fd7d83e2d63f093b71c5f3b84c27cff66a7802",
-  "0xacfbe6979d58b55a681875fc9adad0da4a37a51b", "0xd6d9bc8e2b894b5c73833947abdb5031cc7a4894",
+  "0x00f109f744B5C918b13d4e6a834887Eb7d651535",
+  "0x645F7dd67479663EE7a42feFEC2E55A857cb1833",
+  "0x4922a015c4407F87432B179bb209e125432E4a2A",
+  "0xdA16D6F08F20249376d01a09FEBbAd395a246b2C",
+  "0x9be4f6a2558f88A82b46947e3703528919CE6414",
+  "0xa7fd7d83e2d63f093b71c5f3b84c27cff66a7802",
+  "0xacfbe6979d58b55a681875fc9adad0da4a37a51b",
+  "0xd6d9bc8e2b894b5c73833947abdb5031cc7a4894",
 
-  ...eulerTokens
-]
+  ...eulerTokens,
+];
 
-const V2_ADDRESS = '0xBA12222222228d8Ba445958a75a0704d566BF2C8'; // shared by all networks
+const V2_ADDRESS = "0xBA12222222228d8Ba445958a75a0704d566BF2C8"; // shared by all networks
 
 const config = {
-  ethereum: { fromBlock: 12272146, },
-  polygon: { fromBlock: 15832990, },
-  arbitrum: { fromBlock: 222832, },
-  xdai: { fromBlock: 24821598, },
-  polygon_zkevm: { fromBlock: 203079, },
-  base: { fromBlock: 1196036, },
-  avax: { fromBlock: 26386141, },
-  mode: { fromBlock: 8110317, },
-  fraxtal: { fromBlock: 4708596 }
-}
+  ethereum: { fromBlock: 12272146 },
+  polygon: { fromBlock: 15832990 },
+  arbitrum: { fromBlock: 222832 },
+  xdai: { fromBlock: 24821598 },
+  polygon_zkevm: { fromBlock: 203079 },
+  base: { fromBlock: 1196036 },
+  avax: { fromBlock: 26386141 },
+  mode: { fromBlock: 8110317 },
+  fraxtal: { fromBlock: 4708596 },
+};
 
 module.exports = {};
 
-Object.keys(config).forEach(chain => {
-  const { fromBlock } = config[chain]
+Object.keys(config).forEach((chain) => {
+  const { fromBlock } = config[chain];
   module.exports[chain] = {
-    tvl: onChainTvl(V2_ADDRESS, fromBlock, { blacklistedTokens })
-  }
-})
+    tvl: onChainTvl(V2_ADDRESS, fromBlock, { blacklistedTokens }),
+    incentives: calculateBALIncentives(),
+  };
+});

--- a/projects/helper/whitelistedExportKeys.json
+++ b/projects/helper/whitelistedExportKeys.json
@@ -12,5 +12,6 @@
   "isHeavyProtocol",
   "deadFrom",
   "ownTokens",
-  "vesting"
+  "vesting",
+  "incentives"
 ]


### PR DESCRIPTION
## Fix: Add Incentives Calculation for Balancer V2 and V3

### Problem
The Balancer protocol's Incentives KPI was incorrectly showing as $0 on DefiLlama, despite active BAL token emissions through the veBAL gauge system.

### Solution
Added `incentives` export to both Balancer V2 and V3 adapters that calculates the current weekly BAL emission rate based on the protocol's emission schedule and returns it in a format that DefiLlama can convert to USD.

### Implementation Details

**Emission Schedule Formula:**
- Pre-reduction (2020-06-01 to 2023-03-28): 145,000 BAL/week
- Post-reduction: Weekly rate reduces by factor of 1.189 each year
- First post-reduction: 121,930 BAL/week
- Formula: `currentWeekly = 121930 / (1.189 ^ yearsSinceReduction)`

The calculation is based on the same emission schedule logic used in `emissions-adapters/protocols/balancer.ts`.

### Changes Made

1. **`projects/helper/balancer.js`**:
   - Added `getCurrentWeeklyBALEmission()` function to calculate weekly BAL emission based on timestamp
   - Added `calculateBALIncentives()` function that returns BAL token amount for the current period
   - Exported `calculateBALIncentives` in module.exports

2. **`projects/balancer/onchain.js`**:
   - Added `incentives: calculateBALIncentives()` export for all chains

3. **`projects/balancer-v3/index.js`**:
   - Added `incentives: calculateBALIncentives()` export for all chains

### Testing
- Verified the function correctly calculates weekly BAL emissions for different timestamps
- Confirmed BAL token is properly added to balances in the correct format
- Tested across multiple chains (ethereum, arbitrum, base, etc.)

### References
- Emission schedule: https://docs-v2.balancer.fi/concepts/governance/bal-token.html#supply--inflation-schedule
- Related: `emissions-adapters/protocols/balancer.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Introduced BAL incentives calculation functionality across all Balancer chains
- Incentive amounts are dynamically computed based on current weekly BAL emission rates
- New incentives data is now available for all supported chains alongside TVL metrics
- Enables tracking of real-time BAL incentive information for liquidity pools

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->