### PR TITLE
Fix: ICP-Swap

### DIFF
--- a/projects/icpswap/index.js
+++ b/projects/icpswap/index.js
@@ -8,5 +8,5 @@ module.exports = {
 
 async function tvl(api) {
   let { tvlUSD } = await get('https://uvevg-iyaaa-aaaak-ac27q-cai.raw.ic0.app/overview')
-  api.addCGToken('tether', tvlUSD)
+  api.addCGToken('tether', Number(tvlUSD))
 }


### PR DESCRIPTION
> Floating number issue : Error in icp: SyntaxError: Cannot convert 3239565.556529 to a BigInt

→ Number()

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue with data type formatting in API requests to ensure proper value handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->