### PR TITLE
Add AlphixLVRFee hook and ETH/USDC, ETH/cbBTC pools on Base

### DIFF
--- a/projects/alphix/index.js
+++ b/projects/alphix/index.js
@@ -2,16 +2,32 @@ const { cachedGraphQuery } = require('../helper/cache')
 
 const config = {
   base: {
-    subgraph: 'https://api.goldsky.com/api/public/project_cmktm2w8l5s0k01u9fz2yetrw/subgraphs/alphix-hook-mainnet/prod/gn',
-    hooks: [
-      '0x831cfdf7c0e194f5369f204b3dd2481b843d60c0', // AlphixETH (ETH/USDC)
-      '0x0e4b892df7c5bcf5010faf4aa106074e555660c0', // Alphix (USDS/USDC)
+    subgraphs: [
+      {
+        url: 'https://api.goldsky.com/api/public/project_cmktm2w8l5s0k01u9fz2yetrw/subgraphs/alphix-hook-mainnet/prod/gn',
+        hooks: [
+          '0x0e4b892df7c5bcf5010faf4aa106074e555660c0', // Alphix (USDS/USDC)
+        ],
+        reHyp: true,
+      },
+      {
+        url: 'https://api.goldsky.com/api/public/project_cmktm2w8l5s0k01u9fz2yetrw/subgraphs/alphix-base-lvrfee/Prod/gn',
+        hooks: [
+          '0x7cbbff9c4fcd74b221c535f4fb4b1db04f1b9044', // AlphixLVRFee (ETH/USDC, ETH/cbBTC)
+        ],
+        reHyp: false,
+      },
     ],
   },
   arbitrum: {
-    subgraph: 'https://api.goldsky.com/api/public/project_cmktm2w8l5s0k01u9fz2yetrw/subgraphs/alphix-arbitrum/prod/gn',
-    hooks: [
-      '0x5e645c3d580976ca9e3fe77525d954e73a0ce0c0',
+    subgraphs: [
+      {
+        url: 'https://api.goldsky.com/api/public/project_cmktm2w8l5s0k01u9fz2yetrw/subgraphs/alphix-arbitrum/prod/gn',
+        hooks: [
+          '0x5e645c3d580976ca9e3fe77525d954e73a0ce0c0',
+        ],
+        reHyp: true,
+      },
     ],
   },
 }
@@ -35,31 +51,36 @@ function toRaw(decimalStr, decimals) {
 
 async function tvl(api) {
   const chain = api.chain
-  const { subgraph, hooks } = config[chain]
+  const { subgraphs } = config[chain]
 
-  // 1. Rehypothecated capital — on-chain via hook's getAmountInYieldSource
-  for (const hook of hooks) {
-    const poolKey = await api.call({
-      abi: 'function getPoolKey() view returns (address, address, uint24, int24, address)',
-      target: hook,
-    })
-    const currencies = [poolKey[0], poolKey[1]]
-    const amounts = await api.multiCall({
-      abi: 'function getAmountInYieldSource(address) view returns (uint256)',
-      calls: currencies.map(c => ({ target: hook, params: [c] })),
-    })
-    api.addTokens(currencies, amounts)
-  }
+  for (const sg of subgraphs) {
+    const hookSet = new Set(sg.hooks)
 
-  // 2. Vanilla pool liquidity — from subgraph (filtered to Alphix-managed pools)
-  const hookSet = new Set(hooks)
-  const { pools } = await cachedGraphQuery(`alphix/${chain}`, subgraph, poolQuery)
-  for (const pool of pools) {
-    if (!hookSet.has(pool.hooks.toLowerCase())) continue
-    const decimals0 = Number(pool.token0.decimals)
-    const decimals1 = Number(pool.token1.decimals)
-    api.add(pool.token0.id, toRaw(pool.totalValueLockedToken0, decimals0))
-    api.add(pool.token1.id, toRaw(pool.totalValueLockedToken1, decimals1))
+    // 1. Rehypothecated capital — on-chain via hook's getAmountInYieldSource
+    if (sg.reHyp) {
+      for (const hook of sg.hooks) {
+        const poolKey = await api.call({
+          abi: 'function getPoolKey() view returns (address, address, uint24, int24, address)',
+          target: hook,
+        })
+        const currencies = [poolKey[0], poolKey[1]]
+        const amounts = await api.multiCall({
+          abi: 'function getAmountInYieldSource(address) view returns (uint256)',
+          calls: currencies.map(c => ({ target: hook, params: [c] })),
+        })
+        api.addTokens(currencies, amounts)
+      }
+    }
+
+    // 2. Pool liquidity — from subgraph (filtered to Alphix-managed pools)
+    const { pools } = await cachedGraphQuery(`alphix/${chain}/${sg.hooks[0]}`, sg.url, poolQuery)
+    for (const pool of pools) {
+      if (!hookSet.has(pool.hooks.toLowerCase())) continue
+      const decimals0 = Number(pool.token0.decimals)
+      const decimals1 = Number(pool.token1.decimals)
+      api.add(pool.token0.id, toRaw(pool.totalValueLockedToken0, decimals0))
+      api.add(pool.token1.id, toRaw(pool.totalValueLockedToken1, decimals1))
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Update Alphix adapter to add the new `AlphixLVRFee` hook on Base with two pools (ETH/USDC and ETH/cbBTC), and remove the deprecated `AlphixETH` hook and its old ETH/USDC pool.

### Changes
- Add new `AlphixLVRFee` hook (`0x7cBbfF9C4fcd74B221C535F4fB4B1Db04F1B9044`) on Base
- Add ETH/USDC and ETH/cbBTC pools served by the new hook
- Remove old `AlphixETH` hook (`0x831CfDf7c0E194f5369f204b3DD2481B843d60c0`)
- Refactor config to support multiple subgraphs per chain (rehypothecation hooks vs fee-only hooks)

### Test results
```
--- base ---
USDC                      58.84 k
USDS                      51.98 k
ETH                       15.02 k
cbBTC                     5.91 k
Total: 131.75 k

--- arbitrum ---
USDT0                     92.25 k
USDC                      13.53 k
Total: 105.79 k

total                    237.53 k
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured configuration system to support more flexible, granular handling of multiple data sources.
  * Improved data fetching and caching strategy for enhanced performance.
  * Added conditional logic for selective protocol rehypothecation behavior per data source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->