### PR TITLE
add checkRegistriesDuplicates script

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "useTokenLabels": "node utils/scripts/useTokenLabels.js",
     "biggest-files": "node utils/scripts/sortTopFilesByLines.js",
     "check-bitcoin-duplicates": "node utils/scripts/checkBTCDupsv2.js",
+    "check-registries-duplicates": "node utils/scripts/checkRegistriesDups.js",
     "string-timestamp": "node utils/scripts/stringTimestamp.js",
     "sort-chains": "node projects/helper/getChainList.js"
   },

--- a/projects/helper/env.js
+++ b/projects/helper/env.js
@@ -79,6 +79,7 @@ const ENV_KEYS = [
   'CRYPTOAPIS_API_KEY',
   'TATUM_PUBLIC_API_KEY',
   'TATUM_API_KEY',
+  'TEAM_WEBHOOK',
 ]
 
 Object.keys(DEFAULTS).forEach(i => {

--- a/registries/utils.js
+++ b/registries/utils.js
@@ -59,6 +59,7 @@ function buildProtocolExports(configs, exportFn) {
     Object.assign(result, topLevel)
     protocols[name] = result
   })
+  Object.defineProperty(protocols, '_rawConfigs', { value: configs, enumerable: false })
   return protocols
 }
 

--- a/utils/scripts/checkRegistriesDups.js
+++ b/utils/scripts/checkRegistriesDups.js
@@ -1,0 +1,92 @@
+const path = require('path');
+const fs = require('fs');
+const sdk = require('@defillama/sdk');
+const { getEnv } = require('../../projects/helper/env');
+
+const Bucket = 'tvl-adapter-cache';
+const REGISTRY_DIR = path.join(__dirname, '../../registries');
+const ADDRESS_RE = /^0x[0-9a-fA-F]{40}$|^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
+const NON_CHAIN_KEYS = new Set(['methodology', 'misrepresentedTokens', 'doublecounted', 'hallmarks', '_options']);
+
+// Keys that identify a tracked contract
+const KEYS = new Set(['factory', 'comptroller', 'masterchef', 'vault', 'registry']);
+
+function addIfAddress(value, found) {
+  if (typeof value === 'string' && ADDRESS_RE.test(value)) found.add(value.toLowerCase());
+}
+
+function extractTrackedAddresses(chainConfig, found = new Set()) {
+  // Shorthand: `chain: '0x...'` — the chain value itself is the factory address
+  if (typeof chainConfig === 'string') {
+    addIfAddress(chainConfig, found);
+    return found;
+  }
+  // Array form: `chain: [{ comptroller: '0x...' }, ...]` — recurse into each
+  if (Array.isArray(chainConfig)) {
+    chainConfig.forEach(item => extractTrackedAddresses(item, found));
+    return found;
+  }
+  if (!chainConfig || typeof chainConfig !== 'object') return found;
+
+  for (const [key, value] of Object.entries(chainConfig)) {
+    if (KEYS.has(key)) addIfAddress(value, found);
+  }
+  return found;
+}
+
+function loadRawConfigs(filePath) {
+  return require(filePath)._rawConfigs;
+}
+
+async function run() {
+  const registryFiles = fs.readdirSync(REGISTRY_DIR)
+    .filter(f => f.endsWith('.js') && f !== 'index.js' && f !== 'utils.js')
+    .map(f => ({ name: f, fullPath: path.join(REGISTRY_DIR, f) }));
+
+  const duplicates = {};
+
+  for (const { name, fullPath } of registryFiles) {
+    let configs;
+    try {
+      configs = loadRawConfigs(fullPath);
+    } catch {
+      console.warn(`Skipping ${name} (could not load)`);
+      continue;
+    }
+
+    if (!configs || typeof configs !== 'object') continue;
+
+    // scoped to this file — same address across registries is not a duplicate
+    const addressMap = {};
+    for (const [protocol, config] of Object.entries(configs)) {
+      if (typeof config !== 'object' || config === null) continue;
+      for (const [chain, chainConfig] of Object.entries(config)) {
+        if (NON_CHAIN_KEYS.has(chain)) continue;
+        for (const addr of extractTrackedAddresses(chainConfig)) {
+          const key = `${chain}:${addr}`;
+          if (!addressMap[key]) addressMap[key] = [];
+          if (!addressMap[key].includes(protocol)) addressMap[key].push(protocol);
+        }
+      }
+    }
+
+    for (const [key, protocols] of Object.entries(addressMap)) {
+      if (protocols.length > 1) duplicates[`${name} ${key}`] = protocols.join(', ');
+    }
+  }
+
+  if (getEnv('STORE_IN_R2')) {
+    try {
+      await sdk.cache.writeCache(`${Bucket}/registry-duplicates.json`, duplicates);
+      console.log('data written to s3 bucket');
+    } catch (e) {
+      sdk.log('failed to write data to s3 bucket: ');
+      sdk.log(e);
+    }
+    return;
+  }
+
+  console.table(Object.entries(duplicates));
+}
+
+run().catch(console.error).then(() => process.exit(0));

--- a/utils/scripts/checkRegistriesDups.js
+++ b/utils/scripts/checkRegistriesDups.js
@@ -1,14 +1,34 @@
+require('dotenv').config();
 const path = require('path');
 const fs = require('fs');
-const sdk = require('@defillama/sdk');
+const axios = require('axios');
 const { getEnv } = require('../../projects/helper/env');
 
