### PR TITLE
Added Zircuit Finance TVL

### DIFF
--- a/projects/zircuit-finance/index.js
+++ b/projects/zircuit-finance/index.js
@@ -1,38 +1,18 @@
 const ADDRESSES = require('../helper/coreAssets.json')
-const { sumTokens2 } = require('../helper/unwrapLPs')
 
-const STRATEGY_MANAGERS = {
-  USDC: '0xf7E745658fa6f1fe8f2CAb47861a273991Cd3374',
-  USDT: '0x075193D36693DA7BA3Bb709cF63bEf070BA04D94',
+const VAULTS = {
+  USDC: '0x03067bbD0d41E3Fe4A0bb6ca67c99e7352Da4CAE',
+  USDT: '0x25d90ABd6c1E8DCCD40932D2fdD2Cd381bfc832D',
 }
 
-const config = {
+module.exports = {
   base: {
-    strategies: [
-      '0xc91E44E9302288FE5Df24d6392875E5069E1aca7', // USDC Aave V3
-      '0xe83EF4375d806c02387069f1b753b2ab76ab1dc5', // USDC Monarq
-      '0x1A48Cec817Bcb5436EFE99BAb6dDe228Cc37e1Cc', // USDT Monarq
-    ],
-  },
-  ethereum: {
-    strategies: [
-      '0x28966Ce36d0F25858dc5d10DfC2829F05C332C49', // USDC Aave V3
-      '0x6424c7548e214f89B64Ea5981c5A0c5Ec22b6e38', // USDT Aave V3
-    ],
-  },
-}
-
-Object.keys(config).forEach(chain => {
-  const { strategies } = config[chain]
-  module.exports[chain] = {
     tvl: async (api) => {
-      await api.erc4626Sum({ calls: strategies, isOG4626: true })
-      const tokensAndOwners = Object.entries(STRATEGY_MANAGERS).map(
-        ([symbol, manager]) => [ADDRESSES[chain][symbol], manager]
-      )
-      return sumTokens2({ api, tokensAndOwners })
+      for (const [symbol, vault] of Object.entries(VAULTS)) {
+        const totalAssets = await api.call({ target: vault, abi: 'uint256:totalAssets' })
+        api.add(ADDRESSES.base[symbol], totalAssets)
+      }
     }
-  }
-})
-
-module.exports.doublecounted = true
+  },
+  doublecounted: true,
+}


### PR DESCRIPTION
##### Name (to be shown on DefiLlama): Zircuit Finance

##### Twitter Link: https://x.com/Zircuit

##### List of audit links if any: https://docs.zircuit.com/zircuit-finance/zircuit-finance-vaults/security

##### Website Link: https://finance.zircuit.com/

##### Logo (High resolution, will be shown with rounded borders): https://finance.zircuit.com/_next/static/media/zircuit-gold.2ce9ffa7.svg

##### Current TVL: $307k

##### Chain: Ethereum, Base

##### Short Description (to be shown on DefiLlama): Zircuit Finance is a secure platform bringing institutional-grade strategies onchain.

##### Category (full list at https://defillama.com/categories) \*Please choose only one: Yield

##### methodology (what is being counted as tvl, how is tvl being calculated): projects/zircuit-finance/index.js -- calculated from onchain vault data:

```
--- ethereum ---
USDC                      26.13 k
USDT                      363.30
Total: 26.50 k 

--- base ---
USDC                      230.96 k
USDT                      49.94 k
Total: 280.90 k 

--- tvl ---
USDC                      257.09 k
USDT                      50.30 k
Total: 307.39 k 

------ TVL ------
base                      280.90 k
ethereum                  26.50 k

total                    307.39 k 
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL calculation for the Base chain covering USDC and USDT vaults.
  * Exposes the TVL value for consumption by downstream tooling.
* **Chores**
  * Marks results as double-counted to indicate aggregated balances may overlap.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->