### PR TITLE
track Hubra TVL (raSOL liquid staking + Earn vaults)

### DIFF
--- a/projects/hubra/index.js
+++ b/projects/hubra/index.js
@@ -11,11 +11,8 @@ const EARN_VAULTS = [
   { asset: '2u1tszSeqZ3qBWF3uNGPFc8TzMk2tdiwknnRMWGWjGWH', vault: '7VZ1XKK7Zns6UzRc1Wz54u6cypN7zaduasVXXr7NysxH' }, // USDG
 ]
 
-async function staking(api) {
-  await getSolBalanceFromStakePool(RASOL_STAKE_POOL, api)
-}
-
 async function tvl(api) {
+  await getSolBalanceFromStakePool(RASOL_STAKE_POOL, api)
   for (const { asset, vault } of EARN_VAULTS) {
     const { data } = await get(`https://api.voltr.xyz/vault/${vault}/share-price`)
     api.add(asset, data.totalValue)
@@ -24,9 +21,8 @@ async function tvl(api) {
 
 module.exports = {
   timetravel: false,
-  methodology: 'Liquid staking TVL is the SOL backing raSOL. Earn TVL is the underlying stablecoins (USDC, USD1, USDT, USDS, USDG) held in Hubra Earn vaults backing the receipt tokens (raUSDC, raUSD1, raUSDT, raUSDS, raUSDG).',
+  methodology: 'TVL is the SOL backing raSOL (from the SPL stake pool) plus the underlying stablecoins (USDC, USD1, USDT, USDS, USDG) held in Hubra Earn vaults backing the receipt tokens (raUSDC, raUSD1, raUSDT, raUSDS, raUSDG).',
   solana: {
     tvl,
-    staking,
   },
 }

--- a/projects/hubra/index.js
+++ b/projects/hubra/index.js
@@ -1,0 +1,32 @@
+const { getSolBalanceFromStakePool } = require('../helper/solana')
+const { get } = require('../helper/http')
+
+const RASOL_STAKE_POOL = 'ECRqn7gaNASuvTyC5xfCUjehWZCSowMXstZiM5DNweyB'
+
+const EARN_VAULTS = [
+  { asset: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', vault: '3maCuTJVPteZ2dFA8dADxz2EbpJHfoAG5txYhXDs6gNQ' }, // USDC
+  { asset: 'USD1ttGY1N17NEEHLmELoaybftRBUSErhqYiQzvEmuB', vault: '663azFYEnHDTLGf4CEk8KpNTje8XxZVLnQwo9LjbSejy' }, // USD1
+  { asset: 'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB', vault: '3kzb6rcDJxSdkWCwXXP9PULSqBy6rVDNWanzw5dBCYCj' }, // USDT
+  { asset: 'USDSwr9ApdHk5bvJKMjzff41FfuX8bSxdKcR81vTwcA', vault: '5mv1cURMSaPU3q3wFVoN4mKMWNFVvUtH3UZrG4Z2Mgfz' }, // USDS
+  { asset: '2u1tszSeqZ3qBWF3uNGPFc8TzMk2tdiwknnRMWGWjGWH', vault: '7VZ1XKK7Zns6UzRc1Wz54u6cypN7zaduasVXXr7NysxH' }, // USDG
+]
+
+async function staking(api) {
+  await getSolBalanceFromStakePool(RASOL_STAKE_POOL, api)
+}
+
+async function tvl(api) {
+  for (const { asset, vault } of EARN_VAULTS) {
+    const { data } = await get(`https://api.voltr.xyz/vault/${vault}/share-price`)
+    api.add(asset, data.totalValue)
+  }
+}
+
+module.exports = {
+  timetravel: false,
+  methodology: 'Liquid staking TVL is the SOL backing raSOL. Earn TVL is the underlying stablecoins (USDC, USD1, USDT, USDS, USDG) held in Hubra Earn vaults backing the receipt tokens (raUSDC, raUSD1, raUSDT, raUSDS, raUSDG).',
+  solana: {
+    tvl,
+    staking,
+  },
+}


### PR DESCRIPTION

**Name (to be shown on DefiLlama):**
Hubra

**Twitter Link:**
[https://twitter.com/HubraApp](https://twitter.com/HubraApp)

**Website Link:**
[https://hubra.app/](https://hubra.app)

**Logo (high resolution, will be shown with rounded borders):**
[https://tinyurl.com/2vw3xc4e](https://tinyurl.com/2vw3xc4e)

---

**List of audit links (if any):**
N/A

---

**Current TVL:**
~$611k
(≈5.6k SOL × SOL price for raSOL staking + ~$57k in Earn vaults at time of reporting)

---

**Chain:**
Solana

---

**Coingecko ID:**
solanahub-staked-sol

---

**Short Description (to be shown on DefiLlama):**
Hubra is a Solana-based DeFi protocol providing institutional-grade, non-custodial yield products, including liquid staking (raSOL) and automated yield vaults (raUSDC, raUSDT, raUSDS, raUSDG, raUSD1). It is designed to make professional yield strategies accessible to everyone.

---

**Token addresses and tickers:**

* raSOL — HUBsveNpjo5pWqNkH57QzxjQASdTVXcSK7bVKTSZtcSX
* raUSDC — 53fZaJGDMHcfku8pzZak5obVFUUjVxwqRTF63M3SQiSS
* raUSD1 — 8eVavBK4fSVLKLRLPpUBgjcm13dd4WDrpoZY81dwod5W
* raUSDT — HDkNbYaFpPDB82pDK3H4L1yXzCeA4T3MvNEf82Ss8ui3
* raUSDS — 7SR3ZZfSR9N7GRs2nTpJCRE4FCbTvDhXTDTbJRkSwoBV
* raUSDG — 7Ao2pNQwkfM5S1oQgkC55Y3jwBCs657Wb6aEhDAML1eX

---

**Category:**
Liquid Staking
Yield

---

**Documentation / Proof:**
[https://docs.hubra.app/overview/earn](https://docs.hubra.app/overview/earn)

---

**Methodology:**
Liquid Staking TVL is calculated as total SOL deposited in the raSOL SPL stake pool (ECRqn7gaNASuvTyC5xfCUjehWZCSowMXstZiM5DNweyB), derived from total lamports.

Earn TVL is calculated as the sum of underlying assets backing each Earn vault (raUSDC, raUSD1, raUSDT, raUSDS, raUSDG), fetched via the Voltr vault share-price endpoint and attributed to the corresponding underlying mint.

---

**GitHub org/user:**
[https://github.com/Hubra-labs](https://github.com/Hubra-labs)

---

**Referral program:**
No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Solana TVL adapter for Hubra that provides real-time monitoring of total value locked across Earn vaults and a raSOL stake pool. Supports multiple stablecoins (USDC, USD1, USDT, USDS, USDG), aggregates on-chain SOL stake balance with vault share values fetched from external endpoints, and includes descriptive methodology and non-time-travelable reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->