### PR TITLE
Add Oku adapter for 0G Chain

### DIFF
--- a/projects/oku-trade/index.js
+++ b/projects/oku-trade/index.js
@@ -5,7 +5,7 @@ module.exports = {
   ...uniV3Export({
     '0g': {
       factory: '0xcb2436774C3e191c85056d248EF4260ce5f27A9D',
-      fromBlock: 6674380,
+      fromBlock: 6673868,
     },
   }),
 };

--- a/projects/oku-trade/index.js
+++ b/projects/oku-trade/index.js
@@ -1,0 +1,11 @@
+const { uniV3Export } = require('../helper/uniswapV3');
+
+module.exports = {
+  methodology: 'Counts liquidity in Oku V3 pools.',
+  ...uniV3Export({
+    '0g': {
+      factory: '0xcb2436774C3e191c85056d248EF4260ce5f27A9D',
+      fromBlock: 6674380,
+    },
+  }),
+};


### PR DESCRIPTION
Added Oku DEX adapter on 0G Chain.

  **Oku:**
  - Factory-based pool discovery using uniV3Export
  - V3 Core Factory: 0xcb2436774C3e191c85056d248EF4260ce5f27A9D
  - Automatically discovers all Uniswap V3 pools on 0G
  - TVL: ~$1.84M (USDC.e, W0G, WBTC, WETH)

  https://oku.trade/
  https://x.com/okutrade

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Oku V3 pool liquidity-counting support. This release integrates a new export that enables counting liquidity for Oku V3 pools and exposes the methodology used for those calculations. The feature is available immediately and expands platform coverage for Oku V3 liquidity tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->