### PR TITLE
Add Mycelium Vaults (Berachain auto-compounder)

### DIFF
--- a/projects/mycelium-vaults/index.js
+++ b/projects/mycelium-vaults/index.js
@@ -1,6 +1,22 @@
+/**
+ * Mycelium Vaults - Auto-Compound Yield Optimizer on Berachain
+ * 
+ * @description Deposits LP tokens into Infrared Gauges and auto-compounds
+ * iBGT rewards every 30 minutes. Charges 1% fee vs Beefy 4.5%.
+ * @see https://berascan.com/address/0x3B4d6c8C73962218724ea140Ad7c7CD13dCF165E
+ */
+
+/** Vault contract address on Berachain */
 const WBERA_HONEY_VAULT = "0x3B4d6c8C73962218724ea140Ad7c7CD13dCF165E";
+
+/** Kodiak Island WBERA-HONEY LP token */
 const WBERA_HONEY_LP = "0x4a254B11810B8EBb63C5468E438FC561Cb1bB1da";
 
+/**
+ * Calculates TVL by reading totalAssets() from the ERC-4626 vault.
+ * This returns the total LP tokens staked in the Infrared Gauge.
+ * @param {object} api - DefiLlama SDK API instance
+ */
 async function berachainTvl(api) {
   const assets = await api.call({ abi: "uint256:totalAssets", target: WBERA_HONEY_VAULT });
   api.add(WBERA_HONEY_LP, assets);

--- a/projects/mycelium-vaults/index.js
+++ b/projects/mycelium-vaults/index.js
@@ -1,23 +1,18 @@
-const VAULTS = {
-  berachain: [
-    {
-      vault: "0x3B4d6c8C73962218724ea140Ad7c7CD13dCF165E",
-      lp: "0x4a254B11810B8EBb63C5468E438FC561Cb1bB1da",
-    },
-  ],
-};
+const { staking } = require("../helper/staking");
 
-async function tvl(api) {
-  for (const v of VAULTS[api.chain] || []) {
-    const totalAssets = await api.call({
-      abi: "function totalAssets() view returns (uint256)",
-      target: v.vault,
-    });
-    api.add(v.lp, totalAssets);
-  }
+// Mycelium Vaults auto-compounds Kodiak LP positions through Infrared Gauges on Berachain.
+// Vault contract holds LP tokens staked in the gauge, totalAssets() returns the current balance.
+// See: https://berascan.com/address/0x3B4d6c8C73962218724ea140Ad7c7CD13dCF165E
+
+const WBERA_HONEY_VAULT = "0x3B4d6c8C73962218724ea140Ad7c7CD13dCF165E";
+const WBERA_HONEY_LP = "0x4a254B11810B8EBb63C5468E438FC561Cb1bB1da";
+
+async function berachainTvl(api) {
+  const assets = await api.call({ abi: "uint256:totalAssets", target: WBERA_HONEY_VAULT });
+  api.add(WBERA_HONEY_LP, assets);
 }
 
 module.exports = {
-  methodology: "TVL is LP tokens in Mycelium auto-compound vaults, staked in Infrared Gauges on Berachain. 1% fee, auto-compounds every 30 min.",
-  berachain: { tvl },
+  methodology: "TVL counts LP tokens held by Mycelium vaults and staked in Infrared gauges.",
+  berachain: { tvl: berachainTvl },
 };

--- a/projects/mycelium-vaults/index.js
+++ b/projects/mycelium-vaults/index.js
@@ -1,9 +1,3 @@
-const { staking } = require("../helper/staking");
-
-// Mycelium Vaults auto-compounds Kodiak LP positions through Infrared Gauges on Berachain.
-// Vault contract holds LP tokens staked in the gauge, totalAssets() returns the current balance.
-// See: https://berascan.com/address/0x3B4d6c8C73962218724ea140Ad7c7CD13dCF165E
-
 const WBERA_HONEY_VAULT = "0x3B4d6c8C73962218724ea140Ad7c7CD13dCF165E";
 const WBERA_HONEY_LP = "0x4a254B11810B8EBb63C5468E438FC561Cb1bB1da";
 
@@ -13,6 +7,7 @@ async function berachainTvl(api) {
 }
 
 module.exports = {
+  doublecounted: true,
   methodology: "TVL counts LP tokens held by Mycelium vaults and staked in Infrared gauges.",
   berachain: { tvl: berachainTvl },
 };

--- a/projects/mycelium-vaults/index.js
+++ b/projects/mycelium-vaults/index.js
@@ -1,0 +1,23 @@
+const VAULTS = {
+  berachain: [
+    {
+      vault: "0x3B4d6c8C73962218724ea140Ad7c7CD13dCF165E",
+      lp: "0x4a254B11810B8EBb63C5468E438FC561Cb1bB1da",
+    },
+  ],
+};
+
+async function tvl(api) {
+  for (const v of VAULTS[api.chain] || []) {
+    const totalAssets = await api.call({
+      abi: "function totalAssets() view returns (uint256)",
+      target: v.vault,
+    });
+    api.add(v.lp, totalAssets);
+  }
+}
+
+module.exports = {
+  methodology: "TVL is LP tokens in Mycelium auto-compound vaults, staked in Infrared Gauges on Berachain. 1% fee, auto-compounds every 30 min.",
+  berachain: { tvl },
+};


### PR DESCRIPTION
## Listing Information

- **Name**: Mycelium Vaults
- **Website**: https://berascan.com/address/0x3B4d6c8C73962218724ea140Ad7c7CD13dCF165E
- **Twitter**: N/A
- **Category**: Yield Aggregator
- **Chain**: Berachain
- **Audit**: Unaudited (verified source on Berascan)
- **TVL estimate**: ~$420
- **Oracle**: N/A (LP token pricing via underlying reserves)

## Description

Mycelium Vaults is an auto-compound yield optimizer on Berachain.

- ERC-4626 vault deposits LP tokens into Infrared Gauges
- Auto-harvests iBGT rewards and compounds every 30 min
- 1% fee (lowest on Berachain vs Beefy's 4.5%)
- Permissionless harvest() with 0.1% caller bounty
- Contract verified on Berascan

## Methodology

TVL = totalAssets() on the ERC-4626 vault, returns LP tokens staked in the Infrared Gauge. Flagged as doublecounted since underlying LP is also counted by Infrared.
