### PR TITLE
elys-lending fix

### DIFF
--- a/projects/elys-lending/index.js
+++ b/projects/elys-lending/index.js
@@ -1,15 +1,17 @@
 const { get } = require('../helper/http')
 
 async function tvl(api) {
-  const { net_stakings } = await get('https://api.elys.network/elys-network/elys/masterchef/chain_tvl')
-  net_stakings.filter(i => i.denom === 'USDC').map(i => api.addCGToken('usd-coin', i.amount))
+  const { vault_tokens } = await get('https://api.elys.network/elys-network/elys/masterchef/chain_tvl')
+  const vaultUsdc = vault_tokens.find(i => i.denom === 'USDC')?.amount || 0
+  api.addCGToken('usd-coin', vaultUsdc)
 }
 
 
 async function borrowed(api) {
-  const { usdc_staking, net_stakings } = await get('https://api.elys.network/elys-network/elys/masterchef/chain_tvl')
-  api.addCGToken('usd-coin', usdc_staking)
-  net_stakings.filter(i => i.denom === 'USDC').map(i => api.addCGToken('usd-coin', i.amount * -1))
+  const { net_stakings, vault_tokens } = await get('https://api.elys.network/elys-network/elys/masterchef/chain_tvl')
+  const vaultUsdc = vault_tokens.find(i => i.denom === 'USDC')?.amount || 0
+  const netUsdc = net_stakings.find(i => i.denom === 'USDC')?.amount || 0
+  api.addCGToken('usd-coin', vaultUsdc - netUsdc)
 }
 
 


### PR DESCRIPTION
showing tvl as total usdc in the vault, can revert to net_stakings to report tvl as 'staked - borrowed'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Total Value Locked (TVL) calculation accuracy by updating data sources and calculation methodology.
  * Refined borrowed amount calculations for more precise reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->