### PR TITLE
Update Fluxtra adapter to Solidity EVM

### DIFF
--- a/projects/fluxtra/index.js
+++ b/projects/fluxtra/index.js
@@ -1,19 +1,18 @@
 const ADDRESSES = require('../helper/coreAssets.json')
+const { sumBoringTvl } = require('../helper/boringVault')
 
 // stMANTRA Liquid Staking (ERC-4626 Vault) — also the stMANTRA token address
 const STAKING_VAULT = '0x4131a80b67BE287627766B858C3C6d7f9e900324'
 
-// Mantra EVM tokens not yet in DefiLlama's pricing DB — map via CoinGecko
-const CG_TOKEN_MAPPING = {
-  '0x3806640578b710d8480910bF51510bc538d2F51A': { coingeckoId: 'tether', decimals: 6 },  // USDT
-}
+const LENS = '0x040aa0d3bEdc4aDBEcED86E85Cdd2fB4f7E9Fe52'
 
 // RFR Vaults (BoringVault / Arctic Architecture)
 const RFR_VAULTS = [
   {
     // wmantraUSD Yield Vault
-    boringVault: '0x320C6ebDd3e0c322AFb42D71d264a316fC81E13A',
+    id: '0x320C6ebDd3e0c322AFb42D71d264a316fC81E13A',
     accountant: '0xcB6C931AC97Da626684B44af070465938eAE20b6',
+    lens: LENS,
   },
   // wmantraUSD Points Vault — add here once deployed
 ]
@@ -32,17 +31,8 @@ async function tvl(api) {
   const totalAssets = await api.call({ abi: 'uint256:totalAssets', target: STAKING_VAULT })
   api.add(ADDRESSES.mantra.wMANTRA, totalAssets)
 
-  // 2. RFR Vaults — TVL = totalSupply * getRate / 10^decimals
-  for (const { boringVault, accountant } of RFR_VAULTS) {
-    const [totalSupply, rate, decimals] = await Promise.all([
-      api.call({ abi: 'uint256:totalSupply', target: boringVault }),
-      api.call({ abi: 'uint256:getRate', target: accountant }),
-      api.call({ abi: 'uint8:decimals', target: boringVault }),
-    ])
-    const base = await api.call({ abi: 'address:base', target: accountant })
-    const assets = BigInt(totalSupply) * BigInt(rate) / (10n ** BigInt(decimals))
-    api.add(base, assets.toString())
-  }
+  // 2. RFR Vaults — uses ArcticArchitectureLens.totalAssets() via shared helper
+  await sumBoringTvl({ vaults: RFR_VAULTS, api })
 
   // 3. LP CLM Vaults — balances() returns (amount0, amount1), wants() returns (token0, token1)
   const balances = await api.multiCall({ abi: 'function balances() view returns (uint256, uint256)', calls: CLM_VAULTS })
@@ -56,12 +46,8 @@ async function tvl(api) {
       if (tokens[j].toLowerCase() === STAKING_VAULT.toLowerCase()) {
         // Skip stMANTRA — its backing OM is already counted by totalAssets() above
         continue
-      } else if (CG_TOKEN_MAPPING[tokens[j]]) {
-        const { coingeckoId, decimals } = CG_TOKEN_MAPPING[tokens[j]]
-        api.addCGToken(coingeckoId, Number(bals[j]) / (10 ** decimals))
-      } else {
-        api.add(tokens[j], bals[j])
       }
+      api.add(tokens[j], bals[j])
     }
   }
 }

--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -49,9 +49,6 @@ const fixBalancesTokens = {
     'pm.pool.asset.3hjz8rcr3pejdc3msntlvy': { coingeckoId: 'usd-coin', decimals: 0 },
     'pm.pool.asset.1y3flutqcyuf8duew1vj2g': { coingeckoId: 'usd-coin', decimals: 0 },
   },
-  mantra: {
-    '0x3806640578b710d8480910bf51510bc538d2f51a': { coingeckoId: 'tether', decimals: 6 },
-  },
 }
 
 ibcChains.forEach(chain => fixBalancesTokens[chain] = { ...ibcMappings, ...(fixBalancesTokens[chain] || {}) })
@@ -97,7 +94,7 @@ function getCoreAssets(chain = 'ethereum') {
 
 function normalizeAddress(address, chain, extractChain = false) {
   if (!chain && extractChain && address.includes(':')) chain = address.split(':')[0]
-  if ((chain === 'sei' || chain === 'mantra') && address?.startsWith('0x')) return address.toLowerCase()
+  if (chain === 'sei' && address?.startsWith('0x')) return address.toLowerCase()
   if (caseSensitiveChains.includes(chain)) return address
   return address.toLowerCase()
 }


### PR DESCRIPTION
## Summary
- Replaces old CosmWasm single-contract LSD adapter with full EVM adapter
- Now covers all three Fluxtra products on MANTRA mainnet (chain ID 5888):
  - **stMANTRA** liquid staking — ERC-4626 vault `totalAssets()`
  - **RFR wmantraUSD yield vault** — BoringVault/Arctic architecture `totalSupply * getRate`
  - **5 LP CLM vaults** on QuickSwap — concentrated liquidity `balances()` + `wants()`
- Adds USDT and mUSD (mantraUSD) to mantra `coreAssets.json`
- Adds USDT `fixBalancesTokens` mapping for mantra chain
- Handles stMANTRA→wOM conversion in LP vaults via `convertToAssets()`

## Test plan
- [x] `node test.js projects/fluxtra/index.js` passes — $89.57k TVL
- [x] No unrecognized tokens in output
- [x] TVL breakdown matches on-chain data: LP vaults ~$75k, stMANTRA ~$14k, RFR vault included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Mantra TVL reporting by aggregating staking, vaults, and LP underlying token balances
  * Added support for USDT and mUSD balances on Mantra

* **Chores**
  * Improved token mapping and address normalization for Mantra to yield more accurate balance and price attribution
<!-- end of auto-generated comment: release notes by coderabbit.ai -->