### PR TITLE
Add Flying Tulip TVL adapter

### DIFF
--- a/projects/flying-tulip/index.js
+++ b/projects/flying-tulip/index.js
@@ -29,6 +29,7 @@ async function tvl(_, __, ___, { api }) {
 module.exports = {
   methodology: "Counts total supply of Flying Tulip vault tokens representing deposited USDC across strategies.",
   start: 1764868523,
+  doublecounted: true,
   ethereum: {
     tvl,
   }


### PR DESCRIPTION
Adds TVL adapter for Flying Tulip

TVL is calculated as the total supply of Flying Tulip vault tokens representing deposited USDC across strategies

Vaults included:
- ftUSDC
- ftAaveUSDC
- ftSparkUSDC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for the flying-tulip project on Ethereum, aggregating vault token supplies and reporting the total in USDC.
  * Added TVL tracking for the MONY project on Ethereum, reporting USD value derived from token supply.

* **Documentation**
  * Exposed TVL metadata for both projects: methodology text, project start timestamps, and a double-counting flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->