### PR TITLE
hyward Integration

### DIFF
--- a/projects/hyward/index.js
+++ b/projects/hyward/index.js
@@ -1,0 +1,36 @@
+const ADDRESSES = {
+  HYBRA_MANAGER: "0x08BD4336ae847169034fA8bd54265E90A531031F",
+  HYBRA_BASE_TOKEN: "0x067b0C72aa4C6Bd3BFEFfF443c536DCd6a25a9C8",
+  KITTEN_MANAGER: "0x88200D47928cF032a368A304f688C62036C07439",
+  KITTEN_BASE_TOKEN: "0x618275F8EFE54c2afa87bfB9F210A52F0fF89364",
+};
+
+const getAllVaultsABI =
+  "function getAllVaults() view returns (tuple(uint256 id, address vault, uint256 veTokenId, string name, uint8 vaultType, address targetToken, bool active)[])";
+
+async function tvl(api) {
+  const managers = [
+    { addr: ADDRESSES.HYBRA_MANAGER, token: ADDRESSES.HYBRA_BASE_TOKEN },
+    { addr: ADDRESSES.KITTEN_MANAGER, token: ADDRESSES.KITTEN_BASE_TOKEN },
+  ];
+
+  for (const { addr, token } of managers) {
+    const vaults = await api.call({ abi: getAllVaultsABI, target: addr });
+
+    const activeVaults = vaults.filter((v) => v.active);
+    if (activeVaults.length === 0) continue;
+
+    const assets = await api.multiCall({
+      abi: "uint256:totalAssets",
+      calls: activeVaults.map((v) => v.vault),
+    });
+
+    assets.forEach((amount) => api.add(token, amount));
+  }
+}
+
+module.exports = {
+  methodology:
+    "TVL is calculated by summing the locked veNFT assets (totalAssets) across all active vaults in the Hyward protocol. Hyward manages ve(3,3) auto-voting delegation for Hybra and Kitten on HyperEVM.",
+  hyperliquid: { tvl },
+};


### PR DESCRIPTION


##### Name (to be shown on DefiLlama): Hyward

##### Twitter Link: https://x.com/HywardFi

##### List of audit links if any:

##### Website Link: https://www.hyward.xyz

##### Logo (High resolution, will be shown with rounded borders):

<img width="300" height="300" alt="Frame 2147228755" src="https://github.com/user-attachments/assets/25184092-38ec-4e36-9512-09e1a63bf0d8" />


##### Current TVL:  553 K

##### Treasury Addresses (if the protocol has treasury)

##### Chain: HyperEvm


##### Short Description (to be shown on DefiLlama):
The first AI-driven ve33 auto-vote engine 

Stacking $BTC & $HYPE for the next generation on autopilot

##### Token address and ticker if any:

##### Category (full list at https://defillama.com/categories) \*Please choose only one:
Yield
##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
 No external oracle is used. TVL is derived directly from on-chain vault totalAssets() calls.
##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

##### forkedFrom (Does your project originate from another project):

##### methodology (what is being counted as tvl, how is tvl being calculated):

##### Github org/user (Optional, if your code is open source, we can track activity):

##### Does this project have a referral program?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Introduced Hyward TVL adapter enabling real-time tracking and monitoring of total value locked across protocol vaults
- Supports comprehensive multi-asset tracking with automatic aggregation by token type
- Delivers detailed protocol metrics with full integration into existing platform infrastructure
- Provides complete visibility and reporting capabilities for thorough protocol analytics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->