### PR TITLE
fix project-x

### DIFF
--- a/registries/uniswapV3.js
+++ b/registries/uniswapV3.js
@@ -1084,6 +1084,7 @@ const uniV3Configs = {
     hyperliquid: {
       factory: '0xff7b3e8c00e57ea31477c32a5b52a58eea47b072',
       fromBlock: 7876741,
+      permitFailure: true,
     },
   },
   'quickswap-v3': {


### PR DESCRIPTION
Alternatively we can add this:

```ts
      blacklistedTokens: [
        '0x0000000000000000000000000000000000000001',
        '0x0000000000000000000000000000000000aaaaaa',
        '0x02c6a2e0fa003ac0e40ff9945c6e17e06fdbbbdf'
      ],
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated protocol registry configuration to extend network-specific settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->