### PR TITLE
feat: add WarpX V3 Mainnet adapter

### DIFF
--- a/projects/warpx-v3/index.js
+++ b/projects/warpx-v3/index.js
@@ -1,0 +1,5 @@
+const { uniV3Export } = require('../helper/uniswapV3')
+
+module.exports = uniV3Export({
+  megaeth: { factory: '0xf67cF9d6FC433e97Ec39Ae4b7E4451B56B171C8a', fromBlock: 4630394 },
+})


### PR DESCRIPTION
Name: WarpX
Twitter: https://x.com/warpexchange
Website: https://warpx.exchange/
Chain: MegaETH
Short Description: The first and most performant DEX on MegaETH.
Category: Dexes
Forked From: Uniswap V3
Methodology: Counts the tokens locked on WarpX V3 AMM pools.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added megaeth blockchain pool configuration with factory parameters and block tracking support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->