### PR TITLE
Spiko/update safo share addresses

### DIFF
--- a/projects/spiko/index.js
+++ b/projects/spiko/index.js
@@ -1,163 +1,180 @@
-const { multiCall } = require("../helper/chain/starknet");
-const { decodeStrKey, SOROBAN_RPC_URL } = require("../helper/chain/stellar");
-const { sumTokens2 } = require("../helper/unwrapLPs");
-const { post } = require("../helper/http");
+const { multiCall } = require('../helper/chain/starknet')
+const { decodeStrKey, SOROBAN_RPC_URL } = require('../helper/chain/stellar')
+const { post } = require('../helper/http')
+const { getUniqueAddresses } = require('../helper/utils')
+const { sumTokens2 } = require('../helper/unwrapLPs')
 
-const config = {
-  polygon: [
-    "0xe4880249745eAc5F1eD9d8F7DF844792D560e750", //USTBL
-    "0xa0769f7A8fC65e47dE93797b4e21C073c117Fc80", //EUTBL
-    "0x903d5990119bc799423e9c25c56518ba7dd19474", //SPKCC
-    "0x99F70A0e1786402a6796c6B0AA997ef340a5c6da", //eurSPKCC
-    "0x970E2aDC2fdF53AEa6B5fa73ca6dc30eAFEDfe3D", //UKTBL
-  ],
+/**
+ * Share-register addresses from Spiko prospectus / Spiko_DLT_Addresses.docx (3 March 2026).
+ * Includes USTBL (USD only), EUTBL, UKTBL (GBP only), and SAFO share classes (EUR unhedged lines under USTBL/UKTBL excluded).
+ * Per-chain lists are de-duplicated (same contract can appear under more than one product).
+ *
+ * UKTBL GBP Starknet: the doc lists 0x01953d6e0462… which is not a valid Starknet felt; the
+ * deployed register is 0x0153d6e0462080bb2842109e9b64f589ef5aa06bb32b26bbdb894aca92674395.
+ */
+
+const rawConfig = {
   ethereum: [
-    "0xe4880249745eAc5F1eD9d8F7DF844792D560e750", //USTBL
-    "0xa0769f7A8fC65e47dE93797b4e21C073c117Fc80", //EUTBL
-    "0x4f33acf823e6eeb697180d553ce0c710124c8d59", //SPKCC
-    "0x3868D4e336d14D38031cf680329d31e4712e11cC", //eurSPKCC
-    "0xf695Df6c0f3bB45918A7A82e83348FC59517734E", //UKTBL
+    // USTBL — USD
+    '0xe4880249745eAc5F1eD9d8F7DF844792D560e750',
+    // EUTBL — EUR
+    '0xa0769f7A8fC65e47dE93797b4e21C073c117Fc80',
+    // UKTBL — GBP
+    '0xf695Df6c0f3bB45918A7A82e83348FC59517734E',
+    // SAFO — EUR / USD / GBP / CHF
+    '0x0990b149e915cb08e2143a5c6f669c907eddc8b0',
+    '0xcbade7d9bdee88411cb6cbcbb29952b742036992',
+    '0xc273986a91e4bfc543610a5cb5860b7cfefb6cc0',
+    '0x18b5c15e5196a38a162b1787875295b76e4313fb',
+  ],
+  polygon: [
+    '0xe4880249745eAc5F1eD9d8F7DF844792D560e750',
+    '0xa0769f7A8fC65e47dE93797b4e21C073c117Fc80',
+    '0x970E2aDC2fdF53AEa6B5fa73ca6dc30eAFEDfe3D',
+    '0x272ea767712cc4839f4a27ee35eb73116158c8a2',
+    '0x6f64f47f95cf656f21b40e14798f6b49f80b3dc5',
+    '0x4fe515c67eeeadb3282780325f09bb7c244fe774',
+    '0x9de2b2dcdcf43540e47143f28484b6d15118f089',
   ],
   arbitrum: [
-    "0x021289588cd81dC1AC87ea91e91607eEF68303F5", //USTBL
-    "0xcbeb19549054cc0a6257a77736fc78c367216ce7", //EUTBL
-    "0x99f70a0e1786402a6796c6b0aa997ef340a5c6da", //SPKCC
-    "0x0e389C83Bc1d16d86412476F6103027555C03265", //eurSPKCC
-    "0x903d5990119bC799423e9C25c56518Ba7DD19474", //UKTBL
+    '0x021289588cd81dC1AC87ea91e91607eEF68303F5',
+    '0xCBeb19549054CC0a6257A77736FC78C367216cE7',
+    '0x903d5990119bC799423e9C25c56518Ba7DD19474',
+    '0x1412632f2b89e87bfa20c1318a43ced25f1d7b76',
+    '0x0c709396739b9cfb72bcea6ac691ce0ddf66479c',
+    '0xbe023308ac2ef7e1c3799f4e6a3003ee6d342635',
+    '0x97e7962bcd091e7ecfb583fc96289b1e1553ac6e',
   ],
   base: [
-    "0xe4880249745eAc5F1eD9d8F7DF844792D560e750", //USTBL
-    "0xa0769f7A8fC65e47dE93797b4e21C073c117Fc80", //EUTBL
-    "0xf695df6c0f3bb45918a7a82e83348fc59517734e", //SPKCC
-    "0x4f33aCf823E6eEb697180d553cE0c710124C8D59", //eurSPKCC
-    "0xA8De1f55Aa0E381cb456e1DcC9ff781eA0079068", //UKTBL
+    '0xe4880249745eAc5F1eD9d8F7DF844792D560e750',
+    '0xa0769f7A8fC65e47dE93797b4e21C073c117Fc80',
+    '0xA8De1f55Aa0E381cb456e1DcC9ff781eA0079068',
+    '0xd879846cbe20751bde8a9342a3cca00a3e56ca47',
+    '0x0bb754d8940e283d9ff6855ab5dafbc14165c059',
+    '0x2f6c0e5e06b43512706a9cdf66cd21f723fe0ec3',
+    '0xd9aa2300e126869182dfb6ecf54984e4c687f36b',
   ],
   starknet: [
-    "0x020ff2f6021ada9edbceaf31b96f9f67b746662a6e6b2bc9d30c0d3e290a71f6", //USTBL
-    "0x04f5e0de717daa6aa8de63b1bf2e8d7823ec5b21a88461b1519d9dbc956fb7f2", //EUTBL
-    "0x04bade88e79a6120f893d64e51006ac6853eceeefa1a50868d19601b1f0a567d", //SPKCC
-    "0x06472cabc51a3805975b9c60c7dec63897c9a287f2db173a1d6c589d18dd1e07", //eurSPKCC
-    "0x0153d6e0462080bb2842109e9b64f589ef5aa06bb32b26bbdb894aca92674395", //UKTBL
+    '0x20ff2f6021ada9edbceaf31b96f9f67b746662a6e6b2bc9d30c0d3e290a71f6',
+    '0x4f5e0de717daa6aa8de63b1bf2e8d7823ec5b21a88461b1519d9dbc956fb7f2',
+    // on-chain register (see header); doc had 0x01953d6e… (invalid felt)
+    '0x0153d6e0462080bb2842109e9b64f589ef5aa06bb32b26bbdb894aca92674395',
+    '0x0128f41ef8017ab56140ffad6439305a3196ed862841ba61ff4d78e380c346a6',
+    '0x035bdc17f7a7d09c45d31ab476a576d4f7aad916676b2948fe172c3bcb33725a',
+    '0x06e8a99926ff6d56f4cb93c37b63286d736cd1f81740d53f88b4875b4cbe7f49',
+    '0x06723dcb428eddb160c5adfc2d0a5e5adc184bf6a7298780c3cbf3fa764f709b',
   ],
   etlk: [
-    "0xe4880249745eAc5F1eD9d8F7DF844792D560e750", //USTBL
-    "0xa0769f7A8fC65e47dE93797b4e21C073c117Fc80", //EUTBL
-    "0x4f33aCf823E6eEb697180d553cE0c710124C8D59", //SPKCC
-    "0x3868D4e336d14D38031cf680329d31e4712e11cC", //eurSPKCC
-    "0x970E2aDC2fdF53AEa6B5fa73ca6dc30eAFEDfe3D", //UKTBL
+    '0xe4880249745eAc5F1eD9d8F7DF844792D560e750',
+    '0xa0769f7A8fC65e47dE93797b4e21C073c117Fc80',
+    '0x970E2aDC2fdF53AEa6B5fa73ca6dc30eAFEDfe3D',
+    '0x35dfec1813c43d82e6b87c682f560bbb8ea0c121',
+    '0x5677a4dc7484762ffccee13cba20b5c979def446',
+    '0xfe20ebe3881491b2e158b9d10cb95bcfa652262d',
+    '0xef53e7d17822b641c6481837238a64a688709301',
   ],
+}
+
+const config = {
+  ethereum: getUniqueAddresses(rawConfig.ethereum),
+  polygon: getUniqueAddresses(rawConfig.polygon),
+  arbitrum: getUniqueAddresses(rawConfig.arbitrum),
+  base: getUniqueAddresses(rawConfig.base),
+  starknet: getUniqueAddresses(rawConfig.starknet, true),
+  etlk: getUniqueAddresses(rawConfig.etlk),
   stellar: [
-    {
-      contract: "CARUUX2FZNPH6DGJOEUFSIUQWYHNL5AVDV7PMVSHWL7OBYIBFC76F4TO",
-      target: "0xe4880249745eAc5F1eD9d8F7DF844792D560e750",
-    }, // USTBL
-    {
-      contract: "CBGV2QFQBBGEQRUKUMCPO3SZOHDDYO6SCP5CH6TW7EALKVHCXTMWDDOF",
-      target: "0xa0769f7A8fC65e47dE93797b4e21C073c117Fc80",
-    }, // EUTBL
-    {
-      contract: "CDWOB6T7SVSMMQN5V3P2OPTBAXOP7DAZHGVW3PYTZIKHVFKN6TBSXR6A",
-      target: "0x3868D4e336d14D38031cf680329d31e4712e11cC",
-    }, // eurSPKCC
-    {
-      contract: "CDS2GCAQTNQINSCJUJIVBJXILKBWP5PU7LOBGHMP3X47QCQBFKPMTCNT",
-      target: "0x4f33acf823e6eeb697180d553ce0c710124c8d59",
-    }, // SPKCC
-    {
-      contract: "CDT3KU6TQZNOHKNOHNAFFDQZDURVC3MSTL4ML7TUTZGNOPBZCLABP4FR",
-      target: "0xf695Df6c0f3bB45918A7A82e83348FC59517734",
-    }, // UKTBL
+    { contract: 'CARUUX2FZNPH6DGJOEUFSIUQWYHNL5AVDV7PMVSHWL7OBYIBFC76F4TO', target: '0xe4880249745eAc5F1eD9d8F7DF844792D560e750' },
+    { contract: 'CBGV2QFQBBGEQRUKUMCPO3SZOHDDYO6SCP5CH6TW7EALKVHCXTMWDDOF', target: '0xa0769f7A8fC65e47dE93797b4e21C073c117Fc80' },
+    { contract: 'CDT3KU6TQZNOHKNOHNAFFDQZDURVC3MSTL4ML7TUTZGNOPBZCLABP4FR', target: '0xf695Df6c0f3bB45918A7A82e83348FC59517734E' },
+    { contract: 'CBOOCGZSVRSZFRE4U2NWR2B4RXYVJWRCBTGOUD2JPI2TDJPWMTJX7FZP', target: '0x0990b149e915cb08e2143a5c6f669c907eddc8b0' },
+    { contract: 'CDGSC6BA4TCAOVSFQCUEHDMOIIHYYVNYBT6YEARS4MX3ITAHUINVGQHX', target: '0xcbade7d9bdee88411cb6cbcbb29952b742036992' },
+    { contract: 'CAGYRRKPFSWKM6SJOE4QAAVYMOSHMDS5WOQ4T5A2E6XNCU7LZZKUNQKP', target: '0xc273986a91e4bfc543610a5cb5860b7cfefb6cc0' },
+    { contract: 'CAJD2IBSP7VO2VYJQUYJSOGPJINTUYV7MQITINXVPTIH3CCLCUENNMW4', target: '0x18b5c15e5196a38a162b1787875295b76e4313fb' },
   ],
-};
-
-const STELLAR_LEDGER_ENTRY_CONTRACT_DATA = 6;
-const STELLAR_SC_ADDRESS_TYPE_CONTRACT = 1;
-const STELLAR_SCVAL_LEDGER_KEY_CONTRACT_INSTANCE = 20;
-const STELLAR_CONTRACT_DATA_PERSISTENT = 1;
-
-function buildContractInstanceKey(contract) {
-  const payload = decodeStrKey(contract);
-  const buf = Buffer.alloc(48);
-  let offset = 0;
-  buf.writeUInt32BE(STELLAR_LEDGER_ENTRY_CONTRACT_DATA, offset);
-  offset += 4;
-  buf.writeUInt32BE(STELLAR_SC_ADDRESS_TYPE_CONTRACT, offset);
-  offset += 4;
-  payload.copy(buf, offset);
-  offset += 32;
-  buf.writeUInt32BE(STELLAR_SCVAL_LEDGER_KEY_CONTRACT_INSTANCE, offset);
-  offset += 4;
-  buf.writeUInt32BE(STELLAR_CONTRACT_DATA_PERSISTENT, offset);
-  return buf.toString("base64");
-}
-
-function parseTotalSupplyFromEntry(xdr) {
-  const buf = Buffer.from(xdr, "base64");
-  const marker = Buffer.from("TotalSupply");
-  const idx = buf.indexOf(marker);
-  if (idx === -1) throw new Error("TotalSupply not found in contract storage");
-  const len = buf.readUInt32BE(idx - 4);
-  let offset = idx + len;
-  offset += (4 - (len % 4)) % 4;
-  const type = buf.readUInt32BE(offset);
-  if (type !== 10) throw new Error("Unexpected TotalSupply type");
-  const hi = buf.readBigInt64BE(offset + 4);
-  const lo = buf.readBigUInt64BE(offset + 12);
-  let value = (hi << 64n) + lo;
-  if (hi < 0n) value = -(((-hi) << 64n) - lo);
-  return value.toString();
-}
-
-async function fetchStellarSupply(contract) {
-  const key = buildContractInstanceKey(contract);
-  const data = await post(SOROBAN_RPC_URL, {
-    jsonrpc: "2.0",
-    id: 1,
-    method: "getLedgerEntries",
-    params: { keys: [key] },
-  });
-  const entry = data?.result?.entries?.[0];
-  if (!entry?.xdr) throw new Error(`Missing contract data for ${contract}`);
-  return parseTotalSupplyFromEntry(entry.xdr);
 }
 
 const totalSupplyAbi = {
-  name: "totalSupply",
-  type: "function",
+  name: 'totalSupply',
+  type: 'function',
   inputs: [],
-  outputs: [
-    {
-      name: "totalSupply",
-      type: "uint256",
-    },
-  ],
-  stateMutability: "view",
-};
+  outputs: [{ name: 'totalSupply', type: 'uint256' }],
+  stateMutability: 'view',
+}
+
+const STELLAR_LEDGER_ENTRY_CONTRACT_DATA = 6
+const STELLAR_SC_ADDRESS_TYPE_CONTRACT = 1
+const STELLAR_SCVAL_LEDGER_KEY_CONTRACT_INSTANCE = 20
+const STELLAR_CONTRACT_DATA_PERSISTENT = 1
+
+function buildContractInstanceKey(contract) {
+  const payload = decodeStrKey(contract)
+  const buf = Buffer.alloc(48)
+  let offset = 0
+  buf.writeUInt32BE(STELLAR_LEDGER_ENTRY_CONTRACT_DATA, offset)
+  offset += 4
+  buf.writeUInt32BE(STELLAR_SC_ADDRESS_TYPE_CONTRACT, offset)
+  offset += 4
+  payload.copy(buf, offset)
+  offset += 32
+  buf.writeUInt32BE(STELLAR_SCVAL_LEDGER_KEY_CONTRACT_INSTANCE, offset)
+  offset += 4
+  buf.writeUInt32BE(STELLAR_CONTRACT_DATA_PERSISTENT, offset)
+  return buf.toString('base64')
+}
+
+function parseTotalSupplyFromEntry(xdr) {
+  const buf = Buffer.from(xdr, 'base64')
+  const marker = Buffer.from('TotalSupply')
+  const idx = buf.indexOf(marker)
+  if (idx === -1) throw new Error('TotalSupply not found in contract storage')
+  const len = buf.readUInt32BE(idx - 4)
+  let offset = idx + len
+  offset += (4 - (len % 4)) % 4
+  const type = buf.readUInt32BE(offset)
+  if (type !== 10) throw new Error('Unexpected TotalSupply type')
+  const hi = buf.readBigInt64BE(offset + 4)
+  const lo = buf.readBigUInt64BE(offset + 12)
+  const value = (hi << 64n) + lo
+  return value.toString()
+}
+
+async function fetchStellarSupply(contract) {
+  const key = buildContractInstanceKey(contract)
+  const data = await post(SOROBAN_RPC_URL, {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'getLedgerEntries',
+    params: { keys: [key] },
+  })
+  const entry = data?.result?.entries?.[0]
+  if (!entry?.xdr) throw new Error(`Missing contract data for ${contract}`)
+  return parseTotalSupplyFromEntry(entry.xdr)
+}
+
+module.exports = {
+  methodology:
+    'Sums ERC-20 / Starknet / Stellar totalSupply for Spiko share registers: USTBL (USD), EUTBL (EUR), UKTBL (GBP), and SAFO (EUR/USD/GBP/CHF). Excludes USTBL and UKTBL EUR-unhedged lines. Priced via DefiLlama.',
+}
 
 Object.keys(config).forEach((chain) => {
-  const assets = config[chain];
+  const assets = config[chain]
   module.exports[chain] = {
     tvl: async (api) => {
-      if (chain === "stellar") {
-        const supplies = await Promise.all(
-          assets.map(({ contract }) => fetchStellarSupply(contract))
-        );
+      if (chain === 'stellar') {
+        const supplies = await Promise.all(assets.map(({ contract }) => fetchStellarSupply(contract)))
         supplies.forEach((supply, i) => {
-          const { target } = assets[i];
-          api.add(`ethereum:${target}`, supply, { skipChain: true });
-        });
-        return api.getBalances();
+          const { target } = assets[i]
+          api.add(`ethereum:${target.toLowerCase()}`, supply, { skipChain: true })
+        })
+        return api.getBalances()
       }
-      let supplies;
-      if (chain === "starknet")
-        supplies = await multiCall({ abi: totalSupplyAbi, calls: assets });
+      let supplies
+      if (chain === 'starknet')
+        supplies = await multiCall({ abi: totalSupplyAbi, calls: assets })
       else
-        supplies = await api.multiCall({
-          abi: "erc20:totalSupply",
-          calls: assets,
-        });
-      api.add(assets, supplies);
-      return sumTokens2({ api });
+        supplies = await api.multiCall({ abi: 'erc20:totalSupply', calls: assets })
+      api.add(assets, supplies)
+      return sumTokens2({ api })
     },
-  };
-});
+  }
+})


### PR DESCRIPTION
Updates projects/spiko/index.js so TVL includes all on-chain share registers from Spiko’s prospectus / DLT address schedule (3 March 2026):

USTBL (USD + EUR unhedged)
EUTBL (EUR)
UKTBL (GBP + EUR unhedged)
SAFO – Amundi Overnight Swap (EUR, USD, GBP, CHF unhedged)
Chains covered: Ethereum, Polygon, Arbitrum, Base, Starknet, Etherlink (etlk), Stellar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Stellar support using Soroban RPC to read contract supplies; Stellar assets now map contract → target and contribute to target balances in TVL.
  * Expanded chain coverage (including Base) and broader token/address inclusion.
  * Published methodology description.

* **Bug Fixes**
  * Removed duplicate address entries across EVM-compatible and Starknet-like chains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->