### PR TITLE
Add Anoncoin adapter

### DIFF
--- a/projects/anoncoin/index.js
+++ b/projects/anoncoin/index.js
@@ -1,0 +1,53 @@
+const { getCache, setCache } = require("../helper/cache");
+const { sumTokens2 } = require("../helper/solana");
+const { get } = require("../helper/http");
+const { sleep } = require("../helper/utils");
+
+const API_BASE = "https://api.dubdub.tv/v1/defillama/tvl";
+const CACHE_KEY = "anoncoin-vaults";
+
+async function fetchAllVaults() {
+    const solOwnersSet = new Set();
+    let page = 1;
+    let hasMore = true;
+
+    while (hasMore) {
+        const { data } = await get(`${API_BASE}?page=${page}`);
+        const pools = data.pools || [];
+
+        for (const pool of pools) {
+            if (pool.isMigrated && pool.dammV2QuoteVault) {
+                solOwnersSet.add(pool.dammV2QuoteVault);
+            } else if (pool.quoteVault) {
+                solOwnersSet.add(pool.quoteVault);
+            }
+        }
+
+        hasMore = data.hasMore === true;
+        page++;
+
+        if (hasMore) await sleep(200);
+    }
+
+    return [...solOwnersSet];
+}
+
+async function tvl() {
+    let solOwners = await getCache(CACHE_KEY, "solana");
+
+    if (!solOwners || !Array.isArray(solOwners) || solOwners.length === 0) {
+        solOwners = await fetchAllVaults();
+        await setCache(CACHE_KEY, "solana", solOwners);
+    }
+
+    return sumTokens2({ solOwners });
+}
+
+module.exports = {
+    timetravel: false,
+    methodology:
+        "TVL is calculated by summing the SOL held in all Anoncoin pool quote vaults (DBC and DAMM v2) on Solana. Only pools with TVL > 0 are included.",
+    solana: {
+        tvl,
+    },
+};

--- a/projects/anoncoin/index.js
+++ b/projects/anoncoin/index.js
@@ -11,6 +11,7 @@ async function fetchAllVaults() {
     const solOwnersSet = new Set();
     let page = 1;
     let hasMore = true;
+    let fullFetchCompleted = false;
 
     while (hasMore) {
         if (page > MAX_PAGES) {
@@ -35,14 +36,19 @@ async function fetchAllVaults() {
         if (hasMore) await sleep(200);
     }
 
-    return [...solOwnersSet];
+    if (!hasMore) fullFetchCompleted = true;
+
+    return { solOwners: [...solOwnersSet], fullFetchCompleted };
 }
 
 async function tvl() {
     let solOwners;
     try {
-        solOwners = await fetchAllVaults();
-        await setCache(CACHE_KEY, "solana", solOwners);
+        const result = await fetchAllVaults();
+        solOwners = result.solOwners;
+        if (result.fullFetchCompleted) {
+            await setCache(CACHE_KEY, "solana", solOwners);
+        }
     } catch (e) {
         console.error("anoncoin: API fetch failed, falling back to cache", e.message);
         const cached = await getCache(CACHE_KEY, "solana");

--- a/projects/anoncoin/index.js
+++ b/projects/anoncoin/index.js
@@ -1,17 +1,14 @@
-const { getCache, setCache } = require("../helper/cache");
 const { sumTokens2 } = require("../helper/solana");
 const { get } = require("../helper/http");
 const { sleep } = require("../helper/utils");
 
 const API_BASE = "https://api.dubdub.tv/v1/defillama/tvl";
-const CACHE_KEY = "anoncoin-vaults";
 const MAX_PAGES = 1000;
 
 async function fetchAllVaults() {
     const solOwnersSet = new Set();
     let page = 1;
     let hasMore = true;
-    let fullFetchCompleted = false;
 
     while (hasMore) {
         if (page > MAX_PAGES) {
@@ -36,25 +33,11 @@ async function fetchAllVaults() {
         if (hasMore) await sleep(200);
     }
 
-    if (!hasMore) fullFetchCompleted = true;
-
-    return { solOwners: [...solOwnersSet], fullFetchCompleted };
+    return { solOwners: [...solOwnersSet] };
 }
 
 async function tvl() {
-    let solOwners;
-    try {
-        const result = await fetchAllVaults();
-        solOwners = result.solOwners;
-        if (result.fullFetchCompleted) {
-            await setCache(CACHE_KEY, "solana", solOwners);
-        }
-    } catch (e) {
-        console.error("anoncoin: API fetch failed, falling back to cache", e.message);
-        const cached = await getCache(CACHE_KEY, "solana");
-        solOwners = Array.isArray(cached) ? cached : [];
-    }
-
+    const { solOwners } = await fetchAllVaults();
     return sumTokens2({ solOwners });
 }
 

--- a/projects/anoncoin/index.js
+++ b/projects/anoncoin/index.js
@@ -5,6 +5,7 @@ const { sleep } = require("../helper/utils");
 
 const API_BASE = "https://api.dubdub.tv/v1/defillama/tvl";
 const CACHE_KEY = "anoncoin-vaults";
+const MAX_PAGES = 1000;
 
 async function fetchAllVaults() {
     const solOwnersSet = new Set();
@@ -12,6 +13,11 @@ async function fetchAllVaults() {
     let hasMore = true;
 
     while (hasMore) {
+        if (page > MAX_PAGES) {
+            console.error(`anoncoin: exceeded MAX_PAGES (${MAX_PAGES}), stopping pagination`);
+            break;
+        }
+
         const { data } = await get(`${API_BASE}?page=${page}`);
         const pools = data.pools || [];
 
@@ -33,11 +39,14 @@ async function fetchAllVaults() {
 }
 
 async function tvl() {
-    let solOwners = await getCache(CACHE_KEY, "solana");
-
-    if (!solOwners || !Array.isArray(solOwners) || solOwners.length === 0) {
+    let solOwners;
+    try {
         solOwners = await fetchAllVaults();
         await setCache(CACHE_KEY, "solana", solOwners);
+    } catch (e) {
+        console.error("anoncoin: API fetch failed, falling back to cache", e.message);
+        const cached = await getCache(CACHE_KEY, "solana");
+        solOwners = Array.isArray(cached) ? cached : [];
     }
 
     return sumTokens2({ solOwners });


### PR DESCRIPTION
## Anoncoin (Solana)

**Protocol:** [anoncoin.it](https://anoncoin.it)
**Category:** Liquidity / Bonding Curve

### What does the adapter do?
Calculates TVL by summing SOL held across all Anoncoin pool quote vaults on Solana — both DBC (Dynamic Bonding Curve) and DAMM v2 (migrated) pools.

### How it works
1. Fetches vault addresses from our paginated API (`api.dubdub.tv/v1/defillama/tvl`)
2. Deduplicates using a Set
3. Uses `sumTokens2` helper to read on-chain SOL balances
4. Caches vault list via `getCache`/`setCache`

### Details
- **Chain:** Solana
- **Pools:** ~7,300 active pools with TVL > 0
- **Timetravel:** false (current state only)
- **Dependencies:** Uses the standard DefiLlama Solana helpers (`sumTokens2`, `getCache`, `setCache`, `get`, `sleep`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Total Value Locked (TVL) tracking for Anoncoin on Solana.
  * Discovers and deduplicates Anoncoin pool vaults from a paginated external API, including migrated DAMM v2 pools.
  * Handles pagination with throttling and page limits for reliable data collection.
  * Aggregates SOL holdings across discovered vaults to compute TVL.
  * Exposes a Solana TVL endpoint with timetravel disabled and a documented methodology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->