### PR TITLE
Strato rpc adapter

### DIFF
--- a/projects/helper/chains.json
+++ b/projects/helper/chains.json
@@ -413,6 +413,7 @@
   "starcoin",
   "stargaze",
   "starknet",
+  "strato",
   "stellar",
   "step",
   "stratis",

--- a/projects/strato/index.js
+++ b/projects/strato/index.js
@@ -84,6 +84,7 @@ function addPriced(api, position, amount) {
     return
   }
 
+  // priceUsd is WAD-scaled (1e18) per the metrics API
   const priceUsd = BigInt(position.priceUsd || '0')
   if (priceUsd === 0n) return
   const usdWei = (amount * priceUsd) / scale

--- a/projects/strato/index.js
+++ b/projects/strato/index.js
@@ -35,7 +35,7 @@ const splitSourceKey = (sourceKey) => {
 }
 
 async function tvl(api) {
-  const { data } = await axios.get(TVL_ENDPOINT)
+  const { data } = await axios.get(TVL_ENDPOINT, { timeout: 15_000 })
   const positions = Array.isArray(data?.positions) ? data.positions : []
 
   // Pool positions carry a concrete holder address — re-verify their balances

--- a/projects/strato/index.js
+++ b/projects/strato/index.js
@@ -1,7 +1,15 @@
 const axios = require('axios')
 
+const RPC_URL = 'https://noderpc.strato.nexus/rpc'
 const TVL_ENDPOINT = 'https://app.strato.nexus/api/metrics/tvl'
 
+// STRATO is not yet in @defillama/sdk's providers.json; fall back to this RPC
+// unless the DefiLlama runner has already set STRATO_RPC in its environment.
+if (!process.env.STRATO_RPC) process.env.STRATO_RPC = RPC_URL
+
+// STRATO-issued tokens aren't listed on CoinGecko. We map them to the underlying
+// asset's CG id so DefiLlama can price them; tokens without a mapping (USDST,
+// SILVST, GOLDST) are priced via the protocol oracle's USD quote.
 const CG_TOKEN_MAP = {
   ETH: 'ethereum',
   WBTC: 'wrapped-bitcoin',
@@ -15,26 +23,76 @@ const CG_TOKEN_MAP = {
   syrupUSDC: 'syrupusdc',
 }
 
+const WAD = 10n ** 18n
+
+const normalize = (addr) => (addr || '').toLowerCase().replace(/^0x/, '')
+
+const splitSourceKey = (sourceKey) => {
+  if (!sourceKey) return [null, null]
+  const [a, b] = sourceKey.split(':')
+  if (a && b) return [normalize(a), normalize(b)]
+  return [null, normalize(a)]
+}
+
 async function tvl(api) {
   const { data } = await axios.get(TVL_ENDPOINT)
-  const assets = data?.assets ?? []
+  const positions = Array.isArray(data?.positions) ? data.positions : []
 
-  for (const asset of assets) {
-    if (!asset?.symbol || asset.amount == null) continue
-    const decimals = Math.pow(10, asset.decimals ?? 18)
-    const amount = asset.amount / decimals
-    const cgId = CG_TOKEN_MAP[asset.symbol]
-    if (cgId) {
-      api.addCGToken(cgId, amount)
-    } else {
-      const usdValue = asset.totalUsd / decimals
-      api.addUSDValue(usdValue)
+  // Pool positions carry a concrete holder address — re-verify their balances
+  // via eth_call. Aggregated buckets (CDP, lending, saveUsdst, safetyModule,
+  // vaults) only expose the asset key, so we use the metrics amount directly.
+  const verifiable = positions
+    .map((pos, i) => {
+      const [holder, sourceToken] = splitSourceKey(pos.sourceKey)
+      const token = normalize(pos.address)
+      if (!token || !holder || !sourceToken || holder === token) return null
+      return { index: i, holder, token }
+    })
+    .filter(Boolean)
+
+  const results = await Promise.allSettled(
+    verifiable.map(({ holder, token }) =>
+      api.call({ target: token, abi: 'erc20:balanceOf', params: holder })
+    )
+  )
+
+  const onchainByIndex = new Map()
+  for (let k = 0; k < verifiable.length; k++) {
+    const result = results[k]
+    if (result.status === 'fulfilled' && result.value != null) {
+      onchainByIndex.set(verifiable[k].index, BigInt(result.value))
     }
+  }
+
+  for (let i = 0; i < positions.length; i++) {
+    const pos = positions[i]
+    const amount = onchainByIndex.has(i) ? onchainByIndex.get(i) : BigInt(pos.amount || '0')
+    addPriced(api, pos, amount)
   }
 }
 
+function addPriced(api, position, amount) {
+  if (amount === 0n) return
+  const decimals = Number(position.decimals ?? 18)
+  const scale = 10n ** BigInt(decimals)
+  const symbol = position.symbol
+  const humanAmount = Number(amount) / Number(scale)
+  const cgId = CG_TOKEN_MAP[symbol]
+
+  if (cgId) {
+    api.addCGToken(cgId, humanAmount)
+    return
+  }
+
+  const priceUsd = BigInt(position.priceUsd || '0')
+  if (priceUsd === 0n) return
+  const usdWei = (amount * priceUsd) / scale
+  api.addUSDValue(Number(usdWei) / Number(WAD))
+}
+
 module.exports = {
-  methodology: 'Counts underlying assets locked in STRATO DeFi contracts across CDP, lending, pools, saveUSDST, safety module, and vaults. Excludes wallet balances, receipt/share tokens, protocol debt, and double counting.',
+  methodology:
+    'Counts underlying assets locked in STRATO DeFi contracts across CDP, lending, pools, saveUSDST, safety module, and vaults. Pool balances are re-verified on-chain via eth_call against the STRATO JSON-RPC; aggregated buckets fall back to the protocol metrics snapshot. Excludes wallet balances, receipt/share tokens, protocol debt, and double counting.',
   misrepresentedTokens: true,
   timetravel: false,
   start: 1775151906,

--- a/projects/strato/index.js
+++ b/projects/strato/index.js
@@ -21,12 +21,13 @@ async function tvl(api) {
 
   for (const asset of assets) {
     if (!asset?.symbol || asset.amount == null) continue
-    const amount = asset.amount / 1e18
+    const decimals = Math.pow(10, asset.decimals ?? 18)
+    const amount = asset.amount / decimals
     const cgId = CG_TOKEN_MAP[asset.symbol]
     if (cgId) {
       api.addCGToken(cgId, amount)
     } else {
-      const usdValue = asset.totalUsd / 1e18
+      const usdValue = asset.totalUsd / decimals
       api.addUSDValue(usdValue)
     }
   }

--- a/projects/strato/index.js
+++ b/projects/strato/index.js
@@ -1,0 +1,41 @@
+const axios = require('axios')
+
+const TVL_ENDPOINT = 'https://app.strato.nexus/api/metrics/tvl'
+
+const CG_TOKEN_MAP = {
+  ETH: 'ethereum',
+  WBTC: 'wrapped-bitcoin',
+  USDC: 'usd-coin',
+  USDT: 'tether',
+  wstETH: 'wrapped-steth',
+  rETH: 'rocket-pool-eth',
+  PAXG: 'pax-gold',
+  XAUt: 'tether-gold',
+  sUSDS: 'susds',
+  syrupUSDC: 'syrupusdc',
+}
+
+async function tvl(api) {
+  const { data } = await axios.get(TVL_ENDPOINT)
+  const assets = data?.assets ?? []
+
+  for (const asset of assets) {
+    if (!asset?.symbol || asset.amount == null) continue
+    const amount = asset.amount / 1e18
+    const cgId = CG_TOKEN_MAP[asset.symbol]
+    if (cgId) {
+      api.addCGToken(cgId, amount)
+    } else {
+      const usdValue = asset.totalUsd / 1e18
+      api.addUSDValue(usdValue)
+    }
+  }
+}
+
+module.exports = {
+  methodology: 'Counts underlying assets locked in STRATO DeFi contracts across CDP, lending, pools, saveUSDST, safety module, and vaults. Excludes wallet balances, receipt/share tokens, protocol debt, and double counting.',
+  misrepresentedTokens: true,
+  timetravel: false,
+  start: 1775151906,
+  strato: { tvl },
+}

--- a/projects/strato/index.js
+++ b/projects/strato/index.js
@@ -1,15 +1,15 @@
-const axios = require('axios')
+const RPC_URL          = 'https://noderpc.strato.nexus/rpc'
+const POOL_FACTORY     = '0x000000000000000000000000000000000000100a'
+const PRICE_ORACLE     = '0x0000000000000000000000000000000000001002'
+const CDP_REGISTRY     = '0x0000000000000000000000000000000000001012'
+const LENDING_REGISTRY = '0x0000000000000000000000000000000000001007'
+const LENDING_POOL     = '0x0000000000000000000000000000000000001005'
+const SAFETY_MODULE    = '0x0000000000000000000000000000000000001015'
+const SAVE_USDST_VAULT = '0x22550671fcad04a213697ac7ae4f4366e96446ed'
+const VAULT            = '0x34bc729f66106a146b0864e673a3571b28fa23e1'
 
-const RPC_URL = 'https://noderpc.strato.nexus/rpc'
-const TVL_ENDPOINT = 'https://app.strato.nexus/api/metrics/tvl'
-
-// STRATO is not yet in @defillama/sdk's providers.json; fall back to this RPC
-// unless the DefiLlama runner has already set STRATO_RPC in its environment.
 if (!process.env.STRATO_RPC) process.env.STRATO_RPC = RPC_URL
 
-// STRATO-issued tokens aren't listed on CoinGecko. We map them to the underlying
-// asset's CG id so DefiLlama can price them; tokens without a mapping (USDST,
-// SILVST, GOLDST) are priced via the protocol oracle's USD quote.
 const CG_TOKEN_MAP = {
   ETH: 'ethereum',
   WBTC: 'wrapped-bitcoin',
@@ -24,76 +24,166 @@ const CG_TOKEN_MAP = {
 }
 
 const WAD = 10n ** 18n
+const RAY = 10n ** 27n
 
-const normalize = (addr) => (addr || '').toLowerCase().replace(/^0x/, '')
+const lc = (v) => v && v.toLowerCase()
 
-const splitSourceKey = (sourceKey) => {
-  if (!sourceKey) return [null, null]
-  const [a, b] = sourceKey.split(':')
-  if (a && b) return [normalize(a), normalize(b)]
-  return [null, normalize(a)]
+async function tryCall(api, opts) {
+  try { return lc(await api.call(opts)) } catch { return null }
+}
+
+async function tryCallRaw(api, opts) {
+  try { return await api.call(opts) } catch { return null }
+}
+
+async function enumerateArray(api, target, abi, max = 50) {
+  const seen = new Set()
+  const out = []
+  for (let i = 0; i < max; i++) {
+    const r = await tryCall(api, { target, abi, params: i })
+    if (!r || r === '0x0000000000000000000000000000000000000000') break
+    if (!seen.has(r)) { seen.add(r); out.push(r) }
+  }
+  return out
+}
+
+async function discoverPools(api) {
+  const poolAddrs = await enumerateArray(
+    api, POOL_FACTORY, 'function allPools(uint256) view returns (address)'
+  )
+  const pools = []
+  for (const pool of poolAddrs) {
+    const tokenA = await tryCall(api, { target: pool, abi: 'function tokenA() view returns (address)' })
+    const tokenB = await tryCall(api, { target: pool, abi: 'function tokenB() view returns (address)' })
+    if (tokenA && tokenB) pools.push({ pool, tokens: [tokenA, tokenB] })
+  }
+  return pools
 }
 
 async function tvl(api) {
-  const { data } = await axios.get(TVL_ENDPOINT, { timeout: 15_000 })
-  const positions = Array.isArray(data?.positions) ? data.positions : []
+  const pools = await discoverPools(api)
 
-  // Pool positions carry a concrete holder address — re-verify their balances
-  // via eth_call. Aggregated buckets (CDP, lending, saveUsdst, safetyModule,
-  // vaults) only expose the asset key, so we use the metrics amount directly.
-  const verifiable = positions
-    .map((pos, i) => {
-      const [holder, sourceToken] = splitSourceKey(pos.sourceKey)
-      const token = normalize(pos.address)
-      if (!token || !holder || !sourceToken || holder === token) return null
-      return { index: i, holder, token }
-    })
-    .filter(Boolean)
+  const cdpVault = await tryCall(api, { target: CDP_REGISTRY, abi: 'function cdpVault() view returns (address)' })
 
-  const results = await Promise.allSettled(
-    verifiable.map(({ holder, token }) =>
-      api.call({ target: token, abi: 'erc20:balanceOf', params: holder })
-    )
+  const collateralVault = await tryCall(api, { target: LENDING_REGISTRY, abi: 'function collateralVault() view returns (address)' })
+  const liquidityPool = await tryCall(api, { target: LENDING_REGISTRY, abi: 'function liquidityPool() view returns (address)' })
+  const borrowableAsset = await tryCall(api, { target: LENDING_POOL, abi: 'function borrowableAsset() view returns (address)' })
+  const lendingCollateralTokens = await enumerateArray(
+    api, LENDING_POOL, 'function configuredAssets(uint256) view returns (address)'
   )
 
-  const onchainByIndex = new Map()
-  for (let k = 0; k < verifiable.length; k++) {
-    const result = results[k]
-    if (result.status === 'fulfilled' && result.value != null) {
-      onchainByIndex.set(verifiable[k].index, BigInt(result.value))
-    }
+  const vaultBotExecutor = await tryCall(api, { target: VAULT, abi: 'function botExecutor() view returns (address)' })
+  const vaultAssets = await enumerateArray(
+    api, VAULT, 'function supportedAssets(uint256) view returns (address)'
+  )
+
+  const saveAsset = await tryCall(api, { target: SAVE_USDST_VAULT, abi: 'function asset() view returns (address)' })
+  const safetyAsset = await tryCall(api, { target: SAFETY_MODULE, abi: 'function asset() view returns (address)' })
+
+  const tokenSet = new Set()
+  pools.forEach(p => p.tokens.forEach(t => tokenSet.add(t)))
+  lendingCollateralTokens.forEach(t => tokenSet.add(t))
+  vaultAssets.forEach(t => tokenSet.add(t))
+  if (borrowableAsset) tokenSet.add(borrowableAsset)
+  if (saveAsset) tokenSet.add(saveAsset)
+  if (safetyAsset) tokenSet.add(safetyAsset)
+  const allTokens = [...tokenSet]
+
+  const tokenInfo = new Map()
+  for (const t of allTokens) {
+    const symbol = await tryCallRaw(api, { target: t, abi: 'erc20:symbol' })
+    const decimals = await tryCallRaw(api, { target: t, abi: 'erc20:decimals' })
+    if (symbol && decimals != null) tokenInfo.set(t, { symbol, decimals: Number(decimals) })
   }
 
-  for (let i = 0; i < positions.length; i++) {
-    const pos = positions[i]
-    const amount = onchainByIndex.has(i) ? onchainByIndex.get(i) : BigInt(pos.amount || '0')
-    addPriced(api, pos, amount)
+  const pairs = []
+  for (const { pool, tokens } of pools) {
+    for (const token of tokens) pairs.push({ holder: pool, token })
+  }
+  if (cdpVault) {
+    for (const token of allTokens) pairs.push({ holder: cdpVault, token })
+  }
+  if (collateralVault) {
+    for (const token of lendingCollateralTokens) pairs.push({ holder: collateralVault, token })
+  }
+  if (liquidityPool && borrowableAsset) {
+    pairs.push({ holder: liquidityPool, token: borrowableAsset })
+  }
+  if (vaultBotExecutor) {
+    for (const token of vaultAssets) pairs.push({ holder: vaultBotExecutor, token })
+  }
+
+  const oracleTokens = allTokens.filter(t => {
+    const info = tokenInfo.get(t); return info && !CG_TOKEN_MAP[info.symbol]
+  })
+
+  const oraclePriceMap = new Map()
+  for (const t of oracleTokens) {
+    const price = await tryCallRaw(api, {
+      target: PRICE_ORACLE,
+      abi: 'function getAssetPrice(address) view returns (uint256)',
+      params: t,
+    })
+    if (price) oraclePriceMap.set(t, BigInt(price))
+  }
+
+  const balances = []
+  for (const { token, holder } of pairs) {
+    balances.push(await tryCallRaw(api, { target: token, abi: 'erc20:balanceOf', params: holder }))
+  }
+
+  let borrowIndex = null, totalScaledDebt = null
+  if (borrowableAsset) {
+    borrowIndex = await tryCallRaw(api, { target: LENDING_POOL, abi: 'function borrowIndex() view returns (uint256)' })
+    totalScaledDebt = await tryCallRaw(api, { target: LENDING_POOL, abi: 'function totalScaledDebt() view returns (uint256)' })
+  }
+
+  for (let i = 0; i < pairs.length; i++) {
+    if (!balances[i]) continue
+    const amount = BigInt(balances[i])
+    if (amount === 0n) continue
+    addToken(api, pairs[i].token, amount, tokenInfo, oraclePriceMap)
+  }
+
+  const saveTotalAssets = saveAsset
+    ? await tryCallRaw(api, { target: SAVE_USDST_VAULT, abi: 'function totalAssets() view returns (uint256)' })
+    : null
+  const safetyTotalAssets = safetyAsset
+    ? await tryCallRaw(api, { target: SAFETY_MODULE, abi: 'function totalAssets() view returns (uint256)' })
+    : null
+
+  if (saveAsset && saveTotalAssets) {
+    const amt = BigInt(saveTotalAssets)
+    if (amt > 0n) addToken(api, saveAsset, amt, tokenInfo, oraclePriceMap)
+  }
+  if (safetyAsset && safetyTotalAssets) {
+    const amt = BigInt(safetyTotalAssets)
+    if (amt > 0n) addToken(api, safetyAsset, amt, tokenInfo, oraclePriceMap)
+  }
+
+  if (borrowableAsset && borrowIndex && totalScaledDebt) {
+    const lendingDebt = (BigInt(totalScaledDebt) * BigInt(borrowIndex)) / RAY
+    if (lendingDebt > 0n) addToken(api, borrowableAsset, lendingDebt, tokenInfo, oraclePriceMap)
   }
 }
 
-function addPriced(api, position, amount) {
-  if (amount === 0n) return
-  const decimals = Number(position.decimals ?? 18)
-  const scale = 10n ** BigInt(decimals)
-  const symbol = position.symbol
-  const humanAmount = Number(amount) / Number(scale)
-  const cgId = CG_TOKEN_MAP[symbol]
-
+function addToken(api, token, amount, tokenInfo, oraclePriceMap) {
+  const info = tokenInfo.get(token)
+  if (!info) return
+  const scale = 10n ** BigInt(info.decimals)
+  const cgId = CG_TOKEN_MAP[info.symbol]
   if (cgId) {
-    api.addCGToken(cgId, humanAmount)
-    return
+    api.addCGToken(cgId, Number(amount) / Number(scale))
+  } else {
+    const priceUsd = oraclePriceMap.get(token)
+    if (!priceUsd) return
+    api.addUSDValue(Number((amount * priceUsd) / scale) / Number(WAD))
   }
-
-  // priceUsd is WAD-scaled (1e18) per the metrics API
-  const priceUsd = BigInt(position.priceUsd || '0')
-  if (priceUsd === 0n) return
-  const usdWei = (amount * priceUsd) / scale
-  api.addUSDValue(Number(usdWei) / Number(WAD))
 }
 
 module.exports = {
   methodology:
-    'Counts underlying assets locked in STRATO DeFi contracts across CDP, lending, pools, saveUSDST, safety module, and vaults. Pool balances are re-verified on-chain via eth_call against the STRATO JSON-RPC; aggregated buckets fall back to the protocol metrics snapshot. Excludes wallet balances, receipt/share tokens, protocol debt, and double counting.',
+    'All values verified on-chain via sequential eth_call (no Multicall3). Swap pools enumerated from PoolFactory.allPools. CDP collateral read from CDPVault, lending deposits from LiquidityPool + CollateralVault, savings from SaveUSDSTVault, staked assets from SafetyModule, and vault holdings from the Vault botExecutor. Holder addresses resolved from on-chain registries (CDPRegistry, LendingRegistry). Prices from CoinGecko or the on-chain PriceOracle.',
   misrepresentedTokens: true,
   timetravel: false,
   start: 1775151906,

--- a/projects/strato/index.js
+++ b/projects/strato/index.js
@@ -11,23 +11,15 @@ if (!process.env.STRATO_RPC) process.env.STRATO_RPC = RPC_URL
 
 const RAY = 10n ** 27n
 
-const lc = (v) => v && v.toLowerCase()
-
-async function tryCall(api, opts) {
-  try { return lc(await api.call(opts)) } catch { return null }
-}
-
-async function tryCallRaw(api, opts) {
-  try { return await api.call(opts) } catch { return null }
-}
-
 async function enumerateArray(api, target, abi, max = 500) {
   const seen = new Set()
   const out = []
   for (let i = 0; i < max; i++) {
-    const r = await tryCall(api, { target, abi, params: i })
+    let r
+    try { r = await api.call({ target, abi, params: i }) } catch { break }
     if (!r || r === '0x0000000000000000000000000000000000000000') break
-    if (!seen.has(r)) { seen.add(r); out.push(r) }
+    const lc = r.toLowerCase()
+    if (!seen.has(lc)) { seen.add(lc); out.push(lc) }
   }
   if (out.length === max) console.warn(`[strato] enumerateArray hit cap ${max} on ${target} — likely truncated`)
   return out
@@ -39,9 +31,9 @@ async function discoverPools(api) {
   )
   const pools = []
   for (const pool of poolAddrs) {
-    const tokenA = await tryCall(api, { target: pool, abi: 'function tokenA() view returns (address)' })
-    const tokenB = await tryCall(api, { target: pool, abi: 'function tokenB() view returns (address)' })
-    if (tokenA && tokenB) pools.push({ pool, tokens: [tokenA, tokenB] })
+    const tokenA = (await api.call({ target: pool, abi: 'function tokenA() view returns (address)' })).toLowerCase()
+    const tokenB = (await api.call({ target: pool, abi: 'function tokenB() view returns (address)' })).toLowerCase()
+    pools.push({ pool, tokens: [tokenA, tokenB] })
   }
   return pools
 }
@@ -49,77 +41,48 @@ async function discoverPools(api) {
 async function tvl(api) {
   const pools = await discoverPools(api)
 
-  const cdpVault = await tryCall(api, { target: CDP_REGISTRY, abi: 'function cdpVault() view returns (address)' })
-
-  const collateralVault = await tryCall(api, { target: LENDING_REGISTRY, abi: 'function collateralVault() view returns (address)' })
-  const liquidityPool = await tryCall(api, { target: LENDING_REGISTRY, abi: 'function liquidityPool() view returns (address)' })
-  const borrowableAsset = await tryCall(api, { target: LENDING_POOL, abi: 'function borrowableAsset() view returns (address)' })
+  const cdpVault         = (await api.call({ target: CDP_REGISTRY,     abi: 'function cdpVault() view returns (address)' })).toLowerCase()
+  const collateralVault  = (await api.call({ target: LENDING_REGISTRY, abi: 'function collateralVault() view returns (address)' })).toLowerCase()
+  const liquidityPool    = (await api.call({ target: LENDING_REGISTRY, abi: 'function liquidityPool() view returns (address)' })).toLowerCase()
+  const borrowableAsset  = (await api.call({ target: LENDING_POOL,     abi: 'function borrowableAsset() view returns (address)' })).toLowerCase()
   const lendingCollateralTokens = await enumerateArray(
     api, LENDING_POOL, 'function configuredAssets(uint256) view returns (address)'
   )
 
-  const vaultBotExecutor = await tryCall(api, { target: VAULT, abi: 'function botExecutor() view returns (address)' })
-  const vaultAssetsRaw = await tryCallRaw(api, {
-    target: VAULT, abi: 'function getSupportedAssets() view returns (address[])'
-  })
-  const vaultAssets = (vaultAssetsRaw || []).map(a => a && a.toLowerCase()).filter(Boolean)
+  const vaultBotExecutor = (await api.call({ target: VAULT, abi: 'function botExecutor() view returns (address)' })).toLowerCase()
+  const vaultAssets      = await enumerateArray(api, VAULT, 'function supportedAssets(uint256) view returns (address)')
 
-  const saveAsset = await tryCall(api, { target: SAVE_USDST_VAULT, abi: 'function asset() view returns (address)' })
-  const safetyAsset = await tryCall(api, { target: SAFETY_MODULE, abi: 'function asset() view returns (address)' })
+  const saveAsset        = (await api.call({ target: SAVE_USDST_VAULT, abi: 'function asset() view returns (address)' })).toLowerCase()
+  const safetyAsset      = (await api.call({ target: SAFETY_MODULE,    abi: 'function asset() view returns (address)' })).toLowerCase()
 
   const tokenSet = new Set()
   pools.forEach(p => p.tokens.forEach(t => tokenSet.add(t)))
   lendingCollateralTokens.forEach(t => tokenSet.add(t))
   vaultAssets.forEach(t => tokenSet.add(t))
-  if (borrowableAsset) tokenSet.add(borrowableAsset)
-  if (saveAsset) tokenSet.add(saveAsset)
-  if (safetyAsset) tokenSet.add(safetyAsset)
+  tokenSet.add(borrowableAsset)
+  tokenSet.add(saveAsset)
+  tokenSet.add(safetyAsset)
   const allTokens = [...tokenSet]
 
   const pairs = []
   for (const { pool, tokens } of pools) {
     for (const token of tokens) pairs.push({ holder: pool, token })
   }
-  if (cdpVault) {
-    for (const token of allTokens) pairs.push({ holder: cdpVault, token })
-  }
-  if (collateralVault) {
-    for (const token of lendingCollateralTokens) pairs.push({ holder: collateralVault, token })
-  }
-  if (liquidityPool && borrowableAsset) {
-    pairs.push({ holder: liquidityPool, token: borrowableAsset })
-  }
-  if (vaultBotExecutor) {
-    for (const token of vaultAssets) pairs.push({ holder: vaultBotExecutor, token })
-  }
+  for (const token of allTokens) pairs.push({ holder: cdpVault, token })
+  for (const token of lendingCollateralTokens) pairs.push({ holder: collateralVault, token })
+  pairs.push({ holder: liquidityPool, token: borrowableAsset })
+  for (const token of vaultAssets) pairs.push({ holder: vaultBotExecutor, token })
 
-  const balances = []
   for (const { token, holder } of pairs) {
-    balances.push(await tryCallRaw(api, { target: token, abi: 'erc20:balanceOf', params: holder }))
+    const balance = await api.call({ target: token, abi: 'erc20:balanceOf', params: holder })
+    if (BigInt(balance) > 0n) api.add(token, balance.toString())
   }
 
-  for (let i = 0; i < pairs.length; i++) {
-    if (!balances[i]) continue
-    const amount = BigInt(balances[i])
-    if (amount === 0n) continue
-    api.add(pairs[i].token, amount.toString())
-  }
+  const saveTotalAssets   = await api.call({ target: SAVE_USDST_VAULT, abi: 'function totalAssets() view returns (uint256)' })
+  const safetyTotalAssets = await api.call({ target: SAFETY_MODULE,    abi: 'function totalAssets() view returns (uint256)' })
 
-  const saveTotalAssets = saveAsset
-    ? await tryCallRaw(api, { target: SAVE_USDST_VAULT, abi: 'function totalAssets() view returns (uint256)' })
-    : null
-  const safetyTotalAssets = safetyAsset
-    ? await tryCallRaw(api, { target: SAFETY_MODULE, abi: 'function totalAssets() view returns (uint256)' })
-    : null
-
-  if (saveAsset && saveTotalAssets) {
-    const amt = BigInt(saveTotalAssets)
-    if (amt > 0n) api.add(saveAsset, amt.toString())
-  }
-  if (safetyAsset && safetyTotalAssets) {
-    const amt = BigInt(safetyTotalAssets)
-    if (amt > 0n) api.add(safetyAsset, amt.toString())
-  }
+  if (BigInt(saveTotalAssets)   > 0n) api.add(saveAsset,   saveTotalAssets.toString())
+  if (BigInt(safetyTotalAssets) > 0n) api.add(safetyAsset, safetyTotalAssets.toString())
 }
 
 // NOTE: CDP debt is intentionally NOT included here. STRATO's CDPEngine stores
@@ -130,17 +93,12 @@ async function tvl(api) {
 // external view getter on CDPEngine or a contract redeploy. Until that lands,
 // `borrowed` reports only the LiquidityPool debt.
 async function borrowed(api) {
-  const borrowableAsset = await tryCall(api, { target: LENDING_POOL, abi: 'function borrowableAsset() view returns (address)' })
-  if (!borrowableAsset) return
-
-  const borrowIndex = await tryCallRaw(api, { target: LENDING_POOL, abi: 'function borrowIndex() view returns (uint256)' })
-  const totalScaledDebt = await tryCallRaw(api, { target: LENDING_POOL, abi: 'function totalScaledDebt() view returns (uint256)' })
-  if (!borrowIndex || !totalScaledDebt) return
+  const borrowableAsset  = await api.call({ target: LENDING_POOL, abi: 'function borrowableAsset() view returns (address)' })
+  const borrowIndex      = await api.call({ target: LENDING_POOL, abi: 'function borrowIndex() view returns (uint256)' })
+  const totalScaledDebt  = await api.call({ target: LENDING_POOL, abi: 'function totalScaledDebt() view returns (uint256)' })
 
   const lendingDebt = (BigInt(totalScaledDebt) * BigInt(borrowIndex)) / RAY
-  if (lendingDebt === 0n) return
-
-  api.add(borrowableAsset, lendingDebt.toString())
+  if (lendingDebt > 0n) api.add(borrowableAsset, lendingDebt.toString())
 }
 
 module.exports = {

--- a/projects/strato/index.js
+++ b/projects/strato/index.js
@@ -1,6 +1,5 @@
 const RPC_URL          = 'https://noderpc.strato.nexus/rpc'
 const POOL_FACTORY     = '0x000000000000000000000000000000000000100a'
-const PRICE_ORACLE     = '0x0000000000000000000000000000000000001002'
 const CDP_REGISTRY     = '0x0000000000000000000000000000000000001012'
 const LENDING_REGISTRY = '0x0000000000000000000000000000000000001007'
 const LENDING_POOL     = '0x0000000000000000000000000000000000001005'
@@ -10,20 +9,6 @@ const VAULT            = '0x34bc729f66106a146b0864e673a3571b28fa23e1'
 
 if (!process.env.STRATO_RPC) process.env.STRATO_RPC = RPC_URL
 
-const CG_TOKEN_MAP = {
-  ETH: 'ethereum',
-  WBTC: 'wrapped-bitcoin',
-  USDC: 'usd-coin',
-  USDT: 'tether',
-  wstETH: 'wrapped-steth',
-  rETH: 'rocket-pool-eth',
-  PAXG: 'pax-gold',
-  XAUt: 'tether-gold',
-  sUSDS: 'susds',
-  syrupUSDC: 'syrupusdc',
-}
-
-const WAD = 10n ** 18n
 const RAY = 10n ** 27n
 
 const lc = (v) => v && v.toLowerCase()
@@ -91,13 +76,6 @@ async function tvl(api) {
   if (safetyAsset) tokenSet.add(safetyAsset)
   const allTokens = [...tokenSet]
 
-  const tokenInfo = new Map()
-  for (const t of allTokens) {
-    const symbol = await tryCallRaw(api, { target: t, abi: 'erc20:symbol' })
-    const decimals = await tryCallRaw(api, { target: t, abi: 'erc20:decimals' })
-    if (symbol && decimals != null) tokenInfo.set(t, { symbol, decimals: Number(decimals) })
-  }
-
   const pairs = []
   for (const { pool, tokens } of pools) {
     for (const token of tokens) pairs.push({ holder: pool, token })
@@ -115,36 +93,16 @@ async function tvl(api) {
     for (const token of vaultAssets) pairs.push({ holder: vaultBotExecutor, token })
   }
 
-  const oracleTokens = allTokens.filter(t => {
-    const info = tokenInfo.get(t); return info && !CG_TOKEN_MAP[info.symbol]
-  })
-
-  const oraclePriceMap = new Map()
-  for (const t of oracleTokens) {
-    const price = await tryCallRaw(api, {
-      target: PRICE_ORACLE,
-      abi: 'function getAssetPrice(address) view returns (uint256)',
-      params: t,
-    })
-    if (price) oraclePriceMap.set(t, BigInt(price))
-  }
-
   const balances = []
   for (const { token, holder } of pairs) {
     balances.push(await tryCallRaw(api, { target: token, abi: 'erc20:balanceOf', params: holder }))
-  }
-
-  let borrowIndex = null, totalScaledDebt = null
-  if (borrowableAsset) {
-    borrowIndex = await tryCallRaw(api, { target: LENDING_POOL, abi: 'function borrowIndex() view returns (uint256)' })
-    totalScaledDebt = await tryCallRaw(api, { target: LENDING_POOL, abi: 'function totalScaledDebt() view returns (uint256)' })
   }
 
   for (let i = 0; i < pairs.length; i++) {
     if (!balances[i]) continue
     const amount = BigInt(balances[i])
     if (amount === 0n) continue
-    addToken(api, pairs[i].token, amount, tokenInfo, oraclePriceMap)
+    api.add(pairs[i].token, amount.toString())
   }
 
   const saveTotalAssets = saveAsset
@@ -156,38 +114,40 @@ async function tvl(api) {
 
   if (saveAsset && saveTotalAssets) {
     const amt = BigInt(saveTotalAssets)
-    if (amt > 0n) addToken(api, saveAsset, amt, tokenInfo, oraclePriceMap)
+    if (amt > 0n) api.add(saveAsset, amt.toString())
   }
   if (safetyAsset && safetyTotalAssets) {
     const amt = BigInt(safetyTotalAssets)
-    if (amt > 0n) addToken(api, safetyAsset, amt, tokenInfo, oraclePriceMap)
-  }
-
-  if (borrowableAsset && borrowIndex && totalScaledDebt) {
-    const lendingDebt = (BigInt(totalScaledDebt) * BigInt(borrowIndex)) / RAY
-    if (lendingDebt > 0n) addToken(api, borrowableAsset, lendingDebt, tokenInfo, oraclePriceMap)
+    if (amt > 0n) api.add(safetyAsset, amt.toString())
   }
 }
 
-function addToken(api, token, amount, tokenInfo, oraclePriceMap) {
-  const info = tokenInfo.get(token)
-  if (!info) return
-  const scale = 10n ** BigInt(info.decimals)
-  const cgId = CG_TOKEN_MAP[info.symbol]
-  if (cgId) {
-    api.addCGToken(cgId, Number(amount) / Number(scale))
-  } else {
-    const priceUsd = oraclePriceMap.get(token)
-    if (!priceUsd) return
-    api.addUSDValue(Number((amount * priceUsd) / scale) / Number(WAD))
-  }
+// NOTE: CDP debt is intentionally NOT included here. STRATO's CDPEngine stores
+// per-collateral debt in `mapping(address => CollateralGlobalState) public record
+// collateralGlobalStates`, and the `record` modifier prevents the standard ABI
+// auto-getter from being exposed via eth_call (selector reverts with "no function
+// for selector"). Reading CDP debt over JSON-RPC requires either an explicit
+// external view getter on CDPEngine or a contract redeploy. Until that lands,
+// `borrowed` reports only the LiquidityPool debt.
+async function borrowed(api) {
+  const borrowableAsset = await tryCall(api, { target: LENDING_POOL, abi: 'function borrowableAsset() view returns (address)' })
+  if (!borrowableAsset) return
+
+  const borrowIndex = await tryCallRaw(api, { target: LENDING_POOL, abi: 'function borrowIndex() view returns (uint256)' })
+  const totalScaledDebt = await tryCallRaw(api, { target: LENDING_POOL, abi: 'function totalScaledDebt() view returns (uint256)' })
+  if (!borrowIndex || !totalScaledDebt) return
+
+  const lendingDebt = (BigInt(totalScaledDebt) * BigInt(borrowIndex)) / RAY
+  if (lendingDebt === 0n) return
+
+  api.add(borrowableAsset, lendingDebt.toString())
 }
 
 module.exports = {
   methodology:
-    'All values verified on-chain via sequential eth_call (no Multicall3). Swap pools enumerated from PoolFactory.allPools. CDP collateral read from CDPVault, lending deposits from LiquidityPool + CollateralVault, savings from SaveUSDSTVault, staked assets from SafetyModule, and vault holdings from the Vault botExecutor. Holder addresses resolved from on-chain registries (CDPRegistry, LendingRegistry). Prices from CoinGecko or the on-chain PriceOracle.',
+    'All values verified on-chain via sequential eth_call (no Multicall3). Swap pools enumerated from PoolFactory.allPools. CDP collateral read from CDPVault, lending deposits (idle liquidity + collateral) from LiquidityPool + CollateralVault, savings from SaveUSDSTVault, staked assets from SafetyModule, and vault holdings from the Vault botExecutor. Holder addresses resolved from on-chain registries (CDPRegistry, LendingRegistry). Outstanding LiquidityPool debt is reported separately under `borrowed` (totalScaledDebt × borrowIndex / RAY against the LiquidityPool borrowableAsset) and is excluded from TVL. CDP debt is not yet included because STRATO CDPEngine state mappings are not exposed via standard ABI auto-getters over eth_call; this will be added once an explicit on-chain view function is available. Prices resolved server-side by DefiLlama for the `strato` chain.',
   misrepresentedTokens: true,
   timetravel: false,
   start: 1775151906,
-  strato: { tvl },
+  strato: { tvl, borrowed },
 }

--- a/projects/strato/index.js
+++ b/projects/strato/index.js
@@ -36,7 +36,7 @@ async function tryCallRaw(api, opts) {
   try { return await api.call(opts) } catch { return null }
 }
 
-async function enumerateArray(api, target, abi, max = 50) {
+async function enumerateArray(api, target, abi, max = 500) {
   const seen = new Set()
   const out = []
   for (let i = 0; i < max; i++) {
@@ -44,6 +44,7 @@ async function enumerateArray(api, target, abi, max = 50) {
     if (!r || r === '0x0000000000000000000000000000000000000000') break
     if (!seen.has(r)) { seen.add(r); out.push(r) }
   }
+  if (out.length === max) console.warn(`[strato] enumerateArray hit cap ${max} on ${target} — likely truncated`)
   return out
 }
 
@@ -73,9 +74,10 @@ async function tvl(api) {
   )
 
   const vaultBotExecutor = await tryCall(api, { target: VAULT, abi: 'function botExecutor() view returns (address)' })
-  const vaultAssets = await enumerateArray(
-    api, VAULT, 'function supportedAssets(uint256) view returns (address)'
-  )
+  const vaultAssetsRaw = await tryCallRaw(api, {
+    target: VAULT, abi: 'function getSupportedAssets() view returns (address[])'
+  })
+  const vaultAssets = (vaultAssetsRaw || []).map(a => a && a.toLowerCase()).filter(Boolean)
 
   const saveAsset = await tryCall(api, { target: SAVE_USDST_VAULT, abi: 'function asset() view returns (address)' })
   const safetyAsset = await tryCall(api, { target: SAFETY_MODULE, abi: 'function asset() view returns (address)' })


### PR DESCRIPTION
## Summary                                                                                              
                                                                                                          
  - Add STRATO as a new chain in `chains.json`                                                            
  - Add TVL adapter at `projects/strato/index.js` that re-verifies pool balances on-chain via STRATO's    
  JSON-RPC                                                                                                
  - Count underlying assets locked in STRATO DeFi contracts across CDP, lending, pools, saveUSDST, safety
  module, and vaults                                                                                      
  - Exclude wallet balances, receipt/share tokens, protocol debt, and double counting
                                                                                                          
  ## Data Sources                                           

  - **JSON-RPC:** `https://noderpc.strato.nexus/rpc` — used for every pool position's `balanceOf(holder)` 
  call via `api.call` / `eth_call`. Public, read-only, no API key.
  - **Metrics endpoint:** `https://app.strato.nexus/api/metrics/tvl` — used as the discovery index (which 
  positions exist) and for the aggregated buckets (CDP, lending, saveUSDST, safety module, vaults) whose  
  underlying holders aren't directly enumerable on-chain yet. Public, read-only.
  - STRATO is already listed in `projects/helper/chains.json`; registering an entry in `@defillama/sdk`'s 
  `providers.json` will follow in a separate upstream PR. The adapter self-registers `STRATO_RPC` at      
  module load so the current SDK resolves the chain correctly in the meantime.
  - DefiLlama confirmed a public read-only API is acceptable for listing (ref:                            
  https://github.com/strato-net/strato-platform/issues/6567)                                              
   
  ## Pricing Approach                                                                                     
                                                            
  - Bridged tokens (ETH, WBTC, USDC, USDT, wstETH, rETH, PAXG, XAUt, sUSDS, syrupUSDC) are priced via     
  CoinGecko IDs using `api.addCGToken()`
  - Native STRATO tokens (USDST, GOLDST, SILVST) without CoinGecko listings use `api.addUSDValue()` with  
  the oracle-derived USD values from the metrics endpoint                                                 
   
  ## Test Output                                                                                          
                                                            
  ```
  strato    8.40 M
  total     8.40 M
  ```                                                                                                     
   
  Run locally with:                                                                                       
                                                            
  ```bash
  STRATO_RPC=https://noderpc.strato.nexus/rpc node test.js projects/strato/index.js
  ```

  ---                                                                                                     
   
  ## New Listing Metadata                                                                                 
                                                            
  ##### Name: STRATO

  ##### Twitter Link: https://x.com/strato_net

  ##### List of audit links if any: N/A

  ##### Website Link: https://app.strato.nexus/
                                                                                                          
  ##### Logo (High resolution, will be shown with rounded borders):
                                           
<img width="200" height="200" alt="strato-logo-round" src="https://github.com/user-attachments/assets/da11d952-ccb0-4327-855a-69123733aaa3" />                                                               
   
  ##### Current TVL: ~$8.4M                                                                               
                                                            
  ##### Treasury Addresses: N/A
                                                                                                          
  ##### Chain: STRATO
                                                                                                          
  ##### Coingecko ID: N/A                                   

  ##### Coinmarketcap ID: N/A

  ##### Short Description: EVM-compatible L1 blockchain with DeFi suite including CDP stablecoin (USDST), 
  lending, AMM pools, tokenized precious metals, and cross-chain bridging. Built by BlockApps (founded    
  2015, first company from ConsenSys).
                                                                                                          
  ##### Token address and ticker if any: N/A                

  ##### Category: Chain

  ##### Oracle Provider(s): Custom PriceOracle contract (on-chain)
                                                                                                          
  ##### Implementation Details: Oracle prices are fed on-chain via a PriceOracle contract used for CDP 
  liquidations, lending risk parameters, and TVL metrics computation. The adapter reaches the chain over  
  STRATO's standard Ethereum JSON-RPC at `https://noderpc.strato.nexus/rpc` (supports `eth_call`,
  `eth_chainId`, `eth_blockNumber`, `eth_getBalance`).                                                    
                                                            
  ##### Documentation/Proof: https://docs.strato.nexus/

  ##### forkedFrom: N/A (original Haskell Ethereum client built in 2014, pre-Ethereum mainnet)
                                                                                                          
  ##### methodology: Counts underlying assets locked in STRATO DeFi contracts across CDP, lending, pools, 
  saveUSDST, safety module, and vaults. Pool balances are re-verified on-chain via `eth_call` against the 
  STRATO JSON-RPC; aggregated buckets fall back to the protocol's public metrics snapshot. Excludes wallet
   balances, receipt/share tokens, protocol debt, and double counting.                                    
                                                            
  ##### Github org/user: https://github.com/strato-net                                                    
   
  ##### Does this project have a referral program? Yes            

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Strato blockchain.
  * Added TVL tracking for Strato computing balances from on-chain sources across pools, lending, savings, and safety modules.
  * USD valuation via CoinGecko mapping with on-chain price oracle fallback.
  * Registered Strato as a supported chain identifier in the helpers list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->