### PR TITLE
fix(dorkfi): only suppress 404 in market box catch, rethrow other errors

### DIFF
--- a/projects/dorkfi/index.js
+++ b/projects/dorkfi/index.js
@@ -128,36 +128,39 @@ function makeBorrowed(chain) {
     const markets = await discoverAllMarkets(chain);
 
     for (const [marketAppId, poolAppId] of markets) {
+      // Only the box fetch may legitimately 404 (market not yet initialised).
+      // Keep all other logic outside the catch so errors from decoding or
+      // lookupAccount propagate instead of being silently swallowed.
+      let boxData;
       try {
-        const boxData = await readMarketBox(chain, poolAppId, marketAppId);
-        const scaledBorrows = readUint256(boxData, BORROWS_OFFSET);
-        if (scaledBorrows === 0n) continue;
-
-        const borrowIndex = readUint256(boxData, BORROW_IDX_OFFSET);
-        const actualBorrows = (scaledBorrows * borrowIndex) / SCALE;
-        if (actualBorrows === 0n) continue;
-
-        // Identify underlying token from the market contract's account
-        const addr = getApplicationAddress(marketAppId);
-        const account = await lookupAccount(chain, addr);
-        const positiveAsset = (account.assets || []).find(
-          (a) => a.amount > 0
-        );
-        if (positiveAsset) {
-          api.add(
-            String(positiveAsset["asset-id"]),
-            actualBorrows.toString()
-          );
-        } else {
-          // Native token market (ALGO / VOI)
-          api.add("1", actualBorrows.toString());
-        }
+        boxData = await readMarketBox(chain, poolAppId, marketAppId);
       } catch (e) {
-        // Only suppress 404 (box not yet initialised for this market).
-        // Re-throw all other errors so decode bugs and transient indexer
-        // failures surface instead of silently under-reporting borrows.
         const status = e?.response?.status ?? e?.status;
-        if (status !== 404) throw e;
+        if (status === 404) continue;
+        throw e;
+      }
+
+      const scaledBorrows = readUint256(boxData, BORROWS_OFFSET);
+      if (scaledBorrows === 0n) continue;
+
+      const borrowIndex = readUint256(boxData, BORROW_IDX_OFFSET);
+      const actualBorrows = (scaledBorrows * borrowIndex) / SCALE;
+      if (actualBorrows === 0n) continue;
+
+      // Identify underlying token from the market contract's account
+      const addr = getApplicationAddress(marketAppId);
+      const account = await lookupAccount(chain, addr);
+      const positiveAsset = (account.assets || []).find(
+        (a) => a.amount > 0
+      );
+      if (positiveAsset) {
+        api.add(
+          String(positiveAsset["asset-id"]),
+          actualBorrows.toString()
+        );
+      } else {
+        // Native token market (ALGO / VOI)
+        api.add("1", actualBorrows.toString());
       }
     }
   };


### PR DESCRIPTION
Addresses reviewer feedback on #18213.

The blanket `catch` was silently swallowing all errors including decode bugs and transient indexer failures, which would cause borrows to be silently under-reported.

This fix:
- Only suppresses HTTP 404 (box not yet initialised for a market)
- Re-throws all other errors so real failures surface

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for data fetching: not-found (404) cases are skipped while other fetch errors are surfaced.
  * Borrow calculations now occur only after successful data retrieval, preventing incorrect or partial results when a fetch fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->