### PR TITLE
feat: add Flare chain support for Morpho Blue

### DIFF
--- a/projects/morpho-blue/index.js
+++ b/projects/morpho-blue/index.js
@@ -153,7 +153,7 @@ const config = {
   },
   flare: {
     morphoBlue: "0xF4346F5132e810f80a28487a79c7559d9797E8B0",
-    fromBlock: 52946050,
+    fromBlock: 52378788,
   }
 }
 


### PR DESCRIPTION
## Description
Add Flare chain support for existing Morpho Blue adapter.

Morpho Blue was deployed on Flare on February 3, 2026.

## Changes
- Added `flare` config to `projects/morpho-blue/index.js`

## Contract Information
- Morpho Blue: `0xF4346F5132e810f80a28487a79c7559d9797E8B0`
- fromBlock: `52946050`

## Test Results
```
flare TVL: $9.28M
- FXRP: $8.00M
- USDT0: $795.13k  
- WFLR: $482.84k
```

## References
- [Flare Explorer - Contract](https://flare-explorer.flare.network/address/0xF4346F5132e810f80a28487a79c7559d9797E8B0)
- [Mystic Finance](https://app.mysticfinance.xyz)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Morpho Blue (Flare) network.
  * Introduced initial sync configuration so the app will start processing Morpho Blue data from a defined starting block.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->