### PR TITLE
Add new Bitcoin address to stacksSBTC

### DIFF
--- a/projects/helper/bitcoin-book/index.js
+++ b/projects/helper/bitcoin-book/index.js
@@ -28,6 +28,7 @@ const stacksSBTC = [
   // https://docs.stacks.co/concepts/sbtc/clarity-contracts/sbtc-deposit
   'bc1pl033nz4lj7u7wz3l2k2ew3f7af4sdja8r25ernl00thflwempayswr5hvc',
   'bc1prcs82tvrz70jk8u79uekwdfjhd0qhs2mva6e526arycu7fu25zsqhyztuy',
+  'bc1p6ys2ervatu00766eeqfmverzegg9fkprn3xjn0ppn70h53qu5vus3yzl0x'
 ]
 
 const magpie = [


### PR DESCRIPTION
Stacks sBTC protocol completer a signer rotation last week. When this happens, we rotate the keys of the signers, which generates a new address for the underlying BTC. The current address it outdated and needs to be updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Bitcoin network configuration with a new address entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->