### PR TITLE
Zenrock: add yield BTC key address to TVL calculation

### DIFF
--- a/projects/helper/bitcoin-book/fetchers.js
+++ b/projects/helper/bitcoin-book/fetchers.js
@@ -302,8 +302,7 @@ module.exports = {
           return btcAddresses;
         }
 
-        async function getChangeAddresses() {
-          const paramsData = await get(ZENBTC_PARAMS_API);
+        async function getChangeAddresses(paramsData) {
           if (!paramsData?.params?.changeAddressKeyIDs) {
             return [];
           }
@@ -321,8 +320,7 @@ module.exports = {
           return changeAddresses;
         }
 
-        async function getRewardsDepositAddress() {
-          const paramsData = await get(ZENBTC_PARAMS_API);
+        async function getRewardsDepositAddress(paramsData) {
           const keyID = paramsData?.params?.rewardsDepositKeyID;
           if (!keyID) return [];
           const keyData = await get(`${ZRCHAIN_KEY_BY_ID_API}/${keyID}/WALLET_TYPE_BTC_MAINNET/`);
@@ -334,10 +332,11 @@ module.exports = {
           return [];
         }
 
+        const paramsData = await get(ZENBTC_PARAMS_API);
         const [btcAddresses, changeAddresses, rewardsAddresses] = await Promise.all([
           getBitcoinAddresses(),
-          getChangeAddresses(),
-          getRewardsDepositAddress(),
+          getChangeAddresses(paramsData),
+          getRewardsDepositAddress(paramsData),
         ]);
         const allAddresses = [...btcAddresses, ...changeAddresses, ...rewardsAddresses];
         return allAddresses;


### PR DESCRIPTION
## Summary

Adds the zenBTC rewards deposit key (yield BTC key) address to the bitcoin address list used for TVL calculation. This address holds BTC accumulated from mint and redeem fees and was previously missing from the address enumeration.

### Implementation

The rewards deposit key ID is fetched dynamically from the zenBTC params API (`rewardsDepositKeyID`), then the corresponding BTC mainnet address is resolved via the `key_by_id` API. This follows the same pattern already used for change addresses.

### Test Results

```
--- bitcoin ---
BTC                       3.00 M

--- zcash ---
ZEC                       383.17 k

--- tvl ---
total                     3.38 M
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rewards deposit addresses are now retrieved and included in address collections.

* **Performance**
  * Address retrieval consolidated to reduce duplicate lookups and improve collection efficiency.

* **Other**
  * Final address aggregation updated to include the new rewards deposit addresses alongside other address types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->