### PR TITLE
Add dflow prediction market TVL adapter

### DIFF
--- a/projects/dflow-prediction-market/index.js
+++ b/projects/dflow-prediction-market/index.js
@@ -1,10 +1,5 @@
 const { sumTokensExport } = require('../helper/solana')
 
-const TOKENS = [
-  'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', // USDC
-  'CASHx9KJUStyftLFWGvEVf59SGeG9sh5FfcnZMVPCASH',
-]
-
 const TREASURIES = [
   'C6tLX41pT7ke9LtJ25cdhzPxVbngWD6KsDaEFTSC4SKE',
   '82TCjUf5YjrbJro4XdEfeCokvpQrNUntD97Zjrip8knr',
@@ -12,9 +7,6 @@ const TREASURIES = [
 
 module.exports = {
   solana: {
-    tvl: sumTokensExport({
-      owners: TREASURIES,
-      tokens: TOKENS,
-    }),
+    tvl: sumTokensExport({ tokenAccounts: TREASURIES, }),
   },
 }


### PR DESCRIPTION
Adds a Solana TVL adapter for dflow prediction market.

TVL counts USDC and CASH held in protocol treasury addresses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Solana TVL tracking for dflow-prediction-market, enabling monitoring of designated treasury account balances.

* **Chores**
  * Simplified Solana adapter configuration to rely on treasury account aggregation rather than an explicit token list.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->