### PR TITLE
Update GBLIN to V3 Vault

### DIFF
--- a/projects/gblin/index.js
+++ b/projects/gblin/index.js
@@ -1,13 +1,13 @@
-const GBLIN_VAULT = "0xc475851f9101A2AC48a84EcF869766A94D301FaA"
+const GBLIN_VAULT = "0x1d913Fb86c1Dd0C43DF80668c3913540D48868f0"
 const BASKET_ABI = 'function basket(uint256) view returns (address token, address oracle, uint24 poolFee, bool isStable, uint256 baseWeight, uint256 dynamicWeight, uint256 peakPrice, uint256 lastPeakUpdate)'
 
 const tvl = async (api) => {
-  const baskets = await api.fetchList({ target : GBLIN_VAULT, itemCount: 10, itemAbi: BASKET_ABI, permitFailure: true })
+  const baskets = await api.fetchList({ target: GBLIN_VAULT, itemCount: 10, itemAbi: BASKET_ABI, permitFailure: true })
   const tokens = baskets.map(b => b?.token).filter(Boolean)
   return api.sumTokens({ owner: GBLIN_VAULT, tokens })
 }
 
 module.exports = {
-  methodology: "TVL is calculated by summing the WETH, cbBTC, and USDC strictly locked as backing collateral inside the GBLIN Autonomous Central Bank contract on Base.",
+  methodology: "TVL is calculated by summing the WETH, cbBTC, and USDC strictly locked as backing collateral inside the GBLIN Autonomous Central Bank V3 contract on Base.",
   base: { tvl }
 }


### PR DESCRIPTION
Migrated the protocol to the V3 contract. Kept the dynamic basket fetching logic as it perfectly supports the new vault structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated methodology description to reflect the latest version reference.

* **Chores**
  * Updated contract address configuration to point to the current vault instance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->