### PR TITLE
[TermMax] update extraKeys to fetch events

### DIFF
--- a/projects/term-structure/index.js
+++ b/projects/term-structure/index.js
@@ -42,6 +42,7 @@ const EVENTS = {
 };
 
 const ADDRESSES = {
+  // Term Structure
   // TermMax
   arbitrum: {
     Factory: {
@@ -108,9 +109,14 @@ const ADDRESSES = {
     TermMax4626Factory: [
       { address: "0x67dcDCc57208B574B05999AA3dFA57bfF2324129", fromBlock: 63208984 },
     ],
+    // MarketV2Factory: [  // it is termMax market v2? https://github.com/DefiLlama/DefiLlama-Adapters/pull/17483 anyway, atm there is only testing with brBTC, excluding it for now
+    //   {
+    //     address: "0x529A60A7aCDBDdf3D71d8cAe72720716BC192106",
+    //     fromBlock: 71136348,
+    //   },
+    // ],
   },
   ethereum: {
-    // Term Structure
     zkTrueUpContractAddress: "0x09E01425780094a9754B2bd8A3298f73ce837CF9",
     Factory: {
       address: "0x37Ba9934aAbA7a49cC29d0952C6a91d7c7043dbc",
@@ -344,7 +350,27 @@ async function getTermMaxVaultOwnerTokens(api) {
 
 async function recordVaultV2Assets(api) {
   const vaultV2Addresses = await getTermMaxVaultV2Addresses(api);
+
   const assets = await api.multiCall({ abi: ABIS.Vault.asset, calls: vaultV2Addresses, })
+  /*
+    const tokensAndOwners = assets.map((asset, idx) => ({ target: asset, params: vaultV2Addresses[idx] }));
+     const assets1 = await api.multiCall({ abi: 'uint256:totalAssets', calls: vaultV2Addresses, })
+    const tokens = await api.multiCall({ abi: 'string:symbol', calls: assets })
+    const tokenBals = await api.multiCall({ abi: 'erc20:balanceOf', calls: tokensAndOwners })
+    const table = []
+  
+    vaultV2Addresses.forEach((vault, i) => {
+      let bal = assets1[i] / 1e18
+      let tokenBal = tokenBals[i] / 1e18
+      if (tokens[i].includes('USD')) {
+        bal = assets1[i] / 1e6
+        tokenBal = tokenBals[i] / 1e6
+      }
+      table.push({ vault, asset: assets[i], symbol: tokens[i], totalAssets: bal, tokenBalance: tokenBal, chain: api.chain })
+    })
+    console.table(table) 
+    */
+  // console.log('TermMax V2 Vaults found:', vaultV2Addresses, assets, tokens, api.chain);
   await sumTokens2({ api, tokensAndOwners2: [assets, vaultV2Addresses] });
 }
 
@@ -362,6 +388,7 @@ async function addTermMaxMarketV2Tvl(api) {
     });
     factoryLogs.forEach(log => tokensAndOwners.push([log.collateral, log.gt]));
   }
+
   await sumTokens2({ api, tokensAndOwners });
 }
 
@@ -377,6 +404,7 @@ async function getTermMaxOwnerTokens(api) {
 }
 
 async function getTermStructureTvl(api) {
+
   const zkTrueUpContractAddress = ADDRESSES[api.chain].zkTrueUpContractAddress;
   if (!zkTrueUpContractAddress) return;
 
@@ -467,6 +495,7 @@ async function erc4626VaultsTvl(api) {
       extraKey: 'StableERC4626ForAaveCreated-20260206',
     });
     aaveVaults.push(...logs.map(i => i.stableERC4626ForAave));
+
 
     logs = await getLogs2({
       api,


### PR DESCRIPTION
In this PR:

- Removed dead code.
- Updated the extra key configuration to fetch events correctly.

If we keep using the original extra key, the 968k USDT in the pool on BNB Chain is not counted. As a result, our protocol’s TVL on BNB Chain is underreported. After updating the extra key, that USDT is properly recognized and included in TVL.

I also tried removing the extra key and letting the adapter generate it automatically, but that caused the adapter to fail. Therefore, I chose to update the extra key instead.

**Original extra key**

```
--- bsc ---
(no aBnbUSDT)
------ TVL ------
bsc                       265.04 k
```

**New extra key (20260206 suffix)**

```
--- bsc ---
aBnbUSDT                  968.67 k
------ TVL ------
bsc                       1.24 M
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Cleaned up commented-out debugging code and extraneous comments to improve code cleanliness.
  * Updated identifiers used for log retrieval to include date suffixes for clearer tracking.
  * Minor formatting and whitespace adjustments to improve readability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->