### PR TITLE
Add DumpFlow (bonding-curve launchpad)

### DIFF
--- a/projects/dumpflow/index.js
+++ b/projects/dumpflow/index.js
@@ -1,0 +1,53 @@
+const { getConnection, sumTokens2 } = require("../helper/solana");
+const { PublicKey } = require("@solana/web3.js");
+
+// dump_contract — Dumpfun's bonding-curve token launchpad ("DumpFlow").
+// Each launched token has a LiquidityPool PDA holding pool state and a
+// liquidity_pool_authority PDA (system-owned) that holds the SOL reserve
+// backing the bonding curve. TVL sums SOL across all authority PDAs.
+const PROGRAM_ID = new PublicKey("DumpFunGAgW6kPHzWMA3Nnqecyrd6SGnLZvNGp2aHwEa");
+
+// Anchor discriminator: sha256("account:LiquidityPool")[0:8]
+const DISC_LIQUIDITY_POOL = Buffer.from([66, 38, 17, 64, 188, 80, 68, 129]);
+const SIZE_LIQUIDITY_POOL = 254;
+
+// LiquidityPool layout (see programs/dump_contract/src/states.rs):
+// 8 disc | 32 creator | 32 platform_fee | 32 company_tax | 32 mint | ...
+const MINT_OFFSET = 8 + 32 + 32 + 32;
+const AUTHORITY_SEED = Buffer.from("authority");
+
+async function tvl(api) {
+  const connection = getConnection();
+
+  const pools = await connection.getProgramAccounts(PROGRAM_ID, {
+    filters: [
+      { memcmp: { offset: 0, bytes: DISC_LIQUIDITY_POOL.toString("base64"), encoding: "base64" } },
+      { dataSize: SIZE_LIQUIDITY_POOL },
+    ],
+    dataSlice: { offset: MINT_OFFSET, length: 32 },
+  });
+
+  const solOwners = pools.map(({ pubkey, account }) => {
+    const mint = new PublicKey(account.data);
+    const [authority] = PublicKey.findProgramAddressSync(
+      [pubkey.toBuffer(), mint.toBuffer(), AUTHORITY_SEED],
+      PROGRAM_ID,
+    );
+    return authority.toBase58();
+  });
+
+  await sumTokens2({ api, solOwners });
+}
+
+module.exports = {
+  timetravel: false,
+  methodology:
+    "TVL counts native SOL held by the bonding-curve reserve PDA " +
+    "(liquidity_pool_authority) of every LiquidityPool launched through " +
+    "the DumpFlow program. Pools are discovered dynamically via " +
+    "getProgramAccounts, and each pool's authority PDA is derived from " +
+    "seeds [liquidity_pool, mint, 'authority']. Platform fees (1% of SOL " +
+    "volume) and company tax are routed to separate wallets and are NOT " +
+    "included in TVL.",
+  solana: { tvl },
+};


### PR DESCRIPTION
##### Name (to be shown on DefiLlama): DumpFlow

##### Twitter Link: https://x.com/dumpfundotio

##### List of audit links if any: https://skynet.certik.com/projects/dumpfun

##### Website Link: https://dumpfun.io

##### Logo (High resolution, will be shown with rounded borders): https://dumpfun.io/logo.webp

##### Current TVL: sol 26 (~$3.64k across 345 active bonding-curve pools)

##### Treasury Addresses (if the protocol has treasury): Platform fee wallet: FeP2VAcRpyfKk6DSaaYm1Zkmf3PhvytewGBJuZs6E2YK. Company tax wallet: 2mYd5PL9N5u8roZ99MEKZk7znxKYWBeKuzhXGpnbYSG2.

##### Chain: Solana

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):

##### Short Description (to be shown on DefiLlama): DumpFlow is Dumpfun's bonding-curve token launchpad on Solana. Anyone can mint a meme token with a configurable virtual SOL reserve, sell-lock period, and dynamic ramping limits. Buys/sells route SOL through a per-token liquidity pool; a 1% SOL fee accrues to the platform fee wallet and sell-side fees split 2.5%/2.5% to creator/company.

##### Token address and ticker if any: Program ID: DumpFunGAgW6kPHzWMA3Nnqecyrd6SGnLZvNGp2aHwEa (each launched token has its own SPL mint).

##### Category (full list at https://defillama.com/categories) *Please choose only one: Launchpad

##### Oracle Provider(s): Specify the oracle(s) used: None — pricing is fully on-chain via the per-pool virtual SOL / real token reserve bonding-curve invariant. TVL does not depend on any price oracle; it sums native SOL held by each pool's reserve PDA.

##### Implementation Details: Briefly describe how the oracle is integrated into your project: N/A — no oracle integration. All price discovery happens via the `buy_exact_tokens`, `buy_tokens_with_exact_sol`, and `sell_exact_tokens` instructions operating on the pool's virtual reserve.

##### Documentation/Proof: https://dumpfun.io/whitepaper, https://skynet.certik.com/projects/dumpfun, https://solscan.io/account/DumpFunGAgW6kPHzWMA3Nnqecyrd6SGnLZvNGp2aHwEa

##### forkedFrom (Does your project originate from another project): N/A

##### methodology (what is being counted as tvl, how is tvl being calculated): TVL sums native SOL held by each pool's `liquidity_pool_authority` PDA — the system-owned account that holds the SOL backing the bonding curve. Pools are discovered dynamically via `getProgramAccounts` on `DumpFunGAgW6kPHzWMA3Nnqecyrd6SGnLZvNGp2aHwEa` filtered by the Anchor `LiquidityPool` discriminator and `dataSize: 254`. For each pool, the authority PDA is derived from seeds `[liquidity_pool, mint, "authority"]`. Platform fees (1% SOL) and company tax accrue to separate wallets and are NOT included in TVL.

##### Github org/user (Optional, if your code is open source, we can track activity):

##### Does this project have a referral program? No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Total Value Locked (TVL) calculation support for DumpFlow bonding-curve launchpad on the Solana blockchain. The new integration tracks SOL reserves held by the platform's liquidity accounts, providing transparent and real-time metrics on total available liquidity for users engaging with DumpFlow's trading activities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->