### PR TITLE
track defi united relief fund

### DIFF
--- a/projects/defi-united/index.js
+++ b/projects/defi-united/index.js
@@ -1,0 +1,20 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+const { sumTokensExport } = require('../helper/unwrapLPs')
+
+const DEFI_UNITED_WALLET = '0x0fCa5194baA59a362a835031d9C4A25970effE68'
+
+module.exports = {
+  methodology: 'Counts the total ETH, USDC, USDT, and DAI contributions held in the DeFi United relief fund address (defiunited.eth), a coordinated recovery effort to restore rsETH backing after the April 2026 KelpDAO exploit.',
+  start: 24934540,
+  ethereum: {
+    tvl: sumTokensExport({
+      owner: DEFI_UNITED_WALLET,
+      tokens: [
+        ADDRESSES.null,
+        ADDRESSES.ethereum.USDC,
+        ADDRESSES.ethereum.USDT,
+        ADDRESSES.ethereum.DAI,
+      ],
+    }),
+  },
+}


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
DeFi United

##### List of audit links if any:
N/A — relief fund wallet, no smart contracts

##### Website Link:
[defiunited.world](https://defiunited.world/)

##### Logo (High resolution, will be shown with rounded borders):


##### Current TVL:
~$1.36M

##### Treasury Addresses (if the protocol has treasury)
ethereum:0x0fCa5194baA59a362a835031d9C4A25970effE68 (defiunited.eth)

##### Chain:
Ethereum

##### Coingecko ID:


##### Coinmarketcap ID:


##### Short Description (to be shown on DefiLlama):
Community-coordinated relief fund collecting ETH and stablecoin donations to help restore rsETH backing after the April 2026 KelpDAO exploit.

##### Token address and ticker if any:
N/A

##### Category:
Treasury

##### Oracle Provider(s):
N/A

##### Implementation Details:
N/A

##### Documentation/Proof:
N/A

##### forkedFrom:
N/A

##### methodology (what is being counted as tvl, how is tvl being calculated):
Counts the total ETH, USDC, USDT, and DAI contributions held in the DeFi United relief fund address (defiunited.eth, 0x0fCa5194baA59a362a835031d9C4A25970effE68), a coordinated recovery effort to restore rsETH backing after the April 2026 KelpDAO exploit.

##### Github org/user:

##### Does this project have a referral program?
No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ethereum TVL tracking for the DeFi United relief fund, aggregating balances of native ETH and major stablecoins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->