### PR TITLE
rename AXC GIFT token to AXC GYTW token

### DIFF
--- a/projects/axc-gytw/index.js
+++ b/projects/axc-gytw/index.js
@@ -2,7 +2,7 @@ const sdk = require('@defillama/sdk');
 
 
 const bscTokens = [
-  "0x6Eca9D3B1ef79F5b45572fb8204835C6A4502bE9", // GIFT
+  "0xfC787d44f3754aDd0242204533b2B4A7eB9876e1", // GYTW
 ];
 
 async function getTokensTvl(api, chain, tokens) {
@@ -23,6 +23,7 @@ module.exports = {
     tvl: (api) => getTokensTvl(api, 'bsc', bscTokens)
   },
   hallmarks: [
-    ["2025-12-31", "Grow Institutional Fund Token (GIFT) is a RWA token which seeks to track the value of the Grow Heritage Fund"]
+      ["2025-12-31", "Grow Institutional Fund Token (GIFT) is a RWA token which seeks to track the value of the Grow Heritage Fund"],
+      ["2025-04-23", "Growth Yield Token Whitelisted (GYTW) is has reissued new tokens to clients with a new token name"]
   ]
 };


### PR DESCRIPTION
This is a set of change with DefiLlama/defilama-server#11835 that updates a token that was added to defilama with PR #17550 .  We have rebranded the token name and reissued the tokens to token holders.  The authenticity of this pull request can be verified by the our official website https://dapp.axc.xyz/vault/260416100623001 which has been updated with the new token name and address.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Modified BSC token tracking for TVL calculations: switched from GIFT token to GYTW token for value computations.
  * Updated token metadata to include new GYTW whitelisting and reissuance record dated 2025-04-23.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->