### PR TITLE
Fix: TVL fixed for tokens with no price support

### DIFF
--- a/projects/rain-one/index.js
+++ b/projects/rain-one/index.js
@@ -65,16 +65,20 @@ async function rainProtocolTvl(api) {
             token = token.toLowerCase()
             tokens.add(token)
 
-            const [balance, decimals] = await Promise.all([
-                api.call({ abi: 'erc20:balanceOf', target: token, params: pool }),
-                api.call({ abi: 'erc20:decimals', target: token }),
-            ])
+            try {
+                const [balance, decimals] = await Promise.all([
+                    api.call({ abi: 'erc20:balanceOf', target: token, params: pool }),
+                    api.call({ abi: 'erc20:decimals', target: token }),
+                ])
 
-            poolData.push({
-                token,
-                balance,
-                decimals,
-            })
+                poolData.push({
+                    token,
+                    balance,
+                    decimals,
+                })
+            } catch {
+                // Skip pools with non-standard tokens
+            }
         })
     )
 


### PR DESCRIPTION
TVL fixed for tokens with no price support,
Previously newer tokens market created on Rain.one which were relatively newer did not show up in TVL as their token prices were shown as 0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate TVL by fetching per-market token balances and using market token prices; skips tokens without price.
  * Improved resilience with tolerant handling of missing/failed token calls; returns 0 when no markets exist.
  * Removed reliance on legacy token-collection logic for safer calculations.

* **Documentation**
  * Methodology updated to clarify TVL includes all markets created on https://rain.one.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->