### PR TITLE
Add Stone Vault TVL adapter (Ethereum)

### DIFF
--- a/projects/stone-vault/index.js
+++ b/projects/stone-vault/index.js
@@ -14,6 +14,7 @@ async function tvl(api) {
 }
 
 module.exports = {
+  doublecounted: true,
   methodology:
     'TVL is calculated as the sum of yield-bearing tokens (sparkDAI, aaveLUSD, scrvUSD) held by the StoneVaultCore contract.',
   start: 1739577600, // 2025-02-15 as baseline deployment era


### PR DESCRIPTION
## Summary

- Add Stone Vault TVL adapter for Ethereum mainnet.
- TVL is computed on-chain by summing yield-bearing balances held in `StoneVaultCore`.

## Project Metadata

- **Project**: Stone Vault
- **Website**: https://stva.io
- **Category**: Yield Aggregator
- **Chains**: Ethereum
- **Slug**: stone-vault
- **GitHub**: https://github.com/StoneVault/stonevault
- **Twitter**: (none yet)
- **Description**: Stone Vault is an immutable, audited ERC-20 vault protocol on Ethereum. It allocates deposited stablecoin liquidity across Spark (MakerDAO), Aave V3, and Curve Finance strategies to optimize yield. SVT token represents shares of the underlying vault. No admin keys, no upgrades, no owner privileges.
- **Audits**: Yes (1)
- **Audit Links**: Nethermind audit (included in GitHub repository)

## Contracts

| Contract | Address |
|---|---|
| StoneVaultCore (SVT) | `0xc5c6cB88598203f3652E531dbb1128Ff52F38621` |
| StoneZapIn | `0xc66df20483e5b89Ae6999B9215DAe2C289652B1B` |
| StoneZapInManual | `0x0F03BFf6401b1620a2Fd7d4B44049B0E02b99B81` |
| StoneZapOut | `0x15fD5f08E06bb6e1D2eA5fc7670F72dFA8f1ebf6` |

## Methodology

- TVL uses `sumTokens2` over yield-bearing tokens held by StoneVaultCore:
  - sparkDAI (`0x4DEDf26112B3Ec8eC46e7E31EA5e123490B05B8B`)
  - aaveLUSD (`0x3Fe6a295459FAe07DF8A0ceCC36F37160FE86AA9`)
  - scrvUSD (`0x0655977FEb2f289A4aB78af67BAB0d17aAb84367`)
- `doublecounted: true` — assets overlap with Spark, Aave, and Curve TVL.

## Test Plan

- [x] `npm install`
- [x] CI test passed (llamabutler confirmed TVL ~$19)
- [x] `doublecounted: true` added per CodeRabbit review
- [x] Validate no unrelated files changed