### PR TITLE
Snuggle: Add V2 vault with multi-DEX support

### DIFF
--- a/projects/snuggle/index.js
+++ b/projects/snuggle/index.js
@@ -12,7 +12,9 @@ const vaultPositionAbi = 'function positions(uint256) view returns (uint256 toke
 // ABI for vault's PoolConfig struct (8 fields)
 const poolConfigAbi = 'function approvedPools(bytes32) view returns (address pool, address token0, address token1, uint24 fee, int24 tickSpacing, bool active, address positionAdapter, address rewardAdapter)'
 
-// Works for Uni V3, Aerodrome CL, and PancakeSwap V3 — tickLower/tickUpper/liquidity at same indices
+// Indices 5/6/7 (tickLower/tickUpper/liquidity) are identical across all three DEXes.
+// Index 4 differs: Uni V3/PancakeSwap have fee (uint24), Aerodrome has tickSpacing (int24).
+// We only destructure { tickLower, tickUpper, liquidity } so the ABI is cross-DEX compatible.
 const nftPositionAbi = 'function positions(uint256) view returns (uint96, address, address, address, uint24, int24 tickLower, int24 tickUpper, uint128 liquidity, uint256, uint256, uint128, uint128)'
 
 // Minimal slot0 ABI — first two returns (sqrtPriceX96, tick) are identical across all V3 DEXes


### PR DESCRIPTION
## Summary
- Add Snuggle V2 vault (`0xd3923beccb6e1ddb048ed00a0a9bd602d16b7470`) which manages concentrated liquidity positions across **Uniswap V3, Aerodrome, and PancakeSwap** on Base
- Enumerates all positions from the vault's `allPositionIds` array and dynamically reads NFT position managers from each adapter — no hardcoded DEX addresses
- Correctly handles positions staked in Aerodrome gauges and PancakeSwap MasterChef (vault tracks all position IDs regardless of NFT ownership)
- V1 vault (`0x43Ca8D329d91ADF0aa471aC7587Aac1B2743F043`) kept for backwards compatibility

## Test
```
node test.js projects/snuggle/index.js

--- base ---
WETH                      231
USDC                      135
cbBTC                     86
Total: 451.93

------ TVL ------
base                      452
total                    451.93
```

## Methodology
TVL = sum of all concentrated liquidity positions managed by the Snuggle vault across Uniswap V3, Aerodrome, and PancakeSwap on Base. Uses `addUniV3LikePosition` with standard V3 liquidity math. `doublecounted: true` since positions are also counted in the underlying DEX TVL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for both legacy and new multi-DEX vaults on Base, covering Uniswap V3, Aerodrome, and PancakeSwap.
  * Enhanced TVL reporting by aggregating per-position data across vaults and adapters for more accurate balances and liquidity handling.

* **Refactor**
  * Reworked data‑gathering and export flow to enable dual‑vault and adapter‑based position discovery while preserving existing public interfaces.

* **Documentation**
  * Updated TVL methodology and start‑time commentary to reflect multi‑DEX coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->