### PR TITLE
feat: add solid eth data in solid yield

### DIFF
--- a/projects/solid-yield/ethereum_constants.js
+++ b/projects/solid-yield/ethereum_constants.js
@@ -10,6 +10,15 @@ const boringVaultsEthereum = [
     startBlock: 22651939,
     baseAsset: ADDRESSES.ethereum.USDC,
   },
+  {
+    name: "Solid ETH",
+    vault: "0xf9039d4f49686F34936b6937D13bBbe413f910c4",
+    accountant: "0x803ed5a218a7704fC8697d36079F70df974Abb11",
+    teller: "0x4149c11b479B26080428Dc5e688F4D27253C4783",
+    lens: "0x074F543E7DaA7C67F77bfD8C41C79127c4dd80d9",
+    startBlock: 24822485,
+    baseAsset: ADDRESSES.ethereum.WETH,
+  },
 ];
 
 module.exports = {

--- a/projects/solid-yield/fuse_constants.js
+++ b/projects/solid-yield/fuse_constants.js
@@ -18,7 +18,16 @@ const boringVaultsV0Fuse = [
     lens: "0x8478Cc70B7e389212D301Fef4f9aDfd4F869f28D",
     startBlock: 40381360, 
     baseAsset: ADDRESSES.fuse.WFUSE, 
-  }
+  },
+  {
+    name: "Solid ETH",
+    vault: "0xEf1c1fFbEabDF358E61D3F5F14777e9c1bC8D1c7",
+    accountant: "0x4BD5873720072b4AC7956898dbCBc543b2fD3749",
+    teller: "0xEaacf4534cCC05CAd929830fAF611d872b291d41",
+    lens: "0x8478Cc70B7e389212D301Fef4f9aDfd4F869f28D",
+    startBlock: 41311096,
+    baseAsset: ADDRESSES.fuse.WETH_3,
+  },
 ];
 
 module.exports = {


### PR DESCRIPTION
  - Registers the new Solid ETH BoringVault on Ethereum (WETH-denominated, start block 24822485) in projects/solid-yield/ethereum_constants.js.
  - Registers the new Solid ETH BoringVault on Fuse (WETH_3-denominated, start block 41311096) in projects/solid-yield/fuse_constants.js.                               
  - No adapter logic changes — the existing helpers pick up the new entries automatically.                                                                     

  Vault addresses                                                                    
                  
  Ethereum                                                                           
  - vault: 0xf9039d4f49686F34936b6937D13bBbe413f910c4
  - accountant: 0x803ed5a218a7704fC8697d36079F70df974Abb11
  - teller: 0x4149c11b479B26080428Dc5e688F4D27253C4783    
  - lens: 0x074F543E7DaA7C67F77bfD8C41C79127c4dd80d9                                 
   
  Fuse                                                                               
  - vault: 0xEf1c1fFbEabDF358E61D3F5F14777e9c1bC8D1c7
  - accountant: 0x4BD5873720072b4AC7956898dbCBc543b2fD3749                           
  - teller: 0xEaacf4534cCC05CAd929830fAF611d872b291d41    
  - lens: 0x8478Cc70B7e389212D301Fef4f9aDfd4F869f28D                                 
                                                                                     
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Solid ETH vault on Ethereum network
  * Added support for Solid ETH vault on Fuse network

<!-- end of auto-generated comment: release notes by coderabbit.ai -->