### PR TITLE
Update the BSquared backend addresses, remove the unused addresses.

### DIFF
--- a/projects/helper/bitcoin-book/index.js
+++ b/projects/helper/bitcoin-book/index.js
@@ -180,10 +180,7 @@ module.exports = {
     "155FvRapVDRbFYxaxGxJ9eCQjgr7X2yC6g",
     "bc1q745ywhqsssknaw8s5ycgkv0gulddnasn4tfsjwgm66tvgp2pqpys0zjzt8",
     "bc1q07er4xwsv209cfjsvsl3fjmpvcx462dvpjrjpj",
-    "bc1pg05lsdyzx8j5wastzk0svu84hdrvkel2zfq560a7the5vvjyp27svxwgyx",
-    "bc1qh6u403822hwm7mhncn2dw8pyaup2mwv4p4j8ckfe9p5zj3wdxyeszpsck8",
     "bc1qmvvnxu7739hk9xvgtk4evsx9ycm20ae25gfand",
-    "bc1que9dvsgwlm6vr5chrxm2gu586c5alnq3uxa4e2",
     "bc1qnp5dfweymkfyl3wzmzqxjyq0ejf2cnpynnfkmr",
     "bc1qe0srwsmxx2z0mkksqxx72nsgc9m2lvj4777aq8"
   ],


### PR DESCRIPTION
Update the BSquared backend addresses, remove the unused addresses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed four deprecated Bitcoin custodian addresses from the system reference list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->