### PR TITLE
Fix BitChill underlying tvl

### DIFF
--- a/projects/ergopad/index.js
+++ b/projects/ergopad/index.js
@@ -1,6 +1,7 @@
 const { sumTokensExport } = require('../helper/sumTokens')
 
 module.exports = {
+  deadFrom: '2026-03-01',
   timetravel: false,
   ergo: {
     tvl: () => ({}),


### PR DESCRIPTION
## Summary
The current BitChill adapter sums receipt tokens (`kDOC`, `kUSDRIF`, `iSUSD`) directly, which undercounts TVL on Rootstock because Tropykus kTokens are mispriced/mis-scaled by a factor of 1e10. Sovryn (`iSUSD`) attribution appears fine.

This PR computes TVL from **underlying stablecoins** held by the handlers:
- Tropykus: `balanceOf(kToken, handler) * exchangeRateStored() / 1e18` → add DOC/USDRIF
- Sovryn: `loanTokenAddress()` + `assetBalanceOf(handler)` → add underlying

Keeps `doublecounted: true` since deposits sit in Tropykus/Sovryn.