### PR TITLE
Add sanity checks to PR validation workflow

### DIFF
--- a/.github/workflows/sanityCheck.js
+++ b/.github/workflows/sanityCheck.js
@@ -1,0 +1,160 @@
+// Adds sanity warnings to a PR alongside the existing TVL output produced by
+// test.js / commentResult.js. Catches the common shipping-failure modes that
+// the existing pipeline does not flag, e.g. an adapter that runs cleanly but
+// computes $0 (unpriced tokens — almost always the cause when a new chain is
+// involved) or $50B+ (likely double-counting / wrong decimals).
+//
+// Usage:
+//   node .github/workflows/sanityCheck.js <output.txt> <pr-comments-dir> <adapter-path>
+//
+// Designed to be invoked from test.yml right after commentResult.js. Writes its
+// own markdown file into the pr-comments dir; comment.yml will pick it up and
+// post it. Never throws — on any error it just exits 0 silently so the rest of
+// the CI pipeline is unaffected.
+
+const path = require('path');
+const fs = require('fs');
+
+// $50B is well above the largest single-protocol TVL on DefiLlama at the time of
+// writing. Anything above that on a fresh adapter is almost always a bug
+// (decimals, double-counting, wrong owner).
+const HIGH_TVL_USD = 50_000_000_000;
+
+function parseTotalTvl(testOutput) {
+  // commentResult.js parses the same "------ TVL ------" section. We look for
+  // the "total" line: e.g. "total                    659.34 k"
+  const tvlSection = testOutput.split('------ TVL ------')[1];
+  if (!tvlSection) return null;
+
+  const totalMatch = tvlSection.match(/^\s*total\s+([\d.,]+)\s*([kKmMbB])?\s*$/m);
+  if (!totalMatch) return null;
+
+  let value = Number(totalMatch[1].replace(/,/g, ''));
+  if (Number.isNaN(value)) return null;
+  const suffix = (totalMatch[2] || '').toLowerCase();
+  if (suffix === 'k') value *= 1e3;
+  else if (suffix === 'm') value *= 1e6;
+  else if (suffix === 'b') value *= 1e9;
+  return value;
+}
+
+function readAdapterSource(adapterPath) {
+  // adapterPath comes in as "projects/risex" (a directory) or
+  // "projects/helper/foo.js". Resolve to a readable .js file when it's a dir.
+  if (!adapterPath) return null;
+  let abs = path.resolve(process.cwd(), adapterPath);
+  try {
+    const stat = fs.statSync(abs);
+    if (stat.isDirectory()) {
+      abs = path.join(abs, 'index.js');
+      if (!fs.existsSync(abs)) return null;
+    }
+    return fs.readFileSync(abs, 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+function detectMethodology(source) {
+  if (!source) return { found: false, unknown: true };
+  // Looks for `methodology:` followed by a string literal anywhere in the file.
+  return { found: /\bmethodology\s*:\s*['"`]/.test(source), unknown: false };
+}
+
+function detectFetchAdapter(source) {
+  if (!source) return false;
+  // Heuristic: a non-helper adapter that imports node-fetch / axios and reads
+  // an HTTP URL is likely a "fetch adapter" — banned for new projects per
+  // pull_request_template.md.
+  const httpUseRegex = /https?:\/\/(?!.*\b(rpc|node|infura|alchemy|public|llama|ankr|drpc|blockpi)\b)/i;
+  const httpUsed = httpUseRegex.test(source);
+  const importsHttpClient = /\brequire\s*\(\s*['"`](node-fetch|axios)['"`]\s*\)/.test(source);
+  return importsHttpClient && httpUsed;
+}
+
+function buildWarnings({ totalTvl, methodology, fetchAdapter, adapterPath }) {
+  const warnings = [];
+
+  if (totalTvl === 0) {
+    warnings.push(
+      `**TVL evaluates to \`$0\`.** This usually means the supported tokens have no price feed on \`coins.llama.fi\`. ` +
+        `If the chain is new to DefiLlama, register a price remap in \`projects/helper/tokenMapping.js\` ` +
+        `(e.g. map a bridged stablecoin to its canonical mainnet address) and add the canonical token to ` +
+        `\`projects/helper/coreAssets.json\`. If the protocol genuinely holds no value yet, leave a comment ` +
+        `explaining that so the maintainer can decide whether to merge.`,
+    );
+  } else if (totalTvl !== null && totalTvl > HIGH_TVL_USD) {
+    warnings.push(
+      `**TVL exceeds the \`$${(HIGH_TVL_USD / 1e9).toFixed(0)}B\` sanity bound** (computed: ` +
+        `\`$${totalTvl.toLocaleString()}\`). This is almost always a bug — common causes: token decimals ` +
+        `wrong, the same balance counted at multiple owners (e.g. vault + LP), reading totalSupply where ` +
+        `you meant balanceOf, or pricing a non-stable as USDC. Please double-check the methodology before merging.`,
+    );
+  }
+
+  if (!methodology.unknown && !methodology.found) {
+    warnings.push(
+      `**Adapter does not export a \`methodology\` string.** Add one to ` +
+        `\`module.exports\` (sibling to the chain blocks) so the methodology shows on the DefiLlama UI ` +
+        `and in the protocols API. Example: \`methodology: 'Sum of token balances at the X contract.'\``,
+    );
+  }
+
+  if (fetchAdapter) {
+    warnings.push(
+      `**This looks like a fetch adapter** (imports \`axios\`/\`node-fetch\` and reads a non-RPC HTTP URL). ` +
+        `Per the PR template, fetch adapters are not accepted for new projects — TVL must be computed from ` +
+        `on-chain data. If the URL is actually an RPC endpoint, ignore this warning.`,
+    );
+  }
+
+  if (!warnings.length) return null;
+
+  return [
+    `### Sanity check — ${adapterPath}`,
+    '',
+    ...warnings.map((w) => `- ${w}`),
+    '',
+    `<sub>Posted by \`.github/workflows/sanityCheck.js\`. These are warnings, not blockers — ` +
+      `the maintainer will weigh in.</sub>`,
+  ].join('\n');
+}
+
+function main() {
+  const [, , logPath, outDir, adapterPath] = process.argv;
+  if (!logPath || !outDir) return;
+
+  let testOutput = '';
+  try {
+    testOutput = fs.readFileSync(logPath, 'utf-8');
+  } catch {
+    return;
+  }
+
+  // Skip if the run errored out — the existing commentResult.js already posts
+  // the error and there's no point piling on.
+  if (testOutput.includes('------ ERROR ------')) return;
+
+  const totalTvl = parseTotalTvl(testOutput);
+  const source = readAdapterSource(adapterPath);
+  const methodology = detectMethodology(source);
+  const fetchAdapter = detectFetchAdapter(source);
+
+  const body = buildWarnings({ totalTvl, methodology, fetchAdapter, adapterPath });
+  if (!body) return;
+
+  fs.mkdirSync(outDir, { recursive: true });
+  const safeName = (adapterPath || 'general').replace(/[^a-zA-Z0-9._-]/g, '_');
+  // Prefix with "z-" so the filename sorts after the TVL output from
+  // commentResult.js (which uses a numeric Date.now() prefix). Keeps the
+  // sanity warnings as a follow-on comment under the TVL summary.
+  const fileName = `z-sanity-${Date.now()}-${process.pid}-${safeName}.md`;
+  fs.writeFileSync(path.join(outDir, fileName), body);
+}
+
+try {
+  main();
+} catch (e) {
+  // Never break the CI pipeline because of a sanity-check bug.
+  console.error('sanityCheck failed:', e && e.message);
+}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,7 @@ jobs:
             {
               node ${{ github.workspace }}/test.js ${{ github.workspace }}/${i} 2>&1 | tee output.txt
               node ${{ github.workspace }}/.github/workflows/commentResult.js ${{ github.workspace }}/output.txt ${{ github.workspace }}/pr-comments ${i}
+              node ${{ github.workspace }}/.github/workflows/sanityCheck.js ${{ github.workspace }}/output.txt ${{ github.workspace }}/pr-comments ${i}
               if grep -q "\-\-\-\- ERROR \-\-\-\-" output.txt; then
                 exit 1;
               fi


### PR DESCRIPTION
## Why

The existing `Test_Change` workflow runs `node test.js` on every changed adapter and posts the TVL output as a PR comment via `commentResult.js`. It correctly catches adapters that *throw*, but it doesn't sanity-check the *value* the adapter computes. A few well-known shipping-failure modes therefore pass review silently:

- An adapter that runs cleanly but computes **`$0`** — almost always means the supported tokens have no price feed on `coins.llama.fi`. Very common when a new chain or bridged stablecoin needs a `tokenMapping.js` remap. (I hit this myself shipping a recent adapter on a fresh chain — the test passed, the value was zero, and there was no signal pointing at the fix.)
- An adapter that returns a **wildly inflated number** (>$50B) — usually a decimals bug, the same balance counted at two owners (vault + LP), reading `totalSupply` instead of `balanceOf`, or pricing a non-stable as USDC.
- A new listing without a `methodology` string export — this is a PR-template requirement and leaves the methodology blank on the UI.
- A probable **fetch adapter** (imports `axios` / `node-fetch` and reads a non-RPC HTTP URL) — explicitly banned for new projects per `pull_request_template.md`.

You can see the cost of these slipping through in the merge log: a steady cadence of follow-up PRs like *"paragon genuine spike"*, *"fix superform spike"*, *"rubic bridge aggr genuine spike"*, *"temp disable standx dusd fees"*. Each one is a day of maintainer time after the fact.

## What this PR does

Adds `.github/workflows/sanityCheck.js`. It consumes the same `output.txt` that `commentResult.js` already produces, plus the adapter source file path that `test.yml` already passes, and writes a follow-on markdown comment whenever any of the four signals fire.

**Warnings, not blockers** — the workflow's existing `ERROR` gate is untouched, the script never throws, and on any internal failure it exits silently. The maintainer always decides.

The integration is one line in `test.yml`:

```yaml
node ${{ github.workspace }}/test.js ...
node ${{ github.workspace }}/.github/workflows/commentResult.js ...
+ node ${{ github.workspace }}/.github/workflows/sanityCheck.js ${{ github.workspace }}/output.txt ${{ github.workspace }}/pr-comments ${i}
if grep -q "...ERROR..." output.txt; then exit 1; fi
```

The sanity comment file is named `z-sanity-<timestamp>-<pid>-<slug>.md` so it sorts after the existing TVL summary and reads as a follow-on note in the PR.

## Behaviour preserved

- The existing `ERROR` gate still fails the workflow on a thrown adapter.
- The existing `commentResult.js` output is unchanged.
- A healthy adapter produces zero warnings — verified locally against a real-world adapter (~$659K TVL, all conventions met).
- If the new script itself crashes for any reason (parsing edge case, file system hiccup, etc.) it logs to stderr and exits without affecting the rest of the pipeline.

## Smoke tests run locally

| Scenario | Expected | Result |
|---|---|---|
| Healthy adapter, $659K TVL, methodology present | no warning | ✅ no comment file produced |
| Adapter producing `$0` total | unpriced-tokens warning with hint about `tokenMapping.js` | ✅ |
| Adapter producing `$200B` total | high-TVL warning citing decimals / double-counting / pricing | ✅ |
| Adapter without `methodology` export | reminder to add a methodology string | ✅ |
| Adapter that errored out | suppressed (handled by `commentResult.js`) | ✅ no comment file produced |

## Files

- `.github/workflows/sanityCheck.js` — new (160 LOC)
- `.github/workflows/test.yml` — one-line addition

## Open questions / notes

- The `$50B` upper bound is conservative — well above the largest single-protocol TVL on DefiLlama at the time of writing — but we can dial it higher if a legitimate TVL approaches it.
- The fetch-adapter heuristic looks for `axios` / `node-fetch` + a non-RPC HTTP URL. It's intentionally a heuristic — false positives are possible (e.g. an adapter that imports axios for an RPC node behind a non-standard hostname). The phrasing of the warning makes that clear and asks the contributor to ignore if not applicable.
- The script reads the adapter source file to detect the `methodology` export and the fetch-adapter pattern. For directories, it looks at `index.js`. For single-file adapters, it reads the file directly.
- I could add a TVL spike check (current vs `-1d` vs `-7d`) as a follow-up — it'd add ~60s per adapter via additional `test.js` runs, which is meaningful but bounded. Happy to do that as a separate PR if you'd like.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI pipeline with additional automated validation checks for adapter quality, including TVL bounds validation and missing configuration field detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->