### PR TITLE
Update Abyss adapter to dynamically fetch all vaults

### DIFF
--- a/projects/abyss/index.js
+++ b/projects/abyss/index.js
@@ -1,10 +1,12 @@
 const sui = require("../helper/chain/sui");
-const { get } = require("../helper/http");
+const { getConfig } = require("../helper/cache");
 
 const VAULTS_SUMMARY_URL = "https://beta.abyssprotocol.xyz/api/vaults/vaults/summary";
 
 async function tvl(api) {
-  const vaults = await get(VAULTS_SUMMARY_URL);
+  const vaults = await getConfig("abyss", VAULTS_SUMMARY_URL);
+
+  if (!Array.isArray(vaults) || vaults.length === 0) throw new Error("Invalid or empty vault list from Abyss API");
 
   const vaultIds = vaults.map((v) => v.vault_id);
   const poolIds = vaults.map((v) => v.margin_pool_id);


### PR DESCRIPTION
**Replace hardcoded vault list with dynamic fetch from Abyss public API**

This PR updates the Abyss adapter to dynamically fetch all vaults from the protocol's public API endpoint instead of maintaining a hardcoded list. This ensures new vaults are automatically tracked without requiring adapter changes.

**Changes:**
- Removed hardcoded `VAULTS` array (previously only 4 vaults: SUI, DEEP, WAL, USDC)
- Added HTTP fetch from `https://beta.abyssprotocol.xyz/api/vaults/vaults/summary` to discover all vaults at runtime
- Now correctly tracks 6 vaults including the newly deployed SUI_USDE and XBTC vaults
- TVL calculation logic remains identical (margin pool shares converted to underlying via pool exchange rate)

**Why:**
The protocol has added new vaults (SUI_USDE, XBTC) that were not being tracked. Rather than adding them to the hardcoded list, this change makes the adapter future-proof so any new vaults added to the protocol are automatically picked up.

**Test output:**
```
USDC                      1.90 M
DEEP                      509.15 k
SUI                       262.38 k
suiUSDe                   251.01 k
WAL                       55.77 k
xBTC                      1.83 k
Total: 2.98 M
```

This is an update to an existing listing -- no new protocol info needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Vault and asset information now sourced dynamically from a live service instead of static definitions, enabling more flexible and up-to-date asset management and IDs.
* **Bug Fixes**
  * Added validation and explicit error handling for fetched vault data to surface invalid or empty responses and prevent incorrect calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->