### PR TITLE
Add Perpl TVL adapter (Monad)

### DIFF
--- a/projects/perpl/index.js
+++ b/projects/perpl/index.js
@@ -1,0 +1,14 @@
+const { sumTokensExport } = require("../helper/unwrapLPs");
+
+const EXCHANGE = "0x34B6552d57a35a1D042CcAe1951BD1C370112a6F";
+const AUSD = "0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a";
+
+module.exports = {
+  methodology:
+    "TVL is the total AUSD collateral deposited in the Perpl Exchange contract.",
+  monad: {
+    tvl: sumTokensExport({
+      tokensAndOwners: [[AUSD, EXCHANGE]],
+    }),
+  },
+};


### PR DESCRIPTION
## Summary
- Adds TVL tracking for [Perpl](https://perpl.exchange), a perpetual futures DEX on Monad mainnet
- Tracks AUSD collateral balance in the Exchange contract (`0x34B6552d57a35a1D042CcAe1951BD1C370112a6F`)
- Uses `sumTokensExport` with AUSD token (`0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a`)

## Test plan
- [x] `MONAD_RPC=https://rpc.monad.xyz node test.js projects/perpl/index.js` — returns ~$195k TVL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Added Perpl protocol TVL adapter to monitor total AUSD collateral in the Perpl Exchange. Enables real-time tracking of the protocol's total value locked and user asset positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->