### PR TITLE
Add Rush Sports Solana TVL adapter

### DIFF
--- a/projects/rush-sports/index.js
+++ b/projects/rush-sports/index.js
@@ -1,0 +1,26 @@
+const { PublicKey } = require('@solana/web3.js');
+const { sumTokens2 } = require('../helper/solana');
+
+const BANKROLL_PROGRAM_ID = new PublicKey('CAzPCZuaji4ycz4KWtmBirvNeXp3ULCqunJgSMFZX5ar');
+const BANKROLL_STATES = [
+  'MVe7JbiTAfa1VinJqHTsSWFXpG6Sap68Zc55ZzVb1ns',
+];
+
+function bankrollVaultPda(bankrollState) {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from('vault'), new PublicKey(bankrollState).toBuffer()],
+    BANKROLL_PROGRAM_ID,
+  )[0].toBase58();
+}
+
+async function tvl() {
+  const solOwners = BANKROLL_STATES.map(bankrollVaultPda);
+  return sumTokens2({ solOwners });
+}
+
+module.exports = {
+  timetravel: false,
+  methodology:
+    'TVL counts SOL held in Rush Sports bankroll vault PDA(s). Vault PDA(s) are derived as ["vault", bankroll_state] under the bankroll program and back LP liquidity plus in-flight game settlement obligations.',
+  solana: { tvl },
+};


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

##### Name (to be shown on DefiLlama):
Rush Sports

##### Twitter Link:
https://x.com/RushSports_xyz

##### List of audit links if any:
None public yet

##### Website Link:
https://rushsports.xyz

##### Logo (High resolution, will be shown with rounded borders):
https://rushsports.xyz/brand/rush-logo-square.png

##### Current TVL:
~54.97 SOL (~$4.3k at submission time)

##### Treasury Addresses (if the protocol has treasury)
N/A

##### Chain:
Solana

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama):
Rush Sports is an on-chain live sports prediction protocol on Solana with LP-backed liquidity and automated settlement.

##### Token address and ticker if any:
N/A

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Prediction Market

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
Polymarket CLOB odds ingested off-chain and published on-chain via Rush Sports Oracle program.

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
A dedicated ingestion service consumes live Polymarket odds and writes timestamped price snapshots/sigma data to Solana. Game settlement verifies outcomes against these on-chain oracle snapshots.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
https://rushsports.xyz/how-it-works

##### forkedFrom (Does your project originate from another project):
N/A

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL counts SOL held in Rush Sports bankroll vault PDA(s). Vault PDA(s) are deterministically derived as ["vault", bankroll_state] under the bankroll program (`CAzPCZuaji4ycz4KWtmBirvNeXp3ULCqunJgSMFZX5ar`) and represent LP liquidity backing settlement obligations.

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/gfenney

##### Does this project have a referral program?
Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rush Sports TVL calculation now available, providing visibility into total value locked in the protocol including vault positions and liquidity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->