### PR TITLE
feat(sui): add move call tx byte helper

### DIFF
--- a/projects/haedal-vault/suiTx.js
+++ b/projects/haedal-vault/suiTx.js
@@ -1,15 +1,4 @@
-const ADDRESSES = require('../helper/coreAssets.json')
-const { hexToBytes, toU64, textToBytes, desU64 } = require('./bytes');
 const sui = require("../helper/chain/sui");
-
-const DUMMY_SENDER = '0x0000000000000000000000000000000000000000000000000000000000000000';
-
-const ProgrammableTransactionIndex = 0;
-const ObjectIndex = 1;
-const SharedObjectIndex = 1;
-const MoveCallIndex = 0;
-const StructIndex = 7;
-const InputIndex = 1;
 
 async function getVaultTokenBalance(packageId, typeParams, vaultId, poolId) {
     // Fetch initialSharedVersion for both shared objects
@@ -17,153 +6,49 @@ async function getVaultTokenBalance(packageId, typeParams, vaultId, poolId) {
         sui.call('sui_getObject', [vaultId, { showOwner: true }]),
         sui.call('sui_getObject', [poolId, { showOwner: true }]),
     ]);
-    const vaultVersion = vaultObj?.owner?.Shared?.initial_shared_version ?? 0;
-    const poolVersion = poolObj?.owner?.Shared?.initial_shared_version ?? 0;
+    const vaultVersion = vaultObj?.owner?.Shared?.initial_shared_version;
+    const poolVersion = poolObj?.owner?.Shared?.initial_shared_version;
+    if (vaultVersion === undefined) throw new Error(`Vault ${vaultId} is not a shared Sui object`);
+    if (poolVersion === undefined) throw new Error(`Pool ${poolId} is not a shared Sui object`);
 
-    const txBlockBytes = buildGetVaultAssetsTxBytes(packageId, typeParams, vaultId, poolId, vaultVersion, poolVersion);
-
-    const inspectionResult = await sui.call(
-        'sui_devInspectTransactionBlock',
-        [DUMMY_SENDER, Buffer.from(txBlockBytes).toString('base64')],
-        { withMetadata: true }
-    );
+    const txBlockBytes = sui.buildProgrammableMoveCallBytes({
+        packageId,
+        module: 'pool',
+        functionName: 'get_vault_assets',
+        typeArguments: typeParams,
+        sharedObjects: [{
+            objectId: vaultId,
+            initialSharedVersion: vaultVersion,
+            mutable: true
+        }, {
+            objectId: poolId,
+            initialSharedVersion: poolVersion,
+            mutable: true
+        }],
+    });
+    const inspectionResult = await sui.devInspectTransactionBlock(txBlockBytes);
 
     if (inspectionResult?.effects?.status?.status !== 'success') {
         throw new Error(JSON.stringify(inspectionResult, null, 2));
     }
 
-    const returnValues = inspectionResult.results[0].returnValues;
-    const coinAData = returnValues[0][0];
-    const coinBData = returnValues[1][0];
-    const coinA = desU64(Uint8Array.from(coinAData)).toString();
-    const coinB = desU64(Uint8Array.from(coinBData)).toString();
+    const returnValues = inspectionResult?.results?.[0]?.returnValues;
+    const coinAData = returnValues?.[0]?.[0];
+    const coinBData = returnValues?.[1]?.[0];
+    if (
+        !Array.isArray(returnValues)
+        || returnValues.length < 2
+        || !Array.isArray(coinAData)
+        || !Array.isArray(coinBData)
+        || coinAData.length !== 8
+        || coinBData.length !== 8
+    ) {
+        const payload = JSON.stringify({ returnValues, coinAData, coinBData, inspectionResult }, null, 2);
+        throw new Error(`Unexpected get_vault_assets devInspect return payload before fromU64: ${payload}`);
+    }
+    const coinA = sui.fromU64(coinAData).toString();
+    const coinB = sui.fromU64(coinBData).toString();
     return [coinA, coinB]
