### PR TITLE
feat: add Lucky38 on-chain casino (Base)

### DIFF
--- a/projects/lucky38/index.js
+++ b/projects/lucky38/index.js
@@ -1,0 +1,22 @@
+// DeFi Llama adapter for Lucky38 (randomy.fun)
+// TVL = USDC balance in SharedTreasury (the single shared pool)
+//
+// Deploy path: projects/lucky38/index.js in DefiLlama-Adapters repo
+
+const { sumTokens2 } = require('../helper/unwrapLPs');
+
+const SHARED_TREASURY = '0x39CEBf6B84d37809625c2E68D0e9b2a16861379a';
+const BASE_USDC        = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+
+async function tvl(api) {
+  return sumTokens2({
+    api,
+    tokens: [BASE_USDC],
+    owners: [SHARED_TREASURY],
+  });
+}
+
+module.exports = {
+  base: { tvl },
+  methodology: 'TVL equals the USDC balance held in SharedTreasury — the single liquidity pool backing all six Lucky38 games.',
+};


### PR DESCRIPTION
Lucky38 (randomy.fun) — provably fair on-chain casino on Base. 6 games share a single USDC treasury (SharedTreasury). TVL = USDC balance in 0x39CEBf6B84d37809625c2E68D0e9b2a16861379a.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Lucky38 (randomy.fun) integration, enabling total value locked tracking on the BASE network by monitoring USDC reserves allocated to the shared pool backing all gaming operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->