### PR TITLE
Blacklist inflated xUSD/USDC market on Plume Morpho Blue

### DIFF
--- a/projects/morpho-blue/index.js
+++ b/projects/morpho-blue/index.js
@@ -99,6 +99,9 @@ const config = {
   plume_mainnet: {
     morphoBlue: "0x42b18785CE0Aed7BF7Ca43a39471ED4C0A3e0bB5",
     fromBlock: 765994,
+    blacklistedMarketIds: [
+      "0x82e7ab8ccabaac59b5f397507ed031ebf19a9a5b2657c00c93bc2423cd0a890d",
+    ],
   },
   lisk: {
     morphoBlue: "0x00cD58DEEbd7A2F1C55dAec715faF8aed5b27BF8",


### PR DESCRIPTION
## Summary
- Blacklists Morpho Blue market `0x82e7ab8ccabaac59b5f397507ed031ebf19a9a5b2657c00c93bc2423cd0a890d` on Plume
- This market uses xUSD (the hacked Stream token) as collateral, causing inflated borrowed USDC
- Uses the existing `blacklistedMarketIds` mechanism which filters out the market from both TVL and borrowed calculations

## Test plan
- [ ] Verify `node test.js projects/morpho-blue` passes
- [ ] Confirm Plume borrowed amount drops to expected levels

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated market filtering for Plume Mainnet to exclude a specific market from the network's list of available markets and associated calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->