### PR TITLE
Add yld adapter

### DIFF
--- a/projects/yld/index.js
+++ b/projects/yld/index.js
@@ -9,13 +9,17 @@ async function tvl(api) {
     .filter(([key, v]) => key.startsWith('ys') && v && typeof v === 'object' && v.address)
     .map(([, v]) => v.address);
 
-  const assets = await api.multiCall({ abi: 'address:asset', calls: vaults });
-  const totalAssets = await api.multiCall({ abi: 'uint256:totalAssets', calls: vaults });
-  api.addTokens(assets, totalAssets);
+  const assets = await api.multiCall({ abi: 'address:asset', calls: vaults, permitFailure: true });
+  const totalAssets = await api.multiCall({ abi: 'uint256:totalAssets', calls: vaults, permitFailure: true });
+
+  assets.forEach((asset, i) => {
+    if (asset && totalAssets[i]) api.add(asset, totalAssets[i]);
+  });
 }
 
 module.exports = {
   methodology: 'TVL is the sum of totalAssets() across all yld ERC-4626 strategy vaults.',
+  timetravel: false,
   doublecounted: true,
   ethereum: { tvl },
 };


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

##### Name (to be shown on DefiLlama):
yld

##### Twitter Link:


##### List of audit links if any:


##### Website Link:
https://yldfi.co

##### Logo (High resolution, will be shown with rounded borders):
https://raw.githubusercontent.com/yldfi/frontend/main/public/logo-512.png

##### Current TVL:
~$81,000

##### Treasury Addresses (if the protocol has treasury)
0x8baecb301FD723Ff35FB1D9a6d595cAD35618A6f

##### Chain:
Ethereum

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):


##### Short Description (to be shown on DefiLlama):
yld is a yield optimizer offering automated, auto-compounding vaults that utilize Yearn V3 tokenized strategies to simplify and optimize DeFi returns.

##### Token address and ticker if any:


##### Category (full list at https://defillama.com/categories) *Please choose only one:
Yield

##### Oracle Provider(s):
N/A

##### Implementation Details:
No oracle used - vaults use standard ERC-4626 totalAssets() for TVL

##### Documentation/Proof:
https://yldfi.co

##### forkedFrom (Does your project originate from another project):
Yearn V3 (uses Yearn Tokenized Strategies)

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL is the sum of totalAssets() across all yld ERC-4626 strategy vaults, which provide auto-compounding yield strategies.

##### Github org/user (Optional, if your code is open source, we can track activity):
yldfi

##### Does this project have a referral program?
No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added YLD TVL tracking that aggregates vault assets for display in the TVL dashboard.
  * Includes a methodology description explaining how values are calculated.
  * Historical lookups (timetravel) are disabled.
  * Marked as potentially double-counted to indicate overlapping asset reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->