### PR TITLE
jade1 refactor

### DIFF
--- a/projects/jade1/index.js
+++ b/projects/jade1/index.js
@@ -1,0 +1,12 @@
+const { pool2 } = require("../helper/pool2");
+
+const farm = "0xFa435cc7b37A1E3E404bBE082D48d83F2fAA3d10";
+const lpToken = "0x7ae960972d668B2651261e9D4Fc40d4D983dc524"
+
+module.exports = {
+    bsc: {
+        tvl: () => ({}),
+        pool2: pool2(farm, lpToken),
+    },
+    methodology: "TVL counts JADE-WBNB LP tokens staked in farm",
+}

--- a/projects/treasury/jade1.js
+++ b/projects/treasury/jade1.js
@@ -1,0 +1,13 @@
+const { treasuryExports } = require("../helper/treasury");
+
+module.exports = treasuryExports({
+    bsc: {
+        tokens: [
+            "0xF1c599E9A5FBDEA408a7409C0176a2fE42C64444", // hachiko inu
+            "0x2789033DFE80593f69d689f65892a75aFA491111", // white monkey
+            "0xF8A0BF9cF54Bb92F17374d9e9A321E6a111a51bD", // binance peg link
+        ],
+        ownTokens: ["0x330f4fe5ef44b4d0742fe8bed8ca5e29359870df"], // jade
+        owners: ["0x62c71392c796b92dFe62aCba30293A60771450b0"], // treasury
+    },
+});


### PR DESCRIPTION
May close #17470 

- fixed invalid path 
- replaced masterchef exports helper with pool2 helper
- replaced `tvl` with `pool2` export (as the lp token is JADE-WBNB)
- removed _"staking pool"_ [EOA](https://bscscan.com/address/0xa8D094c72a6F0047eE9D6Ba47E4d6DeFb879A853) and `staking` export
- added treasury adapter to track the treasury address referenced in original PR description (jade tokens as `ownTokens`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Jade1 support on BSC with pool2 metrics displaying JADE-WBNB LP staked in the farm.
  * Introduced Jade1 treasury tracking on BSC, aggregating holdings across specified tokens and a designated treasury wallet.
  * Included methodology text clarifying that TVL reflects JADE-WBNB LP tokens staked in the farm.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->