### PR TITLE
feat: add Elusiv, Vanish Trade, and Turbine Cash (Solana privacy protocols)

### DIFF
--- a/projects/elusiv/index.js
+++ b/projects/elusiv/index.js
@@ -1,0 +1,21 @@
+const { sumTokensExport } = require('../helper/solana')
+const ADDRESSES = require('../helper/coreAssets.json')
+
+// Elusiv — Solana privacy protocol (sunset, TVL remains locked in pool)
+// Pool address: HszJz1zLnYpK5e8TvsRDPSDrxc19qFuhWrFQG6xY2aMX
+
+module.exports = {
+  deadFrom: '2024-01-01', // protocol sunset
+  methodology: 'Total value of all tokens held in the Elusiv privacy pool smart contract',
+  solana: {
+    tvl: sumTokensExport({
+      owners: ['HszJz1zLnYpK5e8TvsRDPSDrxc19qFuhWrFQG6xY2aMX'],
+      tokens: [
+        ADDRESSES.solana.USDC,
+        ADDRESSES.solana.USDT,
+        ADDRESSES.solana.BONK,
+      ],
+      solOwners: ['HszJz1zLnYpK5e8TvsRDPSDrxc19qFuhWrFQG6xY2aMX'],
+    }),
+  },
+}

--- a/projects/turbine-cash/index.js
+++ b/projects/turbine-cash/index.js
@@ -1,4 +1,4 @@
-const { sumTokensExport } = require('../helper/solana')
+const { getTokenSupplies } = require('../helper/solana')
 
 // Turbine — Solana privacy protocol using zSOL (wrapped SOL)
 // zSOL mint: zso1EF4k8HNteye34aD8w2Fm6pYVWMDgkgWCUrMLip1
@@ -7,9 +7,6 @@ const { sumTokensExport } = require('../helper/solana')
 module.exports = {
   methodology: 'Circulating supply of zSOL tokens, each backed 1:1 by SOL deposited into Turbine privacy pools',
   solana: {
-    tvl: sumTokensExport({
-      tokens: ['zso1EF4k8HNteye34aD8w2Fm6pYVWMDgkgWCUrMLip1'],
-      useDefaultCoreAssets: false,
-    }),
+    tvl: getTokenSupplies(['zso1EF4k8HNteye34aD8w2Fm6pYVWMDgkgWCUrMLip1']),
   },
 }

--- a/projects/turbine-cash/index.js
+++ b/projects/turbine-cash/index.js
@@ -1,0 +1,15 @@
+const { sumTokensExport } = require('../helper/solana')
+
+// Turbine — Solana privacy protocol using zSOL (wrapped SOL)
+// zSOL mint: zso1EF4k8HNteye34aD8w2Fm6pYVWMDgkgWCUrMLip1
+// TVL = circulating supply of zSOL (each zSOL backed 1:1 by SOL in the pool)
+
+module.exports = {
+  methodology: 'Circulating supply of zSOL tokens, each backed 1:1 by SOL deposited into Turbine privacy pools',
+  solana: {
+    tvl: sumTokensExport({
+      tokens: ['zso1EF4k8HNteye34aD8w2Fm6pYVWMDgkgWCUrMLip1'],
+      useDefaultCoreAssets: false,
+    }),
+  },
+}

--- a/projects/vanish-trade/index.js
+++ b/projects/vanish-trade/index.js
@@ -1,0 +1,13 @@
+const { sumTokensExport } = require('../helper/solana')
+
+// Vanish Trade — Solana privacy protocol
+// Pool: 8MjKXQgj97NPVNhj9gJrQNP7BibGCGkFMVJ2qZsC58E
+
+module.exports = {
+  methodology: 'Total value of SOL held in the Vanish Trade shielded pool contract',
+  solana: {
+    tvl: sumTokensExport({
+      solOwners: ['8MjKXQgj97NPVNhj9gJrQNP7BibGCGkFMVJ2qZsC58E'],
+    }),
+  },
+}


### PR DESCRIPTION
## New adapters: Solana Privacy Protocols

Adding TVL adapters for three Solana privacy protocols not yet listed on DefiLlama.

### Elusiv (~$334K TVL)
- Privacy protocol on Solana (sunset, funds remain locked)
- Pool: `HszJz1zLnYpK5e8TvsRDPSDrxc19qFuhWrFQG6xY2aMX`
- Tracks: SOL, USDC, USDT, BONK

### Vanish Trade (~$43K TVL)
- Live Solana privacy protocol
- Pool: `8MjKXQgj97NPVNhj9gJrQNP7BibGCGkFMVJ2qZsC58E`
- Tracks: SOL

### Turbine Cash (~$9.7K TVL)
- Live Solana privacy protocol using zSOL (1:1 SOL-backed)
- zSOL mint: `zso1EF4k8HNteye34aD8w2Fm6pYVWMDgkgWCUrMLip1`
- Tracks: zSOL supply

**Data verified against:** https://www.shieldedsol.com (Solana privacy TVL tracker)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for Elusiv on Solana.
  * Added TVL tracking for Turbine Cash on Solana.
  * Added TVL tracking for Vanish Trade on Solana.
  * Provides visibility into assets held in these Solana privacy and shielded-pool contracts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->