### PR TITLE
Fix missing base leg USD value for Drift perps without spot mint

### DIFF
--- a/projects/neutral-trade/utils/drift.js
+++ b/projects/neutral-trade/utils/drift.js
@@ -2099,9 +2099,12 @@ async function getTvl(api, driftVaultAddresses) {
         if (baseTokenMint) {
           api.add(baseTokenMint, baseBalance);
         } else {
-          // e.g. HYPE-PERP: no SPL spot mint; skip base leg to avoid "missing token"
-          // console.log(`No spot mint for perp market ${position.market_index} (${meta?.name}); skipping base leg`);
-          // TODO: find usd price and api.add(getTokenMintFromMarketIndex(0), usdValue); 
+          const perpAccount = perpAccountMap[position.market_index];
+          if (perpAccount && perpAccount.data) {
+            const price = perpAccount.data.readBigInt64LE(72);
+            const usdValue = (position.base_asset_amount * price) / BigInt(10 ** 9);
+            api.add(getTokenMintFromMarketIndex(0), usdValue);
+          }
         }
 
         const quoteTokenMint = getTokenMintFromMarketIndex(0);


### PR DESCRIPTION
## Summary
- Implements the previously-skipped TODO in `projects/neutral-trade/utils/drift.js`
- Computes USD value for perp positions whose base token has no SPL spot mint (e.g., HYPE-PERP)
- Uses the cached oracle price from the perp account buffer at offset 72
- Math: `usdValue = (base_asset_amount * lastOraclePrice) / 10^9`

## Test plan
- [ ] Verify neutral-trade TVL includes HYPE-PERP and similar positions
- [ ] Confirm TVL is consistent with Drift dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)