### PR TITLE
fix: VII Finance TVL for Monad

### DIFF
--- a/projects/helper/unwrapLPs.js
+++ b/projects/helper/unwrapLPs.js
@@ -102,6 +102,7 @@ async function unwrapUniswapV4NFTs({ balances = {}, api, owner, nftAddress, stat
       case 'bsc': stateViewer = '0xd13Dd3D6E93f276FAfc9Db9E6BB47C1180aeE0c4'; break;
       case 'unichain': stateViewer = '0x86e8631A016F9068C3f085fAF484Ee3F5fDee8f2'; break;
       case 'base': stateViewer = '0xA3c0c9b65baD0b08107Aa264b0f3dB444b867A71'; break;
+      case 'monad': stateViewer = '0x77395f3b2e73ae90843717371294fa97cc419d64'; break;
       default: throw new Error('missing default uniswap state viewer address chain: ' + chain)
     }
 
@@ -113,6 +114,7 @@ async function unwrapUniswapV4NFTs({ balances = {}, api, owner, nftAddress, stat
       case 'bsc': nftAddress = '0x7A4a5c919aE2541AeD11041A1AEeE68f1287f95b'; break;
       case 'unichain': nftAddress = '0x4529A01c7A0410167c5740C487A8DE60232617bf'; break;
       case 'base': nftAddress = '0x7C5f5A4bBd8fD63184577525326123B519429bDc'; break;
+      case 'monad': nftAddress = '0x5b7ec4a94ff9bedb700fb82ab09d5846972f4016'; break;
       default: throw new Error('missing default uniswap nft address chain: ' + chain)
     }
 
@@ -142,6 +144,7 @@ async function unwrapUniswapV4NFTs({ balances = {}, api, owner, nftAddress, stat
       arbitrum: '655x11nEGRudi5Nh4attV1uMt2YnyFRMaSKRM5QndXLK',
       polygon: '2UKncUpdgZeJVyh6Dv8ai2fTL2MQnig8ySh7YkYcHCsL',
       optimism: '3Tn7Y1NJAr4ySKm7KFu1dwvH2WM3mHJnXzXAxQsdBDvW',
+      monad: '6CQtx9W4b9Kn9cjznXJNLeTvLV1hbpxkaJZkbyXirJuz',
     }
 
     let endpoint = commonConfig.uniV4ExtraConfig.subgraph ?? defaultGraphEndpoints[chain]

--- a/projects/vii-finance/index.js
+++ b/projects/vii-finance/index.js
@@ -6,7 +6,6 @@ const { sumERC4626VaultsExport2 } = require('../helper/erc4626');
 const WRAPPER_FACTORIES = {
   unichain: { address: '0x7777655b9474D2f3F27EE44F3FD1343e33ce2777', fromBlock: 42132957 },
   ethereum: { address: '0x77774aBb84EEAbaE05CE00D8a1b83dfc6E93f777', fromBlock: 24589014 },
-  monad: { address: '0x7777dc1a68addc8b5ab991c7f29dc2904367e777', fromBlock: 66930998 },
 };
 
 const eulerVaultOwners = ['0x12e74f3C61F6b4d17a9c3Fdb3F42e8f18a8bB394'];
@@ -54,8 +53,7 @@ module.exports = {
   monad: {
     tvl: async (api) => {
       await sumERC4626VaultsExport2({ vaults: monadVaults })(api);
-      for (const owner of monadUniV4Wrappers)
-        await sumTokens2({ api, owner, resolveUniV4: true });
+      await Promise.all(monadUniV4Wrappers.map(owner => sumTokens2({ api, owner, resolveUniV4: true })));
     }
   },
 };

--- a/projects/vii-finance/index.js
+++ b/projects/vii-finance/index.js
@@ -1,14 +1,33 @@
 const { getCuratorTvl } = require("../helper/curators");
 const { getLogs2 } = require('../helper/cache/getLogs');
 const { sumTokens2 } = require('../helper/unwrapLPs');
+const { sumERC4626VaultsExport2 } = require('../helper/erc4626');
 
 const WRAPPER_FACTORIES = {
   unichain: { address: '0x7777655b9474D2f3F27EE44F3FD1343e33ce2777', fromBlock: 42132957 },
   ethereum: { address: '0x77774aBb84EEAbaE05CE00D8a1b83dfc6E93f777', fromBlock: 24589014 },
-  monad: {address: '0x7777dc1a68addc8b5ab991c7f29dc2904367e777', fromBlock: 66930998},
+  monad: { address: '0x7777dc1a68addc8b5ab991c7f29dc2904367e777', fromBlock: 66930998 },
 };
 
 const eulerVaultOwners = ['0x12e74f3C61F6b4d17a9c3Fdb3F42e8f18a8bB394'];
+
+const monadUniV4Wrappers = [
+  "0x43c8edfe8bdb8a9dc98a9c5dccfeb057bed25950",
+  "0x6a593b01138c8d522b6a2fe026f1773d3216ae8f",
+  "0x7ac4680086d84f96d6f9031367ccac197b9b4397",
+  "0xa878dac5c606b27cac9ddfb33c7952161b4e77f5",
+  "0xdb1b130512aedbbd7ff5da85b640250dd8230a41",
+  "0xe69fd165953bd28fee5025981155184dacdd23c3",
+];
+
+const monadVaults = [
+  "0x5e43e6cb7DAf0cFC810d0F80A1e05b3D49FA9192",
+  "0x852E9D248b1a294566737633C2f829Ea8257553b",
+  "0x3d4bB6cd6a2207D3e1747cE757364eEAaD684C79",
+  "0x7a5Ab5Bd7F2DB9960813763e86eB789192F56768",
+  "0xc5251BC7f19d9579CafE6aD619EC568E947DC0C5",
+  "0x56e07C30ca75A6aA9b8437975ff3130E3dC7A699",
+];
 
 async function getUniV4CollateralTvl(api) {
   const config = WRAPPER_FACTORIES[api.chain];
@@ -32,5 +51,11 @@ module.exports = {
   doublecounted: true,
   unichain: { tvl },
   ethereum: { tvl },
-  monad: {tvl},
+  monad: {
+    tvl: async (api) => {
+      await sumERC4626VaultsExport2({ vaults: monadVaults })(api);
+      for (const owner of monadUniV4Wrappers)
+        await sumTokens2({ api, owner, resolveUniV4: true });
+    }
+  },
 };


### PR DESCRIPTION
@waynebruce0x

We relied on events emitted by `GenericVaultFactory` from Euler and `UniswapV4WrapperFactory` from VII Finance to get the Euler vaults and UniswapV4Wrappers created by the VII Finance deployer. That was failing in the case of Monad. So, for Monad, we are using a static list of vaults and wrappers to get the TVL. This will fix the problem discussed [here](https://github.com/DefiLlama/DefiLlama-Adapters/pull/18716#issuecomment-4288952243).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Monad support: improved Uniswap V4 NFT unwrap handling and default endpoint resolution for Monad chains.
  * Improved Monad TVL calculation: now aggregates ERC‑4626 vault assets and Uniswap V4 collateral in parallel for more accurate totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->