### PR TITLE
Add Lotto Run (Aptos lottery protocol)

### DIFF
--- a/projects/lotto-run/index.js
+++ b/projects/lotto-run/index.js
@@ -1,0 +1,38 @@
+const { function_view } = require("../helper/chain/aptos");
+
+const MODULE = "lotto_run";
+const APT = "0x1::aptos_coin::AptosCoin";
+
+const POOLS = [
+  "0xc38c49cd3008de7e0f41aadd83155ba1e4e380694db1e48b1f13c404e2451f16",
+  "0x2ee2377b4b358cdf272cb7f3e8d22525c9d42a7db64816605f10f12819421c37",
+  "0x53d1c36ff2af28bf67df3b1b2d2229e6bdf307efd6cacacdff8b4e2c2e1aace8",
+  "0x55a51900d3c7bf85347c260448f7e5ffca9f37bbe8157679dbcb274967fae421",
+];
+
+async function tvl(api) {
+  for (const pool of POOLS) {
+    // pool_info returns [pool_size, label, current_round, total_draws]
+    const poolInfo = await function_view({
+      functionStr: `${pool}::${MODULE}::pool_info`,
+      args: [pool],
+    });
+    const currentRound = poolInfo[2];
+
+    // round_state returns [status, sold, pool_size, pot]
+    const roundState = await function_view({
+      functionStr: `${pool}::${MODULE}::round_state`,
+      args: [pool, currentRound],
+    });
+    const pot = roundState[3]; // in octas (1e8)
+
+    api.add(APT, pot);
+  }
+}
+
+module.exports = {
+  timetravel: false,
+  methodology:
+    "TVL is the sum of APT locked in the active lottery round vaults across the 4 immutable Aptos pool contracts.",
+  aptos: { tvl },
+};


### PR DESCRIPTION
## Protocol

- **Name:** Lotto Run
- **Website:** https://lotto.run
- **Chain:** Aptos
- **Category:** Luck Games

## Description

Lotto Run is a decentralized, operatorless lottery protocol on Aptos. Four pools (100, 1K, 10K, 100K APT) run continuously in parallel. Every ticket costs 1 APT. No operator, no house cut, Aptos VRF for verifiable randomness. All four contracts are immutable (upgrade_policy = 2).

## TVL Methodology

TVL is the sum of APT locked in the active lottery round vaults across the 4 immutable Aptos pool contracts.

For each pool:
1. Call `pool_info(pool_addr)` to get the current round number
2. Call `round_state(pool_addr, current_round)` to get the vault pot value
3. Sum all pot values across all 4 pools

The adapter queries contract view functions, not simple account balances.

## Pool Contracts (all immutable)

| Pool | Address |
|------|---------|
| 100 APT | `0xc38c49cd3008de7e0f41aadd83155ba1e4e380694db1e48b1f13c404e2451f16` |
| 1K APT | `0x2ee2377b4b358cdf272cb7f3e8d22525c9d42a7db64816605f10f12819421c37` |
| 10K APT | `0x53d1c36ff2af28bf67df3b1b2d2229e6bdf307efd6cacacdff8b4e2c2e1aace8` |
| 100K APT | `0x55a51900d3c7bf85347c260448f7e5ffca9f37bbe8157679dbcb274967fae421` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Aptos TVL adapter for Lotto Run, enabling total value locked tracking across four pool contracts on the Aptos blockchain
  * TVL calculated from active lottery round vaults, providing real-time visibility into pooled assets

<!-- end of auto-generated comment: release notes by coderabbit.ai -->