### PR TITLE
Add Unified Labs Risk Curator

### DIFF
--- a/projects/unified-labs/index.js
+++ b/projects/unified-labs/index.js
@@ -1,0 +1,28 @@
+const { getCuratorExport } = require("../helper/curators");
+
+const configs = {
+  methodology: 'Count all assets deposited in vaults curated by Unified Labs.',
+  blockchains: {
+    ethereum: {
+      morphoVaultOwners: [
+        '0x75B3C335B85C931B1eE7BEeB3c0e40429F002373',
+      ],
+    },
+    polygon: {
+      morphoVaultOwners: [
+        '0x75B3C335B85C931B1eE7BEeB3c0e40429F002373',
+      ],
+    },
+    monad: {
+      morphoVaultOwners: [
+        '0x75B3C335B85C931B1eE7BEeB3c0e40429F002373',
+      ],
+    },
+    arbitrum: {
+      morphoVaultOwners: [
+        '0x75B3C335B85C931B1eE7BEeB3c0e40429F002373',
+      ],
+    },
+  },
+}
+module.exports = getCuratorExport(configs)

--- a/projects/unified-labs/index.js
+++ b/projects/unified-labs/index.js
@@ -17,6 +17,9 @@ const configs = {
       morphoVaultOwners: [
         '0x75B3C335B85C931B1eE7BEeB3c0e40429F002373',
       ],
+      morpho: [
+        '0x35E4f3111B37135B1A8EBd72d8cBC9624AeE863a',
+      ],
     },
     arbitrum: {
       morphoVaultOwners: [


### PR DESCRIPTION
Add Unified Labs as a Morpho ecosystem Risk Curator tracking vaults across Ethereum, Polygon, Monad, and Arbitrum using the morphoVaultOwners pattern via getCuratorExport.

https://claude.ai/code/session_01WuzcaKTdH9ds9hyABzCL28

**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

## Summary
Add Unified Labs as a Risk Curator on DefiLlama.

Unified Labs is Asia's first institutional-grade Risk Curator in the Morpho ecosystem, focused on RWA lending. We are currently live on Monad with initial deposits, and are preparing to launch our vaults across multiple chains with tens of millions of dollars in committed capital.

The adapter uses `getCuratorExport` with `morphoVaultOwners` to track all Morpho vaults curated by Unified Labs across supported chains.

---

## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
Unified Labs

##### Twitter Link:
https://x.com/unifiedlabs_

##### List of audit links if any:
N/A — Unified Labs operates as a Risk Curator on Morpho's audited infrastructure.

##### Website Link:
https://unifiedlabs.io/

##### Logo (High resolution, will be shown with rounded borders):
https://raw.githubusercontent.com/louisunifiedlabs/logo/main/Unified%20Venture-logoVerticalWhite.png

##### Current TVL:

##### Treasury Addresses (if the protocol has treasury):

##### Chain:
Ethereum, Polygon, Monad, Arbitrum

##### Coingecko ID:

##### Coinmarketcap ID:

##### Curator Owner Address:
0x75B3C335B85C931B1eE7BEeB3c0e40429F002373


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a new project with multi-blockchain configuration across Ethereum, Polygon, Monad, and Arbitrum, including per-chain vault/contract mappings and a documented methodology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->