### PR TITLE
fix: bifrost ethereum tvl not updating

### DIFF
--- a/projects/bifrost-staking/index.js
+++ b/projects/bifrost-staking/index.js
@@ -18,8 +18,8 @@ module.exports = {
 	ethereum: {
 		tvl: async () => {
 			const { bifrost } = getExports("bifrost-staking", ["bifrost"]);
-			const { eth } = await bifrost.tvl();
-			return { eth };
+			const tvl = await bifrost.tvl();
+			return { ethereum: tvl.ethereum };
 		},
 	},
 	astar: {


### PR DESCRIPTION
The ethereum tvl handler was destructuring `eth` from the api result, but the api returns `ethereum` as the key (matching the coingecko id). This caused ethereum chain tvl to always be undefined

Fixes #18089

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the data structure returned for Ethereum staking TVL calculations to properly reflect the underlying chain data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->