### PR TITLE
Add Pharos support and RPC configurations for r25

### DIFF
--- a/projects/helper/chains.json
+++ b/projects/helper/chains.json
@@ -336,6 +336,7 @@
   "persistence",
   "pg",
   "pgn",
+  "pharos",
   "planq",
   "plasma",
   "plume",

--- a/projects/helper/env.js
+++ b/projects/helper/env.js
@@ -49,6 +49,7 @@ const DEFAULTS = {
   PROPTECH_RPC: "https://mainnet.ptekcoin.com",
   WHITELISTED_MORPH_RPC: 'https://explorer.morphl2.io/api/eth-rpc',
   BCYPHER_RPC: "https://mainapi.bchscan.io,https://datahub-asia01.bchscan.io,https://datahub-asia02.bchscan.io",
+  PHAROS_RPC_MULTICALL: "0xca11bde05977b3631167028862be2a173976ca11",  // v3
 }
 
 const ENV_KEYS = [

--- a/registries/erc4626.js
+++ b/registries/erc4626.js
@@ -259,6 +259,15 @@ const configs = {
     start: '2026-04-11',
     base: ['0x71c298a6eb10e7958ce25a450a706330a4c946c0']
   },
+  'r25': {
+    pharos: Object.values({
+      vRPCWeeklyVault: '0x1c2bc8b553d9a7e61f7531a3a4bf2162f4569268',
+      vRPCQuarterlyVault: '0x94f7ebc6ae0819a4b4e231ae6ddaaf9bfd2a1a86',
+      vRPCSemiYearlyVault: '0xee26bb0989691735c997dfdc49a4a607f75e190b',
+      pCreditVault: '0x39976f3Ef143a5824d4E4c28c204d556113dCF7f',
+    }),
+    methodology: "TVL represents the total value of assets held within the vault. Each vault token is minted using USDC and appreciates in line with the performance of the underlying asset.",
+  }
 }
 
 module.exports = buildProtocolExports(configs, erc4626ExportFn)


### PR DESCRIPTION
Introduce support for the Pharos protocol and configure the necessary RPC settings for the r25 version. This update enhances the existing functionality by integrating new vaults and their respective methodologies.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Pharos protocol with RPC multicall configuration.
  * Integrated Pharos vault registry for protocol analysis and metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->