### PR TITLE
add hubra (refactor)

### DIFF
--- a/projects/hubra/index.js
+++ b/projects/hubra/index.js
@@ -1,0 +1,33 @@
+const { getSolBalanceFromStakePool, getConnection } = require('../helper/solana')
+const { PublicKey } = require('@solana/web3.js')
+
+const RASOL_STAKE_POOL = 'ECRqn7gaNASuvTyC5xfCUjehWZCSowMXstZiM5DNweyB'
+
+// Voltr vault account layout:
+// offset 104: asset mint (pubkey, 32 bytes)
+// offset 168: totalValue (u64, 8 bytes)
+const EARN_VAULTS = [
+  '3maCuTJVPteZ2dFA8dADxz2EbpJHfoAG5txYhXDs6gNQ', // USDC
+  '663azFYEnHDTLGf4CEk8KpNTje8XxZVLnQwo9LjbSejy', // USD1
+  '3kzb6rcDJxSdkWCwXXP9PULSqBy6rVDNWanzw5dBCYCj', // USDT
+  '5mv1cURMSaPU3q3wFVoN4mKMWNFVvUtH3UZrG4Z2Mgfz', // USDS
+  '7VZ1XKK7Zns6UzRc1Wz54u6cypN7zaduasVXXr7NysxH', // USDG
+]
+
+async function tvl(api) {
+  await getSolBalanceFromStakePool(RASOL_STAKE_POOL, api)
+
+  const connection = getConnection()
+  const accounts = await connection.getMultipleAccountsInfo(EARN_VAULTS.map(v => new PublicKey(v)))
+  for (const account of accounts) {
+    if (!account || account.data.length < 176) continue
+    const asset = new PublicKey(account.data.slice(104, 136)).toBase58()
+    const totalValue = account.data.readBigUInt64LE(168)
+    if (totalValue > 0n) api.add(asset, totalValue.toString())
+  }
+}
+
+module.exports = {
+  methodology: 'TVL is the SOL backing raSOL (from the SPL stake pool) plus the underlying stablecoins held in Hubra Earn vaults (Voltr), read directly from on-chain vault account data.',
+  solana: { tvl },
+}

--- a/projects/hubra/index.js
+++ b/projects/hubra/index.js
@@ -1,8 +1,6 @@
 const { getSolBalanceFromStakePool, getConnection } = require('../helper/solana')
 const { PublicKey } = require('@solana/web3.js')
 
-const RASOL_STAKE_POOL = 'ECRqn7gaNASuvTyC5xfCUjehWZCSowMXstZiM5DNweyB'
-
 // Voltr vault account layout:
 // offset 104: asset mint (pubkey, 32 bytes)
 // offset 168: totalValue (u64, 8 bytes)
@@ -15,8 +13,6 @@ const EARN_VAULTS = [
 ]
 
 async function tvl(api) {
-  await getSolBalanceFromStakePool(RASOL_STAKE_POOL, api)
-
   const connection = getConnection()
   const accounts = await connection.getMultipleAccountsInfo(EARN_VAULTS.map(v => new PublicKey(v)))
   for (const account of accounts) {
@@ -28,6 +24,6 @@ async function tvl(api) {
 }
 
 module.exports = {
-  methodology: 'TVL is the SOL backing raSOL (from the SPL stake pool) plus the underlying stablecoins held in Hubra Earn vaults (Voltr), read directly from on-chain vault account data.',
+  methodology: 'TVL is the underlying stablecoins held in Hubra Earn vaults (Voltr), read directly from on-chain vault account data.',
   solana: { tvl },
 }


### PR DESCRIPTION
resolves #18733

formerly 'solanahub', which still tracks >500k tvl from rasol staking contract: https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/registries/solanaStakePool.js#L86

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL calculation and tracking for the Hubra project on Solana network, providing real-time visibility into total value locked across stake pools and Earn (Voltr) vaults
  * Includes methodology documentation for TVL calculations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->