### PR TITLE
Add VIRTUS Protocol TVL adapter (Base)

### DIFF
--- a/projects/virtus-protocol/index.js
+++ b/projects/virtus-protocol/index.js
@@ -1,0 +1,27 @@
+const sdk = require('@defillama/sdk')
+const { uniV3Export } = require('../helper/uniswapV3')
+const { getUniTVL } = require('../helper/unknownTokens')
+
+const v2Abis = {
+  allPairsLength: 'uint256:allPoolsLength',
+  allPairs: 'function allPools(uint256) view returns (address)',
+}
+
+const clTvl = uniV3Export({
+  base: {
+    factory: '0x0e5Ab24beBdA7e5Bb3961f7E9b3532a83aE86B48',
+    fromBlock: 42960000,
+    eventAbi: 'event PoolCreated(address indexed token0, address indexed token1, int24 indexed tickSpacing, address pool)',
+    topics: ['0xab0d57f0df537bb25e80245ef7748fa62353808c54d6e528a9dd20887aed9ac2'],
+  },
+})
+
+module.exports = {
+  misrepresentedTokens: true,
+  base: {
+    tvl: sdk.util.sumChainTvls([
+      clTvl.base.tvl,
+      getUniTVL({ factory: '0x7F03ae4452192b0E280fB0d4f9c225DDa88C7623', useDefaultCoreAssets: true, hasStablePools: true, abis: v2Abis }),
+    ]),
+  },
+}


### PR DESCRIPTION
Adds TVL adapter for VIRTUS Protocol (Aerodrome fork) on Base mainnet.

Uses uniswapV2 helper for basic AMM pools (PoolFactory: 0x7F03ae4452192b0E280fB0d4f9c225DDa88C7623) and uniswapV3 helper for concentrated liquidity pools (CLFactory: 0x0e5Ab24beBdA7e5Bb3961f7E9b3532a83aE86B48).

Website: https://virtus-protocol.com
Twitter: https://x.com/VirtusCEO

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Virtus Protocol integration for TVL tracking across multiple liquidity sources and networks.
  * Aggregates TVL from distinct pool discovery methods to provide a single, combined TVL metric.
  * Improved handling of token representations to produce more accurate total value locked calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->