### PR TITLE
quell: migrate from Base to Arbitrum (Spark sUSDC)

### DIFF
--- a/projects/quell/index.js
+++ b/projects/quell/index.js
@@ -3,5 +3,5 @@ const RWA_VAULT = ["0x25cf6D8BacCFbF66DC0567844182F063b8BD0051"];
 module.exports = {
   doublecounted: true,
   methodology: "TVL is the total USDC deposited in the Quell RWAVault, an ERC-4626 vault on Arbitrum that routes to Spark sUSDC for RWA yield via the Sky Savings Rate.",
-  arbitrum: { tvl: (api) => { api.erc4626Sum({ calls: RWA_VAULT.map(vault => vault), tokenAbi: 'address:asset', balanceAbi: 'uint256:totalAssets' }) } },
+  arbitrum: { tvl: (api) => api.erc4626Sum({ calls: RWA_VAULT, tokenAbi: 'address:asset', balanceAbi: 'uint256:totalAssets' }) },
 };


### PR DESCRIPTION
## Summary
- Migrate Quell TVL tracking from Base to Arbitrum One
- Update vault address from Base RWAVault to Arbitrum RWAVault
- Update methodology to reflect new yield source (Spark sUSDC / Sky Savings Rate)

## Changes
- Chain: `base` -> `arbitrum`
- Vault: `0xd85A...868b` (Base) -> `0x25cf...0051` (Arbitrum)
- Yield source: Steakhouse USDC MetaMorpho -> Spark sUSDC (Sky Savings Rate)

## Verification
- Contract verified on Arbiscan: https://arbiscan.io/address/0x25cf6D8BacCFbF66DC0567844182F063b8BD0051
- ERC-4626 vault, `totalAssets()` returns USDC (6 decimals)
- Protocol website: https://quell.fi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Migrated Quell RWAVault tracking from Base to Arbitrum network.
  * Vault routing switched to Spark sUSDC via Sky Savings Rate.
  * Replaced the tracked vault address and updated TVL reporting to reflect the Arbitrum deployment and ERC‑4626 aggregation.
  * Methodology description updated to match the new routing and TVL computation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->