### PR TITLE
[Cabal] Add iUSD and Delta Neutral INIT vault TVL

### DIFF
--- a/projects/cabal/index.js
+++ b/projects/cabal/index.js
@@ -1,9 +1,19 @@
 const { post } = require('../helper/http')
+const { ethers } = require('ethers')
 
-const REST_URL = 'https://rest.initia.xyz/initia/move/v1/view/json'
+const INITIA_REST_RPC = 'https://rest.initia.xyz/initia/move/v1/view/json'
+const CABAL_EVM_RPC = 'https://jsonrpc-cabal-1.anvil.asia-southeast.initia.xyz'
 const CABAL_MODULE_ADDRESS = '0x53c3f5d8e11844ba3747ebaec1b2d25051574ffbeedc69d72068395991e3ea28'
 const INIT_METADATA_ADDRESS = '0x8e4733bdabcf7d4afc3d14f0dd46c9bf52fb0fce9e4b996c939e195b8bc891d9'
 const USDC_INIT_LP_METADATA_ADDRESS = '0x543b35a39cfadad3da3c23249c474455d15efd2f94f849473226dee8a3c7a9e1'
+const IUSD_VAULT_ADDRESS = '0x5Eb1A2e8218a0140151ce3445A3799d6C4433f46'
+const DN_VAULT_ADDRESS = '0x69fdf919612Ef40e89e56282C6891aca41640204'
+
+const ABI = {
+  totalAssets: 'function totalAssets() view returns (uint256)',
+}
+
+const vaultInterface = new ethers.Interface([ABI.totalAssets])
 
 function toNum(str) {
   const clean = String(str).replace(/[^\d.]/g, '');
@@ -11,7 +21,7 @@ function toNum(str) {
 }
 
 async function fetchView(functionName, moduleName, args) {
-  const response = await post(REST_URL, {
+  const response = await post(INITIA_REST_RPC, {
     address: CABAL_MODULE_ADDRESS,
     module_name: moduleName,
     function_name: functionName,
@@ -21,18 +31,36 @@ async function fetchView(functionName, moduleName, args) {
   return response.data
 }
 
+async function fetchEVMTotalAssets(vaultAddress) {
+  const callData = vaultInterface.encodeFunctionData('totalAssets')
+  const response = await post(CABAL_EVM_RPC, {
+    jsonrpc: '2.0',
+    method: 'eth_call',
+    params: [{ to: vaultAddress, data: callData }, 'latest'],
+    id: 1
+  })
+  const [totalAssets] = vaultInterface.decodeFunctionResult('totalAssets', response.result)
+  // iUSD has 18 decimals, price ≈ $1
+  return Number(totalAssets) / 1e18
+}
+
 async function tvl(api) {
-  const [initStakes, lpStakes] = await Promise.all([
+  const [initStakes, lpStakes, iusdAssets, dnAssets] = (await Promise.allSettled([
     fetchView('get_real_total_stakes', 'pool_router', [`"${INIT_METADATA_ADDRESS}"`]),
-    fetchView('get_real_total_stakes', 'pool_router', [`"${USDC_INIT_LP_METADATA_ADDRESS}"`])
-  ])
-  api.add(INIT_METADATA_ADDRESS, toNum(initStakes))
-  api.add(USDC_INIT_LP_METADATA_ADDRESS, toNum(lpStakes))
+    fetchView('get_real_total_stakes', 'pool_router', [`"${USDC_INIT_LP_METADATA_ADDRESS}"`]),
+    fetchEVMTotalAssets(IUSD_VAULT_ADDRESS),
+    fetchEVMTotalAssets(DN_VAULT_ADDRESS),
+  ])).map(r => r.status === 'fulfilled' ? r.value : null)
+
+  if (initStakes) api.add(INIT_METADATA_ADDRESS, toNum(initStakes))
+  if (lpStakes) api.add(USDC_INIT_LP_METADATA_ADDRESS, toNum(lpStakes))
+  api.addUSDValue((iusdAssets ?? 0) + (dnAssets ?? 0))
 }
 
 module.exports = {
+  misrepresentedTokens: true,
   timetravel: false,
-  methodology: 'TVL is calculated as the sum of INIT token stakes and USDC-INIT LP token stakes, each multiplied by their on-chain USD value.',
+  methodology: 'TVL is calculated as the sum of: INIT token stakes (sxINIT vault), USDC-INIT LP token stakes (cbl LP vault), and iUSD holdings across the Cabal iUSD and Delta Neutral INIT EVM vaults on the cabal-1 L2, each valued at their on-chain USD price.',
   initia: {
     tvl
   }


### PR DESCRIPTION
This is an update to an existing adapter (not a new listing), so the template fields don't apply. Here's a PR note:                                                      
                                                                                                                                                                           
  ---                                                                                                                                                                      
  Update Cabal adapter: add iUSD and Delta Neutral INIT vault TVL                                                                                                          
                                                                                                                                                                           
  Extends the existing Cabal adapter to include TVL from two EVM vaults deployed on the cabal-1 L2 chain.                                                                  
                                                                                                                                                                           
  What changed:                                                                                                                                                            
  - Added Cabal iUSD vault (0x5Eb1A2e8218a0140151ce3445A3799d6C4433f46) — users deposit iUSD to earn optimized stablecoin yield                                            
  - Added Delta Neutral INIT vault (0x69fdf919612Ef40e89e56282C6891aca41640204) — delta-neutral strategy on iUSD                                                           
                                                                                                                
  Implementation notes:                                                                                                                                                    
  - Both vaults implement ERC4626 standard; TVL is fetched via totalAssets() on the cabal-1 EVM JSON-RPC endpoint                                                          
  - cabal-1 is not in DefiLlama's chain registry, so api.addUSDValue() is used for EVM vault TVL (iUSD is a $1 stablecoin)                                                 
  - Promise.allSettled is used so a failure in one RPC source doesn't suppress TVL from the others                                                                         
  - misrepresentedTokens: true set accordingly                                                                                                                             
                                                                                                                                                                           
  Verified via:                                                                                                                                                            
  node test.js projects/cabal/index.js     
  
  Results:
  ```
  Building prices get queries for 3 tokens
--- initia ---
USDT                      889.46 k
USDC-INIT                 581.62 k
INIT                      379.21 k
Total: 1.85 M 

--- tvl ---
USDT                      889.46 k
USDC-INIT                 581.62 k
INIT                      379.20 k
Total: 1.85 M 

------ TVL ------
initia                    1.85 M

total                    1.85 M 
```