### PR TITLE
fix(ssi-protocol): compute TVL from custody balances

### DIFF
--- a/projects/ssi-protocol/index.js
+++ b/projects/ssi-protocol/index.js
@@ -1,5 +1,6 @@
 const { sumTokensExport } = require('../helper/sumTokens')
 const sdk = require('@defillama/sdk')
+const { PublicKey } = require('@solana/web3.js')
 
 const SWAP_CONTRACT = '0x640cB7201810BC920835A598248c4fe4898Bb5e0'
 const TAKER_ADDRESSES_ABI = 'function getTakerAddresses() view returns (string[] receivers, string[] senders)'
@@ -36,11 +37,14 @@ const isBitcoinAddress = address => /^(1|3|bc1)/.test(address)
 const isDogeAddress = address => /^D/.test(address)
 const isRippleAddress = address => /^r/.test(address)
 const isCardanoAddress = address => /^addr/.test(address)
-const isSolanaAddress = address => /^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(address)
-  && !isBitcoinAddress(address)
-  && !isDogeAddress(address)
-  && !isRippleAddress(address)
-  && !isCardanoAddress(address)
+function isSolanaAddress(address) {
+  try {
+    new PublicKey(address)
+    return true
+  } catch {
+    return false
+  }
+}
 
 function normalizeOwner(address) {
   if (isEVMAddress(address)) return address.toLowerCase()

--- a/projects/ssi-protocol/index.js
+++ b/projects/ssi-protocol/index.js
@@ -1,12 +1,8 @@
 const { sumTokensExport } = require('../helper/sumTokens')
+const sdk = require('@defillama/sdk')
 
 const SWAP_CONTRACT = '0x640cB7201810BC920835A598248c4fe4898Bb5e0'
-
-// Custody wallets returned by getTakerAddresses() on SWAP_CONTRACT on Base.
-const EVM_CUSTODY_OWNERS = [
-  '0x605B50f07F46251A7A39fA18C2247FB612f7452F',
-  '0x55ac87E54019fa2e2156a0fAf13176DcdDFA16ce',
-]
+const TAKER_ADDRESSES_ABI = 'function getTakerAddresses() view returns (string[] receivers, string[] senders)'
 
 const ETH_TOKENS = [
   '0x514910771AF9Ca656af840dff83E8264EcF986CA', // LINK
@@ -26,12 +22,6 @@ const BSC_TOKENS = [
   '0xfb5B838b6cfEEdC2873aB27866079AC55363D37E', // FLOKI
 ]
 
-const SOLANA_CUSTODY_OWNERS = [
-  'GQkn3fPeCV4pH1MGZVHsWPpRdq5ENYnaB8GVwSubjkCZ',
-  '8yVXip9eFwdmrbTxPqHsuCvVR5ktBdLGz7S1bUpSx7j6',
-  'CeuKmW1XqgKz4E8JNpZxrysMRsvkEz55qUvm9soqhALY',
-]
-
 const SOLANA_TOKENS = [
   'JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN', // JUP
   'EKpQGSJtjMFqKZ9KQanSqYXRcF8BopzLHYxdM65zcjm', // WIF
@@ -41,31 +31,64 @@ const SOLANA_TOKENS = [
   'pumpCmXqMfrsAkQ5r49WcJnRayYRqmXz6ae8H7H9Dfn', // PUMP
 ]
 
-const SOLANA_TOKENS_AND_OWNERS = SOLANA_TOKENS
-  .map(token => SOLANA_CUSTODY_OWNERS.map(owner => [token, owner]))
-  .flat()
+const isEVMAddress = address => /^0x[0-9a-fA-F]{40}$/.test(address)
+const isBitcoinAddress = address => /^(1|3|bc1)/.test(address)
+const isDogeAddress = address => /^D/.test(address)
+const isRippleAddress = address => /^r/.test(address)
+const isCardanoAddress = address => /^addr/.test(address)
+const isSolanaAddress = address => /^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(address)
+  && !isBitcoinAddress(address)
+  && !isDogeAddress(address)
+  && !isRippleAddress(address)
+  && !isCardanoAddress(address)
+
+async function getTakerAddresses(api) {
+  const baseApi = api.chain === 'base' ? api : new sdk.ChainApi({ chain: 'base', timestamp: api.timestamp })
+  const [receivers] = await baseApi.call({ target: SWAP_CONTRACT, abi: TAKER_ADDRESSES_ABI })
+  return [...new Set(receivers)]
+}
+
+async function getOwners(api, filter) {
+  return (await getTakerAddresses(api)).filter(filter)
+}
+
+async function evmTvl(api, tokens) {
+  const owners = await getOwners(api, isEVMAddress)
+  return sumTokensExport({ owners, tokens })(api)
+}
+
+async function solanaTvl(api) {
+  const owners = await getOwners(api, isSolanaAddress)
+  const tokensAndOwners = SOLANA_TOKENS.map(token => owners.map(owner => [token, owner])).flat()
+  return sumTokensExport({ tokensAndOwners, computeTokenAccount: true, allowError: true })(api)
+}
+
+async function chainTvl(api, filter, normalize = address => address) {
+  const owners = (await getOwners(api, filter)).map(normalize)
+  return sumTokensExport({ owners })(api)
+}
 
 module.exports = {
-  methodology: `TVL counts assets held in SSI protocol custody addresses on each chain. Custody addresses are exposed by the SSI swap contract (${SWAP_CONTRACT}) getTakerAddresses() on Base; basket composition view functions are not used for TVL.`,
+  methodology: `TVL counts assets held in SSI protocol custody addresses on each chain. Custody addresses are fetched from the SSI swap contract (${SWAP_CONTRACT}) getTakerAddresses() on Base; basket composition view functions are not used for TVL.`,
   ethereum: {
-    tvl: sumTokensExport({ owners: EVM_CUSTODY_OWNERS, tokens: ETH_TOKENS }),
+    tvl: api => evmTvl(api, ETH_TOKENS),
   },
   bsc: {
-    tvl: sumTokensExport({ owners: EVM_CUSTODY_OWNERS, tokens: BSC_TOKENS }),
+    tvl: api => evmTvl(api, BSC_TOKENS),
   },
   solana: {
-    tvl: sumTokensExport({ tokensAndOwners: SOLANA_TOKENS_AND_OWNERS, computeTokenAccount: true, allowError: true }),
+    tvl: solanaTvl,
   },
   bitcoin: {
-    tvl: sumTokensExport({ owners: ['1BH4rZH7ptWyjim6fLJDp9t8Jp2DgXiBDM'] }),
+    tvl: api => chainTvl(api, isBitcoinAddress),
   },
   doge: {
-    tvl: sumTokensExport({ owners: ['D5gedqfZm198AyTFVg8NqWFUh8bFTdmKj7', 'DPQ3EbacSG6gdakZmXwMu7qS6SbpRUjY4a'] }),
+    tvl: api => chainTvl(api, isDogeAddress),
   },
   ripple: {
-    tvl: sumTokensExport({ owners: ['rp53vxWXuEe9LL6AHcCtzzAvdtynSL1aVM'] }),
+    tvl: api => chainTvl(api, isRippleAddress, address => address.split(':')[0]),
   },
   cardano: {
-    tvl: sumTokensExport({ owners: ['addr1v9nkv9p0gz83ha7hx0h6pg6lrte0t0dsj8tyersc8np5gegrwwxpp'] }),
+    tvl: api => chainTvl(api, isCardanoAddress),
   },
 }

--- a/projects/ssi-protocol/index.js
+++ b/projects/ssi-protocol/index.js
@@ -42,14 +42,20 @@ const isSolanaAddress = address => /^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(address)
   && !isRippleAddress(address)
   && !isCardanoAddress(address)
 
+function normalizeOwner(address) {
+  if (isEVMAddress(address)) return address.toLowerCase()
+  if (isRippleAddress(address)) return address.split(':')[0]
+  return address
+}
+
 async function getTakerAddresses(api) {
   const baseApi = api.chain === 'base' ? api : new sdk.ChainApi({ chain: 'base', timestamp: api.timestamp })
   const [receivers] = await baseApi.call({ target: SWAP_CONTRACT, abi: TAKER_ADDRESSES_ABI })
-  return [...new Set(receivers)]
+  return receivers
 }
 
 async function getOwners(api, filter) {
-  return (await getTakerAddresses(api)).filter(filter)
+  return [...new Set((await getTakerAddresses(api)).map(normalizeOwner).filter(filter))]
 }
 
 async function evmTvl(api, tokens) {
@@ -63,8 +69,8 @@ async function solanaTvl(api) {
   return sumTokensExport({ tokensAndOwners, computeTokenAccount: true, allowError: true })(api)
 }
 
-async function chainTvl(api, filter, normalize = address => address) {
-  const owners = (await getOwners(api, filter)).map(normalize)
+async function chainTvl(api, filter) {
+  const owners = await getOwners(api, filter)
   return sumTokensExport({ owners })(api)
 }
 
@@ -86,7 +92,7 @@ module.exports = {
     tvl: api => chainTvl(api, isDogeAddress),
   },
   ripple: {
-    tvl: api => chainTvl(api, isRippleAddress, address => address.split(':')[0]),
+    tvl: api => chainTvl(api, isRippleAddress),
   },
   cardano: {
     tvl: api => chainTvl(api, isCardanoAddress),

--- a/projects/ssi-protocol/index.js
+++ b/projects/ssi-protocol/index.js
@@ -1,67 +1,71 @@
-const sdk = require('@defillama/sdk')
-const { getBlock } = require('../helper/http');
+const { sumTokensExport } = require('../helper/sumTokens')
 
-const abi = {
-  getBasket: 'function getBasket() view returns ((string chain, string symbol, string addr, uint8 decimals, uint256 amount)[])'
-}
+const SWAP_CONTRACT = '0x640cB7201810BC920835A598248c4fe4898Bb5e0'
 
-const ssi_tokens = [
-  // MAG7.ssi
-  '0x9E6A46f294bB67c20F1D1E7AfB0bBEf614403B55',
-  // DEFI.ssi
-  '0x164ffdaE2fe3891714bc2968f1875ca4fA1079D0',
-  // MEME.ssi
-  '0xdd3acDBDc7b358Df453a6CB6bCA56C92aA5743aA'
+// Custody wallets returned by getTakerAddresses() on SWAP_CONTRACT on Base.
+const EVM_CUSTODY_OWNERS = [
+  '0x605B50f07F46251A7A39fA18C2247FB612f7452F',
+  '0x55ac87E54019fa2e2156a0fAf13176DcdDFA16ce',
 ]
 
-function underlyingExports(chains) {
-  const exportObj = {};
-  Object.entries(chains).forEach(([chain, [chain_name, native_token]]) => {
-    exportObj[chain] = {
-      tvl: async (api, ethBlock, chainBlocks) => {
-        const balances = {};
-        const base_block = await getBlock(api.timestamp, 'base', chainBlocks);
-        const baskets = await Promise.all(ssi_tokens.map(async (ssi_token) => {
-          const res = await sdk.api.abi.call({
-            abi: abi.getBasket,
-            target: ssi_token,
-            chain: 'base',
-            block: base_block,
-          });
-          return res.output;
-        }));
-        baskets.forEach(basket => {
-          basket.forEach(token => {
-            if (token.chain == chain_name) {
-              let token_addr;
-              let token_amount;
-              if (token.addr != '') {
-                token_addr = chain + ':' + token.addr;
-                token_amount = token.amount;
-              } else {
-                token_addr = native_token;
-                token_amount = token.amount / 10 ** token.decimals;
-              }
-              sdk.util.sumSingleBalance(balances, token_addr, token_amount);
-            }
-          });
-        });
-        return balances;
-      }
-    }
-  });
-  return exportObj;
-}
+const ETH_TOKENS = [
+  '0x514910771AF9Ca656af840dff83E8264EcF986CA', // LINK
+  '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984', // UNI
+  '0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9', // AAVE
+  '0x57e114B691Db790C35207b2e685D4A43181e6061', // ENA
+  '0xfAbA6f8e4a5E8Ab82F62fe7C39859FA577269BE3', // ONDO
+  '0x56072C95FAA701256059aa122697B133aDEd9279', // SKY
+  '0xD533a949740bb3306d119CC777fa900bA034cd52', // CRV
+  '0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE', // SHIB
+  '0x6982508145454Ce325dDbE47a25d4ec3d2311933', // PEPE
+  '0xE0f63A424a4439cBE457D80E4f4b51aD25b2c56C', // SPX
+]
+
+const BSC_TOKENS = [
+  '0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82', // CAKE
+  '0xfb5B838b6cfEEdC2873aB27866079AC55363D37E', // FLOKI
+]
+
+const SOLANA_CUSTODY_OWNERS = [
+  'GQkn3fPeCV4pH1MGZVHsWPpRdq5ENYnaB8GVwSubjkCZ',
+  '8yVXip9eFwdmrbTxPqHsuCvVR5ktBdLGz7S1bUpSx7j6',
+  'CeuKmW1XqgKz4E8JNpZxrysMRsvkEz55qUvm9soqhALY',
+]
+
+const SOLANA_TOKENS = [
+  'JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN', // JUP
+  'EKpQGSJtjMFqKZ9KQanSqYXRcF8BopzLHYxdM65zcjm', // WIF
+  'DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263', // BONK
+  '6p6xgHyF7AeE6TZkSmFsko444wqoP15icUSqi2jfGiPN', // TRUMP
+  '2zMMhcVQEXDtdE6vsFS7S7D5oUodfJHE8vd1gnBouauv', // PENGU
+  'pumpCmXqMfrsAkQ5r49WcJnRayYRqmXz6ae8H7H9Dfn', // PUMP
+]
+
+const SOLANA_TOKENS_AND_OWNERS = SOLANA_TOKENS
+  .map(token => SOLANA_CUSTODY_OWNERS.map(owner => [token, owner]))
+  .flat()
 
 module.exports = {
-  methodology: 'TVL counts the underlying tokens in the baskets of the SSI tokens.',
-  ...underlyingExports({
-    ethereum: ['ETH', 'ethereum'],
-    bsc: ['BSC_BNB', 'binancecoin'],
-    doge: ['DOGE', 'dogecoin'],
-    solana: ['SOL', 'solana'],
-    bitcoin: ['BTC', 'bitcoin'],
-    cardano: ['ADA', 'cardano'],
-    ripple: ['XRP', 'ripple'],
-  })
-};
+  methodology: `TVL counts assets held in SSI protocol custody addresses on each chain. Custody addresses are exposed by the SSI swap contract (${SWAP_CONTRACT}) getTakerAddresses() on Base; basket composition view functions are not used for TVL.`,
+  ethereum: {
+    tvl: sumTokensExport({ owners: EVM_CUSTODY_OWNERS, tokens: ETH_TOKENS }),
+  },
+  bsc: {
+    tvl: sumTokensExport({ owners: EVM_CUSTODY_OWNERS, tokens: BSC_TOKENS }),
+  },
+  solana: {
+    tvl: sumTokensExport({ tokensAndOwners: SOLANA_TOKENS_AND_OWNERS, computeTokenAccount: true, allowError: true }),
+  },
+  bitcoin: {
+    tvl: sumTokensExport({ owners: ['1BH4rZH7ptWyjim6fLJDp9t8Jp2DgXiBDM'] }),
+  },
+  doge: {
+    tvl: sumTokensExport({ owners: ['D5gedqfZm198AyTFVg8NqWFUh8bFTdmKj7', 'DPQ3EbacSG6gdakZmXwMu7qS6SbpRUjY4a'] }),
+  },
+  ripple: {
+    tvl: sumTokensExport({ owners: ['rp53vxWXuEe9LL6AHcCtzzAvdtynSL1aVM'] }),
+  },
+  cardano: {
+    tvl: sumTokensExport({ owners: ['addr1v9nkv9p0gz83ha7hx0h6pg6lrte0t0dsj8tyersc8np5gegrwwxpp'] }),
+  },
+}


### PR DESCRIPTION
Fixes #17720

  ## Summary

  Updates the existing SSI Protocol adapter to compute TVL from custody wallet balances instead of SSI basket composition view functions.

  The previous adapter used `getBasket()` on the SSI index token contracts, which reports basket accounting. PR #18375 moved to `getTokenset() * totalSupply`, but that still used view-returned
  accounting data rather than querying custodian balances on-chain.

  This change uses the custody addresses returned by `getTakerAddresses()` on the SSI swap contract on Base:

  `0x640cB7201810BC920835A598248c4fe4898Bb5e0`

  Then it sums the actual assets held by those custody wallets across the supported chains.

  ## Methodology

  TVL counts assets held in SSI Protocol custody addresses on each chain. Custody addresses are exposed by the SSI swap contract `getTakerAddresses()` on Base. Basket composition view functions such as
  `getBasket()` / `getTokenset()` are not used for TVL.

  ## Chains / Assets

  - Ethereum: LINK, UNI, AAVE, ENA, ONDO, SKY, CRV, SHIB, PEPE, SPX
  - BSC: CAKE, FLOKI
  - Solana: JUP, WIF, BONK, TRUMP, PENGU, PUMP
  - Bitcoin, Dogecoin, XRP, Cardano custody addresses

  ## Testing

  ```bash
  node test.js projects/ssi-protocol/index.js
  node test.js projects/ssi-protocol/index.js 2026-04-28
  npx eslint -c eslint.config.js projects/ssi-protocol/index.js
  git diff --check

  Latest local output:

  ethereum                  4.86 M
  doge                      391.70 k
  solana                    239.38 k
  bsc                       154.39 k
  ripple                    278.00
  cardano                   0.00
  bitcoin                   0.00

  total                     5.65 M
```

  ## Notes

  - Existing adapter fix, not a new listing.
  - No new npm dependencies.
  - No lockfile changes.
  - No volume/fees/revenue adapter changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TVL accuracy by aggregating balances from custody/taker addresses across Ethereum, BSC, Solana, Bitcoin, Dogecoin, Ripple and Cardano.

* **New Features**
  * Added explicit per-chain TVL reporting for Ethereum, BSC, Solana, Bitcoin, Dogecoin, Ripple and Cardano.
  * Expanded token coverage on Ethereum, BSC and Solana with per-chain allowlists and more tolerant token-account handling.

* **Refactor**
  * Updated methodology to reflect custody-address-based TVL calculation and clarified per-chain handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->