### PR TITLE
Update: Morpho

### DIFF
--- a/projects/morpho-blue/index.js
+++ b/projects/morpho-blue/index.js
@@ -139,14 +139,14 @@ const config = {
     morphoBlue: "0x8183d41556Be257fc7aAa4A48396168C8eF2bEAD",
     fromBlock: 450759,
   },
-  // monad: {
-  //   morphoBlue: "0xD5D960E8C380B724a48AC59E2DfF1b2CB4a1eAee",
-  //   fromBlock: 31907457,
-  // },
-  // stable: {
-  //   morphoBlue: "0xa40103088A899514E3fe474cD3cc5bf811b1102e",
-  //   fromBlock: 2348260,
-  // },
+  monad: {
+    morphoBlue: "0xD5D960E8C380B724a48AC59E2DfF1b2CB4a1eAee",
+    fromBlock: 31907457,
+  },
+  stable: {
+    morphoBlue: "0xa40103088A899514E3fe474cD3cc5bf811b1102e",
+    fromBlock: 2348260,
+  },
   linea: {
     morphoBlue: "0x6B0D716aC0A45536172308e08fC2C40387262c9F",
     fromBlock: 25072608,
@@ -155,10 +155,10 @@ const config = {
     morphoBlue: "0xF4346F5132e810f80a28487a79c7559d9797E8B0",
     fromBlock: 52378788,
   },
-  // citrea: {
-  //   morphoBlue: "0x99D31FEcc885204b4136ea5D2ef2a37F36E3AeB8",
-  //   fromBlock: 2528230,
-  // },
+  citrea: {
+    morphoBlue: "0x99D31FEcc885204b4136ea5D2ef2a37F36E3AeB8",
+    fromBlock: 2528230,
+  },
 }
 
 const eventAbis = {


### PR DESCRIPTION
```
------ TVL ------
borrowed                  3.80 B
ethereum                  3.22 B
ethereum-borrowed         2.25 B
base                      2.06 B
base-borrowed             1.05 B
hyperliquid               424.82 M
katana                    270.78 M
plume_mainnet-borrowed    129.60 M
hyperliquid-borrowed      119.72 M
katana-borrowed           103.53 M
arbitrum-borrowed         88.57 M
arbitrum                  84.57 M
flare                     27.40 M
optimism                  24.60 M
polygon                   17.22 M
wc                        16.38 M
optimism-borrowed         15.62 M
flare-borrowed            13.69 M
unichain                  13.26 M
plume_mainnet             10.38 M
unichain-borrowed         9.37 M
polygon-borrowed          8.13 M
wc-borrowed               8.11 M
etlk-borrowed             2.81 M
etlk                      1.91 M
soneium                   1.42 M
sei                       1.22 M
abstract                  1.00 M
soneium-borrowed          332.44 k
lisk                      206.83 k
abstract-borrowed         170.77 k
sei-borrowed              151.86 k
lisk-borrowed             67.19 k
tac                       54.67 k
tac-borrowed              9.83 k
corn-borrowed             5.79 k
scroll                    5.47 k
corn                      2.64 k
hemi                      1.67 k
fraxtal                   307
hemi-borrowed             257
fraxtal-borrowed          211
sonic                     84
btnx                      18
sonic-borrowed            15
bsc                       12
bsc-borrowed              5
ink                       1
scroll-borrowed           1
btnx-borrowed             1
ink-borrowed              1
mode-borrowed             0
btr-borrowed              0
zircuit-borrowed          0
btr                       0
mode                      0
zircuit                   0
xdai-borrowed             0
linea-borrowed            0

total                    6.17 B
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced TVL calculation for Morpho Blue to accurately account for idle market supply in scenarios where there are no outstanding borrows, improving overall calculation precision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->