### PR TITLE
Fix RCE vulnerability in uno-farm adapter

### DIFF
--- a/projects/uno-farm/apps.json
+++ b/projects/uno-farm/apps.json
@@ -6,7 +6,7 @@
       ],
       "masterChefs": ["0x0769fd68dFb93167989C6f7254cd0D766Fb2841F"],
       "factory": "0xb8698FbDFcd6044fA9C56938a50D7D0FDD22e8F0",
-      "getLPAddress": ["((a) => a)"],
+      "getLPAddress": ["raw"],
       "name": "sushiswap"
     },
     {
@@ -15,7 +15,7 @@
       ],
       "masterChefs": ["0x54aff400858Dcac39797a81894D9920f16972D1D"],
       "factory": "0x35E19FD59212985209339aDD9fe0649604ffB7Be",
-      "getLPAddress": ["((a) => a)"],
+      "getLPAddress": ["raw"],
       "name": "apeswap"
     },
     {
@@ -34,7 +34,7 @@
           ],
         "masterChefs": ["0xa5f8C5Dbd5F286960b9d90548680aE5ebFf07652"],
         "factory": "0xd62c64a8846d704c7775679982219e477dcB564A",
-        "getLPAddress": ["((a) => a)"],
+        "getLPAddress": ["raw"],
         "name": "pancakeswap"
       },
       {
@@ -43,7 +43,7 @@
         ],
         "masterChefs": ["0x5c8D727b265DBAfaba67E050f2f739cAeEB4A6F9"],
         "factory": "0x50cE50F5c2835D3A9c257A27D814E8d2C039449b",
-        "getLPAddress": ["((a) => a[0])"],
+        "getLPAddress": ["index0"],
         "name": "apeswap"
       }
   ],
@@ -54,7 +54,7 @@
         ],
         "masterChefs": ["0x3838956710bcc9D122Dd23863a0549ca8D5675D6"],
         "factory": "0x552f55dDbCD8a5e2ae6f07b5e369675A62c1F957",
-        "getLPAddress": ["((a) => a)"],
+        "getLPAddress": ["raw"],
         "name": "Trisolaris Stable"
       },
       {
@@ -64,7 +64,7 @@
         ],
         "masterChefs": ["0x1f1Ed214bef5E83D8f5d0eB5D7011EB965D0D79B","0x3838956710bcc9D122Dd23863a0549ca8D5675D6"],
         "factory": "0x64c9899fcdB6f9565Ba69B0939Aec51e320C5489",
-        "getLPAddress": ["((a) => a[0])","((a) => a)"],
+        "getLPAddress": ["index0","raw"],
         "name": "Trisolaris Standard"
       }
       
@@ -77,7 +77,7 @@
       ],
       "masterChefs": ["0x188bED1968b795d5c9022F6a0bb5931Ac4c18F00","0x4483f0b6e2F5486D06958C20f8C39A7aBe87bf8F"],
       "factory": "0x6Eae93D177BFDDAF5ee238F55C36A847A35E62A0",
-      "getLPAddress": ["((a) => a[0])","((a) => a[0])"],
+      "getLPAddress": ["index0","index0"],
       "name": "Traderjoe"
     }
   ]

--- a/projects/uno-farm/index.js
+++ b/projects/uno-farm/index.js
@@ -8,6 +8,11 @@ const {
 const { getUserMasterChefBalances } = require("../helper/masterchef");
 const apps = require("./apps.json");
 
+const addressStrategies = {
+  raw: (a) => a,
+  index0: (a) => a[0],
+};
+
 async function defaultTVL({ balances, chain, block, app }) {
   const farms = await getUnoFarms({ chain, block, factory: app.factory });
   const promises = [];
@@ -22,7 +27,7 @@ async function defaultTVL({ balances, chain, block, app }) {
           block,
           chain,
           poolInfoABI: app.poolInfoABI[k],
-          getLPAddress: app.getLPAddress[k] ? eval(app.getLPAddress[k]) : null,
+          getLPAddress: app.getLPAddress[k] ? addressStrategies[app.getLPAddress[k]] : null,
         })
       );
     }


### PR DESCRIPTION
## Summary
- Eliminates `eval()` arbitrary code execution vulnerability in `projects/uno-farm/index.js`
- Replaces dynamically evaluated stringified functions in `apps.json` with a safe lookup map using named strategy keys (`raw`, `index0`)
- No behavioral change — same TVL output

## Security Impact
The original code used `eval()` on JSON-stored lambda strings (e.g., `eval("((a) => a)")`), allowing arbitrary code execution if the JSON was tampered with. This replaces them with a deterministic lookup map.

## Test plan
- [ ] Verify uno-farm TVL output matches before/after
- [ ] Confirm no eval() calls remain in the adapter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated LP address extraction configuration across farm networks (Polygon, Binance Smart Chain, Aurora, and Avalanche) to enhance code maintainability and reduce complexity without impacting user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->