### PR TITLE
Update Lynx TVL

### DIFF
--- a/projects/lynx/index.js
+++ b/projects/lynx/index.js
@@ -1,343 +1,196 @@
-const ADDRESSES = require('../helper/coreAssets.json')
-const { sumTokensExport } = require("../helper/unwrapLPs");
+/**
+ * Lynx Protocol - DefiLlama TVL Adapter
+ *
+ * Lynx is a multi-chain derivatives protocol for perpetual trading
+ * and binary options with liquidity pool management.
+ *
+ * TVL = settlement assets deposited in LexPool (perps) + LiquidityPoolV2 (options)
+ *
+ * Pools hold "chip" tokens (wrapped representations of source-chain assets).
+ * We read the chip balance and map it back to the original token for pricing.
+ */
 
-const config = {
-  // Engine Chips
-  sonic: {
-    tokenAndOwnerPair: [
-      [
-        // wS Token
-        ADDRESSES.sonic.wS,
-        // EngineChip (owner)
-        "0x0e7a7a477ab4dDFB2d7a500D33c38A19372a70Fc"
-      ],
-      [
-        // AG Token
-        "0x005851f943ee2957b1748957f26319e4f9edebc1",
-        // EngineChip (owner)
-        "0x4461913eCa88EDE2d76B576C8fA5D08535bb714A"
-      ],
-    ]
-  },
-  fantom: {
-    tokenAndOwnerPair: [
-      [
-        // WFTM Token
-        ADDRESSES.fantom.WFTM,
-        // EngineChip (owner)
-        "0x614aA983f54409D475aeC5D18120FECFD6320eF4"
-      ],
-      // [
-      //   // FTM Token
-      //   ADDRESSES.GAS_TOKEN_2,
-      //   // EngineChip (owner)
-      //   "0x614aA983f54409D475aeC5D18120FECFD6320eF4"
-      // ],
-      [
-        // USDC Token
-        "0x2F733095B80A04b38b0D10cC884524a3d09b836a",
-        // EngineChip (owner)
-        "0x194609ea1C1D77e66eaB28C48CE266A48f3bC30a",
-      ],
-      [
-        // SPIRIT Token
-        "0x5cc61a78f164885776aa610fb0fe1257df78e59b",
-        // EngineChip (owner)
-        "0x1401C2C092df468862e23502B88A8795e2e9aecf",
-      ],
-      [
-        // FSONIC Token
-        "0x05e31a691405d06708a355c029599c12d5da8b28",
-        // EngineChip (owner)
-        "0xCCC0d9d276176FED7E6918dCf99F23DCAaCFcAc5"
-      ],
-      [
-        // BRUSH Token
-        "0x85dec8c4b2680793661bca91a8f129607571863d",
-        // EngineChip (owner)
-        "0xCBd1A63A84af4BAA9541331420fF98d8Fca3ba1C",
-      ],
-      [
-        // POLTER Token
-        "0x5c725631FD299703D0A74C23F89a55c6B9A0C52F",
-        // EngineChip (owner)
-        "0x089cD8AC58D9a1488b3cDfDfeb20963e7BB33732",
-      ],
-      [
-        // fBUX Token
-        "0x1e2Ea3f3209D66647f959CF00627107e079B870d",
-        // EngineChip (owner)
-        "0x86fAcB048FEe156A16104531Bd36CDfF118d8107",
-      ],
-      [
-        // fTAILS Token
-        "0x5cF90b977C86415a53CE3B7bE13b26f6abdDfee2",
-        // EngineChip (owner)
-        "0x2c241eeFc4b61ed475d7f1DeD112df99E5De0E8F",
-      ],
-      [
-        // sGOAT Token
-        "0x43f9a13675e352154f745d6402e853fecc388aa5",
-        // EngineChip (owner)
-        "0xa8ddbf9B7E307100ba689C02CC1360112d660206",
-      ],
-      [
-        // EQUAL Token
-        "0x3fd3a0c85b70754efc07ac9ac0cbbdce664865a6",
-        // EngineChip (owner)
-        "0x59698CA79B8568F25294d6Eab6281667712079eE",
-      ],
-    ],
-  },
-  boba: {
-    tokenAndOwnerPair: [
-      [
-        // BOBA Token
-        ADDRESSES.boba.BOBA,
-        // EngineChip (owner)
-        "0x9beABD8699E2306c5632C80E663dE9953e104C3f"
-      ],
-      [
-        // USDC Token
-        ADDRESSES.boba.USDC,
-        // EngineChip (owner)
-        "0xcDD339d704Fb8f35A3a2f7d9B064238D33DC7550"
-      ],
-    ]
-  },
+const ADDRESSES = require('../helper/coreAssets.json');
 
-  // OFT Chips
-  fuse: {
-    tokenAndOwnerPair: [
-      [
-        // WFUSE Token
-        ADDRESSES.fuse.WFUSE,
-        // OFTChipAdapter (owner)
-        "0x962FD1B229c8c775bC2E37A8a90dac4f3C0105B7",
-      ],
-      [
-        // MST Token
-        "0x2363Df84fDb7D4ee9d4E1A15c763BB6b7177eAEe",
-        // OFTChipAdapter (owner)
-        "0x028815b56433a4AAe10087290d1Ed9Ef7437068F",
-      ],
-      [
-        // sFUSE Token
-        ADDRESSES.fuse.SFUSE,
-        // OFTChipAdapter (owner)
-        "0x707f3d554B47E17F1FDfb408FE091B39D51929CF",
-      ],
-      [
-        // VOLT Token
-        "0xC5E782E2A4E2cFCb7eD454CF5a7b6aa2bB424B90",
-        // OFTChipAdapter (owner)
-        "0x094DE4d315198Df981D3a20ceFc3381B2182a572",
-      ],
-    ],
-  },
-  linea: {
-    tokenAndOwnerPair: [
-      [
-        // veLVC Token
-        "0xcc22F6AA610D1b2a0e89EF228079cB3e1831b1D1",
-        // OFTChipAdapter (owner)
-        "0xc5e782e2a4e2cfcb7ed454cf5a7b6aa2bb424b90",
-      ],
-      [
-        // LVC Token
-        "0xcc22F6AA610D1b2a0e89EF228079cB3e1831b1D1",
-        // OFTChipAdapter (owner)
-        "0x55f2f3fA843C1755e17eb5F32D29a35c99a3aF09",
-      ],
-    ],
-  },
-  arbitrum: {
-    tokenAndOwnerPair: [
-      [
-        // stEUR Token
-        ADDRESSES.arbitrum.ARB,
-        // OFTChipAdapter (owner)
-        "0x094DE4d315198Df981D3a20ceFc3381B2182a572",
-      ],
-      [
-        // stEUR Token
-        ADDRESSES.celo.STEUR,
-        // OFTChipAdapter (owner)
-        "0xc5e782e2a4e2cfcb7ed454cf5a7b6aa2bb424b90",
-      ],
-      [
-        // TST Token
-        "0xf5a27e55c748bcddbfea5477cb9ae924f0f7fd2e",
-        // OFTChipAdapter (owner)
-        "0xd22c72ab0f4967edb876d84773bff0b60a92e51a",
-      ],
-      [
-        // EUROs Token
-        "0x643b34980e635719c15a2d4ce69571a258f940e9",
-        // OFTChipAdapter (owner)
-        "0x3552fE61af3F6d3235Dd1CB75402d4281d1FbaC6",
-      ],
-      [
-        // GRAI Token
-        "0x894134a25a5faC1c2C26F1d8fBf05111a3CB9487",
-        // OFTChipAdapter (owner)
-        "0xBe1fa4177fBf43683434CecD5563DA6Ea00FD474",
-      ],
-      [
-        // SLIZ Token
-        "0x463913D3a3D3D291667D53B8325c598Eb88D3B0e",
-        // OFTChipAdapter (owner)
-        "0x1E1F546dF45A82F2a29E709C85331E3974dC26b0",
-      ],
-      [
-        // SCALES Token
-        "0xe6af844d5740b6b297b6dd7fb2ce299ee9e3d16f",
-        // OFTChipAdapter (owner)
-        "0x1E71Fad2d453dAb287Dad8CD003CA24A9d9194EA",
-      ],
-      [
-        // USDFI Token
-        "0x249c48e22e95514ca975de31f473f30c2f3c0916",
-        // OFTChipAdapter (owner)
-        "0x24d6318B87ABB45B62D981693FCF25A5956F41e2",
-      ],
-      [
-        // STABLE Token
-        "0x666966ef3925b1c92fa355fda9722899f3e73451",
-        // OFTChipAdapter (owner)
-        "0x2E2a9b820BDDfD54487f8d5A0Dfd5940D5Dac6A9",
-      ],
-      [
-        // uniBTC Token
-        "0x6B2a01A5f79dEb4c2f3c0eDa7b01DF456FbD726a",
-        // OFTChipAdapter (owner)
-        "0xCf3562bbe462A249a4b2B2a421dF00b93E081066",
-      ],
-    ],
-  },
-  optimism: {
-    tokenAndOwnerPair: [
-      [
-        // SONNE Token
-        "0x1db2466d9f5e10d7090e7152b68d62703a2245f0",
-        // OFTChipAdapter (owner)
-        "0xc5e782e2a4e2cfcb7ed454cf5a7b6aa2bb424b90",
-      ],
-    ],
-  },
-  mantle: {
-    tokenAndOwnerPair: [
-      [
-        // aUSD Token
-        "0xD2B4C9B0d70e3Da1fBDD98f469bD02E77E12FC79",
-        // OFTChipAdapter (owner)
-        "0xC5E782E2A4E2cFCb7eD454CF5a7b6aa2bB424B90",
-      ],
-    ],
-  },
-  polygon: {
-    tokenAndOwnerPair: [
-      [
-        // WMATIC Token
-        ADDRESSES.polygon.WMATIC_2,
-        // OFTChipAdapter (owner)
-        "0x028815b56433a4aae10087290d1ed9ef7437068f",
-      ],
-      [
-        // MIMATIC Token
-        "0xa3fa99a148fa48d14ed51d610c367c61876997f1",
-        // OFTChipAdapter (owner)
-        "0x7279d1cFf1510E503B6Be64fBBAd64088034504C",
-      ],
-    ],
-  },
-  bsc: {
-    tokenAndOwnerPair: [
-      [
-        // wBNB Token
-        ADDRESSES.bsc.WBNB,
-        // OFTChipAdapter (owner)
-        "0x67ac4355787fe8313D6cAfd23aEa4463704fBaeC",
-      ],
-      [
-        // USDT Token
-        ADDRESSES.bsc.USDT,
-        // OFTChipAdapter (owner)
-        "0x7eDb95ba0294EfD054221141FcC8f12F2Ada1129",
-      ],
-      [
-        // lisUSD Token
-        "0x0782b6d8c4551B9760e74c0545a9bCD90bdc41E5",
-        // OFTChipAdapter (owner)
-        "0x3b7ed1cdf0fc64d95c0d0428b9cc99b6a9a5cb94",
-      ],
-    ],
-  },
-  mode: {
-    tokenAndOwnerPair: [
-      [
-        // MODE Token
-        "0xDfc7C877a950e49D2610114102175A06C2e3167a",
-        // OFTChipAdapter (owner)
-        "0x3b7ED1cDF0Fc64d95c0D0428b9Cc99b6A9a5CB94",
-      ],
-      [
-        // ION Token
-        "0x18470019bF0E94611f15852F7e93cf5D65BC34CA",
-        // OFTChipAdapter (owner)
-        "0xD22c72aB0f4967edB876d84773BfF0b60A92e51a",
-      ],
-    ],
-  },
-  celo: {
-    tokenAndOwnerPair: [
-      [
-        // CELO Token
-        ADDRESSES.celo.CELO,
-        // OFTChipAdapter (owner)
-        "0x7279d1cFf1510E503B6Be64fBBAd64088034504C",
-      ],
-      [
-        // USDT Token
-        ADDRESSES.celo.USDT_1,
-        // OFTChipAdapter (owner)
-        "0xA36cB6e644cCE5fB98bDa9aa538927B2c934D8fa",
-      ],
-    ]
-  },
-  zircuit: {
-    tokenAndOwnerPair: [
-      [
-        // ZRC Token
-        "0xfd418e42783382e86ae91e445406600ba144d162",
-        // OFTChipAdapter (owner)
-        "0xa624818151078Ccc936BF056DEf51114808BFE16",
-      ],
-    ]
-  },
-  ethereum: {
-    tokenAndOwnerPair: [
-      [
-        // WEETh Token
-        ADDRESSES.ethereum.WEETH,
-        // OFTChipAdapter (owner)
-        "0x66Aaf6Da70dA10aC8dC024E668edcade1C8F5b44",
-      ],
-      [
-        // TUNA Token
-        "0xadd353fb2e2c563383ff3272a500f3e7134dafe4",
-        // OFTChipAdapter (owner)
-        "0x3b7ED1cDF0Fc64d95c0D0428b9Cc99b6A9a5CB94",
-      ],
-    ],
-  }
+// -- ABIs --
+const TOTAL_ASSETS_ABI = "uint256:totalAssets"; // Options V2 pool: returns TVL
+
+// -- Chain ID to DefiLlama chain name --
+const CHAIN_NAME = {
+  146: "sonic",
+  288: "boba",
+  14: "flare",
 };
 
-Object.keys(config).forEach((chain) => {
-  const { tokenAndOwnerPair } = config[chain];
-  module.exports[chain] = {
-    tvl: sumTokensExport({
-      tokensAndOwners: tokenAndOwnerPair,
-    }),
-  };
-});
+// ============================================================
+//  SONIC — Perps Pools (LexPool)
+// ============================================================
+// Each entry: [poolAddress, chipAddress, originalTokenAddress, sourceChainId]
+// When sourceChainId === 146 (sonic), the token is native to sonic.
+const SONIC_PERPS_POOLS = [
+  ["0x0720F76645bdd96838139ca8bB5b3AC9217EccE4", "0x0e7a7a477ab4dDFB2d7a500D33c38A19372a70Fc", ADDRESSES.sonic.wS, 146],       // wS
+  ["0x4738D724F3f8Ebec0F363c630E23eC814efD1D6E", "0x4461913eCa88EDE2d76B576C8fA5D08535bb714A", "0x005851f943ee2957b1748957f26319e4f9edebc1", 146],   // AG
+  ["0x0DdF9aF077bB85a74E504721B32eC6189Cb10b22", "0xb02bD75a0814585ba7c4d5a1C421b092aDF96da0", ADDRESSES.sonic.USDC_e, 146],   // USDC
+  ["0xC295820e5c35e2b2c678CA9D0Fd84D1691A7f0A1", "0x8A5e46c8dE8c301201af475DbEF7cF4fA6Cc71F2", "0xbf5899166ac476370b3117c9256b7fc45624f4ea", 146],   // GFI
+  ["0x62D4CFCf3475c575b5E9CA3dfDdA8eCA99Fb37BD", "0x1444E226a93eE7228A7634D3101413a4d1AEa4bd", "0x7A0C53F7eb34C5BC8B01691723669adA9D6CB384", 146],   // BOO
+  ["0xD86636FA9a010E62a904c92810A0AC8041040584", "0x443D0a82De44FDF8236D40d72A40486c804764b9", "0xa95ea1cfabccf0e9eb94b646cefe9ed71ff5d605", 146],   // xBOO
+  ["0x042675c5a2129Eb6D1f5Fe8Ce7E00235977aF7dD", "0xb0D87B27282501E64Ffa575aaED393c373Ee24b8", "0xa04bc7140c26fc9bb1f36b1a604c7a5a88fb0e70", 146],   // SWPx
+  ["0x0929CFF984b3497CFE15a8a1fF940B65CFFC1d3D", "0x73c0EeA1faDd305d9A7e0a4c8943B16Adff0a04A", ADDRESSES.sonic.scUSD, 146],    // scUSD
+  ["0x5f687742DDf4067B79667E52CB2a62175A1A5f22", "0x4A6132bb6a3c001937581822479474F2aE4C855d", "0x9F0dF7799f6FDAd409300080cfF680f5A23df4b1", 146],   // wOS
+  ["0xeA334D47C366a9aBAa39BDcBA77dd6f10D1531f1", "0xaec5a1f07B459c50a0dfd5001798DC8b683b6023", "0xe6cc4D855B4fD4A9D02F46B9adae4C5EfB1764B5", 146],   // LUDWIG
+  ["0x07775efcf73e31CdED88E239FdF6bB1Cf4eCBB55", "0x5e9aAC66C5CF0d1035f9213A2De323aFcA19653a", ADDRESSES.sonic.STS, 146],      // stS
+  ["0x726cFDcfb77a911C31E4C57958C0EEE314c9807e", "0x83E2e4ca591c7f1f77588C684A83a0b5C92Ac377", "0x71E99522EaD5E21CF57F1f542Dc4ad2E841F7321", 146],   // METRO
+  ["0x6E9D974d76F883cfeE60aFE322679474db223553", "0x1423D2dc2a8E884b4535b349aD4B724b9a6F0FA1", "0x6c9B3A74ae4779da5Ca999371eE8950e8DB3407f", 146],   // FLY
+  ["0xf66D9B8A85928FB087FE95a3f2b5a3EAAAc5838e", "0xd50995818ac9E1Fa49Eed8E560a42Bc5970A7c61", "0xb4444468e444f89e1c2CAc2F1D3ee7e336cBD1f5", 146],   // RZR
+];
+
+// ============================================================
+//  SONIC — Options V2 Pool
+// ============================================================
+const SONIC_OPTIONS_POOLS = [
+  // [poolAddress, assetAddress]
+  ["0xe875c6987df6e0c38d2e18a67ae5061f921df417", ADDRESSES.sonic.wS], // wS
+];
+
+// ============================================================
+//  BOBA — Perps Pools (LexPool)
+// ============================================================
+const BOBA_PERPS_POOLS = [
+  ["0x27b66f41E8ba74fF804C8b4D983b137D78D559a4", "0xcDD339d704Fb8f35A3a2f7d9B064238D33DC7550", ADDRESSES.boba.USDC, 288],     // USDC
+  ["0xDa9de011c65376CA2D7bd902Ce05a48b85D93175", "0x9beABD8699E2306c5632C80E663dE9953e104C3f", ADDRESSES.boba.BOBA, 288],     // BOBA
+  ["0x881cc6150f9d30C4B003A7aecfB38Ea3Bca69C3D", "0x222a41942ac89533C77cC0c7C185E056CdA76e2e", "0x52E4d8989fa8b3E1C06696e7b16DEf5d7707A0d1", 288], // bobaETH
+];
+
+// ============================================================
+//  BOBA — Options V2 Pool
+// ============================================================
+const BOBA_OPTIONS_POOLS = [
+  ["0xc56726980981fb2ace7454b6f9ecff2d04bad4f6", ADDRESSES.boba.BOBA], // BOBA
+];
+
+// ============================================================
+//  FLARE — Perps Pools (LexPool)
+// ============================================================
+const FLARE_PERPS_POOLS = [
+  ["0x93e9B41F3906472Cc83bb9Bb826648D20A94b929", "0xf764EECe331caB7D7c451a3972e139B4645d6fe8", ADDRESSES.flare.WFLR, 14],     // wFLR
+  ["0x0FE9CD465A7E7250489a64E099632560bcE445dB", "0x23011e38Addd5dA64ab8Ad940eE6219095E39382", "0x12e605bc104e93B45e1aD99F9e555f659051c2BB", 14], // sFLR
+  ["0xb9656529c75563aB158be4B1d2c71f4e6aC4925e", "0x7e1C6870be30c1f8216f0187C7f181C13c52977A", "0xe7cd86e13AC4309349F30B3435a9d337750fC82D", 14], // USDT0
+  ["0xE9A1b26c8A36bac235A608d2F1F248ab65A23525", "0x695b696E80f6f7137731eF509D64023F17550eCE", "0xAd552A648C74D49E10027AB8a618A3ad4901c5bE", 14], // FXRP
+  ["0xE69bAAc97591AB53EFee4903000a8995eD246A97", "0x4D131a30aE842B3290651EEd58466a0bC0aC6FD1", "0x4C18Ff3C89632c3Dd62E796c0aFA5c07c4c1B2b3", 14], // stXRP
+];
+
+// ============================================================
+//  FLARE — Options V2 Pool
+// ============================================================
+const FLARE_OPTIONS_POOLS = [
+  ["0xa3c1c1374319a6238b9ecd39e52448224711dc4c", ADDRESSES.flare.WFLR], // wFLR
+];
+
+// ============================================================
+//  TVL Calculation
+// ============================================================
+
+/**
+ * Calculate TVL for LexPool (perps) pools.
+ *
+ * Each pool holds a "chip" token representing the source-chain asset.
+ * We read the chip balance held by the pool and map it to the original
+ * token on its source chain so DefiLlama can price it correctly.
+ */
+async function perpsPoolsTvl(api, pools) {
+  const engineChainId = api.getChainId();
+
+  // Read chip balances held by each pool
+  const balances = await api.multiCall({
+    abi: "erc20:balanceOf",
+    calls: pools.map(([pool, chip]) => ({ target: chip, params: [pool] })),
+  });
+
+  // Read decimals of chip tokens and original tokens to rescale
+  const chipDecimals = await api.multiCall({
+    abi: "erc20:decimals",
+    calls: pools.map(([, chip]) => chip),
+  });
+  const originalDecimals = await api.multiCall({
+    abi: "erc20:decimals",
+    calls: pools.map(([, , originalToken]) => originalToken),
+  });
+
+  for (let i = 0; i < pools.length; i++) {
+    const [, , originalToken, sourceChainId] = pools[i];
+    const balance = BigInt(balances[i]);
+    const chipDec = Number(chipDecimals[i]);
+    const origDec = Number(originalDecimals[i]);
+
+    // Balance is in chip-token decimals but will be interpreted using original token decimals.
+    // Rescale: if chip has 18 decimals and original has 6, divide by 10^12.
+    const decDiff = chipDec - origDec;
+    const adjusted = decDiff > 0
+      ? balance / BigInt(10 ** decDiff)
+      : balance * BigInt(10 ** (-decDiff));
+
+    if (sourceChainId === engineChainId) {
+      api.add(originalToken, adjusted.toString());
+    } else {
+      const chainName = CHAIN_NAME[sourceChainId];
+      if (chainName) {
+        api.add(`${chainName}:${originalToken}`, adjusted.toString());
+      }
+    }
+  }
+}
+
+/**
+ * Calculate TVL for Options V2 liquidity pools.
+ *
+ * These are ERC-4626-style vaults. We call totalAssets() which returns
+ * the total settlement assets held, and map to the asset token.
+ */
+async function optionsPoolsTvl(api, pools) {
+  const totalAssets = await api.multiCall({
+    abi: TOTAL_ASSETS_ABI,
+    calls: pools.map(([pool]) => pool),
+  });
+
+  for (let i = 0; i < pools.length; i++) {
+    const [, assetAddress] = pools[i];
+    api.add(assetAddress, totalAssets[i]);
+  }
+}
+
+// ============================================================
+//  Chain TVL Functions
+// ============================================================
+
+async function sonicTvl(api) {
+  await perpsPoolsTvl(api, SONIC_PERPS_POOLS);
+  await optionsPoolsTvl(api, SONIC_OPTIONS_POOLS);
+}
+
+async function bobaTvl(api) {
+  await perpsPoolsTvl(api, BOBA_PERPS_POOLS);
+  await optionsPoolsTvl(api, BOBA_OPTIONS_POOLS);
+}
+
+async function flareTvl(api) {
+  await perpsPoolsTvl(api, FLARE_PERPS_POOLS);
+  await optionsPoolsTvl(api, FLARE_OPTIONS_POOLS);
+}
+
+// ============================================================
+//  Module Exports
+// ============================================================
+
+module.exports = {
+  methodology:
+    "TVL is the sum of settlement assets deposited in Lynx perpetual trading liquidity pools (LexPool) and binary options liquidity pools (LiquidityPoolV2) across all supported chains.",
+  sonic: {
+    tvl: sonicTvl,
+  },
+  boba: {
+    tvl: bobaTvl,
+  },
+  flare: {
+    tvl: flareTvl,
+  },
+};


### PR DESCRIPTION
Update the TVL for Lynx project.

**Summary** 

- Add missing assets
- Remove stale chains — Drop Fantom, Fuse, Linea, Arbitrum, Optimism, Mantle, Polygon, BSC, Mode, Celo, Zircuit, and Ethereum entries that are no longer active Lynx deployments. Keep only Sonic, Boba, and Flare.
- Use ADDRESSES constants from coreAssets.json where available (wS, USDC_e, scUSD, STS, BOBA, USDC, WFLR) instead of hardcoded addresses.
- Add Options V2 pool TVL — Include totalAssets() from ERC-4626 binary options liquidity pools, which were previously untracked.

Test plan
 node test.js projects/lynx/index.js passes with correct values:
Sonic: ~$84K (matches on-chain pool data)
Boba: ~$86K
Flare: ~$219K
Total: ~$390K
 No "value too high" warnings for any token

Live verification [https://app.lynx.finance/pools](https://app.lynx.finance/pools)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured TVL calculation architecture to support multiple chains (Sonic, Boba, Flare) with improved modularity
  * Enhanced cross-chain asset mapping and decimal scaling for perps and options pools
  * Streamlined TVL computation endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->