### PR TITLE
Fix Gearbox TVL by unwrapping beefy vault wrappers

### DIFF
--- a/projects/kpk/index.js
+++ b/projects/kpk/index.js
@@ -16,7 +16,7 @@ const GearboxCompressorABI = {
 // ---- Curator config ----
 const configs = {
   methodology:
-    "Counts (1) assets in curated ERC-4626 vaults and (2) collateral held in Gearbox v3.1 credit accounts for the configured market configurator. Morpho v1/v2 vault discovery is deduplicated to avoid double-counting.",
+    "Tracks curated ERC-4626 vault assets and Gearbox v3.1 credit-account collateral, with Morpho v1/v2 TVL deduplicated."
   blockchains: {
     ethereum: {
       // Option 1: discover Morpho vaults owned by these addresses (dynamic, event-based).


### PR DESCRIPTION
This PR updates `projects/kpk/index.js` to resolve wrapped collateral before pricing (recursive unwrap, max depth 2). It adds explicit force-lists for ERC-4626 wrappers (and optional Beefy-style wrappers), while keeping a safe fallback to count tokens as-is when unwrapping is not supported. I've also cleaned up some comments to be more descriptive.

Result: previously undercounted wrapped positions are now included in TVL



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved collateral detection with enhanced support for wrapped token unwrapping
  * Added customizable configuration options for token unwrap behavior
  * Enhanced token resolution with robust fallback handling and multi-layer unwrap support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->