### PR TITLE
Add RockawayX Risk Curator

### DIFF
--- a/projects/mev-capital/index.js
+++ b/projects/mev-capital/index.js
@@ -247,10 +247,7 @@ const configs = {
         '0xa01227a26a7710bc75071286539e47adb6dea417', // Terminal tUSDe
         '0xa1150cd4a014e06f5e0a6ec9453fe0208da5adab', // Terminal tWETH
       ],
-      midas: [
-        '0x030b69280892c888670edcdcd8b69fd8026a0bf3', // Midas mMEV Vault
-        '0xb64c014307622eb15046c66ff71d04258f5963dc', // Midas mevBTC Vault (price not in the api yet)
-      ],
+      midas: [],
       upshift: [
         '0x5fde59415625401278c4d41c6befce3790eb357f', // The Treehouse Growth Vault
       ],

--- a/projects/rockawayx/index.js
+++ b/projects/rockawayx/index.js
@@ -1,69 +1,56 @@
-const ADDRESSES = require('../helper/coreAssets.json');
 const { getCuratorExport } = require("../helper/curators");
 
-const MMEV_VAULTS = {
-  ethereum: {
-    token: '0x030b69280892c888670EDCDCD8B69Fd8026A0BF3',
-    dataFeed: '0x5f09Aff8B9b1f488B7d1bbaD4D89648579e55d61',
-    underlying: ADDRESSES.ethereum.USDC,
-    underlyingDecimals: 6,
-  },
-  plume_mainnet: {
-    token: '0x7d611dC23267F508DE90724731Dc88CA28Ef7473',
-    dataFeed: '0x4e5B43C9c8B7299fd5C7410b18e3c0B718852061',
-    underlying: ADDRESSES.plume_mainnet.USDC,
-    underlyingDecimals: 6,
-  },
-  etlk: {
-    token: '0x5542F82389b76C23f5848268893234d8A63fd5c8',
-    dataFeed: '0x077670B2138Cc23f9a9d0c735c3ae1D4747Bb516',
-    underlying: ADDRESSES.etlk.USDC,
-    underlyingDecimals: 6,
-  },
-};
-
-const MEVBTC = {
-  token: '0xb64C014307622eB15046C66fF71D04258F5963DC',
-  dataFeed: '0xffd462e0602Dd9FF3F038fd4e77a533f8c474b65',
-  underlying: ADDRESSES.ethereum.WBTC,
-  underlyingDecimals: 8,
+const MIDAS_VAULTS = {
+  ethereum: [
+    '0x030b69280892c888670EDCDCD8B69Fd8026A0BF3', // mMEV
+    '0xb64C014307622eB15046C66fF71D04258F5963DC', // mevBTC
+  ],
+  plume_mainnet: [
+    '0x7d611dC23267F508DE90724731Dc88CA28Ef7473', // mMEV
+  ],
+  etlk: [
+    '0x5542F82389b76C23f5848268893234d8A63fd5c8', // mMEV
+  ],
 };
 
 const configs = {
   methodology: 'Count all assets deposited in all vaults curated by RockawayX.',
   blockchains: {
+    ethereum: {
+      morpho: [
+        '0x5f829B1B473cBA86838E1B7BB7E144DbDE228e21',
+        '0xE0181090c22579B6A217f1522cbf8c9f1F0C1965',
+        '0x64C18DCC4Ccb3b8D27877a4aeBB4C3126CB39cB9',
+      ],
+    },
     solana: {
       kaminoLendVaults: ['DWSXb18xZApz29vnQpgR2m6MynCT7PznaXt7Ut7M7KaP'], // Kamino RWA USDC
     },
   }
 }
 
-async function midasDataFeedTvl(api, { token, dataFeed, underlying, underlyingDecimals }) {
-  const totalSupply = await api.call({ abi: 'uint256:totalSupply', target: token });
-  const lastAnswer = await api.call({ abi: 'int256:lastAnswer', target: dataFeed });
-  if (lastAnswer <= 0) return;
-  const feedDecimals = await api.call({ abi: 'uint8:decimals', target: dataFeed });
-
-  const totalValue = (BigInt(lastAnswer) * BigInt(totalSupply) * BigInt(10 ** underlyingDecimals)) /
-                     (BigInt(10 ** Number(feedDecimals)) * BigInt(10 ** 18));
-  api.add(underlying, totalValue.toString());
-}
-
 const adapterExport = getCuratorExport(configs);
 
-for (const [chain, vault] of Object.entries(MMEV_VAULTS)) {
+async function midasTvl(api, vaults) {
+  const totalSupplies = await api.multiCall({
+    abi: 'uint256:totalSupply',
+    calls: vaults,
+    permitFailure: true
+  });
+  for (let i = 0; i < vaults.length; i++) {
+    if (totalSupplies[i] === null || totalSupplies[i] === undefined) continue;
+    api.add(vaults[i], totalSupplies[i]);
+  }
+}
+
+for (const [chain, vaults] of Object.entries(MIDAS_VAULTS)) {
+  const baseTvl = adapterExport[chain]?.tvl;
   adapterExport[chain] = {
     tvl: async (api) => {
-      await midasDataFeedTvl(api, vault);
+      if (baseTvl) await baseTvl(api);
+      await midasTvl(api, vaults);
     }
   };
 }
-
-// Add mevBTC on ethereum
-const baseEthTvl = adapterExport.ethereum.tvl;
-adapterExport.ethereum.tvl = async (api) => {
-  await baseEthTvl(api);
-  await midasDataFeedTvl(api, MEVBTC);
-};
 
 module.exports = adapterExport;


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
RockawayX

##### Twitter Link:
https://x.com/Rockaway_X

##### List of audit links if any:
N/A

##### Website Link:
https://rockawayx.com/

##### Logo (High resolution, will be shown with rounded borders):
https://drive.google.com/drive/folders/1bLhLlWG6LC1YMS-wG9KAIuW0Eief51al

##### Current TVL:
~$30M

##### Treasury Addresses (if the protocol has treasury)
N/A

##### Chain:
Ethereum, Etherlink, Plume, Solan

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):


##### Short Description (to be shown on DefiLlama):
On-chain asset manager. Risk curator on Morpho and other DeFi lending protocols. Market-neutral yield strategies for institutional and HNWI clients - stablecoins, ETH, BTC, SOL.

##### Token address and ticker if any:
N/A

##### Category (full list at https://defillama.com/categories) \*Please choose only one:
Risk Curators

##### Oracle Provider(s):
Chainlink, Redstone

##### Implementation Details:
RockawayX curates Money Market vaults as a risk manager, selects collateral types, sets LTV parameters, monitors liquidation risks via real-time monitoring tools and proprietary risk scoring matrix. Non-custodial via ForDeFi MPC infrastructure.

##### Documentation/Proof:
https://rockawayx.com/

##### forkedFrom:
N/A

##### methodology:
Sum of assets deposited in curated Morpho vaults under RockawayX risk management, across all supported chains.

##### Github org/user:


##### Does this project have a referral program?
No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RockawayX TVL augmentation to include additional vault supplies across multiple chains, increasing visibility of those assets in overall TVL.

* **Changes**
  * Removed two Midas vaults from Ethereum TVL calculations for MEV Capital, so those specific vault supplies are no longer counted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->