### PR TITLE
Add Veda Kraken Vaults

### DIFF
--- a/projects/veda/ethereum_constants.js
+++ b/projects/veda/ethereum_constants.js
@@ -278,7 +278,16 @@ const boringVaultsV0Ethereum = [
     lens: "0x5232bc0F5999f8dA604c42E1748A13a170F94A1B",
     startBlock: 23231987,
     baseAsset: ADDRESSES.ethereum.WETH,
-  }
+  },
+  {
+    name: "Sentora Advanced Yields ETH",
+    vault: "0xf15351A0d66743E09457C45EaE88dF34FcEe8CB7",
+    accountant: "0xE803d9283450189f168c825AC462dfe035345114",
+    teller: "0xc7bF176A0b782f594c8D7106E61bBcE705767c75",
+    lens: "0xA2c83e64990C6C53b76390678436d63d006534fB",
+    startBlock: 24250028,
+    baseAsset: ADDRESSES.ethereum.WETH,
+  },
 ];
 
 module.exports = {

--- a/projects/veda/index.js
+++ b/projects/veda/index.js
@@ -11,6 +11,7 @@ const { boringVaultsV0Scroll } = require("./scroll_constants");
 const { sumLegacyTvl, sumBoringTvl } = require("./helper_methods");
 const { boringVaultsV0Hyperevm } = require("./hyperevm_constants");
 const { boringVaultsV0Plasma } = require("./plasma_constants");
+const { boringVaultsV0Ink } = require("./ink_constants");
 
 // Returns list of vault addresses that are deployed based on their start block
 function filterActiveLegacyVaults(vaults, blockHeight) {
@@ -75,5 +76,6 @@ module.exports = {
   ["sonic"]: { tvl: (api) => chainTvl(api, boringVaultsV0Sonic) },
   ["scroll"]: { tvl: (api) => chainTvl(api, boringVaultsV0Scroll) },
   ["hyperliquid"]: { tvl: (api) => chainTvl(api, boringVaultsV0Hyperevm) },
-  ["plasma"]: { tvl: (api) => chainTvl(api, boringVaultsV0Plasma) }
+  ["plasma"]: { tvl: (api) => chainTvl(api, boringVaultsV0Plasma) },
+  ["ink"]: { tvl: (api) => chainTvl(api, boringVaultsV0Ink) },
 };

--- a/projects/veda/ink_constants.js
+++ b/projects/veda/ink_constants.js
@@ -1,0 +1,44 @@
+const ADDRESSES = require("../helper/coreAssets.json");
+
+const boringVaultsV0Ink = [
+  {
+    name: "Sentora Advanced Yields USD",
+    vault: "0x63D124cF1afC22F0CCEa376168200508d2A0868E",
+    accountant: "0x8C9C454C51eCc717eA03eC03B904565f405DEAF7",
+    teller: "0x50e951CB35aa8e36459436fB4515Bb8361Cac522",
+    lens: "0x90983EBF38E981AE38f7Da9e71804380e316A396",
+    startBlock: 29559921,
+    baseAsset: ADDRESSES.ink.USDC,
+  },
+  {
+    name: "Advanced Strategies USDC",
+    vault: "0x9761DDF8e79930b334f1Be1BD93aBE3695061CcA",
+    accountant: "0x427a3c091F09fa6212d177060bb7456Abf538b22",
+    teller: "0x48639C1934F14Dc666Af663299294F9e863BDedB",
+    lens: "0x5232bc0F5999f8dA604c42E1748A13a170F94A1B",
+    startBlock: 29501466,
+    baseAsset: ADDRESSES.ink.USDC,
+  },
+  {
+    name: "Balanced Yield USDC",
+    vault: "0xcaae49fb7f74cCFBE8A05E6104b01c097a78789f",
+    accountant: "0x0C4dF79d9e35E5C4876BC1aE4663E834312DDc67",
+    teller: "0xC151E263d5c890FD0Bceb33a6525F1A76a8329fC",
+    lens: "0x90983EBF38E981AE38f7Da9e71804380e316A396",
+    startBlock: 29483710,
+    baseAsset: ADDRESSES.ink.USDC,
+  },
+  {
+    name: "Boosted Yield USDC",
+    vault: "0xDbD87325D7b1189Dcc9255c4926076fF4a96A271",
+    accountant: "0x9c2477D4Ea17d3cCC45e6b1087c94d14926F54C9",
+    teller: "0xc46f2443b3521632E2E2a903D6da8f965B46f6a0",
+    lens: "0x5232bc0F5999f8dA604c42E1748A13a170F94A1B",
+    startBlock: 29554306,
+    baseAsset: ADDRESSES.ink.USDC,
+  },
+];
+
+module.exports = {
+  boringVaultsV0Ink,
+};


### PR DESCRIPTION
Adds 4 new Veda vaults on Ink chain (Sentora Advanced Yields USD, Advanced Strategies USDC, Balanced Yield USDC, Boosted Yield USDC) and one new vault on Ethereum mainnet (Sentora Advanced Yields ETH).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Sentora Advanced Yields vault support for Ethereum.
  * Introduced support for vaults on the Ink chain.
  * Expanded TVL (Total Value Locked) aggregation to include newly integrated vault entries across multiple networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->