### PR TITLE
moor: include stfuel in tvl

### DIFF
--- a/projects/moor/index.js
+++ b/projects/moor/index.js
@@ -10,7 +10,8 @@ async function tvl(api) {
   const stakingContract = '0x79d2a26b57974e2b2e4d39dc189e818fcc86399337406dec65165b189a6f1ed7'
   const owners = [contractId, stakingContract]
 
-  await sumTokens({ api, owners })
+  const balances = await sumTokens({ api, owners })
+  if (balances[ST_FUEL]) return balances
   return sumTokens({ api, owners, tokens: [ST_FUEL] })
 }
 

--- a/projects/moor/index.js
+++ b/projects/moor/index.js
@@ -1,10 +1,17 @@
 const { sumTokens } = require("../helper/chain/fuel")
 
+// stFUEL (The Rig) — asset id on Fuel; needed explicitly because the bulk
+// contractBalances path does not always surface this receipt token balance.
+const ST_FUEL =
+  "0x5505d0f58bea82a052bc51d2f67ab82e9735f0a98ca5d064ecb964b8fd30c474"
+
 async function tvl(api) {
   const contractId = '0xd7795099227cc0b9dc5872d29ca2b10691d9db6bd45853a6bb532e68dd166ce3'
   const stakingContract = '0x79d2a26b57974e2b2e4d39dc189e818fcc86399337406dec65165b189a6f1ed7'
+  const owners = [contractId, stakingContract]
 
-  return sumTokens({ api, owners: [contractId,stakingContract] })
+  await sumTokens({ api, owners })
+  return sumTokens({ api, owners, tokens: [ST_FUEL] })
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- Fix Moor Fuel TVL to include stFUEL balances explicitly.
- Adds stFUEL asset id (`0x5505d0f58bea82a052bc51d2f67ab82e9735f0a98ca5d064ecb964b8fd30c474`) in `projects/moor/index.js`.
- Keeps existing owner-based token summing logic and extends it to include stFUEL directly.

## Why
Issue #17812 reports missing stFUEL TVL on Moor. stFUEL now has pricing support, so it should be counted directly in adapter TVL.

## Test
- `node test.js projects/moor/index.js`
- Result includes `stFUEL` line item in TVL output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of total value locked (TVL) calculations by ensuring receipt token balances are consistently captured during aggregation across multiple contracts.
  * Ensured the specific receipt token ST_FUEL is always included in TVL computations so its balance is reliably reflected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->