### PR TITLE
Add Api3 curator TVL

### DIFF
--- a/projects/api3/index.js
+++ b/projects/api3/index.js
@@ -19,7 +19,7 @@ const configs = {
 const staking = async (api) => {
   const balances = await api.call({ target: api3CirculatingSupply, abi: "uint256:getLockedVestings" })
   api.add(api3_token, -balances)
-  return sumTokens2({ owner: api3_dao_pool, tokens: [api3_token] })
+  return sumTokens2({ owner: api3_dao_pool, tokens: [api3_token], api })
 }
 
 module.exports = {


### PR DESCRIPTION
Hello DefiLlama team!

This PR adds curator TVL for Api3 from their curated Morpho vaults.

https://app.morpho.org/ethereum/vault/0x54210d3f1A066413891AF9E17210E787d5C6e3f4/kabu-usdc
https://app.morpho.org/ethereum/vault/0xe2221Aa07ec3266DA87763E2b1e28d07A8a4e53b/api3-core-usdc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Staking calculation simplified and reorganized; staking is now the primary callable entry for Ethereum.
  * Module now integrates curator-provided exports and removes the previous empty TVL entry.

* **Documentation**
  * Updated methodology: TVL now includes Api3 tokens staked in the DAO Pool and assets deposited in Api3-curated vaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->