### PR TITLE
chore(tron): remove unused getTrxBalance function

### DIFF
--- a/projects/helper/chain/tron.js
+++ b/projects/helper/chain/tron.js
@@ -1,22 +1,10 @@
-const { getEnv } = require('../env')
-const { get, post, } = require('../http')
+const { get } = require('../http')
 
 async function getStakedTron(account) {
   const data = await get(`https://apilist.tronscan.org/api/vote?candidate=${account}`)
   return data.totalVotes
 }
 
-
-// not used anywhere?
-async function getTrxBalance(account) {
-  const data = await post(getEnv('TRON_RPC')+'/wallet/getaccount', {
-    address: account,
-    visible: true,
-  })
-  return data.balance + (data.frozen?.reduce((t, { frozen_balance }) => t + frozen_balance, 0) ?? 0)
-}
-
 module.exports = {
   getStakedTron,
-  getTrxBalance,
 }


### PR DESCRIPTION
## Summary
- Removes `getTrxBalance` function marked as unused, along with its unused imports (`post`, `getEnv`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)