### PR TITLE
Adding Morpho V2 Factory addresses

### DIFF
--- a/projects/helper/curators/configs.js
+++ b/projects/helper/curators/configs.js
@@ -57,6 +57,12 @@ const MorphoConfigs = {
         fromBlock: 21439510,
       },
     ],
+    vaultFactoriesV2: [
+      {
+        address: '0xA1D94F746dEfa1928926b84fB2596c06926C0405',
+        fromBlock: 23375073,
+      },
+    ],
   },
   base: {
     vaultFactories: [
@@ -67,6 +73,12 @@ const MorphoConfigs = {
       {
         address: '0xFf62A7c278C62eD665133147129245053Bbf5918',
         fromBlock: 23928808,
+      },
+    ],
+    vaultFactoriesV2: [
+      {
+        address: '0x4501125508079A99ebBebCE205DeC9593C2b5857',
+        fromBlock: 35615206,
       },
     ],
   },
@@ -145,6 +157,12 @@ const MorphoConfigs = {
       {
         address: '0x878988f5f561081deEa117717052164ea1Ef0c82',
         fromBlock: 296447195,
+      },
+    ],
+    vaultFactoriesV2: [
+      {
+        address: '0x6b46fa3cc9EBF8aB230aBAc664E37F2966Bf7971',
+        fromBlock: 387016724,
       },
     ],
   },


### PR DESCRIPTION
Commiting a few changes for Morpho Curators who now are allocating V2 vaults directly into markets

# The Problem

- getMorphoVaults() discovers curator vaults by querying factory contract events. 
- It queries V1 factories (CreateMetaMorpho events) and V2 factories (CreateVaultV2 events), but only if the chain has vaultFactoriesV2 configured in MorphoConfigs. 
- Before this fix, only Monad had a V2 factory configured.

# The Fix

Added vaultFactoriesV2 entries for ethereum, base, and arbitrum so getMorphoVaults() now also queries CreateVaultV2 events on those chains. V2 vaults are discovered and their totalAssets() is counted properly alongside V1 vaults, with the existing de-duplication logic handling any overlap.


#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/adapters).
> - If you would like to add a `liquidations` adapter, please refer to [this readme document](https://github.com/DefiLlama/DefiLlama-Adapters/tree/main/liquidations) for details.

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
3. Please fill the form below **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
4. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can edit it there and put up a PR
5. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
6. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap

---

##### Name (to be shown on DefiLlama):

##### Twitter Link:

##### List of audit links if any:

##### Website Link:

##### Logo (High resolution, will be shown with rounded borders):

##### Current TVL:

##### Treasury Addresses (if the protocol has treasury)

##### Chain:

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama):

##### Token address and ticker if any:

##### Category (full list at https://defillama.com/categories) \*Please choose only one:

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

##### forkedFrom (Does your project originate from another project):

##### methodology (what is being counted as tvl, how is tvl being calculated):

##### Github org/user (Optional, if your code is open source, we can track activity):

##### Does this project have a referral program?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended vault factory support with new V2 configurations for Ethereum, Base, and Arbitrum networks. Each network now includes additional factory address definitions with proper tracking parameters, enabling enhanced operational flexibility and broader compatibility for vault management across all supported blockchain environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->