### PR TITLE
feat: add MegaETH support to Skate AMM adapter

### DIFF
--- a/projects/skate-amm/index.js
+++ b/projects/skate-amm/index.js
@@ -33,6 +33,7 @@ const evm_config = {
   ],
   "0g": [{ kernelEventEmitter: '0xFBD495862410c549f200Ce224Ad3D02a0bAe260D', fromBlock: 5961960 }],
   monad: [{ kernelEventEmitter: '0xFBD495862410c549f200Ce224Ad3D02a0bAe260D', fromBlock: 33372521 }],
+  megaeth: [{ kernelEventEmitter: '0x613d5b5f248Ff95557A8855B7b69Cbde09955C43', fromBlock: 7999879 }],
 }
 
 const svm_config = {


### PR DESCRIPTION
## Summary

- Adds MegaETH chain support to the Skate AMM adapter
- Configures `kernelEventEmitter` at `0x613d5b5f248Ff95557A8855B7b69Cbde09955C43` with `fromBlock: 7999879`

## Test plan

- [x] Verify TVL is returned for MegaETH via the Skate AMM adapter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Megaeth chain support: Skate AMM now includes support for the Megaeth blockchain network. This addition enables kernel event tracking on Megaeth, allowing users to monitor and interact with Skate AMM services seamlessly. The integration maintains full compatibility with all existing supported chains, ensuring no disruption to current users while expanding platform availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->