### PR TITLE
feat(wildcat-fi): add Plasma chain deployment

### DIFF
--- a/projects/wildcat-fi/index.js
+++ b/projects/wildcat-fi/index.js
@@ -1,6 +1,7 @@
-// https://wildcat-protocol.gitbook.io/wildcat/technical-deep-dive/contract-deployments
+// https://docs.wildcat.finance/technical-overview/contract-deployments
 const config = {
   ethereum: { archController: '0xfEB516d9D946dD487A9346F6fee11f40C6945eE4', },
+  plasma: { archController: '0xdb2e0DE97d6d96aa56754635704a4273E0F348ae', },
   // sepolia: { archController: '0xC003f20F2642c76B81e5e1620c6D8cdEE826408f', },
 }
 


### PR DESCRIPTION
Wildcat launched on Plasma mainnet (https://docs.wildcat.finance/technical-overview/contract-deployments). The existing adapter already handles all chains generically — this adds the Plasma ArchController address.

**Change:** One line added to `config` in `projects/wildcat-fi/index.js`:
```js
plasma: { archController: '0xdb2e0DE97d6d96aa56754635704a4273E0F348ae' },
```

Address sourced directly from Wildcat's official deployment docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Plasma blockchain network with total value locked (TVL) and borrowed asset tracking functionality.

* **Documentation**
  * Updated documentation reference links to current resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->