### PR TITLE
Add new Base pools and need oracle support

### DIFF
--- a/projects/zyfai/base.js
+++ b/projects/zyfai/base.js
@@ -16,6 +16,7 @@ const MORPHO_POOL_ADDRESSES = {
     'Spark USDC Vault': '0x7BfA7C4f149E7415b73bdeDfe609237e29CBF34A',
     'Steakhouse Prime USDC': '0xBEEFE94c8aD530842bfE7d8B397938fFc1cb83b2',
     'Steakhouse High Yield USDC': '0xBEEFA7B88064FeEF0cEe02AAeBBd95D30df3878F',
+    'Clearstar USDC Reactor': '0x1D3b1Cd0a0f242d598834b3F2d126dC6bd774657'
 };
 const SPARK_POOL_ADDRESSES = {
     'USDC': '0x3128a0F7f0ea68E7B7c9B00AFa7E41045828e858'
@@ -38,6 +39,9 @@ const YIELDFI_BASE_POOLS = {
     'yUSD': '0x4772D2e014F9fC3a820C444e3313968e9a5C8121',
     'vyUSD': '0xF4F447E6AFa04c9D11Ef0e2fC0d7f19C24Ee55de',
 };
+const BASE_EULER_POOLS = {
+    'AlphaGrowth': '0x4C1aeda9B43EfcF1da1d1755b18802aAbe90f61E',
+};
 
 const allPoolTokens = [
     ...Object.values(HARVEST_POOLS),
@@ -48,6 +52,7 @@ const allPoolTokens = [
     ...Object.values(SPARK_POOL_ADDRESSES),
     ...Object.values(MORPHO_POOL_ADDRESSES),
     ...Object.values(FLUID_POOL_ADDRESSES),
+    ...Object.values(BASE_EULER_POOLS),
     COMPOUND_TOKEN_ADDRESS,
     AAVE_TOKEN_ADDRESS,
 ]


### PR DESCRIPTION
New Pools for Base
```
const Morpho = {
'Clearstar USDC Reactor': '0x1D3b1Cd0a0f242d598834b3F2d126dC6bd774657'
}

const BASE_EULER_POOLS = {
    'AlphaGrowth': '0x4C1aeda9B43EfcF1da1d1755b18802aAbe90f61E',
};
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Clearstar USDC Reactor pool
  * Added support for AlphaGrowth pool

<!-- end of auto-generated comment: release notes by coderabbit.ai -->