### PR TITLE
Include latest kpk Morpho 'Yield' vaults in TVL calc

### DIFF
--- a/projects/kpk/index.js
+++ b/projects/kpk/index.js
@@ -30,12 +30,16 @@ const configs = {
       // (de-duplication is automatically applied)
       // You can use BOTH morphoVaultOwners and morpho together - they will be combined
       morpho: [
-        "0xe108fbc04852B5df72f9E44d7C29F47e7A993aDd", //Morpho USDC Prime (v1)
-        "0x0c6aec603d48eBf1cECc7b247a2c3DA08b398DC1", //Morpho EURC Yield (v1)
-        "0xd564F765F9aD3E7d2d6cA782100795a885e8e7C8", //Morpho ETH Prime (v1)
-        "0x4Ef53d2cAa51C447fdFEEedee8F07FD1962C9ee6", //Morpho v2 USDC 
-        "0xa877D5bb0274dcCbA8556154A30E1Ca4021a275f", //Morpho v2 EURC
-        "0xbb50a5341368751024ddf33385ba8cf61fe65ff9", //Morpho v2 ETH
+        "0xe108fbc04852B5df72f9E44d7C29F47e7A993aDd", //Morpho v1 USDC Prime 
+        "0x0c6aec603d48eBf1cECc7b247a2c3DA08b398DC1", //Morpho v1 EURC Yield 
+        "0xd564F765F9aD3E7d2d6cA782100795a885e8e7C8", //Morpho v1 ETH Prime
+        "0x4Ef53d2cAa51C447fdFEEedee8F07FD1962C9ee6", //Morpho v2 USDC Prime
+        "0xa877D5bb0274dcCbA8556154A30E1Ca4021a275f", //Morpho v2 EURC Yield
+        "0xbb50a5341368751024ddf33385ba8cf61fe65ff9", //Morpho v2 ETH Prime
+        "0x5dbf760b4fd0cDdDe0366b33aEb338b2A6d77725", //Morpho v2 ETH Yield
+        "0xc88eFFD6e74D55c78290892809955463468E982A", //Morpho v1 ETH Yield
+        "0xD5cCe260E7a755DDf0Fb9cdF06443d593AaeaA13", //Morpho v2 USDC Yield
+        "0x9178eBE0691593184c1D785a864B62a326cc3509", //Morpho v1 USDC Yield
       ],
 
       // Other ERC-4626 vaults (non-Morpho)
@@ -51,6 +55,7 @@ const configs = {
         // You can use either morphoVaultOwners or morpho here too
         morpho: [
           "0x2C609d9CfC9dda2dB5C128B2a665D921ec53579d", //Morpho USDC Yield
+          "0x5837e4189819637853a357aF36650902347F5e73", //Morpho USDC Yield v2
         ],
       },
   },


### PR DESCRIPTION
Adding TVL for the following Morpho vaults:
* kpk USDC Yield (v1 and v2) on Ethereum
* kpk ETH Yield (v1 and v2) on Ethereum
* kpk USDC Yield (v2) on Arbitrum
which were missing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded Morpho vault support with new v2 variant vaults, including enhanced yield and prime configurations now available across Ethereum and Arbitrum networks.

* **Chores**
  * Minor formatting improvements and code style updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->