### PR TITLE
Add minebtc

### DIFF
--- a/projects/minebtc/index.js
+++ b/projects/minebtc/index.js
@@ -14,12 +14,9 @@ const LP_SUPPLY_OFFSET = 333; // u64 LE offset for lp_supply in Raydium CP-Swap 
 // --- Token Vaults ---
 const STAKED_DOGEBTC_CUSTODIAN = "523EuRZDDyvCaVJGsqgcAuifcLiVvgAYynmjVWd1RXDR";
 const STAKED_LP_CUSTODIAN = "Eyzfok5go6ddaKHEddVza5QTKzo4tcYF282cM1nU8GqV";
-const FACTION_TREASURY_VAULT = "GUrrK4c1RmTDqYbEbWSjq6mfUcujpgTtasU4JXVzEKMA";
-const NFT_FLOOR_SWEEP_VAULT = "DRvR4WpLj85Lfvwk3im7Ucrz1s9FPLPUtrTihUiqaPve";
 
 // --- SOL Vaults ---
 const SOL_PRIZE_POT = "GqMyratKThjEKzqZQStUy2LNB3dogZ3ETDBMQ33fmUw5";
-const STAKER_SOL_REWARD_VAULT = "HiGNRiXWrqtFbwEH1YKQVHommFU15auksXbe7Qv7Nrrb";
 
 async function getStakedLpUnderlyingValue(api) {
   const connection = getConnection();
@@ -54,20 +51,11 @@ async function getStakedLpUnderlyingValue(api) {
 }
 
 async function tvl(api) {
-  // SOL in protocol vaults + faction/sweep DogeBTC vaults
+  // SOL in betting prize pot (funded by user bets, paid out to winners)
   await sumTokens2({
     api,
-    tokenAccounts: [
-      FACTION_TREASURY_VAULT,
-      NFT_FLOOR_SWEEP_VAULT,
-    ],
-    solOwners: [
-      SOL_PRIZE_POT,
-      STAKER_SOL_REWARD_VAULT,
-    ],
+    solOwners: [SOL_PRIZE_POT],
   });
-
-  return api.getBalances();
 }
 
 async function staking(api) {
@@ -76,21 +64,17 @@ async function staking(api) {
     api,
     tokenAccounts: [STAKED_DOGEBTC_CUSTODIAN],
   });
-
-  return api.getBalances();
 }
 
 async function pool2(api) {
   // Staked LP (DogeBTC/SOL) -> pro-rata underlying value
   await getStakedLpUnderlyingValue(api);
-
-  return api.getBalances();
 }
 
 module.exports = {
   timetravel: false,
   methodology:
-    "TVL includes SOL in betting prize pot and staker reward vault, DogeBTC in faction treasury and NFT floor sweep vaults. Staking tracks staked DogeBTC. Pool2 tracks staked DogeBTC/SOL LP tokens valued by their pro-rata share of underlying assets in the Raydium pool.",
+    "TVL includes SOL in the betting prize pot. Staking tracks user-staked DogeBTC. Pool2 tracks staked DogeBTC/SOL LP tokens valued by their pro-rata share of underlying assets in the Raydium pool.",
   solana: {
     tvl,
     staking,

--- a/projects/treasury/minebtc.js
+++ b/projects/treasury/minebtc.js
@@ -1,0 +1,27 @@
+const { sumTokens2 } = require("../helper/solana");
+
+const DOGEBTC_MINT = "BwMCF5LSHPvrR8pLVvcsa4k1AMg4VWVnMWUiNEXMtLkE";
+
+// Protocol-owned DogeBTC vaults (funded by 1% transfer tax)
+const FACTION_TREASURY_VAULT = "GUrrK4c1RmTDqYbEbWSjq6mfUcujpgTtasU4JXVzEKMA";
+const NFT_FLOOR_SWEEP_VAULT = "DRvR4WpLj85Lfvwk3im7Ucrz1s9FPLPUtrTihUiqaPve";
+
+// Protocol-owned SOL vault (staker reward fees from bets)
+const STAKER_SOL_REWARD_VAULT = "HiGNRiXWrqtFbwEH1YKQVHommFU15auksXbe7Qv7Nrrb";
+
+module.exports = {
+  solana: {
+    tvl: async (api) => {
+      await sumTokens2({
+        api,
+        solOwners: [STAKER_SOL_REWARD_VAULT],
+      });
+    },
+    ownTokens: async (api) => {
+      await sumTokens2({
+        api,
+        tokenAccounts: [FACTION_TREASURY_VAULT, NFT_FLOOR_SWEEP_VAULT],
+      });
+    },
+  },
+};


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/adapters).
> - If you would like to add a `liquidations` adapter, please refer to [this readme document](https://github.com/DefiLlama/DefiLlama-Adapters/tree/main/liquidations) for details.

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
3. Please fill the form below **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
4. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can edit it there and put up a PR
5. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
6. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap

---

##### Name (to be shown on DefiLlama):
MineBTC

##### Twitter Link:
https://x.com/minebtcdotfun
  
##### List of audit links if any:

##### Website Link:
https://minebtc.fun


##### Logo (High resolution, will be shown with rounded borders):
https://assets.minebtc.fun/btc-logo.png


##### Current TVL:
$12 (just launched, protocol vaults seeded with minimal SOL)


##### Treasury Addresses (if the protocol has treasury)
  - SOL Treasury: 6rBKBaVK2m8rGjHXa65ohjWjD3B3VGDSKUpJrxraPmX1
  - Doges Treasury: 3burVzSiwhZgix68DyWqa8rhd5USUhBq9sAHZDBtxRSq
  - Buybacks SOL Vault: DbDXDZtp88iQAFy9y1iJCyZ6toxGG29AEH6BcVembr6n
  
  
##### Chain:
Solana


##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama):
A speculative entertainment and betting experiment building a fully AI-driven reserve currency on Solana. Players compete in 60-second faction warfare rounds to mine $dogeBTC — a deflationary Token-2022 with self-adjusting emissions that respond to market conditions. Features evolvable AI-generated Doge NFTs that power lore, gaming, and an AI content engine.
    
##### Token address and ticker if any:
BwMCF5LSHPvrR8pLVvcsa4k1AMg4VWVnMWUiNEXMtLkE — $dogeBTC (Token-2022 with 1% transfer tax)

##### Category (full list at https://defillama.com/categories) \*Please choose only one:
Gamified Mining 

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
https://gameplay.minebtc.fun/introduction


##### forkedFrom (Does your project originate from another project):
No

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL includes SOL in betting prize pot and staker reward vault, staked DogeBTC in custodian vault, DogeBTC in faction treasury and NFT floor sweep vaults. Staked LP tokens are valued by their pro-rata share of underlying SOL and DogeBTC in the Raydium pool (using total LP supply from pool state, which includes burned LP).
    
##### Github org/user (Optional, if your code is open source, we can track activity):
LifeOrDream

##### Does this project have a referral program?
Yes — referrers earn 3% of referred users' staking rewards, and referred users receive a 1% bonus.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Solana integration for minebtc with TVL tracking (prize pot SOL)
  * Staking metrics for custodial DogeBTC holdings
  * Liquidity pool staking that reports pro‑rata underlying asset values for LP positions
  * Treasury reporting: TVL and owned-token accounting for protocol vaults and reward vaults
  * Includes metadata describing methodology and disables historical timetravel
<!-- end of auto-generated comment: release notes by coderabbit.ai -->