### PR TITLE
Update GBLIN Vault V5 to final production contract

### DIFF
--- a/projects/gblin/index.js
+++ b/projects/gblin/index.js
@@ -12,7 +12,7 @@ async function tvl(api) {
 }
 
 module.exports = {
-  methodology: "TVL is calculated by summing the balances of WETH, cbBTC, and USDC strictly locked as backing collateral inside the GBLIN V4 Vault contract on Base.",
+  methodology: "TVL is calculated by summing the balances of WETH, cbBTC, and USDC strictly locked as backing collateral inside the GBLIN V5 Vault contract on Base.",
   base: {
     tvl
   }


### PR DESCRIPTION
Updated the GBLIN V5 vault address to the final uncapped production contract on Base Network. The TVL correctly reflects the 1:1 backing in WETH, cbBTC, and USDC.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated vault reference used for calculating and attributing locked token balances (affects displayed TVL).

* **Documentation**
  * Revised methodology description to reference “GBLIN V5 Vault” for summed balances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->