### PR TITLE
Add send hinkal app

### DIFF
--- a/projects/send-hinkal/index.js
+++ b/projects/send-hinkal/index.js
@@ -1,0 +1,1 @@
+module.exports = require("../hinkal");


### PR DESCRIPTION
Once Rabby trying to connect with send-hinkal, warning appears. So, we need listing our second app, with the same TVL as hinkal. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the send-hinkal package to re-export hinkal, ensuring consistent module exports between both packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->