### PR TITLE
Add WETH to Rho X TVL tracking

### DIFF
--- a/projects/rho-x/index.js
+++ b/projects/rho-x/index.js
@@ -11,6 +11,7 @@ module.exports = {
           ADDRESSES.ethereum.USDT,
           ADDRESSES.ethereum.USDC,
           '0x4274cD7277C7bb0806Bd5FE84b9aDAE466a8DA0a',
+          ADDRESSES.ethereum.WETH,
         ]
       })
     }


### PR DESCRIPTION
Added WETH token to the Rho X exchange adapter to track WETH deposits in TVL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * WETH tokens are now included in TVL (Total Value Locked) calculations, providing more comprehensive coverage of locked assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->