### PR TITLE
add SparkDEX stFLR Liquid Staking

### DIFF
--- a/projects/sparkdex-stflr/index.js
+++ b/projects/sparkdex-stflr/index.js
@@ -1,0 +1,35 @@
+/**
+ * SparkDEX stFLR Liquid Staking - DeFiLlama TVL Adapter
+ *
+ * stFLR is SparkDEX's liquid staking token for FLR.
+ * It allows users to stake FLR while maintaining liquidity.
+ *
+ * Contract: 0x0988C6ba244A90C07a917ebE609eB3264bE716fF
+ * Documentation: https://docs.sparkdex.ai/sparkdex-defi-ecosystem/stflr-liquid-staking
+ */
+
+const ADDRESSES = require('../helper/coreAssets.json');
+
+const STFLR_CONTRACT = '0x0988C6ba244A90C07a917ebE609eB3264bE716fF';
+const FLR_ADDRESS = ADDRESSES.null; // Native FLR token
+
+async function tvl(api) {
+  // Get total pooled FLR from the contract
+  // This includes all FLR backing stFLR tokens: staked FLR on P-Chain, buffer reserves, and pending deposits
+  const totalPooledFlr = await api.call({
+    target: STFLR_CONTRACT,
+    abi: 'function totalPooledFlr() view returns (uint256)',
+  });
+
+  // Add native FLR to TVL
+  api.add(FLR_ADDRESS, totalPooledFlr);
+
+  return api.getBalances();
+}
+
+module.exports = {
+  flare: {
+    tvl,
+  },
+  methodology: 'TVL is calculated by calling totalPooledFlr() on the stFLR contract, which returns the total amount of FLR backing the liquid staking tokens, including staked FLR on P-Chain, buffer reserves, and pending deposits.',
+};


### PR DESCRIPTION
## Summary

Add TVL adapter for **SparkDEX stFLR** liquid staking protocol on **Flare** network. stFLR is SparkDEX's liquid staking token for FLR, allowing users to stake FLR while maintaining liquidity.

**Implementation:**
- Single chain: **flare**
- Contract: `0x0988C6ba244A90C07a917ebE609eB3264bE716fF`
- Uses `totalPooledFlr()` method to get total FLR backing the liquid staking tokens
- TVL includes: staked FLR on P-Chain, buffer reserves, and pending deposits

---

##### Name (to be shown on DefiLlama):
SparkDEX stFLR

##### Website Link:
https://sparkdex.ai

##### Current TVL:
~$344k USD (as of testing)

##### Chain:
Flare

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):
sparkdex-staked-flr

##### Short Description (to be shown on DefiLlama):
Liquid staking protocol for FLR on Flare network. Users can stake FLR to receive stFLR tokens, maintaining liquidity while earning staking rewards.

##### Token address and ticker if any:
stFLR Token: `0x0988C6ba244A90C07a917ebE609eB3264bE716fF`

##### Category (full list at https://defillama.com/categories) \*Please choose only one:
Liquid Staking

##### forkedFrom (Does your project originate from another project):
No

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL is calculated by calling `totalPooledFlr()` on the stFLR contract (`0x0988C6ba244A90C07a917ebE609eB3264bE716fF`), which returns the total amount of FLR backing the liquid staking tokens. This includes:
- FLR staked on P-Chain (Platform Chain)
- Buffer reserves (liquid FLR kept in the contract for instant withdrawals)
- Pending deposits (FLR queued for staking)

The adapter reads the `totalPooledFlr()` value directly from the smart contract on-chain, ensuring accurate and real-time TVL calculation.

---

## Technical Details

- **Contract Address**: `0x0988C6ba244A90C07a917ebE609eB3264bE716fF`
- **Documentation**: https://docs.sparkdex.ai/sparkdex-defi-ecosystem/stflr-liquid-staking
- **Method Used**: `totalPooledFlr() view returns (uint256)`
- **Chain**: Flare (Chain ID: 14)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SparkDEX stFLR total value locked (TVL) tracking, enabling real-time visibility into total FLR assets backing liquid staking tokens within the Flare ecosystem. Includes comprehensive methodology documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->