### PR TITLE
Add Dash config to near-intents adapter

### DIFF
--- a/projects/near-intents/index.js
+++ b/projects/near-intents/index.js
@@ -38,6 +38,7 @@ const CONFIG = {
 
   stellar: { owners: ['GDJ4JZXZELZD737NVFORH4PSSQDWFDZTKW3AIDKHYQG23ZXBPDGGQBJK'] },
   cardano: { owners: ['addr1v8wfpcg4qfhmnzprzysj6j9c53u5j56j8rvhyjp08s53s6g07rfjm'], tokens: [native] },
+  dash: { owners: ['XxA9DbXaFpF4GFY8KUNX7eAxhZPsWtcKhc'] },
 }
 
 const tvl = async (api) => {


### PR DESCRIPTION
As the DeFi Llama team asked, I have added the Dash treasury account to the Near Intents adapter config.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Dash blockchain network to supported chains
  * Enabled TVL metrics tracking for Dash

<!-- end of auto-generated comment: release notes by coderabbit.ai -->