### PR TITLE
Add JPMorgan MONY tokenized money market fund adapter

### DIFF
--- a/projects/jpmorgan-mony/index.js
+++ b/projects/jpmorgan-mony/index.js
@@ -1,0 +1,15 @@
+const MONY = '0x6a7c6aa2b8b8a6A891dE552bDEFFa87c3F53bD46'
+
+async function tvl(api) {
+  const [decimals, supply] = await Promise.all([
+    api.call({ target: MONY, abi: 'erc20:decimals' }),
+    api.call({ target: MONY, abi: 'erc20:totalSupply' }),
+  ])
+  api.addUSDValue(supply / 10 ** decimals)
+}
+
+module.exports = {
+  ethereum: { tvl },
+  misrepresentedTokens: true,
+  methodology: 'TVL is the total supply of MONY tokens (My OnChain Net Yield Fund), JPMorgan Asset Management\'s tokenized money market fund on Ethereum, valued at approximately $1 per token.',
+}


### PR DESCRIPTION


---

##### Name :
JPMorgan MONY

##### Twitter Link:
https://twitter.com/jpmorgan

##### Website Link:
https://am.jpmorgan.com/us/en/asset-management/adv/about-us/media/press-releases/jp-morgan-asset-management-launches-its-first-tokenized-money-market-fund/

##### Current TVL:
~$101M

##### Chain:
Ethereum

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):

##### Short Description 
JPMorgan Asset Management's first tokenized money market fund (My OnChain Net Yield Fund) on Ethereum, investing in US Treasury securities and repo agreements, powered by Kinexys Digital Assets.

##### Category:
RWA

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL is the total supply of MONY tokens on Ethereum, valued at approximately $1 per token (the fund targets a stable $1 NAV as a money market fund).

---

* **New Features**
  * Added TVL tracking support for MONY (My OnChain Net Yield Fund) token on Ethereum, providing real-time value metrics based on total supply data. Token marked for special handling in the system.
