### PR TITLE
fix broken enuls adapters

### DIFF
--- a/projects/gate-io/index.js
+++ b/projects/gate-io/index.js
@@ -1672,6 +1672,7 @@ const config = {
 const unsupportedChains = ['aeternity', 'beam', 'binance', 'bitchain', 'bitcoincash', 'bittensor', 'bone', 'callisto', 'chainx', 'clv', 'concordium', 'conflux', 'cmp', 'dash', 'cube', 'defichain', 'edg', 'elastos', 'elys', 'equilibrium', 'evmos', 'filecoin', 'findora', 'flow', 'fusion', 'heiko', 'hydra', 'hyperliquid', 'icon', 'icp', 'interlay', 'kadena', 'karura', 'kava', 'kintsugi', 'kusuma', 'manta_atlantic', 'lisk', 'neo', 'neo3', 'near', 'nibiru', 'nuls', 'ontology', 'oasis', 'parallel', 'pokt', 'polkadex', 'proton', 'reef', 'rvn', 'shiden', 'sora', 'stafi', 'starcoin', 'syscoin', 'stellar', 'telos', 'thorchain', 'velas', 'venom', 'vite', 'waves', 'wax', 'zilliqa', 'secret', 'etn', 'tara', 'zkfair',
   'vinu', 'rollux', 'syscoin', 'aelf', 'ailayer', 'heco', 'archway',
   'ton', // never had any tvl
+  'enuls'
 ]
 
 unsupportedChains.forEach(chain => delete config[chain]);

--- a/projects/nutbox/index.js
+++ b/projects/nutbox/index.js
@@ -15,6 +15,8 @@ Object.keys(config).forEach(chain => {
   module.exports[chain] = {
     tvl: () => ({}),
     staking: async (api) => {
+      // enuls has no tvl and broken rpc urls
+      if(chain === 'enuls') return {};
       const logs = await getLogs({
         api,
         target: factory,

--- a/registries/uniswapV2.js
+++ b/registries/uniswapV2.js
@@ -1467,6 +1467,7 @@ const uniV2Configs = {
   },
   'pheasantswap': {
     enuls: '0x7bf960B15Cbd9976042257Be3F6Bb2361E107384',
+    deadFrom: '2026-02-11'
   },
   'phenix-dex': {
     cronos: '0x6Bae09822c36a9359d563A22fc7d134eF27a5f60',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed enuls chain support from Gate.io integration.
  * Disabled enuls chain staking data for Nutbox.
  * Marked Pheasant Swap on enuls as deprecated (effective 2026-02-11).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->