### PR TITLE
varlamore hallmark and hydrex note

### DIFF
--- a/projects/varlamore-capital/index.js
+++ b/projects/varlamore-capital/index.js
@@ -27,3 +27,5 @@ const configs = {
 }
 
 module.exports = getCuratorExport(configs)
+// https://github.com/DefiLlama/DefiLlama-Adapters/pull/18101
+module.exports.hallmarks = [['2026-02-23', 'broken Stream finance vaults blacklisted']]

--- a/registries/uniswapV3.js
+++ b/registries/uniswapV3.js
@@ -690,7 +690,7 @@ const uniV3Configs = {
         '0x8d9a525463e6891bca541828ddd5c9551d8d6697',
         '0x995bb7f2fc1c628f029baf04204b7b6ab6667271',
         '0x893ade07ce949d9686267898a31fb9660c264276',
-        '0xd02f50e1017f493ffffa70c8fcf09e349e11d6c9',
+        '0xd02f50e1017f493ffffa70c8fcf09e349e11d6c9', // DGLD token hacked on 2026-02-23 (caused tvl to spike): https://basescan.org/address/0x9bC08c9afa50475AB7B68E734fbf6fFb9bdEd6F9
       ],
     },
   },


### PR DESCRIPTION
- added hallmark to varlamore capital's adapter to explain drop in tvl
- added comment explaining why DGLD was blacklisted from Hydrex Integral

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Updates**
  * Added registry documentation and tracking for broken Stream finance vaults identified on February 23, 2026, enabling users to avoid exposure to compromised liquidity pools
  * Updated token blacklist entries with clarifying information regarding documented security incidents and known exploits

<!-- end of auto-generated comment: release notes by coderabbit.ai -->