### PR TITLE
Adding new Tokens yValos and yPythagoras

### DIFF
--- a/projects/yield-fi/index.js
+++ b/projects/yield-fi/index.js
@@ -69,6 +69,14 @@ const yhlp = {
     ethereum: "0x386e0983d0e05f5239fd029793ef3ba37b468e9c",
 }
 
+const yvalos = {
+    ethereum: "0xd04ae722b3fe56812e13bb212a79cea7c1b08ff0",
+}
+
+const ypythagoras = {
+    ethereum: "0x06c2c73f30135c831d010ec7b82d0f32321c4f27",
+}
+
 const lockbox = "0x659b5bc7F2F888dB3D5901b78Cdb34DF270E2231";
 
 const l2Chains = Object.keys(yusd_config).filter(chain => chain !== 'ethereum')
@@ -85,6 +93,8 @@ l2Chains.forEach(chain => {
                 vybtc_config[chain],
                 yprism[chain],
                 yhlp[chain],
+                yvalos[chain],
+                ypythagoras[chain],
             ].filter(Boolean)
             const supply = await api.multiCall({ calls, abi: 'erc20:totalSupply' })
             api.add(calls, supply);
@@ -118,7 +128,7 @@ module.exports['ethereum'] = {
             target: vybtc_config['ethereum'],
             owner: lockbox
         })
-        const ethSupply = await api.multiCall({ calls: [ yusd_config['ethereum'], vyusd_config['ethereum'], yeth_config['ethereum'], vyeth_config['ethereum'], ybtc_config['ethereum'], vybtc_config['ethereum'], yprism['ethereum'], yhlp['ethereum']], abi: 'erc20:totalSupply' })
+        const ethSupply = await api.multiCall({ calls: [ yusd_config['ethereum'], vyusd_config['ethereum'], yeth_config['ethereum'], vyeth_config['ethereum'], ybtc_config['ethereum'], vybtc_config['ethereum'], yprism['ethereum'], yhlp['ethereum'], yvalos['ethereum'], ypythagoras['ethereum']], abi: 'erc20:totalSupply' })
         const supply = (ethSupply[0] - lockboxSupply.output);
         const supplyVyusd = (ethSupply[1] - lockboxSupplyVyusd.output);
         const supplyYeth = (ethSupply[2] - lockboxSupplyYeth.output);
@@ -127,6 +137,8 @@ module.exports['ethereum'] = {
         const supplyVybtc = (ethSupply[5] - lockboxSupplyVybtc.output);
         const supplyYprism = ethSupply[6];
         const supplyYhlp = ethSupply[7];
-        api.add([yusd_config['ethereum'], vyusd_config['ethereum'], yeth_config['ethereum'], vyeth_config['ethereum'], ybtc_config['ethereum'], vybtc_config['ethereum'], yprism['ethereum'], yhlp['ethereum']], [supply, supplyVyusd, supplyYeth, supplyVyeth, supplyYbtc, supplyVybtc, supplyYprism, supplyYhlp]);
+        const supplyYvalos = ethSupply[8];
+        const supplyYpythagoras = ethSupply[9];
+        api.add([yusd_config['ethereum'], vyusd_config['ethereum'], yeth_config['ethereum'], vyeth_config['ethereum'], ybtc_config['ethereum'], vybtc_config['ethereum'], yprism['ethereum'], yhlp['ethereum'], yvalos['ethereum'], ypythagoras['ethereum']], [supply, supplyVyusd, supplyYeth, supplyVyeth, supplyYbtc, supplyVybtc, supplyYprism, supplyYhlp, supplyYvalos, supplyYpythagoras]);
     }
 }


### PR DESCRIPTION
In this PR, we have added newly launched yValos and yPythagoras

yValos: https://etherscan.io/address/0xd04ae722b3fe56812e13bb212a79cea7c1b08ff0
yPythagoras: https://etherscan.io/address/0x06c2c73f30135c831d010ec7b82d0f32321c4f27

Please update the price feed for these vaults,
Thanks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for yvalos and ypythagoras tokens. These tokens are now included in total value locked calculations across Ethereum and L2 chains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->