### PR TITLE
Add hyperithm moand&katana morpho vault

### DIFF
--- a/projects/hyperithm/index.js
+++ b/projects/hyperithm/index.js
@@ -30,7 +30,14 @@ const vaultConfigs = {
     monad: {
       morphoVaultOwners: [
         '0xC56EA16EA06B0a6A7b3B03B2f48751e549bE40fD',
+        '0x9B97783B747c51b39c3d320050dc9C512868dAa8'
       ],
+    },
+    katana: {
+      morphoVaultOwners: [
+        '0x9B97783B747c51b39c3d320050dc9C512868dAa8',
+        '0xC56EA16EA06B0a6A7b3B03B2f48751e549bE40fD'
+      ]
     }
   }
 };


### PR DESCRIPTION
Added monad & katana hyperithm morpho vaults

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new blockchain configuration entry ("Katana") and updated vault owner lists.
  * Synchronized vault owner settings across existing blockchain entries to reflect the new additions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->