### PR TITLE
fix(linx): include WBTC and other non-ALPH tokens in TVL

### DIFF
--- a/projects/linx/index.js
+++ b/projects/linx/index.js
@@ -46,7 +46,10 @@ async function getTokenBalance(marketContractId, tokenId) {
         return BigInt((await alephium.getAlphBalance(contractAddress)).balance);
     } else {
         const tokensBalance = await alephium.getTokensBalance(contractAddress);
-        const tokenBalance = tokensBalance.find(b => b.tokenId === tokenId);
+        // Use case-insensitive comparison to handle hex token IDs with mixed casing
+        // This fixes WBTC and other non-ALPH collateral tokens being excluded from TVL
+        const tokenIdLower = tokenId.toLowerCase();
+        const tokenBalance = (tokensBalance ?? []).find(b => b.tokenId.toLowerCase() === tokenIdLower);
         return BigInt(tokenBalance?.balance ?? 0);
     }
 }


### PR DESCRIPTION
Closes #18029

### Root cause
`getTokenBalance()` used strict equality (`===`) to match token IDs,
but the Alephium API returns token IDs in a different casing than what
the contract emits. WBTC (and any other non-ALPH collateral) silently
returned `0n`, excluding it from TVL.

### Fix
- Normalise both sides to lowercase before comparison
- Added a null-guard on `tokensBalance` for safety


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced token balance lookup with case-insensitive matching and improved null value handling for greater reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->