### PR TITLE
Add Rage TVL adapter

### DIFF
--- a/projects/rage/index.js
+++ b/projects/rage/index.js
@@ -1,0 +1,54 @@
+// pTokens are share tokens without independent pricing.
+// We unwrap them into underlying assets for TVL.
+
+const { sumTokens2 } = require("../helper/unwrapLPs");
+
+const TREASURY = "0xff70Cd1E1931372F869c936582a7F42e49B6DA4c";
+
+// Underlying tokens (priced by DefiLlama)
+const HESTIA = "0xbc7755a153e852cf76cccddb4c2e7c368f6259d8";
+const CIRCLE = "0x5babfc2f240bc5de90eb7e19d789412db1dec402";
+
+// pTokens (shares) held by treasury (unpriced, so we unwrap them)
+const PHESTIA = "0xF760fD8fEB1F5E3bf3651E2E4f227285a82470Ff";
+const PCIRCLE = "0x55A81dA2a319dD60fB028c53Cb4419493B56f6c0";
+
+// ERC4626-style unwrap (most common for share tokens)
+const erc4626Abi = {
+  balanceOf: "function balanceOf(address) view returns (uint256)",
+  convertToAssets: "function convertToAssets(uint256 shares) view returns (uint256 assets)",
+};
+
+async function tvl(_, _b, _cb, { api }) {
+  // 1) Count raw underlying tokens held by treasury
+  await sumTokens2({
+    api,
+    owner: TREASURY,
+    tokens: [HESTIA, CIRCLE],
+  });
+
+  // 2) Read pToken share balances
+  const [pHestiaShares, pCircleShares] = await api.multiCall({
+    abi: erc4626Abi.balanceOf,
+    calls: [PHESTIA, PCIRCLE].map((target) => ({ target, params: [TREASURY] })),
+  });
+
+  // 3) Convert shares -> underlying asset amounts
+  const [hestiaFromShares, circleFromShares] = await api.multiCall({
+    abi: erc4626Abi.convertToAssets,
+    calls: [
+      { target: PHESTIA, params: [pHestiaShares] },
+      { target: PCIRCLE, params: [pCircleShares] },
+    ],
+  });
+
+  // 4) Add unwrapped underlying amounts to TVL
+  api.add(HESTIA, hestiaFromShares);
+  api.add(CIRCLE, circleFromShares);
+
+  return api.getBalances();
+}
+
+module.exports = {
+  base: { tvl },
+};


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/adapters).
> - If you would like to add a `liquidations` adapter, please refer to [this readme document](https://github.com/DefiLlama/DefiLlama-Adapters/tree/main/liquidations) for details.

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
3. Please fill the form below **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
4. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can edit it there and put up a PR
5. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
6. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap

---

##### Name (to be shown on DefiLlama): 
RAGE Protocol

##### Twitter Link: 
https://x.com/therageprotocol

##### List of audit links if any: 
https://ultraroundmoney.com/rage/audit.pdf

##### Website Link: 
https://ultraroundmoney.com/rage

##### Logo (High resolution, will be shown with rounded borders): 
![rage-logo](https://github.com/user-attachments/assets/1477c64f-a37c-46a9-b12f-c325c25ea854)

##### Current TVL: 
261k

##### Treasury Addresses (if the protocol has treasury): 
0xff70Cd1E1931372F869c936582a7F42e49B6DA4c

##### Chain: 
base

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): 
(https://api.coingecko.com/api/v3/coins/list) 
rage-protocol

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama): 
The Rage Buying Protocol (RBP) re-imagines the MicroStrategy and ETH Strategy investment strategies through an innovative smart contract that features a Peapods integration.

##### Token address and ticker if any:

##### Category (full list at https://defillama.com/categories) \*Please choose only one: 
Onchain Capital Allocator

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.): 
N/A

##### Implementation Details: Briefly describe how the oracle is integrated into your project: 
N/A

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage: 
N/A

##### forkedFrom (Does your project originate from another project): 
No

##### methodology (what is being counted as tvl, how is tvl being calculated): 
TVL includes backing assets held by the RageBuyingProtocol contract. This consists of raw HESTIA and CIRCLE balances held directly by the treasury, as well as HESTIA and CIRCLE backing represented by pHestia and pCircle share tokens. pTokens are unwrapped into their underlying assets using on-chain conversion logic, and TVL reflects the total underlying backing assets controlled by the protocol.

##### Github org/user (Optional, if your code is open source, we can track activity): 
https://github.com/ultraroundMoney/rage-protocol

##### Does this project have a referral program? 
Yes. The protocol includes a referral mechanism where users can mark a referrer address, and referrers receive commissions distributed periodically by the protocol.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Total Value Locked (TVL) calculation for the Rage treasury, which unwraps tokenized assets into their underlying components and computes aggregate value across both direct holdings and wrapped asset positions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->