### PR TITLE
feat: use marketIds directly instead of collaterals

### DIFF
--- a/projects/lista-lending/index.js
+++ b/projects/lista-lending/index.js
@@ -14,7 +14,7 @@ const abi = {
 async function getMarketIds(api) {
   const { vaultInfo } = config[api.chain]
   const { data: { list: vaults } } = await getConfig('lista/lending-' + api.chain, vaultInfo)
-  const ids = vaults.map(vault => vault.collaterals.map(collateral => collateral.id)).flat()
+  const ids = vaults.map(vault => vault.marketIds).flat()
   return [...new Set(ids)]
 }
 


### PR DESCRIPTION
Update the key usage for lista-lending protocol

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified how market identifiers are sourced (now taken directly from each vault's listed markets), which affects which markets are included in protocol totals and borrow calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->