### PR TITLE
evo refactor

### DIFF
--- a/projects/evo/index.js
+++ b/projects/evo/index.js
@@ -1,0 +1,46 @@
+const { invokeViewFunction } = require("../helper/chain/supra");
+
+// Constants
+const EVO_CLMM_PACKAGE =
+    "0x6511aa4c617887b8eb34608484424d4fb98cf30cd15479e38c1aa4fb8a61bcb9";
+const GET_ALL_POOLS_FUNCTION = `${EVO_CLMM_PACKAGE}::evo_clamm_liquidity_pool::get_all_pools`;
+const GET_POOL_VIEW_FUNCTION = `${EVO_CLMM_PACKAGE}::evo_clamm_liquidity_pool::get_pool_view`;
+
+// Returns all pool Ids from the EVO CLMM contract
+const getPoolIds = async () => {
+    const pools = await invokeViewFunction(
+        GET_ALL_POOLS_FUNCTION,
+        [],
+        []
+    );
+    return pools[0].map(pool => pool.inner);
+};
+
+// Returns pool data by pool Id
+const getPoolData = async (poolId) => {
+    const result = await invokeViewFunction(
+        GET_POOL_VIEW_FUNCTION,
+        [],
+        [poolId]
+    );
+    return result[0];
+};
+
+const tvl = async (api) => {
+    const poolIds = await getPoolIds();
+    const poolDataPromises = poolIds.map(id => getPoolData(id));
+    const poolsData = await Promise.all(poolDataPromises);
+
+    poolsData.forEach(pool => {
+        if (pool) {
+            api.add(pool.token_0, pool.token_0_reserve);
+            api.add(pool.token_1, pool.token_1_reserve);
+        }
+    });
+}
+
+module.exports = {
+    timetravel: false,
+    methodology: "Aggregates TVL in all pools in EVO CLMM.",
+    supra: { tvl }
+};


### PR DESCRIPTION
May close #16941 


Supra stablecoin backing notes (for [this comment](https://github.com/DefiLlama/DefiLlama-Adapters/pull/16941#issuecomment-3521863412)):

- [Supra ETH bridge](https://etherscan.io/address/0xf530214106d443cde08a858e9c7e057048edb5a6) shows $34.75k USDC and $12.64k USDT locked. 
- [Supra USDC contract](https://suprascan.io/fa/0xf90b4b9d4a9d87c39fb3140513e52edc3ead5eaddcb9881b02becdeb63c5793d/f?pageNo=1&rows=10) (supUSDC) shows $34.75k total supply.
- [Supra USDT contract](https://suprascan.io/fa/0x7b6463ca7a54ee37e113c8333db9c0af49de39555ee1cb44837db4c085f8964/f?tab=holders&pageNo=1&rows=10) (supUSDT) shows $12.64k total supply. 

TVL seems to be accurately reflected on [Evo's frontend](https://app.evo.market/pools) but the adapter seems to have trouble pricing supUSDT.
- [Pool](https://suprascan.io/address/0x93d3249eab3cbb2b5b60eeead87d9711a435e4caaf421679ae758016ea932723/f?tab=coins&pageNo=1&rows=10&assetType=fa) with 10 USDT
- [Pool](https://suprascan.io/address/0x9c957b273ddff321dd26542d080abe267795374a7c78a833e36d0e702fdd36b5/f?tab=coins&pageNo=1&rows=10&assetType=fa) with 24 USDT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TVL tracking for EVO CLMM pools now available, aggregating total value locked across all liquidity pools.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->