### PR TITLE
Extend Sumtokens2 helper for historical support for solana

### DIFF
--- a/projects/helper/solana.js
+++ b/projects/helper/solana.js
@@ -266,7 +266,6 @@ async function sumTokens2({
 
   // Route to Allium-based historical path when api.timestamp is before today (UTC)
   if (api && api.timestamp && (chain === 'solana' || !chain) && api.timestamp < getUniqStartOfTodayTimestamp()) {
-    sdk.log('sumTokens2: using historical Allium path for date', date);
     return sumTokens2_historical({
       api, balances, tokensAndOwners, tokens, owners, owner,
       tokenAccounts, solOwners, blacklistedTokens, allowError,
@@ -469,6 +468,7 @@ async function sumTokens2_historical({
 }) {
   const date = new Date(api.timestamp * 1000).toISOString().slice(0, 10);
   if (!date) throw new Error('sumTokens2_historical requires a date (YYYY-MM-DD)');
+  sdk.log('sumTokens2: using historical Allium path for date', date);
   if (includeStakedSol) throw new Error('includeStakedSol is not supported for historical backfilling (RPC-only)');
 
   if (api) chain = api.chain;
@@ -589,7 +589,7 @@ async function sumTokens2_historical({
 
       // Helper to check if mint is native SOL (canonical: So11111..., Allium variant: Sol11111...)
       const isNativeSOL = (mint) => {
-        return mint === ADDRESSES.solana.SOL || mint === 'Sol11111111111111111111111111111111111111112';
+        return mint === ADDRESSES.solana.SOL || mint === 'So11111111111111111111111111111111111111112';
       };
 
       const tokenBalances = {};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retrieve historical token balances for dates before today via an Allium-based historical data path.
  * Automatic routing to the appropriate data path based on requested timestamp (historical vs current).
  * Improved balance retrieval with trusted-token filtering, cross-source token/account matching, and SOL vs SPL handling.
  * SQL-safe querying added and RPC-based flow preserved as a fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->