### PR TITLE
Add BigBeautifulBoard TVL adapter (Base)

### DIFF
--- a/projects/bigbeautifulboard/index.js
+++ b/projects/bigbeautifulboard/index.js
@@ -1,15 +1,18 @@
 const ADDRESSES = require('../helper/coreAssets.json')
 const { sumTokensExport } = require('../helper/unwrapLPs')
 
-// Oracle wallet — holds the prize pool (rollover pot + pending payouts)
-const ORACLE_WALLET = '0xF1946486A6172087a1AbefFe83Ffc6E4FeAb75F4'
+// BBBEscrow — trustless USDC escrow contract with Pyth Entropy VRF winner selection.
+// All player USDC deposits go directly to this contract. No withdraw() function exists —
+// funds can only leave via VRF-determined winner payouts.
+// Verified: https://basescan.org/address/0x6d62b69069eb3db1e414331b75516341e5a606a7
+const ESCROW_CONTRACT = '0x6d62b69069eb3db1e414331b75516341e5a606a7'
 
 module.exports = {
-  methodology: 'TVL is the USDC held in the BBB oracle wallet, representing the active prize pool and rollover pot for the on-chain tile game.',
+  methodology: 'TVL is the USDC held in the BBBEscrow smart contract on Base. Players deposit USDC to buy tiles; the contract holds deposits as the active prize pool. Winner selection uses Pyth Entropy (on-chain verifiable randomness). No withdraw() function exists — funds can only leave via VRF-determined payouts.',
   start: '2026-02-04',
   base: {
     tvl: sumTokensExport({
-      owners: [ORACLE_WALLET],
+      owners: [ESCROW_CONTRACT],
       tokens: [ADDRESSES.base.USDC],
     }),
   },


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
BigBeautifulBoard

##### Twitter Link:
https://x.com/BBBonBase

##### List of audit links if any:
N/A

##### Website Link:
https://bigbeautifulboard.xyz

##### Logo (High resolution, will be shown with rounded borders):
https://bigbeautifulboard.xyz/BIGBEAUTIFULBOARD-icon.png

##### Current TVL:
~$0.41 (early stage — game live on Base mainnet)

##### Treasury Addresses (if the protocol has treasury)
BBBEscrow contract (holds prize pool): [`0x6d62b69069eb3db1e414331b75516341e5a606a7`](https://basescan.org/address/0x6d62b69069eb3db1e414331b75516341e5a606a7#code)

##### Chain:
Base

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):


##### Short Description (to be shown on DefiLlama):
On-chain tile game on Base. Buy tiles with USDC, fill blocks, win prize pools. Winner selection uses Pyth Entropy (verifiable on-chain randomness). Accepts USDC from Ethereum, Optimism, Arbitrum, and Polygon via Relay Protocol bridge — all funds settle to the Base escrow contract.

##### Token address and ticker if any:
N/A

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Luck Games

##### Oracle Provider(s):
Pyth Entropy (on-chain VRF for winner selection)

##### Implementation Details:
All player USDC deposits are held in the BBBEscrow smart contract on Base ([verified source](https://basescan.org/address/0x6d62b69069eb3db1e414331b75516341e5a606a7#code)). When a block of 100 tiles fills, the contract requests verifiable randomness from Pyth Entropy. The entropy callback picks the winner (`randomNumber % 100`) and transfers USDC atomically on-chain.

Cross-chain deposits from Ethereum, Optimism, Arbitrum, and Polygon are bridged to the Base escrow via Relay Protocol (EXACT_OUTPUT mode — exact tile cost arrives at escrow, user pays bridge fee on source chain).

The contract has no `withdraw()` function and no `selfdestruct`. Funds exit only via VRF-determined payouts or the `payout()` function (oracle-only, used for dev fees and refunds).

##### Documentation/Proof:
- BBBEscrow contract (verified, holds TVL): https://basescan.org/address/0x6d62b69069eb3db1e414331b75516341e5a606a7#code
- BBBGame ERC-1155 (tile NFTs, no USDC): https://basescan.org/address/0x7A0FeDbD62ae641B5bD9bA1785ffbC9f50e8Eb9a

##### forkedFrom (Does your project originate from another project):
N/A (original design)

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL = USDC balance in the BBBEscrow contract (`0x6d62b69069eb3db1e414331b75516341e5a606a7`) on Base. This is a smart contract, not an EOA.

The escrow holds:
- Active prize pool (accumulated from player deposits across all supported chains)
- Rollover pot from completed blocks (90% of each block rolls forward)
- Pending VRF payouts awaiting Pyth Entropy callback

The adapter uses `sumTokensExport` to read the on-chain USDC balance of the escrow contract.

Game mechanics: Players send USDC to buy tiles on a 100-tile block. When a block fills, 8% dev fee is deducted, 10% goes to the block winner (selected by Pyth Entropy VRF), and 90% rolls to the next block's pot. The last block winner gets 100% of the accumulated rollover.

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/DefiDevChris

##### Does this project have a referral program?
No