### PR TITLE
fix(sablier-legacy): normalize blacklisted tokens using getUniqueAddresses

### DIFF
--- a/projects/sablier-legacy/index.js
+++ b/projects/sablier-legacy/index.js
@@ -4,12 +4,11 @@ const { covalentGetTokens } = require('../helper/token')
 const { isWhitelistedToken } = require('../helper/streamingHelper')
 const { getUniqueAddresses } = require('../helper/utils')
 
-const blacklistedTokens = [
+const blacklistedTokens = getUniqueAddresses([
   ADDRESSES.ethereum.sUSD_OLD,
-  // TODO: We shouldn't need to lowercase here
-  ADDRESSES.ethereum.SAI.toLowerCase(),
+  ADDRESSES.ethereum.SAI,
   ADDRESSES.ethereum.MKR,
-]
+])
 
 const config = {
   ethereum: {


### PR DESCRIPTION
## Summary
- Fixes token blacklist filtering by wrapping `blacklistedTokens` in `getUniqueAddresses()` at definition time
- Previously, case-sensitive comparison could miss blacklisted tokens (SAI address)
- Resolves existing TODO in the codebase

## Test plan
- [ ] Verify sablier-legacy TVL output is correct
- [ ] Confirm SAI tokens are properly excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated address deduplication to use runtime-based generation instead of static configuration, maintaining the same functional behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->