### PR TITLE
linx: include WBTC in TVL output

### DIFF
--- a/projects/linx/index.js
+++ b/projects/linx/index.js
@@ -7,6 +7,9 @@ const config = {
 }
 
 const ALPH_TOKEN_ID = '0000000000000000000000000000000000000000000000000000000000000000';
+const WBTC_TOKEN_ID = '383bc735a4de6722af80546ec9eeb3cff508f2f68e97da19489ce69f3e703200';
+const WBTC_COINGECKO_ID = 'wrapped-bitcoin';
+const WBTC_DECIMALS = 8;
 
 const MARKET_CREATED_EVENT_INDEX = 4;
 const MARKET_METHOD_INDEX = 4;
@@ -56,7 +59,11 @@ async function tvl(api) {
     for (const market of markets) {
         const collateral = await getTokenBalance(market.contractId, market.collateralTokenId);
         const loanBalance = await getTokenBalance(market.contractId, market.loanTokenId);
-        api.add(market.collateralTokenId, collateral);
+        if (market.collateralTokenId === WBTC_TOKEN_ID) {
+            api.addCGToken(WBTC_COINGECKO_ID, Number(collateral) / 10 ** WBTC_DECIMALS);
+        } else {
+            api.add(market.collateralTokenId, collateral);
+        }
         api.add(market.loanTokenId, loanBalance);
     }
 }


### PR DESCRIPTION
Fixes #18029

### Summary
- add fallback for Linx WBTC collateral token id using api.addCGToken('wrapped-bitcoin', ...)
- keep existing path for all other collateral and loan tokens

### Why
- raw balances include the Alephium WBTC token id
- current price response for that token id is null
- WBTC was skipped in TVL output

### Test
node test.js projects/linx/index.js

```
--- alephium-borrowed ---
USDTeth                   60.76 k
Total: 60.76 k 

--- alephium ---
ALPH                      306.35 k
WBTC                      5.76 k
USDTeth                   3.47 k
Total: 315.58 k 

--- borrowed ---
USDTeth                   60.76 k
Total: 60.76 k 

--- tvl ---
ALPH                      306.35 k
WBTC                      5.76 k
USDTeth                   3.47 k
Total: 315.58 k 
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added WBTC (Wrapped Bitcoin) support for use as collateral in TVL calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->