### PR TITLE
Add Solid Fuse vault to TVL adapter

### DIFF
--- a/projects/solid-yield/fuse_constants.js
+++ b/projects/solid-yield/fuse_constants.js
@@ -9,6 +9,15 @@ const boringVaultsV0Fuse = [
     lens: "0x8478Cc70B7e389212D301Fef4f9aDfd4F869f28D",
     startBlock: 36144442, 
     baseAsset: ADDRESSES.fuse.USDC_3, 
+  },
+  {
+    name: "Solid Fuse",
+    vault: "0xb33c8F0b0816fd147FCF896C594a3ef408845e2C",
+    accountant: "0xb29B5F760d38587f7F4C896C458B9EEB5CAd9C0C",
+    teller: "0x4Aa13c96d45FDF14731acEF8F6a2DBf17D6BD53c",
+    lens: "0x8478Cc70B7e389212D301Fef4f9aDfd4F869f28D",
+    startBlock: 40381360, 
+    baseAsset: ADDRESSES.fuse.WFUSE, 
   }
 ];
 


### PR DESCRIPTION
## Summary
- Adds the new Solid Fuse boring vault to the existing `solid-yield` TVL adapter on the Fuse chain
- Vault: `0xb33c8F0b0816fd147FCF896C594a3ef408845e2C`
- Accountant: `0xb29B5F760d38587f7F4C896C458B9EEB5CAd9C0C`
- Teller: `0x4Aa13c96d45FDF14731acEF8F6a2DBf17D6BD53c`
- Base asset: WFUSE
- Start block: 40381360

## Changes
- `projects/solid-yield/fuse_constants.js`: Added the new "Solid Fuse" vault entry to the `boringVaultsV0Fuse` array

## Test
```bash
node test.js projects/solid-yield
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new Solid Fuse vault, expanding vault options available on the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->