### PR TITLE
Support LeverUp Mon staking TVL count

### DIFF
--- a/projects/leverup/index.js
+++ b/projects/leverup/index.js
@@ -3,10 +3,17 @@ const { sumTokens2 } = require('../helper/unwrapLPs')
 // Issuer contract addresses
 const LVUSD_Issuer = "0x135951057cfcccA7E8ef87ee41318D670f723F68";
 const LVMON_Issuer = "0xbF52cED429C3901AfA4BBF25849269eF7A4ad105";
+const MONStakingVault = "0xf71B390448df37C8379332F372f344A576574d4A";
 
 const Issuers = [LVUSD_Issuer, LVMON_Issuer];
 
 async function tvl(api) {
+  const stakingState = await api.call({
+    target: MONStakingVault,
+    abi: "function stakingState() external view returns ((uint256 stakedBalance, uint64 lastEpoch))",
+  });
+  const stakedBalance = stakingState.stakedBalance ?? stakingState[0];
+
   // 1. Get Transparency contract address from each Issuer
   const transparencies = await api.multiCall({
     calls: Issuers,
@@ -30,14 +37,16 @@ async function tvl(api) {
   })
 
   // 4. Use sumTokens2 to automatically calculate TVL
-  return sumTokens2({
+  await sumTokens2({
     api,
     tokensAndOwners2: [tokens, allVaults],
   })
+
+  api.addGasToken(stakedBalance);
 }
 
 module.exports = {
-  methodology: "Counts the balance of reserve tokens held in all vaults retrieved from the Transparency contracts of LVUSD and LVMON issuers.",
+  methodology: "Counts reserve tokens held in all vaults retrieved from LVUSD and LVMON issuers' Transparency contracts, plus MONStakingVault.stakingState.stakedBalance.",
   monad: { 
     tvl
   }


### PR DESCRIPTION
This PR adds support for counting the portion of MON that LeverUp uses for PoS staking as part of the TVL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated MONStakingVault staked balance into TVL calculations for more comprehensive value tracking.

* **Documentation**
  * Updated methodology documentation to include staked balance component in TVL calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->