### PR TITLE
Biconomy minor update

### DIFF
--- a/projects/biconomy/index.js
+++ b/projects/biconomy/index.js
@@ -75,7 +75,7 @@ const config = {
 module.exports = {
   hallmarks: [
     ["2022-05-07", "UST depeg"],
-    ["2024-12-31", "Biconomy decomissions Hyphen"],
+    ["2024-12-31", "Biconomy decommissions Hyphen"],
   ],
   deadFrom: "2024-12-31",
   methodology:


### PR DESCRIPTION
- removes [duplicated address](https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/biconomy-cex/index.js#L8) that is being tracked in `projects/biconomy-cex`
- adds `deadFrom` and [hallmark](https://l2beat.com/bridges/projects/hyphen)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Biconomy marked as decommissioned effective December 31, 2024
  * Removed a bridge address from network configuration
  * Updated historical event records with standardized date format

<!-- end of auto-generated comment: release notes by coderabbit.ai -->