### PR TITLE
feat(napier): rewrite v2 TVL adapter to API-based

### DIFF
--- a/projects/napier/v2.js
+++ b/projects/napier/v2.js
@@ -7,7 +7,7 @@ const TOKI_LENS_GET_TVL_ABI =
 const config = {
   ethereum: {
     factory: "0x0000001afbCA1E8CF82fe458B33C9954A65b987B",
-    tokiLens: "0x000000896D3C2837797e9f334b4Cf366Bf645fdF",
+    tokiLens: "0x00000031F662013D68E6CD0ceFe97043AE0ac5b8",
     fromBlock: 21942450,
   },
   base: {


### PR DESCRIPTION
## Summary

Rewrites Napier v2 TVL adapter to support both Curve TwoCrypto and TokiHook (Uniswap V4) pool types, fully on-chain.

## Changes

- **Curve pools**: `sumTokens2` balanceOf for PT vault + pool (unchanged approach)
- **TokiHook pools**: `sumTokens2` for PT vault + `TokiLens.getTVL()` for pool liquidity (held in Uniswap V4 PoolManager, not the pool contract)
- Pool type auto-detected via `i_poolKey()` — succeeds for TokiHook, reverts for Curve
- `TokiLens` deployed on Ethereum + Arbitrum (`0x000000896D3C2837797e9f334b4Cf366Bf645fdF`)
- Chains without TokiLens gracefully fallback to PT vault only
- Added Plume chain support
- `permitFailure: true` on resolver scale calls

## How it works

```
For each deployed market:
  1. Fetch Deployed events from Factory
  2. Get resolver, asset, scale for each PT
  3. Detect pool type via i_poolKey()

  Curve pools:
    → balanceOf(target, pt) + balanceOf(target, pool)

  TokiHook pools:
    → balanceOf(target, pt) + TokiLens.getTVL(pool).poolTVLInShare

  Convert target → asset using scale
```

## Testing

Tested on ethereum (38 tokens), arbitrum (8), plume (2), sonic (10). No API dependency.

## Related PRs

- Fees + Dexs: [dimension-adapters #6065](https://github.com/DefiLlama/dimension-adapters/pull/6065)
- Yield: [yield-server #2445](https://github.com/DefiLlama/yield-server/pull/2445)

Linear: NAP-2116