### PR TITLE
Kasu: add XDC chain and improve historic TVL accuracy

### DIFF
--- a/projects/kasu/index.js
+++ b/projects/kasu/index.js
@@ -1,11 +1,22 @@
 const { cachedGraphQuery } = require('../helper/cache')
 const ADDRESSES = require('../helper/coreAssets.json')
 
-const GRAPH_URLS = {
-  base: 'https://api.goldsky.com/api/public/project_cmgzlpxm300765np2a19421om/subgraphs/kasu-base/v1.0.13/gn',
-  plume_mainnet: 'https://api.goldsky.com/api/public/project_cm9t3064xeuyn01tgctdo3c17/subgraphs/kasu-plume/prod/gn',
-  xdc: 'https://api.goldsky.com/api/public/project_cmgzlpxm300765np2a19421om/subgraphs/kasu-xdc/v1.0.0/gn',
-};
+const CONFIG = {
+  base: {
+    graphURL: 'https://api.goldsky.com/api/public/project_cmgzlpxm300765np2a19421om/subgraphs/kasu-base/v1.0.13/gn',
+    externalContract: '0x662379FEBb3e4F91400B5f7d4f7F7ce4699F3c9F',
+    asset: ADDRESSES.base.USDC
+  },
+  xdc: {
+    graphURL: 'https://api.goldsky.com/api/public/project_cmgzlpxm300765np2a19421om/subgraphs/kasu-xdc/v1.0.0/gn',
+    externalContract: '0xCCB4156964377CF36441f3775A2A800dbeCB8094',
+    asset: ADDRESSES.xdc['USDC.e']
+  },
+  plume_mainnet: {
+    graphURL: 'https://api.goldsky.com/api/public/project_cm9t3064xeuyn01tgctdo3c17/subgraphs/kasu-plume/prod/gn',
+    asset: ADDRESSES.plume_mainnet.pUSD
+  }
+}
 
 const POOL_QUERY = `{
   lendingPools(first: 1000, where: { isStopped: false }) {
@@ -13,69 +24,23 @@ const POOL_QUERY = `{
   }
 }`;
 
-const EXTERNAL_TVL_CONTRACTS = {
-  base: '0x662379FEBb3e4F91400B5f7d4f7F7ce4699F3c9F',
-  xdc: '0xCCB4156964377CF36441f3775A2A800dbeCB8094',
-};
+const tvl = async (api) => {
+  // Get pool addresses from subgraph (current state, for discovery only)
+  const chain = api.chain
+  const { graphURL, externalContract, asset } = CONFIG[chain]
+  const result = await cachedGraphQuery('kasu/' + chain, graphURL, POOL_QUERY);
+  const pools = result.lendingPools || [];
+  const poolAddresses = pools.map(pool => pool.id);
+  const supplies = await api.multiCall({ abi: 'function totalSupply() view returns (uint256)', calls: poolAddresses, permitFailure: true });
+  const poolTvl = supplies.reduce((sum, s) => sum + Number(s || 0), 0);
+  api.addTokens(asset, poolTvl)
 
-const CHAIN_ASSET = {
-  base: {
-    asset: ADDRESSES.base.USDC,
-    decimals: 6,
-  },
-  plume_mainnet: {
-    asset: ADDRESSES.plume_mainnet.pUSD,
-    decimals: 6,
-  },
-  xdc: {
-    asset: ADDRESSES.xdc['USDC.e'],
-    decimals: 6,
-  },
-};
-
-function tvl(chain) {
-  return async (api) => {
-    // Get pool addresses from subgraph (current state, for discovery only)
-    const result = await cachedGraphQuery('kasu/' + chain, GRAPH_URLS[chain], POOL_QUERY);
-    const pools = result.lendingPools || [];
-    const poolAddresses = pools.map(pool => pool.id);
-
-    // Read on-chain totalSupply for each pool (LendingPool is ERC20, totalSupply = pool value in USDC)
-    // This automatically uses the correct historic block when DefiLlama backfills
-    const supplies = await api.multiCall({
-      abi: 'function totalSupply() view returns (uint256)',
-      calls: poolAddresses,
-      permitFailure: true,
-    });
-    const poolTvl = supplies.reduce((sum, s) => sum + Number(s || 0), 0);
-
-    let externalTvl = 0;
-    if (EXTERNAL_TVL_CONTRACTS[chain]) {
-      const externalTvlResults = await api.multiCall({
-        abi: 'function externalTVLOfPool(address) view returns (uint256)',
-        calls: poolAddresses.map(addr => ({
-          target: EXTERNAL_TVL_CONTRACTS[chain],
-          params: [addr],
-        })),
-        permitFailure: true,
-      });
-      externalTvl = externalTvlResults.reduce((a, b) => a + Number(b || 0), 0);
-    }
-
-    api.addTokens([CHAIN_ASSET[chain].asset], [poolTvl + externalTvl]);
-    return api.getBalances();
-  };
+  if (externalContract) {
+    const calls = poolAddresses.map(addr => ({ target: externalContract, params: [addr] }))
+    const externalTvl = await api.multiCall({ abi: 'function externalTVLOfPool(address) view returns (uint256)', calls, permitFailure: true })
+    api.add(asset, externalTvl)
+  }
 }
 
-module.exports = {
-  methodology: 'Count all assets deposited to Kasu Lending Pools plus externally managed TVL',
-  base: {
-    tvl: tvl('base'),
-  },
-  plume_mainnet: {
-    tvl: tvl('plume_mainnet'),
-  },
-  xdc: {
-    tvl: tvl('xdc'),
-  },
-};
+module.exports.methodology = 'Count all assets deposited to Kasu Lending Pools plus externally managed TVL'
+Object.keys(CONFIG).forEach(chain => module.exports[chain] = { tvl })


### PR DESCRIPTION
## Changes

- **Add XDC chain** with Goldsky subgraph for pool discovery and ExternalTVL tracking
- **Switch to on-chain totalSupply() reads** for pool balances (instead of subgraph balance field), enabling accurate historic data when DefiLlama backfills
- **Add ExternalTVL** for XDC (same pattern as Base)
- **Update Base subgraph** to v1.0.13

## Why on-chain reads?

The subgraph is now used only for pool address discovery. Actual balances are read via multiCall totalSupply() on each LendingPool contract (ERC20, 6 decimals matching USDC). This automatically returns the correct historic value at any block, enabling DefiLlama to backfill TVL history.

## Test Results

Current:
- Base: $6.32M
- Plume: $0 (pools currently empty)
- XDC: $5 (new deployment)

Historic (Jan 15, 2025):
- Base: $3.18M (correct growth trajectory)

## Contracts

| Chain | ExternalTVL | USDC |
|-------|-----------|------|
| Base | 0x662379FEBb3e4F91400B5f7d4f7F7ce4699F3c9F | Native USDC |
| XDC | 0xCCB4156964377CF36441f3775A2A800dbeCB8094 | 0xfa2958cb79b0491cc627c1557f441ef849ca8eb1 |
| Plume | N/A | pUSD |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the XDC blockchain with USDC asset tracking.
  * Introduced generic pool discovery and unified per-chain configuration enabling dynamic chain support and per-chain TVL exposure.
  * TVL aggregation now includes externally managed balances per pool for more complete totals.

* **Documentation**
  * Updated TVL methodology to count deposits plus externally managed TVL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->