### PR TITLE
feat: add HypeZion Finance TVL adapter

### DIFF
--- a/projects/hypezion-finance/index.js
+++ b/projects/hypezion-finance/index.js
@@ -8,17 +8,10 @@
  *   - Direct stHYPE staking (secondary)
  *
  * TVL is aggregated on-chain via getProtocolTVL() on HypeZionExchangeInformation.
- * Staking tracks hzUSD deposited in the shzUSD vault (ERC-4626).
  */
 
 // HypeZionExchangeInformation proxy (Hyperliquid Mainnet)
 const EXCHANGE_INFO = "0x9286ABAC7c29e8A183155E961a4E4BBA2E162c7A";
-
-// StakedHzUSD (shzUSD) vault
-const STAKED_HZUSD = "0xce01a9B9bc08f0847fb745044330Eff1181360Cd";
-
-// hzUSD token
-const HZUSD = "0x6E2ade6FFc94d24A81406285c179227dfBFc97CE";
 
 const abis = {
   getProtocolTVL:
@@ -33,19 +26,11 @@ async function tvl(api) {
   api.addGasToken(tvlData.totalTVLInHYPE);
 }
 
-async function staking(api) {
-  const totalAssets = await api.call({
-    target: STAKED_HZUSD,
-    abi: "uint256:totalAssets",
-  });
-  api.add(HZUSD, totalAssets);
-}
-
 module.exports = {
   methodology:
-    "TVL is the sum of all HYPE reserves across four yield sources: kHYPE via Kinetiq, Valantis kHYPE/WHYPE and stHYPE/WHYPE LP pools, and direct stHYPE staking. Staking TVL tracks hzUSD deposited in the shzUSD vault.",
+    "TVL is the sum of all HYPE reserves across four yield sources: kHYPE via Kinetiq, Valantis kHYPE/WHYPE and stHYPE/WHYPE LP pools, and direct stHYPE staking. Marked doublecounted because these reserves are also reported by the underlying Kinetiq, Valantis, and stHYPE adapters. Staking (hzUSD in shzUSD vault) is intentionally not tracked to avoid double-counting the same HYPE collateral already reflected in TVL.",
+  doublecounted: true,
   hyperliquid: {
     tvl,
-    staking,
   },
 };

--- a/projects/hypezion-finance/index.js
+++ b/projects/hypezion-finance/index.js
@@ -1,0 +1,51 @@
+/**
+ * HypeZion — Structured Product Protocol on Hyperliquid L1
+ *
+ * Issues stablecoin (hzUSD) and leverage token (BullHYPE) backed by HYPE reserves.
+ * Reserves are deployed across multiple yield sources:
+ *   - Kinetiq kHYPE liquid staking (primary)
+ *   - Valantis kHYPE/WHYPE and stHYPE/WHYPE LP pools (secondary)
+ *   - Direct stHYPE staking (secondary)
+ *
+ * TVL is aggregated on-chain via getProtocolTVL() on HypeZionExchangeInformation.
+ * Staking tracks hzUSD deposited in the shzUSD vault (ERC-4626).
+ */
+
+// HypeZionExchangeInformation proxy (Hyperliquid Mainnet)
+const EXCHANGE_INFO = "0x9286ABAC7c29e8A183155E961a4E4BBA2E162c7A";
+
+// StakedHzUSD (shzUSD) vault
+const STAKED_HZUSD = "0xce01a9B9bc08f0847fb745044330Eff1181360Cd";
+
+// hzUSD token
+const HZUSD = "0x6E2ade6FFc94d24A81406285c179227dfBFc97CE";
+
+const abis = {
+  getProtocolTVL:
+    "function getProtocolTVL() view returns (tuple(uint256 totalTVLInHYPE, uint256 primaryReserveInHYPE, uint256 secondaryReserveInHYPE, uint256 stakedHzUSDAmount, uint256 hypePriceUSD))",
+};
+
+async function tvl(api) {
+  const tvlData = await api.call({
+    target: EXCHANGE_INFO,
+    abi: abis.getProtocolTVL,
+  });
+  api.addGasToken(tvlData.totalTVLInHYPE);
+}
+
+async function staking(api) {
+  const totalAssets = await api.call({
+    target: STAKED_HZUSD,
+    abi: "uint256:totalAssets",
+  });
+  api.add(HZUSD, totalAssets);
+}
+
+module.exports = {
+  methodology:
+    "TVL is the sum of all HYPE reserves across four yield sources: kHYPE via Kinetiq, Valantis kHYPE/WHYPE and stHYPE/WHYPE LP pools, and direct stHYPE staking. Staking TVL tracks hzUSD deposited in the shzUSD vault.",
+  hyperliquid: {
+    tvl,
+    staking,
+  },
+};


### PR DESCRIPTION
## HypeZion Finance — TVL Adapter

**Protocol**: Structured product protocol on Hyperliquid L1. Issues stablecoin
(hzUSD) and leverage token (BullHYPE) backed by HYPE reserves.

**Chain**: Hyperliquid
**Category**: CDP

### TVL sources (v2 target allocation; actual may vary during rebalancing)
- Kinetiq kHYPE liquid staking (15%)
- Valantis kHYPE/WHYPE LP pool (35%)
- Valantis stHYPE/WHYPE LP pool (35%)
- Direct stHYPE staking (15%)

> V1 ran 100% Kinetiq. V2 (just live) introduces the 15/35/35/15 split, but
> reserves are still concentrated in Kinetiq while the protocol onboards more
> users. Actual allocation will converge to target as TVL grows.

### How the adapter works
- **TVL**: single `getProtocolTVL()` call on `ExchangeInformation` — aggregates
  all reserves on-chain in HYPE (gas token), converted to USD via HYPE price
- **Double-counting flag**: `doublecounted: true` is set at the module export
  because the underlying HYPE is also reported by the Kinetiq, Valantis, and
  stHYPE adapters. The protocol page still shows the full TVL; only the chain
  total aggregation excludes it
- **Staking is intentionally not exported**: hzUSD staked in the shzUSD vault
  is a derivative of HYPE collateral already counted in `tvl()`. Tracking it
  would double-count the same collateral (same resolution as Cap Money
  PR #18018 for stcUSD)

### Local test output
    $ node test.js projects/hypezion-finance/index.js

    --- hyperliquid ---
    HYPE   15.63k   (356.75 HYPE × $43.79)
    ------ TVL ------
    hyperliquid   15.63k
    total         15.63k

### Related PRs
- Price adapter: DefiLlama/defillama-server#11672
- Yield adapter: DefiLlama/yield-server#2529

### Links
- Website: https://www.hypezion.com/
- Twitter: https://x.com/0xhypezion
- Docs: https://docs.hypezion.com/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated HypeZion protocol support for Hyperliquid Mainnet, enabling TVL tracking of HYPE reserves aggregated across multiple yield sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->