### PR TITLE
Add BTCB token to alphasec-bridge TVL tracking

### DIFF
--- a/projects/alphasec-bridge/index.js
+++ b/projects/alphasec-bridge/index.js
@@ -12,6 +12,7 @@ async function tvl(api) {
       [ADDRESSES.klaytn.WETH, L1_ERC20_GATEWAY],                    // WETH
       [ADDRESSES.klaytn.BORA, L1_ERC20_GATEWAY],                    // BORA
       ['0x18bc5bcc660cf2b9ce3cd51a404afe1a0cbd3c22', L1_ERC20_GATEWAY], // IDRX
+      ['0x15d9f3ab1982b0e5a415451259994ff40369f584', L1_ERC20_GATEWAY], // BTCB
     ],
   })
 }


### PR DESCRIPTION
We recently launched the BTC market on AlphaSec, and this PR adds BTCB token tracking to the TVL adapter so that the locked BTCB in our bridge is accurately reflected.

## Changes
- Added BTCB ([`0x15d9f3ab1982b0e5a415451259994ff40369f584`](https://kaiascan.io/token/0x15d9f3ab1982b0e5a415451259994ff40369f584)) locked in L1 ERC20 Gateway

## Newly Added Tokens
| Token | Type | Contract |
|-------|------|----------|
| **BTCB** | **ERC20** | **L1 ERC20 Gateway** |

* https://kaiascan.io/token/0x15d9f3ab1982b0e5a415451259994ff40369f584?tabId=tokenTransfer&page=1
* https://kaiascan.io/address/0x483a9ed25747711f38778a69d4d99b7e5365e506?tabId=tokenBalance&page=1

---

## Question: Historical TVL Breakdown data backfill

While submitting this PR, we'd also like to ask about historical data accuracy. We've noticed that when new tokens are added to an adapter (e.g., KAIA native and IDRX in #17956), the TVL chart (https://defillama.com/protocol/tvl/alphasec) shows them appearing abruptly from the PR merge date (Feb 10, 2026) rather than reflecting when those tokens were actually deposited into the bridge contracts on-chain.

Since this adapter reads on-chain contract balances, the historical state could be available on the Kaia blockchain at any past block height. Would it be possible for DefiLlama to re-compute the historical TVL data points using the updated adapter code? This would give a more accurate representation of TVL over time — showing the gradual inflow of existing tokens and now BTCB, rather than a sudden jump on the day each PR was merged.

We understand this is purely on DefiLlama's side (there's no separate backfill API involved — just re-running the adapter against historical blocks), so we completely understand if this isn't feasible or isn't part of the current workflow. Just wanted to ask in case it's something that can be done.

Thank you for the continued support!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added BTCB token to TVL tracking, enabling comprehensive asset coverage across the Kaia L1 network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->