### PR TITLE
✨Add defindex adapter for Stellar

### DIFF
--- a/projects/defindex/index.js
+++ b/projects/defindex/index.js
@@ -1,18 +1,19 @@
 const { getConfig } = require('../helper/cache')
 
 const DEFINDEX_API_BASE_URL = 'https://api.defindex.io'
-const DEFINDEX_VAIULTS_INFO_URL = `${DEFINDEX_API_BASE_URL}/vault/discover?network=mainnet`
+const DEFINDEX_VAULTS_INFO_URL = `${DEFINDEX_API_BASE_URL}/vault/discover?network=mainnet`
 
 async function tvl(api) {
-    const res = await getConfig('defindex', DEFINDEX_VAIULTS_INFO_URL)
-    const vaults = res.vaults
+    const res = await getConfig('defindex', DEFINDEX_VAULTS_INFO_URL)
+    const vaults = res?.vaults || [] 
     for (const vault of vaults) {
         if (!vault.totalManagedFunds || vault.totalManagedFunds.length === 0) {
             continue
         }
         for (const fund of vault.totalManagedFunds) {
-            const amount = fund.total_amount
-            api.add(fund.asset, amount)
+            if (fund.asset && fund.total_amount != null) {
+                api.add(fund.asset, fund.total_amount)
+            }
         }
 
     }


### PR DESCRIPTION
## Summary
  - Adds a new adapter for [DeFindex](https://defindex.io), a vault-based DeFi protocol on Stellar
  - Uses a fetch-based approach via the DeFindex API (`/vault/discover`) to retrieve vault data and total managed funds

  ## Why fetch instead of on-chain queries?
  DefiLlama's SDK does not have full support for Stellar (no RPC helpers, no contract call abstractions, limited chain tooling). Implementing direct on-chain queries to Stellar/Soroban smart contracts would require significant custom work outside the scope of a standard adapter.
  Instead, this adapter fetches TVL data from DeFindex's own API, which already aggregates total managed funds per vault (both idle and invested in strategies).

  ## How it works
  1. Fetches all mainnet vaults from `api.defindex.com/vault/discover`
  2. Iterates over each vault's `totalManagedFunds`
  3. Adds each asset and its amount to the TVL calculation

  ## Test plan
  - [x] Run `pnpm tvl defindex` to verify the adapter returns valid TVL data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Defindex TVL tracking, aggregating managed funds by asset and reporting totals under the Stellar TVL view.
  * Vaults with missing or empty managed-funds data are safely skipped to avoid incorrect totals.

* **Documentation**
  * Included a methodology description explaining how the TVL is calculated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->