### PR TITLE
chore: remove unused shadowed variable in testInteractive.js

### DIFF
--- a/utils/testInteractive.js
+++ b/utils/testInteractive.js
@@ -47,7 +47,6 @@ async function run() {
 }
 
 async function runAdapter(adapterPath, debugMode) {
-  const startTime = Date.now()
   return new Promise((resolve, reject) => {
     const env = {
       ...process.env,


### PR DESCRIPTION
## Summary
- Removes unused `startTime` variable from `utils/testInteractive.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)