### PR TITLE
Add MorpheusAI Arbitrum builders TVL

### DIFF
--- a/projects/MorpheusAI/index.js
+++ b/projects/MorpheusAI/index.js
@@ -1,6 +1,9 @@
 const ADDRESSES = require('../helper/coreAssets.json')
 const PROJECT_CONTRACT = '0x47176B2Af9885dC6C4575d4eFd63895f7Aaa4790';
 const PROJECT_CONTRACT_V2 = '0xDf1AC1AC255d91F5f4B1E3B4Aef57c5350F64C7A';
+const ARBITRUM_BUILDERS_CONTRACT = '0xC0eD68f163d44B6e9985F0041fDf6f67c6BCFF3f';
+const ARBITRUM_MOR = '0x092bAaDB7DEf4C3981454dD9c0A0D7FF07bCFc86';
+const MOR_COINGECKO_ID = 'morpheusai';
 
 async function tvl(api) {
   const v2Deployment = +new Date('2025-09-17') / 1e3
@@ -18,6 +21,16 @@ async function tvl(api) {
 
 }
 
+async function buildersTvl(api) {
+  const buildersMor = await api.call({
+    target: ARBITRUM_MOR,
+    params: [ARBITRUM_BUILDERS_CONTRACT],
+    abi: 'function balanceOf(address) view returns (uint256)',
+  })
+
+  api.addCGToken(MOR_COINGECKO_ID, Number(buildersMor) / 1e18)
+}
+
 const abi = {
   "getAllATokens": "function getAllATokens() view returns ((string symbol, address tokenAddress)[])",
   "getAllReservesTokens": "function getAllReservesTokens() view returns ((string symbol, address tokenAddress)[])",
@@ -26,9 +39,10 @@ const abi = {
 module.exports = {
   timetravel: true,
   misrepresentedTokens: false,
-  methodology: 'Calculates TVL based on stETH deposits in the project contract.',
+  methodology: 'Calculates TVL from Ethereum capital deposits in Morpheus pool contracts and MOR deposited in Arbitrum Builders pools.',
   start: '2024-02-08',  // Feb-08-2024 07:33:35 AM UTC in Unix timestamp
   ethereum: { tvl },
+  arbitrum: { tvl: buildersTvl },
   hallmarks: [
     ['2024-04-06', "MOR token launch"],  // May-08-2024 12:00:00 AM UTC in Unix timestamp
   ],


### PR DESCRIPTION
Adds Arbitrum TVL for MorpheusAI by counting MOR deposited in the Builders contract. This addresses the missing Arbitrum holdings reported in #18908.

Tested with:

```bash
LLAMA_RUN_LOCAL=true node test.js projects/MorpheusAI/index.js
```

Output includes an Arbitrum bucket with MOR TVL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Total Value Locked (TVL) tracking for MorpheusAI on the Arbitrum blockchain.

* **Documentation**
  * Updated methodology description to reflect TVL calculation including combined Ethereum capital deposits and MOR token holdings in Arbitrum Builders pools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->