### PR TITLE
Refactor Solend Eclipse token mapping to use central helper

### DIFF
--- a/projects/helper/portedTokens.js
+++ b/projects/helper/portedTokens.js
@@ -73,7 +73,7 @@ function transformChainAddress(
 ) {
 
   return addr => {
-    if (['solana'].includes(chain)) {
+    if (svmChains.includes(chain)) {
       return mapping[addr] ? mapping[addr] : `${chain}:${addr}`
     }
     if (!addr.startsWith('0x')) return addr

--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -28,6 +28,12 @@ const caseSensitiveChains = [...ibcChains, ...svmChains, 'tezos', 'ton', 'algora
 ]
 
 const transformTokens = {
+  eclipse: {
+    '8gEs8igcTdyrKzvEQh3oPpZm4HqNYozyczBCPQmZrsyp': 'eclipse:' + ADDRESSES.eclipse.ETH_2,
+    '7rCPN5Lcaxomf92ssF4M9dd8FVMoM43NLsWZyMd6DpNp': 'eclipse:' + ADDRESSES.eclipse.WIF,
+    '7mZCsut9beY53V9VWWovrRTBurGv6dozAmuhbwbyHsqk': 'eclipse:' + ADDRESSES.eclipse.SOL,
+    'Hke78vy1Mzzt5eEJ2jMeKtdqddedDe2rmzjsq16p9ETW': 'eclipse:' + ADDRESSES.eclipse.USDC,
+  },
   // Sample Code
   // cronos: {
   //   "0x065de42e28e42d90c2052a1b49e7f83806af0e1f": "0x123", // CRK token is mispriced

--- a/projects/solend/index.js
+++ b/projects/solend/index.js
@@ -25,29 +25,8 @@ async function tvl() {
   return sumTokens2({ owners: markets.map(i => i.authorityAddress) });
 }
 
-// TODO: Find a dynamic way to obtain this mapping
-const TOKEN_MINT_TO_TOKEN2022_MINT = {
-  [ADDRESSES.solana.SOL]: ADDRESSES.solana.SOL,
-  '8gEs8igcTdyrKzvEQh3oPpZm4HqNYozyczBCPQmZrsyp': ADDRESSES.eclipse.ETH_2,
-  '7rCPN5Lcaxomf92ssF4M9dd8FVMoM43NLsWZyMd6DpNp': ADDRESSES.eclipse.WIF,
-  '7mZCsut9beY53V9VWWovrRTBurGv6dozAmuhbwbyHsqk': ADDRESSES.eclipse.SOL,
-  'Hke78vy1Mzzt5eEJ2jMeKtdqddedDe2rmzjsq16p9ETW': ADDRESSES.eclipse.USDC,
-};
-
 async function eclipseTvl(api) {
-  const balances = await sumTokens2({ api, owners: ['5Gk1kTdDqqacmA2UF3UbNhM7eEhVFvF3p8nd9p3HbXxk'] });
-
-  const token2022MappedBalances = {};
-  for (const [key, value] of Object.entries(balances)) {
-    const token = key.split(':')[1];
-    if (TOKEN_MINT_TO_TOKEN2022_MINT[token]) {
-      token2022MappedBalances[`eclipse:${TOKEN_MINT_TO_TOKEN2022_MINT[token]}`] = value;
-    } else {
-      token2022MappedBalances[key] = value;
-    }
-  }
-
-  return token2022MappedBalances;
+  return sumTokens2({ api, owners: ['5Gk1kTdDqqacmA2UF3UbNhM7eEhVFvF3p8nd9p3HbXxk'] });
 }
 
 module.exports = {
@@ -64,4 +43,3 @@ module.exports = {
     ['2022-11-07', "FTX collapse, SOL whale liquidated"],
   ],
 };
-


### PR DESCRIPTION
## Summary
- Moves eclipse token mappings from solend adapter into global `transformTokens` map
- Uses `svmChains` instead of hardcoded `['solana']` in `portedTokens.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)