### PR TITLE
feat: add Cronos Treasury Reserve (CTR) adapter

### DIFF
--- a/projects/cronos-treasury-reserve/index.js
+++ b/projects/cronos-treasury-reserve/index.js
@@ -1,0 +1,29 @@
+const { sumTokensExport } = require("../helper/unwrapLPs");
+
+const TREASURY_WALLET = "0x96A6cd06338eFE754f200Aba9fF07788c16E5F20";
+
+// Treasury reserve assets
+const CDCBTC = "0x2e53c5586e12a99d4CAE366E9Fc5C14fE9c6495d";  // Wrapped BTC on Cronos
+const LCRO  = "0x9Fae23A2700FEeCd5b93e43fDBc03c76AA7C08A6";  // Liquid staked CRO
+const CDCETH = "0x7a7c9db510aB29A2FC362a4c34260BEcB5cE3446"; // Wrapped ETH on Cronos
+const USDC  = "0xc21223249CA28397B4B6541dfFaEcC539BfF0c59";  // USDC on Cronos
+const PACK  = "0x0d0b4a6FC6e7f5635C2FF38dE75AF2e96D6D6804";  // PACK ecosystem token
+
+// Protocol own token
+const CTR   = "0xF3672F0cF2E45B28AC4a1D50FD8aC2eB555c21FC";
+
+module.exports = {
+  methodology:
+    "TVL is the USD value of all reserve assets (CDCBTC, LCRO, CDCETH, USDC, PACK) held in the CTR treasury wallet. " +
+    "OwnTokens tracks CTR held in the treasury (tax proceeds awaiting conversion).",
+  cronos: {
+    tvl: sumTokensExport({
+      owner: TREASURY_WALLET,
+      tokens: [CDCBTC, LCRO, CDCETH, USDC, PACK],
+    }),
+    ownTokens: sumTokensExport({
+      owner: TREASURY_WALLET,
+      tokens: [CTR],
+    }),
+  },
+};


### PR DESCRIPTION
# Cronos Treasury Reserve (CTR)

## Protocol Information

- **Protocol name:** Cronos Treasury Reserve
- **Token ticker:** CTR
- **Token address:** `0xF3672F0cF2E45B28AC4a1D50FD8aC2eB555c21FC`
- **Chain:** Cronos EVM
- **Category:** Indexes
- **Website:** https://cronostreasury.github.io/
- **Twitter:** https://twitter.com/CronosTreasury
- **Discord:** https://discord.gg/vs58fDZFbn

## What does this adapter do?

Tracks the TVL of Cronos Treasury Reserve, a treasury-backed index token on Cronos EVM. CTR collects a 10% transaction tax which is diversified into a basket of reserve assets.

**TVL:** USD value of reserve assets (CDCBTC, LCRO, CDCETH, USDC, PACK) in the treasury wallet.

**OwnTokens:** CTR held in treasury (tax proceeds awaiting conversion).

**Treasury wallet:** `0x96A6cd06338eFE754f200Aba9fF07788c16E5F20`

## Methodology

The adapter uses `sumTokensExport` to query ERC-20 balances directly from the Cronos chain. All data is on-chain and supports time-travel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Cronos Treasury Reserve module for monitoring reserve asset values, including CDCBTC, LCRO, CDCETH, USDC, and PACK holdings.
  * Added CTR token holdings tracking for treasury measurements.
  * Included methodology documentation for TVL and ownTokens calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->