### PR TITLE
feat: add new RWAs on Stellar chain support for Templar

### DIFF
--- a/projects/templarfi/index.js
+++ b/projects/templarfi/index.js
@@ -17,6 +17,12 @@ function detectCrossChainToken(tokenId) {
     const stellarMappings = {
       '111bzQBB5v7AhLyPMDwS8uJgQV24KaAPXtwyVWu2KXbbfQU6NXRCz': 'coingecko:stellar',
       '111bzQBB65GxAPAVoxqmMcgYo5oS3txhqs1Uh1cgahKQUeTUq1TJu': 'coingecko:usd-coin',
+      '111bzQBB62XZkuam1hPr5wsG54FvwhYaPvecKwgZo1ZoKMWEXcE2n': 'coingecko:paypal-usd',
+      '111bzQBB66Lr9d7WU1sDna78SqG5x1ZraFjkpPdiYXjHFRnZJUhuV': 'coingecko:defi-janus-henderson-anemoy-aaa-clo-fund',
+      '111bzQBB5y5yhcUCbDKaCx4zNjEHQbwLAdvwucCecVzC5Ub7uNKEb': 'coingecko:defi-janus-henderson-anemoy-aaa-clo-fund',
+      '111bzQBB5xzU1EsXby4ckez2qjWFTBiPoqHzZpPkq1Gr9gB7FQpeZ': 'coingecko:solv-protocol-btc',
+      '111bzQBB5uBD3Wrr7pthp8XhJsreEcwTVnmjQ1wpbzkvHLEQf3ygS': 'coingecko:etherfuse-cetes',
+      '111bzQBB5yT2A5maKJqJQsuNg7BA6VG4S4ZATpqmKYLwYBsfEfh6e': 'coingecko:ustbl',
     }
     const match = tokenId.match(/1100_([a-zA-Z0-9]+)$/)
     if (match && stellarMappings[match[1]]) {


### PR DESCRIPTION
This PR adds 6 more assets to be supported on Stellar chain for Templar

 ### Context

All tokens arrive as Nep245 assets with token_id like nep245:v2_1.omni.hot.tg:1100_{suffix}. The existing detectCrossChainToken regex /1100_([a-zA-Z0-9]+)$/ already extracts the suffix correctly, so no logic
 changes are needed — only data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded support for additional Stellar tokens bridged cross-chain, enabling automatic recognition and price retrieval for these assets.
  * Enhanced portfolio accuracy: balances, valuations, and charts now reflect the newly supported tokens.
  * Token detail views will display up-to-date pricing where available.
  * Existing token detection behavior remains unchanged for all other assets, ensuring a seamless upgrade.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->