### PR TITLE
fix(term-structure): track StableERC4626ForCustomize vaults and fix Gnosis Safe TVL

### DIFF
--- a/projects/term-structure/index.js
+++ b/projects/term-structure/index.js
@@ -629,15 +629,25 @@ async function erc4626VaultsTvl(api) {
   const stableUnderlyings = await api.multiCall({ abi: 'address:underlying', calls: stableERC4626For4626Vaults })
   const thirdPools = await api.multiCall({ abi: 'address:thirdPool', calls: stableERC4626For4626Vaults })
   const stableTokensAndOwners = [];
+  const stableFallbackTokensAndOwners = [];
+  const thirdPoolSupplies = await api.multiCall({
+    abi: 'uint256:totalSupply',
+    calls: thirdPools,
+    permitFailure: true,
+  })
   stableERC4626For4626Vaults.forEach((vault, i) => {
     stableTokensAndOwners.push([stableUnderlyings[i], vault])
-    stableTokensAndOwners.push([thirdPools[i], vault])
-    // fallback: if thirdPool is not ERC20 (e.g. Gnosis Safe), count underlying held by thirdPool
-    stableTokensAndOwners.push([stableUnderlyings[i], thirdPools[i]])
+    if (thirdPoolSupplies[i] == null) {
+      // thirdPool is not ERC20 (e.g. Gnosis Safe), count underlying held by thirdPool
+      stableFallbackTokensAndOwners.push([stableUnderlyings[i], thirdPools[i]])
+    } else {
+      stableTokensAndOwners.push([thirdPools[i], vault])
+    }
   })
 
   await sumTokens2({ api, tokensAndOwners });
-  await sumTokens2({ api, tokensAndOwners: stableTokensAndOwners, permitFailure: true });
+  await sumTokens2({ api, tokensAndOwners: stableTokensAndOwners });
+  await sumTokens2({ api, tokensAndOwners: stableFallbackTokensAndOwners });
 }
 
 module.exports = {

--- a/projects/term-structure/index.js
+++ b/projects/term-structure/index.js
@@ -37,7 +37,8 @@ const EVENTS = {
   TermMax4626Factory: {
     "StableERC4626For4626Created": "event StableERC4626For4626Created(address indexed caller, address indexed stableERC4626For4626)",
     "StableERC4626ForAaveCreated": "event StableERC4626ForAaveCreated(address indexed caller, address indexed stableERC4626ForAave)",
-    "VariableERC4626ForAaveCreated": "event VariableERC4626ForAaveCreated(address indexed caller, address indexed variableERC4626ForAave)"
+    "VariableERC4626ForAaveCreated": "event VariableERC4626ForAaveCreated(address indexed caller, address indexed variableERC4626ForAave)",
+    "StableERC4626ForCustomizeCreated": "event StableERC4626ForCustomizeCreated(address indexed caller, address indexed stableERC4626ForCustomize)"
   }
 };
 
@@ -125,6 +126,7 @@ const ADDRESSES = {
     },
     TermMax4626Factory: [
       { address: "0xD594eb03a43b4974Aa7B32b5740cdeCe961151Fa", fromBlock: 23489745 },
+      { address: "0x3Cc88086C0a613970565C96F9a1b6BdAd61C5f14", fromBlock: 24790495 },
     ],
     FactoryV2: [
       {
@@ -590,6 +592,15 @@ async function erc4626VaultsTvl(api) {
 
     logs = await getLogs2({
       api,
+      eventAbi: EVENTS.TermMax4626Factory.StableERC4626ForCustomizeCreated,
+      fromBlock: factory.fromBlock,
+      target: factory.address,
+      extraKey: 'StableERC4626ForCustomizeCreated',
+    });
+    stableERC4626For4626Vaults.push(...logs.map(i => i.stableERC4626ForCustomize));
+
+    logs = await getLogs2({
+      api,
       eventAbi: EVENTS.TermMax4626Factory.StableERC4626ForAaveCreated,
       fromBlock: factory.fromBlock,
       target: factory.address,
@@ -616,13 +627,17 @@ async function erc4626VaultsTvl(api) {
   })
 
   const stableUnderlyings = await api.multiCall({ abi: 'address:underlying', calls: stableERC4626For4626Vaults })
-  const thirdPools = await api.multiCall({ abi: 'address:thirdPool', calls: stableERC4626For4626Vaults })  // morpho vaults?
+  const thirdPools = await api.multiCall({ abi: 'address:thirdPool', calls: stableERC4626For4626Vaults })
+  const stableTokensAndOwners = [];
   stableERC4626For4626Vaults.forEach((vault, i) => {
-    tokensAndOwners.push([stableUnderlyings[i], vault])
-    tokensAndOwners.push([thirdPools[i], vault])
+    stableTokensAndOwners.push([stableUnderlyings[i], vault])
+    stableTokensAndOwners.push([thirdPools[i], vault])
+    // fallback: if thirdPool is not ERC20 (e.g. Gnosis Safe), count underlying held by thirdPool
+    stableTokensAndOwners.push([stableUnderlyings[i], thirdPools[i]])
   })
 
   await sumTokens2({ api, tokensAndOwners });
+  await sumTokens2({ api, tokensAndOwners: stableTokensAndOwners, permitFailure: true });
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- Add new TermMax4626Factory (`0x3Cc88...`) on Ethereum (fromBlock 24790495)
- Track `StableERC4626ForCustomizeCreated` event to capture customize vaults (e.g. XAUt vault)
- Fix TVL calculation for vaults where `thirdPool` is a Gnosis Safe instead of an ERC20 token, by adding `[underlying, thirdPool]` fallback with `permitFailure`

## Test plan
- [x] Verified XAUt ($19.87k) now appears in Ethereum TVL
- [x] Confirmed no double-counting with Morpho-backed vaults (e.g. gtUSDC)
- [x] Total Ethereum TVL: $23.95M (previously $23.93M)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects and tracks additional stable vaults created via factory events across supported chains.

* **Improvements**
  * More accurate TVL calculation for stable vaults with two-phase token/owner aggregation.
  * Improved fallback handling for non-standard pool contracts to ensure assets are included in TVL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->