### PR TITLE
fix "borrowed" to use the amount borrowed by borrowers

### DIFF
--- a/projects/twyne/index.js
+++ b/projects/twyne/index.js
@@ -91,17 +91,27 @@ async function tvl(api) {
 }
 
 async function borrowed(api) {
-    const twyneVaults = await getTwyneEVaults(api);
+    const collateralVaults = await getCollateralVaults(api);
+    if (collateralVaults.length === 0) return;
 
-    const totalBorrows = await api.multiCall({
-        calls: twyneVaults,
-        abi: 'uint256:totalBorrows',
+    const targetAssets = await api.multiCall({
+        calls: collateralVaults,
+        abi: 'address:targetAsset',
     });
-    await addUnderlyingBalances(api, twyneVaults, totalBorrows);
+    const debts = await api.multiCall({
+        calls: collateralVaults,
+        abi: 'uint256:maxRepay',
+    });
+
+    debts.forEach((amount, i) => {
+        if (targetAssets[i] && amount) {
+            api.add(targetAssets[i], amount);
+        }
+    });
 }
 
 module.exports = {
-    methodology: 'TVL is total credit delegated to intermediate vaults and collateral deposited to Twyne collateral vaults. Borrowed represents outstanding borrows from EVaults.',
+    methodology: 'TVL is total credit delegated to intermediate vaults and collateral deposited to Twyne collateral vaults. Borrowed represents outstanding borrows from external lending protocols (Euler, Aave V3) by Twyne collateral vaults.',
     ethereum: {
         tvl,
         borrowed,


### PR DESCRIPTION
Can you also replace all the existing audit links with

https://twyne.gitbook.io/twyne/resources/security

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated borrowed amount calculation methodology to use collateral vault data sources, replacing the previous calculation approach.
  * Updated documentation to reflect the new data sourcing method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->