### PR TITLE
Morpho Blue: blacklist Kinto (K) token on Arbitrum

### DIFF
--- a/projects/morpho-blue/index.js
+++ b/projects/morpho-blue/index.js
@@ -34,7 +34,7 @@ const config = {
   },
   arbitrum: {
     morphoBlue: "0x6c247b1F6182318877311737BaC0844bAa518F5e",
-    blackList: ["0xf8b3fa720a9cd8abeed5a81f11f80cd8f93e6b57"],
+    blackList: ["0xf8b3fa720a9cd8abeed5a81f11f80cd8f93e6b57", "0x010700ab046dd8e92b0e3587842080df36364ed3"], // K token inflated by Kinto exploit
     fromBlock: 296446593,
   },
   fraxtal: {


### PR DESCRIPTION
## Summary
- Blacklists Kinto (K) token (`0x010700ab046dd8e92b0e3587842080df36364ed3`) on Arbitrum Morpho Blue
- Market `0xfdb8221e...` (K/USDC, 62.5% LLTV) has been inactive since July 2025 with a stuck 100%-utilised position. A single `AccrueInterest` call on April 6 2026 recognised ~$250M of accumulated bad debt interest in one shot, causing a spurious TVL spike on Arbitrum.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Excluded a problematic token from total value locked (TVL) calculations to address inflated or abusive data in aggregation metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->