### PR TITLE
Fix SSL verification disabled in proxiedFetch

### DIFF
--- a/projects/helper/http.js
+++ b/projects/helper/http.js
@@ -111,11 +111,7 @@ async function proxiedFetch(url) {
 
   const [host, username, password] = authInfo.split(':')
 
-  const client = axios.create({
-    httpsAgent: new https.Agent({
-      rejectUnauthorized: false,
-    }),
-  });
+  const client = axios.create();
   const { data } = await client
     .get(url.toString(), {
       proxy: {

--- a/projects/helper/http.test.js
+++ b/projects/helper/http.test.js
@@ -1,0 +1,82 @@
+
+const { test, describe, before, after, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const axios = require('axios');
+const httpHelper = require('./http');
+
+describe('http helper', () => {
+  describe('proxiedFetch', () => {
+    let originalCreate;
+    let originalProxyAuth;
+
+    // Store original create method
+    originalCreate = axios.create;
+
+    beforeEach(() => {
+        originalProxyAuth = process.env.PROXY_AUTH;
+    });
+
+    afterEach(() => {
+        if (originalProxyAuth === undefined) {
+            delete process.env.PROXY_AUTH;
+        } else {
+            process.env.PROXY_AUTH = originalProxyAuth;
+        }
+        // Restore axios.create in case a test failed to restore it or modified it
+        axios.create = originalCreate;
+    });
+
+    test('should NOT disable SSL verification', async () => {
+      let capturedConfig;
+      let createCalled = false;
+
+      // Mock axios.create
+      axios.create = (config) => {
+        capturedConfig = config;
+        createCalled = true;
+        return {
+          get: async () => ({ data: 'success' })
+        };
+      };
+
+      process.env.PROXY_AUTH = 'host:user:pass';
+
+      // Call the function
+      await httpHelper.proxiedFetch('https://example.com');
+
+      assert.strictEqual(createCalled, true, 'axios.create should be called');
+
+      // Verify that if httpsAgent is present, rejectUnauthorized is NOT false
+      if (capturedConfig && capturedConfig.httpsAgent && capturedConfig.httpsAgent.options) {
+         assert.notStrictEqual(capturedConfig.httpsAgent.options.rejectUnauthorized, false, 'rejectUnauthorized should not be false');
+      } else {
+         // If config is undefined or no httpsAgent, it uses default secure agent.
+         assert.ok(true, 'Secure default config used');
+      }
+    });
+
+    test('should verify correct proxy configuration', async () => {
+      let capturedProxyConfig;
+
+      axios.create = () => {
+        return {
+          get: async (url, config) => {
+            capturedProxyConfig = config.proxy;
+            return { data: 'success' };
+          }
+        };
+      };
+
+      process.env.PROXY_AUTH = 'proxy.example.com:user123:pass456';
+
+      await httpHelper.proxiedFetch('https://target.com');
+
+      assert.deepStrictEqual(capturedProxyConfig, {
+        protocol: "https",
+        host: "proxy.example.com",
+        port: 8000,
+        auth: { username: "user123", password: "pass456" },
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Removes `rejectUnauthorized: false` from `proxiedFetch` in `projects/helper/http.js`
- This was silently disabling SSL certificate verification for all proxied HTTP requests, making them vulnerable to MITM attacks
- Also removes the unused/broken `https` import that caused a ReferenceError

## Test plan
- [ ] Verify proxied fetches still work with SSL enabled
- [ ] Run adapter tests that use proxiedFetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored default TLS certificate verification behavior for HTTP requests over proxies.

* **Tests**
  * Added unit tests to verify SSL verification remains enabled and proxy configuration is correctly applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->