### PR TITLE
Add Circuit protocol treasury adapter

### DIFF
--- a/projects/treasury/circuitdao.js
+++ b/projects/treasury/circuitdao.js
@@ -31,5 +31,8 @@ async function tvl(api) {
 }
 
 module.exports = {
-  chia: { tvl },
+  chia: { 
+    tvl: () => ({}),
+    ownTokens: tvl,
+  },
 };


### PR DESCRIPTION
## Circuit Protocol — Treasury Adapter

[Circuit](https://circuitdao.com) is a CDP protocol on the Chia blockchain. Users deposit XCH as collateral to borrow Bytecash (BYC), a USD-pegged stablecoin.

The protocol treasury holds BYC accumulated from stability fees, liquidation penalties and recharge auctions, less any interest paid out to savers, BYC used to recover bad debt or discharged via surplus auctions. Its balance is tracked on-chain and reported via the Circuit stats API as `treasury_balance` in mBYC (1 BYC = 1000 mBYC = $1 USD).

Note: the `treasury` field also needs to be added to the Circuit entry in `defillama-server/defi/src/protocols/data5.ts` (`treasury: "circuitdao.js"`).

### Verification

Statistics can be independently verified by running the open-source Circuit block scanner: https://github.com/circuitdao/circuit-analytics

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated Circuit protocol treasury adapter enabling real-time monitoring of treasury balances.
  * Automatic conversion of treasury values to USD for clear, consistent financial reporting.
  * Live data synchronization to surface current treasury valuation and make balances readily available in dashboards and reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->