### PR TITLE
Add Glorb Protocol (Base)

### DIFF
--- a/projects/glorb/index.js
+++ b/projects/glorb/index.js
@@ -7,15 +7,15 @@ const MINES_CONTRACT = '0x8536f84d0300Be2B6733B69Bcd48613a9E04E918';
 const GLORB_TOKEN = '0xa26303226Baa2299adA8D573a6FcD792aB1CFB07';
 
 module.exports = {
-  methodology: 'TVL is ETH locked in Snatch prize pot and jackpot, plus ETH in Mines jackpot and operational pools. Own-token TVL tracks GLORB held in Mines emission and jackpot pools. Revenue: 5% of Snatch buys fund GLORB buyback-and-burn; Mines swaps 85% of ETH payments to GLORB for miner emissions and burns 10% of GLORB upgrade costs.',
+  methodology: 'TVL is ETH locked in Snatch prize pot and jackpot, plus ETH in Mines jackpot and operational pools. Staking tracks GLORB held in Mines emission and jackpot pools.',
   start: 1738368000,
   base: {
     tvl: sumTokensExport({
       owners: [SNATCH_CONTRACT, MINES_CONTRACT],
       tokens: [ADDRESSES.null],
     }),
-    ownTokens: sumTokensExport({
-      owners: [SNATCH_CONTRACT, MINES_CONTRACT],
+    staking: sumTokensExport({
+      owners: [MINES_CONTRACT],
       tokens: [GLORB_TOKEN],
     }),
   },


### PR DESCRIPTION
## Glorb Protocol

**Category:** AI Agents

**Description:**
Glorb is an autonomous AI agent operating on Base with two onchain games generating TVL:

1. **Goblin Snatch** - Prize pot game where players buy in with ETH; last buyer before timer expires wins the pot
2. **Glorb Mines** - Idle mining game where players register with ETH, upgrade stats with GLORB tokens, and earn GLORB emissions

**Contracts (Base - Chain ID 8453):**
- Snatch Game: `0x1Ef75dc4904b71021F308a8D276be346889fEe62`
- Mines Game (UUPS Proxy): `0x8536f84d0300Be2B6733B69Bcd48613a9E04E918`
- GLORB Token (ERC-20): `0xa26303226Baa2299adA8D573a6FcD792aB1CFB07`

**TVL Methodology:**
- ETH locked in Snatch prize pot contract
- ETH locked in Mines contract (jackpot pool + operational funds)
- GLORB tokens held in Mines contract (emission pool + GLORB jackpot pool)

**Token pricing:**
- GLORB has a Uniswap V4 pool on Base with ~$25k liquidity

**Links:**
- Website: https://glorb.wtf
- Snatch Game: https://snatch.glorb.wtf
- Mines Game: https://mines.glorb.wtf
- Twitter: https://x.com/Glorb_wtf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Glorb protocol reporting: overall TVL tracking and Glorb-token holdings across protocol contracts.
  * Included own-token valuation separate from asset TVL (staking).
  * Added adapter metadata (methodology description and start timestamp) to clarify calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->