### PR TITLE
include megaeth chain for purrlend

### DIFF
--- a/registries/aaveV3.js
+++ b/registries/aaveV3.js
@@ -20,6 +20,7 @@ const configs = {
   },
   'purrlend': {
     hyperliquid: ['0xa8Ca6a4A485485910aA4023b9963Dfd2f3A5aeb0'],
+    megaeth: ['0xfCaE4E9Acb1E5C78aa699d43c5cc0eAC5399E754'],
   },
   // --- newly migrated aaveV3Export protocols ---
   'zentra': {


### PR DESCRIPTION
Purrlend is already integrated on DefiLlama UI.

This PR just includes the megaeth chain for TVL calculations to be shown on the UI as well


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new deployment network, extending the registry configuration to enable operations on an additional environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->