### PR TITLE
fix(ssi-protocol): query custody owners on-chain for TVL

### DIFF
--- a/projects/ssi-protocol/index.js
+++ b/projects/ssi-protocol/index.js
@@ -1,7 +1,17 @@
+const sdk = require('@defillama/sdk')
 const { sumTokens } = require('../helper/sumTokens')
 
 const SWAP_CONTRACT = '0x640cB7201810BC920835A598248c4fe4898Bb5e0'
-const takerAbi = 'function getTakerAddresses() view returns (string[] receivers, string[] senders)'
+const takerAbi = {
+  name: 'getTakerAddresses',
+  type: 'function',
+  stateMutability: 'view',
+  inputs: [],
+  outputs: [
+    { name: 'receivers', type: 'string[]' },
+    { name: 'senders', type: 'string[]' },
+  ],
+}
 
 const ETH_TOKENS = [
   '0x514910771AF9Ca656af840dff83E8264EcF986CA',
@@ -34,7 +44,8 @@ const custodyCache = {}
 
 async function getCustodyOwners(api) {
   if (custodyCache[api.timestamp]) return custodyCache[api.timestamp]
-  const { receivers = [], senders = [] } = await api.call({ target: SWAP_CONTRACT, chain: 'base', abi: takerAbi })
+  const output = await sdk.api.abi.call({ target: SWAP_CONTRACT, chain: 'base', abi: takerAbi })
+  const [receivers = [], senders = []] = output?.output ?? []
   const values = [...receivers, ...senders].filter(Boolean)
   const unique = [...new Set(values)]
 

--- a/projects/ssi-protocol/index.js
+++ b/projects/ssi-protocol/index.js
@@ -1,67 +1,111 @@
-const sdk = require('@defillama/sdk')
-const { getBlock } = require('../helper/http');
+const { sumTokens } = require('../helper/sumTokens')
 
-const abi = {
-  getBasket: 'function getBasket() view returns ((string chain, string symbol, string addr, uint8 decimals, uint256 amount)[])'
-}
+const SWAP_CONTRACT = '0x640cB7201810BC920835A598248c4fe4898Bb5e0'
+const takerAbi = 'function getTakerAddresses() view returns (string[] receivers, string[] senders)'
 
-const ssi_tokens = [
-  // MAG7.ssi
-  '0x9E6A46f294bB67c20F1D1E7AfB0bBEf614403B55',
-  // DEFI.ssi
-  '0x164ffdaE2fe3891714bc2968f1875ca4fA1079D0',
-  // MEME.ssi
-  '0xdd3acDBDc7b358Df453a6CB6bCA56C92aA5743aA'
+const ETH_TOKENS = [
+  '0x514910771AF9Ca656af840dff83E8264EcF986CA',
+  '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984',
+  '0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9',
+  '0x57e114B691Db790C35207b2e685D4A43181e6061',
+  '0xfAbA6f8e4a5E8Ab82F62fe7C39859FA577269BE3',
+  '0x56072C95FAA701256059aa122697B133aDEd9279',
+  '0xD533a949740bb3306d119CC777fa900bA034cd52',
+  '0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE',
+  '0x6982508145454Ce325dDbE47a25d4ec3d2311933',
+  '0xE0f63A424a4439cBE457D80E4f4b51aD25b2c56C',
 ]
 
-function underlyingExports(chains) {
-  const exportObj = {};
-  Object.entries(chains).forEach(([chain, [chain_name, native_token]]) => {
-    exportObj[chain] = {
-      tvl: async (api, ethBlock, chainBlocks) => {
-        const balances = {};
-        const base_block = await getBlock(api.timestamp, 'base', chainBlocks);
-        const baskets = await Promise.all(ssi_tokens.map(async (ssi_token) => {
-          const res = await sdk.api.abi.call({
-            abi: abi.getBasket,
-            target: ssi_token,
-            chain: 'base',
-            block: base_block,
-          });
-          return res.output;
-        }));
-        baskets.forEach(basket => {
-          basket.forEach(token => {
-            if (token.chain == chain_name) {
-              let token_addr;
-              let token_amount;
-              if (token.addr != '') {
-                token_addr = chain + ':' + token.addr;
-                token_amount = token.amount;
-              } else {
-                token_addr = native_token;
-                token_amount = token.amount / 10 ** token.decimals;
-              }
-              sdk.util.sumSingleBalance(balances, token_addr, token_amount);
-            }
-          });
-        });
-        return balances;
-      }
-    }
-  });
-  return exportObj;
+const BSC_TOKENS = [
+  '0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82',
+  '0xfb5B838b6cfEEdC2873aB27866079AC55363D37E',
+]
+
+const SOLANA_TOKENS = [
+  'JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN',
+  'EKpQGSJtjMFqKZ9KQanSqYXRcF8BopzLHYxdM65zcjm',
+  'DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263',
+  '6p6xgHyF7AeE6TZkSmFsko444wqoP15icUSqi2jfGiPN',
+  '2zMMhcVQEXDtdE6vsFS7S7D5oUodfJHE8vd1gnBouauv',
+  'pumpCmXqMfrsAkQ5r49WcJnRayYRqmXz6ae8H7H9Dfn',
+]
+
+const custodyCache = {}
+
+async function getCustodyOwners(api) {
+  if (custodyCache[api.timestamp]) return custodyCache[api.timestamp]
+  const { receivers = [], senders = [] } = await api.call({ target: SWAP_CONTRACT, chain: 'base', abi: takerAbi })
+  const values = [...receivers, ...senders].filter(Boolean)
+  const unique = [...new Set(values)]
+
+  const owners = {
+    evm: [],
+    solana: [],
+    bitcoin: [],
+    doge: [],
+    ripple: [],
+    cardano: [],
+  }
+
+  unique.forEach((owner) => {
+    const value = owner.trim()
+    if (!value) return
+    if (/^0x[a-fA-F0-9]{40}$/.test(value)) return owners.evm.push(value)
+    if (value.startsWith('addr1')) return owners.cardano.push(value)
+    if (value.startsWith('rp')) return owners.ripple.push(value.split(':')[0])
+    if (value.startsWith('D')) return owners.doge.push(value)
+    if (value.startsWith('1') || value.startsWith('bc1')) return owners.bitcoin.push(value)
+    owners.solana.push(value)
+  })
+
+  Object.keys(owners).forEach(k => owners[k] = [...new Set(owners[k])])
+  custodyCache[api.timestamp] = owners
+  return owners
+}
+
+async function tvlEthereum(api) {
+  const { evm } = await getCustodyOwners(api)
+  return sumTokens({ api, chain: 'ethereum', owners: evm, tokens: ETH_TOKENS })
+}
+
+async function tvlBsc(api) {
+  const { evm } = await getCustodyOwners(api)
+  return sumTokens({ api, chain: 'bsc', owners: evm, tokens: BSC_TOKENS })
+}
+
+async function tvlSolana(api) {
+  const { solana } = await getCustodyOwners(api)
+  const tokensAndOwners = SOLANA_TOKENS.map(token => solana.map(owner => [token, owner])).flat()
+  return sumTokens({ api, chain: 'solana', tokensAndOwners, computeTokenAccount: true, allowError: true })
+}
+
+async function tvlBitcoin(api) {
+  const { bitcoin } = await getCustodyOwners(api)
+  return sumTokens({ api, chain: 'bitcoin', owners: bitcoin })
+}
+
+async function tvlDoge(api) {
+  const { doge } = await getCustodyOwners(api)
+  return sumTokens({ api, chain: 'doge', owners: doge })
+}
+
+async function tvlRipple(api) {
+  const { ripple } = await getCustodyOwners(api)
+  return sumTokens({ api, chain: 'ripple', owners: ripple })
+}
+
+async function tvlCardano(api) {
+  const { cardano } = await getCustodyOwners(api)
+  return sumTokens({ api, chain: 'cardano', owners: cardano })
 }
 
 module.exports = {
-  methodology: 'TVL counts the underlying tokens in the baskets of the SSI tokens.',
-  ...underlyingExports({
-    ethereum: ['ETH', 'ethereum'],
-    bsc: ['BSC_BNB', 'binancecoin'],
-    doge: ['DOGE', 'dogecoin'],
-    solana: ['SOL', 'solana'],
-    bitcoin: ['BTC', 'bitcoin'],
-    cardano: ['ADA', 'cardano'],
-    ripple: ['XRP', 'ripple'],
-  })
-};
+  methodology: `TVL counts assets held in SSI custody addresses queried dynamically from getTakerAddresses() on swap contract ${SWAP_CONTRACT}. Basket view functions are not used.`,
+  ethereum: { tvl: tvlEthereum },
+  bsc: { tvl: tvlBsc },
+  solana: { tvl: tvlSolana },
+  bitcoin: { tvl: tvlBitcoin },
+  doge: { tvl: tvlDoge },
+  ripple: { tvl: tvlRipple },
+  cardano: { tvl: tvlCardano },
+}


### PR DESCRIPTION
Fixes #17720 

## Summary
- replace basket-view based TVL accounting with custody-balance based accounting in `projects/ssi-protocol/index.js`
- fetch custody owners dynamically at runtime from `getTakerAddresses()` on the SSI swap contract (`0x640cB7201810BC920835A598248c4fe4898Bb5e0`) instead of hardcoding owner arrays
- normalize returned string addresses into per-chain owner sets (evm/solana/bitcoin/doge/ripple/cardano) and sum chain balances from those source custody wallets

## Test plan
- [x] `pnpm exec eslint projects/ssi-protocol/index.js`
- [ ] `node test.js projects/ssi-protocol/index.js` (local environment currently missing `rpc-websockets/dist/lib/client` via solana dependency path)
- [x] sanity-checked live return shape of `getTakerAddresses()` using Base RPC (returns `string[] receivers, string[] senders`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated Total Value Locked (TVL) calculation methodology across all supported blockchain networks (Ethereum, BSC, Solana, Bitcoin, Doge, Ripple, and Cardano) for improved accuracy and consistency in asset value tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->