### PR TITLE
hydrex fix

### DIFF
--- a/registries/uniswapV3.js
+++ b/registries/uniswapV3.js
@@ -690,6 +690,7 @@ const uniV3Configs = {
         '0x8d9a525463e6891bca541828ddd5c9551d8d6697',
         '0x995bb7f2fc1c628f029baf04204b7b6ab6667271',
         '0x893ade07ce949d9686267898a31fb9660c264276',
+        '0xd02f50e1017f493ffffa70c8fcf09e349e11d6c9',
       ],
     },
   },


### PR DESCRIPTION
blacklists [dgld](https://basescan.org/address/0xd02f50E1017F493ffFFa70c8fCf09e349e11d6c9) as it spiked tvl from $10M to $750M

[this pool](https://basescan.org/address/0x9bC08c9afa50475AB7B68E734fbf6fFb9bdEd6F9#code) has 280 USDC and 170k DGLD (each DGLD is supposed to represent 1 oz gold)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated token filtering configuration for Uniswap V3 by expanding the blacklist to exclude an additional token from pool operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->