### PR TITLE
fix: morpho-blue collateral filter index mismatch

### DIFF
--- a/projects/morpho-blue/index.js
+++ b/projects/morpho-blue/index.js
@@ -191,7 +191,11 @@ const tvl = async (api) => {
   const marketInfos = await api.multiCall({ target: morphoBlue, calls: markets, abi: abi.morphoBlueFunctions.idToMarketParams })
   const collCalls = [...new Set(marketInfos.map(m => m.collateralToken.toLowerCase()).filter(addr => addr !== nullAddress))];
   const withdrawQueueLengths = await api.multiCall({ calls: collCalls, abi: abi.metaMorphoFunctions.withdrawQueueLength, permitFailure: true })
-  const filterMarkets = marketInfos.filter((_, i) => withdrawQueueLengths[i] == null || withdrawQueueLengths[i] > 30 || withdrawQueueLengths[i] < 0);
+  const collateralWQLMap = new Map(collCalls.map((addr, i) => [addr, withdrawQueueLengths[i]]));
+  const filterMarkets = marketInfos.filter(m => {
+    const wql = collateralWQLMap.get(m.collateralToken.toLowerCase());
+    return wql == null || wql > 30 || wql < 0;
+  });
   const tokens = filterMarkets.flatMap(({ collateralToken, loanToken }) => [collateralToken, loanToken])
   return sumTokens2({ api, owner: morphoBlue, tokens, blacklistedTokens: blackList, permitFailure: true })
 }


### PR DESCRIPTION
## Summary

- Fix index mismatch bug in Morpho Blue adapter's MetaMorpho vault collateral filter
- The filter used market index `i` to look up `withdrawQueueLengths`, but that array is indexed by **unique collateral tokens** (deduplicated), not by market. This caused markets to be checked against the wrong collateral token's withdrawal queue length
- Build a proper `Map<collateralAddress, withdrawQueueLength>` and look up each market's actual collateral

## Impact

On chains where some collateral tokens are MetaMorpho vaults, this could incorrectly include or exclude markets from TVL. The bug was dormant on chains like Katana (no MetaMorpho vault collateral), but could affect chains like Ethereum and Base where MetaMorpho vaults exist as collateral.

## Test plan

- [x] Ran adapter locally for Katana — returns $643.75M TVL (matches on-chain data)
- [x] Ran adapter locally for Ethereum — 395 tokens returned, no errors
- [x] Verified fix preserves existing filter semantics (null/undefined → keep, 1-30 → exclude, >30 → keep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced market filtering logic to more robustly handle missing data entries, ensuring improved reliability in market selection and inclusion decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->