### PR TITLE
feat: update gaib aid script and remove aida data

### DIFF
--- a/projects/gaib/index.js
+++ b/projects/gaib/index.js
@@ -1,28 +1,19 @@
 // AID token address — same on all chains (LayerZero OFT + CREATE2)
 const AID = "0x18F52B3fb465118731d9e0d276d4Eb3599D57596";
 
-// sAID ERC-4626 vault (Ethereum only)
-const SAID_VAULT = "0xB3B3c527BA57cd61648e2EC2F5e006A0B390A9F8";
-
 async function tvl(api) {
   const supply = await api.call({ abi: "erc20:totalSupply", target: AID });
   // Price AID via ethereum mapping so non-ethereum chain balances are valued too.
   api.add(`ethereum:${AID}`, supply, { skipChain: true });
 }
 
-// sAID staking — AID locked in the vault. Shown as sub-category, not double-counted.
-async function staking(api) {
-  const supply = await api.call({ abi: "erc20:totalSupply", target: SAID_VAULT });
-  api.add(`ethereum:${SAID_VAULT}`, supply, { skipChain: true });
-}
-
 module.exports = {
   methodology:
-    "TVL is the total supply of AID (AI Dollar) across all deployed chains. AID is a synthetic dollar backed 1:1 by US Treasuries and stablecoins. sAID staking shows AID deposited in the ERC-4626 yield vault.",
+    "TVL is the total supply of AID (AI Dollar) across all deployed chains. AID is a synthetic dollar backed 1:1 by US Treasuries and stablecoins.",
   misrepresentedTokens: true,
   timetravel: true,
   start: 1730419200,
-  ethereum: { tvl, staking },
+  ethereum: { tvl },
   arbitrum: { tvl },
   base: { tvl },
   bsc: { tvl },


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `volume` adapter please submit the PR [here](https://github.com/DefiLlama/adapters).
> - If you would like to add a `liquidations` adapter, please refer to [this readme document](https://github.com/DefiLlama/DefiLlama-Adapters/tree/main/liquidations) for details.

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to be computed from blockchain data. If you have trouble with creating the adapter, please hop onto our Discord—we are happy to assist you.
3. Please fill the form below  **only if the PR is for listing a new protocol**, else it can be ignored/replaced with reason/details about the PR.
4. **For updating listing info** it is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts — you can edit it there and put up a PR.
5. Do not edit/push `package-lock.json` file as part of your changes. We use lockfileVersion 2, and most use v1; using that messes up our CI.
6. No need to go to our Discord and announce that you've created a PR—we monitor all PRs and will review it ASAP.

---

##### Name (to be shown on DefiLlama): 
GAIB

##### Twitter Link:
[https://x.com/gaib_ai](https://x.com/gaib_ai)

##### List of audit links if any:
https://docs.gaib.ai/audits

##### Website Link:
[https://gaib.ai](https://gaib.ai)

##### Logo (High resolution, will be shown with rounded borders):
[logo](https://avatars.githubusercontent.com/u/182863120?s=200&v=4)

##### Current TVL:
**AID.v0 Total Supply** (across Ethereum, Arbitrum, Base, BSC)

##### Treasury Addresses (if the protocol has treasury):


##### Chain:
Ethereum, Arbitrum, Base, BSC

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):  

gaib-aid

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):  
*Pending listing*

##### Short Description (to be shown on DefiLlama):
GAIB is the economic layer transforming AI infrastructure investment by turning GPU-backed assets into yield-generating opportunities. Through AID, GAIB’s AI synthetic dollar, investors can seamlessly access the AI economy while earning real yield from AI-powered compute. Staking AID (sAID) provides passive income while maintaining liquidity, enabling broader participation in AI-driven financial markets. GAIB also powers AI infrastructure by providing capital solutions for cloud providers and data centers, optimizing their access to compute resources. With integrations across DeFi protocols, including lending, borrowing, and structured products, GAIB bridges AI and blockchain finance - unlocking new opportunities at the intersection of technology and investment.

##### Token address and ticker if any:

- **AID.v0** (Ethereum, Arbitrum, Base, BSC): `0x18F52B3fb465118731d9e0d276d4Eb3599D57596`

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Commodities

##### Oracle Provider(s):  


##### Implementation Details:  
- **TVL**: Calls `totalSupply()` on AID (`0x18F52B3fb465118731d9e0d276d4Eb3599D57596`) on each chain (Ethereum, Arbitrum, Base, BSC). AID is pegged 1:1 to USD, so supply is mapped to each chain's native USDC for pricing.
- **Staking**: Calls `totalAssets()` on the sAID ERC-4626 vault (`0xB3B3c527BA57cd61648e2EC2F5e006A0B390A9F8`) on Ethereum to track AID locked in the yield vault. Reported separately to avoid double-counting.
- Uses `misrepresentedTokens: true` since AID balances are represented as USDC equivalents.

##### Documentation/Proof:  
https://docs.gaib.ai/

##### forkedFrom (Does your project originate from another project):  
Not a fork

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL tracks AID.v0 total supply across Ethereum, Arbitrum, Base, and BSC using the `totalSupply()` function on-chain.

##### Github org/user (Optional, if your code is open source, we can track activity):  
[https://github.com/gaib-ai](https://github.com/gaib-ai)

##### Smart Contract Details (Adapter Implementation):

The GAIB adapter tracks AID.v0 total supply across all supported chains.

**Token:**
- **AID.v0**: `0x18F52B3fb465118731d9e0d276d4Eb3599D57596` (Ethereum, Arbitrum, Base, BSC)

**TVL Calculation:**
The adapter uses `totalSupply()` to track AID supply on each chain:

```js
async function aidSupply(api) {
    const supply = await api.call({
        abi: "function totalSupply() external view returns (uint256)",
        target: AID_TOKEN,
    });
    api.add(`ethereum:${AID_TOKEN}`, supply, { skipChain: true });
    return api.getBalances();
}
```

**Adapter Exports:**
- **ethereum**: tvl (aidSupply)
- **arbitrum**: tvl (aidSupply)
- **base**: tvl (aidSupply)
- **bsc**: tvl (aidSupply)

Supported chains: Ethereum, Arbitrum, Base, BSC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposes AID-based TVL per chain with chain-aware valuation and preserved sAID staking metric.
  * Updated project metadata and added hallmarks for clarity.

* **Refactor**
  * Unified supply-based TVL model replacing legacy pool-level aggregation.
  * Simplified exports and removed legacy per-pool mappings.
  * Chains with no balances now return empty TVL stubs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->