### PR TITLE
Add Starknet BTC Staking TVL adapter

### DIFF
--- a/projects/starknet-btc-staking/index.js
+++ b/projects/starknet-btc-staking/index.js
@@ -14,9 +14,10 @@ const abis = {
   get_total_stake_for_token: {
     name: "get_total_stake_for_token",
     type: "function",
-    inputs: [{ name: "token_address", type: "core::starknet::contract_address::ContractAddress" }],
+    inputs: [{ name: "token_address", type: "felt" }],
     outputs: [{ type: "core::integer::u128" }],
-    state_mutability: "view"
+    state_mutability: "view",
+    customInput: "address",
   },
 }
 


### PR DESCRIPTION
## Summary

Adds a TVL adapter for the Starknet BTC Staking protocol.

- Contract: `0x00ca1702e64c81d9a07b86bd2c540188d92a2c73cf5cc0e508d949015e7e84a7` (Starknet Staking)
- Dynamically fetches active BTC tokens via `get_active_tokens`, then queries `get_total_stake_for_token` for each
- STRK (reward token) is excluded from TVL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for computing Total Value Locked (TVL) metrics for Starknet BTC staking, enabling tracking of aggregate stake amounts across supported tokens in the protocol.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->