### PR TITLE
Add Stable (USDX) protocol adapter   

### DIFF
--- a/projects/stable/index.js
+++ b/projects/stable/index.js
@@ -1,0 +1,36 @@
+const { PublicKey } = require('@solana/web3.js')
+const { getConnection } = require('../helper/solana')
+
+const USDX_EVM = {
+  ethereum: '0xfea577f08d1984e6654813be0acee3140e5d7d42',
+  monad: '0xd0a4BDb0422DB3fA77dC46189b6d043D2cd5A7B9',
+}
+
+const USDX_SOLANA_MINT = '9Gst2E7KovZ9jwecyGqnnhpG1mhHKdyLpJQnZonkCFhA'
+
+const methodology =
+  'TVL is the circulating supply of USDX across all chains on which it has been issued. ' +
+  'USDX is the fully-collateralized stablecoin issued by Stable (trystable.co), backed by ' +
+  'real-world mortgage debt NFTs (tokenized real estate loans) plus on-chain yield reserves ' +
+  '(idle USDC and positions in Jupiter Lend and Kamino). USDX is minted 1:1 against ' +
+  'collateral, so circulating supply equals total backing.'
+
+async function solanaTvl(api) {
+  const conn = getConnection()
+  const supply = await conn.getTokenSupply(new PublicKey(USDX_SOLANA_MINT))
+  api.addUSDValue(supply.value.uiAmount)
+}
+
+module.exports = {
+  methodology,
+  solana: { tvl: solanaTvl },
+}
+
+for (const [chain, target] of Object.entries(USDX_EVM)) {
+  module.exports[chain] = {
+    tvl: async (api) => {
+      const supply = await api.call({ abi: 'erc20:totalSupply', target })
+      api.addUSDValue(Number(supply) / 1e18)
+    },
+  }
+}


### PR DESCRIPTION
## Summary

Adds a TVL adapter for **Stable** — the project behind USDX, the mortgage-backed stablecoin, a fully-collateralized stablecoin backed by tokenized real estate mortgage debt NFTs plus on-chain yield reserves (idle USDC, Jupiter Lend, Kamino). Active on Solana today, with USDX token contracts also deployed on Ethereum and Monad for future expansion.

**⚠️ Naming note:** There is an existing `projects/usdx/` adapter in this repo for an unrelated project called "usdx.money" (token `0xf3527ef8...`, CoinGecko slug `usdx-money-usdx`, chains ethereum/bsc/arbitrum). **This PR does not touch that folder.** Stable's USDX is a different protocol on different chains (ethereum/monad/solana) with different contracts. To disambiguate, this adapter uses folder name `stable` (the protocol name), not `usdx`.

## Methodology

TVL is the circulating supply of USDX across all chains it has been issued on. USDX is minted 1:1 against collateral (real estate debt NFTs + yield reserves), so circulating supply equals total backing. Reading supply rather than enumerating every collateral venue keeps the adapter simple and robust across rebalances.

## (Template answers)

##### Name (to be shown on DefiLlama):
Stable

##### Twitter Link:
https://x.com/stable_tweets

##### List of audit links if any:
-

##### Website Link:
https://trystable.co

##### Logo (High resolution, will be shown with rounded borders):
Brand kit with logos: https://www.trystable.co/brand

![stable-icon-gold (1)](https://github.com/user-attachments/assets/0ecf68b6-352d-4e01-9a32-64d694421a01)

##### Current TVL:
~$1.14M (Solana USDX supply; Ethereum and Monad USDX deployed but not yet meaningfully minted)

##### Treasury Addresses (if the protocol has treasury)
-

##### Chain:
Solana (primary), Ethereum, Monad

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):
stable-3
https://www.coingecko.com/en/coins/stable

##### Coinmarketcap ID:
-

##### Short Description (to be shown on DefiLlama):
Stable is a real estate finance technology provider that tokenizes mortgages as on-chain debt NFTs and issues USDX, 
a fully-collateralized stablecoin backed by that debt plus yield reserves.

##### Token address and ticker if any:
USDX — Solana mint `9Gst2E7KovZ9jwecyGqnnhpG1mhHKdyLpJQnZonkCFhA`; 
Ethereum `0xfea577f08d1984e6654813be0acee3140e5d7d42`; 
Monad `0xd0a4BDb0422DB3fA77dC46189b6d043D2cd5A7B9`

##### Category:
RWA

##### Oracle Provider(s):
Switchboard https://ondemand.switchboard.xyz/solana/mainnet/feed/Z6yHUWH6inzJHruXzFFWsXTApbVsS15WBVoNb4mAAaR

##### Implementation Details:
Market price oracle for USDX

##### Documentation/Proof:
https://trystable.co
https://docs.trystable.co

##### forkedFrom:
None

##### methodology (what is being counted as tvl, how is tvl being calculated):
Sum of USDX `totalSupply()` across Ethereum, Monad, and Solana, treated as $1 per token. USDX is minted 1:1 against collateral (tokenized real estate debt NFTs plus on-chain yield reserves on Solana — idle USDC, Jupiter Lend, Kamino), so supply equals total backing.

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/stable-finance

##### Does this project have a referral program?
https://app.trystable.co/referrals

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added USDX total value locked (TVL) calculation and tracking across Solana and EVM networks including Ethereum and Monad.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->