### PR TITLE
fix: Cauldron TVL heuristic and precision bug

### DIFF
--- a/projects/cauldron/index.js
+++ b/projects/cauldron/index.js
@@ -13,11 +13,8 @@ async function tvl({ timestamp }) {
     return acc + BigInt(token_pair.satoshis)
   }, BigInt(0));
 
-  // TODO: Map tokens to CoinGecko identifiers.
-  // Currently, no tokens on the Bitcoin Cash are on CoinGecko.
-
   return {
-    'bitcoin-cash': Number(total_sats / 100000000n),
+    'bitcoin-cash': Number(total_sats) * 2 / 1e8,
   }
 }
 


### PR DESCRIPTION
## Summary
- Fixes BigInt integer-division precision loss in Cauldron BCH TVL calculation
- Applies 2x multiplier heuristic for CPMM pools (each pool has two sides, API returns one-side satoshis)
- Changes from `Number(total_sats / 100000000n)` to `Number(total_sats) * 2 / 1e8`

## Test plan
- [ ] Verify Cauldron BCH TVL is within expected range
- [ ] Confirm precision is maintained for large sats values

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Bitcoin Cash (BCH) Total Value Locked (TVL) calculation to reflect adjusted values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->