### PR TITLE
Add ENNI protocol (Ethereum) CDP

### DIFF
--- a/projects/enni/index.js
+++ b/projects/enni/index.js
@@ -31,8 +31,6 @@ async function tvl(api) {
       [USDC, DIRECT_MINT],
       [USDT, DIRECT_MINT],
       [ZCHF, DIRECT_MINT_CHF],
-      [enUSD, SAVINGS_USD],
-      [enCHF, SAVINGS_CHF],
     ],
   });
 }

--- a/projects/enni/index.js
+++ b/projects/enni/index.js
@@ -1,0 +1,69 @@
+const { sumTokens2 } = require("../helper/unwrapLPs");
+
+// ── Tokens ──
+const WETH  = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+const USDC  = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+const USDT  = "0xdAC17F958D2ee523a2206206994597C13D831ec7";
+const ZCHF  = "0xB58E61C3098d85632Df34EecfB899A1Ed80921cB";
+const enUSD = "0xbaA433574b33ff48dB1eCBc805eC2e4f3113Aab8";
+const enCHF = "0x48F062b9d07056b206Ff5BA3A18270C2e2aDdecb";
+const ENNI  = "0xE364450b3F702d12b02F0290E0392f02DE53b8E2";
+
+// ── Protocol ──
+const CDP_USD         = "0x2DBa9be6A0A62428f8158ef6775b4dB67693e6a9";
+const CDP_CHF         = "0x8AD59EC3Ea144f43Fa1AaC08509fC95dA17E717b";
+const DIRECT_MINT     = "0xa25AB106aA34581fCeF0cb4483033f1663AeDF67";
+const DIRECT_MINT_CHF = "0xa4C209C1173ae57a4A34FAf3797F3E3381497163";
+const SAVINGS_USD     = "0xED301b687a01634c33e87412190Ca73139f3F305";
+const SAVINGS_CHF     = "0xa01f76c33Dd24C351DC3F5B210c532CCC44b1457";
+const MASTER_CHEF     = "0x428160D0B951017acF534D8B20f656D119B0bD5D";
+
+// ── LP tokens ──
+const ENNI_USDC_LP = "0x9B2Bf44022a57faD4B061E5FB4875142e34A675B";
+
+// ── Core TVL ──
+async function tvl(api) {
+  return sumTokens2({
+    api,
+    tokensAndOwners: [
+      [WETH, CDP_USD],
+      [WETH, CDP_CHF],
+      [USDC, DIRECT_MINT],
+      [USDT, DIRECT_MINT],
+      [ZCHF, DIRECT_MINT_CHF],
+      [enUSD, SAVINGS_USD],
+      [enCHF, SAVINGS_CHF],
+    ],
+  });
+}
+
+// ── Staking (ENNI in MasterChef pool 0, includes Vault deposits) ──
+async function staking(api) {
+  return sumTokens2({
+    api,
+    tokensAndOwners: [
+      [ENNI, MASTER_CHEF],
+    ],
+  });
+}
+
+// ── Pool2 (ENNI-USDC LP in MasterChef pool 1) ──
+async function pool2(api) {
+  return sumTokens2({
+    api,
+    tokensAndOwners: [
+      [ENNI_USDC_LP, MASTER_CHEF],
+    ],
+    resolveLP: true,
+  });
+}
+
+module.exports = {
+  methodology:
+    "TVL counts WETH collateral in CDP contracts, USDC/USDT reserves in DirectMint, ZCHF reserves in DirectMintGeneric, and enUSD/enCHF deposited in Savings. ENNI staked in MasterChef (including via Vault) is counted as staking. ENNI-USDC LP in MasterChef is counted as pool2.",
+  ethereum: {
+    tvl,
+    staking,
+    pool2,
+  },
+};


### PR DESCRIPTION
**NOTE**
#### Please enable "Allow edits by maintainers" while putting up the PR.
---
1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [[here](https://github.com/DefiLlama/dimension-adapters)](https://github.com/DefiLlama/dimension-adapters).
2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** It is a different repo, you can find your listing in [[this file](https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts)](https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts), you can edit it there and put up a PR
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes
---

## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
ENNI

##### Twitter Link:
https://x.com/Enni_Index

##### List of audit links if any:
https://enni.ch/Hashlock-Audit.pdf
https://enni.ch/Blockbite-Audit.pdf

##### Website Link:
https://enni.ch

##### Logo (High resolution, will be shown with rounded borders):
![](https://enni.ch/enni-200x200.png)

##### Current TVL:
$36

##### Treasury Addresses (if the protocol has treasury)
N/A

##### Chain:
Ethereum

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):


##### Short Description (to be shown on DefiLlama):
Immutable CDP protocol on Ethereum. Borrow stablecoins against WETH at 0% interest. No governance. No admin keys.

##### Token address and ticker if any:
0xE364450b3F702d12b02F0290E0392f02DE53b8E2 ENNI

##### Category (full list at https://defillama.com/categories) \*Please choose only one:
CDP

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
Chainlink, RedStone

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
Dual-feed oracle reads ETH/USD from Chainlink (primary) and RedStone (fallback). For non-USD markets (enCHF), a Chainlink CHF/USD translator feed derives ETH/CHF. Each feed has staleness thresholds (6h Chainlink, 24h RedStone, 24h translator). Falls back to cached price if both feeds are stale.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
https://enni.ch/docs/security/oracles

##### forkedFrom (Does your project originate from another project):
N/A

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL counts WETH collateral in CDP contracts, USDC/USDT reserves in DirectMint, ZCHF reserves in DirectMintGeneric, and enUSD/enCHF deposited in Savings. ENNI staked in MasterChef (including via Vault) is counted as staking. ENNI-USDC LP in MasterChef is counted as pool2.

##### Github org/user (Optional, if your code is open source, we can track activity):
enni-ch

##### Does this project have a referral program?
No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ENNI protocol integration on Ethereum, providing visibility into:
    - Total Value Locked (TVL) across protocol contracts
    - ENNI token staking metrics
    - ENNI–USDC liquidity pool holdings and positions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->