### PR TITLE
Add PigeonHouse — Solana token launchpad with deflationary PIGEON burns

### DIFF
--- a/projects/pigeonhouse/index.js
+++ b/projects/pigeonhouse/index.js
@@ -10,6 +10,7 @@
 const { getConnection, sumTokens2 } = require("../helper/solana");
 const { PublicKey } = require("@solana/web3.js");
 const { createHash } = require("crypto");
+const bs58 = require("bs58");
 
 const PROGRAM_ID = "BV1RxkAaD5DjXMsnofkVikFUUYdrDg1v8YgsQ3iyDNoL";
 const PIGEON_MINT = "4fSWEw2wbYEUCcMtitzmeGUfqinoafXxkhqZrA9Gpump";
@@ -29,7 +30,7 @@ async function tvl() {
   // Fetch all bonding curve accounts from the program
   const accounts = await connection.getProgramAccounts(programId, {
     filters: [
-      { memcmp: { offset: 0, bytes: require("bs58").encode(discriminator) } },
+      { memcmp: { offset: 0, bytes: bs58.encode(discriminator) } },
     ],
   });
 


### PR DESCRIPTION
## Protocol Information

**Protocol:** PigeonHouse
**Website:** https://941pigeon.fun
**Chain:** Solana
**Category:** DEX / Token Launchpad (Bonding Curve)
**Twitter:** https://x.com/941pigeondotfun

## Description

PigeonHouse is a token launchpad on Solana where every trade permanently burns PIGEON tokens.

- Bonding curves with fair price discovery — no presales, no insider allocation
- Auto-graduation to Raydium CPMM with permanently locked LP
- Multi-quote support — PIGEON, SOL, or SKR
- 2% platform fee — 1.5% permanent PIGEON burn + 0.5% treasury
- Token-2022 native, mint authority revoked at creation

**Program ID:** BV1RxkAaD5DjXMsnofkVikFUUYdrDg1v8YgsQ3iyDNoL
**Verified Build:** https://verify.osec.io/status/BV1RxkAaD5DjXMsnofkVikFUUYdrDg1v8YgsQ3iyDNoL
**Source Code:** https://github.com/noegppgeon-boop/Pigeonhouse

## Methodology

TVL = sum of quote token reserves (PIGEON, SOL, SKR) held in active bonding curve PDAs. Graduated tokens excluded (liquidity on Raydium).

The adapter reads all BondingCurve program accounts on-chain, detects old/new layouts, filters graduated curves, and uses sumTokens2 for balance aggregation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for PigeonHouse on Solana, aggregating active bonding-curve reserves and excluding graduated tokens.
  * Adapter computes total token reserves across bonding-curve accounts and reports TVL on Solana with historical snapshots disabled.

* **Documentation**
  * Added methodology describing how TVL is calculated and which graduated tokens are excluded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->