### PR TITLE
feat: improve templarfi requests cache

### DIFF
--- a/projects/templarfi/index.js
+++ b/projects/templarfi/index.js
@@ -323,7 +323,7 @@ async function processMarket(marketContract) {
       collateralDecimals,
     }
   } catch (error) {
-    if (error.message && (error.message.includes('does not exist') || error.message.includes('Buffer') || error.message.includes('Received undefined'))) {
+    if (error.message && FAST_FAIL_PATTERNS.some(p => error.message.includes(p))) {
       console.log(`Market ${marketContract} skipped (not a market): ${error.message}`)
       return null
     }

--- a/projects/templarfi/index.js
+++ b/projects/templarfi/index.js
@@ -23,8 +23,8 @@ const CONTRACTS_TO_SKIP = new Set([
   'proxy-oracle-iltc-ixlmusdc.v1.tmplr.near',
   'proxy-oracle-ixrp-ixlmusdc.v1.tmplr.near',
   'proxy-oracle-izec-ixlmusdc.v1.tmplr.near',
-  'proxy-oracle-linear-usdt.v1.tmplr.near"',
-  'proxy-oracle-stnear-usdt.v1.tmplr.near",'
+  'proxy-oracle-linear-usdt.v1.tmplr.near',
+  'proxy-oracle-stnear-usdt.v1.tmplr.near,'
 ]);
 
 const FAST_FAIL_PATTERNS = ['does not exist', 'Buffer', 'Received undefined']
@@ -381,7 +381,10 @@ let cachedMarketDataPromise = null
 
 async function getMarketDataMemoized() {
   if (!cachedMarketDataPromise) {
-    cachedMarketDataPromise = getMarketData()
+    cachedMarketDataPromise = getMarketData().catch(error => {
+      cachedMarketDataPromise = null
+      throw error
+    })
   }
   return cachedMarketDataPromise
 }

--- a/projects/templarfi/index.js
+++ b/projects/templarfi/index.js
@@ -24,7 +24,7 @@ const CONTRACTS_TO_SKIP = new Set([
   'proxy-oracle-ixrp-ixlmusdc.v1.tmplr.near',
   'proxy-oracle-izec-ixlmusdc.v1.tmplr.near',
   'proxy-oracle-linear-usdt.v1.tmplr.near',
-  'proxy-oracle-stnear-usdt.v1.tmplr.near,'
+  'proxy-oracle-stnear-usdt.v1.tmplr.near'
 ]);
 
 const FAST_FAIL_PATTERNS = ['does not exist', 'Buffer', 'Received undefined']

--- a/projects/templarfi/index.js
+++ b/projects/templarfi/index.js
@@ -9,7 +9,25 @@ const MAX_RETRY_ATTEMPTS = 3
 const RETRY_DELAY_MS = 1000
 const CALL_TIMEOUT_MS = 30000
 
-const sleep = (ms) =>  new Promise(resolve => setTimeout(resolve, ms))
+const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms))
+
+// These are proxy oracles, adapters and deleted test markets
+const CONTRACTS_TO_SKIP = new Set([
+  'liqtest-ixlm-ixlmusdc.v1.tmplr.near',
+  'proxy-oracle-ixlmcetes-ixlmusdc.v1.tmplr.near',
+  'redstone-adapter.v1.tmplr.near',
+  'proxy-oracle-ixlmustry-ixlmusdc.v1.tmplr.near',
+  'proxy-oracle-iada-ixlmusdc.v1.tmplr.near',
+  'proxy-oracle-ibtc-ixlmusdc.v1.tmplr.near',
+  'proxy-oracle-idoge-ixlmusdc.v1.tmplr.near',
+  'proxy-oracle-iltc-ixlmusdc.v1.tmplr.near',
+  'proxy-oracle-ixrp-ixlmusdc.v1.tmplr.near',
+  'proxy-oracle-izec-ixlmusdc.v1.tmplr.near',
+  'proxy-oracle-linear-usdt.v1.tmplr.near"',
+  'proxy-oracle-stnear-usdt.v1.tmplr.near",'
+]);
+
+const FAST_FAIL_PATTERNS = ['does not exist', 'Buffer', 'Received undefined']
 
 function detectCrossChainToken(tokenId) {
   // Stellar tokens via HOT omnichain bridge (chain ID 1100)
@@ -89,7 +107,7 @@ async function withRetry(fn, maxAttempts = MAX_RETRY_ATTEMPTS, delayMs = RETRY_D
       return await fn()
     } catch (error) {
       lastError = error
-      if (error.message && error.message.includes('does not exist')) {
+      if (error.message && FAST_FAIL_PATTERNS.some(p => error.message.includes(p))) {
         throw error
       }
       if (attempt === maxAttempts) throw lastError
@@ -254,7 +272,14 @@ async function fetchDeploymentsFromContract(registryContract) {
     offset += limit
   }
 
-  return deployments
+  return deployments.filter(deployment => {
+    if (CONTRACTS_TO_SKIP.has(deployment)) {
+      console.log(`Skipping known non-market contract: ${deployment}`)
+      return false
+    }
+
+    return true
+  })
 }
 
 async function processMarket(marketContract) {
@@ -352,21 +377,24 @@ function aggregateByChain(marketData, type) {
   return chainBalances
 }
 
-let cachedMarketData = null
+let cachedMarketDataPromise = null
+
+async function getMarketDataMemoized() {
+  if (!cachedMarketDataPromise) {
+    cachedMarketDataPromise = getMarketData()
+  }
+  return cachedMarketDataPromise
+}
 
 async function getChainTvl(chain) {
-  if (!cachedMarketData) {
-    cachedMarketData = await getMarketData()
-  }
-  const chainBalances = aggregateByChain(cachedMarketData, 'tvl')
+  const data = await getMarketDataMemoized()
+  const chainBalances = aggregateByChain(data, 'tvl')
   return chainBalances[chain] || {}
 }
 
 async function getChainBorrowed(chain) {
-  if (!cachedMarketData) {
-    cachedMarketData = await getMarketData()
-  }
-  const chainBalances = aggregateByChain(cachedMarketData, 'borrowed')
+  const data = await getMarketDataMemoized()
+  const chainBalances = aggregateByChain(data, 'borrowed')
   return chainBalances[chain] || {}
 }
 


### PR DESCRIPTION
# Summary

Improves adapter for Templar

### This PR adds a few improvements:
- Fixes markets data requests cache. Now it is just one request per each market which is reused for all the chains / analytics.
- Adds a list of known non-markets to prevent from the redundant requests that will fail anyway
- Introduces general set of exceptions thrown by non-market contracts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Broader fast-fail detection to more reliably stop on known non-recoverable errors.
  * Filtered out non-market contracts from deployment listings to avoid noise; skipped deployments are now logged.

* **Performance**
  * Concurrent callers now share in-flight market-data requests via promise-based memoization; cache is cleared on failure to allow retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->