### PR TITLE
add Edel adapter

### DIFF
--- a/registries/aaveV3.js
+++ b/registries/aaveV3.js
@@ -75,6 +75,11 @@ const configs = {
       staking: ['0x5C75A733656c3E42E44AFFf1aCa1913611F49230', '0x25356aeca4210eF7553140edb9b8026089E49396'],
     },
   },
+  'edel': {
+    ethereum: {
+      poolDatas: ['0xf3A3F900151c092007FD495ABf3f0f6162A37501']
+    }
+  }
 }
 
 module.exports = buildProtocolExports(configs, aaveV3ExportFn)


### PR DESCRIPTION
### PR rewritten from the original PR #18520 

Name (to be shown on DefiLlama):
Edel

Twitter Link:
https://x.com/edeldotfinance

List of audit links if any:
Not yet (in progress)

Website Link:
https://www.edel.finance/

Logo (High resolution, will be shown with rounded borders):
Edel_Logo_Icon

Current TVL:
$369,190

Treasury Addresses (if the protocol has treasury):
0xBbE015118d6CA79C8E1DA11CD7015E5B1107eC36

Chain:
Ethereum

Coingecko ID:
edel

Coinmarketcap ID:
38966

Short Description:
Edel is the global platform for tokenized stocks. The next-generation infrastructure for tokenized securities: transparent, efficient, and built for scale.

Token address and ticker if any:
Ticker: EDEL
Base: 0xFb31f85A8367210B2e4Ed2360D2dA9Dc2D2Ccc95
Ethereum: 0xbf59dbc154421a7b37f4f2841e11f4ed2a1dee7c
BSC: 0xbf59dbc154421a7b37f4f2841e11f4ed2a1dee7c
Solana: 5g6wVay8NYQ5Tspo4irj9YqSFfQoPDW7apkX352N29PP

Category:
Lending

Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
Chainlink

Implementation Details: Briefly describe how the oracle is integrated into your project:
https://docs.edel.finance/concepts/oracles

Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
https://docs.edel.finance/
https://docs.edel.finance/concepts/oracles

forkedFrom: Aave V3 Fork
methodology:
TVL: Counts the tokens locked in the contracts to be used as collateral to borrow or to earn yield. Borrowed coins are not counted towards the TVL, so only the coins actually locked in the contracts are counted.

Github org/user:
https://github.com/Edel-Finance

Does this project have a referral program?
No