### PR TITLE
Add Quell TVL adapter (Base, ERC-4626 vault)

### DIFF
--- a/projects/quell/index.js
+++ b/projects/quell/index.js
@@ -1,12 +1,7 @@
-const { sumERC4626VaultsExport } = require("../helper/erc4626");
-
-const RWA_VAULT = "0xd85A4301706124699CbA8d0b59E5ED635360868b";
+const RWA_VAULT = ["0xd85A4301706124699CbA8d0b59E5ED635360868b"];
 
 module.exports = {
   doublecounted: true,
-  methodology:
-    "TVL is the total USDC deposited in the Quell RWAVault, an ERC-4626 vault on Base that routes to the Steakhouse USDC MetaMorpho vault for RWA yield.",
-  base: {
-    tvl: sumERC4626VaultsExport({ vaults: [RWA_VAULT] }),
-  },
+  methodology: "TVL is the total USDC deposited in the Quell RWAVault, an ERC-4626 vault on Base that routes to the Steakhouse USDC MetaMorpho vault for RWA yield.",
+  base: { tvl: (api) => { api.erc4626Sum({ calls: RWA_VAULT.map(vault => vault), tokenAbi: 'address:asset', balanceAbi: 'uint256:totalAssets' }) } },
 };


### PR DESCRIPTION
### Protocol: Quell
### Website/App: https://quell.fi / https://app.quell.fi
### Chain: Base
### Twitter: N/A
### Audit: Pre-audit (Slither clean, 101 Foundry tests, 48hr timelock, $100K TVL cap)
### Category: Yield

### Description
Quell is an ERC-4626 USDC yield vault on Base that routes deposits into the Steakhouse USDC MetaMorpho vault via Morpho for RWA-backed yield. Net APY ~3.33% after 0.2% management fee + 10% performance fee. Fees are split 60/40 between QUELL token stakers and treasury.

### Contracts
- RWAVault (rvUSDC): [0xd85A4301706124699CbA8d0b59E5ED635360868b](https://basescan.org/address/0xd85A4301706124699CbA8d0b59E5ED635360868b)
- MorphoAdapter: [0xc804F2F92Fd45d7A5bd8cf49DBC795EEd874328C](https://basescan.org/address/0xc804F2F92Fd45d7A5bd8cf49DBC795EEd874328C)
- QUELL Token: [0xab1F67524ab5248E06ac1992478959E0A7503399](https://basescan.org/address/0xab1F67524ab5248E06ac1992478959E0A7503399)
- GovStaking: [0x30A7e517799e409d5E68AAf0b34543b9c8BB1aC7](https://basescan.org/address/0x30A7e517799e409d5E68AAf0b34543b9c8BB1aC7)
- FeeDistributor: [0xeb39D2C50Fb70235120a853CdDFeD5325bc3D3d7](https://basescan.org/address/0xeb39D2C50Fb70235120a853CdDFeD5325bc3D3d7)
- TimelockController: [0xE1EF2c167a94aCf5F4eb62EC8ec12BE14448E15e](https://basescan.org/address/0xE1EF2c167a94aCf5F4eb62EC8ec12BE14448E15e)

### Token
- QUELL: 0xab1F67524ab5248E06ac1992478959E0A7503399 (Base)
- Fixed 100M supply, no minting

### Methodology
TVL is calculated using the ERC-4626 `totalAssets()` function on the RWAVault contract, which returns the total USDC deposited. Marked as `doublecounted: true` because deposits route into the Steakhouse USDC MetaMorpho vault, which is already tracked on DefiLlama.

### Similar to
Morpho MetaMorpho vaults, Yearn V3

### Forked from
Not a fork — original protocol built on OpenZeppelin v5 ERC-4626.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking support for the Quell RWA vault on Base, showing total USDC deposited (including assets routed through a Steakhouse MetaMorpho vault) and enabling aggregate TVL reporting for that vault.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->