### PR TITLE
Add paradex-options TVL adapter (mirrors unified collateral pool)

### DIFF
--- a/projects/paradex-options/index.js
+++ b/projects/paradex-options/index.js
@@ -1,0 +1,11 @@
+// Paradex uses a unified USDC collateral bridge on Ethereum shared across
+// all products (perps, spot, options). TVL is already reported by the main
+// `paradex` adapter (wired to the `paradex-bridge` listing). This adapter
+// re-exports it so the Paradex Options venue on DefiLlama reflects the same
+// unified collateral pool. `doublecounted: true` prevents the shared USDC
+// from being summed twice into aggregate DeFi TVL.
+module.exports = {
+  ...require('../paradex'),
+  doublecounted: true,
+  methodology: 'Paradex options share the unified USDC collateral bridge on Ethereum with Paradex perps and spot. TVL mirrors the main Paradex (Bridge) adapter; `doublecounted` prevents aggregation of the same pool twice.',
+};


### PR DESCRIPTION
## Summary
DefiLlama currently lists Paradex Options as a child of the Paradex parent protocol at https://defillama.com/protocol/paradex-options, but its TVL is empty because the listing is wired to `dummy.js` in the protocols registry (id `7652`).

Paradex uses a **unified USDC collateral bridge** on Ethereum (`0xE3cbE3A636AB6A754e9e41B12b09d09Ce9E53Db3`) shared across all of its products — perps, spot, and options all draw margin from the same pool. The existing `projects/paradex/index.js` adapter already measures this bridge and feeds the Paradex Bridge child listing.

This PR adds `projects/paradex-options/index.js` as a thin re-export of the main `paradex` adapter with `doublecounted: true` so the Paradex Options venue page surfaces the same collateral pool without double-counting it in aggregate DeFi TVL.

## Registry update required
The Paradex Options entry (slug `paradex-options`, id `7652`) is currently configured with `module: dummy.js`. For this adapter to take effect, the protocols registry will need to be updated to point that entry at `paradex-options/index.js` when merging. Happy to adjust the folder name / approach if there's a preferred pattern.

## Why a re-export instead of a copy
- DRY — no duplicated bridge address
- If Paradex ever changes the collateral contract, only `projects/paradex/index.js` needs updating
- Matches the `doublecounted` convention used by 285+ other adapters in the repo (e.g. `yearn`, `yieldnest`, `swell-earn-eth`)

## Test plan
- [x] `node test.js projects/paradex-options/index.js` → `ethereum: 52.63M USDC`
- [x] `node test.js projects/paradex/index.js` → `ethereum: 52.63M USDC` (cross-check: same pool)
- [x] On-chain verification via `eth_call balanceOf` → `52,638,378 USDC` at the bridge address

## Context
This is a follow-up to https://github.com/DefiLlama/dimension-adapters/pull/6356 which fixed the Paradex Options volume adapter. The volume side is now reporting correctly; this PR completes the TVL side of the listing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Paradex options with proper collateral accounting to prevent TVL double-counting across the platform's unified USDC liquidity pool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->