### PR TITLE
Add Punks Terminal (CryptoPunks trading terminal)

### DIFF
--- a/projects/punks-terminal/index.js
+++ b/projects/punks-terminal/index.js
@@ -5,22 +5,14 @@ const STASH_FACTORY = '0x000000000000A6fA31F5fC51c1640aAc76866750'
 const WETH = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'
 const ETH = '0x0000000000000000000000000000000000000000'
 
-module.exports = {
-  methodology: 'TVL is the sum of ETH and WETH held across all Stash contracts deployed via the Stash Factory.',
-  ethereum: {
-    tvl: async (api) => {
-      const logs = await getLogs2({
-        api,
-        target: STASH_FACTORY,
-        eventAbi: 'event Deployed(address indexed proxy, address indexed implementation)',
-        fromBlock: 19000000,
-      })
-      const stashAddresses = [...new Set(logs.map(log => log.proxy.toLowerCase()))]
-      const tokensAndOwners = stashAddresses.flatMap(stash => [
-        [ETH, stash],
-        [WETH, stash],
-      ])
-      return sumTokens2({ api, tokensAndOwners, permitFailure: true })
-    }
-  }
+const DEPLOYED_ABI = 'event Deployed(address indexed proxy, address indexed implementation)'
+
+const tvl = async (api) => {
+  const logs = await getLogs2({ api, target: STASH_FACTORY, eventAbi: DEPLOYED_ABI, fromBlock: 19000000, onlyArgs: true })
+  const owners = logs.map(log => log.proxy)
+  return sumTokens2({ api, owners, tokens: [ETH, WETH], permitFailure: true })
+}
+
+module.exports =  {
+  ethereum : { tvl }
 }


### PR DESCRIPTION
## Protocol Description\n\nPunks Terminal is a CryptoPunks trading terminal built by Lightyear. Users deploy Stash contracts via the audited Stash Factory, deposit ETH/WETH liquidity, and place trait-filtered Merkle bids using EIP-712 signatures.\n\n## Methodology\n\nTVL is the sum of ETH and WETH held across all Stash contracts deployed via the Stash Factory (0x000000000000A6fA31F5fC51c1640aAc76866750). The adapter queries Deployed events from the factory to enumerate all stash addresses dynamically.\n\n## Checklist\n\n- [x] Adapter calculates TVL from on-chain data\n- [x] No new npm dependencies added\n- [x] pnpm-lock.yaml not modified\n\n## Protocol Information\n\n- **Website:** https://punks.lightyear.build\n- **Category:** NFT Marketplace\n- **Chain:** Ethereum\n- **Forked from:** N/A (original protocol)\n- **Contract:** 0x000000000000A6fA31F5fC51c1640aAc76866750 (Stash Factory)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Ethereum TVL reporting that discovers related stash contracts from historical on-chain events, aggregates ETH and WETH balances across them, offers coverage back to earlier blocks, and tolerates partial balance-retrieval failures for more robust totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->