### PR TITLE
Add Morpheus builders TVL

### DIFF
--- a/projects/morpheusai/index.js
+++ b/projects/morpheusai/index.js
@@ -2,7 +2,18 @@ const ADDRESSES = require('../helper/coreAssets.json')
 const PROJECT_CONTRACT = '0x47176B2Af9885dC6C4575d4eFd63895f7Aaa4790';
 const PROJECT_CONTRACT_V2 = '0xDf1AC1AC255d91F5f4B1E3B4Aef57c5350F64C7A';
 
-async function tvl(api) {
+const builderContracts = {
+  arbitrum: {
+    token: '0x092bAaDB7DEf4C3981454dD9c0A0D7FF07bCFc86',
+    owner: '0xC0eD68f163d44B6e9985F0041fDf6f67c6BCFF3f',
+  },
+  base: {
+    token: '0x7431aDa8a591C955a994a21710752EF9b882b8e3',
+    owner: '0x42BB446eAE6dca7723a9eBdb81EA88aFe77eF4B9',
+  },
+}
+
+async function ethereumTvl(api) {
   const v2Deployment = +new Date('2025-09-17') / 1e3
   if (api.timestamp < v2Deployment) {
     return api.sumTokens({ owner: PROJECT_CONTRACT, tokens: [ADDRESSES.ethereum.STETH] })
@@ -18,6 +29,8 @@ async function tvl(api) {
 
 }
 
+const buildersTvl = ({ token, owner }) => async (api) => api.sumTokens({ owner, tokens: [token], permitFailure: true })
+
 const abi = {
   "getAllATokens": "function getAllATokens() view returns ((string symbol, address tokenAddress)[])",
   "getAllReservesTokens": "function getAllReservesTokens() view returns ((string symbol, address tokenAddress)[])",
@@ -26,9 +39,11 @@ const abi = {
 module.exports = {
   timetravel: true,
   misrepresentedTokens: false,
-  methodology: 'Calculates TVL based on stETH deposits in the project contract.',
+  methodology: 'Counts stETH/Aave deposits in Morpheus capital contracts on Ethereum and MOR deposits in the Builders contracts on Arbitrum and Base.',
   start: '2024-02-08',  // Feb-08-2024 07:33:35 AM UTC in Unix timestamp
-  ethereum: { tvl },
+  ethereum: { tvl: ethereumTvl },
+  arbitrum: { tvl: buildersTvl(builderContracts.arbitrum) },
+  base: { tvl: buildersTvl(builderContracts.base) },
   hallmarks: [
     ['2024-04-06', "MOR token launch"],  // May-08-2024 12:00:00 AM UTC in Unix timestamp
   ],


### PR DESCRIPTION
Adds missing Morpheus Builders TVL from issue #18908.

Changes:
- Counts MOR deposited in the Arbitrum Builders contract.
- Counts MOR deposited in the Base Builders contract, since the same Builders protocol is deployed there.
- Keeps existing Ethereum capital-provider TVL logic intact.
- Renames the project folder to lowercase so `node test.js` can run this adapter directly.

Tested:
```
node test.js projects/morpheusai/index.js
```

Current output includes Arbitrum (~$579.6k), Base (~$2.20M), and Ethereum (~$14.16M).

Please enable "Allow edits by maintainers" if GitHub does not keep it enabled by default.