### PR TITLE
fix: correct signed integer reading for TON workchain in utils

### DIFF
--- a/projects/helper/utils/ton.js
+++ b/projects/helper/utils/ton.js
@@ -58,12 +58,7 @@ function parseFriendlyAddress(src) {
 
   isBounceable = tag === bounceable_tag;
 
-  let workchain = null;
-  if (addr[1] === 0xff) { // TODO we should read signed integer here
-      workchain = -1;
-  } else {
-      workchain = addr[1];
-  }
+  let workchain = addr.readInt8(1);
 
   const hashPart = addr.subarray(2, 34);
 


### PR DESCRIPTION
## Summary
- Replaces manual if/else workchain parsing with `addr.readInt8(1)` for correct signed integer reading
- The original code only handled `0xff` (-1) and treated everything else as unsigned
- Resolves TODO: "we should read signed integer here"

## Test plan
- [ ] Verify TON adapter TVL is unchanged
- [ ] Confirm workchain -1 and 0 are both parsed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced address parsing to correctly interpret workchain values across all supported address formats. The updated parsing logic ensures proper handling of addresses with various byte patterns, improving compatibility and reducing potential issues with address processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->