### PR TITLE
Update surf-liquid TVL adapter with V2/V3 vault support and staking

### DIFF
--- a/projects/surf-liquid/index.js
+++ b/projects/surf-liquid/index.js
@@ -71,7 +71,6 @@ async function staking(api) {
 module.exports = {
   methodology: "TVL counts Morpho vault deposits across V2 and V3 Surf Liquid vaults. Staking includes SURF staked and SURF subscriptions.",
   doublecounted: true,
-  misrepresentedTokens: true,
   hallmarks: [["2025-11-30", "V3 factory launched"]],
   base: {
     tvl,


### PR DESCRIPTION
## Summary
- Update TVL adapter to dynamically enumerate V2 vaults via factory (`getTotalVaults`/`getVaultInfo`) and V3 vaults via `VaultDeployed` event logs
- Count Morpho ERC-4626 vault share positions held by each vault as TVL
- Add staking section: SURF staked in SURFStakingV5 + CreatorBid SURF subscriptions (SURF locked in the token contract)

## Test results
- TVL: ~$239k (Morpho vault deposits across V2 + V3 vaults)
- Staking: ~$31k (SURF staked + CreatorBid subscriptions)

## Contracts
- V2 Factory: `0x1D283b668F947E03E8ac8ce8DA5505020434ea0E` (Base)
- V3 Factory: `0xf1d64dee9f8e109362309a4bfbb523c8e54fa1aa` (Base)
- SURF Staking: `0xB0fDFc081310A5914c2d2c97e7582F4De12FA9d6` (Base)
- SURF Token: `0xcdca2eaae4a8a6b83d7a3589946c2301040dafbf` (Base)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced TVL tracking that discovers and aggregates positions across V2 and V3 vaults (replaces previous target-based approach).
  * SURF staking and creator subscription balances are now included in TVL reporting.
  * Expanded asset support including USDC, WETH and CBBTC.

* **Documentation**
  * Methodology updated for multi-source TVL and staking; metadata now marks double-counting and adds a V3 factory hallmark.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->