### PR TITLE
Add Slender Protocol TVL adapter (Soroban / Stellar)

### DIFF
--- a/projects/slender/index.js
+++ b/projects/slender/index.js
@@ -45,10 +45,14 @@ async function getReserveAddresses(assetSac) {
   return { sTokenAddress: rt[1], debtTokenAddress: rt[2] }
 }
 
-// Keep all coefficient math in BigInt until the final division by decimals to avoid
-// Number precision loss on high-TVL pools (raw values can exceed Number.MAX_SAFE_INTEGER).
+// Keep large-value math in BigInt to avoid Number.MAX_SAFE_INTEGER overflow, then recover
+// the fractional part via remainder before converting to Number.
+// e.g. 551700000n with decimals=7: whole=55n, rem=1700000n → 55 + 0.17 = 55.17
 function scaleDown(rawBigInt, decimals) {
-  return Number(rawBigInt / BigInt(10 ** decimals))
+  const divisor = BigInt(10 ** decimals)
+  const whole = rawBigInt / divisor
+  const rem = rawBigInt % divisor
+  return Number(whole) + Number(rem) / (10 ** decimals)
 }
 
 async function tvl(api) {

--- a/projects/slender/index.js
+++ b/projects/slender/index.js
@@ -34,8 +34,13 @@ const RESERVES = [
 // Slender stores collat_coeff and debt_coeff at 1e9 precision (initial value = 1_000_000_000n)
 const COEFF_PRECISION = 1_000_000_000n
 
-// callSoroban('get_reserve') returns the full ReserveData MAP; reserve_type is a VEC within it.
-// Runtime-verified: { ..., reserve_type: ["Fungible", s_token_addr, debt_token_addr], ... }
+/**
+ * Resolve the sToken and debtToken contract addresses for a given reserve asset.
+ * callSoroban('get_reserve') returns the full ReserveData MAP; reserve_type is a VEC within it.
+ * Runtime-verified structure: { ..., reserve_type: ["Fungible", s_token_addr, debt_token_addr], ... }
+ * @param {string} assetSac - Stellar Asset Contract address of the reserve asset
+ * @returns {{ sTokenAddress: string, debtTokenAddress: string }}
+ */
 async function getReserveAddresses(assetSac) {
   const data = await callSoroban(POOL_ID, 'get_reserve', [assetSac])
   const rt = data?.reserve_type
@@ -45,9 +50,15 @@ async function getReserveAddresses(assetSac) {
   return { sTokenAddress: rt[1], debtTokenAddress: rt[2] }
 }
 
-// Keep large-value math in BigInt to avoid Number.MAX_SAFE_INTEGER overflow, then recover
-// the fractional part via remainder before converting to Number.
-// e.g. 551700000n with decimals=7: whole=55n, rem=1700000n → 55 + 0.17 = 55.17
+/**
+ * Convert a raw BigInt token amount to a human-readable Number, preserving fractional precision.
+ * Keeps large-value math in BigInt (avoids Number.MAX_SAFE_INTEGER overflow), then recovers
+ * the fractional part via remainder before the final Number conversion.
+ * e.g. 551700000n with decimals=7: whole=55n, rem=1700000n → 55 + 0.17 = 55.17
+ * @param {bigint} rawBigInt - raw on-chain token amount
+ * @param {number} decimals - token decimal places (7 for all Stellar/Soroban tokens)
+ * @returns {number}
+ */
 function scaleDown(rawBigInt, decimals) {
   const divisor = BigInt(10 ** decimals)
   const whole = rawBigInt / divisor
@@ -55,6 +66,11 @@ function scaleDown(rawBigInt, decimals) {
   return Number(whole) + Number(rem) / (10 ** decimals)
 }
 
+/**
+ * Compute TVL: total underlying deposited per reserve.
+ * underlying = sToken total supply × collat_coeff / 1e9 (all BigInt until final scaleDown)
+ * @param {object} api - DefiLlama adapter API object
+ */
 async function tvl(api) {
   for (const r of RESERVES) {
     const { sTokenAddress } = await getReserveAddresses(r.sac)
@@ -64,12 +80,16 @@ async function tvl(api) {
       callSoroban(POOL_ID, 'collat_coeff', [r.sac]),
     ])
 
-    // underlying (in 1e7 units) = sTokenSupply × collatCoeff / 1e9 — all BigInt
     const underlyingRaw = sTokenSupply * collatCoeff / COEFF_PRECISION
     api.addCGToken(r.geckoId, scaleDown(underlyingRaw, r.decimals))
   }
 }
 
+/**
+ * Compute borrowed: total outstanding loans per reserve.
+ * underlying = debtToken total supply × debt_coeff / 1e9 (all BigInt until final scaleDown)
+ * @param {object} api - DefiLlama adapter API object
+ */
 async function borrowed(api) {
   for (const r of RESERVES) {
     const { debtTokenAddress } = await getReserveAddresses(r.sac)

--- a/projects/slender/index.js
+++ b/projects/slender/index.js
@@ -1,0 +1,84 @@
+/**
+ * Slender Protocol — TVL + Borrowed adapter
+ *
+ * Slender is a noncustodial overcollateralized lending protocol on Soroban (Stellar).
+ * Users deposit XLM, XRP, or USDC and receive sTokens (interest-accruing receipt tokens).
+ *
+ * Data flow (per reserve):
+ *   pool.get_reserve(asset) → { reserve_type: ["Fungible", s_token, debt_token], ... }
+ *   pool.token_total_supply(s_token)   → sToken supply  (in 1e7 asset units)
+ *   pool.collat_coeff(asset)           → coefficient     (1e9 precision, starts at 1e9)
+ *   underlying_deposited = sToken_supply × collat_coeff / 1e9
+ *
+ *   pool.token_total_supply(debt_token) → debtToken supply (in 1e7 asset units)
+ *   pool.debt_coeff(asset)              → coefficient      (1e9 precision)
+ *   underlying_borrowed = debtToken_supply × debt_coeff / 1e9
+ *
+ * Stellar Community Fund grant: $97,500 | Live: 2024-08-01
+ * Source: https://github.com/eq-lab/slender
+ */
+
+const { callSoroban } = require('../helper/chain/stellar')
+const methodologies = require('../helper/methodologies')
+
+const POOL_ID = 'CCL2KTHYOVMNNOFDT7PEAHACUBYVFLRH2LYWVQB6IPMHHAVUBC7ZUUC2'
+
+// Stellar Asset Contract (SAC) address for each reserve — passed to pool.get_reserve(asset).
+// Decimals: 7 (standard for all Stellar/Soroban token contracts)
+const RESERVES = [
+  { symbol: 'XLM',  sac: 'CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA', geckoId: 'stellar',  decimals: 7 },
+  { symbol: 'XRP',  sac: 'CAAV3AE3VKD2P4TY7LWTQMMJHIJ4WOCZ5ANCIJPC3NRSERKVXNHBU2W7', geckoId: 'ripple',   decimals: 7 },
+  { symbol: 'USDC', sac: 'CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75', geckoId: 'usd-coin', decimals: 7 },
+]
+
+const COEFF_PRECISION = 1_000_000_000n // 1e9 — Slender stores coefficients at 9 decimal precision
+
+async function getReserveAddresses(assetSac) {
+  const data = await callSoroban(POOL_ID, 'get_reserve', [assetSac])
+  // reserve_type is a VEC: ["Fungible", s_token_address, debt_token_address]
+  const rt = data?.reserve_type
+  if (!Array.isArray(rt) || rt[0] !== 'Fungible' || rt.length < 3) {
+    throw new Error(`Unexpected reserve_type for ${assetSac}: ${JSON.stringify(rt)}`)
+  }
+  return { sTokenAddress: rt[1], debtTokenAddress: rt[2] }
+}
+
+async function tvl(api) {
+  for (const r of RESERVES) {
+    const { sTokenAddress } = await getReserveAddresses(r.sac)
+
+    // sToken supply and the collateral coefficient (sToken → underlying exchange rate)
+    const [sTokenSupply, collatCoeff] = await Promise.all([
+      callSoroban(POOL_ID, 'token_total_supply', [sTokenAddress]),
+      callSoroban(POOL_ID, 'collat_coeff', [r.sac]),
+    ])
+
+    // underlying_in_1e7 = sTokenSupply × collatCoeff / 1e9
+    // then divide by 1e7 to get the human-readable token amount
+    const underlyingRaw = sTokenSupply * collatCoeff / COEFF_PRECISION
+    api.addCGToken(r.geckoId, Number(underlyingRaw) / Math.pow(10, r.decimals))
+  }
+}
+
+async function borrowed(api) {
+  for (const r of RESERVES) {
+    const { debtTokenAddress } = await getReserveAddresses(r.sac)
+
+    const [debtTokenSupply, debtCoeff] = await Promise.all([
+      callSoroban(POOL_ID, 'token_total_supply', [debtTokenAddress]),
+      callSoroban(POOL_ID, 'debt_coeff', [r.sac]),
+    ])
+
+    const underlyingRaw = debtTokenSupply * debtCoeff / COEFF_PRECISION
+    api.addCGToken(r.geckoId, Number(underlyingRaw) / Math.pow(10, r.decimals))
+  }
+}
+
+module.exports = {
+  timetravel: false,
+  methodology: `${methodologies.lendingMarket}. TVL is derived from sToken total supply × collateral coefficient per reserve; borrowed from debtToken total supply × debt coefficient per reserve. Both queried on-chain via Soroban RPC simulation of pool.get_reserve(), pool.token_total_supply(), pool.collat_coeff(), and pool.debt_coeff().`,
+  stellar: {
+    tvl,
+    borrowed,
+  },
+}

--- a/projects/slender/index.js
+++ b/projects/slender/index.js
@@ -31,11 +31,13 @@ const RESERVES = [
   { symbol: 'USDC', sac: 'CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75', geckoId: 'usd-coin', decimals: 7 },
 ]
 
-const COEFF_PRECISION = 1_000_000_000n // 1e9 — Slender stores coefficients at 9 decimal precision
+// Slender stores collat_coeff and debt_coeff at 1e9 precision (initial value = 1_000_000_000n)
+const COEFF_PRECISION = 1_000_000_000n
 
+// callSoroban('get_reserve') returns the full ReserveData MAP; reserve_type is a VEC within it.
+// Runtime-verified: { ..., reserve_type: ["Fungible", s_token_addr, debt_token_addr], ... }
 async function getReserveAddresses(assetSac) {
   const data = await callSoroban(POOL_ID, 'get_reserve', [assetSac])
-  // reserve_type is a VEC: ["Fungible", s_token_address, debt_token_address]
   const rt = data?.reserve_type
   if (!Array.isArray(rt) || rt[0] !== 'Fungible' || rt.length < 3) {
     throw new Error(`Unexpected reserve_type for ${assetSac}: ${JSON.stringify(rt)}`)
@@ -43,20 +45,24 @@ async function getReserveAddresses(assetSac) {
   return { sTokenAddress: rt[1], debtTokenAddress: rt[2] }
 }
 
+// Keep all coefficient math in BigInt until the final division by decimals to avoid
+// Number precision loss on high-TVL pools (raw values can exceed Number.MAX_SAFE_INTEGER).
+function scaleDown(rawBigInt, decimals) {
+  return Number(rawBigInt / BigInt(10 ** decimals))
+}
+
 async function tvl(api) {
   for (const r of RESERVES) {
     const { sTokenAddress } = await getReserveAddresses(r.sac)
 
-    // sToken supply and the collateral coefficient (sToken → underlying exchange rate)
     const [sTokenSupply, collatCoeff] = await Promise.all([
       callSoroban(POOL_ID, 'token_total_supply', [sTokenAddress]),
       callSoroban(POOL_ID, 'collat_coeff', [r.sac]),
     ])
 
-    // underlying_in_1e7 = sTokenSupply × collatCoeff / 1e9
-    // then divide by 1e7 to get the human-readable token amount
+    // underlying (in 1e7 units) = sTokenSupply × collatCoeff / 1e9 — all BigInt
     const underlyingRaw = sTokenSupply * collatCoeff / COEFF_PRECISION
-    api.addCGToken(r.geckoId, Number(underlyingRaw) / Math.pow(10, r.decimals))
+    api.addCGToken(r.geckoId, scaleDown(underlyingRaw, r.decimals))
   }
 }
 
@@ -70,7 +76,7 @@ async function borrowed(api) {
     ])
 
     const underlyingRaw = debtTokenSupply * debtCoeff / COEFF_PRECISION
-    api.addCGToken(r.geckoId, Number(underlyingRaw) / Math.pow(10, r.decimals))
+    api.addCGToken(r.geckoId, scaleDown(underlyingRaw, r.decimals))
   }
 }
 

--- a/projects/slender/index.js
+++ b/projects/slender/index.js
@@ -2,19 +2,16 @@
  * Slender Protocol — TVL + Borrowed adapter
  *
  * Slender is a noncustodial overcollateralized lending protocol on Soroban (Stellar).
- * Users deposit XLM, XRP, or USDC and receive sTokens (interest-accruing receipt tokens).
+ * Users deposit XLM, XRP, or USDC into a per-reserve sToken contract and receive
+ * sTokens (interest-accruing receipt tokens). Borrowed underlying leaves the
+ * sToken contract; deposits earning interest stay there.
  *
  * Data flow (per reserve):
  *   pool.get_reserve(asset) → { reserve_type: ["Fungible", s_token, debt_token], ... }
- *   pool.token_total_supply(s_token)   → sToken supply  (in 1e7 asset units)
- *   pool.collat_coeff(asset)           → coefficient     (1e9 precision, starts at 1e9)
- *   underlying_deposited = sToken_supply × collat_coeff / 1e9
+ *   <asset_SAC>.balance(s_token) → underlying held by the sToken contract = TVL
  *
- *   pool.token_total_supply(debt_token) → debtToken supply (in 1e7 asset units)
- *   pool.debt_coeff(asset)              → coefficient      (1e9 precision)
- *   underlying_borrowed = debtToken_supply × debt_coeff / 1e9
+ *   pool.token_total_supply(debt_token) × pool.debt_coeff(asset) / 1e9 = borrowed
  *
- * Stellar Community Fund grant: $97,500 | Live: 2024-08-01
  * Source: https://github.com/eq-lab/slender
  */
 
@@ -23,24 +20,14 @@ const methodologies = require('../helper/methodologies')
 
 const POOL_ID = 'CCL2KTHYOVMNNOFDT7PEAHACUBYVFLRH2LYWVQB6IPMHHAVUBC7ZUUC2'
 
-// Stellar Asset Contract (SAC) address for each reserve — passed to pool.get_reserve(asset).
-// Decimals: 7 (standard for all Stellar/Soroban token contracts)
 const RESERVES = [
-  { symbol: 'XLM',  sac: 'CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA' },
-  { symbol: 'XRP',  sac: 'CAAV3AE3VKD2P4TY7LWTQMMJHIJ4WOCZ5ANCIJPC3NRSERKVXNHBU2W7' },
+  { symbol: 'XLM', sac: 'CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA' },
+  { symbol: 'XRP', sac: 'CAAV3AE3VKD2P4TY7LWTQMMJHIJ4WOCZ5ANCIJPC3NRSERKVXNHBU2W7' },
   { symbol: 'USDC', sac: 'CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75' },
 ]
 
-// Slender stores collat_coeff and debt_coeff at 1e9 precision (initial value = 1_000_000_000n)
 const COEFF_PRECISION = 1_000_000_000n
 
-/**
- * Resolve the sToken and debtToken contract addresses for a given reserve asset.
- * callSoroban('get_reserve') returns the full ReserveData MAP; reserve_type is a VEC within it.
- * Runtime-verified structure: { ..., reserve_type: ["Fungible", s_token_addr, debt_token_addr], ... }
- * @param {string} assetSac - Stellar Asset Contract address of the reserve asset
- * @returns {{ sTokenAddress: string, debtTokenAddress: string }}
- */
 async function getReserveAddresses(assetSac) {
   const data = await callSoroban(POOL_ID, 'get_reserve', [assetSac])
   const rt = data?.reserve_type
@@ -50,30 +37,14 @@ async function getReserveAddresses(assetSac) {
   return { sTokenAddress: rt[1], debtTokenAddress: rt[2] }
 }
 
-/**
- * Compute TVL: total underlying deposited per reserve.
- * underlying = sToken total supply × collat_coeff / 1e9 (BigInt math throughout)
- * @param {object} api - DefiLlama adapter API object
- */
 async function tvl(api) {
   for (const r of RESERVES) {
     const { sTokenAddress } = await getReserveAddresses(r.sac)
-
-    const [sTokenSupply, collatCoeff] = await Promise.all([
-      callSoroban(POOL_ID, 'token_total_supply', [sTokenAddress]),
-      callSoroban(POOL_ID, 'collat_coeff', [r.sac]),
-    ])
-
-    const underlyingRaw = sTokenSupply * collatCoeff / COEFF_PRECISION
-    api.add(r.sac, underlyingRaw.toString())
+    const balance = await callSoroban(r.sac, 'balance', [sTokenAddress])
+    api.add(r.sac, balance.toString())
   }
 }
 
-/**
- * Compute borrowed: total outstanding loans per reserve.
- * underlying = debtToken total supply × debt_coeff / 1e9 (BigInt math throughout)
- * @param {object} api - DefiLlama adapter API object
- */
 async function borrowed(api) {
   for (const r of RESERVES) {
     const { debtTokenAddress } = await getReserveAddresses(r.sac)
@@ -90,7 +61,7 @@ async function borrowed(api) {
 
 module.exports = {
   timetravel: false,
-  methodology: `${methodologies.lendingMarket}. TVL is derived from sToken total supply × collateral coefficient per reserve; borrowed from debtToken total supply × debt coefficient per reserve. Both queried on-chain via Soroban RPC simulation of pool.get_reserve(), pool.token_total_supply(), pool.collat_coeff(), and pool.debt_coeff().`,
+  methodology: methodologies.lendingMarket,
   stellar: {
     tvl,
     borrowed,

--- a/projects/slender/index.js
+++ b/projects/slender/index.js
@@ -26,9 +26,9 @@ const POOL_ID = 'CCL2KTHYOVMNNOFDT7PEAHACUBYVFLRH2LYWVQB6IPMHHAVUBC7ZUUC2'
 // Stellar Asset Contract (SAC) address for each reserve — passed to pool.get_reserve(asset).
 // Decimals: 7 (standard for all Stellar/Soroban token contracts)
 const RESERVES = [
-  { symbol: 'XLM',  sac: 'CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA', geckoId: 'stellar',  decimals: 7 },
-  { symbol: 'XRP',  sac: 'CAAV3AE3VKD2P4TY7LWTQMMJHIJ4WOCZ5ANCIJPC3NRSERKVXNHBU2W7', geckoId: 'ripple',   decimals: 7 },
-  { symbol: 'USDC', sac: 'CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75', geckoId: 'usd-coin', decimals: 7 },
+  { symbol: 'XLM',  sac: 'CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA' },
+  { symbol: 'XRP',  sac: 'CAAV3AE3VKD2P4TY7LWTQMMJHIJ4WOCZ5ANCIJPC3NRSERKVXNHBU2W7' },
+  { symbol: 'USDC', sac: 'CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75' },
 ]
 
 // Slender stores collat_coeff and debt_coeff at 1e9 precision (initial value = 1_000_000_000n)
@@ -51,24 +51,8 @@ async function getReserveAddresses(assetSac) {
 }
 
 /**
- * Convert a raw BigInt token amount to a human-readable Number, preserving fractional precision.
- * Keeps large-value math in BigInt (avoids Number.MAX_SAFE_INTEGER overflow), then recovers
- * the fractional part via remainder before the final Number conversion.
- * e.g. 551700000n with decimals=7: whole=55n, rem=1700000n → 55 + 0.17 = 55.17
- * @param {bigint} rawBigInt - raw on-chain token amount
- * @param {number} decimals - token decimal places (7 for all Stellar/Soroban tokens)
- * @returns {number}
- */
-function scaleDown(rawBigInt, decimals) {
-  const divisor = BigInt(10 ** decimals)
-  const whole = rawBigInt / divisor
-  const rem = rawBigInt % divisor
-  return Number(whole) + Number(rem) / (10 ** decimals)
-}
-
-/**
  * Compute TVL: total underlying deposited per reserve.
- * underlying = sToken total supply × collat_coeff / 1e9 (all BigInt until final scaleDown)
+ * underlying = sToken total supply × collat_coeff / 1e9 (BigInt math throughout)
  * @param {object} api - DefiLlama adapter API object
  */
 async function tvl(api) {
@@ -81,13 +65,13 @@ async function tvl(api) {
     ])
 
     const underlyingRaw = sTokenSupply * collatCoeff / COEFF_PRECISION
-    api.addCGToken(r.geckoId, scaleDown(underlyingRaw, r.decimals))
+    api.add(r.sac, underlyingRaw.toString())
   }
 }
 
 /**
  * Compute borrowed: total outstanding loans per reserve.
- * underlying = debtToken total supply × debt_coeff / 1e9 (all BigInt until final scaleDown)
+ * underlying = debtToken total supply × debt_coeff / 1e9 (BigInt math throughout)
  * @param {object} api - DefiLlama adapter API object
  */
 async function borrowed(api) {
@@ -100,7 +84,7 @@ async function borrowed(api) {
     ])
 
     const underlyingRaw = debtTokenSupply * debtCoeff / COEFF_PRECISION
-    api.addCGToken(r.geckoId, scaleDown(underlyingRaw, r.decimals))
+    api.add(r.sac, underlyingRaw.toString())
   }
 }
 


### PR DESCRIPTION
## What

Adds TVL + borrowed tracking for [Slender Protocol](https://github.com/eq-lab/slender), a noncustodial overcollateralized lending protocol on Soroban (Stellar's smart-contract platform).

- **Pool contract:** `CCL2KTHYOVMNNOFDT7PEAHACUBYVFLRH2LYWVQB6IPMHHAVUBC7ZUUC2`
- **Reserves:** XLM · XRP · USDC (Aave-style sToken / debtToken architecture)
- **Live since:** 2024-08-01
- **Stellar Community Fund grant:** $97,500

## Methodology

**TVL** = sToken total supply × collateral coefficient per reserve (= total underlying deposited, including lent-out funds)

**Borrowed** = debtToken total supply × debt coefficient per reserve (= total outstanding loans)

Coefficients are stored at 1e9 precision on-chain; they start at 1e9 and accrue as interest accumulates.

## Data flow

```
pool.get_reserve(asset_sac)
  → reserve_type: ["Fungible", s_token_address, debt_token_address]

pool.token_total_supply(s_token)  × pool.collat_coeff(asset) / 1e9  → TVL per reserve
pool.token_total_supply(debt_tok) × pool.debt_coeff(asset)   / 1e9  → borrowed per reserve

api.addCGToken(geckoId, amount)  — priced via CoinGecko
```

All calls via `callSoroban` from `projects/helper/chain/stellar` (no external SDK).

## Adapter design

| Field | Value |
|---|---|
| Chain | `stellar` |
| Exports | `{ stellar: { tvl, borrowed } }` |
| RPC | Soroban `simulateTransaction` via `callSoroban` helper |
| Pricing | CoinGecko (`stellar`, `ripple`, `usd-coin`) |
| Timetravel | `false` (Soroban ledger state not historically retrievable) |

## Test output (2026-04-28, live on-chain)

```
--- stellar ---
XLM    55.17
USDC   43.64
XRP     1.60
Total: 100.42

--- stellar-borrowed ---
USDC   10.74
XLM     3.29
Total: 14.04
```

## Test

```bash
node test.js projects/slender/index.js
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Slender lending protocol support on Stellar.
  * Tracks total value locked (TVL) and borrowed amounts for Slender reserves (XLM, XRP, USDC).
  * Reads on-chain reserve and token data to compute per-asset TVL and borrow balances.
  * Applies precise scaling so metrics are reported in human-readable units.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->