### PR TITLE
Add SimpleDEX adapter (Proton chain)

### DIFF
--- a/projects/simple-dex/index.js
+++ b/projects/simple-dex/index.js
@@ -41,7 +41,7 @@ async function getAllPools() {
 }
 
 function getTokenKey(contract, symbol) {
-  return \`\${symbol}:\${contract}\`;
+  return `${symbol}:${contract}`;
 }
 
 async function tvl() {


### PR DESCRIPTION
## Summary
- Adds TVL adapter for **SimpleDEX**, an AMM DEX on XPR Network (Proton chain)
- SimpleDEX uses constant product (x*y=k) AMM pools with configurable fees
- Contract: `simpledex` on Proton mainnet
- Website: https://dex.protonnz.com

## TVL Methodology
- Queries all pools from the on-chain `pools` table
- For XPR-paired pools: TVL = 2 × XPR reserve value (AMM equal-value invariant)
- For stablecoin pools (XUSDC, XMD, XUSDT): priced at face value
- XPR price fetched from Proton exchange rates API

## Test
```
$ node test.js projects/simple-dex/index.js

--- proton ---
USDT                      3.85 k
Total: 3.85 k

------ TVL ------
proton                    3.85 k
total                     3.85 k
```

## Checklist
- [x] Adapter runs successfully with `node test.js`
- [x] TVL is calculated correctly from on-chain data
- [x] No API keys required
- [x] Uses existing Proton chain helpers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SimpleDEX TVL adapter for the Proton network to compute total liquidity pool value.
  * Calculates TVL across pools, skipping paused pools and aggregating into USDT-equivalent balances.
  * Supports pricing for XPR‑paired pools and key stablecoins; applies AMM equal‑value logic when only one side is priceable.
  * Publishes TVL methodology and marks tokens as misrepresented for transparency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->