### PR TITLE
Add Arc Network chain and Meridian Finance TVL adapter

### DIFF
--- a/projects/helper/chains.json
+++ b/projects/helper/chains.json
@@ -18,6 +18,7 @@
   "ao",
   "apechain",
   "aptos",
+  "arc",
   "arbitrum",
   "arbitrum_nova",
   "archway",

--- a/projects/helper/coreAssets.json
+++ b/projects/helper/coreAssets.json
@@ -284,6 +284,9 @@
     "VGLMR": "0xffffffff99dabe1a8de0ea22baa6fd48fde96f6c",
     "FIL": "0xffffffffcd0ad0ea6576b7b285295c85e94cf4c1"
   },
+  "arc": {
+    "USDC": "0x3600000000000000000000000000000000000000"
+  },
   "arbitrum": {
     "WETH": "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
     "WBTC": "0x2f2a2543b76a4166549f7aab2e75bef0aefc5b0f",

--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -41,6 +41,10 @@ const ibcMappings = {
 }
 
 const fixBalancesTokens = {
+  arc: {
+    '0x3600000000000000000000000000000000000000': { coingeckoId: 'usd-coin', decimals: 6 },
+    '0xe9185f0c5f296ed1797aae4238d26ccabeadb86c': { coingeckoId: 'hashnote-usyc', decimals: 6 },
+  },
   ozone: {
     // '0x83048f0bf34feed8ced419455a4320a735a92e9d': { coingeckoId: "ozonechain", decimals: 18 }, // was mapped to wrong chain
   },

--- a/projects/meridian-finance/index.js
+++ b/projects/meridian-finance/index.js
@@ -1,0 +1,26 @@
+const USDC_ARC = '0x3600000000000000000000000000000000000000'
+const USYC_ARC = '0xe9185F0c5F296Ed1797AaE4238D26CCaBEadb86C'
+
+const YIELD_VAULT = '0x2f685b5Ef138Ac54F4CB1155A9C5922c5A58eD25'
+const FIRMATA_COMMERCE_ARC = '0x5806a1f82a1b3fcbefcd2efc5d873c2167ee3a8e'
+const FIRMATA_ESCROW_ARC = '0x9a1690aaf6c33c8d97755cff00f0edca61965dfa'
+
+async function arcTvl(api) {
+  return api.sumTokens({
+    tokensAndOwners: [
+      [USDC_ARC, YIELD_VAULT],
+      [USDC_ARC, FIRMATA_COMMERCE_ARC],
+      [USDC_ARC, FIRMATA_ESCROW_ARC],
+      [USYC_ARC, YIELD_VAULT],
+      [USYC_ARC, FIRMATA_COMMERCE_ARC],
+      [USYC_ARC, FIRMATA_ESCROW_ARC],
+    ],
+  })
+}
+
+module.exports = {
+  methodology: 'TVL is the sum of USDC and USYC deposited in Meridian Finance YieldVault, Firmata Commerce escrow, and Firmata Escrow contracts on Arc Network.',
+  arc: {
+    tvl: arcTvl,
+  },
+}

--- a/projects/meridian-finance/index.js
+++ b/projects/meridian-finance/index.js
@@ -12,8 +12,6 @@ async function arcTvl(api) {
       [USDC_ARC, FIRMATA_COMMERCE_ARC],
       [USDC_ARC, FIRMATA_ESCROW_ARC],
       [USYC_ARC, YIELD_VAULT],
-      [USYC_ARC, FIRMATA_COMMERCE_ARC],
-      [USYC_ARC, FIRMATA_ESCROW_ARC],
     ],
   })
 }


### PR DESCRIPTION
- Add "arc" to chains.json
- Add Arc USDC to coreAssets.json
- Add USDC and USYC token mappings for Arc in tokenMapping.js
- Add Meridian Finance adapter tracking TVL across:
  - YieldVault V3 (USDC + USYC deposits)
  - Firmata Commerce escrow (USDC)
  - Firmata Escrow (USDC)

Arc Network details:
- Chain ID: 5042002
- RPC: https://rpc.testnet.arc.network
- Native token: USDC (0x3600...0000)
- Explorer: https://testnet.arcscan.app

Test: `ARC_RPC=https://rpc.testnet.arc.network node test.js projects/meridian-finance/index.js`

Links:
- Website: https://themeridian.finance
- Twitter: https://x.com/Meridian_Fi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Arc blockchain support with core asset definitions.
  * Enabled token balance mapping and tracking for USDC and USYC on Arc.
  * Added TVL calculation for Meridian Finance on Arc, covering deposits and escrow positions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->