### PR TITLE
ton/octus bridge refactor

### DIFF
--- a/projects/tonbridge.js
+++ b/projects/tonbridge.js
@@ -49,10 +49,14 @@ const config = {
     },
 }
 
+
 module.exports = {
-    hallmarks: [["2022-05-07", "UST depeg"]],
-    ...Object.entries(config).reduce((acc, [chain, { tokens }]) => {
-        acc[chain] = { tvl: sumTokensExport({ owner: "0x54c55369a6900731d22eacb0df7c0253cf19dfff", tokens }) }
-        return acc
-    }, {}),
+  hallmarks: [["2022-05-07", "UST depeg"]],
+  everscale: { tvl: () => ({}), },
 }
+Object.keys(config).forEach(chain => {
+  const { tokens, } = config[chain]
+  module.exports[chain] = {
+    tvl: sumTokensExport({ owner: "0x54c55369a6900731d22eacb0df7c0253cf19dfff", tokens })
+  }
+})


### PR DESCRIPTION
refactored to query bridge contract token balances on evm chains instead of token's total supply on everscale (endpoint is also broken)
- the team doesn't seem to be active ([twitter](https://x.com/OctusBridge), [discord](https://discord.com/invite/qDjdGhd9C6)), but since their [website](https://octusbridge.io/) and [api](https://api.octusbridge.io/v1/staking/main) are still functional so I did not include `deadFrom`
- The TVL reported on their frontend is $53M and their staking api returns 2.7M, but the balance of their evm bridge contracts is around $400k

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Consolidated TVL calculation across Avalanche, BSC, Ethereum, Fantom, and Polygon into a unified, data-driven approach for more consistent per-chain TVL reporting.
  * Added a historical event marker (hallmark) to project metadata.

* **Deprecation**
  * Project marked as deprecated, with support ending 2024-08-29.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->