### PR TITLE
Move Oku 0G deployment under Uniswap V3

### DIFF
--- a/projects/uniswap/index.js
+++ b/projects/uniswap/index.js
@@ -79,6 +79,7 @@ const uniV3Config = {
   plasma: { factory: '0xcb2436774C3e191c85056d248EF4260ce5f27A9D', fromBlock: 430127, },
   monad: { factory: "0x204faca1764b154221e35c0d20abb3c525710498", fromBlock: 29255827, blacklistedTokens: ['0x760afe86e5de5fa0ee542fc7b7b713e1c5425701'] },
   tempo: { factory: '0x24a3d4757e330890a8b8978028c9e58e04611fd6', fromBlock: 6455886, },
+  '0g': { factory: '0xcb2436774C3e191c85056d248EF4260ce5f27A9D', fromBlock: 6673868 },
 }
 
 Object.keys(uniV3Config).forEach(chain => {

--- a/registries/uniswapV3.js
+++ b/registries/uniswapV3.js
@@ -1702,12 +1702,6 @@ const uniV3Configs = {
       blacklistedTokens: ['0xded1660192d4d82e7c0b628ba556861edbb5cada', '0x5d442b349590a6048eb2dc0ec346caa5f47a9ab5'],
     }
   },
-  'oku-trade': {
-    "0g": {
-      factory: '0xcb2436774C3e191c85056d248EF4260ce5f27A9D',
-      fromBlock: 6673868
-    }
-  }
 }
 
 module.exports = buildProtocolExports(uniV3Configs, uniV3Export)


### PR DESCRIPTION
Follow-up to #18851.

The Oku Trade deployment on 0G is a canonical Uniswap V3 deployment - ownership of the contracts is passed back to the Uniswap Foundation (standard Oku process across all their chains), with Oku operating the interface. Same factory address (0xcb2436774C3e191c85056d248EF4260ce5f27A9D) is already used in projects/uniswap/index.js for bob, corn, telos,goat, sonic, xdc, plasma, etlk, lightlink_phoenix.

This PR:
  - Adds 0G entry to `uniV3Config` in `projects/uniswap/index.js`
  - Removes the `oku-trade` block from `registries/uniswapV3.js`

Net effect: 0G's TVL (~$2.24M currently) moves from the "oku-trade" listing to "Uniswap V3", matching how Oku is listed on all other chains.

Also answers @g1nt0ki's question on #18828 — confirmed with Oku team that deployment ownership belongs to Uniswap Foundation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new chain configuration to the Uniswap v3 Total Value Locked (TVL) tracking setup, specifying network factory address and initial blockchain reference.
  * Removed a legacy registry entry from the Uniswap v3 configuration, consolidating protocol deployment mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->