### PR TITLE
fix(predmart): correct chain to Polygon, add borrowed TVL, update category to Lending

### DIFF
--- a/projects/predmart/index.js
+++ b/projects/predmart/index.js
@@ -1,10 +1,26 @@
+// projects/predmart/index.js
+const ADDRESSES = require('../helper/coreAssets.json')
+
+const LENDING_POOL = "0xD90D012990F0245cAD29823bDF0B4C9AF207d9ee";
+const USDC = ADDRESSES.polygon.USDC;
+
 module.exports = {
-    base: {
-      tvl: async (api) => {
-        await api.sumTokens({
-          owners: ["0x0a7EFC7161fAa3DFA597481C62bb7B232AAB2Fa0"],
-          tokens: ["0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"],
-        });
-      },
+  methodology: "TVL represents liquid USDC currently available in the PredMart lending pool (total deposits minus outstanding borrows). Borrowed reflects total USDC actively lent out to borrowers who posted Polymarket prediction market shares as collateral. Total lender deposits = TVL + Borrowed.",
+  polygon: {
+    tvl: async (api) => {
+      // Liquid USDC sitting in the lending pool contract
+      await api.sumTokens({
+        owners: [LENDING_POOL],
+        tokens: [USDC],
+      });
     },
-  };
+    borrowed: async (api) => {
+      // Total USDC currently lent out to borrowers
+      const totalBorrowed = await api.call({
+        target: LENDING_POOL,
+        abi: "function totalBorrowAssets() view returns (uint256)",
+      });
+      api.add(USDC, totalBorrowed);
+    },
+  },
+};


### PR DESCRIPTION
## Summary

PredMart has pivoted from a prediction market to a **non-custodial USDC lending protocol** on **Polygon**. This PR fixes the adapter to reflect the current protocol and requests a metadata update.

### What changed in the adapter

| | Before | After |
|---|---|---|
| Chain | `base` | `polygon` |
| Contract | `0x0a7EFC7161fAa3DFA597481C62bb7B232AAB2Fa0` | `0xD90D012990F0245cAD29823bDF0B4C9AF207d9ee` |
| Token | USDC on Base | `ADDRESSES.polygon.USDC` (0x2791Bca...) |
| Borrowed tracking | ❌ | ✅ via `totalBorrowAssets()` |

### Protocol description (please update)

**Category:** `Lending` (was: `Prediction Market`)

**Description:** PredMart is a non-custodial USDC lending protocol on Polygon. Lenders supply USDC to earn yield; borrowers post Polymarket prediction market shares (ERC-1155 tokens) as collateral to borrow USDC, enabling leveraged exposure on prediction markets.

### TVL methodology

- **TVL** = liquid USDC in the lending pool contract (total deposits minus outstanding borrows), tracked via `api.sumTokens`
- **Borrowed** = total USDC actively lent out, tracked via `totalBorrowAssets()` on the lending pool
- **Total deposits** = TVL + Borrowed

### Links

- Website: https://predmart.com
- Docs: https://predmart.com
- Contract on Polygonscan: https://polygonscan.com/address/0xD90D012990F0245cAD29823bDF0B4C9AF207d9ee

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PredMart DeFi protocol support on Polygon network with comprehensive TVL tracking. Monitor liquid USDC held in the lending pool including both deposits and total borrowed assets for complete economic activity visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->