### PR TITLE
Add Evolve protocol TVL adapter for Sei chain

### DIFF
--- a/projects/goevolve/index.js
+++ b/projects/goevolve/index.js
@@ -2,22 +2,18 @@ const eusd = {
     sei: "0xf2282e641cd3ceeafd4e24663d409fcb68edc1df",
 }
 
-const l2Chains = Object.keys(eusd).filter(chain => chain !== 'ethereum')
-
-l2Chains.forEach(chain => {
-    module.exports[chain] = {
+module.exports['sei'] = {
         tvl: async (api) => {
             const calls = [
-                eusd[chain],
+                eusd['sei'],
             ].filter(Boolean)
             const supply = await api.multiCall({ calls, abi: 'erc20:totalSupply' })
             api.addTokens(calls, supply, {
                 name: 'eUSD',
                 symbol: 'eUSD',
                 decimals: 18,
-                chain: chain,
-                address: eusd[chain],
+                chain: 'sei',
+                address: eusd['sei'],
             });
         }
     }
-});


### PR DESCRIPTION
On Sei chain, a new Protocol Evolve, is launched using YieldFi Infra,

website: https://goevolve.xyz/
docs: https://docs.goevolve.xyz/about-evolve
token: https://seiscan.io//token/0xf2282e641cd3ceeafd4e24663d409fcb68edc1df

please add price feed for this

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Sei chain support with eUSD token total value locked (TVL) tracking and metadata registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->