### PR TITLE
Add ONEPOT no-loss lottery vault adapter

### DIFF
--- a/projects/onepot/index.js
+++ b/projects/onepot/index.js
@@ -1,0 +1,18 @@
+const SAFE_ADDRESS = '0xe879F812300ee4147247Be0A6CF1338d76645bf2';
+const USDC         = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+const A_BASE_USDC  = '0x4e65fE4DbA92790696d040ac24Aa414708F5c0AB';
+
+async function tvl(api) {
+  await api.sumTokens({
+    owner: SAFE_ADDRESS,
+    tokens: [USDC, A_BASE_USDC],
+  });
+}
+
+module.exports = {
+  methodology:
+    'TVL is the sum of USDC and aBasUSDC (AAVE v3 Base) held in the ONEPOT Safe multisig. ' +
+    'Depositors supply USDC which is lent on AAVE v3. The daily yield buys Megapot lottery ' +
+    'tickets. Principal remains intact and is never used to buy tickets.',
+  base: { tvl },
+};


### PR DESCRIPTION
ONEPOT is a no-loss lottery vault on Base. Users deposit USDC lent on AAVE v3. The daily yield buys Megapot lottery tickets on behalf of all depositors. Principal remains intact and is never used to buy tickets. If the vault wins, 100% of the prize is redistributed proportionally with no fees.
TVL = USDC + aBasUSDC in Safe 0xe879F812300ee4147247Be0A6CF1338d76645bf2 on Base.

---

##### Name (to be shown on DefiLlama):
ONEPOT

##### Twitter Link:
https://twitter.com/onepotapp

##### List of audit links if any:

##### Website Link:
https://onepot.app

##### Logo (High resolution, will be shown with rounded borders):
(attach image below)

##### Current TVL:

##### Treasury Addresses (if the protocol has treasury)
0xe879F812300ee4147247Be0A6CF1338d76645bf2

##### Chain:
Base

##### Coingecko ID:

##### Coinmarketcap ID:

##### Short Description (to be shown on DefiLlama):
No-loss lottery vault on Base — deposit USDC, earn yield on AAVE v3, and the daily yield buys Megapot lottery tickets. Principal is always intact.

##### Token address and ticker if any:

##### Category:
Yield

##### Oracle Provider(s):
None

##### Implementation Details:
N/A — TVL is read directly from on-chain token balances.

##### Documentation/Proof:

##### forkedFrom:

##### methodology:
TVL is the sum of USDC and aBasUSDC (AAVE v3 Base) held in the ONEPOT Safe multisig. Depositors supply USDC which is lent on AAVE v3. The daily yield buys Megapot lottery tickets. Principal remains intact and is never used to buy tickets.

##### Github org/user:

##### Does this project have a referral program?
No
<img width="400" height="400" alt="IMG_5063" src="https://github.com/user-attachments/assets/c5294079-594f-42c3-8d1d-00bff5e8c5c2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for calculating Total Value Locked (TVL) for ONEPOT on Base network, tracking USDC and AAVE v3 Base token positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->