### PR TITLE
remove defituna fusion pool duplication

### DIFF
--- a/projects/defituna_liquidity.js
+++ b/projects/defituna_liquidity.js
@@ -45,7 +45,7 @@ async function tvl(api) {
       ? orcaPoolsMap[pool].tickCurrentIndex : undefined;
 
     // Add concentrated liquidity position to TVL
-    if(tickCurrentIndex)
+    if(tickCurrentIndex!==undefined)
       addUniV3LikePosition({
       api,
       tickLower: position.account.tickLowerIndex,


### PR DESCRIPTION
fusion pools were counted in both defituna and defituna-liquidity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed Fusion AMM support from liquidity tracking and calculations.
  * Consolidated pool data retrieval to exclusively use the Orca protocol.
  * Positions are now added only when required pool tick/index data is available.

* **Chores**
  * Updated TUNA token launch date in hallmarks to 2025-07-30.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->