### PR TITLE
quell: add adapter (Arbitrum ERC-4626 RWAVault)

### DIFF
--- a/projects/quell/index.js
+++ b/projects/quell/index.js
@@ -1,0 +1,18 @@
+const { sumERC4626VaultsExport } = require('../helper/erc4626');
+
+// Quell RWAVault on Arbitrum One (ERC-4626, USDC in / rvUSDC out).
+// Yield routes into Spark sUSDC via the protocol's IYieldAdapter.
+const RWA_VAULT_ARBITRUM = '0x82bDeB9239d33AAE4b8c38C0C0ef3B088b0Fc791';
+
+module.exports = {
+  methodology:
+    'TVL is totalAssets() of the Quell RWAVault (ERC-4626) on Arbitrum One. ' +
+    'Underlying asset is native USDC (0xaf88...5831). Yield route: Spark sUSDC.',
+  arbitrum: {
+    tvl: sumERC4626VaultsExport({
+      vaults: [RWA_VAULT_ARBITRUM],
+      tokenAbi: 'asset',
+      balanceAbi: 'totalAssets',
+    }),
+  },
+};


### PR DESCRIPTION
Adds a TVL adapter for Quell — an RWA yield router live on Arbitrum One. The protocol already has a DefiLlama listing but no adapter was ever merged, so `defillama.com/protocol/quell` currently shows TVL 0. This PR is the adapter-side fix; the metadata update for the listing goes in a separate `defillama-server` PR.

##### Name (to be shown on DefiLlama):

Quell

##### Twitter Link:

https://twitter.com/quellfi

##### List of audit links if any:

No paid third-party audit. Self-audited via Slither + Foundry fuzz/invariant suites, informed by Pashov's open-source audit skills.

##### Website Link:

https://quell.fi

##### Current TVL:

Live — read from `totalAssets()` on the Arbitrum RWAVault (`0x82bDeB9239d33AAE4b8c38C0C0ef3B088b0Fc791`).

##### Chain:

Arbitrum

##### Short Description (to be shown on DefiLlama):

RWA yield router on Arbitrum. USDC deposits receive ERC-4626 shares (rvUSDC); capital is routed to Spark sUSDC for RWA-backed yield via the Sky Savings Rate. Non-custodial, no KYC, no lockup, no emissions.

##### Category:

RWA

##### forkedFrom:

None.

##### methodology:

TVL is `totalAssets()` of the Quell RWAVault (ERC-4626) on Arbitrum One, denominated in the vault's `asset()` — native USDC (`0xaf88d065e77c8cC2239327C5EDb3A432268e5831`). Yield route is Spark sUSDC (`0x940098b108fB7D0a7E374f6eDED7760787464609`) via the protocol's `IYieldAdapter`. Single vault, single chain.

##### Github org/user:

https://github.com/thedelph/quell-contracts

##### Does this project have a referral program?

No.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for calculating Total Value Locked (TVL) on Arbitrum One for Quell RWAVault
  * New project configuration with methodology documentation for vault assets and yield routes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->