### PR TITLE
feat: add Cork Phoenix TVL adapter

### DIFF
--- a/projects/cork-phoenix/index.js
+++ b/projects/cork-phoenix/index.js
@@ -5,12 +5,16 @@ const { getLogs } = require('../helper/cache/getLogs')
 // Contracts: https://github.com/Cork-Technology/phoenix/blob/main/config/prod.toml
 
 const POOL_MANAGER = '0xccCCcCcCCccCfAE2Ee43F0E727A8c2969d74B9eC'
-const FROM_BLOCK = 24238826
+const FROM_BLOCK = 24238826 // history_last_deployment_block (mainnet)
 
+// MarketId is bytes32 — emitted on every new pool creation
 const marketCreatedAbi = 'event MarketCreated(bytes32 indexed poolId, address indexed referenceAsset, address indexed collateralAsset, uint256 expiry, address rateOracle, address principalToken, address swapToken)'
+
+// Returns amounts of CA and REF currently locked in each pool
 const assetsAbi = 'function assets(bytes32 poolId) external view returns (uint256 collateralAssets, uint256 referenceAssets)'
 
 async function tvl(api) {
+  // Discover all pools via MarketCreated events
   const logs = await getLogs({
     api,
     target: POOL_MANAGER,
@@ -21,26 +25,26 @@ async function tvl(api) {
 
   if (!logs.length) return {}
 
+  // Each log gives us poolId (bytes32), collateralAsset, referenceAsset
   const poolIds = logs.map(l => l.poolId)
-  const collateralAssets = logs.map(l => l.collateralAsset)
-  const referenceAssets = logs.map(l => l.referenceAsset)
 
+  // Query locked amounts per pool — pattern: calls = array of single-arg values
   const assetAmounts = await api.multiCall({
     abi: assetsAbi,
-    calls: poolIds.map(id => ({ target: POOL_MANAGER, params: [id] })),
+    target: POOL_MANAGER,
+    calls: poolIds,
   })
 
-  assetAmounts.forEach((data, i) => {
-    if (BigInt(data.collateralAssets) > 0n)
-      api.add(collateralAssets[i], data.collateralAssets)
-    if (BigInt(data.referenceAssets) > 0n)
-      api.add(referenceAssets[i], data.referenceAssets)
+  // Accumulate balances — named destructuring matches string ABI return names
+  assetAmounts.forEach(({ collateralAssets, referenceAssets }, i) => {
+    api.add(logs[i].collateralAsset, collateralAssets)
+    api.add(logs[i].referenceAsset, referenceAssets)
   })
 }
 
 module.exports = {
   doublecounted: true,
-  methodology: 'Sum of collateral assets and reference assets locked across all active Cork Phoenix pools. Collateral assets are deposited by liquidity providers; reference assets accumulate as cST holders exercise their swap rights.',
+  methodology: 'Sum of collateral assets (deposited by LPs) and reference assets (accumulated via cST exercise) locked across all Cork Phoenix pools on the CorkPoolManager contract.',
   hallmarks: [
     ['2025-05-28', 'Cork v1 exploit ($12M) — protocol rebuilt as Phoenix'],
   ],

--- a/projects/cork-phoenix/index.js
+++ b/projects/cork-phoenix/index.js
@@ -1,0 +1,49 @@
+const { getLogs } = require('../helper/cache/getLogs')
+
+// Cork Phoenix (v2) — rebuilt after the May 2025 exploit
+// Docs: https://docs.cork.tech
+// Contracts: https://github.com/Cork-Technology/phoenix/blob/main/config/prod.toml
+
+const POOL_MANAGER = '0xccCCcCcCCccCfAE2Ee43F0E727A8c2969d74B9eC'
+const FROM_BLOCK = 24238826
+
+const marketCreatedAbi = 'event MarketCreated(bytes32 indexed poolId, address indexed referenceAsset, address indexed collateralAsset, uint256 expiry, address rateOracle, address principalToken, address swapToken)'
+const assetsAbi = 'function assets(bytes32 poolId) external view returns (uint256 collateralAssets, uint256 referenceAssets)'
+
+async function tvl(api) {
+  const logs = await getLogs({
+    api,
+    target: POOL_MANAGER,
+    eventAbi: marketCreatedAbi,
+    fromBlock: FROM_BLOCK,
+    onlyArgs: true,
+  })
+
+  if (!logs.length) return {}
+
+  const poolIds = logs.map(l => l.poolId)
+  const collateralAssets = logs.map(l => l.collateralAsset)
+  const referenceAssets = logs.map(l => l.referenceAsset)
+
+  const assetAmounts = await api.multiCall({
+    abi: assetsAbi,
+    calls: poolIds.map(id => ({ target: POOL_MANAGER, params: [id] })),
+  })
+
+  assetAmounts.forEach((data, i) => {
+    if (BigInt(data.collateralAssets) > 0n)
+      api.add(collateralAssets[i], data.collateralAssets)
+    if (BigInt(data.referenceAssets) > 0n)
+      api.add(referenceAssets[i], data.referenceAssets)
+  })
+}
+
+module.exports = {
+  doublecounted: true,
+  methodology: 'Sum of collateral assets and reference assets locked across all active Cork Phoenix pools. Collateral assets are deposited by liquidity providers; reference assets accumulate as cST holders exercise their swap rights.',
+  hallmarks: [
+    ['2025-05-28', 'Cork v1 exploit ($12M) — protocol rebuilt as Phoenix'],
+  ],
+  ethereum: { tvl },
+}
+// node test.js projects/cork-phoenix/index.js

--- a/projects/cork-phoenix/index.js
+++ b/projects/cork-phoenix/index.js
@@ -1,53 +1,37 @@
-const { getLogs } = require('../helper/cache/getLogs')
+const { getLogs2 } = require('../helper/cache/getLogs')
+const { sumTokens2 } = require('../helper/unwrapLPs')
 
 // Cork Phoenix (v2) — rebuilt after the May 2025 exploit
 // Docs: https://docs.cork.tech
 // Contracts: https://github.com/Cork-Technology/phoenix/blob/main/config/prod.toml
 
 const POOL_MANAGER = '0xccCCcCcCCccCfAE2Ee43F0E727A8c2969d74B9eC'
-const FROM_BLOCK = 24238826 // history_last_deployment_block (mainnet)
+const FROM_BLOCK = 24238837 // history_last_deployment_block (mainnet)
 
 // MarketId is bytes32 — emitted on every new pool creation
 const marketCreatedAbi = 'event MarketCreated(bytes32 indexed poolId, address indexed referenceAsset, address indexed collateralAsset, uint256 expiry, address rateOracle, address principalToken, address swapToken)'
 
-// Returns amounts of CA and REF currently locked in each pool
-const assetsAbi = 'function assets(bytes32 poolId) external view returns (uint256 collateralAssets, uint256 referenceAssets)'
-
 async function tvl(api) {
   // Discover all pools via MarketCreated events
-  const logs = await getLogs({
+  const logs = await getLogs2({
     api,
     target: POOL_MANAGER,
     eventAbi: marketCreatedAbi,
     fromBlock: FROM_BLOCK,
-    onlyArgs: true,
   })
 
-  if (!logs.length) return {}
+  const tokenSet = new Set();
 
-  // Each log gives us poolId (bytes32), collateralAsset, referenceAsset
-  const poolIds = logs.map(l => l.poolId)
+  logs.forEach(log => {
+    tokenSet.add(log.referenceAsset)
+    tokenSet.add(log.collateralAsset)
+  });
 
-  // Query locked amounts per pool — pattern: calls = array of single-arg values
-  const assetAmounts = await api.multiCall({
-    abi: assetsAbi,
-    target: POOL_MANAGER,
-    calls: poolIds,
-  })
-
-  // Accumulate balances — named destructuring matches string ABI return names
-  assetAmounts.forEach(({ collateralAssets, referenceAssets }, i) => {
-    api.add(logs[i].collateralAsset, collateralAssets)
-    api.add(logs[i].referenceAsset, referenceAssets)
-  })
+  await sumTokens2({api, tokens: Array.from(tokenSet), owner: POOL_MANAGER});
 }
 
 module.exports = {
   doublecounted: true,
   methodology: 'Sum of collateral assets (deposited by LPs) and reference assets (accumulated via cST exercise) locked across all Cork Phoenix pools on the CorkPoolManager contract.',
-  hallmarks: [
-    ['2025-05-28', 'Cork v1 exploit ($12M) — protocol rebuilt as Phoenix'],
-  ],
   ethereum: { tvl },
 }
-// node test.js projects/cork-phoenix/index.js


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
Cork Phoenix

##### Twitter Link:
https://x.com/Corkprotocol

##### List of audit links if any:
Quantstamp, Cantina, Sherlock (Phoenix audits) — https://docs.cork.tech

##### Website Link:
https://app.cork.tech

##### Logo (High resolution, will be shown with rounded borders):
https://www.cork.tech/favicon.ico

##### Current TVL:
Live on Ethereum mainnet — supply-capped beta, TVL growing

##### Chain:
Ethereum

##### Coingecko ID:

##### Coinmarketcap ID:

##### Short Description (to be shown on DefiLlama):
Cork Phoenix is a programmable risk layer for onchain assets. Users deposit a Collateral Asset to mint cPT (principal token) and cST (swap token). cST holders can swap their Reference Asset for the Collateral Asset at any time before expiry — providing guaranteed redemption liquidity against depeg risk.

##### Category:
Insurance

##### Oracle Provider(s):
Custom rate oracle per market (ConstraintRateAdapter)

##### forkedFrom:
None (original protocol, rebuilt after v1 exploit)

##### methodology:
TVL is the sum of Collateral Assets deposited by LPs and Reference Assets accumulated via cST exercise, queried directly from the CorkPoolManager proxy via `assets(bytes32 poolId)`. Markets are discovered by indexing `MarketCreated` events from the same contract.

##### Github org/user:
https://github.com/Cork-Technology/phoenix

---

**Implementation notes:**
- `CorkPoolManager` proxy: `0xccCCcCcCCccCfAE2Ee43F0E727A8c2969d74B9eC`
- Deployment block: `24238826` (from official [prod.toml](https://github.com/Cork-Technology/phoenix/blob/main/config/prod.toml))
- `doublecounted: true` because CA tokens (e.g. sUSDe) are already counted in their own protocol adapters
- Hallmark added for the May 2025 v1 exploit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Cork Phoenix v2 TVL tracking with automatic pool discovery and collateral aggregation across pools.
  * TVL output is marked as double-counted where applicable.
  * Included a user-facing methodology description for how totals are computed and exposed via the Ethereum adapter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->