### PR TITLE
Add OraclBet — Prediction Market on Polygon

### DIFF
--- a/projects/oraclbet/index.js
+++ b/projects/oraclbet/index.js
@@ -1,0 +1,14 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+const { sumTokensExport } = require('../helper/unwrapLPs')
+
+const MARKET_FACTORY = '0x5FF7f71cE54f21a678621D4992789482741afD8A'
+
+module.exports = {
+  polygon: {
+    tvl: sumTokensExport({
+      owners: [MARKET_FACTORY],
+      tokens: [ADDRESSES.polygon.USDC_CIRCLE, ADDRESSES.polygon.USDC, ADDRESSES.polygon.USDT],
+    }),
+  },
+  methodology: 'TVL is the total USDC and USDT held in OraclBet prediction market smart contracts on Polygon, representing active market liquidity and open positions.',
+}


### PR DESCRIPTION
## Protocol Description

OraclBet is a decentralized prediction market exchange on Polygon. Users trade binary event contracts (Yes/No) with USDC across crypto, politics, sports, economics, science, entertainment, and technology categories.

## Category
Prediction Markets

## Chain
Polygon

## Key Facts
- 4,700+ active markets across 7 categories
- Dual trading: LMSR (instant) + EIP-712 on-chain order book
- Chainlink oracle-verified resolution (BTC, ETH, SOL, DOGE, ADA, AAPL, GOOGL)
- ERC-1155 conditional token positions
- BTC 5-minute Up/Down markets (new every 5 min, 24/7)
- Cross-chain deposits from Ethereum, Base, Arbitrum
- Card deposits via Stripe

## Contract Addresses (Polygon)
- Market Factory: `0x5FF7f71cE54f21a678621D4992789482741afD8A`

## Website
https://oraclbet.com

## TVL Methodology
Total USDC and USDT held in the Market Factory contract on Polygon, representing active market liquidity and open positions.

## Test Output
```
--- polygon ---
Total: 0.00

--- tvl ---
Total: 0.00
```
TVL will populate as the platform grows — recently launched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL (Total Value Locked) tracking for OraclBet on Polygon, monitoring USDC and USDT holdings in smart contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->