### PR TITLE
Add Soul Reaper adapter (Solana)

### DIFF
--- a/projects/soul-reaper/index.js
+++ b/projects/soul-reaper/index.js
@@ -21,7 +21,7 @@ module.exports = {
     "The LP Fund holds SOL earmarked for SOUL/SOL liquidity pool seeding.",
   solana: {
     tvl: sumTokensExport({
-      solOwners: [TREASURY_PDA, LP_FUND_PDA],
+      solOwners: [TREASURY_PDA,],
     }),
   },
 };


### PR DESCRIPTION
### Protocol: Soul Reaper
### Website: https://voidreaper.com
### Chain: Solana
### Category: Gaming / Gamified Mining
### Twitter: https://x.com/VoidReaperSOL

## What does the adapter do?

Tracks TVL for **Soul Reaper**, a provably fair gamified mining game on Solana.

**Program ID:** `HKPj22otN2crrNS7buiJFFKsE6r98GHFmuBjMywxhZ7A`

TVL = SOL held in two program-derived accounts (PDAs):

| PDA | Address | Purpose |
|-----|---------|---------|
| Treasury | `C3DdpRWF3Vkz1T3boxf37jjoDJqW4MdiwydauppGiV3C` | Player deposits, jackpot reserves, house bankroll |
| LP Fund | `3kXCCXr7WaEgh2iM7TMS1CTrvPE1T7rgTqnJZnDrya5N` | SOL earmarked for SOUL/SOL LP seeding |

Uses `sumTokensExport` with `solOwners` to track native SOL balances.

### Test output

```
--- solana ---
SOL                       711.51
Total: 711.51

--- tvl ---
SOL                       712
Total: 711.51
```

### Methodology
TVL is the total SOL held in the Soul Reaper Treasury and LP Fund PDAs. The Treasury holds player deposits, jackpot reserves, and house bankroll. The LP Fund holds SOL earmarked for SOUL/SOL liquidity pool seeding.

- `timetravel: false` — PDA list is static but on-chain state changes
- No extra npm packages required

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL monitoring for Soul Reaper to track SOL held in protocol accounts for real-time liquidity visibility.
  * Initial release focuses on the Treasury holdings; LP Fund support is defined and planned but not yet included in active calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->