### PR TITLE
Track ezETH bridged TVL on Monad

### DIFF
--- a/projects/renzo/index.js
+++ b/projects/renzo/index.js
@@ -35,7 +35,19 @@ async function solanaTvl() {
   )
 }
 
-const chains = ["mode", "blast", "bsc", "linea", "arbitrum", "base", "optimism", "fraxtal","zircuit","sei" ]
+const chains = [
+  "arbitrum",
+  "base",
+  "bsc",
+  "blast",
+  "fraxtal",
+  "linea",
+  "monad",
+  "mode",
+  "optimism",
+  "sei",
+  "zircuit"
+]
 
 module.exports = {
   doublecounted: true,


### PR DESCRIPTION
Includes Monad in the list of chains that hold [ezETH as bridged TVL](https://monad.socialscan.io/address/0x2416092f143378750bb29b79ed961ab195cceea5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Monad blockchain for TVL tracking and aggregation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->