### PR TITLE
Feat/add missing tvl from ethereum and arbitrum chains

### DIFF
--- a/projects/yo/index.js
+++ b/projects/yo/index.js
@@ -1,5 +1,4 @@
-const vaults = {
-  base: [
+const yoVaultsBase = [
     '0x3a43aec53490cb9fa922847385d82fe25d0e9de7',
     '0xbCbc8cb4D1e8ED048a6276a5E94A3e952660BcbC',
     '0x0000000f2eB9f69274678c76222B35eEc7588a65',


### PR DESCRIPTION
Existing project, but want these fields to be updated on defillama if possible: 

##### List of audit links if any: docs.yo.xyz/security-audits

##### Current TVL: $66M

##### Chain: Base, Ethereum, Arbitrum

##### Coingecko ID: yo

##### Token address and ticker if any: $YO 0x1925450f5e5fb974b0aae1f3408cf5286fbd1a72

##### methodology (what is being counted as tvl, how is tvl being calculated): We calculate TVL based on the Total Assets of each vault contract on each chain where users deposit into YO vaults


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ethereum and Arbitrum vault networks with TVL metrics.
  * Expanded Base network vault support with additional addresses.

* **Documentation**
  * Updated TVL calculation methodology documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->