### PR TITLE
Refactor Dedust adapter to use price server for SCALE token

### DIFF
--- a/projects/dedust/index.js
+++ b/projects/dedust/index.js
@@ -1,8 +1,6 @@
 const { get } = require('../helper/http')
 const { call } = require('../helper/chain/ton')
 const { transformDexBalances } = require('../helper/portedTokens')
-const ADDRESSES = require("../helper/coreAssets.json");
-
 
 const SCALE_STAKING_ADDRESS = 'EQBNZB91JJX9Ub7KMEAUoQNVcQlCsob5e_WMFbvsML_UoAKD'
 const SCALE = "EQBlqsm144Dq6SjbPI4jjZvA1hqTIP3CvHovbIfW_t-SCALE"
@@ -26,10 +24,7 @@ module.exports = {
     },
     staking: async (api) => {
       const get_staking_data = await call({ target: SCALE_STAKING_ADDRESS, abi: "get_staking_data" })
-      // TODO: move this to price server
-      const price_response = await get(`https://tonapi.io/v2/rates?tokens=${SCALE}&currencies=ton`)
-      const scale_price = price_response.rates[SCALE].prices.TON
-      return api.add(ADDRESSES.ton.TON, parseInt(get_staking_data[3]) * scale_price)
+      api.add(SCALE, parseInt(get_staking_data[3]))
     }
   }
 }


### PR DESCRIPTION
## Summary
- Replaces manual price fetch from tonapi.io with direct `api.add(SCALE, ...)` call
- Eliminates external API dependency; DefiLlama price server handles conversion

🤖 Generated with [Claude Code](https://claude.com/claude-code)