### PR TITLE
fix(predmart): correct chain to Polygon, add borrowed TVL, update category to Lending

### DIFF
--- a/projects/predmart/index.js
+++ b/projects/predmart/index.js
@@ -6,6 +6,9 @@ const USDC = ADDRESSES.polygon.USDC;
 
 module.exports = {
   methodology: "TVL represents liquid USDC currently available in the PredMart lending pool (total deposits minus outstanding borrows). Borrowed reflects total USDC actively lent out to borrowers who posted Polymarket prediction market shares as collateral. Total lender deposits = TVL + Borrowed.",
+  base: {
+    tvl: () => ({}),
+  },
   polygon: {
     tvl: async (api) => {
       // Liquid USDC sitting in the lending pool contract


### PR DESCRIPTION
## Summary

PredMart has pivoted from a prediction market to a **non-custodial USDC lending protocol** on **Polygon**. This PR fixes the adapter to reflect the current protocol and requests a metadata update.

### What changed in the adapter

| | Before | After |
|---|---|---|
| Chain | `base` | `polygon` |
| Contract | `0x0a7EFC7161fAa3DFA597481C62bb7B232AAB2Fa0` | `0xD90D012990F0245cAD29823bDF0B4C9AF207d9ee` |
| Token | USDC on Base | `ADDRESSES.polygon.USDC` (0x2791Bca…) |
| Borrowed tracking | ❌ | ✅ via `totalBorrowAssets()` |

### Metadata update request

**Category:** `Lending` (was: `Prediction Market`)

**Description:** PredMart is a non-custodial USDC lending protocol on Polygon. Lenders supply USDC to earn yield; borrowers post Polymarket prediction market shares (ERC-1155 tokens) as collateral to borrow USDC, enabling leveraged exposure on prediction markets.

### TVL methodology

- **TVL** = liquid USDC in the lending pool (total deposits minus borrows), tracked via `api.sumTokens`
- **Borrowed** = outstanding USDC loans, tracked via `totalBorrowAssets()` on the lending pool
- **Total deposits** = TVL + Borrowed

### Links

- Website: https://predmart.com
- Contract: https://polygonscan.com/address/0xD90D012990F0245cAD29823bDF0B4C9AF207d9ee

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Polygon network support with total value locked tracking.
  * Introduced borrowed assets monitoring and reporting.

* **Documentation**
  * Added methodology documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->