### PR TITLE
Add ethereum chain support to goldenasset adapter

### DIFF
--- a/projects/goldenasset/index.js
+++ b/projects/goldenasset/index.js
@@ -2,45 +2,54 @@ const sdk = require('@defillama/sdk');
 const { fetchURL } = require('../helper/utils');
 
 const PRICE_DISCOUNT = 0.098;
+const TOKEN_ADDRESSES = {
+  sei: '0x372B2dC06478AA2c8182EeE0f12eA0e9A15E2913',
+  ethereum: '0x372B2dC06478AA2c8182EeE0f12eA0e9A15E2913',
+};
+
+async function tvl(api, tokenAddress) {
+  // The timestamp here is a number (seconds since epoch)
+  // 1. Fetch the total token supply
+  const totalSupply = await api.call({
+    abi: 'erc20:totalSupply',
+    target: tokenAddress,
+  });
+
+  // 2. Fetch the historical price
+  const url = `https://api.gemswap.org/prices/gem?adjustTo=2024-12-03`;
+  const response = await fetchURL(url);
+  const { price: currentPrice, history } = response.data;
+
+  // 3. Convert the timestamp to an ISO date string at UTC 00:00
+  const dateVal = new Date(Number(api.timestamp) * 1000);
+  if (isNaN(dateVal.getTime())) {
+    throw new Error(`Invalid timestamp: ${api.timestamp}`);
+  }
+  const isoDateKey = dateVal
+    .toISOString()
+    .split('T')[0] + 'T00:00:00.000Z';
+
+  // 4. Retrieve the historical price from the history (fallback to currentPrice)
+  const rawPrice = history[isoDateKey] !== undefined
+    ? history[isoDateKey]
+    : currentPrice;
+
+  // 5. Apply the discount
+  const price = rawPrice * (1 - PRICE_DISCOUNT);
+
+  // 6. Calculate TVL in USD
+  const supply = totalSupply / 1e18;
+  return { 'usd-coin': supply * price };
+}
 
 module.exports = {
   misrepresentedTokens: true,
   start: 1727914080, // Protocol launch: October 3, 2024 UTC
 
   sei: {
-    tvl: async (api) => {
-      // The timestamp here is a number (seconds since epoch)
-      // 1. Fetch the total token supply
-      const totalSupply = await api.call({
-        abi: 'erc20:totalSupply',
-        target: '0x372B2dC06478AA2c8182EeE0f12eA0e9A15E2913',
-      });
-
-      // 2. Fetch the historical price
-      const url = `https://api.gemswap.org/prices/gem?adjustTo=2024-12-03`;
-      const response = await fetchURL(url);
-      const { price: currentPrice, history } = response.data;
-
-      // 3. Convert the timestamp to an ISO date string at UTC 00:00
-      const dateVal = new Date(Number(api.timestamp) * 1000);
-      if (isNaN(dateVal.getTime())) {
-        throw new Error(`Invalid timestamp: ${api.timestamp}`);
-      }
-      const isoDateKey = dateVal
-        .toISOString()
-        .split('T')[0] + 'T00:00:00.000Z';
-
-      // 4. Retrieve the historical price from the history (fallback to currentPrice)
-      const rawPrice = history[isoDateKey] !== undefined
-        ? history[isoDateKey]
-        : currentPrice;
-
-      // 5. Apply the discount
-      const price = rawPrice * (1 - PRICE_DISCOUNT);
-
-      // 6. Calculate TVL in USD
-      const supply = totalSupply / 1e18;
-      return { 'usd-coin': supply * price };
-    },
+    tvl: (api) => tvl(api, TOKEN_ADDRESSES.sei),
+  },
+  ethereum: {
+    tvl: (api) => tvl(api, TOKEN_ADDRESSES.ethereum),
   },
 };


### PR DESCRIPTION
## Description

This change extends the `goldenasset` adapter to support both `sei` and `ethereum` TVL calculation paths.

### What changed

- Added an `ethereum` chain export alongside the existing `sei` export.
- Refactored the duplicated TVL logic into a shared `tvl(api, tokenAddress)` helper.
- Introduced a `TOKEN_ADDRESSES` map to keep chain-specific token contract addresses in one place.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ethereum TVL calculation support alongside existing SEI network configuration.

* **Refactor**
  * Updated TVL calculation implementation with historical price lookup and centralized token address configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->