### PR TITLE
[codex] add tristero margin adapter

### DIFF
--- a/projects/tristero/index.js
+++ b/projects/tristero/index.js
@@ -33,7 +33,11 @@ const abis = {
 const activePositionsCache = new WeakMap();
 
 function getPositionIds(totalPositions) {
-  const total = Number(totalPositions);
+  if (totalPositions === null || totalPositions === undefined) return [];
+
+  const total = Number(BigInt(totalPositions.toString()));
+  if (!Number.isSafeInteger(total) || total < 0) return [];
+
   return Array.from({ length: total }, (_, index) => index + 1);
 }
 


### PR DESCRIPTION
## What changed
- adds a new `projects/tristero/index.js` adapter for Tristero margin TVL and borrowed balances
- tracks active margin escrows on Arbitrum, Base, and Ethereum
- keeps the legacy Arbitrum escrow live for historical continuity while using the new escrow from April 2, 2026 onward

## Why
Tristero shipped a new shared router and a new margin escrow deployment on April 2, 2026. The DefiLlama adapter needs to recognize the current live escrow layout without dropping legacy Arbitrum positions from TVL and borrowed metrics.

## Impact
- Tristero margin TVL and borrowed should now report against the current deployment setup
- historical Arbitrum positions remain included instead of disappearing after the migration

## Validation
- `node -c projects/tristero/index.js`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Tristero margin position tracking with chain-specific support for Arbitrum, Base, and Ethereum.
  * Added Total Value Locked (TVL) metrics that aggregate collateral across active positions per chain.
  * Added borrowed amount aggregation that reports outstanding debt across active positions per chain.
  * Exposed per-chain start dates and a public methodology summary for transparency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->