### PR TITLE
Upgrade Hako adapter

### DIFF
--- a/projects/hako/index.js
+++ b/projects/hako/index.js
@@ -1,20 +1,26 @@
-const {toUSDTBalances} = require("../helper/balances");
-const {default: BigNumber} = require("bignumber.js");
+const { toUSDTBalances } = require('../helper/balances')
+const BigNumber = require('bignumber.js')
 
-const homeVault = "0x717882AB8e82aFD999C7E5bEA87E07eC78D82C62"
+const HAKO_STABLE_VAULT = '0xda6600Dd3124f07EC82304b059248e5b529864df'
+const NORMALIZED_DECIMALS = 18
 
 async function tvl(api) {
-    const asset = await api.call({
-        target: homeVault,
-        abi: 'uint256:totalAssets'
-    })
-    const vaultTVL = BigNumber(asset).div(1e18).toFixed(0)
-    return toUSDTBalances(vaultTVL)
+  const totalAssets = await api.call({
+    target: HAKO_STABLE_VAULT,
+    abi: 'uint256:totalAssets',
+  })
+
+  const vaultTVL = BigNumber(totalAssets.toString())
+    .div(BigNumber(10).pow(NORMALIZED_DECIMALS))
+    .toFixed(0)
+
+  return toUSDTBalances(vaultTVL)
 }
 
 module.exports = {
-    methodology: "We calculate TVL based on the total managed assets (in USD) of our home proxy contracts, accounting for all assets and LP tokens",
-    polygon: {
-        tvl
-    },
-};
+  start: 1771681367,
+  methodology: "We calculate TVL based on the total managed assets (in USD) of our home proxy contract on Base, accounting for all assets and LP tokens",
+  base: {
+    tvl,
+  },
+}


### PR DESCRIPTION
Hako has migrated its canonical vault accounting from the previous Polygon setup to the Base `HakoStableVault`.

Tested with:

`node test.js projects/hako/index.js`

Current output reports approximately 411 TVL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Migrated TVL tracking from Polygon to Base blockchain
  * Updated contract monitoring for TVL computation
  * Added tracking start date to metadata
  * Refined normalization methodology

<!-- end of auto-generated comment: release notes by coderabbit.ai -->