### PR TITLE
Add TideSwap TVL adapter (Uniswap V2 on Ink)

### DIFF
--- a/projects/tideswap/index.js
+++ b/projects/tideswap/index.js
@@ -1,0 +1,12 @@
+// TideSwap TVL Adapter
+// Repo: DefiLlama/DefiLlama-Adapters
+// Path: projects/tideswap/index.js
+//
+// TideSwap is a Uniswap V2 fork + meta-aggregator (0x + LI.FI) on Ink L2.
+// TVL = liquidity locked in TideSwap's Uniswap V2 AMM pools.
+
+const { uniTvlExport } = require('../helper/unknownTokens')
+
+const FACTORY = '0x2ebE0528aDED9fA8d745B7C7082fb90d7C7B6Ec8'
+
+module.exports = uniTvlExport('ink', FACTORY)


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
TideSwap

##### Twitter Link:
https://x.com/TideSwapApp

##### List of audit links if any:

##### Website Link:
tideswap.app

##### Logo (High resolution, will be shown with rounded borders):
https://tideswap.app/logo-512.png

##### Current TVL:
~$500

##### Treasury Addresses (if the protocol has treasury)
0x647128722e6aC0FDF10C1c5bEB9d37C66cE6f907

##### Chain:
Ink (57073)

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):

##### Short Description (to be shown on DefiLlama):
Meta-aggregator (0x + LI.FI) and Uniswap V2 AMM on Ink L2

##### Token address and ticker if any:

##### Category:
Dexes

##### Oracle Provider(s):
None

##### Implementation Details:
N/A

##### Documentation/Proof:
N/A

##### forkedFrom:
Uniswap V2

##### methodology:
TVL is the total value of tokens locked in TideSwap's Uniswap V2 AMM liquidity pools on Ink. Computed on-chain via the factory contract using the uniTvlExport helper.

##### Github org/user:
Cryptodian1

##### Does this project have a referral program?
No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TideSwap TVL tracking for the Ink network, enabling monitoring of liquidity and total value locked for the TideSwap protocol.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->