### PR TITLE
fix: add DorkFi Twitter handle and audit link

### DIFF
--- a/projects/dorkfi/index.js
+++ b/projects/dorkfi/index.js
@@ -168,6 +168,8 @@ function makeBorrowed(chain) {
 
 module.exports = {
   timetravel: false,
+  twitter: "dork_fi",
+  audit_links: ["https://github.com/DorkFi/audits/tree/main"],
   methodology:
     "TVL counts all native tokens and ASAs deposited into DorkFi lending pools " +
     "on Algorand and Voi. Borrowed amounts are read from pool contract market " +


### PR DESCRIPTION
Adds `audit_links` pointing to the DorkFi audits repo: https://github.com/DorkFi/audits/tree/main

This will surface the **Audits: Yes** badge on the DorkFi DeFi Llama listing page.

Also includes `twitter: "dork_fi"` in case it's not already present in the current codebase.