### PR TITLE
Add xlayer subgraph to Uniswap V4

### DIFF
--- a/projects/uniswap-v4/index.js
+++ b/projects/uniswap-v4/index.js
@@ -57,8 +57,8 @@ Object.keys(subgraphs).forEach(chain => {
             hooks
           }
         }`
-      const result = await cachedGraphQuery(`uniswap-v4/${chain}`, endpoint, query, { api, fetchById: true })
-      const mappedResults = result.pools.map(pool => { return { token0: pool.token0.id, token1: pool.token1.id, hooks: pool.hooks}})
+      const result = await cachedGraphQuery(`uniswap-v4/${chain}`, endpoint, query, { api, fetchById: true, useBlock: true })
+      const mappedResults = result.map(pool => { return { token0: pool.token0.id, token1: pool.token1.id, hooks: pool.hooks}})
       return processResult(api, mappedResults, factory, subgraphs[chain].blacklistedTokens)
     }
   }


### PR DESCRIPTION
I added a subgraph for xlayer on Uniswap V4 and a helper function to process both logs and subgraph results

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added xlayer chain support for TVL via subgraph-based queries and a new xlayer TVL entry point.

* **Refactor**
  * Unified TVL aggregation flow for pools and hooks for consistent results.
  * Added caching and run-time safeguards to improve reliability and performance of TVL updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->