### PR TITLE
Add CipherDLMM (Orbit Finance) TVL adapter

### DIFF
--- a/projects/orbit-finance/index.js
+++ b/projects/orbit-finance/index.js
@@ -1,32 +1,19 @@
 const { sumTokens2 } = require("../helper/solana");
-const { getConfig } = require("../helper/cache");
+const { get } = require("../helper/http");
+const { Program } = require("@coral-xyz/anchor");
+const { getProvider } = require("../helper/solana");
 
 const ADAPTER_BASE = "https://orbit-dex.api.cipherlabsx.com";
 
 // CIPHER native token mint
 const CIPHER_MINT = "Ciphern9cCXtms66s8Mm6wCFC27b2JProRQLYmiLMH3N";
 
-/**
- * Computes TVL by summing token balances in all CipherDLMM pool vaults
- * (base + quote) on Solana. Vault addresses are fetched from the adapter
- * API (cached via getConfig) and verified on-chain via sumTokens2.
- * All tokens (including CIPHER) are counted here; staking tracks
- * CIPHER locked in Streamflow separately (different tokens, no double-count).
- */
-async function tvl() {
-  const data = await getConfig("orbit-finance", `${ADAPTER_BASE}/api/v1/pools`);
-  if (!Array.isArray(data?.pools)) throw new Error("Unexpected API response: missing pools array");
-
-  const tokenAccounts = new Set();
-  for (const pool of data.pools) {
-    if (typeof pool?.baseVault === "string" && pool.baseVault) tokenAccounts.add(pool.baseVault);
-    if (typeof pool?.quoteVault === "string" && pool.quoteVault) tokenAccounts.add(pool.quoteVault);
-  }
-  if (data.pools.length > 0 && tokenAccounts.size === 0) {
-    throw new Error("Unexpected API response: pools found but no valid vault addresses");
-  }
-
-  return sumTokens2({ tokenAccounts: [...tokenAccounts] });
+async function tvl(api) {
+  const provider = getProvider();
+  const program = new Program(idl, provider);
+  const accounts = await program.account.pool.all();
+  const tokenAccounts = accounts.flatMap(({ account }) => [account.baseVault, account.quoteVault]);
+  return sumTokens2({ api, tokenAccounts, blacklistedTokens: [CIPHER_MINT] });  // exclude projects own token from the tvl
 }
 
 /**
@@ -35,7 +22,7 @@ async function tvl() {
  * read the aggregate total from the adapter's Streamflow indexer.
  */
 async function staking() {
-  const data = await getConfig("orbit-finance-staking", `${ADAPTER_BASE}/api/v1/streamflow/vaults`);
+  const data = await get(`${ADAPTER_BASE}/api/v1/streamflow/vaults`);
   const cipherVault = (data.vaults ?? []).find((v) => v.tokenMint === CIPHER_MINT);
   if (!cipherVault?.total_staked_raw) return {};
   return { ["solana:" + CIPHER_MINT]: cipherVault.total_staked_raw };
@@ -47,3 +34,98 @@ module.exports = {
   methodology:
     "TVL is the sum of all token balances in CipherDLMM pool vaults (base + quote) on Solana. Staking TVL separately counts CIPHER locked in the Streamflow staking pool.",
 };
+
+
+const idl = {
+  "address": "Fn3fA3fjsmpULNL7E9U79jKTe1KHxPtQeWdURCbJXCnM",
+  "metadata": {"name": "orbit_finance", "version": "0.1.0", "spec": "0.1.0"},
+  "instructions": [],
+  "accounts": [{"name": "Pool", "discriminator": [241, 154, 109, 4, 17, 177, 109, 188]}],
+  "events": [],
+  "errors": [],
+  "types": [
+    {
+      "name": "Pool",
+      "docs": [
+        "Main pool account holding configuration, authorities, price cache and vaults.",
+        "Fields are ordered to minimize padding for zero-copy compatibility."
+      ],
+      "serialization": "bytemuck",
+      "repr": {"kind": "c"},
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {"name": "admin", "type": "pubkey"},
+          {"name": "config_authority", "type": "pubkey"},
+          {"name": "pause_guardian", "type": "pubkey"},
+          {"name": "fee_withdraw_authority", "type": "pubkey"},
+          {"name": "creator", "type": "pubkey"},
+          {"name": "base_mint", "type": "pubkey"},
+          {"name": "quote_mint", "type": "pubkey"},
+          {"name": "base_vault", "type": "pubkey"},
+          {"name": "quote_vault", "type": "pubkey"},
+          {"name": "creator_fee_vault", "type": "pubkey"},
+          {"name": "holders_fee_vault", "type": "pubkey"},
+          {"name": "nft_fee_vault", "type": "pubkey"},
+          {
+            "name": "protocol_fee_vault",
+            "docs": ["Protocol fee vault (12.5% of total swap fees)", "Can be permissionlessly swept to Squads multisig"],
+            "type": "pubkey"
+          },
+          {"name": "lp_mint", "type": "pubkey"},
+          {"name": "price_q64_64", "type": "u128"},
+          {"name": "total_shares", "type": "u128"},
+          {
+            "name": "total_holder_units",
+            "docs": [
+              "Sync checkpoint for holder rewards index (per-pool).",
+              "Used by `sync_reward_indexes` to aggregate deltas into global holder index."
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "total_nft_units",
+            "docs": ["Sync checkpoint for NFT rewards index (per-pool).", "Used by `sync_reward_indexes` to aggregate deltas into global NFT index."],
+            "type": "u128"
+          },
+          {"name": "reward_indexes", "type": {"defined": {"name": "RewardIndexes"}}},
+          {"name": "last_updated", "type": "i64"},
+          {"name": "last_swap_time", "docs": ["Legacy: timestamp of last swap (can be used for analytics/legacy)"], "type": "i64"},
+          {"name": "last_volatility_update", "docs": ["timestamp of last volatility update"], "type": "i64"},
+          {"name": "initial_bin_id", "type": "i32"},
+          {"name": "active_bin", "type": "i32"},
+          {"name": "previous_bin", "type": "i32"},
+          {"name": "reference_bin", "type": "i32"},
+          {"name": "split_holders_microbps", "type": "u32"},
+          {"name": "split_nft_microbps", "type": "u32"},
+          {"name": "split_creator_extra_microbps", "type": "u32"},
+          {"name": "variable_fee_control", "docs": ["variable_fee_control (C)"], "type": "u32"},
+          {"name": "max_volatility_accumulator", "docs": ["cap on va accumulator"], "type": "u32"},
+          {"name": "volatility_reference", "docs": ["vr state"], "type": "u32"},
+          {"name": "volatility_accumulator", "docs": ["va state"], "type": "u32"},
+          {"name": "bin_step_bps", "type": "u16"},
+          {"name": "base_fee_bps", "type": "u16"},
+          {"name": "creator_cut_bps", "type": "u16"},
+          {"name": "legacy_volatility_multiplier_bps", "type": "u16"},
+          {"name": "filter_period", "docs": ["seconds"], "type": "u16"},
+          {"name": "decay_period", "type": "u16"},
+          {"name": "reduction_factor_bps", "docs": ["0..=10000"], "type": "u16"},
+          {"name": "max_dynamic_fee_bps", "docs": ["Cap on total fee (base + variable)"], "type": "u16"},
+          {"name": "version", "type": "u8"},
+          {"name": "bump", "type": "u8"},
+          {"name": "pause_bits", "type": "u8"},
+          {"name": "accounting_mode", "docs": ["Accounting mode:", "0 = legacy global LP shares", "1 = position-bin shares"], "type": "u8"},
+          {"name": "dynamic_fee_enabled", "docs": ["Dynamic fee enabled flag (0 = disabled, 1 = enabled)"], "type": "u8"},
+          {"name": "_fee_reserved", "docs": ["Reserved for future parameters (and padding)"], "type": {"array": ["u8", 5]}},
+          {"name": "_pad2", "docs": ["Explicit padding to bring total struct size to a multiple of 8"], "type": {"array": ["u8", 2]}}
+        ]
+      }
+    },
+    {
+      "name": "RewardIndexes",
+      "docs": ["Tracks accumulated reward indexes for holders and NFT stakers."],
+      "repr": {"kind": "c"},
+      "type": {"kind": "struct", "fields": [{"name": "holders_q128", "type": "u128"}, {"name": "nft_q128", "type": "u128"}]}
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds TVL adapter for **CipherDLMM (Orbit Finance)** — a concentrated liquidity DLMM on Solana
- Program ID: `Fn3fA3fjsmpULNL7E9U79jKTe1KHxPtQeWdURCbJXCnM`
- Enumerates pool vault addresses via adapter API, then verifies on-chain balances using `sumTokens2`

## Methodology
- TVL = sum of SPL token balances in all CipherDLMM pool vaults (base + quote) on Solana
- Vault addresses fetched from `https://orbit-dex.api.cipherlabsx.com/api/v1/pools`
- On-chain verification via DefiLlama's `sumTokens2` helper

## Links
- Website: [orbitdex.io](https://orbitdex.io)
- Adapter API: `https://orbit-dex.api.cipherlabsx.com`
- Source: [github.com/Cipherlabsx/cipher-integrations](https://github.com/Cipherlabsx/cipher-integrations)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Solana TVL tracking for Orbit Finance, aggregating non-native token balances across all protocol pool vaults.
  * Added staking TVL reporting for CIPHER held in the protocol’s staking pool.

* **Documentation**
  * Methodology clarified: TVL sums base+quote vault balances excluding the native CIPHER token; staking counts CIPHER locked in staking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->