### PR TITLE
Morpho Blue: blacklist K/USDC market on Arbitrum

### DIFF
--- a/projects/morpho-blue/index.js
+++ b/projects/morpho-blue/index.js
@@ -36,6 +36,9 @@ const config = {
     morphoBlue: "0x6c247b1F6182318877311737BaC0844bAa518F5e",
     blackList: ["0xf8b3fa720a9cd8abeed5a81f11f80cd8f93e6b57"],
     fromBlock: 296446593,
+    blacklistedMarketIds: [
+      "0xfdb8221edcae73f73485d55c30e706906114bc2ff4634870c5c57e8fb83eae6a", // K/USDC bad debt from Kinto exploit
+    ],
   },
   fraxtal: {
     morphoBlue: "0xa6030627d724bA78a59aCf43Be7550b4C5a0653b",


### PR DESCRIPTION
## Summary
- Blacklists market `0xfdb8221edcae73f73485d55c30e706906114bc2ff4634870c5c57e8fb83eae6a` (K/USDC, 62.5% LLTV) on Arbitrum Morpho Blue
- This market has been inactive since July 2025 with a stuck over-utilised position from the Kinto (K) token exploit. A single `AccrueInterest` call on April 6 2026 recognised ~$250M of accumulated bad debt interest in one shot, causing a spurious TVL spike on both the supply and borrow sides on Arbitrum.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed a problematic market from the Arbitrum network to prevent exposure to bad debt from a recent exploit, improving data accuracy and system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->