### PR TITLE
ctusd tvl

### DIFF
--- a/projects/citrea-ctusd/index.js
+++ b/projects/citrea-ctusd/index.js
@@ -1,19 +1,14 @@
+const { sumTokensExport } = require("../helper/sumTokens");
+
 const ctUsd = "0x8D82c4E3c936C7B5724A382a9c5a4E6Eb7aB6d5D";
 const mToken = "0x866A2BF4E572CbcF37D5071A7a58503Bfb36be1b";
-
-async function tvl(api) {
-    const bal = await api.call({
-        target: mToken,
-        abi: "erc20:balanceOf",
-        params: [ctUsd],
-    })
-
-    api.add(mToken, bal);
-}
 
 module.exports = {
     methodology: "TVL counts the total value of M tokens backing ctUSD.",
     citrea: {
-        tvl,
+        tvl: sumTokensExport({
+            owners: [ctUsd],
+            tokens: [mToken],
+        }),
     }
 }


### PR DESCRIPTION
- [ctUSD](https://docs.citrea.xyz/developer-documentation/citrea-usd-ctusd) is an [m0 stablecoin](https://dashboard.m0.org/stablecoins)
- wM is [1:1](https://etherscan.io/tx/0x009094f26185734b13c943b42c443041d77fac83aae023f37c9d2b478485a3c4) with M
- copies [usDAI adapter](https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/usdai/index.js#L52) (another m0 stable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Citrea ctUSD TVL adapter to track the total value of mTokens backing ctUSD on the Citrea network.
  * Exposed a user-facing TVL metric for Citrea ctUSD and included a clear methodology describing how the TVL is calculated and reported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->