### PR TITLE
feat(kpk): add Zodiac-managed institutional Safes

### DIFF
--- a/projects/kpk/index.js
+++ b/projects/kpk/index.js
@@ -213,7 +213,6 @@ const ZODIAC_MANAGED_SAFES = [
   '0x9009B4411D0e1171cc042b77D7701f46B737Fdb9', // CoW Validator Safe
   '0x4D1D9D7741740A3E2ffC5507aC643DbA5e81cAe5', // Arbitrum DAO
   '0x8e53D04644E9ab0412a8c6bd228C84da7664cFE3', // Nexus Mutual
-  '0x0EFcCBb9E2C09Ea29551879bd9Da32362b32fc89', // Balancer Core Treasury
 ]
 const ZODIAC_CHAINS = ['ethereum', 'arbitrum', 'base', 'xdai', 'optimism', 'bsc', 'polygon']
 

--- a/projects/kpk/index.js
+++ b/projects/kpk/index.js
@@ -1,3 +1,6 @@
+const axios = require("axios")
+const { getEnv } = require("../helper/env")
+const { nullAddress } = require("../helper/sumTokens")
 const { getCuratorExport } = require("../helper/curators")
 const { sumTokensDebank } = require("../helper/debank")
 
@@ -18,7 +21,7 @@ const GearboxCompressorABI = {
 // ---- Config (extend as needed) ----
 const configs = {
   methodology:
-    "Sum of curated vault deposits (Morpho, Aleph, Euler, Gearbox), Gearbox v3.1 credit account collateral, and kpk Fund AUM via onchain NAV Calculators.",
+    "Sum of curated vault deposits (Morpho, Aleph, Euler, Gearbox), Gearbox v3.1 credit account collateral, kpk Fund AUM, and positions in Safes actively managed by kpk via Zodiac Roles Modifier.",
   blockchains: {
     ethereum: {
       // Option 1: Use morphoVaultOwners to dynamically get all Morpho vaults owned by these addresses
@@ -137,11 +140,81 @@ async function getAlephVaultTvl(api, vaults) {
   }
 }
 
-// ---- kpk Fund (OIV) TVL via DeBank ----
-const FUND_CHAINS = ['ethereum', 'arbitrum', 'base', 'xdai', 'optimism']
+// ---- DeBank wallet-token helper (adapter-local) ----
+// sumTokensDebank (shared helper) walks all_complex_protocol_list only, so wallet-held
+// ERC20s sitting directly in a Safe are missed. We fetch them from all_token_list here
+// instead of extending the shared helper to avoid changing behavior for other adapters
+// (contango, stakedao, dhedge, sideshift-ai) whose treasuries combine an on-chain
+// wallet-balance fetch with DeBank protocol positions and would otherwise double-count.
+const DEBANK_API_BASE = "https://pro-openapi.debank.com/v1/user"
+const debankToLlamaChain = {
+  eth: 'ethereum', op: 'optimism', arb: 'arbitrum', avax: 'avax', bsc: 'bsc',
+  ftm: 'fantom', sonic: 'sonic', base: 'base', matic: 'polygon',
+  frax: 'fraxtal', mnt: 'mantle', gno: 'xdai',
+}
+const _walletCache = {}
 
-async function getKpkFundTvl(api) {
-  await sumTokensDebank(api, [PORTFOLIO_SAFE])
+async function _fetchDebankWalletTokens(owners) {
+  const key = owners.map(o => o.toLowerCase()).sort().join(',')
+  if (_walletCache[key]) return _walletCache[key]
+  const apiKey = getEnv('DEBANK_API_KEY')
+  if (!apiKey) {
+    _walletCache[key] = Promise.resolve(owners.map(() => []))
+    return _walletCache[key]
+  }
+  const headers = { accept: 'application/json', AccessKey: apiKey }
+  _walletCache[key] = Promise.all(
+    owners.map(id =>
+      axios.get(`${DEBANK_API_BASE}/all_token_list`, {
+        params: { id, is_all: false },
+        headers,
+      }).then(r => r.data).catch(e => {
+        console.log(`DeBank all_token_list failed for ${id}: ${e.response?.status || e.message}`)
+        return []
+      })
+    )
+  )
+  return _walletCache[key]
+}
+
+async function addDebankWalletTokens(api, owners) {
+  const tokenData = await _fetchDebankWalletTokens(owners)
+  for (const tokens of tokenData) {
+    for (const token of tokens || []) {
+      const llamaChain = debankToLlamaChain[token.chain] || token.chain
+      if (llamaChain !== api.chain) continue
+      if (!token.id) continue
+      const addr = token.id === 'eth' ? nullAddress : token.id.toLowerCase()
+      if (token.amount > 0) api.add(addr, token.amount * 10 ** token.decimals)
+    }
+  }
+}
+
+// ---- kpk Fund (OIV) TVL via DeBank ----
+const OIV_SAFES = [PORTFOLIO_SAFE]
+const OIV_CHAINS = ['ethereum', 'arbitrum', 'base', 'xdai', 'optimism']
+
+async function getOivTvl(api) {
+  await sumTokensDebank(api, OIV_SAFES)
+  await addDebankWalletTokens(api, OIV_SAFES)
+}
+
+// ---- Zodiac-managed Safes (Institutional vertical) TVL via DeBank ----
+// Safes owned by external institutions but actively managed by kpk via Zodiac Roles Modifier.
+const ZODIAC_MANAGED_SAFES = [
+  '0x4F2083f5fBede34C2714aFfb3105539775f7FE64', // ENS Endowment Fund
+  '0x616dE58c011F8736fa20c7Ae5352F7f6FB9F0669', // CoW Main Treasury
+  '0x7F8987D6A8bee31bD7bE80E877732579E2582a28', // CoW Defense Fund
+  '0x9009B4411D0e1171cc042b77D7701f46B737Fdb9', // CoW Validator Safe
+  '0x4D1D9D7741740A3E2ffC5507aC643DbA5e81cAe5', // Arbitrum DAO
+  '0x8e53D04644E9ab0412a8c6bd228C84da7664cFE3', // Nexus Mutual
+  '0x0EFcCBb9E2C09Ea29551879bd9Da32362b32fc89', // Balancer Core Treasury
+]
+const ZODIAC_CHAINS = ['ethereum', 'arbitrum', 'base', 'xdai', 'optimism', 'bsc', 'polygon']
+
+async function getZodiacManagedTvl(api) {
+  await sumTokensDebank(api, ZODIAC_MANAGED_SAFES)
+  await addDebankWalletTokens(api, ZODIAC_MANAGED_SAFES)
 }
 
 // ---- Combined TVL export per chain ----
@@ -161,15 +234,28 @@ for (const [chain, chainCfg] of Object.entries(configs.blockchains)) {
 }
 
 // Add kpk Fund (OIV) TVL to each chain the fund is deployed on
-for (const chain of FUND_CHAINS) {
+for (const chain of OIV_CHAINS) {
   if (exportObjects[chain]) {
     const originalTvl = exportObjects[chain].tvl
     exportObjects[chain].tvl = async (api) => {
       await originalTvl(api)
-      await getKpkFundTvl(api)
+      await getOivTvl(api)
     }
   } else {
-    exportObjects[chain] = { tvl: getKpkFundTvl }
+    exportObjects[chain] = { tvl: getOivTvl }
+  }
+}
+
+// Add Zodiac-managed Safe TVL to each chain where managed funds exist
+for (const chain of ZODIAC_CHAINS) {
+  if (exportObjects[chain]) {
+    const originalTvl = exportObjects[chain].tvl
+    exportObjects[chain].tvl = async (api) => {
+      await originalTvl(api)
+      await getZodiacManagedTvl(api)
+    }
+  } else {
+    exportObjects[chain] = { tvl: getZodiacManagedTvl }
   }
 }
 

--- a/projects/kpk/index.js
+++ b/projects/kpk/index.js
@@ -153,12 +153,17 @@ const debankToLlamaChain = {
   frax: 'fraxtal', mnt: 'mantle', gno: 'xdai',
 }
 const _walletCache = {}
+let _debankKeyWarned = false
 
 async function _fetchDebankWalletTokens(owners) {
   const key = owners.map(o => o.toLowerCase()).sort().join(',')
   if (_walletCache[key]) return _walletCache[key]
   const apiKey = getEnv('DEBANK_API_KEY')
   if (!apiKey) {
+    if (!_debankKeyWarned) {
+      console.warn('kpk adapter: DEBANK_API_KEY is not set; skipping DeBank wallet-token fetch. Wallet-held ERC20 balances will be missing from TVL.')
+      _debankKeyWarned = true
+    }
     _walletCache[key] = Promise.resolve(owners.map(() => []))
     return _walletCache[key]
   }


### PR DESCRIPTION
## Summary

Adds TVL tracking for **6 Safes that kpk actively manages** via the Zodiac
Roles Modifier on behalf of external institutions.

- **~$146M added** across ethereum, arbitrum, xdai, base, bsc, polygon, optimism
- **Scope:** single file (`projects/kpk/index.js`), no shared helper touched
- **Note on CI bot under-report:** the PR-check environment has no
  `DEBANK_API_KEY`, so the bot's reported TVL excludes the DeBank-sourced
  portion. See the [pinned comment](https://github.com/DefiLlama/DefiLlama-Adapters/pull/18793#issuecomment-4268066688)
  for the per-Safe breakdown — any address can be spot-checked at
  `https://debank.com/profile/<address>`.

### Safes included

| Client | Safe |
|---|---|
| ENS Endowment Fund | `0x4F2083f5fBede34C2714aFfb3105539775f7FE64` |
| CoW Main Treasury | `0x616dE58c011F8736fa20c7Ae5352F7f6FB9F0669` |
| CoW Defense Fund | `0x7F8987D6A8bee31bD7bE80E877732579E2582a28` |
| CoW Validator Safe | `0x9009B4411D0e1171cc042b77D7701f46B737Fdb9` |
| Arbitrum DAO | `0x4D1D9D7741740A3E2ffC5507aC643DbA5e81cAe5` |
| Nexus Mutual | `0x8e53D04644E9ab0412a8c6bd228C84da7664cFE3` |

**Scope note (2026-04-21):** An earlier revision of this PR also included the
Balancer Core Treasury Safe (`0x0EFcCBb9E2C09Ea29551879bd9Da32362b32fc89`).
Removed at DefiLlama's request (@RohanNero review) since
`projects/treasury/balancer.js` already tracks that address. The remaining 6
Safes have no overlap with any existing adapter (verified via grep).

## Why these belong in Risk Curation

These are DAO-governance-approved mandates (ENS, CoW, Arbitrum, Nexus Mutual)
where kpk operates scoped permissions via Zodiac Roles Modifier smart
contracts — analogous to how Sentora tracks ITB PositionManager TVL in this
category (see PR #18574).

## Why an adapter-local wallet-token fetch?

The existing shared helper `projects/helper/debank.js::sumTokensDebank` walks
only DeBank's `all_complex_protocol_list`, which covers protocol positions.
Wallet-held ERC20s sitting directly in a Safe (common for treasury-style
addresses like these) are not returned by that endpoint — they live in
`all_token_list`.

The obvious DRY option would be to extend `sumTokensDebank` to also fetch
`all_token_list` behind a flag. We considered and rejected that for this PR
because the helper is already consumed by 4 other adapters via
`projects/helper/treasury.js` (`treasuryExports` with `isComplex: true`):

- `projects/treasury/contango.js`
- `projects/treasury/stakedao.js`
- `projects/treasury/dhedge.js`
- `projects/treasury/sideshift-ai.js`

Those treasuries combine `sumTokensExport` (an on-chain wallet-balance fetch)
with `sumTokensDebank` (DeBank protocol positions) and sum the two. Adding
wallet balances to the shared helper — even behind an opt-in flag — carries
the risk of accidentally flipping the flag on and double-counting wallet
tokens. Keeping the shared helper untouched makes the blast radius of this PR
exactly zero for every other adapter.

**Ideal follow-up (not in this PR):** once maintainers are comfortable, the
inlined helper here (`addDebankWalletTokens`) could be promoted to
`helper/debank.js` as an opt-in `{ includeWalletTokens: true }` parameter on
`sumTokensDebank`, and this adapter updated to use it. Happy to do that as a
separate PR if preferred.

## What changed in `projects/kpk/index.js`

1. Added 6 Zodiac-managed Safe addresses + `ZODIAC_CHAINS` loop.
2. Added a small adapter-local helper `addDebankWalletTokens` that hits
   `all_token_list` for wallet balances (same chain mapping and caching
   shape as the shared `sumTokensDebank` helper).
3. Both the existing kpk Fund (OIV) and the new Zodiac Safes now call
   `sumTokensDebank` + `addDebankWalletTokens` so wallet tokens are
   included.
4. Renamed `FUND_CHAINS`/`getKpkFundTvl` → `OIV_CHAINS`/`getOivTvl` for
   clarity now that there are two DeBank-based Safe sources.
5. Extended methodology string.
6. Emit a one-time `console.warn` when `DEBANK_API_KEY` is unset so
   misconfigured deployments surface the silent fallback (addresses
   CodeRabbit feedback).

## Test plan
- [x] Local run with `DEBANK_API_KEY` set — per-Safe DeBank TVL matches
      DeBank UI. Full breakdown in the
      [pinned comment](https://github.com/DefiLlama/DefiLlama-Adapters/pull/18793#issuecomment-4268066688).
- [x] On-chain vault TVL covered by the automated bot report (~$66M);
      adds to the ~$156M DeBank portion for a ~$222M aggregate in production.
- [x] Confirmed `projects/helper/debank.js` diff is empty (no shared-helper
      change).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Enhanced kpk Fund AUM tracking to include positions in Safes actively managed via Zodiac Roles Modifier.
  * Integrated DeBank wallet token data for improved portfolio visibility across chains.
  * Added TVL aggregation for Zodiac-managed Safes with wallet token augmentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->