### PR TITLE
Deepbook v3 margin pool TVL

### DIFF
--- a/projects/deepbook-v3/index.js
+++ b/projects/deepbook-v3/index.js
@@ -1,4 +1,3 @@
-const ADDRESSES = require('../helper/coreAssets.json')
 const { get } = require("../helper/http");
 
 const assetsUrl = "https://deepbook-indexer.mainnet.mystenlabs.com/assets";
@@ -16,14 +15,9 @@ const tvl = async (api) => {
   })
 
   // Add margin supply
-  const symbolToCoin = {}
-  Object.entries(assets).forEach(([symbol, info]) => {
-    symbolToCoin[symbol] = info.asset_type
-  })
   const marginSupply = await get(`${endpointUrl}/${marginSupplyEndpoint}`)
   Object.entries(marginSupply).forEach(([symbol, amount]) => {
-    const coin = symbolToCoin[symbol]
-    if (coin) api.add(coin, amount)
+    if (assets[symbol]) api.add(assets[symbol].asset_type, amount)
   })
 
   const { usdTvl } = await api.getUSDJSONs();


### PR DESCRIPTION
Add margin supply to DeepBook V3 TVL                                                                 
                                                                                                       
Includes margin supply balances from the /margin_supply endpoint in the TVL calculation.
                                                                                                       
Changes:                                                                                             
- Fetch and add margin supply data to TVL                 
- Remove unused ADDRESSES import                                                                     
                                                                                                       
TVL impact: +$2.26M (~15% increase)

Note: Our API directly queries the SUI blockchain for margin supply numbers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TVL calculations now incorporate margin supply data for more comprehensive liquidity metrics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->