### PR TITLE
limitless (base): add additional resolver holding collateral balances

### DIFF
--- a/projects/limitless-exchange/index.js
+++ b/projects/limitless-exchange/index.js
@@ -5,6 +5,7 @@ const eventAbi = "event FixedProductMarketMakerCreation(address indexed creator,
 const config = [
   { factory: "0x8E50578ACa3C5E2Ef5ed2aA4bd66429B5e44C16E", resolver: "0x15A61459d65D89A25a9e91e0dc9FC69598791505", fromBlock: 13547870 },
   { factory: "0xc397D5d70cb3B56B26dd5C2824d49a96c4dabF50", resolver: "0xc9c98965297bc527861c898329ee280632b76e18", fromBlock: 13547845 },
+  { factory: "0xc397D5d70cb3B56B26dd5C2824d49a96c4dabF50", resolver: "0x5d6C6a4fEA600E0b1A3Ab3eF711060310E27886A", fromBlock: 13547845 },
 ];
 
 const blacklistedTokens = ['0xd7788ffc73c9ae39ce24dfc1098b375792dd42ac']


### PR DESCRIPTION
This PR includes an additional collateral-holding resolver address for Limitless on Base:

0x5d6C6a4fEA600E0b1A3Ab3eF711060310E27886A

This address currently holds active collateral balances (~140k USDC) that were not covered by the existing resolver configuration.

The change keeps the same factory and fromBlock configuration and simply includes this additional address in the TVL calculation.

No changes to token discovery logic or blacklisted tokens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new market configuration to the platform. This new market is now included in total value locked (TVL) calculations, providing more comprehensive and accurate portfolio tracking across all supported markets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->