### PR TITLE
Royco: migrate to on-chain TVL calculation

### DIFF
--- a/projects/royco-v2/index.js
+++ b/projects/royco-v2/index.js
@@ -24,6 +24,25 @@ const config = {
   },
 };
 
+// Reserve addresses -- balances held by multisigs and earn vaults
+// that are not deposited into Royco Market Vaults
+const reserves = {
+  [slug[1]]: [
+    {
+      owner: "0x170ff06326ebb64bf609a848fc143143994af6c8", // Multisig
+      tokens: [
+        "0x98c23e9d8f34fefb1b7bd6a91b7ff122f4e16f5c", // aaveUSDC (Aave v3)
+      ],
+    },
+    {
+      owner: "0xcd9f5907f92818bc06c9ad70217f089e190d2a32", // Earn vault
+      tokens: [
+        "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // USDC
+      ],
+    },
+  ],
+};
+
 const calculateTvl = async ({ api, chain }) => {
   // Market Vaults
   const { factoryFromBlock, factoryAddress } = config[chain];
@@ -61,6 +80,16 @@ const calculateTvl = async ({ api, chain }) => {
     const jtDivisor = 10n ** BigInt(jtMapping ? jtMapping.decimalsOffset : 0);
     api.add(jtToken, BigInt(result.jtAssets) / jtDivisor);
   });
+
+  // Reserves — multisigs and earn vaults
+  const chainReserves = reserves[chain];
+  if (chainReserves) {
+    await api.sumTokens({
+      tokensAndOwners: chainReserves.flatMap(({ owner, tokens }) =>
+        tokens.map(token => [token, owner])
+      ),
+    });
+  }
 };
 
 module.exports.methodology = "TVL is computed by reading MarketDeployed events from the Royco V2 factory and summing totalAssets() across senior and junior tranches.";


### PR DESCRIPTION
## Changes
- Replace subgraph-based TVL fetching with on-chain log-based approach using `getLogs` from factory contract
- Scope chains to Ethereum and Avalanche (Royco V2 markets)
- Add token mapping for sNUSD→NUSD and autoUSD→USDC decimal adjustments
- Add reserve balances (multisig and earn vault holdings) to TVL on Ethereum
- Remove deprecated graphql-request dependency usage

## Methodology
TVL is calculated by:
1. Reading `MarketDeployed` events from the factory contract
2. Querying `totalAssets()` on each senior/junior tranche
3. Mapping non-standard tokens to their canonical equivalents
4. Summing reserve balances held by multisigs and earn vaults (not deposited into Market Vaults)

All data is sourced directly from on-chain calls (no external APIs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RoyCo v2 TVL adapter enabling total value locked tracking across multiple supported blockchains with automated chain-specific configurations
  * TVL calculations now aggregate both senior and junior tranches along with protocol reserves sourced from multisigs and earn vaults
  * Includes comprehensive and transparent methodology documentation detailing the full TVL calculation process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->