### PR TITLE
Add Durianfun (KUB Chain meme launchpad)

### DIFF
--- a/projects/durianfun/index.js
+++ b/projects/durianfun/index.js
@@ -1,0 +1,84 @@
+/**
+ * Durianfun — meme-token launchpad on KUB Chain (chainId 96).
+ *
+ * TVL = native KUB locked in:
+ *   1. Bonding-curve markets that have NOT yet graduated (V4.5 + V4.2)
+ *   2. DurianAMM pools that hold the post-graduation liquidity
+ *
+ * Token-side reserves are intentionally NOT counted to avoid the circular
+ * pricing problem (each meme token's price IS its AMM pool — counting both
+ * sides would inflate TVL via tautology). The Factory-D test environment is
+ * also excluded since dKUB is mintable by the project.
+ *
+ * Event source:
+ *   event TokenCreated(
+ *     address indexed token,
+ *     address indexed market,        // ← curve contract that holds KUB pre-graduation
+ *     address indexed creator,
+ *     string  name, string symbol,
+ *     uint256 totalSupply, uint256 timestamp
+ *   );
+ *
+ * Each market exposes:  function ammPool() view returns (address)
+ *   - returns 0x0 while still on the bonding curve
+ *   - returns the DurianAMM pool address after graduation (KUB moves there)
+ */
+
+const { getLogs } = require("../helper/cache/getLogs");
+const { nullAddress } = require("../helper/unwrapLPs");
+
+const FACTORY_V45 = "0xdf4f3dB298A9aDe853191F58b4b2a322D47EC005";
+const FACTORY_V42 = "0xeadEc9dA89F97Ae6215362EBA4B33F3F1d1775b2";
+
+const FACTORY_V45_BLOCK = 30_999_992;
+const FACTORY_V42_BLOCK = 30_990_140;
+
+const TOKEN_CREATED_ABI =
+  "event TokenCreated(address indexed token, address indexed market, address indexed creator, string name, string symbol, uint256 totalSupply, uint256 timestamp)";
+
+async function tvl(api) {
+  // 1. Pull every TokenCreated event from both factories.
+  const [logsV45, logsV42] = await Promise.all([
+    getLogs({
+      api,
+      target: FACTORY_V45,
+      eventAbi: TOKEN_CREATED_ABI,
+      fromBlock: FACTORY_V45_BLOCK,
+      onlyArgs: true,
+    }),
+    getLogs({
+      api,
+      target: FACTORY_V42,
+      eventAbi: TOKEN_CREATED_ABI,
+      fromBlock: FACTORY_V42_BLOCK,
+      onlyArgs: true,
+    }),
+  ]);
+
+  // 2. Each `market` is a bonding-curve contract that holds KUB until graduation.
+  const markets = [...logsV45, ...logsV42].map((l) => l.market);
+
+  // 3. After graduation `market.ammPool()` returns the DurianAMM pool address;
+  //    pre-graduation it returns the zero address.
+  const ammPools = await api.multiCall({
+    abi: "function ammPool() view returns (address)",
+    calls: markets,
+    permitFailure: true,
+  });
+
+  const liveAmmPools = ammPools.filter(
+    (a) => a && a.toLowerCase() !== nullAddress
+  );
+
+  // 4. Sum native KUB held across every market AND every graduated AMM pool.
+  //    `permitFailure` keeps the loop alive if a single contract reverts.
+  const owners = [...markets, ...liveAmmPools];
+  return api.sumTokens({ owners, tokens: [nullAddress] });
+}
+
+module.exports = {
+  methodology:
+    "TVL counts native KUB locked in (a) Durianfun bonding-curve markets that have not yet graduated, and (b) DurianAMM liquidity pools that hold post-graduation liquidity. Meme-token reserves are intentionally excluded to avoid circular pricing, and the separately-deployed Factory-D test environment is excluded.",
+  start: FACTORY_V42_BLOCK,
+  bitkub: { tvl },
+};

--- a/projects/durianfun/index.js
+++ b/projects/durianfun/index.js
@@ -59,20 +59,27 @@ async function tvl(api) {
   const markets = [...logsV45, ...logsV42].map((l) => l.market);
 
   // 3. After graduation `market.ammPool()` returns the DurianAMM pool address;
-  //    pre-graduation it returns the zero address.
+  //    pre-graduation it returns the zero address. We split markets into two
+  //    sets so the curve side counts ONLY ungraduated markets (matches the
+  //    methodology) — graduated markets have transferred their KUB to the
+  //    AMM pool, so counting both would double-count any residual dust.
   const ammPools = await api.multiCall({
     abi: "function ammPool() view returns (address)",
     calls: markets,
     permitFailure: true,
   });
 
-  const liveAmmPools = ammPools.filter(
-    (a) => a && a.toLowerCase() !== nullAddress
-  );
+  const isGraduated = (a) =>
+    a && typeof a === "string" && a.toLowerCase() !== nullAddress;
 
-  // 4. Sum native KUB held across every market AND every graduated AMM pool.
-  //    `permitFailure` keeps the loop alive if a single contract reverts.
-  const owners = [...markets, ...liveAmmPools];
+  const ungraduatedMarkets = markets.filter((_, i) => !isGraduated(ammPools[i]));
+  const liveAmmPools = ammPools.filter(isGraduated);
+
+  // 4. Sum native KUB held across (a) ungraduated markets + (b) graduated AMM
+  //    pools. Dedup owners as a defensive measure against any duplicate event
+  //    log echoes. `permitFailure` on multiCall above already protects against
+  //    individual contract reverts.
+  const owners = Array.from(new Set([...ungraduatedMarkets, ...liveAmmPools]));
   return api.sumTokens({ owners, tokens: [nullAddress] });
 }
 


