### PR TITLE
Add Mayan Finance TVL adapter (Swift cross-chain bridge)

### DIFF
--- a/projects/mayan-finance/index.js
+++ b/projects/mayan-finance/index.js
@@ -1,4 +1,4 @@
-const { sumTokens2 } = require("../helper/unwrapLPs");
+const { sumTokensExport } = require("../helper/unwrapLPs");
 const ADDRESSES = require("../helper/coreAssets.json");
 
 const SWIFT = "0xC38e4e6A15593f908255214653d3D947CA1c2338";
@@ -11,20 +11,15 @@ const TOKENS = {
   bsc: [ADDRESSES.bsc.USDC, ADDRESSES.bsc.ETH],
   polygon: [ADDRESSES.polygon.USDC, ADDRESSES.polygon.USDC_CIRCLE],
   optimism: [ADDRESSES.optimism.USDC_CIRCLE, ADDRESSES.optimism.WETH_1],
-  hyperliquid: [ADDRESSES.hyperliquid.USDC],
+  hyperliquid: [ADDRESSES.hyperliquid.USDT0, '0xb88339cb7199b77e23db6e890353e22632ba630f'],
   unichain: [ADDRESSES.unichain.USDC, ADDRESSES.unichain.WETH],
 };
 
-async function tvl(api) {
-  const tokens = TOKENS[api.chain];
-  if (!tokens) return {};
-  return sumTokens2({ api, owners: [SWIFT], tokens });
-}
 
 module.exports = {
   methodology: "Tracks tokens locked in Mayan Finance Swift escrow contract (0xC38e4e6A...) across all supported EVM chains while cross-chain swaps are in-flight.",
 };
 
 Object.keys(TOKENS).forEach(chain => {
-  module.exports[chain] = { tvl };
+  module.exports[chain] = { tvl: sumTokensExport({ owner: SWIFT, tokens: TOKENS[chain] }) };
 });


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
Mayan Finance

##### Twitter Link:
https://twitter.com/mayanfinance

##### List of audit links if any:
https://docs.mayan.finance/security/audits

##### Website Link:
https://mayan.finance

##### Logo (High resolution, will be shown with rounded borders):
https://mayan.finance/logo.png

##### Current TVL:
~$377K

##### Treasury Addresses (if the protocol has treasury)

##### Chain:
Ethereum, Arbitrum, Base, Avalanche, BNB Chain, Polygon, Optimism

##### Coingecko ID:

##### Coinmarketcap ID:

##### Short Description (to be shown on DefiLlama):
Cross-chain swap protocol using Swift intent-based bridging and MCTP.

##### Token address and ticker if any:

##### Category:
Bridge

##### Oracle Provider(s):
None

##### Implementation Details:
N/A

##### Documentation/Proof:

##### forkedFrom:

##### methodology:
Tracks USDC and WETH locked in Mayan Swift escrow contract
(0xC38e4e6A15593f908255214653d3D947CA1c2338) across 7 EVM chains
while cross-chain swaps are in-flight.

##### Github org/user:
https://github.com/mayan-finance

##### Does this project have a referral program?
No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL calculation and per-chain reporting for Mayan Finance Swift escrow across Ethereum, Arbitrum, Base, Avalanche, BSC, Polygon, Optimism, Hyperliquid, and Unichain.
  * Published a methodology and standardized per-chain TVL endpoints for consistent balance aggregation and reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->