### PR TITLE
Add Morpho Blue Celo deployment

### DIFF
--- a/projects/morpho-blue/index.js
+++ b/projects/morpho-blue/index.js
@@ -171,6 +171,10 @@ const config = {
     morphoBlue: "0x99D31FEcc885204b4136ea5D2ef2a37F36E3AeB8",
     fromBlock: 2528230,
   },
+  celo: {
+    morphoBlue: "0xd24ECdD8C1e0E57a4E26B1a7bbeAa3e95466A569",
+    fromBlock: 40249329,
+  }
 }
 
 const eventAbis = {


### PR DESCRIPTION
## Summary

Add Celo chain support to the Morpho Blue adapter.

- Morpho Blue was deployed on Celo at block **40249329** ([deployment tx](https://celoscan.io/tx/0xc9dc790fe7ca55d0c33201b6ab5565b71ea45a8d9c7cfd98513519c1eb6789b9))
- Contract address: [`0xd24ECdD8C1e0E57a4E26B1a7bbeAa3e95466A569`](https://celoscan.io/address/0xd24ECdD8C1e0E57a4E26B1a7bbeAa3e95466A569#code)
- Reference: [Morpho V1 Contracts - Celo](https://docs.morpho.org/contracts/morpho-v1/)

This is not a new listing — just adding a new chain to the existing `morpho-blue` adapter config.

## Test plan
- [x] Verified `celo` is already in `projects/helper/chains.json`
- [x] Verified contract address and fromBlock match the deployment transaction
- [x] `node test.js projects/morpho-blue/index.js` — test exits with pre-existing RPC failure on `stable` chain (unrelated to this change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Celo chain, enabling TVL and borrowing data tracking on the Morpho Blue protocol.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->