-}
-
-function buildGetVaultAssetsTxBytes(packageId, typeParams, vaultId, poolId, vaultVersion = 0, poolVersion = 0) {
-    const kind = {
-        "ProgrammableTransaction": {
-            "inputs": [{
-                "Object": {
-                    "SharedObject": {
-                        "objectId": vaultId,
-                        "initialSharedVersion": vaultVersion,
-                        "mutable": true
-                    }
-                },
-            }, {
-                "Object": {
-                    "SharedObject": {
-                        "objectId": poolId,
-                        "initialSharedVersion": poolVersion,
-                        "mutable": true
-                    }
-                },
-            }],
-            "commands": [{
-                "MoveCall": {
-                    "package": packageId,
-                    "module": "pool",
-                    "function": "get_vault_assets",
-                    "typeArguments": typeParams,
-                    "arguments": [{
-                        "Input": 0,
-                    }, {
-                        "Input": 1,
-                    }]
-                }
-            }]
-        }
-    };
-
-    const moduleArg = textToBytes(kind.ProgrammableTransaction.commands[0].MoveCall.module);
-    const functionArg = textToBytes(kind.ProgrammableTransaction.commands[0].MoveCall.function);
-
-    const typeArgs = kind.ProgrammableTransaction.commands[0].MoveCall.typeArguments.map(t => {
-        const parsed = parseSuiAddress(t);
-        return {
-            address: parsed.address,
-            module: parsed.module,
-            name: parsed.name,
-            typeParams: parsed.typeParams || []
-        };
-    });
-
-    let bytes = [
-        ProgrammableTransactionIndex,
-        kind.ProgrammableTransaction.inputs.length,
-    ];
-
-    bytes = bytes.concat([
-        ObjectIndex,
-        SharedObjectIndex,
-        ...hexToBytes(kind.ProgrammableTransaction.inputs[0].Object.SharedObject.objectId),
-        ...toU64(kind.ProgrammableTransaction.inputs[0].Object.SharedObject.initialSharedVersion),
-        kind.ProgrammableTransaction.inputs[0].Object.SharedObject.mutable ? 1 : 0,
-    ]);
-
-    bytes = bytes.concat([
-        ObjectIndex,
-        SharedObjectIndex,
-        ...hexToBytes(kind.ProgrammableTransaction.inputs[1].Object.SharedObject.objectId),
-        ...toU64(kind.ProgrammableTransaction.inputs[1].Object.SharedObject.initialSharedVersion),
-        kind.ProgrammableTransaction.inputs[1].Object.SharedObject.mutable ? 1 : 0,
-    ]);
-
-    bytes = bytes.concat([
-        kind.ProgrammableTransaction.commands.length,
-        MoveCallIndex,
-        ...hexToBytes(kind.ProgrammableTransaction.commands[0].MoveCall.package),
-        moduleArg.length,
-        ...moduleArg,
-        functionArg.length,
-        ...functionArg,
-    ]);
-
-    bytes = bytes.concat([
-        typeArgs.length,
-    ]);
-
-    for (const typeArg of typeArgs) {
-        const typeModule = textToBytes(typeArg.module);
-        const typeName = textToBytes(typeArg.name);
-
-        bytes = bytes.concat([
-            StructIndex,
-            ...hexToBytes(typeArg.address),
-            typeModule.length,
-            ...typeModule,
-            typeName.length,
-            ...typeName,
-            typeArg.typeParams.length,
-        ]);
-    }
-    bytes = bytes.concat([
-        kind.ProgrammableTransaction.commands[0].MoveCall.arguments.length,
-        InputIndex,
-        kind.ProgrammableTransaction.commands[0].MoveCall.arguments[0].Input,
-        0,
-        InputIndex,
-        kind.ProgrammableTransaction.commands[0].MoveCall.arguments[1].Input,
-        0,
-    ]);
-
-    return Uint8Array.from(bytes);
-}
-
-function parseSuiAddress(str) {
-    const STRUCT_REGEX = /^([^:]+)::([^:]+)::([^<]+)(<(.+)>)?/;
-    const structMatch = str.match(STRUCT_REGEX);
-    if (structMatch) {
-        return {
-            address: structMatch[1],
-            module: structMatch[2],
-            name: structMatch[3],
-            typeParams: [],
-        };
-    }
-
-    throw new Error(`Encountered unexpected token when parsing type args for ${str}`);
 }
 
 module.exports = {

--- a/projects/helper/chain/sui.js
+++ b/projects/helper/chain/sui.js
@@ -23,6 +23,186 @@ async function fnSleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+const DUMMY_SENDER = '0x0000000000000000000000000000000000000000000000000000000000000000'
+
+const typeTagIndexes = {
+  bool: 0,
+  u8: 1,
+  u64: 2,
+  u128: 3,
+  address: 4,
+  signer: 5,
+  u16: 8,
+  u32: 9,
+  u256: 10,
+}
+
+function hexToBytes(hex) {
+  const normalized = String(hex).replace(/^0x/i, '')
+  if (!/^[0-9a-fA-F]+$/.test(normalized) || normalized.length > 64) throw new Error(`Invalid Sui hex value: ${hex}`)
+  return Array.from(Buffer.from(normalized.padStart(64, '0'), 'hex'))
+}
+const textToBytes = (value) => Array.from(new TextEncoder().encode(value))
+
+function uleb128(value) {
+  const bytes = []
+  let num = Number(value)
+  if (!Number.isSafeInteger(num) || num < 0) throw new Error(`Invalid uleb128 value: ${value}`)
+  do {
+    let byte = num % 0x80
+    num = Math.floor(num / 0x80)
+    if (num > 0) byte |= 0x80
+    bytes.push(byte)
+  } while (num > 0)
+  return bytes
+}
+
+function toLittleEndian(value, size) {
+  const bits = size * 8
+  let bigint
+  try {
+    if (typeof value === 'number' && !Number.isInteger(value)) throw new Error()
+    bigint = BigInt(value)
+  } catch {
+    throw new Error(`Invalid u${bits} value: ${value}`)
+  }
+  const max = 1n << BigInt(bits)
+  if (bigint < 0n || bigint >= max) throw new Error(`Value out of range for u${bits}: ${value}`)
+
+  const result = new Uint8Array(size)
+  let i = 0
+  while (bigint > 0) {
+    result[i] = Number(bigint % 256n)
+    bigint /= 256n
+    i += 1
+  }
+  return Array.from(result)
+}
+
+const toU16 = (value) => toLittleEndian(value, 2)
+const toU64 = (value) => toLittleEndian(value, 8)
+const toU128 = (value) => toLittleEndian(value, 16)
+
+function fromLittleEndian(data, offset = 0, size = 8) {
+  if (!Number.isInteger(offset) || offset < 0) throw new RangeError(`Invalid byte offset: ${offset}`)
+  if (!Number.isInteger(size) || size < 1) throw new RangeError(`Invalid integer byte size: ${size}`)
+  const source = Uint8Array.from(data)
+  if (source.length < offset + size) throw new RangeError(`Expected ${size} bytes at offset ${offset}, got ${source.length}`)
+  const bytes = source.slice(offset, offset + size)
+  let value = 0n
+  for (let i = bytes.length - 1; i >= 0; i--) value = (value << 8n) + BigInt(bytes[i])
+  return value
+}
+
+const fromU64 = (data, offset = 0) => fromLittleEndian(data, offset, 8)
+const fromU128 = (data, offset = 0) => fromLittleEndian(data, offset, 16)
+
+function splitTypeArgs(value) {
+  const items = []
+  let depth = 0
+  let start = 0
+  for (let i = 0; i < value.length; i++) {
+    if (value[i] === '<') depth++
+    if (value[i] === '>') {
+      depth--
+      if (depth < 0) throw new Error(`Unbalanced type argument brackets: ${value}`)
+    }
+    if (value[i] === ',' && depth === 0) {
+      items.push(value.slice(start, i).trim())
+      start = i + 1
+    }
+  }
+  if (depth !== 0) throw new Error(`Unbalanced type argument brackets: ${value}`)
+  const last = value.slice(start).trim()
+  if (last) items.push(last)
+  return items
+}
+
+function parseStructTag(type) {
+  const match = String(type).trim().match(/^([^:]+)::([^:]+)::([^<]+)(?:<(.+)>)?$/)
+  if (!match) throw new Error(`Invalid Sui struct tag: ${type}`)
+  return {
+    address: match[1],
+    module: match[2],
+    name: match[3],
+    typeParams: match[4] ? splitTypeArgs(match[4]) : [],
+  }
+}
+
+function typeTagToBytes(type) {
+  const tag = String(type).trim()
+  if (typeTagIndexes[tag] !== undefined) return [typeTagIndexes[tag]]
+  if (tag.startsWith('vector<') && tag.endsWith('>')) return [6, ...typeTagToBytes(tag.slice(7, -1))]
+
+  const { address, module, name, typeParams } = parseStructTag(tag)
+  const moduleBytes = textToBytes(module)
+  const nameBytes = textToBytes(name)
+  return [
+    7,
+    ...hexToBytes(address),
+    ...uleb128(moduleBytes.length),
+    ...moduleBytes,
+    ...uleb128(nameBytes.length),
+    ...nameBytes,
+    ...uleb128(typeParams.length),
+    ...typeParams.flatMap(typeTagToBytes),
+  ]
+}
+
+function buildProgrammableMoveCallBytes({
+  packageId,
+  module,
+  function: functionName,
+  functionName: namedFunction,
+  typeArguments = [],
+  sharedObjects = [],
+  arguments: moveArguments,
+}) {
+  if (functionName && namedFunction && functionName !== namedFunction) {
+    throw new Error(`Conflicting move function names: function="${functionName}" vs functionName="${namedFunction}"`)
+  }
+  const moveFunction = functionName || namedFunction
+  if (!packageId || !module || !moveFunction) throw new Error('Missing packageId, module, or functionName')
+
+  const moduleBytes = textToBytes(module)
+  const functionBytes = textToBytes(moveFunction)
+  const args = moveArguments || sharedObjects.map((_, i) => ({ Input: i }))
+  const inputCount = sharedObjects.length
+  const bytes = [0, ...uleb128(sharedObjects.length)]
+
+  sharedObjects.forEach(({ objectId, initialSharedVersion, mutable = false }) => {
+    bytes.push(1, 1, ...hexToBytes(objectId), ...toU64(initialSharedVersion), mutable ? 1 : 0)
+  })
+
+  bytes.push(
+    ...uleb128(1),
+    0,
+    ...hexToBytes(packageId),
+    ...uleb128(moduleBytes.length),
+    ...moduleBytes,
+    ...uleb128(functionBytes.length),
+    ...functionBytes,
+    ...uleb128(typeArguments.length),
+    ...typeArguments.flatMap(typeTagToBytes),
+    ...uleb128(args.length),
+  )
+
+  args.forEach((arg) => {
+    const input = typeof arg === 'number' ? arg : arg.Input ?? arg.input
+    if (!Number.isInteger(input) || input < 0 || input > 0xffff) {
+      throw new Error(`Unsupported Sui move call argument: ${JSON.stringify(arg)}`)
+    }
+    if (input >= inputCount) throw new Error(`Sui move call argument input ${input} exceeds input count ${inputCount}`)
+    bytes.push(1, ...toU16(input))
+  })
+
+  return Uint8Array.from(bytes)
+}
+
+async function devInspectTransactionBlock(txBlockBytes, { sender = DUMMY_SENDER } = {}) {
+  return call('sui_devInspectTransactionBlock', [sender, Buffer.from(txBlockBytes).toString('base64')], { withMetadata: true })
+}
+
 async function queryEvents({ eventType, transform = i => i }) {
   let filter = {}
   if (eventType) filter.MoveEventType = eventType
@@ -216,4 +396,15 @@ module.exports = {
   sumTokensExport,
   queryEventsByType,
   getTokenSupply,
+  DUMMY_SENDER,
+  buildProgrammableMoveCallBytes,
+  devInspectTransactionBlock,
+  parseStructTag,
+  typeTagToBytes,
+  hexToBytes,
+  textToBytes,
+  toU64,
+  toU128,
+  fromU64,
+  fromU128,
 };


### PR DESCRIPTION
Closes #13746

## Context

Adds shared Sui transaction-byte utilities so adapters can build programmable Move call payloads for `sui_devInspectTransactionBlock`.

## Changes

- Add Sui helpers for programmable Move calls, type tags, integer encoding/decoding, and dev-inspection.
- Refactor `projects/haedal-vault/suiTx.js` to use the shared Sui helper.
- Validate shared objects, encoded values, type tags, input indexes, and devInspect return values before decoding balances.

## Tests

```bash
node -c projects/helper/chain/sui.js
node -c projects/haedal-vault/suiTx.js
node test.js projects/haedal-vault/index.js
```