### PR TITLE
Citrea bridge tvl

### DIFF
--- a/projects/citrea/index.js
+++ b/projects/citrea/index.js
@@ -23,7 +23,7 @@ module.exports = {
     },
     bitcoin: {
         tvl: () => sumTokens({
-            owners: ['bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh']
+            owners: ['bc1pl7grnght2uhp75wm03djde5a56syp06ssdjf7ucm4wkq0tetpqas5e20e9']
         })
     }
 }


### PR DESCRIPTION
tracks tokens locked in ethereum [bridges](https://docs.citrea.xyz/developer-documentation/canonical-contract-addresses#bridges) and clementine btc [vault](https://docs.citrea.xyz/developer-documentation/canonical-bitcoin-addresses#mainnet), which back [USDC.e](https://explorer.mainnet.citrea.xyz/address/0xE045e6c36cF77FAA2CfB54466D71A3aEF7bbE839), [USDT.e](https://explorer.mainnet.citrea.xyz/address/0x9f3096Bac87e7F03DC09b0B416eB0DF837304dc4), [WBTC.e](https://explorer.mainnet.citrea.xyz/address/0xDF240DC08B0FdaD1d93b74d5048871232f6BEA3d), and native cBTC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Total Value Locked (TVL) calculation for the Citrea project on Ethereum and Bitcoin.
  * Ethereum TVL now includes USDC, USDT and WBTC holdings.
  * Bitcoin TVL now includes BTC holdings for the project.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->