### PR TITLE
Update Spark Liquidity Layer allocations

### DIFF
--- a/projects/spark-liquidity-layer/index.js
+++ b/projects/spark-liquidity-layer/index.js
@@ -29,6 +29,7 @@ const mainnetAllocatorToTokens = {
     '0x43415eB6ff9DB7E26A15b704e7A3eDCe97d31C4e', // USTB
     '0x8c213ee79581Ff4984583C6a801e5263418C4b86', // JTSRY
     '0x80ac24aA929eaF5013f6436cdA2a7ba190f5Cc0b', // syrupUSDC
+    '0x356B8d89c1e1239Cbbb9dE4815c39A1474d5BA7D', // syrupUSDT
     '0x779224df1c756b4EDD899854F32a53E8c2B2ce5d', // spPYUSD
     '0xe7dF13b8e3d6740fe17CBE928C7334243d86c92f', // spUSDT
     '0x377C3bd93f2a2984E1E7bE6A5C22c525eD4A4815', // spUSDC
@@ -103,6 +104,7 @@ async function tvl(api) {
   await addMorphoBalances(api)
   await addEthenaUnstakeBalance(api)
   await addCurveBalances(api)
+  await addVaultBalances(api)
 
   const allTokens = Object.values(tokenRecords).flat()
   api.add(allTokens, balances)
@@ -321,4 +323,25 @@ async function addCurveBalances(api) {
   )
 
   api.add(tokens, balances)
+}
+
+const erc4626Configs = {
+  ethereum: [
+    '0x38464507E02c983F20428a6E8566693fE9e422a9', // Arkis sparkPrimeUSDC1
+  ],
+  base: [],
+  arbitrum: [],
+  optimism: [],
+  unichain: [],
+  avax: [],
+}
+
+async function addVaultBalances(api) {
+  const vaults = erc4626Configs[api.chain]
+  if (vaults.length === 0) {
+    return
+  }
+
+  const balances = await api.erc4626Sum2({ calls: vaults })
+  api.addBalances(balances)
 }


### PR DESCRIPTION
Adds syrupUSDT and Arkis allocation to SLL's TVL, matches: https://data.spark.fi/spark-liquidity-layer
There is still 150M not counted from Anchorage which doesn't expose data on-chain