### PR TITLE
add alvara adapter

### DIFF
--- a/projects/alvara/index.js
+++ b/projects/alvara/index.js
@@ -1,0 +1,21 @@
+// Alvara Protocol — ALVA held by the public treasury multisig (on-chain balance).
+// Full ERC-7621 basket TVL would require enumerating all BasketToken contracts
+// (factory address + event indexers); this is a minimal, verifiable lower bound.
+
+const ALVA = '0x8e729198d1C59B82bd6bBa579310C40d740A11C2' // canonical ALVA (ethereum)
+const TREASURY = '0x689ac37b02a36e77d2ad1ea7d923a05233a0d8e2' // alvaraprotocol.eth
+
+async function tvl (api) {
+  const bal = await api.call({
+    target: ALVA,
+    abi: 'erc20:balanceOf',
+    params: [TREASURY],
+  })
+  api.add(ALVA, bal)
+}
+
+module.exports = {
+  methodology:
+    'Sums the ALVA (ERC-20) token balance held by the Alvara treasury multisig on Ethereum. Basket-level ERC-7621 reserve TVL is not included because basket contracts are permissionlessly deployed and must be enumerated from the on-chain factory or logs.',
+  ethereum: { tvl },
+}


### PR DESCRIPTION

##### Name (to be shown on DefiLlama):
Alvara

##### Twitter Link:
https://x.com/AlvaraProtocol

##### List of audit links if any:
N/A (not publicly listed in docs)

##### Website Link:
https://alvara.xyz

##### Logo (High resolution, will be shown with rounded borders):
https://alvara.xyz/favicon/apple-touch-icon.png

##### Current TVL:
~$118 (at test time; on-chain treasury ALVA balance)

##### Treasury Addresses (if the protocol has treasury)
0x689ac37b02a36e77d2ad1ea7d923a05233a0d8e2 (alvaraprotocol.eth)

##### Chain:
ethereum

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)
alvara-protocol

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
(leave blank)

##### Short Description (to be shown on DefiLlama):
Alvara is an on-chain basket/fund management protocol built around the ERC-7621 basket token standard.

##### Token address and ticker if any:
ALVA: 0x8e729198d1c59b82bd6bba579310c40d740a11c2

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Yield Aggregator

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
N/A for this TVL adapter (direct on-chain token balances)

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
TVL is computed from on-chain ERC20 `balanceOf` calls only; no oracle usage in adapter logic.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
https://alvara.xyz  
https://docs.alvara.xyz/

##### forkedFrom (Does your project originate from another project):
None

##### methodology (what is being counted as tvl, how is tvl being calculated):
Sums ALVA token balance held by Alvara treasury address on Ethereum using on-chain `erc20:balanceOf` call:
- token: 0x8e729198d1c59b82bd6bba579310c40d740a11c2
- owner: 0x689ac37b02a36e77d2ad1ea7d923a05233a0d8e2

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/Alvara-Protocol

##### Does this project have a referral program?
No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ethereum TVL adapter for Alvara that tracks the treasury token balance on-chain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->