### PR TITLE
Add USD.AI (USDai) adapter

### DIFF
--- a/projects/usd-ai/index.js
+++ b/projects/usd-ai/index.js
@@ -1,0 +1,22 @@
+const USDai = "0x0A1a1A107E45b7Ced86833863f482BC5f4ed82EF"
+
+const chains = ["arbitrum", "plasma", "base"]
+
+module.exports = {
+  misrepresentedTokens: true,
+  methodology:
+    "TVL is calculated as the total supply of USDai on each supported chain. " +
+    "USDai is a synthetic dollar backed by tokenized U.S. Treasuries and loans against GPU/AI compute hardware. " +
+    "sUSDai (staked USDai) is not counted separately as the underlying USDai remains in total supply. " +
+    "Yield is generated from real-world GPU hardware deals (NVIDIA B300, GB300, RTX 6000, B200) " +
+    "deployed across data centers globally, plus a PYUSD incentive program.",
+}
+
+const tvl = async (api) => {
+  const supply = await api.call({ target: USDai, abi: "erc20:totalSupply" })
+  api.add(USDai, supply)
+}
+
+chains.forEach((chain) => {
+  module.exports[chain] = { tvl }
+})


### PR DESCRIPTION
## USD.AI Adapter

**Protocol:** [USD.AI](https://usd.ai) — Synthetic dollar backed by tokenized U.S. Treasuries and GPU/AI hardware loans

**TVL Methodology:** Total supply of USDai on each supported chain

### Chains
- **Arbitrum** (primary) — ~$380M TVL
- **Plasma** (chain ID 9745) — ~$81M TVL
- **Base** — recently deployed

### Token Addresses
USDai and sUSDai use the same addresses on all chains (LayerZero OFT):
- USDai: `0x0A1a1A107E45b7Ced86833863f482BC5f4ed82EF`
- sUSDai: `0x0B2b2B2076d95dda7817e785989fE353fe955ef9`

### Notes
- sUSDai (staked USDai) is not counted separately to avoid double-counting — the underlying USDai remains in total supply
- Current APY: ~6.25% from real-world GPU hardware deals (NVIDIA B300, GB300, RTX 6000, B200) + PYUSD incentive program
- Projected APY: ~8.44% as new deals come online

### Test Results
```
--- arbitrum ---
USDai                     379.86 M

--- plasma ---
USDai                     81.01 M

--- base ---
Total: 0

total                    460.87 M
```

### Links
- Website: https://usd.ai
- Docs: https://docs.usd.ai
- Contract Addresses: https://docs.usd.ai/technical-overview/contract-addresses
- API: https://api.usd.ai/usdai/dashboard/tvl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added USDai token tracking with Total Value Locked (TVL) monitoring across Arbitrum, Plasma, and Base blockchains.
- TVL calculations now include USDai supply metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->