### PR TITLE
move rage tvl out of treasury directory

### DIFF
--- a/projects/rage/index.js
+++ b/projects/rage/index.js
@@ -1,15 +1,13 @@
-const { treasuryExports } = require("../helper/treasury");
+const { sumTokensExport } = require("../helper/unwrapLPs");
 
 const TREASURY = "0xff70Cd1E1931372F869c936582a7F42e49B6DA4c";
-
 const HESTIA = "0xbc7755a153e852cf76cccddb4c2e7c368f6259d8";
 const CIRCLE = "0x5babfc2f240bc5de90eb7e19d789412db1dec402";
 const PHESTIA = "0xF760fD8fEB1F5E3bf3651E2E4f227285a82470Ff";
 const PCIRCLE = "0x55A81dA2a319dD60fB028c53Cb4419493B56f6c0";
 
-module.exports = treasuryExports({
-  base: {
-    owners: [TREASURY],
-    tokens: [HESTIA, CIRCLE, PHESTIA, PCIRCLE],
-  },
-});
+module.exports = {
+    base: {
+        tvl: sumTokensExport({ owner: TREASURY, tokens: [HESTIA, CIRCLE, PHESTIA, PCIRCLE], }),
+    },
+};


### PR DESCRIPTION
Moves [Rage protocol](https://ultraroundmoney.com/rage) back into main projects/ directory

Notes: 
- users can deposit and withdraw tokens from the treasury ([whitepaper](https://ultraroundmoney.com/rage/whitepaper.pdf))
- the protocol's [multi-sig](https://basescan.org/address/0x507fbde39ba40da4fc79426ad5e3c64944fe43d4#asset-multichain) holds RAGE, but their balance is excluded from backing calculations
- [HESTIA](https://ultraroundmoney.com/hestia) and [CIRCLE](https://ultraroundmoney.com/circle) back RAGE so adding tvl adapters for these tokens will double count with this one (same parent protocol).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the method for calculating Total Value Locked (TVL) to use a more direct calculation approach, improving the efficiency of TVL computation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->