### PR TITLE
Revert "Zircuit misrepresentedTokens"

### DIFF
--- a/projects/zircuit-finance/index.js
+++ b/projects/zircuit-finance/index.js
@@ -45,4 +45,3 @@ Object.keys(config).forEach(chain => {
 })
 
 module.exports.doublecounted = true
-module.exports.misrepresentedTokens = true // zUSDC/zUSDT mapped to USDC/USDT


### PR DESCRIPTION
Reverts DefiLlama/DefiLlama-Adapters#18155

zUSDC/zUSDT is no longer being mapped anywhere as monarq strategies use USDC/USDT as asset()

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused internal configuration flag to streamline the project setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->