### PR TITLE
update prism-dex megaeth factory address

### DIFF
--- a/projects/prism-dex/index.js
+++ b/projects/prism-dex/index.js
@@ -1,12 +1,12 @@
 const { uniV3Export } = require("../helper/uniswapV3");
 
 module.exports = {
-  methodology: "Counts TVL from all Uniswap V3 pools deployed via the factory contract at 0xef349aa6cc5e87559e716ac293845a48cadf30d5",
-  start: 3520571,
+  methodology: "Counts TVL from all Uniswap V3 pools deployed via the factory contract at 0x1adb8f973373505bb206e0e5d87af8fb1f5514ef",
+  start: 7845865,
   ...uniV3Export({
     megaeth: {
-      factory: "0xef349aa6cc5e87559e716ac293845a48cadf30d5",
-      fromBlock: 3520571,
+      factory: "0x1adb8f973373505bb206e0e5d87af8fb1f5514ef",
+      fromBlock: 7845865,
     },
   })
 };


### PR DESCRIPTION
## Summary
- Updates the Prism DEX adapter on MegaETH to use the new Uniswap V3 factory address.
- Replaces old factory `0xef349aa6cc5e87559e716ac293845a48cadf30d5` with new factory `0x1adb8f973373505bb206e0e5d87af8fb1f5514ef`.
- Keeps adapter scope simple by using only the new factory (old factory deprecated).

## Why
Prism DEX migrated to a new factory contract on MegaETH mainnet launch. The adapter must follow the new factory so TVL is sourced from the active deployment.

## Validation
- Ran locally:
  - `node test.js projects/prism-dex/index.js`
- Adapter returned valid TVL output on MegaETH.

## Notes
- Historical continuity from the old factory is intentionally not included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Uniswap V3 TVL tracking configuration with revised factory contract references and adjusted data collection starting block to ensure accurate liquidity metrics tracking across all pools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->