### PR TITLE
Add Cardano native SPO staking adapter

### DIFF
--- a/projects/cardano-spo-staking/index.js
+++ b/projects/cardano-spo-staking/index.js
@@ -14,7 +14,11 @@ const KOIOS_API = "https://api.koios.rest/api/v1";
 
 async function staking() {
   // Step 1: Get the current epoch number from chain tip
-  const [tip] = await get(`${KOIOS_API}/tip`);
+  const tipResponse = await get(`${KOIOS_API}/tip`);
+  if (!tipResponse || !tipResponse.length) {
+    throw new Error("Failed to fetch current epoch from Koios /tip");
+  }
+  const [tip] = tipResponse;
   const currentEpoch = tip.epoch_no;
 
   // Step 2: Get epoch info which includes active_stake
@@ -27,11 +31,16 @@ async function staking() {
   );
 
   // active_stake is returned in lovelace (1 ADA = 1,000,000 lovelace)
-  const activeStakeLovelace = Number(epochInfo[0].active_stake);
+  // Use BigInt to avoid precision loss for values exceeding Number.MAX_SAFE_INTEGER
+  if (!epochInfo || !epochInfo.length || !epochInfo[0].active_stake) {
+    throw new Error(`No active_stake data for epoch ${epochToQuery}`);
+  }
+  const activeStakeLovelace = BigInt(epochInfo[0].active_stake);
+  const activeStakeAda = Number(activeStakeLovelace / BigInt(1e6));
 
   // Return as ADA using coingecko ID; DeFi Llama SDK handles USD conversion
   return {
-    cardano: activeStakeLovelace / 1e6,
+    cardano: activeStakeAda,
   };
 }
 


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

> - If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/adapters).
> - If you would like to add a `liquidations` adapter, please refer to [this readme document](https://github.com/DefiLlama/DefiLlama-Adapters/tree/main/liquidations) for details.

1. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
2. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
3. Please fill the form below **only if the PR is for listing a new protocol** else it can be ignored/replaced with reason/details about the PR
4. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can edit it there and put up a PR
5. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
6. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap

---

<html><head></head><body><h5>Name (to be shown on DefiLlama):</h5>
<p>Cardano SPO Staking</p>
<h5>Twitter Link:</h5>
<p>https://x.com/Cardano</p>
<h5>List of audit links if any:</h5>
<p>N/A — This adapter queries Cardano's native Ouroboros PoS consensus layer, not a smart contract. The staking mechanism is part of the core protocol, peer-reviewed and formally verified by IOHK Research (https://iohk.io/en/research/library/).</p>
<h5>Website Link:</h5>
<p>https://cardano.org/stake-pool-operation</p>
<h5>Logo (High resolution, preferably in .svg and .png, for application on both white and black backgrounds. Will be shown with rounded borders):</h5>
<p>https://cryptologos.cc/logos/cardano-ada-logo.svg
https://cryptologos.cc/logos/cardano-ada-logo.png</p>
<h5>Current TVL:</h5>
<pre><code>--- cardano-staking ---
ADA         21.82 B (~$6.3B at $0.29/ADA)
Total:      ~$6.3B
</code></pre>
<h5>Treasury Addresses (if the protocol has treasury):</h5>
<p>N/A — Native protocol-level staking, not a contract with a treasury address.</p>
<h5>Chain:</h5>
<p>Cardano</p>
<h5>Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):</h5>
<p>cardano</p>
<h5>Coinmarketcap ID (so your TVL can appear on Coinmarketcap):</h5>
<p>https://coinmarketcap.com/currencies/cardano/</p>
<h5>Short Description (to be shown on DefiLlama):</h5>
<p>Cardano's native proof-of-stake delegation to ~2,948 stake pool operators (SPOs) via the Ouroboros consensus protocol. ADA holders delegate to pools without locking — staked ADA remains liquid and spendable at all times with no unbonding period.</p>
<h5>Token address and ticker if any:</h5>
<p>ADA (native token, no contract address)</p>
<h5>Category (Yield/Dexes/Lending/Minting/Assets/Insurance/Options/Indexes/Staking):</h5>
<p>Staking</p>
<h5>Methodology:</h5>
<p>Counts the total ADA actively delegated to all Cardano stake pool operators (SPOs) via the Ouroboros proof-of-stake consensus mechanism. Data is sourced from the Koios decentralized API's <code>/epoch_info</code> endpoint, which reports the aggregate <code>active_stake</code> (in lovelace) snapshot across all registered stake pools for each epoch (~5 days). The adapter queries the most recently completed epoch to ensure the stake snapshot is finalized.</p>
<h5>Github org/user (Optional, if your code is open source):</h5>
<p>https://github.com/cardano-community/koios-artifacts (data source)
https://github.com/IntersectMBO/cardano-node (protocol)</p>
<hr>
<h3>Additional Context</h3>
<p><strong>Why this adapter is needed:</strong>
Over 63% of circulating ADA (~21.82B ADA, ~$6.3B) is delegated to SPOs, but this is currently invisible on DeFi Llama. The existing Cardano "Total Staked" page shows only ~$27.9M from DeFi protocol-level staking (governance token staking in protocols like SundaeSwap, Liqwid). This adapter surfaces the native chain-level PoS staking under the "Staking" toggle, not default TVL.</p>
<p><strong>Data source:</strong>
Koios (https://api.koios.rest) — a decentralized, community-maintained, open-source REST API for Cardano blockchain data, operated by multiple independent node providers globally. It reads directly from <code>cardano-db-sync</code>, which indexes on-chain ledger state. The <code>active_stake</code> value comes from the Cardano ledger's epoch boundary snapshot.</p>
<p><strong>Cross-reference validation:</strong></p>

Source | Total ADA Staked | USD (~$0.29/ADA)
-- | -- | --
Cardanoscan.io | 21.82B ADA | ~$6.33B
Cexplorer.io | ~21.8B ADA | ~$6.3B
PoolTool.io | ~21.8B ADA | ~$6.3B


<p><strong>Key distinction:</strong> Cardano staking is natively liquid — delegated ADA is never locked, has no unbonding period, and can be spent/moved at any time while still earning rewards.</p></body></html>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Cardano SPO staking TVL tracking: retrieves active stake from the blockchain, validates the data, converts values to ADA, and displays the total active stake as a staking metric. Includes user-facing methodology text describing the calculation and provides an explicit staking metric for Cardano.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->