### PR TITLE
Add Single Depositor Vaults support for Aera v3

### DIFF
--- a/projects/aera-v3/contracts.js
+++ b/projects/aera-v3/contracts.js
@@ -2,7 +2,7 @@ const { ethers } = require("ethers");
 
 const topics = {
     MultiDepositorVault_VaultCreated: ethers.id("VaultCreated(address,address,address,(string,string),(address,address,address),address,string)"),
-    SingleDepositorVault_VaultCreated: ethers.id("VaultCreated(address,address,address,(string,string),(address,address,address),address,string)"),
+    SingleDepositorVault_VaultCreated: ethers.id("VaultCreated(address,address,address,address,address,address,string)"),
 }
 const eventAbis = {
     MultiDepositorVault_VaultCreated: 'event VaultCreated(address indexed vault, address indexed owner, address hooks, (string name, string symbol) erc20Params, (address feeCalculator, address feeToken, address feeRecipient) feeVaultParams, address beforeTransferHook, string description)',

--- a/projects/aera-v3/index.js
+++ b/projects/aera-v3/index.js
@@ -1,10 +1,10 @@
-const { getMultiDepositorVaults } = require('./utils');
+const { getMultiDepositorVaults, getSingleDepositorVaults } = require('./utils');
 
 async function tvl(api) {
     const multiDepositorVaults = await getMultiDepositorVaults(api);
+    const singleDepositorVaults = await getSingleDepositorVaults(api);
 
     // Compute TVL for multi depositor vaults
-    // TODO: Add single depositor vaults
     await Promise.all(multiDepositorVaults.map(async (vault) => {
         const [totalSupply, feeCalculator, decimals ] = await Promise.all([
             api.call({
@@ -37,6 +37,45 @@ async function tvl(api) {
         const numeraireBalance = totalSupply * unitPrice / 10 ** decimals;
 
         api.add(numeraireToken, numeraireBalance);
+    }));
+
+    // Compute TVL for single depositor vaults
+    await Promise.all(singleDepositorVaults.map(async ({ vault, feeCalculator }) => {
+        const numeraireToken = await api.call({
+            abi: 'function NUMERAIRE() view returns (address)',
+            target: feeCalculator,
+        });
+
+        try {
+            const value = await api.call({
+                abi: 'function value() view returns (uint256)',
+                target: vault,
+            });
+            api.add(numeraireToken, value);
+        } catch (e) {
+            // Fallback: use getVaultState if value() fails
+            try {
+                const [vaultState, decimals] = await Promise.all([
+                    api.call({
+                        abi: 'function getVaultState(address vault) external view returns ((bool paused, uint8 maxPriceAge, uint16 minUpdateIntervalMinutes, uint16 maxPriceToleranceRatio, uint16 minPriceToleranceRatio, uint8 maxUpdateDelayDays, uint32 timestamp, uint24 accrualLag, uint128 unitPrice, uint128 highestPrice, uint128 lastTotalSupply))',
+                        target: feeCalculator,
+                        params: [vault],
+                    }),
+                    api.call({
+                        abi: 'function decimals() view returns (uint8)',
+                        target: vault,
+                    }).catch(() => 18) // Default to 18 if decimals() fails
+                ]);
+
+                const unitPrice = vaultState.unitPrice;
+                const lastTotalSupply = vaultState.lastTotalSupply;
+                const numeraireBalance = lastTotalSupply * unitPrice / 10 ** decimals;
+
+                api.add(numeraireToken, numeraireBalance);
+            } catch (e2) {
+                console.log(`Failed to get TVL for single depositor vault ${vault}`);
+            }
+        }
     }));
 }
 

--- a/projects/aera-v3/utils.js
+++ b/projects/aera-v3/utils.js
@@ -17,6 +17,24 @@ async function getMultiDepositorVaults(api) {
     return vaults;
 }
 
+async function getSingleDepositorVaults(api) {
+    const factory = contracts[api.chain].singleDepositorVaultFactory;
+    const logs = await getLogs({
+        api,
+        target: factory.address,
+        topic: factory.topic,
+        topics: factory.topics,
+        eventAbi: factory.eventAbi,
+        fromBlock: factory.fromBlock,
+        onlyArgs: true,
+    });
+    return logs.map(x => ({
+        vault: x.vault,
+        feeCalculator: x.feeCalculator
+    }));
+}
+
 module.exports = {
     getMultiDepositorVaults,
+    getSingleDepositorVaults,
 };


### PR DESCRIPTION
## Summary
- Adds TVL tracking for Aera v3 single depositor vaults
- Fixes topic hash for `SingleDepositorVault_VaultCreated` in contracts.js
- Calculates TVL using `value()` with `getVaultState()` fallback

## Test plan
- [ ] Verify Aera v3 TVL includes single depositor vaults
- [ ] Confirm existing vault TVL is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)