### PR TITLE
Add RamsesX Polygon and Arbitrum TVL exports

### DIFF
--- a/registries/uniswapV2.js
+++ b/registries/uniswapV2.js
@@ -2660,7 +2660,6 @@ const uniV2Configs = {
   'ramses': {
     _options: { hasStablePools: true, stablePoolSymbol: 'crAMM' },
     arbitrum: { factory: '0xAAA20D08e59F6561f242b08513D36266C5A29415', staking: ["0xAAA343032aA79eE9a6897Dab03bef967c3289a06", "0xaaa6c1e32c55a7bfa8066a6fae9b42650f262418"] },
-    hyperliquid: '0xd0a07E160511c40ccD5340e94660E9C9c01b0D27',
   },
   'ramses-hl-legacy': {
     _options: { hasStablePools: true, stablePoolSymbol: 'cAMM' },

--- a/registries/uniswapV2.js
+++ b/registries/uniswapV2.js
@@ -2665,6 +2665,10 @@ const uniV2Configs = {
     _options: { hasStablePools: true, stablePoolSymbol: 'cAMM' },
     hyperliquid: '0xd0a07E160511c40ccD5340e94660E9C9c01b0D27',
   },
+  'ramsesx-arb-legacy': {
+    _options: { hasStablePools: true, stablePoolSymbol: 'cAMM' },
+    arbitrum: '0xADd32480630A16dfAcEe6eeFcB3ab2181449Dc3B',
+  },
   'ramsesx-poly-legacy': {
     _options: { hasStablePools: true, stablePoolSymbol: 'cAMM' },
     polygon: '0xA87c8308722237F6442Ef4762B7287afB84fB191',

--- a/registries/uniswapV2.js
+++ b/registries/uniswapV2.js
@@ -2665,6 +2665,10 @@ const uniV2Configs = {
     _options: { hasStablePools: true, stablePoolSymbol: 'cAMM' },
     hyperliquid: '0xd0a07E160511c40ccD5340e94660E9C9c01b0D27',
   },
+  'ramsesx-poly-legacy': {
+    _options: { hasStablePools: true, stablePoolSymbol: 'cAMM' },
+    polygon: '0xA87c8308722237F6442Ef4762B7287afB84fB191',
+  },
   'sharkyswap': {
     arbitrum: { factory: '0x36800286f652dDC9bDcFfEDc4e71FDd207C1d07C', staking: ["0xD5f406eB9E38E3B3E35072A8A35E0DcC671ea8DB", "0x73eD68B834e44096eB4beA6eDeAD038c945722F1"] },
   },

--- a/registries/uniswapV3.js
+++ b/registries/uniswapV3.js
@@ -1142,6 +1142,12 @@ const uniV3Configs = {
       fromBlock: 18149975,
     },
   },
+  'ramsesx-poly-cl': {
+    polygon: {
+      factory: '0x2Bef16A0081565E72100D73CBe19B1Bd2d802380',
+      fromBlock: 82177771,
+    },
+  },
   'reservoir-tools-v3': {
     abstract: {
       factory: '0xA1160e73B63F322ae88cC2d8E700833e71D0b2a1',

--- a/registries/uniswapV3.js
+++ b/registries/uniswapV3.js
@@ -1135,10 +1135,6 @@ const uniV3Configs = {
       factory: '0xaa2cd7477c451e703f3b9ba5663334914763edf8',
       fromBlock: 90593047,
     },
-    hyperliquid: {
-      factory: '0x07E60782535752be279929e2DFfDd136Db2e6b45',
-      fromBlock: 17985840,
-    },
   },
   'ramses-hl-cl': {
     hyperliquid: {

--- a/registries/uniswapV3.js
+++ b/registries/uniswapV3.js
@@ -1142,6 +1142,12 @@ const uniV3Configs = {
       fromBlock: 18149975,
     },
   },
+  'ramsesx-arb-cl': {
+    arbitrum: {
+      factory: '0xd0019e86edB35E1fedaaB03aED5c3c60f115d28b',
+      fromBlock: 420275312,
+    },
+  },
   'ramsesx-poly-cl': {
     polygon: {
       factory: '0x2Bef16A0081565E72100D73CBe19B1Bd2d802380',


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
RamsesX (Parent Already Existing)

##### Twitter Link:
https://x.com/RamsesExchange

##### List of audit links if any:
https://docs.ramses.xyz/pages/audits

##### Website Link:
https://ramses.xyz

##### Logo (High resolution, will be shown with rounded borders):
https://github.com/DefiLlama/icons/pull/2358

##### Chain:
Arbitrum, Polygon

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)
ramses-exchange

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
23858

##### Short Description (to be shown on DefiLlama):
RamsesX is a ve(3,3) / x(3,3) DEX with separate legacy and concentrated liquidity deployments.

##### Token address and ticker if any:
RAM: `0x555570a286F15EbDFE42B66eDE2f724Aa1AB5555`

##### Category (full list at https://defillama.com/categories) *Please choose only one:
DEX

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
DefiLlama standard pricing pipeline

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
This PR adds the TVL-side child exports for the Polygon and Arbitrum RamsesX deployments. TVL is computed from onchain pool balances via the standard DefiLlama adapter flow.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
https://docs.ramses.xyz/pages/contract-addresses#polygon
https://docs.ramses.xyz/pages/contract-addresses#arbitrum

##### forkedFrom (Does your project originate from another project):
Solidly / Uniswap-style AMM architecture

##### methodology (what is being counted as tvl, how is tvl being calculated):
Counts liquidity held in the RamsesX Polygon and Arbitrum pool contracts. Legacy and concentrated liquidity deployments are exported as separate child entries.

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/RamsesExchange

##### Does this project have a referral program?
No

## Notes
- Adds the TVL-side child exports:
  - `ramsesx-poly-legacy`
  - `ramsesx-poly-cl`
  - `ramsesx-arb-legacy`
  - `ramsesx-arb-cl`
- These remain separate from the existing `ramses`, `ramses-cl`, `ramses-hl-cl`, and `ramses-hl-legacy` deployments.

## Companion PRs
- `dimension-adapters`: sibling PR in this batch adds the matching RamsesX Polygon/Arbitrum dex adapters and limits those chain stats to fees and volume https://github.com/DefiLlama/dimension-adapters/pull/6442
- `defillama-server`: sibling PR in this batch adds the RamsesX Polygon/Arbitrum child metadata under the RamsesX parent https://github.com/DefiLlama/defillama-server/pull/11788
- `icons`: https://github.com/DefiLlama/icons/pull/2358

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Ramses X on Arbitrum and Polygon with legacy variants for both V2 and concentrated liquidity protocols.
  * Enabled stable pool functionality for new Ramses X configurations.

* **Updates**
  * Removed Hyperliquid chain support from existing Ramses protocol configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->