### PR TITLE
mark nucleus as deprecated

### DIFF
--- a/projects/nucleus/index.js
+++ b/projects/nucleus/index.js
@@ -59,7 +59,6 @@ module.exports = {
   hallmarks: [
     ["2025-12-19", "Nucleus protocol deprecated"]
   ],
-  deadFrom: "2025-12-19",
   ethereum: { tvl: (api) => tvl(api, 1) },
   plume_mainnet: { tvl: (api) => tvl(api, 98866) },
   arbitrum: { tvl: (api) => tvl(api, 42161) },


### PR DESCRIPTION
https://docs.nucleusearn.io/nucleus-architecture/deprecation-guide

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Nucleus protocol formally marked as deprecated, effective December 19, 2025.
  * This adds a public deprecation hallmark; there are no changes to functionality or runtime behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->