### PR TITLE
feat: add omnichain factories to more vaults

### DIFF
--- a/projects/more-vaults/index.js
+++ b/projects/more-vaults/index.js
@@ -1,36 +1,63 @@
 const config = {
   flow: {
-    moreVaultsRegistries: ["0xd640db4Ae39b32985CcF91770efd31b9f9b5A419"],
+    moreVaultsFactories: ["0xd640db4Ae39b32985CcF91770efd31b9f9b5A419"],
+    moreOmnichainVaultsFactories: ["0x7bDB8B17604b03125eFAED33cA0c55FBf856BB0C"],
+  },
+  base: {
+    moreOmnichainVaultsFactories: ["0x7bDB8B17604b03125eFAED33cA0c55FBf856BB0C"],
+  },
+  ethereum: {
+    moreOmnichainVaultsFactories: ["0x7bDB8B17604b03125eFAED33cA0c55FBf856BB0C"],
+  },
+  arbitrum: {
+    moreOmnichainVaultsFactories: ["0x7bDB8B17604b03125eFAED33cA0c55FBf856BB0C"],
+  },
+  avax: {
+    moreOmnichainVaultsFactories: ["0x7bDB8B17604b03125eFAED33cA0c55FBf856BB0C"],
   },
 };
 
 async function tvl(api) {
-  const { moreVaultsRegistries } = config[api.chain] || {};
+  const { moreVaultsFactories = [], moreOmnichainVaultsFactories = [] } = config[api.chain] || {};
 
-  if (!moreVaultsRegistries?.length) return {};
+  if (moreVaultsFactories.length) {
+    const vaultArrays = await api.multiCall({
+      abi: 'function getDeployedVaults() external view returns (address[])',
+      calls: moreVaultsFactories,
+    });
+    const allVaults = vaultArrays.flat();
+    if (allVaults.length) {
+      await api.erc4626Sum({ calls: allVaults, tokenAbi: 'address:asset', balanceAbi: 'uint256:totalAssets' });
+    }
+  }
 
-  const vaultArrays = await api.multiCall({
-    abi: 'function getDeployedVaults() external view returns (address[])',
-    calls: moreVaultsRegistries,
-  });
-
-  const allVaults = vaultArrays.flat();
-
-  if (!allVaults.length) return {};
-
-  // More Vaults uses EIP-2535 Diamond architecture with ERC4626-compatible facets
-  await api.erc4626Sum({
-    calls: allVaults,
-    tokenAbi: 'address:asset',
-    balanceAbi: 'uint256:totalAssets'
-  });
+  if (moreOmnichainVaultsFactories.length) {
+    const vaultArrays = await api.multiCall({
+      abi: 'function getDeployedVaults() external view returns (address[])',
+      calls: moreOmnichainVaultsFactories,
+    });
+    const allVaults = vaultArrays.flat();
+    if (allVaults.length) {
+      const isHubResults = await api.multiCall({
+        abi: 'function isHub() external view returns (bool)',
+        calls: allVaults,
+      });
+      // Spoke vaults report TVL to the hub via cross-chain messages, only count hubs to avoid double-counting
+      const hubVaults = allVaults.filter((_, i) => isHubResults[i]);
+      if (hubVaults.length) {
+        await api.erc4626Sum({ calls: hubVaults, tokenAbi: 'address:asset', balanceAbi: 'uint256:totalAssets' });
+      }
+    }
+  }
 
   return api.getBalances();
 }
 
 module.exports = {
-  methodology: "TVL is calculated by summing the total assets of all EIP-2535 Diamond vaults deployed through the More Vaults registry contracts on Flow. Each Diamond vault implements ERC4626-compatible facets for asset management and yield generation.",
-  flow: {
-    tvl,
-  },
+  methodology: "TVL is calculated by summing the total assets across all MORE Vaults deployed through the registry contracts. MORE Vaults allows users to compose, rebalance, and upgrade DeFi portfolios atomically without redeploying, while depositors hold familiar receipt tokens through every strategy upgrade.",
+  flow: { tvl },
+  base: { tvl },
+  ethereum: { tvl },
+  arbitrum: { tvl },
+  avax: { tvl },
 };

--- a/projects/more-vaults/index.js
+++ b/projects/more-vaults/index.js
@@ -54,10 +54,11 @@ async function tvl(api) {
 }
 
 module.exports = {
-  methodology: "TVL is calculated by summing the total assets across all MORE Vaults deployed through the registry contracts. MORE Vaults allows users to compose, rebalance, and upgrade DeFi portfolios atomically without redeploying, while depositors hold familiar receipt tokens through every strategy upgrade.",
+  methodology: "TVL is calculated by summing totalAssets for MORE Vaults discovered from factory contracts. For omnichain deployments, only hub vaults are counted because spoke vaults report TVL to the hub via cross-chain messages. MORE Vaults allows users to compose, rebalance, and upgrade DeFi portfolios atomically without redeploying, while depositors hold familiar receipt tokens through every strategy upgrade.",
   flow: { tvl },
   base: { tvl },
   ethereum: { tvl },
   arbitrum: { tvl },
   avax: { tvl },
+  doublecounted: true,
 };


### PR DESCRIPTION
Update of [MORE Vaults](https://defillama.com/protocol/tvl/more-vaults)

##### Name (to be shown on DefiLlama):
MORE Vaults

##### Twitter Link:
https://x.com/more_defi

##### List of audit links if any:

##### Website Link:
https://app.more.markets/vaults/

##### Logo (High resolution, will be shown with rounded borders):
https://drive.google.com/file/d/1-OGQBwoB-uR3LwAL75np9Y6RXu5sPnqI/view

##### Current TVL:
$560k

##### Treasury Addresses (if the protocol has treasury)

##### Chain:
FLOW EVM, Ethereum, Base, Arbitrum, Avalanche

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama):

##### Token address and ticker if any:

##### Category (full list at https://defillama.com/categories) \*Please choose only one:

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

##### forkedFrom (Does your project originate from another project):

##### methodology (what is being counted as tvl, how is tvl being calculated):

##### Github org/user (Optional, if your code is open source, we can track activity):

##### Does this project have a referral program?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added vault support for Base, Ethereum, Arbitrum, and Avax alongside Flow.
  * Integrated omnichain vault discovery for cross-chain asset tracking.
* **Bug Fixes / Accuracy**
  * Improved TVL calculation with hub-vs-spoke deduplication and guarded summing to avoid double-counting.
  * Added a reliable fallback to return balances when no vault registries are found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->