### PR TITLE
Add Ferdy treasury MegaETH

### DIFF
--- a/projects/ferdyflip/index.js
+++ b/projects/ferdyflip/index.js
@@ -9,6 +9,9 @@ const config = {
   base: {
     tokens: [ADDRESSES.base.WETH, nullAddress], owners: ['0x3b6014e4b38791444a352D687022D6d6d79Eb99c'],
   },
+  mantle: {
+    tokens: [ADDRESSES.mantle.WMNT, nullAddress], owners: ['0x559036D9466C93d8Ca3c2232626548e62ceBC07c'],
+  },
 };
 
 Object.keys(config).forEach((chain) => {

--- a/projects/ferdyflip/index.js
+++ b/projects/ferdyflip/index.js
@@ -13,6 +13,7 @@ const config = {
 
 Object.keys(config).forEach((chain) => {
   module.exports[chain] = {
+    start: 1675962000, //Fri Feb 10 2023
     tvl: sumTokensExport(config[chain]),
   };
 });

--- a/projects/ferdyflip/index.js
+++ b/projects/ferdyflip/index.js
@@ -4,13 +4,16 @@ const { sumTokensExport, nullAddress } = require("../helper/unwrapLPs");
 // https://docs.ferdyflip.xyz/developers/contracts/platform
 const config = {
   avax: {
-    tokens: [ADDRESSES.avax.WAVAX, nullAddress], owners: ['0x20AfbaC35B333dA4fE7230CC60946F88ee87aAA3', '0xe0a69f4d29c891b9c5c7368b591ed3109bcb80f7'],
+    tokens: [ADDRESSES.avax.WAVAX, nullAddress], owners: ['0xe0a69f4d29c891b9c5c7368b591ed3109bcb80f7'],
   },
   base: {
     tokens: [ADDRESSES.base.WETH, nullAddress], owners: ['0x3b6014e4b38791444a352D687022D6d6d79Eb99c'],
   },
   mantle: {
     tokens: [ADDRESSES.mantle.WMNT, nullAddress], owners: ['0x559036D9466C93d8Ca3c2232626548e62ceBC07c'],
+  },
+  megaeth: {
+    tokens: [ADDRESSES.megaeth.ETH, nullAddress], owners: ['0x58Daa362b6732d224a618149C5872b4942947681'],
   },
 };
 

--- a/projects/ferdyflip/index.js
+++ b/projects/ferdyflip/index.js
@@ -4,7 +4,7 @@ const { sumTokensExport, nullAddress } = require("../helper/unwrapLPs");
 // https://docs.ferdyflip.xyz/developers/contracts/platform
 const config = {
   avax: {
-    tokens: [ADDRESSES.avax.WAVAX, nullAddress], owners: ['0x20AfbaC35B333dA4fE7230CC60946F88ee87aAA3'],
+    tokens: [ADDRESSES.avax.WAVAX, nullAddress], owners: ['0xe0a69f4d29c891b9c5c7368b591ed3109bcb80f7'],
   },
   base: {
     tokens: [ADDRESSES.base.WETH, nullAddress], owners: ['0x3b6014e4b38791444a352D687022D6d6d79Eb99c'],
@@ -12,11 +12,14 @@ const config = {
   mantle: {
     tokens: [ADDRESSES.mantle.WMNT, nullAddress], owners: ['0x559036D9466C93d8Ca3c2232626548e62ceBC07c'],
   },
+  megaeth: {
+    tokens: [ADDRESSES.megaeth.ETH, nullAddress], owners: ['0x58Daa362b6732d224a618149C5872b4942947681'],
+  },
 };
 
 Object.keys(config).forEach((chain) => {
   module.exports[chain] = {
-    start: 1675962000, //Fri Feb 10 2023
+    start: '2023-02-09', //Fri Feb 10 2023
     tvl: sumTokensExport(config[chain]),
   };
 });


### PR DESCRIPTION
Adding the Ferdy treasury on MegaETH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Mega ETH blockchain network support, enabling users to monitor assets and liquidity with comprehensive tracking capabilities across this new blockchain ecosystem while maintaining seamless platform integration.

* **Updates**
  * Updated Avalanche network configuration for continued support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->