### PR TITLE
add network megaeth to gaming-dex

### DIFF
--- a/registries/balancer.js
+++ b/registries/balancer.js
@@ -93,8 +93,8 @@ const configs = {
     monad: { vault: '0xd315a9c38ec871068fec378e4ce78af528c76293', fromBlock: 32389136 },
   },
   'gaming-dex': {
-    defiverse: null,
     oas: { vault: '0xfb6f8FEdE0Cb63674Ab964affB93D65a4a7D55eA', fromBlock: 4522800 },
+    megaeth: { vault: '0xd5e99c20b2e7Ab4C18b2e1709Fd6F5A20F488637', fromBlock: 9729855 },
   },
   'sobal': {
     neon_evm: { vault: '0x7122e35ceC2eED4A989D9b0A71998534A203972C', fromBlock: 206166057, blacklistedTokens: ['0x4440000000000000000000000000000000000002'] },

--- a/registries/balancer.js
+++ b/registries/balancer.js
@@ -93,6 +93,7 @@ const configs = {
     monad: { vault: '0xd315a9c38ec871068fec378e4ce78af528c76293', fromBlock: 32389136 },
   },
   'gaming-dex': {
+    defiverse: null,
     oas: { vault: '0xfb6f8FEdE0Cb63674Ab964affB93D65a4a7D55eA', fromBlock: 4522800 },
     megaeth: { vault: '0xd5e99c20b2e7Ab4C18b2e1709Fd6F5A20F488637', fromBlock: 9729855 },
   },


### PR DESCRIPTION
Add network MegaETH to gaming-dex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the megaeth blockchain to the gaming-dex Balancer registry, enabling TVL reporting for the megaeth vault.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->