### PR TITLE
fix: ctUSD TVL for Citrea projects

### DIFF
--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -83,7 +83,6 @@ const fixBalancesTokens = {
     '0x0000000000000000000000000000000000000000': { coingeckoId: 'bitcoin', decimals: 18 },
     '0x3100000000000000000000000000000000000006': { coingeckoId: 'bitcoin', decimals: 18 },
     '0xE045e6c36cF77FAA2CfB54466D71A3aEF7bbE839': { coingeckoId: 'usd-coin', decimals: 6 },
-    '0x8D82c4E3c936C7B5724A382a9c5a4E6Eb7aB6d5D': { coingeckoId: 'citrea-usd', decimals: 6 },
     '0x9f3096Bac87e7F03DC09b0B416eB0DF837304dc4': { coingeckoId: 'tether', decimals: 6 },
     '0xDF240DC08B0FdaD1d93b74d5048871232f6BEA3d': { coingeckoId: 'wrapped-bitcoin', decimals: 8 },
   },


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/adapters).
> - If you would like to add a `liquidations` adapter, please refer to [this readme document](https://github.com/DefiLlama/DefiLlama-Adapters/tree/main/liquidations) for details.

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
3. Please fill the form below **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
4. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can edit it there and put up a PR
5. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
6. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap

---

##### Name (to be shown on DefiLlama):

##### Twitter Link:

##### List of audit links if any:

##### Website Link:

##### Logo (High resolution, will be shown with rounded borders):

##### Current TVL:

##### Treasury Addresses (if the protocol has treasury)

##### Chain:

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama):

##### Token address and ticker if any:

##### Category (full list at https://defillama.com/categories) \*Please choose only one:

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

##### forkedFrom (Does your project originate from another project):

##### methodology (what is being counted as tvl, how is tvl being calculated):

##### Github org/user (Optional, if your code is open source, we can track activity):

##### Does this project have a referral program?


From what I understand the coingecko entry for `ctUSD` overrides the price that can be fetched from `coins.llama.fi. Now satsuma & juiceswap TVL is indexed properly.

```sh
> node test.js satsuma                                                            
Loaded module satsuma from registry
Building prices get queries for 8 tokens
--- citrea ---
ctUSD                     255.73 k
USDC                      234.83 k
BTC                       64.77 k
WBTC                      29.37 k
USDT                      10.047587770549399
Total: 584.71 k 

--- tvl ---
ctUSD                     255.73 k
USDC                      234.83 k
BTC                       64.77 k
WBTC                      29.37 k
USDT                      10
Total: 584.71 k 

------ TVL ------
citrea                    584.71 k

total                    584.71 k 


> node test.js juiceswap                                                                        
Loaded module juiceswap from registry
Building prices get queries for 10 tokens
--- citrea ---
BTC                       253.53 k
ctUSD                     7.38 k
USDC                      4.04 k
USDT                      561.9614171203317
WBTC                      3.038200133467222
Total: 265.52 k 

--- tvl ---
BTC                       253.53 k
ctUSD                     7.38 k
USDC                      4.04 k
USDT                      562
WBTC                      3
Total: 265.52 k 

------ TVL ------
citrea                    265.52 k

total                    265.52 k 
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a token mapping entry for the Citrea chain, which previously associated a specific token address with its corresponding identifier and decimal configuration. This change affects token recognition for that particular address on the Citrea network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->