### PR TITLE
Add Decibel TVL adapter

### DIFF
--- a/projects/decibel/index.js
+++ b/projects/decibel/index.js
@@ -1,0 +1,55 @@
+/**
+ * Decibel TVL adapter for DefiLlama.
+ * Decibel is a perpetual futures DEX on Aptos.
+ * TVL is computed from the protocol's on-chain USDC collateral stores.
+ * @module decibel
+ */
+
+const ADDRESSES = require("../helper/coreAssets.json");
+const { function_view } = require("../helper/chain/aptos");
+
+/** @constant {string} DECIBEL_PERP - Decibel perp engine package address on Aptos */
+const DECIBEL_PERP = "0x50ead22afd6ffd9769e3b3d6e0e64a2a350d68e8b102c4e72e33d0b8cfdfdb06";
+
+/** @constant {string} DECIBEL_PREDEPOSIT - Decibel predeposit package address on Aptos */
+const DECIBEL_PREDEPOSIT = "0xc5939ec6e7e656cb6fed9afa155e390eb2aa63ba74e73157161829b2f80e1538";
+
+/** @constant {string} USDC - Native USDC fungible asset address on Aptos */
+const USDC = ADDRESSES.aptos.USDC_3;
+
+/**
+ * Calculates TVL for Decibel on Aptos.
+ * Sums USDC collateral in the perp engine and predeposit vault.
+ * @param {object} api - DefiLlama ChainApi instance
+ */
+async function tvl(api) {
+  // Perp engine collateral
+  const perpBalance = await function_view({
+    functionStr: `${DECIBEL_PERP}::perp_engine::get_global_primary_store_balance`,
+  });
+  api.add(USDC, perpBalance);
+
+  // Predeposit vault (ua deposits + DLP contributions)
+  const stateAddr = await function_view({
+    functionStr: `${DECIBEL_PREDEPOSIT}::predeposit::predeposit_address`,
+    args: [DECIBEL_PREDEPOSIT],
+  });
+  const uaTotal = await function_view({
+    functionStr: `${DECIBEL_PREDEPOSIT}::predeposit::ua_total`,
+    args: [stateAddr],
+  });
+  api.add(USDC, uaTotal);
+
+  const dlpTotal = await function_view({
+    functionStr: `${DECIBEL_PREDEPOSIT}::predeposit::dlp_total`,
+    args: [stateAddr],
+  });
+  api.add(USDC, dlpTotal);
+}
+
+/** @type {object} DefiLlama adapter export */
+module.exports = {
+  methodology: "TVL is the total USDC collateral in the Decibel perp engine plus USDC in the predeposit vault.",
+  timetravel: false,
+  aptos: { tvl },
+};


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
Decibel

##### Twitter Link:
https://x.com/DecibelTrade

##### List of audit links if any:

##### Website Link:
https://app.decibel.trade

##### Logo (High resolution, will be shown with rounded borders):
https://app.decibel.trade/apple-icon.png

##### Current TVL:
~$53m

##### Treasury Addresses (if the protocol has treasury)

##### Chain:
Aptos

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):

##### Short Description (to be shown on DefiLlama):
Decibel is a composable, onchain trading engine for spot, perps, and yield opportunities. Trade onchain, trade loud with Decibel.

##### Token address and ticker if any:

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Derivatives

##### Oracle Provider(s):
Chainlink

##### Implementation Details:
Queries the global collateral store balance from the Decibel perp engine contract and predeposit vault on Aptos mainnet. TVL = total USDC deposited as trading collateral + predeposit funds not yet transitioned.

##### Documentation/Proof:

##### forkedFrom:

##### methodology:
TVL is the total USDC collateral deposited by users into the Decibel perpetual futures protocol, including predeposit vault funds.

##### Github org/user:

##### Does this project have a referral program?
Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a TVL adapter for Decibel on Aptos that reports total USDC across the protocol — including perp engine collateral and predeposit balances (unallocated deposits and DLP contributions). The adapter provides TVL information even though the predeposit component is not yet launched.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->