### PR TITLE
Add Derpy Dave (DERPYDAVE/SOL Meteora DAMM V2 Pool)

### DIFF
--- a/projects/derpy-dave/index.js
+++ b/projects/derpy-dave/index.js
@@ -1,0 +1,42 @@
+const { getConnection } = require("../helper/solana");
+const { PublicKey } = require("@solana/web3.js");
+
+// Meteora DAMM V2 Pool: DERPYDAVE/SOL
+const POOL_ADDRESS = "BJ5468WZcJHK9uAgzoKSFJ26atrZQwVt2Rve5vvmJndq";
+
+// Token addresses
+const DERPYDAVE_MINT = "2wT8AcQFEzXMEjb6qbs1GDg3mJ3DKBw6eBWp7GqsBAGS";
+const SOL_MINT = "So11111111111111111111111111111111111111112";
+
+async function tvl() {
+  const connection = getConnection();
+  const poolPubkey = new PublicKey(POOL_ADDRESS);
+  
+  const tokenAccounts = await connection.getParsedTokenAccountsByOwner(poolPubkey, {
+    programId: new PublicKey("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA")
+  });
+  
+  const balances = {};
+  
+  for (const account of tokenAccounts.value) {
+    const info = account.account.data.parsed.info;
+    const mint = info.mint;
+    const amount = info.tokenAmount.uiAmount;
+    
+    if (mint === SOL_MINT) {
+      balances["solana:" + SOL_MINT] = amount;
+    } else if (mint === DERPYDAVE_MINT) {
+      balances["solana:" + DERPYDAVE_MINT] = amount;
+    }
+  }
+  
+  return balances;
+}
+
+module.exports = {
+  timetravel: false,
+  methodology: "TVL is calculated from the permanently locked DERPYDAVE/SOL liquidity in the Meteora DAMM V2 pool.",
+  solana: {
+    tvl,
+  },
+};


### PR DESCRIPTION
## Protocol: Derpy Dave ($DERPYDAVE)

**Protocol Name:** Derpy Dave
**Chain:** Solana
**Twitter:** https://x.com/Being_DerpyAF
**Website:** https://derpydave.xyz/

### Description
Derpy Dave ($DERPYDAVE) is a 100% community-owned meme coin on the Solana blockchain. The project features a permanently locked liquidity pool on Meteora's DAMM V2 protocol.

### Methodology
TVL is calculated by querying the Meteora DAMM V2 pool at address `BJ5468WZcJHK9uAgzoKSFJ26atrZQwVt2Rve5vvmJndq`. The pool contains DERPYDAVE tokens and SOL. The adapter fetches token balances from the pool to calculate total TVL in USD. All liquidity in this pool is 100% permanently locked.

### Token Info
- **Ticker:** $DERPYDAVE
- **Token Address:** `2wT8AcQFEzXMEjb6qbs1GDg3mJ3DKBw6eBWp7GqsBAGS`
- **Pool Address:** `BJ5468WZcJHK9uAgzoKSFJ26atrZQwVt2Rve5vvmJndq`
- **DEX:** Meteora DAMM V2

### Category
Meme / DEX Liquidity

### Audit
N/A (Meteora DAMM V2 protocol is audited: https://docs.meteora.ag/resources/audits/overview)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New Solana TVL adapter to track locked liquidity for a Meteora DAMM V2 pool, monitoring SOL and DERPYDAVE tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->