### PR TITLE
Add 2xSwap TVL adapter

### DIFF
--- a/projects/twoxswap/index.js
+++ b/projects/twoxswap/index.js
@@ -1,0 +1,13 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+
+const X2Pool = '0x2a315Fef86916B30905086C85A9cB55E5DCD7ED3'
+
+async function tvl(api) {
+  const totalAssets = await api.call({ target: X2Pool, abi: 'uint256:totalAssets' })
+  api.add(ADDRESSES.ethereum.USDC, totalAssets)
+}
+
+module.exports = {
+  methodology: 'TVL is the total USDC deposited in the X2Pool ERC-4626 vault, measured via totalAssets().',
+  ethereum: { tvl },
+}


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
2xSwap

##### Twitter Link:
https://x.com/2xswap

##### List of audit links if any:
Audited by Null Return (report available)

##### Website Link:
https://2xswap.com

##### Logo (High resolution, will be shown with rounded borders):
https://2xswap.com/2xswap-logo.png

##### Current TVL:
~$2.2k (protocol recently launched on mainnet)

##### Treasury Addresses (if the protocol has treasury)
N/A

##### Chain:
Ethereum

##### Coingecko ID:

##### Coinmarketcap ID:

##### Short Description (to be shown on DefiLlama):
2x leverage swaps with no liquidation and no interest. Liquidity providers deposit USDC into an ERC-4626 vault.

##### Token address and ticker if any:
N/A

##### Category:
Derivatives

##### Oracle Provider(s):
Chainlink (ETH/USD, BTC/USD price feeds used by swap contracts)

##### Implementation Details:
Chainlink price feeds are used by X2Swap contracts to determine entry/exit prices for leveraged positions. The TVL adapter reads totalAssets() from the ERC-4626 vault which holds all protocol USDC liquidity.

##### Documentation/Proof:
https://github.com/XUser77/2x-swap

##### forkedFrom:
N/A

##### methodology:
TVL is the total USDC deposited in the X2Pool ERC-4626 vault (0x2a315Fef86916B30905086C85A9cB55E5DCD7ED3), measured via the totalAssets() function. This vault holds all protocol liquidity used by the WETH and WBTC 2x leverage swap contracts.

##### Github org/user:
XUser77

##### Does this project have a referral program?
No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated TwoXSwap TVL tracking on Ethereum, providing visibility into total value locked across the protocol.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->