### PR TITLE
add kpk zodiac safes (refactor)

### DIFF
--- a/projects/helper/debank.js
+++ b/projects/helper/debank.js
@@ -25,12 +25,12 @@ function getLlamaChain(debankChain) {
 
 const _cache = {}
 
-function _cacheKey(endpoint, owners) {
-  return endpoint + ':' + owners.map(o => o.toLowerCase()).sort().join(',')
+function _cacheKey(endpoint, owners, isAll) {
+  return endpoint + ':' + isAll + ':' + owners.map(o => o.toLowerCase()).sort().join(',')
 }
 
-async function _fetchDebank(endpoint, owners) {
-  const key = _cacheKey(endpoint, owners)
+async function _fetchDebank(endpoint, owners, { isAll = true } = {}) {
+  const key = _cacheKey(endpoint, owners, isAll)
   if (!_cache[key]) {
     const apiKey = getEnv('DEBANK_API_KEY')
     if (!apiKey) {
@@ -41,7 +41,7 @@ async function _fetchDebank(endpoint, owners) {
     _cache[key] = Promise.all(
       owners.map(id =>
         axios.get(`${DEBANK_API_BASE}/${endpoint}`, {
-          params: { id, is_all: true },
+          params: { id, is_all: isAll },
           headers,
         }).then(r => r.data).catch(e => {
           console.log(`DeBank ${endpoint} failed for ${id}: ${e.response?.status || e.message}`)
@@ -58,14 +58,16 @@ function _normalizeAddr(rawId) {
   return rawId === 'eth' ? nullAddress : rawId.toLowerCase()
 }
 
-async function sumTokensDebank(api, owners, { blacklistedTokens = [], stripPoolTokens = false } = {}) {
+async function sumTokensDebank(api, owners, { blacklistedTokens = [], blacklistedPools = [], stripPoolTokens = false, includeWalletTokens = false } = {}) {
   const allData = await _fetchDebank('all_complex_protocol_list', owners)
   const blacklist = new Set(blacklistedTokens.map(t => t.toLowerCase()))
+  const poolBlacklist = blacklistedPools.length ? new Set(blacklistedPools.map(p => p.toLowerCase())) : null
 
   for (const protocols of allData) {
     for (const protocol of protocols || []) {
       if (getLlamaChain(protocol.chain) !== api.chain) continue
       for (const item of protocol.portfolio_item_list || []) {
+        if (poolBlacklist && item.pool?.id && poolBlacklist.has(item.pool.id.toLowerCase())) continue
         for (const token of item.asset_token_list || []) {
           const addr = _normalizeAddr(token.id)
           if (!addr || blacklist.has(addr)) continue
@@ -74,6 +76,18 @@ async function sumTokensDebank(api, owners, { blacklistedTokens = [], stripPoolT
         if (stripPoolTokens && item.pool?.id) {
           api.removeTokenBalance(item.pool.id.toLowerCase())
         }
+      }
+    }
+  }
+
+  if (includeWalletTokens) {
+    const walletData = await _fetchDebank('all_token_list', owners, { isAll: false })
+    for (const tokens of walletData) {
+      for (const token of tokens || []) {
+        if (getLlamaChain(token.chain) !== api.chain) continue
+        const addr = _normalizeAddr(token.id)
+        if (!addr || blacklist.has(addr)) continue
+        if (token.amount > 0) api.add(addr, token.amount * 10 ** token.decimals)
       }
     }
   }

--- a/projects/helper/debank.js
+++ b/projects/helper/debank.js
@@ -58,6 +58,17 @@ function _normalizeAddr(rawId) {
   return rawId === 'eth' ? nullAddress : rawId.toLowerCase()
 }
 
+/**
+ * Sum token balances from DeBank for the given wallet addresses.
+ * Uses `all_complex_protocol_list` for DeFi protocol positions (decomposed into underlying assets)
+ * and optionally `all_token_list` for idle wallet-held tokens not in any protocol.
+ *
+ * @param {string[]} owners - Wallet addresses to query
+ * @param {string[]} [opts.blacklistedTokens] - Token addresses to skip when adding balances (applies to both endpoints)
+ * @param {string[]} [opts.blacklistedPools] - Skip protocol positions whose pool.id matches (e.g. vault addresses already tracked on-chain)
+ * @param {boolean} [opts.stripPoolTokens] - Remove pool/LP token balances that have been added by a separate on-chain read (avoids double-counting with DeBank)
+ * @param {boolean} [opts.includeWalletTokens] - Also fetch idle wallet tokens via `all_token_list` (is_all=false filters out protocol-derived tokens)
+ */
 async function sumTokensDebank(api, owners, { blacklistedTokens = [], blacklistedPools = [], stripPoolTokens = false, includeWalletTokens = false } = {}) {
   const allData = await _fetchDebank('all_complex_protocol_list', owners)
   const blacklist = new Set(blacklistedTokens.map(t => t.toLowerCase()))

--- a/projects/kpk/index.js
+++ b/projects/kpk/index.js
@@ -18,22 +18,13 @@ const GearboxCompressorABI = {
 // ---- Config (extend as needed) ----
 const configs = {
   methodology:
-    "Sum of curated vault deposits (Morpho, Aleph, Euler, Gearbox), Gearbox v3.1 credit account collateral, and kpk Fund AUM via onchain NAV Calculators.",
+    "Sum of curated vault deposits (Morpho, Aleph, Euler, Gearbox), Gearbox v3.1 credit account collateral, kpk Fund AUM, and positions in Safes actively managed by kpk via Zodiac Roles Modifier.",
   blockchains: {
     ethereum: {
-      // Option 1: Use morphoVaultOwners to dynamically get all Morpho vaults owned by these addresses
-      // (vaults are discovered from event logs, and de-duplication is automatically applied)
-      morphoVaultOwners: [
-        // Add owner addresses here to discover all their Morpho vaults
-        // Example: '0x0000aeB716a0DF7A9A1AAd119b772644Bc089dA8',
-      ],
-
-      // Option 2: Use morpho: to specify static Morpho vault addresses
-      // (de-duplication is automatically applied)
-      // You can use BOTH morphoVaultOwners and morpho together - they will be combined
+      morphoVaultOwners: [],
       morpho: [
-        "0xe108fbc04852B5df72f9E44d7C29F47e7A993aDd", //Morpho v1 USDC Prime 
-        "0x0c6aec603d48eBf1cECc7b247a2c3DA08b398DC1", //Morpho v1 EURC Yield 
+        "0xe108fbc04852B5df72f9E44d7C29F47e7A993aDd", //Morpho v1 USDC Prime
+        "0x0c6aec603d48eBf1cECc7b247a2c3DA08b398DC1", //Morpho v1 EURC Yield
         "0xd564F765F9aD3E7d2d6cA782100795a885e8e7C8", //Morpho v1 ETH Prime
         "0x4Ef53d2cAa51C447fdFEEedee8F07FD1962C9ee6", //Morpho v2 USDC Prime
         "0xa877D5bb0274dcCbA8556154A30E1Ca4021a275f", //Morpho v2 EURC Yield
@@ -138,38 +129,59 @@ async function getAlephVaultTvl(api, vaults) {
 }
 
 // ---- kpk Fund (OIV) TVL via DeBank ----
-const FUND_CHAINS = ['ethereum', 'arbitrum', 'base', 'xdai', 'optimism']
+const OIV_SAFES = [PORTFOLIO_SAFE]
+const OIV_CHAINS = ['ethereum', 'arbitrum', 'base', 'xdai', 'optimism']
 
-async function getKpkFundTvl(api) {
-  await sumTokensDebank(api, [PORTFOLIO_SAFE])
+// ---- Zodiac-managed Safes (Institutional vertical) TVL via DeBank ----
+// Safes owned by external institutions but actively managed by kpk via Zodiac Roles Modifier.
+const ZODIAC_MANAGED_SAFES = [
+  '0x4F2083f5fBede34C2714aFfb3105539775f7FE64', // ENS Endowment Fund
+  '0x616dE58c011F8736fa20c7Ae5352F7f6FB9F0669', // CoW Main Treasury
+  '0x7F8987D6A8bee31bD7bE80E877732579E2582a28', // CoW Defense Fund
+  '0x9009B4411D0e1171cc042b77D7701f46B737Fdb9', // CoW Validator Safe
+  '0x4D1D9D7741740A3E2ffC5507aC643DbA5e81cAe5', // Arbitrum DAO
+  '0x8e53D04644E9ab0412a8c6bd228C84da7664cFE3', // Nexus Mutual
+  '0x0EFcCBb9E2C09Ea29551879bd9Da32362b32fc89', // Balancer Core Treasury
+]
+const ZODIAC_CHAINS = ['ethereum', 'arbitrum', 'base', 'xdai', 'optimism', 'bsc', 'polygon']
+
+// Returns all kpk curated vaults to use as blacklistedPools in DeBank calls to avoid
+// double counting positions already captured by the curator export's totalAssets()
+function getCuratedVaults(chain) {
+  const cfg = configs.blockchains[chain]
+  if (!cfg) return []
+  return [...(cfg.morpho || []), ...(cfg.erc4626 || []), ...(cfg.alephVaults || [])]
+}
+
+async function getDebankTvl(api, safes) {
+  await sumTokensDebank(api, safes, { includeWalletTokens: true, blacklistedPools: getCuratedVaults(api.chain) })
 }
 
 // ---- Combined TVL export per chain ----
 
+const allChains = [...new Set([...Object.keys(configs.blockchains), ...OIV_CHAINS, ...ZODIAC_CHAINS])]
 const exportObjects = getCuratorExport(configs)
 
-// Add Gearbox v3.1 collateral + Aleph vault TVL to each chain
-for (const [chain, chainCfg] of Object.entries(configs.blockchains)) {
-  if (exportObjects[chain] && (chainCfg.gearboxMarketConfigurator || chainCfg.alephVaults)) {
-    const originalTvl = exportObjects[chain].tvl
-    exportObjects[chain].tvl = async (api) => {
-      await originalTvl(api)
-      await getGearboxV31Collateral(api, chainCfg.gearboxMarketConfigurator)
-      await getAlephVaultTvl(api, chainCfg.alephVaults)
-    }
-  }
-}
+for (const chain of allChains) {
+  const curatorTvl = exportObjects[chain]?.tvl
+  exportObjects[chain] = {
+    tvl: async (api) => {
+      // Curated vault deposits (Morpho, Euler, etc.) via getCuratorExport
+      if (curatorTvl) await curatorTvl(api)
 
-// Add kpk Fund (OIV) TVL to each chain the fund is deployed on
-for (const chain of FUND_CHAINS) {
-  if (exportObjects[chain]) {
-    const originalTvl = exportObjects[chain].tvl
-    exportObjects[chain].tvl = async (api) => {
-      await originalTvl(api)
-      await getKpkFundTvl(api)
+      // Gearbox v3.1 credit account collateral + Aleph vault TVL
+      const chainCfg = configs.blockchains[chain]
+      const hasGearbox = chainCfg?.gearboxMarketConfigurator
+      const hasAleph = chainCfg?.alephVaults
+      if (hasGearbox) await getGearboxV31Collateral(api, hasGearbox)
+      if (hasAleph) await getAlephVaultTvl(api, hasAleph)
+
+      // kpk Fund (OIV) TVL via DeBank
+      if (OIV_CHAINS.includes(chain)) await getDebankTvl(api, OIV_SAFES)
+
+      // Zodiac-managed Safe TVL via DeBank
+      if (ZODIAC_CHAINS.includes(chain)) await getDebankTvl(api, ZODIAC_MANAGED_SAFES)
     }
-  } else {
-    exportObjects[chain] = { tvl: getKpkFundTvl }
   }
 }
 

--- a/projects/kpk/index.js
+++ b/projects/kpk/index.js
@@ -21,7 +21,16 @@ const configs = {
     "Sum of curated vault deposits (Morpho, Aleph, Euler, Gearbox), Gearbox v3.1 credit account collateral, kpk Fund AUM, and positions in Safes actively managed by kpk via Zodiac Roles Modifier.",
   blockchains: {
     ethereum: {
-      morphoVaultOwners: [],
+      // Option 1: Use morphoVaultOwners to dynamically get all Morpho vaults owned by these addresses
+      // (vaults are discovered from event logs, and de-duplication is automatically applied)
+      morphoVaultOwners: [
+        // Add owner addresses here to discover all their Morpho vaults
+        // Example: '0x0000aeB716a0DF7A9A1AAd119b772644Bc089dA8',
+      ],
+
+      // Option 2: Use morpho: to specify static Morpho vault addresses
+      // (de-duplication is automatically applied)
+      // You can use BOTH morphoVaultOwners and morpho together - they will be combined
       morpho: [
         "0xe108fbc04852B5df72f9E44d7C29F47e7A993aDd", //Morpho v1 USDC Prime
         "0x0c6aec603d48eBf1cECc7b247a2c3DA08b398DC1", //Morpho v1 EURC Yield

--- a/projects/kpk/index.js
+++ b/projects/kpk/index.js
@@ -150,7 +150,6 @@ const ZODIAC_MANAGED_SAFES = [
   '0x9009B4411D0e1171cc042b77D7701f46B737Fdb9', // CoW Validator Safe
   '0x4D1D9D7741740A3E2ffC5507aC643DbA5e81cAe5', // Arbitrum DAO
   '0x8e53D04644E9ab0412a8c6bd228C84da7664cFE3', // Nexus Mutual
-  '0x0EFcCBb9E2C09Ea29551879bd9Da32362b32fc89', // Balancer Core Treasury
 ]
 const ZODIAC_CHAINS = ['ethereum', 'arbitrum', 'base', 'xdai', 'optimism', 'bsc', 'polygon']
 

--- a/projects/treasury/balancer.js
+++ b/projects/treasury/balancer.js
@@ -4,7 +4,7 @@ const { nullAddress, treasuryExports } = require("../helper/treasury");
 
 // Treasury addresses per chain
 const eth = "0x10A19e7eE7d7F8a52822f6817de8ea18204F2e4f";
-// const eth2 = "0x0EFcCBb9E2C09Ea29551879bd9Da32362b32fc89"; // Managed and tracked by kpk (removed 2026-4-21)
+const eth2 = "0x0EFcCBb9E2C09Ea29551879bd9Da32362b32fc89";
 const arb = "0xaF23DC5983230E9eEAf93280e312e57539D098D0";
 const pol = "0xeE071f4B516F69a1603dA393CdE8e76C40E5Be85";
 const zkevm = "0x2f237e7643a3bF6Ef265dd6FCBcd26a7Cc38dbAa";
@@ -108,7 +108,7 @@ const avaxOwnTokens = [
 // Keeping old code because karpatkey's api tends to break
 module.exports = treasuryExports({
   ethereum: {
-    owners: [eth],
+    owners: [eth, eth2],
     //tokens: ethTokens,
     ownTokens: ethOwnTokens
   },

--- a/projects/treasury/balancer.js
+++ b/projects/treasury/balancer.js
@@ -4,7 +4,7 @@ const { nullAddress, treasuryExports } = require("../helper/treasury");
 
 // Treasury addresses per chain
 const eth = "0x10A19e7eE7d7F8a52822f6817de8ea18204F2e4f";
-const eth2 = "0x0EFcCBb9E2C09Ea29551879bd9Da32362b32fc89";
+// const eth2 = "0x0EFcCBb9E2C09Ea29551879bd9Da32362b32fc89"; // Managed and tracked by kpk (removed 2026-4-21)
 const arb = "0xaF23DC5983230E9eEAf93280e312e57539D098D0";
 const pol = "0xeE071f4B516F69a1603dA393CdE8e76C40E5Be85";
 const zkevm = "0x2f237e7643a3bF6Ef265dd6FCBcd26a7Cc38dbAa";
@@ -108,7 +108,7 @@ const avaxOwnTokens = [
 // Keeping old code because karpatkey's api tends to break
 module.exports = treasuryExports({
   ethereum: {
-    owners: [eth, eth2],
+    owners: [eth],
     //tokens: ethTokens,
     ownTokens: ethOwnTokens
   },


### PR DESCRIPTION
resolves #18793 

- excludes safe balances in vaults curated by kpk to prevent counting the same assets twice

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added option to exclude curated pools from DeBank results and to include wallet-held (idle) tokens in portfolio totals.
  * Extended TVL coverage to include positions in safes actively managed via Zodiac.

* **Updates**
  * Unified per-chain export flow to sequentially aggregate curated exports, protocol vaults, and DeBank-derived TVL.
  * Methodology wording updated to reflect expanded AUM and managed-position coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->