### PR TITLE
feat: add Pool Party — Canton Network AMM

### DIFF
--- a/projects/pool-party/index.js
+++ b/projects/pool-party/index.js
@@ -1,0 +1,53 @@
+/*
+ * Pool Party — Canton Network AMM
+ *
+ * Pool Party is the first AMM on Canton Network, built by Send Foundation.
+ * Pairs at launch: CC/CUSD, CC/USDCx, USDCx/CUSD.
+ *
+ * TVL methodology:
+ *   This adapter mirrors the existing `wcc` adapter
+ *   (projects/wcc/index.js) — the only currently supported Canton TVL pattern.
+ *   It queries the public Canton Lighthouse API for the CC balance held by
+ *   Pool Party's Canton party and reports it as gas-token (CC) TVL.
+ *
+ *   The Lighthouse API exposes Canton Coin balances per party only; CUSD and
+ *   USDCx (the stablecoin sides of Pool Party's pools) are not currently
+ *   queryable through public Canton APIs. As a result this adapter
+ *   underreports the full pool TVL by roughly the value of the stablecoin
+ *   sides. Adding the stablecoin sides is tracked as Phase 2.
+ *
+ * Docs: https://info.send.it/docs/pool-party/overview
+ * App:  https://cantonwallet.com/pools/
+ */
+
+const { get } = require('../helper/http')
+
+const BASE_URL = 'https://lighthouse.cantonloop.com/api/parties/'
+
+// Pool Party's Canton party ID. Source:
+// https://info.send.it/docs/miscellaneous/send-contract-addresses
+const parties = [
+  'poolparty::1220f1b0d7a83c7eaaf6d712d95d5952ea2c801238af9c342e8d83c87dfc45c999dc',
+]
+
+async function tvl(api) {
+  for (const party of parties) {
+    const { balance } = await get(BASE_URL + party + '/balance')
+    // total_coin_holdings is a decimal-string CC balance.
+    // Convert to atomic units (CC has 18 decimals, matching the wcc adapter's
+    // 1e18 multiplier).
+    api.addGasToken(Number(balance.total_coin_holdings) * 1e18)
+  }
+}
+
+module.exports = {
+  timetravel: false,
+  canton: { tvl },
+  methodology:
+    "TVL is the total Canton Coin (CC) balance held by Pool Party's Canton " +
+    "party, fetched from the public Lighthouse API. Stablecoin sides of pools " +
+    "(CUSD, USDCx) are not yet queryable through public Canton APIs and are " +
+    "not included; this matches the methodology used by the existing wcc " +
+    "adapter and is expected to be expanded once Canton APIs surface " +
+    "non-CC token balances per party.",
+}


### PR DESCRIPTION
## Adapter approach

This adapter mirrors the existing [`projects/wcc/index.js`](https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/wcc/index.js) — the established Canton Network TVL pattern in this repo. It exports `canton: { tvl }` (chain-keyed, **not** a top-level `fetch` export), and queries the public Lighthouse API for the CC balance held by Pool Party's Canton party:

```
GET https://lighthouse.cantonloop.com/api/parties/{partyId}/balance
```

Pool Party's Canton party ID: `poolparty::1220f1b0d7a83c7eaaf6d712d95d5952ea2c801238af9c342e8d83c87dfc45c999dc` (sourced from [Send's docs](https://info.send.it/docs/miscellaneous/send-contract-addresses)).

Re: the PR template note about fetch adapters — happy to discuss in Discord, but this is the same chain-keyed TVL shape that `wcc` already uses (Canton uses configurable privacy via DAML, so external on-chain balance reads aren't possible without going through Lighthouse / cantonscan). If a different pattern is preferred, please point me at the example to mirror.

## Methodology

> TVL is the total Canton Coin (CC) balance held by Pool Party's Canton party, fetched from the public Lighthouse API. Stablecoin sides of pools (CUSD, USDCx) are not yet queryable through public Canton APIs and are not included; this matches the methodology used by the existing wcc adapter and is expected to be expanded once Canton APIs surface non-CC token balances per party.

## Known limitations

- **CC-only TVL.** Lighthouse exposes only Canton Coin balances per party. Pool Party's pools also hold CUSD (Send's privacy stablecoin) and USDCx (bridged USDC); neither has a public per-party query path on Canton today. Same trade-off as wcc.
- **No `timetravel`** — Lighthouse returns current balance only.

## Verification

```bash
curl -s 'https://lighthouse.cantonloop.com/api/parties/poolparty::1220f1b0d7a83c7eaaf6d712d95d5952ea2c801238af9c342e8d83c87dfc45c999dc/balance' | jq '.balance.total_coin_holdings'
# → "71115.5943498504"
```

Single new file: `projects/pool-party/index.js`. No new dependencies, no `pnpm-lock.yaml` changes.

---

## Listing info

##### Name (to be shown on DefiLlama):
Pool Party

##### Twitter Link:
https://x.com/send

##### List of audit links if any:
_(Send Foundation to confirm — none publicly disclosed at time of submission)_

##### Website Link:
https://poolparty.fun

##### Logo (High resolution, will be shown with rounded borders):
https://info.send.it/img/PoolParty_Icon.png

##### Current TVL:
~71,115 CC held by Pool Party's Canton party (live: see verification curl above). USD value depends on current CC price.

##### Treasury Addresses (if the protocol has treasury):
Pool Party Canton party: `poolparty::1220f1b0d7a83c7eaaf6d712d95d5952ea2c801238af9c342e8d83c87dfc45c999dc`

##### Chain:
Canton

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):
_(Pool Party itself is not a token; the project doesn't have a Coingecko ID. CC native gas token is at coingecko: canton-network)_

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):
_(N/A — Pool Party doesn't have a token. CC is at coinmarketcap.com/currencies/canton-network)_

##### Short Description (to be shown on DefiLlama):
First AMM on Canton Network. Built by Send Foundation. Live pairs: CC/CUSD, CC/USDCx, USDCx/CUSD. Accessible from the Send Canton Wallet. Launched February 2026.

##### Token address and ticker if any:
N/A — the AMM does not have its own token. The Send Foundation governance/ecosystem token `$SEND` is on Base: `0xEab49138BA2Ea6dd776220fE26b7b8E446638956`.

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Dexes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Canton Network TVL adapter for Pool Party, enabling comprehensive monitoring of total value locked on the Canton Network. This adapter provides real-time balance tracking and seamless integration with existing platform infrastructure, enhancing visibility into Pool Party's assets and holdings. Automated reporting and monitoring capabilities now available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->