### PR TITLE
add hypersafe (refactor)

### DIFF
--- a/projects/hypersafe/index.js
+++ b/projects/hypersafe/index.js
@@ -1,0 +1,19 @@
+const {sumTokens2, nullAddress} = require("../helper/unwrapLPs");
+
+async function tvl(api) {
+  const tokens = await api.call({
+    target: "0x5534C7Fc1faF7b87ca58fEdA22cC8be47A2F2B44",
+    abi: "function getAllTokens() returns (address[])",
+  })
+  
+  await sumTokens2({ api, owners: tokens, token: nullAddress })
+}
+
+module.exports = {
+  methodology:
+    "TVL is the sum of all ETH held in bonding curve token contracts deployed via the HyperSafe TokenFactory on Base. Each token contract holds ETH proportional to tokens purchased along its bonding curve.",
+  start: "2026-03-10",
+  base: {
+    tvl,
+  },
+};


### PR DESCRIPTION
Resolves #18390 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking HyperSafe Total Value Locked (TVL) on Base chain, measuring ETH holdings in bonding curve contracts deployed via the HyperSafe TokenFactory, with tracking starting March 10, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->