### PR TITLE
exclude lista vaults historically

### DIFF
--- a/projects/gauntlet/index.js
+++ b/projects/gauntlet/index.js
@@ -283,11 +283,20 @@ async function combinedBaseTvl(api) {
   // await aeraV3.base.tvl(api);
 }
 
+async function combinedBscTvl(api) {
+  const LISTA_START = 1777303000 // 2026-04-27, listing date for BSC Lista (Moolah) vaults
+  
+  if (api.timestamp < LISTA_START) return;
+  const curatorExport = getCuratorExport(configs);
+  if (curatorExport.bsc?.tvl) await curatorExport.bsc.tvl(api);
+}
+
 module.exports = {
   ...getCuratorExport(configs),
   solana: { tvl },
   ethereum: { tvl: combinedEthereumTvl },
   base: { tvl: combinedBaseTvl },
+  bsc: { tvl: combinedBscTvl },
   timetravel: false,
   hallmarks: [
     ["2026-03-22", "Resolve USR hack"],


### PR DESCRIPTION
- Only attributes lista vaults to gauntlet tvl after listing/announcment: https://x.com/lista_dao/status/2048685351246406079

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Binance Smart Chain (BSC) Total Value Locked (TVL) tracking and reporting capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->