### PR TITLE
ignition refactor

### DIFF
--- a/projects/ignition/index.js
+++ b/projects/ignition/index.js
@@ -1,0 +1,24 @@
+const { getConnection } = require('../helper/solana')
+const { decodeAccount } = require('../helper/utils/solana/layout')
+const { PublicKey } = require('@solana/web3.js')
+
+async function tvl() {
+    const connection = getConnection('fogo');
+    const stakePoolAddress = new PublicKey('ign1zuR3YsvLVsEu8WzsyazBA8EVWUxPPHKnhqhoSTB')
+    const accountInfo = await connection.getAccountInfo(stakePoolAddress);
+    const deserializedAccountInfo = decodeAccount('stakePool', accountInfo)
+
+    const totalStakedLamports = +deserializedAccountInfo.totalLamports
+
+    return {
+        fogo: Number(totalStakedLamports) / 1e9,
+    };
+}
+
+module.exports = {
+    timetravel: false,
+    methodology: "TVL is the total FOGO staked in the Ignition stake pool",
+    fogo: {
+        tvl
+    }
+}


### PR DESCRIPTION
May resolve #17704

Valiant-trading can use `sumTokens` as the valiant liquid staking token prices are being [tracked now](https://github.com/DefiLlama/defillama-server/pull/11261).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for the Ignition stake pool, displaying the total amount of FOGO staked.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->