### PR TITLE
euler vaults zerolend

### DIFF
--- a/projects/zerolend-vaults/index.js
+++ b/projects/zerolend-vaults/index.js
@@ -38,8 +38,6 @@ const configs = {
   sonic: {
     eulerVaultOwners: multisigs,
     euler: [
-      '0x8c7a2c0729afb927da27d4c9aa172bc5a5fb12bb',
-      '0x9ccf74e64922d8a48b87aa4200b7c27b2b1d860a',
     ],
   }
 }


### PR DESCRIPTION
Zerolend has shut down and these two euler vaults on sonic contain bad debt https://x.com/zerolendxyz/status/2023402141545791866

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Sonic network configuration by removing two addresses from the vetted euler accounts list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->