### PR TITLE
feat: add TVL adapter for Token Mill (Solana + Avalanche)

### DIFF
--- a/projects/token-mill/index.js
+++ b/projects/token-mill/index.js
@@ -1,0 +1,60 @@
+const { getConnection, sumTokens2, getAssociatedTokenAddress } = require('../helper/solana')
+const { sumTokens2: evmSumTokens } = require('../helper/unwrapLPs')
+const { PublicKey } = require('@solana/web3.js')
+
+const SOLANA_PROGRAM = 'JoeaRXgtME3jAoz5WuFXGEndfv4NPH9nBxsLq44hk9J'
+const AVAX_FACTORY = '0x501ee2D4AA611C906F785e10cC868e145183FCE4'
+
+// Token Mill Solana market account layout (368 bytes):
+//   offset  0 -  7: Anchor discriminator
+//   offset  8 - 39: config account (factory-owned)
+//   offset 40 - 71: creator pubkey
+//   offset 72 -103: base token mint
+//   offset 104-135: quote token mint
+// Each market PDA owns two ATAs: ATA(market, base_mint) and ATA(market, quote_mint)
+async function solanaTvl(api) {
+  const connection = getConnection()
+  const programId = new PublicKey(SOLANA_PROGRAM)
+
+  const markets = await connection.getProgramAccounts(programId, {
+    filters: [{ dataSize: 368 }],
+  })
+
+  const tokenAccounts = []
+  for (const { pubkey, account } of markets) {
+    const data = account.data
+    const baseMint = new PublicKey(data.slice(72, 104))
+    const quoteMint = new PublicKey(data.slice(104, 136))
+    tokenAccounts.push(getAssociatedTokenAddress(baseMint, pubkey).toString())
+    tokenAccounts.push(getAssociatedTokenAddress(quoteMint, pubkey).toString())
+  }
+
+  return sumTokens2({ tokenAccounts, api, allowError: true })
+}
+
+async function avalancheTvl(api) {
+  const markets = await api.fetchList({
+    target: AVAX_FACTORY,
+    itemAbi: 'function getMarketAt(uint256) view returns (address)',
+    lengthAbi: 'function getMarketsLength() view returns (uint256)',
+  })
+
+  const [baseTokens, quoteTokens] = await Promise.all([
+    api.multiCall({ abi: 'function getBaseToken() view returns (address)', calls: markets }),
+    api.multiCall({ abi: 'function getQuoteToken() view returns (address)', calls: markets }),
+  ])
+
+  const tokensAndOwners = []
+  markets.forEach((market, i) => {
+    tokensAndOwners.push([baseTokens[i], market])
+    tokensAndOwners.push([quoteTokens[i], market])
+  })
+
+  return evmSumTokens({ api, tokensAndOwners })
+}
+
+module.exports = {
+  methodology: 'Token balances held in all Token Mill market vaults across Solana and Avalanche.',
+  solana: { tvl: solanaTvl },
+  avax: { tvl: avalancheTvl },
+}


### PR DESCRIPTION
Closes #13031

Adds a TVL adapter for Token Mill, a permissionless market-making DEX by Trader Joe on Solana and Avalanche.

**Chains covered:** Solana, Avalanche

**How TVL is calculated:**
- Solana: `getProgramAccounts` on factory program filtered by 368-byte market accounts. Base mint at offset 72, quote mint at offset 104. Vault addresses are ATAs derived from `(market_pda, mint)` — confirmed on-chain via `getTokenAccountsByOwner`. Balances summed with `allowError: true` to skip uninitialised vaults on newly listed markets.
- Avalanche: `getMarketsLength()` + `getMarketAt(uint256)` enumerates all markets from the factory proxy. `getBaseToken()` + `getQuoteToken()` per market, balances summed via `sumTokens2` from `helper/unwrapLPs`.

**Helpers used:** `../helper/solana` (`getConnection`, `sumTokens2`, `getAssociatedTokenAddress`), `../helper/unwrapLPs` (`sumTokens2`)

**Test output:**
```
--- solana ---
SOL   28.31k
--- avax ---
WAVAX 42.14k
total 70.44k
```

**Reviewer notes:**
- ABI names confirmed by keccak256 selector matching against live RPC on the implementation at `0xbaa2d7d2c903afdca72ce8ead3d99071964364e5`.
- Solana layout offsets verified: ATA derivation offline matches `getTokenAccountsByOwner` output on a live market PDA.
- `allowError: true` required as new markets may not have vaults initialised yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Token Mill TVL calculations across Solana and Avalanche networks
  * Aggregates token balances from Token Mill market vaults across both blockchains

<!-- end of auto-generated comment: release notes by coderabbit.ai -->