### PR TITLE
fix(exotic-markets): tolerate Solana RPC throttling

### DIFF
--- a/projects/exotic-markets/index.js
+++ b/projects/exotic-markets/index.js
@@ -2,17 +2,48 @@
 
 const { getProvider, sumTokens2 } = require('../helper/solana')
 const { PublicKey } = require('@solana/web3.js')
+const { sleep } = require('../helper/utils')
 const snapshot = require('./vaults.json')
 
 // ---- Config ----
 const PROGRAM_ID = new PublicKey('exomt54Csh4fvkUiyV5h6bjNqxDqLdpgHJmLd4eqynk')
 const TOKEN_PROG = new PublicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA')
+const MAX_TAIL_LIMIT = 200
+const RATE_LIMIT_RETRIES = 2
+const SPL_ACCOUNT_CHUNK_SIZE = 50
 // scan this many recent signatures each run (tunable via env)
-const TAIL_LIMIT = Number(process.env.TAIL_LIMIT || 0)
+const TAIL_LIMIT = getTailLimit()
 // ----------------
+
+function getTailLimit() {
+  const rawLimit = process.env.TAIL_LIMIT
+  if (!rawLimit) return 0
+
+  const parsedLimit = Number.parseInt(rawLimit, 10)
+  if (!Number.isFinite(parsedLimit) || parsedLimit <= 0) return 0
+
+  return Math.min(parsedLimit, MAX_TAIL_LIMIT)
+}
 
 function isRateLimitError(error) {
   return /429|too many requests/i.test(error?.message || String(error))
+}
+
+async function getMultipleAccountsInfo(conn, publicKeys, { allowRateLimitSkip = false } = {}) {
+  for (let attempt = 0; attempt <= RATE_LIMIT_RETRIES; attempt++) {
+    try {
+      return conn.getMultipleAccountsInfo(publicKeys)
+    } catch (error) {
+      if (!isRateLimitError(error)) throw error
+      if (attempt === RATE_LIMIT_RETRIES) {
+        if (allowRateLimitSkip) return []
+        throw error
+      }
+      await sleep(500 * (attempt + 1))
+    }
+  }
+
+  return []
 }
 
 function keyAt(msg, i) {
@@ -64,22 +95,15 @@ async function getTailCandidates(conn) {
   return [...seen]
 }
 
-async function filterToSplTokenAccounts(conn, addrs) {
+async function filterToSplTokenAccounts(conn, addrs, options) {
   if (!addrs.length) return []
   // Use owner + data length to verify “is SPL token account” quickly
 
   const out = []
-  const CHUNK_SIZE = 50
 
-  for (let i = 0; i < addrs.length; i += CHUNK_SIZE) {
-    const chunk = addrs.slice(i, i + CHUNK_SIZE)
-    let infos
-    try {
-      infos = await conn.getMultipleAccountsInfo(chunk.map(a => new PublicKey(a)))
-    } catch (error) {
-      if (isRateLimitError(error)) continue
-      throw error
-    }
+  for (let i = 0; i < addrs.length; i += SPL_ACCOUNT_CHUNK_SIZE) {
+    const chunk = addrs.slice(i, i + SPL_ACCOUNT_CHUNK_SIZE)
+    const infos = await getMultipleAccountsInfo(conn, chunk.map(a => new PublicKey(a)), options)
 
     for (let j = 0; j < infos.length; j++) {
       const info = infos[j]
@@ -97,8 +121,9 @@ async function tvl() {
 
   const base = snapshot.tokenAccounts || []
   const tailCandidates = await getTailCandidates(connection)
-  const candidates = [...new Set([...base, ...tailCandidates])]
-  const tokenAccounts = await filterToSplTokenAccounts(connection, candidates)
+  const baseAccounts = await filterToSplTokenAccounts(connection, base)
+  const tailAccounts = await filterToSplTokenAccounts(connection, tailCandidates, { allowRateLimitSkip: true })
+  const tokenAccounts = [...new Set([...baseAccounts, ...tailAccounts])]
 
   return sumTokens2({ tokenAccounts })
 }

--- a/projects/exotic-markets/index.js
+++ b/projects/exotic-markets/index.js
@@ -32,7 +32,7 @@ function isRateLimitError(error) {
 async function getMultipleAccountsInfo(conn, publicKeys, { allowRateLimitSkip = false } = {}) {
   for (let attempt = 0; attempt <= RATE_LIMIT_RETRIES; attempt++) {
     try {
-      return conn.getMultipleAccountsInfo(publicKeys)
+      return await conn.getMultipleAccountsInfo(publicKeys)
     } catch (error) {
       if (!isRateLimitError(error)) throw error
       if (attempt === RATE_LIMIT_RETRIES) {

--- a/projects/exotic-markets/index.js
+++ b/projects/exotic-markets/index.js
@@ -18,8 +18,9 @@ const TAIL_LIMIT = getTailLimit()
 function getTailLimit() {
   const rawLimit = process.env.TAIL_LIMIT
   if (!rawLimit) return 0
+  if (!/^\d+$/.test(rawLimit)) return 0
 
-  const parsedLimit = Number.parseInt(rawLimit, 10)
+  const parsedLimit = Number(rawLimit)
   if (!Number.isFinite(parsedLimit) || parsedLimit <= 0) return 0
 
   return Math.min(parsedLimit, MAX_TAIL_LIMIT)

--- a/projects/exotic-markets/index.js
+++ b/projects/exotic-markets/index.js
@@ -42,8 +42,6 @@ async function getMultipleAccountsInfo(conn, publicKeys, { allowRateLimitSkip = 
       await sleep(500 * (attempt + 1))
     }
   }
-
-  return []
 }
 
 function keyAt(msg, i) {
@@ -97,7 +95,7 @@ async function getTailCandidates(conn) {
 
 async function filterToSplTokenAccounts(conn, addrs, options) {
   if (!addrs.length) return []
-  // Use owner + data length to verify “is SPL token account” quickly
+  // Use owner + data length to verify SPL token accounts quickly.
 
   const out = []
 

--- a/projects/exotic-markets/index.js
+++ b/projects/exotic-markets/index.js
@@ -18,9 +18,10 @@ const TAIL_LIMIT = getTailLimit()
 function getTailLimit() {
   const rawLimit = process.env.TAIL_LIMIT
   if (!rawLimit) return 0
-  if (!/^\d+$/.test(rawLimit)) return 0
+  const normalizedLimit = rawLimit.trim()
+  if (!/^\d+$/.test(normalizedLimit)) return 0
 
-  const parsedLimit = Number(rawLimit)
+  const parsedLimit = Number(normalizedLimit)
   if (!Number.isFinite(parsedLimit) || parsedLimit <= 0) return 0
 
   return Math.min(parsedLimit, MAX_TAIL_LIMIT)

--- a/projects/exotic-markets/index.js
+++ b/projects/exotic-markets/index.js
@@ -8,8 +8,12 @@ const snapshot = require('./vaults.json')
 const PROGRAM_ID = new PublicKey('exomt54Csh4fvkUiyV5h6bjNqxDqLdpgHJmLd4eqynk')
 const TOKEN_PROG = new PublicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA')
 // scan this many recent signatures each run (tunable via env)
-const TAIL_LIMIT = Number(process.env.TAIL_LIMIT || 200)
+const TAIL_LIMIT = Number(process.env.TAIL_LIMIT || 0)
 // ----------------
+
+function isRateLimitError(error) {
+  return /429|too many requests/i.test(error?.message || String(error))
+}
 
 function keyAt(msg, i) {
   const k = msg.accountKeys?.[i]
@@ -17,15 +21,29 @@ function keyAt(msg, i) {
 }
 
 async function getTailCandidates(conn) {
+  if (TAIL_LIMIT <= 0) return []
+
   // Fetch most-recent program txs
-  const sigs = await conn.getSignaturesForAddress(PROGRAM_ID, { limit: TAIL_LIMIT })
+  let sigs
+  try {
+    sigs = await conn.getSignaturesForAddress(PROGRAM_ID, { limit: TAIL_LIMIT })
+  } catch (error) {
+    if (isRateLimitError(error)) return []
+    throw error
+  }
   const seen = new Set()
 
   // Very cheap heuristics:
   //  - include every token account appearing in postTokenBalances (actually received/held tokens)
   //  - include initializeAccount* targets from Token Program CPIs (new vaults created)
   for (const s of sigs) {
-    const tx = await conn.getTransaction(s.signature, { maxSupportedTransactionVersion: 0 })
+    let tx
+    try {
+      tx = await conn.getTransaction(s.signature, { maxSupportedTransactionVersion: 0 })
+    } catch (error) {
+      if (isRateLimitError(error)) break
+      continue
+    }
     if (!tx?.meta) continue
     const msg = tx.transaction.message
 
@@ -51,11 +69,17 @@ async function filterToSplTokenAccounts(conn, addrs) {
   // Use owner + data length to verify “is SPL token account” quickly
 
   const out = []
-  const CHUNK_SIZE = 100
+  const CHUNK_SIZE = 50
 
   for (let i = 0; i < addrs.length; i += CHUNK_SIZE) {
     const chunk = addrs.slice(i, i + CHUNK_SIZE)
-    const infos = await conn.getMultipleAccountsInfo(chunk.map(a => new PublicKey(a)))
+    let infos
+    try {
+      infos = await conn.getMultipleAccountsInfo(chunk.map(a => new PublicKey(a)))
+    } catch (error) {
+      if (isRateLimitError(error)) continue
+      throw error
+    }
 
     for (let j = 0; j < infos.length; j++) {
       const info = infos[j]
@@ -82,5 +106,5 @@ async function tvl() {
 module.exports = {
   timetravel: false, // discovery uses recent live txs
   solana: { tvl },
-  methodology: 'Sums balances of snapshot vault SPL token accounts and unions a small live scan of recent program transactions to discover newly created/funded vaults. The snapshot is updated weekly via a separate process.',
+  methodology: 'Sums balances of snapshot vault SPL token accounts and can union an optional best-effort live scan of recent program transactions to discover newly created/funded vaults. The snapshot is updated weekly via a separate process.',
 }


### PR DESCRIPTION
Closes #16663

## Context

Follow-up for Exotic Markets tracking from #16663. The adapter had two reliability problems:

- The default recent-transaction scan could hit Solana RPC 429s before TVL was calculated.
- Closed snapshot token accounts could make `sumTokens2` abort with `Invalid account`.

This is not a new listing PR; it is a reliability fix for the existing Exotic Markets adapter.

## Changes

- Make recent transaction discovery opt-in with `TAIL_LIMIT` instead of scanning 200 signatures by default.
- Parse, trim, validate, and clamp `TAIL_LIMIT` so RPC calls never receive `NaN`, partial numbers, or invalid limits.
- Validate snapshot accounts as SPL token accounts before summing, so closed accounts are ignored.
- Keep snapshot validation strict after bounded retries to avoid silently undercounting TVL.
- Treat rate limits during optional tail discovery as non-fatal.

## Tests

```bash
node -c projects/exotic-markets/index.js
node test.js projects/exotic-markets/index.js
TAIL_LIMIT=2 node test.js projects/exotic-markets/index.js
TAIL_LIMIT=abc node test.js projects/exotic-markets/index.js
TAIL_LIMIT=200foo node test.js projects/exotic-markets/index.js
TAIL_LIMIT=' 2 ' node test.js projects/exotic-markets/index.js
```