### PR TITLE
Add Premarkets by Stryke

### DIFF
--- a/projects/premarket/index.js
+++ b/projects/premarket/index.js
@@ -1,0 +1,44 @@
+const { getLogs2 } = require('../helper/cache/getLogs')
+const { sumTokens2 } = require('../helper/unwrapLPs')
+
+const OPTION_MARKET_VAULT = '0xD4Aa38D6Ee04A401Cd7067A66201f680CbD1E7E4'
+const MARKETS_REGISTRY = '0x1c5FFbaEBa3Ef9fB6C650a4FF364918Bce418675'
+const FROM_BLOCK = 12885655
+
+const MARKET_ADDED_EVENT =
+  'event MarketAdded((address underlying,address collateral,address delivery,address owner,uint256 tickSize,uint256 tickSpacing,uint256 tokensPerTickSize,uint256 expiry,uint256 depositFeeBps,uint256 redeemFeeBps,uint256 makerFeeBps,uint256 takerFeeBps,uint256 rolloverFeeBps,uint8 marketType,bool isCollateralScaled,bool nonRollable,bool isSpread,bool useAbsoluteSpreadCollateral) market, uint256 marketId)'
+
+/**
+ * Sums all collateral and delivery token balances held by the Premarket vault.
+ */
+async function tvl(api) {
+  const logs = await getLogs2({
+    api,
+    target: MARKETS_REGISTRY,
+    fromBlock: FROM_BLOCK,
+    eventAbi: MARKET_ADDED_EVENT,
+    onlyArgs: true,
+    transform: ({ market }) => [market.collateral, market.delivery],
+  })
+
+  const tokens = [
+    ...new Set(
+      logs
+        .flat()
+        .map((token) => token.toLowerCase())
+    ),
+  ]
+
+  return sumTokens2({
+    api,
+    owner: OPTION_MARKET_VAULT,
+    tokens,
+  })
+}
+
+module.exports = {
+  methodology:
+    'TVL is the collateral and delivery token balances held by the Premarket OptionMarketVault.',
+  start: 1776277239,
+  megaeth: { tvl },
+}


### PR DESCRIPTION


##### Name (to be shown on DefiLlama):
Premarkets
##### Twitter Link:
https://x.com/premarket_xyz

##### Website Link:
https://premarket.xyz/

##### Logo (High resolution, will be shown with rounded borders):
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/36ce8dde-321d-4f82-95fe-8c394d68e093" />

##### Chain:
MegaETH


##### Short Description (to be shown on DefiLlama):
Premarket is a prediction-market style protocol for trading premarket/outcome exposure
##### Token address and ticker if any:

##### Category (full list at https://defillama.com/categories) \*Please choose only one:  prediction-market

##### methodology (what is being counted as tvl, how is tvl being calculated):
Deposits into a vault. The total balance of the tokens in the vault.

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/stryke-xyz



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a TVL adapter for the premarket ecosystem that discovers markets from on-chain events, identifies collateral and delivery tokens, normalizes and deduplicates token addresses, and aggregates balances to report total value locked for the option market vault. Also includes a published methodology and a protocol start timestamp.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->