### PR TITLE
Add Flying Tulip ftUSD and Lend TVL adapters

### DIFF
--- a/projects/flying-tulip-ftusd/index.js
+++ b/projects/flying-tulip-ftusd/index.js
@@ -1,0 +1,31 @@
+// Flying Tulip ftUSD — yield-bearing stablecoin backed by yield-wrapped collateral.
+// Prod addresses from https://api.flyingtulip.com/ftusd/contracts/all.
+
+const MINT_AND_REDEEM = {
+  ethereum: '0xaa48ecbc843cf7e9a29155d112b8cb27902bd23c',
+  sonic: '0x0c6f8ec81c3ea5bff06f6cd0791780f9f050ee31',
+}
+
+async function tvl(api) {
+  const target = MINT_AND_REDEEM[api.chain]
+  const count = await api.call({ target, abi: 'uint256:collateralCount' })
+  const indices = Array.from({ length: Number(count) }, (_, i) => i)
+  const tokens = await api.multiCall({
+    target,
+    abi: 'function collateralAt(uint256) view returns (address)',
+    calls: indices,
+  })
+  const balances = await api.multiCall({
+    target,
+    abi: 'function collateralAssets(address) view returns (uint256)',
+    calls: tokens,
+  })
+  api.add(tokens, balances)
+}
+
+module.exports = {
+  methodology:
+    'Sum of collateral tokens backing ftUSD, read via MintAndRedeem.collateralAssets() for each enabled collateral. Covers yield-wrapper principal plus accrued strategy yield.',
+  ethereum: { tvl },
+  sonic: { tvl },
+}

--- a/projects/flying-tulip-lend/index.js
+++ b/projects/flying-tulip-lend/index.js
@@ -1,0 +1,53 @@
+const LENDING_LENS = {
+  sonic: '0x3682168023e6ba8d1f995fda1d920827c5a8a43e',
+}
+
+const RESERVES = {
+  sonic: [
+    '0x29219dd400f2bf60e5a23d13be72b486d4038894', // USDC
+    '0x039e2fb66102314ce7b64ce5ce3e5183bc94ad38', // wS
+    '0x5dd1a7a369e8273371d2dbf9d83356057088082c', // FT (address LendingLens is configured to key on)
+    '0xe5da20f15420ad15de0fa650600afc998bbe3955', // stS
+    '0xf7d85ec4e7710f71992752eac2111312e73e9c9c', // ftUSD
+    '0x50c42deacd8fc9773493ed674b675be577f2634b', // WETH
+    '0x0555e30da8f98308edb960aa94c0db47230d2b9c', // WBTC
+  ],
+}
+
+const ASSET_STATE_ABI =
+  'function assetState(address) view returns (uint256 cash, uint256 borrows, uint256 reserves, uint256 utilWad)'
+
+async function fetchStates(api) {
+  return api.multiCall({
+    target: LENDING_LENS[api.chain],
+    abi: ASSET_STATE_ABI,
+    calls: RESERVES[api.chain],
+  })
+}
+
+async function tvl(api) {
+  const states = await fetchStates(api)
+  const reserves = RESERVES[api.chain]
+  reserves.forEach((token, i) => {
+    const s = states[i]
+    if (!s) return
+    const supplied = BigInt(s.cash) + BigInt(s.borrows)
+    api.add(token, supplied.toString())
+  })
+}
+
+async function borrowed(api) {
+  const states = await fetchStates(api)
+  const reserves = RESERVES[api.chain]
+  reserves.forEach((token, i) => {
+    const s = states[i]
+    if (!s) return
+    api.add(token, s.borrows.toString())
+  })
+}
+
+module.exports = {
+  methodology:
+    'TVL: sum of cash + borrows per reserve from LendingLens.assetState(). Borrowed: sum of borrows per reserve.',
+  sonic: { tvl, borrowed },
+}

--- a/projects/flying-tulip-lend/index.js
+++ b/projects/flying-tulip-lend/index.js
@@ -18,31 +18,31 @@ const ASSET_STATE_ABI =
   'function assetState(address) view returns (uint256 cash, uint256 borrows, uint256 reserves, uint256 utilWad)'
 
 async function fetchStates(api) {
-  return api.multiCall({
+  const reserves = RESERVES[api.chain]
+  const states = await api.multiCall({
     target: LENDING_LENS[api.chain],
     abi: ASSET_STATE_ABI,
-    calls: RESERVES[api.chain],
+    calls: reserves,
   })
+  states.forEach((state, i) => {
+    if (!state) throw new Error(`Missing LendingLens assetState for ${api.chain}:${reserves[i]}`)
+  })
+  return { reserves, states }
 }
 
 async function tvl(api) {
-  const states = await fetchStates(api)
-  const reserves = RESERVES[api.chain]
+  const { reserves, states } = await fetchStates(api)
   reserves.forEach((token, i) => {
     const s = states[i]
-    if (!s) return
     const supplied = BigInt(s.cash) + BigInt(s.borrows)
     api.add(token, supplied.toString())
   })
 }
 
 async function borrowed(api) {
-  const states = await fetchStates(api)
-  const reserves = RESERVES[api.chain]
+  const { reserves, states } = await fetchStates(api)
   reserves.forEach((token, i) => {
-    const s = states[i]
-    if (!s) return
-    api.add(token, s.borrows.toString())
+    api.add(token, states[i].borrows.toString())
   })
 }
 


### PR DESCRIPTION
## Summary

Adds two new Flying Tulip product TVL adapters:

- `projects/flying-tulip-ftusd/index.js` — ftUSD stablecoin backing on Ethereum and Sonic. Enumerates collateral via `MintAndRedeem.collateralCount()` / `collateralAt()` and sums `collateralAssets()` per token (covers yield-wrapper principal + accrued strategy yield).
- `projects/flying-tulip-lend/index.js` — Flying Tulip Lend (ftDNMM) on Sonic. Supplied TVL per reserve is \`cash + borrows\` and a separate \`borrowed\` export sums \`borrows\`, both read via \`LendingLens.assetState()\`. Lend is **not** an Aave V3 fork; it uses a custom \`PositionsManager\` + \`LendingLens\`, so no helper reuse.

Both are wired to a new \`parent#flying-tulip\` entry in the companion defillama-server PR so they roll up with the existing Flying Tulip Treasury.

Numbers verified against \`api.flyingtulip.com\`:
- ftUSD: \$759.89k Ethereum + \$334.40k Sonic = **\$1.09M** (matches live API)
- Lend: **\$607.59k supplied / \$10.85k borrowed** on Sonic

## Companion PRs

- defillama-server: protocol entries + parent
- dimension-adapters: Lend fees adapter

## Test plan

- [x] \`node test.js projects/flying-tulip-ftusd/index.js\` reconciles per-chain with \`api.flyingtulip.com/ftusd/metrics\`
- [x] \`node test.js projects/flying-tulip-lend/index.js\` reconciles with \`api.flyingtulip.com/mm/lend\`
- [x] All contract addresses normalized to lowercase
- [x] BigInt arithmetic uses literals, no precision loss

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Flying Tulip FTUSD TVL is now tracked across Ethereum and Sonic networks, enabling consolidated value monitoring per chain.
  * Flying Tulip Lend TVL and borrowed amounts are now tracked on the Sonic network, providing visibility into lending balances and outstanding borrows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->