### PR TITLE
Update telosRex (Rex staking)

### DIFF
--- a/projects/telosRex.js
+++ b/projects/telosRex.js
@@ -2,7 +2,7 @@ const { get } = require('./helper/http')
 
 async function tvl() {
   const tvlTlos = (await get(
-    "https://telos.caleos.io/v2/history/get_deltas?code=eosio.token&scope=eosio.rex&table=accounts",
+    "https://mainnet.telos.net/v2/history/get_deltas?code=eosio.token&scope=eosio.rex&table=accounts",
   )).deltas.map(d => d.data.amount);
 
   return {


### PR DESCRIPTION
The API’s Certbot certificate was not renewed → the API has been changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the data source endpoint for Telos Rex account information to ensure continued reliable service delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->