### PR TITLE
Add JPMorgan MONY TVL adapter

### DIFF
--- a/projects/jpm-mony/index.js
+++ b/projects/jpm-mony/index.js
@@ -1,0 +1,22 @@
+const MONY = "0x6a7c6aa2b8b8a6a891de552bdeffa87c3f53bd46"
+
+async function tvl(_, __, ___, { api }) {
+  const supply = await api.call({
+    target: MONY,
+    abi: "erc20:totalSupply",
+  })
+
+  const tvl = Number(supply) / 1e4
+
+  api.addUSDValue(tvl)
+
+  return api.getBalances()
+}
+
+module.exports = {
+  methodology: "Tracks total supply of MONY representing shares in JPMorgan My OnChain Net Yield Fund.",
+  start: 1764247931,
+  ethereum: {
+    tvl,
+  }
+}


### PR DESCRIPTION
Tracks TVL of JPMorgan tokenized money market fund MONY on Ethereum

TVL is calculated from the total supply of MONY tokens (4 decimals)
mapped to USD stablecoin pricing

Closes #17540

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Total Value Locked (TVL) calculation and monitoring for the MONY token, enabling real-time tracking of total supply metrics and fund share values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->