### PR TITLE
Add Solana TVL support for Printr Protocol

### DIFF
--- a/projects/printr-protocol/index.js
+++ b/projects/printr-protocol/index.js
@@ -49,7 +49,11 @@ async function fetchAllSolanaTokens() {
   while (true) {
     const endpoint = `${PRINTR_API}/chains/${SOLANA_CHAIN_ID}/tokenlist.json?size=${PAGE_SIZE}&skip=${skip}`
     const data = await getConfig(`printr-protocol/${SOLANA_CHAIN_ID}/${skip}`, endpoint)
-    if (!data || !Array.isArray(data.tokens) || !data.tokens.length) break
+    if (!data || !Array.isArray(data.tokens)) {
+      if (skip === 0) throw new Error(`Invalid token list response from ${endpoint}`)
+      break
+    }
+    if (!data.tokens.length) break
     tokens.push(...data.tokens)
     if (data.tokens.length < PAGE_SIZE) break
     skip += PAGE_SIZE
@@ -67,9 +71,19 @@ async function solanaTvl(api) {
   const active = tokens.filter(t => t.extensions?.curveAddress && !t.extensions?.isGraduated)
   if (!active.length) return
 
-  const connection = getConnection()
-  const curveKeys = active.map(t => new PublicKey(t.extensions.curveAddress))
+  const seen = new Set()
+  const curveKeys = []
+  for (const t of active) {
+    const addr = t.extensions.curveAddress
+    if (seen.has(addr)) continue
+    seen.add(addr)
+    try {
+      curveKeys.push(new PublicKey(addr))
+    } catch (e) { }
+  }
+  if (!curveKeys.length) return
 
+  const connection = getConnection()
   const chunks = sliceIntoChunks(curveKeys, 100)
   for (const chunk of chunks) {
     const accounts = await connection.getMultipleAccountsInfo(chunk)
@@ -92,6 +106,7 @@ async function solanaTvl(api) {
 }
 
 module.exports = {
+  timetravel: false,
   methodology: `Omnichain token launchpad with Proof of Belief staking, configurable fee distribution, custom bonding curves, and anti-PVP mechanics across 8 chains.
 
 TVL: Sum of reserves locked in active Printr bonding curves and tokens locked in Proof of Belief (POB) staking pools. Each curve holds a base pair token (e.g., USDC, USDT, USD1) that users deposit to buy tokens. Graduated tokens (curves with completionThreshold=0) are excluded as their liquidity has moved to DEX pools (Meteora on Solana, Uniswap V3 on ETH/Base/Arb/Avax, PancakeSwap V3 on BNB/Monad, Merchant Moe on Mantle). Locked POB tokens are not used as liquidity, they represent onchain commitment only.


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
Printr

##### Logo:
<img src="https://github.com/user-attachments/assets/dee4d2f8-9aff-4f57-99b7-d9416fb4e205" width="256">

##### Twitter Link:
https://x.com/Printr

##### Website Link:
https://www.printr.money

##### Current TVL:
~30k across 8 chains

##### Chain:
Ethereum, BSC, Arbitrum, Base, Avalanche, Mantle, Monad, Solana

##### Short Description (to be shown on DefiLlama):
Omnichain token launchpad with Proof of Belief staking, configurable fee distribution, custom bonding curves, and anti-PVP mechanics across 8 chains.

##### Category:
Launchpad

##### Oracle Provider(s):
N/A (uses bonding curve math, no external oracle)

##### Implementation Details:
Printr uses constant product bonding curves for token pricing on EVM chains and Meteora Dynamic Bonding Curves (DBC) on Solana. No external oracle required.

##### forkedFrom:
N/A

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL: Sum of reserves locked in active Printr bonding curves and tokens locked in Proof of Belief (POB) staking pools. Each curve holds a base pair token (e.g., USDC, USDT, USD1) that users deposit to buy tokens. Graduated tokens (curves with completionThreshold=0) are excluded as their liquidity has moved to DEX pools (Meteora on Solana, Uniswap V3 on ETH/Base/Arb/Avax, PancakeSwap V3 on BNB/Monad, Merchant Moe on Mantle). Locked POB tokens are not used as liquidity, they represent onchain commitment only.

EVM: Reads treasury balance and wrapped native token via on-chain contract calls.
Solana: Fetches token list from Printr API (/chains/900/tokenlist.json) with pagination, then reads Meteora DBC VirtualPool accounts on-chain to decode quote_reserve (wSOL). Migrated/graduated curves are excluded via the is_migrated flag.

##### Github org/user:
PrintrFi

##### Does this project have a referral program?
No

---

## Summary
- Add Solana chain support to the Printr Protocol adapter (8th chain)
- Paginate Solana tokenlist API requests (size=500, skip offset)
- Read Meteora DBC VirtualPool accounts on-chain to sum active curve reserves as wSOL
- Exclude migrated/graduated curves to avoid double-counting with DEX liquidity
- Update methodology with full protocol description including fees, revenue, and POB staking

## Test plan
- [ ] Verify EVM chains (Ethereum, BSC, Arbitrum, Base, Avalanche, Mantle, Monad) still report correct TVL
- [ ] Verify Solana chain reports TVL in wSOL from active bonding curves
- [ ] Confirm graduated/migrated curves are excluded on Solana
- [ ] Confirm pagination fetches all tokens (>100)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Solana network support added for Total Value Locked (TVL) tracking and monitoring.
  * Platform expanded with omnichain capabilities to enable unified cross-chain asset analysis and tracking.
  * Module exports updated to support Solana TVL functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->