### PR TITLE
Track Denario DGC TVL

### DIFF
--- a/projects/denario/index.js
+++ b/projects/denario/index.js
@@ -2,7 +2,6 @@
 // Price is determined by the price of silver on the spot market plus premium.
 // The price is stored in the price oracle and updated every minute.
 
-const sdk = require('@defillama/sdk');
 const ADDRESSES = require('../helper/coreAssets.json')
 
 const silverAddress = ADDRESSES.polygon.DSC
@@ -31,10 +30,10 @@ async function tvl(api) {
 		abi: 'erc20:totalSupply',
 		target: silverAddress,
 	})
-	// const totalGoldSupply = await api.call({
-	// 	abi: 'erc20:totalSupply',
-	// 	target: goldAddress,
-	// })
+	const totalGoldSupply = await api.call({
+		abi: 'erc20:totalSupply',
+		target: goldAddress,
+	})
 
 	const silverPrice = await api.call({
 		target: priceOracle,
@@ -51,7 +50,7 @@ async function tvl(api) {
 
 	return {
 		[silverAddress]: totalSilverSupply,
-		// [goldAddress]: totalGoldSupply,
+		[goldAddress]: totalGoldSupply,
 	}
 }
 


### PR DESCRIPTION
Adds Denario Gold Coin (DGC) total supply to the Denario adapter. The adapter already had the DGC core asset configured but the supply read was commented out, so only DSC was being returned.

Related to #18067.

Tested with:

```bash
LLAMA_RUN_LOCAL=true node test.js projects/denario/index.js
```

Output now includes both DSC and DGC in Polygon TVL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected TVL calculation to include all token supplies for improved accuracy.

* **Refactor**
  * Removed unused imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->