### PR TITLE
feat: add Tempo chain support to Skate AMM

### DIFF
--- a/projects/skate-amm/index.js
+++ b/projects/skate-amm/index.js
@@ -34,7 +34,7 @@ const evm_config = {
   "0g": [{ kernelEventEmitter: '0xFBD495862410c549f200Ce224Ad3D02a0bAe260D', fromBlock: 5961960 }],
   monad: [{ kernelEventEmitter: '0xFBD495862410c549f200Ce224Ad3D02a0bAe260D', fromBlock: 33372521 }],
   megaeth: [{ kernelEventEmitter: '0x613d5b5f248Ff95557A8855B7b69Cbde09955C43', fromBlock: 7999879 }],
-  tempo: [{ kernelEventEmitter: '0x613d5b5f248Ff95557A8855B7b69Cbde09955C43', fromBlock: 14656375 }],
+  tempo: [{ kernelEventEmitter: '0x8f794F042831345DfA6bFD7FB72d25128AD6ee1b', fromBlock: 14656375 }],
 }
 
 const svm_config = {

--- a/projects/skate-amm/index.js
+++ b/projects/skate-amm/index.js
@@ -34,6 +34,7 @@ const evm_config = {
   "0g": [{ kernelEventEmitter: '0xFBD495862410c549f200Ce224Ad3D02a0bAe260D', fromBlock: 5961960 }],
   monad: [{ kernelEventEmitter: '0xFBD495862410c549f200Ce224Ad3D02a0bAe260D', fromBlock: 33372521 }],
   megaeth: [{ kernelEventEmitter: '0x613d5b5f248Ff95557A8855B7b69Cbde09955C43', fromBlock: 7999879 }],
+  tempo: [{ kernelEventEmitter: '0x613d5b5f248Ff95557A8855B7b69Cbde09955C43', fromBlock: 14656375 }],
 }
 
 const svm_config = {


### PR DESCRIPTION
## Summary
- Add Tempo chain to the Skate AMM adapter EVM config
- KernelEventEmitter: `0x613d5b5f248Ff95557A8855B7b69Cbde09955C43`, fromBlock: `14656375`

## Test plan
- [ ] Verify Tempo chain TVL is fetched correctly via the adapter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Tempo EVM chain TVL tracking.
  * Exposes a Tempo TVL endpoint so total value locked data for Tempo is now available alongside existing chains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->