### PR TITLE
Add Probable TVL adapter (BSC)

### DIFF
--- a/projects/probable/index.js
+++ b/projects/probable/index.js
@@ -5,6 +5,6 @@ const USDT = "0x55d398326f99059fF775485246999027B3197955";
 
 module.exports = {
   bsc: {
-    tvl: sumTokensExport({ tokens: [[USDT, TREASURY]] }),
+    tvl: sumTokensExport({ tokens: [USDT], owner: TREASURY }),
   },
 };


### PR DESCRIPTION
Adds a TVL adapter for Probable on BSC.
TVL is calculated as USDT held in the protocol treasury.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tracking Probable project TVL on Binance Smart Chain.
  * Treasury wallet USDT holdings monitoring now available, enabling visibility into USDT balances held by the project treasury and reflecting in overall TVL metrics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->