### PR TITLE
update ea-finance tvl

### DIFF
--- a/projects/ea-finance/index.js
+++ b/projects/ea-finance/index.js
@@ -26,7 +26,7 @@ module.exports = {
   start: 1767126150,
   methodology: "TVL is calculated as the total amount of WCC tokens staked in the staking contract. WCC is a wrapped version of CC token (from Canton network) with a 1:1 peg. WCC price should track CC token price.",
   bsc: {
-    tvl: () => ({}),
-    staking: staking
+    tvl: staking,
+    // staking: staking
   }
 }


### PR DESCRIPTION
1. WCC is a wrapped version of CC token (from Canton network) with a 1:1 peg. 
2. Although WCC is a token issued by our platform, it is generated by a Mint contract and is not manually controlled. We strictly control the 1:1 correspondence between Canton and BSC. We are simply providing users with a way to stake Canton CC on the BSC chain. Strictly speaking, users are staking Canton CC, which should be considered as TVL (Total Value Locked).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated TVL (Total Value Locked) calculation for EA Finance to directly utilize staking logic, streamlining how metrics are computed and improving consistency across the module.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->