### PR TITLE
Add Canonic (MegaETH on-chain orderbook DEX)

### DIFF
--- a/projects/canonic/index.js
+++ b/projects/canonic/index.js
@@ -16,6 +16,12 @@ const CLP_BTC_USDM  = '0x26F35fcbA3C1387dBaC477d82Bb8a66fA2eDfb4E'
 const CLP_WETH_USDM = '0x11469caf743C2bFBD663C42A2E339A75E053075C'
 const CLP_USDT0_USDM = '0xC397f8ffd517EDA78da4dE59c53516B65846a82A'
 
+/**
+ * Calculates Canonic protocol TVL by summing balanceOf for base and quote
+ * tokens across all MAOB orderbook and CLP vault contracts on MegaETH.
+ * @param {object} api - DefiLlama SDK ChainApi instance.
+ * @returns {Promise<object>} Token balances keyed by address.
+ */
 async function tvl(api) {
   return sumTokens2({
     api,


### PR DESCRIPTION
## Summary

Adds TVL adapter for **Canonic**, an on-chain orderbook DEX (CLOB) on **MegaETH**. TVL = all tokens held in MAOB orderbook contracts + CLP liquidity vault contracts.

---

##### Name (to be shown on DefiLlama):
Canonic

##### Website Link:
https://canonic.trade

##### Current TVL:
Live on MegaETH mainnet — check https://canonic.trade

##### Chain:
MegaETH

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):


##### Short Description (to be shown on DefiLlama):
On-chain orderbook DEX (CLOB) on MegaETH with managed liquidity vaults. Markets anchored around oracle midprices with discrete price rungs.

##### Token address and ticker if any:


##### Category (full list at https://defillama.com/categories) *Please choose only one:
Dexes

##### forkedFrom (Does your project originate from another project):
No

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL is calculated by summing `balanceOf` for the base and quote tokens held in each MAOB orderbook contract and each CLP vault contract. MAOB contracts hold all resting limit order liquidity (including funds deployed by CLP vaults). CLP contracts hold free/undeployed funds not yet placed as orders.

Contracts tracked:
- MAOB BTC.b/USDm: `0xaD7e5CBfB535ceC8d2E58Dca17b11d9bA76f555E`
- MAOB WETH/USDm: `0x23469683e25b780DFDC11410a8e83c923caDF125`
- MAOB USDT0/USDm: `0xDf1576c3C82C9f8B759C69f4cF256061C6Fe1f9e`
- CLP BTC.b/USDm: `0x26F35fcbA3C1387dBaC477d82Bb8a66fA2eDfb4E`
- CLP WETH/USDm: `0x11469caf743C2bFBD663C42A2E339A75E053075C`
- CLP USDT0/USDm: `0xC397f8ffd517EDA78da4dE59c53516B65846a82A`

Tokens: WETH, BTC.b, USDm, USDT0

---

## Protocol Links

- Website: https://canonic.trade
- Twitter: https://x.com/_canonic