-const Bucket = 'tvl-adapter-cache';
 const REGISTRY_DIR = path.join(__dirname, '../../registries');
 const ADDRESS_RE = /^0x[0-9a-fA-F]{40}$|^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
 
 // Keys that identify a tracked contract
 const KEYS = new Set(['factory', 'comptroller', 'masterchef', 'vault', 'registry', 'address']);
+
+// Based on defillama-server/defi/src/utils/discord.ts
+async function sendDiscord(message, formatted = true) {
+  const webhookUrl = getEnv('TEAM_WEBHOOK');
+  if (!webhookUrl) {
+    throw new Error(`Missing TEAM_WEBHOOK env var. Could not send: "${message}"`);
+  }
+  const formattedMessage = formatted ? '```\n' + message + '\n```' : message;
+  if (formattedMessage.length >= 2000) {
+    const lines = message.split('\n');
+    if (lines.length <= 2) throw new Error('Lines are too long, reaching infinite recursivity');
+    const mid = Math.round(lines.length / 2);
+    await sendDiscord(lines.slice(0, mid).join('\n'), formatted);
+    await sendDiscord(lines.slice(mid).join('\n'), formatted);
+    return;
+  }
+  await axios.post(`${webhookUrl}?wait=true`, { content: formattedMessage }, {
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
 
 function addIfAddress(value, found) {
   if (typeof value === 'string' && ADDRESS_RE.test(value)) found.add(value.toLowerCase());
@@ -35,6 +55,14 @@ function extractTrackedAddresses(chainConfig, found = new Set()) {
 
 function loadRawConfigs(filePath) {
   return require(filePath)._rawConfigs;
+}
+
+function formatDuplicates(duplicates) {
+  const entries = Object.entries(duplicates);
+  if (!entries.length) return null;
+  const lines = [`Found ${entries.length} duplicate registry entries:`, ''];
+  for (const [key, protocols] of entries) lines.push(`${key}\n  → ${protocols}`);
+  return lines.join('\n');
 }
 
 async function run() {
@@ -72,18 +100,19 @@ async function run() {
     }
   }
 
-  if (getEnv('STORE_IN_R2')) {
-    try {
-      await sdk.cache.writeCache(`${Bucket}/registry-duplicates.json`, duplicates);
-      console.log('data written to s3 bucket');
-    } catch (e) {
-      sdk.log('failed to write data to s3 bucket: ');
-      sdk.log(e);
-    }
-    return;
-  }
-
   console.table(Object.entries(duplicates));
+
+  const message = formatDuplicates(duplicates);
+  if (message) await sendDiscord(message);
+  else console.log('No duplicate registry entries found.');
 }
 
-run().catch(console.error).then(() => process.exit(0));
+run().catch(async (e) => {
+  console.error(e);
+  try {
+    await sendDiscord(`check-registries-duplicates failed: ${e.message}`);
+  } catch (sendErr) {
+    console.error('Also failed to send discord error:', sendErr.message);
+  }
+  process.exitCode = 1;
+});

--- a/utils/scripts/checkRegistriesDups.js
+++ b/utils/scripts/checkRegistriesDups.js
@@ -6,10 +6,9 @@ const { getEnv } = require('../../projects/helper/env');
 const Bucket = 'tvl-adapter-cache';
 const REGISTRY_DIR = path.join(__dirname, '../../registries');
 const ADDRESS_RE = /^0x[0-9a-fA-F]{40}$|^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
-const NON_CHAIN_KEYS = new Set(['methodology', 'misrepresentedTokens', 'doublecounted', 'hallmarks', '_options']);
 
 // Keys that identify a tracked contract
-const KEYS = new Set(['factory', 'comptroller', 'masterchef', 'vault', 'registry']);
+const KEYS = new Set(['factory', 'comptroller', 'masterchef', 'vault', 'registry', 'address']);
 
 function addIfAddress(value, found) {
   if (typeof value === 'string' && ADDRESS_RE.test(value)) found.add(value.toLowerCase());
@@ -21,7 +20,7 @@ function extractTrackedAddresses(chainConfig, found = new Set()) {
     addIfAddress(chainConfig, found);
     return found;
   }
-  // Array form: `chain: [{ comptroller: '0x...' }, ...]` — recurse into each
+  // Array form: `chain: [{ comptroller: '0x...' }, ...]`
   if (Array.isArray(chainConfig)) {
     chainConfig.forEach(item => extractTrackedAddresses(item, found));
     return found;
@@ -56,12 +55,10 @@ async function run() {
 
     if (!configs || typeof configs !== 'object') continue;
 
-    // scoped to this file — same address across registries is not a duplicate
     const addressMap = {};
     for (const [protocol, config] of Object.entries(configs)) {
       if (typeof config !== 'object' || config === null) continue;
       for (const [chain, chainConfig] of Object.entries(config)) {
-        if (NON_CHAIN_KEYS.has(chain)) continue;
         for (const addr of extractTrackedAddresses(chainConfig)) {
           const key = `${chain}:${addr}`;
           if (!addressMap[key]) addressMap[key] = [];


### PR DESCRIPTION
`npm run check-registries-duplicates` to check each registry file for duplicate address entries

- Doesn't work for `aave.js` currently

Console output:
<img width="801" height="171" alt="image" src="https://github.com/user-attachments/assets/d6251c41-bb6a-4fde-bb4a-1def27636e32" />

Discord output: 
<img width="719" height="361" alt="image" src="https://github.com/user-attachments/assets/2d38747b-9edc-4d74-be6d-5c518a7de4f7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new CLI script to scan registries and report duplicate contract addresses across protocols.
  * Added TEAM_WEBHOOK environment key to allow posting scan results to a configured webhook.
  * Registry objects now include hidden metadata to improve duplicate-detection tooling and reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->