### PR DESCRIPTION
TVL = native KUB locked in (a) bonding-curve markets that have not yet graduated, plus (b) DurianAMM liquidity pools that hold post-graduation liquidity. Token-side reserves of AMM pools are intentionally excluded to avoid circular pricing. The Factory-D test environment is excluded because its base asset dKUB is mintable by the project.

Factory V4.5 (current): 0xdf4f3dB298A9aDe853191F58b4b2a322D47EC005
Factory V4.2 (legacy):  0xeadEc9dA89F97Ae6215362EBA4B33F3F1d1775b2

Both contracts are verified on https://www.kubscan.com.

**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).

2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** It is a different repo, you can find your listing in [this file](https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts), you can edit it there and put up a PR
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes

---
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama): Durianfun

##### Twitter Link:@ https://x.com/duriandotfun

##### List of audit links if any: https://app.gitbook.com/o/eYI1Qez2vzbM4Pm1fn9Q/s/CoErujqwujmvYmZomKBd/resources/audit-summary-and-attack-simulation

##### Website Link: https://durianfun.xyz

##### Logo (High resolution, will be shown with rounded borders): https://durianfun.xyz/logo-square-512.png

##### Current TVL: 3 USD

##### Treasury Addresses (if the protocol has treasury) : -

##### Chain: KUB (chainId 96)

### Verification
Adapter tested locally with node test.js projects/durianfun/index.js:

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama): Fair-launch meme-token launchpad on KUB. Tokens start on an exponential bonding curve, then graduate to a sealed DurianAMM liquidity pool. No presale, no team allocation, 14.3% of trading fees shared back to creators.

##### Token address and ticker if any:

##### Category (full list at https://defillama.com/categories) \*Please choose only one: Launchpad

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.): None — protocol does not use external oracles.

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
Pricing is fully on-chain and deterministic:
- Pre-graduation: exponential bonding curve formula (no oracle needed; price computed from token supply locked in the curve).
- Post-graduation: x*y=k constant-product AMM (DurianAMM) — price discovered from on-pool reserves.

For TVL display purposes, the adapter measures raw native KUB balances held by each market/AMM contract, so no price oracle is required for the TVL calculation either.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
N/A (no oracle dependency).

Project documentation: https://durianandfun.gitbook.io/durianfun/
Smart-contract source verified on https://www.kubscan.com:
- Factory V4.5: https://www.kubscan.com/address/0xdf4f3dB298A9aDe853191F58b4b2a322D47EC005
- Factory V4.2: https://www.kubscan.com/address/0xeadEc9dA89F97Ae6215362EBA4B33F3F1d1775b2

##### forkedFrom (Does your project originate from another project): Original implementation. Inspired by the pump.fun bonding-curve → AMM graduation model but rebuilt from scratch in Solidity 0.8.24 with custom curve parameters and graduation logic for KUB Chain. All rights reserved by the Durianfun team.

##### methodology (what is being counted as tvl, how is tvl being calculated): 
TVL = native KUB locked in:
1. Every BondingCurveMarket contract created by Factory V4.5 + V4.2 that has not yet graduated (KUB sits in the curve until graduation threshold).
2. Every DurianAMM liquidity pool created post-graduation (KUB-side reserves).

Only the KUB side of AMM pools is counted to avoid the circular-pricing problem (each meme token's only price discovery IS its AMM pool — counting both sides would inflate TVL via tautology).

Factory-D test environment is intentionally excluded because its base asset dKUB is mintable by the project.

Adapter implementation walks every TokenCreated event from both factories, then reads native KUB balances of each market + each post-graduation AMM pool address (returned by `market.ammPool()`).

##### Github org/user (Optional, if your code is open source, we can track activity): https://github.com/Duriandotfun

##### Does this project have a referral program?: No (But next version)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking total value locked (TVL) on the Durianfun meme-token launchpad on KUB Chain. The adapter now monitors both graduated AMM pools and ungraduated curve markets to provide comprehensive TVL metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->