### PR TITLE
Add Citrea token mappings for JuiceSwap

### DIFF
--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -83,9 +83,11 @@ const fixBalancesTokens = {
     '0x0000000000000000000000000000000000000000': { coingeckoId: 'bitcoin', decimals: 18 },
     '0x3100000000000000000000000000000000000006': { coingeckoId: 'bitcoin', decimals: 18 },
     '0xE045e6c36cF77FAA2CfB54466D71A3aEF7bbE839': { coingeckoId: 'usd-coin', decimals: 6 },
-    '0x8D82c4E3c936C7B5724A382a9c5a4E6Eb7aB6d5D': { coingeckoId: 'citrea-usd', decimals: 6 },
+    '0x8D82c4E3c936C7B5724A382a9c5a4E6Eb7aB6d5D': { coingeckoId: 'tether', decimals: 6 },
     '0x9f3096Bac87e7F03DC09b0B416eB0DF837304dc4': { coingeckoId: 'tether', decimals: 6 },
     '0xDF240DC08B0FdaD1d93b74d5048871232f6BEA3d': { coingeckoId: 'wrapped-bitcoin', decimals: 8 },
+    '0x384157027B1CDEAc4e26e3709667BB28735379Bb': { coingeckoId: 'bitcoin', decimals: 8 },
+    '0x1b70ae756b1089cc5948e4f8a2AD498DF30E897d': { coingeckoId: 'usd-coin', decimals: 18 },
   },
   btnx: {
     '0x0000000000000000000000000000000000000000': { coingeckoId: 'botanix-pegged-bitcoin', decimals: 18 },


### PR DESCRIPTION
Add token mappings for syBTC, svJUSD, and ctUSD on Citrea to properly price all JuiceSwap pool tokens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated token mapping configuration for the Citrea network
  * Added support for Bitcoin and USD Coin tokens on Citrea

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->