### PR TITLE
Add Signals (Citrea)

### DIFF
--- a/projects/signals/index.js
+++ b/projects/signals/index.js
@@ -1,0 +1,19 @@
+const SIGNALS_CORE = "0x516312275875932ec2B53A41df4De02743131729";
+const CTUSD = "0x8D82c4E3c936C7B5724A382a9c5a4E6Eb7aB6d5D";
+
+async function tvl(api) {
+  const balance = await api.call({
+    abi: "erc20:balanceOf",
+    target: CTUSD,
+    params: [SIGNALS_CORE],
+  });
+  api.add(CTUSD, balance);
+}
+
+module.exports = {
+  methodology:
+    "TVL is ctUSD deposited in the SignalsCore contract as liquidity for range-based prediction markets on Citrea.",
+  citrea: {
+    tvl,
+  },
+};


### PR DESCRIPTION
## Signals

Range-based prediction market on Citrea (Bitcoin L2). Binary markets only tell you "up or down" — Signals lets users predict exactly where BTC will close by picking a price range, producing a full probability distribution curve instead of a single number.

- Website: https://signals.wtf
- App: https://app.signals.wtf
- Docs: https://docs.signals.wtf
- Contract: 0x516312275875932ec2B53A41df4De02743131729 (Citrea Mainnet)
- Collateral: ctUSD (0x8D82c4E3c936C7B5724A382a9c5a4E6Eb7aB6d5D)
- GitHub: https://github.com/signals-protocol/v1-contract

TVL = ctUSD deposited in SignalsCore contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a signals module that calculates Total Value Locked (TVL) for Citrea's SignalsCore.
  * Enables automated CTUSD balance tracking and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->