### PR TITLE
Update alphasec-bridge: add KAIA native and IDRX token tracking

### DIFF
--- a/projects/alphasec-bridge/index.js
+++ b/projects/alphasec-bridge/index.js
@@ -1,17 +1,24 @@
 const ADDRESSES = require('../helper/coreAssets.json')
 
-
 // https://docs.alphasec.trade/for-developers/contract-addresses
+const BRIDGE = '0xF31CE581A8440f0f4850eDEb343a28372572a088'       // Native KAIA lockup
+const L1_ERC20_GATEWAY = '0x483A9ed25747711F38778a69d4d99b7e5365e506' // ERC20 token lockup
+
 async function tvl(api) {
   return api.sumTokens({
-    owners: ['0x483a9ed25747711f38778a69d4d99b7e5365e506', '0xf31ce581a8440f0f4850edeb343a28372572a088', ],
-    tokens: [ADDRESSES.klaytn.USDT_1, ADDRESSES.klaytn.WETH, ADDRESSES.klaytn.BORA],
+    tokensAndOwners: [
+      [ADDRESSES.null, BRIDGE],                                      // KAIA (native)
+      [ADDRESSES.klaytn.USDT_1, L1_ERC20_GATEWAY],                  // USDT
+      [ADDRESSES.klaytn.WETH, L1_ERC20_GATEWAY],                    // WETH
+      [ADDRESSES.klaytn.BORA, L1_ERC20_GATEWAY],                    // BORA
+      ['0x18bc5bcc660cf2b9ce3cd51a404afe1a0cbd3c22', L1_ERC20_GATEWAY], // IDRX
+    ],
   })
 }
 
-
 module.exports = {
+  methodology: 'TVL is the total value of tokens locked in the AlphaSec bridge gateway contracts on Kaia L1.',
   klaytn: {
     tvl,
-  }
+  },
 }


### PR DESCRIPTION
  Thanks for the initial listing of AlphaSec Bridge — much appreciated.

  This PR updates the TVL adapter to track additional tokens locked in the bridge contracts.

  ### Changes
  - Switched from `owners` + `tokens` to `tokensAndOwners` for precise contract-to-token mapping
    - Native KAIA locked in Bridge contract (`0xF31CE581A8440f0f4850eDEb343a28372572a088`)
    - ERC20 tokens locked in L1 ERC20 Gateway (`0x483A9ed25747711F38778a69d4d99b7e5365e506`)
  - Added KAIA native token tracking
  - Added IDRX token (`0x18bc5bcc660cf2b9ce3cd51a404afe1a0cbd3c22`)
  - Added methodology description

  ### Test Results
  --- klaytn ---
  USD₮                      253.59 k
  WETH                      76.59 k
  KLAY                      37.34 k
  IDRX                      29.14 k
  bora                      8.62 k
  Total: 405.29 k

  Contract references: https://docs.alphasec.trade/for-developers/contract-addresses

  If there's anything that should be changed, please don't hesitate to comment. We're happy to iterate on this.

  Looking forward to your review — thanks again!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded bridge gateway token tracking to include additional assets for improved TVL coverage.

* **Documentation**
  * Added TVL methodology documentation explaining the approach to calculating total value locked in bridge contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->