### PR TITLE
Fix soso index TVL: rewrite adapter with on-chain balances

### DIFF
--- a/projects/ssi-protocol/index.js
+++ b/projects/ssi-protocol/index.js
@@ -1,67 +1,52 @@
 const sdk = require('@defillama/sdk')
-const { getBlock } = require('../helper/http');
 
 const abi = {
   getBasket: 'function getBasket() view returns ((string chain, string symbol, string addr, uint8 decimals, uint256 amount)[])'
 }
 
 const ssi_tokens = [
-  // MAG7.ssi
-  '0x9E6A46f294bB67c20F1D1E7AfB0bBEf614403B55',
-  // DEFI.ssi
-  '0x164ffdaE2fe3891714bc2968f1875ca4fA1079D0',
-  // MEME.ssi
-  '0xdd3acDBDc7b358Df453a6CB6bCA56C92aA5743aA'
+  '0x9E6A46f294bB67c20F1D1E7AfB0bBEf614403B55', // MAG7.ssi
+  '0x164ffdaE2fe3891714bc2968f1875ca4fA1079D0', // DEFI.ssi
+  '0xdd3acDBDc7b358Df453a6CB6bCA56C92aA5743aA', // MEME.ssi
 ]
 
-function underlyingExports(chains) {
-  const exportObj = {};
-  Object.entries(chains).forEach(([chain, [chain_name, native_token]]) => {
-    exportObj[chain] = {
-      tvl: async (api, ethBlock, chainBlocks) => {
-        const balances = {};
-        const base_block = await getBlock(api.timestamp, 'base', chainBlocks);
-        const baskets = await Promise.all(ssi_tokens.map(async (ssi_token) => {
-          const res = await sdk.api.abi.call({
-            abi: abi.getBasket,
-            target: ssi_token,
-            chain: 'base',
-            block: base_block,
-          });
-          return res.output;
-        }));
-        baskets.forEach(basket => {
-          basket.forEach(token => {
-            if (token.chain == chain_name) {
-              let token_addr;
-              let token_amount;
-              if (token.addr != '') {
-                token_addr = chain + ':' + token.addr;
-                token_amount = token.amount;
-              } else {
-                token_addr = native_token;
-                token_amount = token.amount / 10 ** token.decimals;
-              }
-              sdk.util.sumSingleBalance(balances, token_addr, token_amount);
-            }
-          });
-        });
-        return balances;
-      }
-    }
-  });
-  return exportObj;
+const chainConfig = {
+  'ETH': { chain: 'ethereum' },
+  'BSC_BNB': { chain: 'bsc' },
+  'DOGE': { chain: 'doge', cgId: 'dogecoin' },
+  'SOL': { chain: 'solana', cgId: 'solana' },
+  'BTC': { chain: 'bitcoin', cgId: 'bitcoin' },
+  'ADA': { chain: 'cardano', cgId: 'cardano' },
+  'XRP': { chain: 'ripple', cgId: 'ripple' },
+  'HYPEREVM_HYPE': { chain: 'hyperliquid' },
 }
 
-module.exports = {
-  methodology: 'TVL counts the underlying tokens in the baskets of the SSI tokens.',
-  ...underlyingExports({
-    ethereum: ['ETH', 'ethereum'],
-    bsc: ['BSC_BNB', 'binancecoin'],
-    doge: ['DOGE', 'dogecoin'],
-    solana: ['SOL', 'solana'],
-    bitcoin: ['BTC', 'bitcoin'],
-    cardano: ['ADA', 'cardano'],
-    ripple: ['XRP', 'ripple'],
-  })
-};
+async function getBaskets(api) {
+  const baseApi = new sdk.ChainApi({ chain: 'base', timestamp: api.timestamp })
+  return Promise.all(ssi_tokens.map(target => baseApi.call({ abi: abi.getBasket, target })))
+}
+
+function makeChainTvl(chainKey) {
+  return async function tvl(api) {
+    const baskets = await getBaskets(api)
+    for (const basket of baskets) {
+      for (const token of basket) {
+        const cfg = chainConfig[token.chain]
+        if (!cfg || cfg.chain !== chainKey) continue
+        if (token.addr) {
+          api.add(token.addr, token.amount)
+        } else if (cfg.cgId) {
+          api.addCGToken(cfg.cgId, token.amount / 10 ** token.decimals)
+        } else {
+          api.addGasToken(token.amount)
+        }
+      }
+    }
+  }
+}
+
+const chains = [...new Set(Object.values(chainConfig).map(c => c.chain))]
+const mod = { methodology: 'TVL counts the underlying tokens in the baskets of the SSI index tokens on Base.' }
+chains.forEach(chain => { mod[chain] = { tvl: makeChainTvl(chain) } })
+
+module.exports = mod


### PR DESCRIPTION
Rewrites the SSI protocol adapter to use the modern api pattern (api.add, api.addCGToken, api.addGasToken) instead of manual sdk.util.sumSingleBalance. Also adds missing HyperEVM/HYPE chain support for the DEFI.ssi basket.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Revamped TVL calculation system for SSI index tokens on Base with enhanced accuracy in underlying token value aggregation
  * Optimized chain-specific balance tracking and consolidation

* **Documentation**
  * Updated TVL methodology documentation to reflect current calculation approach

<!-- end of auto-generated comment: release notes by coderabbit.ai -->