### PR TITLE
Add Pythian Council Ops Multisig to Pyth treasury

### DIFF
--- a/projects/treasury/pyth.js
+++ b/projects/treasury/pyth.js
@@ -1,5 +1,11 @@
 const { treasuryExports } = require("../helper/treasury");
 
 module.exports = treasuryExports({
-    solana: { owners: ['Gx4MBPb1vqZLJajZmsKLg8fGw9ErhoKsR8LeKcCKFyak'], },
+    solana: {
+        owners: [
+            'Gx4MBPb1vqZLJajZmsKLg8fGw9ErhoKsR8LeKcCKFyak',  // Pyth DAO Treasury
+            'GAdn7TZhszf5KTfwNRx3A2nP6KCRFEWucZubgdEqbJA2',  // Pythian Council Ops Multisig
+            'CUVeiL7SMWHfNNUKN9nF3DqrQrTwZaBNRN7uUNRcuEgn',  // Jupiter DCA escrow (in-flight buyback funds)
+        ],
+    },
 })


### PR DESCRIPTION
## Summary
Adds the Pythian Council Ops Multisig wallet to Pyth treasury tracking.

## Changes
- Added `GAdn7TZhszf5KTfwNRx3A2nP6KCRFEWucZubgdEqbJA2` (Pythian Council Ops Multisig)

## Context
This wallet:
- Receives protocol revenue (USDC/SOL) from the DAO Treasury
- Executes monthly PYTH token purchases via Jupiter DCA
- Is controlled by the elected Pythian Council (6/8 multisig)

The wallet was established via [OP-PIP-87: PYTH Token Phase 2 — Strategic Reserve](https://forum.pyth.network/t/passed-op-pip-87-pyth-token-phase-2-pyth-strategic-reserve/2293), which directs 33% of the DAO treasury balance monthly toward programmatic PYTH purchases.

## Wallets
| Wallet | Address | Purpose |
|--------|---------|---------|
| Pyth DAO Treasury | `Gx4MBPb1vqZLJajZmsKLg8fGw9ErhoKsR8LeKcCKFyak` | Main treasury (existing) |
| Pythian Council Ops | `GAdn7TZhszf5KTfwNRx3A2nP6KCRFEWucZubgdEqbJA2` | Buyback execution (new) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Solana treasury owner configuration to include additional addresses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->