### PR TITLE
fix yo doublecount 

### DIFF
--- a/projects/yo/index.js
+++ b/projects/yo/index.js
@@ -1,32 +1,39 @@
+const YOUSD = '0x0000000f2eB9f69274678c76222B35eEc7588a65'
+const ALCHEMIST_CS = '0x87428d886F43068A44d7bDEeF106D3c42E1d6f23'
+
 const vaults = {
     base: [
         '0x3a43aec53490cb9fa922847385d82fe25d0e9de7',
         '0xbCbc8cb4D1e8ED048a6276a5E94A3e952660BcbC',
-        '0x0000000f2eB9f69274678c76222B35eEc7588a65',
         '0x50c749aE210D3977ADC824AE11F3c7fd10c871e9'
     ],
     ethereum: [
         '0x3a43aec53490cb9fa922847385d82fe25d0e9de7',
         '0xbCbc8cb4D1e8ED048a6276a5E94A3e952660BcbC',
-        '0x0000000f2eB9f69274678c76222B35eEc7588a65',
         '0x50c749aE210D3977ADC824AE11F3c7fd10c871e9',
         '0x586675A3a46B008d8408933cf42d8ff6c9CC61a1'
     ],
-    arbitrum: [
-        '0x0000000f2eB9f69274678c76222B35eEc7588a65'
-    ]
+    arbitrum: []
 }
 
 async function tvl(api) {
-    return api.erc4626Sum2({
-        calls: vaults[api.chain],
-    });
+    await api.erc4626Sum2({ calls: [...vaults[api.chain], YOUSD] });
+}
+
+async function ethereumTvl(api) {
+    await tvl(api);
+    // Subtract AlchemistCS's yoUSD position to prevent double counting
+    // yoGOLD -> AlchemistCS -> yoUSD
+    const shares = await api.call({ abi: 'erc20:balanceOf', target: YOUSD, params: ALCHEMIST_CS })
+    const assets = await api.call({ abi: 'function convertToAssets(uint256) view returns (uint256)', target: YOUSD, params: shares })
+    const asset = await api.call({ abi: 'address:asset', target: YOUSD })
+    api.add(asset, -assets)
 }
 
 module.exports = {
     methodology: "We calculate TVL based on the Total Assets of each vault contract on each chain where users can deposit into YO vaults",
     doublecounted: true,
     base: { tvl },
-    ethereum: { tvl },
+    ethereum: { tvl: ethereumTvl },
     arbitrum: { tvl },
 };


### PR DESCRIPTION
The [yoGOLD vault](https://app.yo.xyz/vault/ethereum/0x586675A3a46B008d8408933cf42d8ff6c9CC61a1/vault-breakdown) allocates to the [AlchemistCS fusion vault](https://app.ipor.io/fusion/ethereum/0x87428d886f43068a44d7bdeef106d3c42e1d6f23), which holds [yoUSD](https://app.yo.xyz/vault/base/0x0000000f2eB9f69274678c76222B35eEc7588a65) shares. This PR removes the AlchemistCS yoUSD shares from the yoUSD tvl on ethereum.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined Total Value Locked (TVL) calculations across blockchain networks with enhanced handling for the Ethereum chain to ensure accurate asset value reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->