### PR TITLE
Add HypurrFi EVK (Euler Vault Kit) TVL adapter for Hyperliquid

### DIFF
--- a/projects/hypurrfi-evk/index.js
+++ b/projects/hypurrfi-evk/index.js
@@ -1,0 +1,37 @@
+const { sumTokens2 } = require("../helper/unwrapLPs");
+
+// HypurrFi EVK (Euler Vault Kit) - ERC-4626 vaults on Hyperliquid
+const EVAULT_FACTORY = "0xcF5552580fD364cdBBFcB5Ae345f75674c59273A";
+
+async function getVaults(api) {
+  const vaults = await api.fetchList({
+    lengthAbi: "getProxyListLength",
+    itemAbi: "proxyList",
+    target: EVAULT_FACTORY,
+  });
+  const tokens = await api.multiCall({ abi: "address:asset", calls: vaults });
+  return { vaults, tokens };
+}
+
+module.exports = {
+  methodology:
+    "TVL is the total value of assets deposited into HypurrFi EVK (Euler Vault Kit) vaults on Hyperliquid, minus outstanding borrows.",
+  hyperliquid: {
+    tvl: async (api) => {
+      const { vaults, tokens } = await getVaults(api);
+      return sumTokens2({
+        api,
+        tokensAndOwners2: [tokens, vaults],
+        permitFailure: true,
+      });
+    },
+    borrowed: async (api) => {
+      const { vaults, tokens } = await getVaults(api);
+      const borrows = await api.multiCall({
+        abi: "uint256:totalBorrows",
+        calls: vaults,
+      });
+      api.add(tokens, borrows);
+    },
+  },
+};


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/adapters).
> - If you would like to add a `liquidations` adapter, please refer to [this readme document](https://github.com/DefiLlama/DefiLlama-Adapters/tree/main/liquidations) for details.

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
3. Please fill the form below **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
4. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can edit it there and put up a PR
5. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
6. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap

This PR adds a TVL adapter for a new product line (EVK/Euler Vault Kit) under the existing HypurrFi protocol. HypurrFi already has two listed adapters: `hypurrfi` (pooled, Aave V3) and `hypurrfi-isolated` (Fraxlend pairs).

##### Name: HypurrFi EVK
##### Twitter Link: https://x.com/hypurrfi
##### Website Link: https://app.hypurr.fi
##### Chain: Hyperliquid
##### Category: Lending
##### forkedFrom: Euler V2
##### methodology: TVL is computed by enumerating all ERC-4626 vaults deployed via the eVault Factory, then summing the underlying asset balances held by each vault. Borrows are read via totalBorrows() on each vault.
##### Github org/user: lastdotnet

All other fields: N/A — existing protocol, new product line only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Integrated HypurrFi EVK (Euler Vault Kit) on Hyperliquid, enabling tracking of total value locked across vaults.
  * Added borrowing metrics to display total outstanding borrows, providing comprehensive vault utilization visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->