### PR TITLE
Add AlphixPro hook and migrate fee hooks to official Uniswap V4 subgraph

### DIFF
--- a/projects/alphix/index.js
+++ b/projects/alphix/index.js
@@ -1,40 +1,45 @@
+const sdk = require('@defillama/sdk')
 const { cachedGraphQuery } = require('../helper/cache')
+
+// Official Uniswap V4 subgraph IDs (used for fee-only hooks)
+const uniV4GraphIds = {
+  base: 'Gqm2b5J85n1bhCyDMpGbtbVn4935EvvdyHdHrx3dibyj',
+}
 
 const config = {
   base: {
-    subgraphs: [
-      {
-        url: 'https://api.goldsky.com/api/public/project_cmktm2w8l5s0k01u9fz2yetrw/subgraphs/alphix-hook-mainnet/prod/gn',
-        hooks: [
-          '0x0e4b892df7c5bcf5010faf4aa106074e555660c0', // Alphix (USDS/USDC)
-        ],
-        reHyp: true,
-      },
-      {
-        url: 'https://api.goldsky.com/api/public/project_cmktm2w8l5s0k01u9fz2yetrw/subgraphs/alphix-base-lvrfee/Prod/gn',
-        hooks: [
-          '0x7cbbff9c4fcd74b221c535f4fb4b1db04f1b9044', // AlphixLVRFee (ETH/USDC, ETH/cbBTC)
-        ],
-        reHyp: false,
-      },
+    // Rehypothecation hooks (Alphix) — queried via custom Goldsky subgraph
+    reHypSubgraph: 'https://api.goldsky.com/api/public/project_cmktm2w8l5s0k01u9fz2yetrw/subgraphs/alphix-hook-mainnet/prod/gn',
+    reHypHooks: [
+      '0x0e4b892df7c5bcf5010faf4aa106074e555660c0', // Alphix (USDS/USDC)
+    ],
+    // Fee-only hooks (AlphixLVRFee, AlphixPro) — queried via official Uniswap V4 subgraph
+    feeHooks: [
+      '0x7cbbff9c4fcd74b221c535f4fb4b1db04f1b9044', // AlphixLVRFee (ETH/USDC, ETH/cbBTC)
+      '0x2f9cf87a6cbfa53c3f1b184900de17298e3f9080', // AlphixPro (ETH/ZFI)
     ],
   },
   arbitrum: {
-    subgraphs: [
-      {
-        url: 'https://api.goldsky.com/api/public/project_cmktm2w8l5s0k01u9fz2yetrw/subgraphs/alphix-arbitrum/prod/gn',
-        hooks: [
-          '0x5e645c3d580976ca9e3fe77525d954e73a0ce0c0',
-        ],
-        reHyp: true,
-      },
+    reHypSubgraph: 'https://api.goldsky.com/api/public/project_cmktm2w8l5s0k01u9fz2yetrw/subgraphs/alphix-arbitrum/prod/gn',
+    reHypHooks: [
+      '0x5e645c3d580976ca9e3fe77525d954e73a0ce0c0',
     ],
+    feeHooks: [],
   },
 }
 
-const poolQuery = `{
+const reHypPoolQuery = `{
   pools(first: 1000) {
     hooks
+    token0 { id decimals }
+    token1 { id decimals }
+    totalValueLockedToken0
+    totalValueLockedToken1
+  }
+}`
+
+const uniV4PoolQuery = (hook) => `{
+  pools(where: { hooks: "${hook.toLowerCase()}" }, orderBy: totalValueLockedUSD, orderDirection: desc, first: 999) {
     token0 { id decimals }
     token1 { id decimals }
     totalValueLockedToken0
@@ -51,35 +56,45 @@ function toRaw(decimalStr, decimals) {
 
 async function tvl(api) {
   const chain = api.chain
-  const { subgraphs } = config[chain]
+  const { reHypSubgraph, reHypHooks, feeHooks } = config[chain]
 
-  for (const sg of subgraphs) {
-    const hookSet = new Set(sg.hooks)
+  // 1. Rehypothecation hooks: on-chain yield + custom subgraph for vanilla LP positions
+  for (const hook of reHypHooks) {
+    const poolKey = await api.call({
+      abi: 'function getPoolKey() view returns (address, address, uint24, int24, address)',
+      target: hook,
+    })
+    const currencies = [poolKey[0], poolKey[1]]
+    const amounts = await api.multiCall({
+      abi: 'function getAmountInYieldSource(address) view returns (uint256)',
+      calls: currencies.map(c => ({ target: hook, params: [c] })),
+    })
+    api.addTokens(currencies, amounts)
+  }
 
-    // 1. Rehypothecated capital — on-chain via hook's getAmountInYieldSource
-    if (sg.reHyp) {
-      for (const hook of sg.hooks) {
-        const poolKey = await api.call({
-          abi: 'function getPoolKey() view returns (address, address, uint24, int24, address)',
-          target: hook,
-        })
-        const currencies = [poolKey[0], poolKey[1]]
-        const amounts = await api.multiCall({
-          abi: 'function getAmountInYieldSource(address) view returns (uint256)',
-          calls: currencies.map(c => ({ target: hook, params: [c] })),
-        })
-        api.addTokens(currencies, amounts)
-      }
-    }
-
-    // 2. Pool liquidity — from subgraph (filtered to Alphix-managed pools)
-    const { pools } = await cachedGraphQuery(`alphix/${chain}/${sg.hooks[0]}`, sg.url, poolQuery)
+  if (reHypHooks.length) {
+    const hookSet = new Set(reHypHooks)
+    const { pools } = await cachedGraphQuery(`alphix/${chain}/rehyp`, reHypSubgraph, reHypPoolQuery)
     for (const pool of pools) {
       if (!hookSet.has(pool.hooks.toLowerCase())) continue
       const decimals0 = Number(pool.token0.decimals)
       const decimals1 = Number(pool.token1.decimals)
       api.add(pool.token0.id, toRaw(pool.totalValueLockedToken0, decimals0))
       api.add(pool.token1.id, toRaw(pool.totalValueLockedToken1, decimals1))
+    }
+  }
+
+  // 2. Fee-only hooks: queried via official Uniswap V4 subgraph
+  if (feeHooks.length) {
+    if (!uniV4GraphIds[chain]) throw new Error(`No Uniswap V4 subgraph configured for chain ${chain}`)
+    for (const hook of feeHooks) {
+      const { pools } = await sdk.graph.request(uniV4GraphIds[chain], uniV4PoolQuery(hook))
+      for (const pool of pools) {
+        const decimals0 = Number(pool.token0.decimals)
+        const decimals1 = Number(pool.token1.decimals)
+        api.add(pool.token0.id, toRaw(pool.totalValueLockedToken0, decimals0))
+        api.add(pool.token1.id, toRaw(pool.totalValueLockedToken1, decimals1))
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #18569: add the new **AlphixPro** hook on Base (serving partner token pools like ETH/ZFI for ZyFAI), and migrate fee-only hooks to the official Uniswap V4 subgraph.

### Changes
- Add `AlphixPro` hook (`0x2f9Cf87A6CbFA53C3F1B184900de17298e3F9080`) on Base with the ETH/ZFI pool
- Migrate fee-only hooks (`AlphixLVRFee`, `AlphixPro`) to query the official Uniswap V4 subgraph via `sdk.graph.request` — same endpoint already used by the repo's `uniV4HookExport` helper in `projects/helper/uniswapV4.js`
- Rehypothecation hooks (original `Alphix` contracts with on-chain yield) continue to use our Goldsky subgraph since they rely on indexed fields not present in the official subgraph
- No new npm dependencies, no `pnpm-lock.yaml` edits, no fetch adapter

### Test results

```
--- base ---
USDC     38.28 k
ZFI      22.79 k
USDS     20.59 k
cbBTC    10.34 k
ETH      7.36 k
Total:   99.36 k

--- arbitrum ---
USDC     144.21 k
USDT0    42.06 k
Total:   186.27 k

total:   285.63 k
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized Alphix TVL data sourcing architecture with refined configuration structure.
  * Separated rehypothecation and fee-based liquidity query paths for enhanced protocol support.
  * Integrated Uniswap V4 pool data sourcing capabilities.
  * Updated data acquisition methodology for improved coverage and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->