### PR TITLE
Add Alphix Arbitrum support

### DIFF
--- a/projects/alphix/index.js
+++ b/projects/alphix/index.js
@@ -1,11 +1,20 @@
 const { cachedGraphQuery } = require('../helper/cache')
 
-const SUBGRAPH = 'https://api.goldsky.com/api/public/project_cmktm2w8l5s0k01u9fz2yetrw/subgraphs/alphix-hook-mainnet/prod/gn'
-
-const HOOKS = [
-  '0x831cfdf7c0e194f5369f204b3dd2481b843d60c0', // AlphixETH (ETH/USDC)
-  '0x0e4b892df7c5bcf5010faf4aa106074e555660c0', // Alphix (USDS/USDC)
-]
+const config = {
+  base: {
+    subgraph: 'https://api.goldsky.com/api/public/project_cmktm2w8l5s0k01u9fz2yetrw/subgraphs/alphix-hook-mainnet/prod/gn',
+    hooks: [
+      '0x831cfdf7c0e194f5369f204b3dd2481b843d60c0', // AlphixETH (ETH/USDC)
+      '0x0e4b892df7c5bcf5010faf4aa106074e555660c0', // Alphix (USDS/USDC)
+    ],
+  },
+  arbitrum: {
+    subgraph: 'https://api.goldsky.com/api/public/project_cmktm2w8l5s0k01u9fz2yetrw/subgraphs/alphix-arbitrum/prod/gn',
+    hooks: [
+      '0x5e645c3d580976ca9e3fe77525d954e73a0ce0c0',
+    ],
+  },
+}
 
 const poolQuery = `{
   pools(first: 1000) {
@@ -25,8 +34,11 @@ function toRaw(decimalStr, decimals) {
 }
 
 async function tvl(api) {
+  const chain = api.chain
+  const { subgraph, hooks } = config[chain]
+
   // 1. Rehypothecated capital — on-chain via hook's getAmountInYieldSource
-  for (const hook of HOOKS) {
+  for (const hook of hooks) {
     const poolKey = await api.call({
       abi: 'function getPoolKey() view returns (address, address, uint24, int24, address)',
       target: hook,
@@ -40,8 +52,8 @@ async function tvl(api) {
   }
 
   // 2. Vanilla pool liquidity — from subgraph (filtered to Alphix-managed pools)
-  const hookSet = new Set(HOOKS)
-  const { pools } = await cachedGraphQuery('alphix/base', SUBGRAPH, poolQuery)
+  const hookSet = new Set(hooks)
+  const { pools } = await cachedGraphQuery(`alphix/${chain}`, subgraph, poolQuery)
   for (const pool of pools) {
     if (!hookSet.has(pool.hooks.toLowerCase())) continue
     const decimals0 = Number(pool.token0.decimals)
@@ -55,5 +67,8 @@ module.exports = {
   methodology: 'TVL is the sum of assets rehypothecated into ERC-4626 yield vaults by Alphix hooks (queried on-chain) plus vanilla Uniswap V4 LP positions in Alphix-managed pools (queried via subgraph).',
   doublecounted: true,
   start: '2026-02-11',
-  base: { tvl },
 }
+
+Object.keys(config).forEach(chain => {
+  module.exports[chain] = { tvl }
+})


### PR DESCRIPTION
Refactor adapter to multi-chain config pattern, adding Arbitrum alongside existing Base chain.

This PR adds Arbitrum support to the existing Alphix adapter — not a new protocol listing.

##### Chain:
Base, Arbitrum

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Arbitrum chain alongside Base chain with dynamic per-chain exports and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->