### PR TITLE
Merge v2 and v3 data to parity

### DIFF
--- a/projects/parity/index.js
+++ b/projects/parity/index.js
@@ -1,0 +1,16 @@
+const { getUniTVL } = require('../helper/unknownTokens')
+const { uniV3Export } = require('../helper/uniswapV3')
+const { mergeExports } = require('../helper/utils')
+
+const v2 = {
+  misrepresentedTokens: true,
+  monad: {
+    tvl: getUniTVL({ factory: '0x6DBb0b5B201d02aD74B137617658543ecf800170', useDefaultCoreAssets: true, hasStablePools: true }),
+  },
+}
+
+const v3 = uniV3Export({
+  monad: { factory: '0x2A6CE23C5017aF1b07B9c4E4014442aDE18Bd404', fromBlock: 54650081 },
+})
+
+module.exports = mergeExports([v2, v3])


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/adapters).
> - If you would like to add a `liquidations` adapter, please refer to [this readme document](https://github.com/DefiLlama/DefiLlama-Adapters/tree/main/liquidations) for details.

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
3. Please fill the form below **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
4. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can edit it there and put up a PR
5. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
6. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap

---

  ##### Name (to be shown on DefiLlama):
  Parity

  ##### Twitter Link:
  https://x.com/ParityDEX

  ##### List of audit links if any:

  ##### Website Link:
  https://app.parity.exchange/

  ##### Logo (High resolution, will be shown with rounded borders):
  https://app.parity.exchange/logos/parity_favicon.png

  ##### Current TVL:
  $2065.89

  ##### Treasury Addresses (if the protocol has treasury)
  0xb06f2D1Fbcc0Eb0b3A2a928f521d29481E3BfeFc

  ##### Chain:
  Monad

  ##### Coingecko ID:

  ##### Coinmarketcap ID:

  ##### Short Description (to be shown on DefiLlama):
  The native liquidity layer on Monad. Solidly V2 AMM + Concentrated Liquidity with ve(3,3) tokenomics.

  ##### Token address and ticker if any:
  PRTY - 0x2afdD003b792253e1C8c17DE0f494aB11d037D33 (Monad)

  ##### Category:
  Dexes

  ##### Oracle Provider(s):
  TWAP (on-chain time-weighted average price from pool reserves)

  ##### Implementation Details:
  V2 pairs use built-in Solidly TWAP oracles via observe(). No external oracle dependency for core DEX operations.

  ##### Documentation/Proof:
  https://docs.parity.exchange

  ##### forkedFrom:
  Velodrome V2, Ramses V3

  ##### methodology:
  V2 TVL: Sum of all token balances locked in V2 AMM pair contracts (stable + volatile pools).
  CL TVL: Sum of all token balances locked in V3 concentrated liquidity pool contracts.

  ##### Github org/user:

  ##### Does this project have a referral program?
  Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Added a new parity index module for tracking total value locked across multiple versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->