### PR TITLE
templarfi: filter out non-market contracts from registry deployments

### DIFF
--- a/projects/templarfi/index.js
+++ b/projects/templarfi/index.js
@@ -5,6 +5,11 @@ const TEMPLAR_REGISTRY_CONTRACTS = [
   'v1.tmplr.near',
 ]
 
+const EXCLUDED_DEPLOYMENT_PATTERNS = [
+  'proxy-oracle-',
+  '-adapter',
+]
+
 const MAX_RETRY_ATTEMPTS = 3
 const RETRY_DELAY_MS = 1000
 const CALL_TIMEOUT_MS = 30000
@@ -223,7 +228,7 @@ async function fetchDeploymentsFromContract(registryContract) {
       hasMore = false
       break
     }
-    const filtered = batch.filter(id => !id.includes('proxy-oracle-') && !id.includes('-adapter'))
+    const filtered = batch.filter(id => !EXCLUDED_DEPLOYMENT_PATTERNS.some(pattern => id.includes(pattern)))
     deployments.push(...filtered)
     hasMore = batch.length === limit
     offset += limit


### PR DESCRIPTION
## Summary                                                                                                                                                                                                       
                                                                                                                                                                                                                   
  The Templar registry (`v1.tmplr.near`) returns all deployment IDs, including infrastructure contracts like proxy oracles and adapters that are not actual lending markets. These contracts don't implement the   
  market interface (`get_current_snapshot`, `get_configuration`) and cause the adapter to fail with cryptic buffer errors.                                                                                         
                                                                                                                                                                                                                   
  - Add `EXCLUDED_DEPLOYMENT_PATTERNS` array to centralize non-market contract exclusion rules                                                                                                                     
  - Filter out deployments matching any pattern before processing them as markets                                                                                                                                  
                                                                                                                                                                                                                   
  **Contracts excluded:**                                                                                                                                                                                          
  - `proxy-oracle-*` (e.g. `proxy-oracle-ixlmcetes-ixlmusdc.v1.tmplr.near`)                                                                                                                                        
  - `*-adapter` (e.g. `redstone-adapter.v1.tmplr.near`)                                                                                                                                                                                                  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed contract registry traversal to exclude specific deployment IDs matching configured patterns, ensuring only relevant deployments are returned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->