### PR TITLE
feat: add zama-protocol-tvs adapter (Zama wrappers registry TVS)

### DIFF
--- a/projects/zama-protocol-tvs/index.js
+++ b/projects/zama-protocol-tvs/index.js
@@ -1,0 +1,91 @@
+/**
+ * DefiLlama SDK adapter — Zama confidential (ERC-7984) wrappers on Ethereum.
+ *
+ * TVS (Total Value Shielded): for every valid (underlying, wrapper) pair in the
+ * official Wrappers Registry, we count wrapper.totalSupply() as the amount of
+ * underlying notionally shielded, normalized to the underlying token's decimals.
+ *
+ * Project path: projects/zama-protocol-tvs/
+ * Registry: https://docs.zama.org/protocol/protocol-apps/addresses/mainnet/ethereum.md
+ */
+
+const REGISTRY = '0xeb5015fF021DB115aCe010f23F55C2591059bBA0';
+
+const registryGetPairsAbi =
+  'function getTokenConfidentialTokenPairs() view returns (tuple(address tokenAddress, address confidentialTokenAddress, bool isValid)[])';
+
+function toBigInt(v) {
+  if (typeof v === 'bigint') return v;
+  if (typeof v === 'number') return BigInt(Math.trunc(v));
+  return BigInt(String(v));
+}
+
+/** underlying smallest units = supply * 10^uDec / 10^wDec */
+function toUnderlyingRawAmount(supply, wrapperDecimals, underlyingDecimals) {
+  const w = BigInt(wrapperDecimals);
+  const u = BigInt(underlyingDecimals);
+  if (w === u) return supply;
+  return (supply * 10n ** u) / 10n ** w;
+}
+
+async function tvl(api) {
+  const pairs = await api.call({
+    target: REGISTRY,
+    abi: registryGetPairsAbi,
+  });
+
+  if (!pairs || !pairs.length) return;
+
+  const valid = pairs.filter((p) => {
+    const ok = Array.isArray(p) ? p[2] : p.isValid;
+    return ok;
+  });
+
+  if (!valid.length) return;
+
+  const wrappers = valid.map((p) => (Array.isArray(p) ? p[1] : p.confidentialTokenAddress));
+  const underlyings = valid.map((p) => (Array.isArray(p) ? p[0] : p.tokenAddress));
+
+  const totalSupplies = await api.multiCall({
+    abi: 'erc20:totalSupply',
+    calls: wrappers.map((target) => ({ target })),
+    permitFailure: true,
+  });
+
+  const wrapperDecimals = await api.multiCall({
+    abi: 'erc20:decimals',
+    calls: wrappers.map((target) => ({ target })),
+    permitFailure: true,
+  });
+
+  const underlyingDecimals = await api.multiCall({
+    abi: 'erc20:decimals',
+    calls: underlyings.map((target) => ({ target })),
+    permitFailure: true,
+  });
+
+  for (let i = 0; i < valid.length; i++) {
+    if (totalSupplies[i] === null || wrapperDecimals[i] === null || underlyingDecimals[i] === null) {
+      continue;
+    }
+    const supply = toBigInt(totalSupplies[i]);
+    if (supply === 0n) continue;
+
+    const wDec = toBigInt(wrapperDecimals[i]);
+    const uDec = toBigInt(underlyingDecimals[i]);
+    const raw = toUnderlyingRawAmount(supply, wDec, uDec);
+    if (raw === 0n) continue;
+
+    api.add(underlyings[i], raw);
+  }
+}
+
+module.exports = {
+  methodology:
+    'Total value shielded (TVS): sums underlying ERC-20 amounts represented by confidential wrapper totalSupply for each valid pair returned by the Zama Wrappers Registry on Ethereum. Balances are priced by DefiLlama as TVL.',
+  timetravel: true,
+  misrepresentedTokens: false,
+  ethereum: {
+    tvl,
+  },
+};

--- a/projects/zama-protocol-tvs/index.js
+++ b/projects/zama-protocol-tvs/index.js
@@ -14,13 +14,24 @@ const REGISTRY = '0xeb5015fF021DB115aCe010f23F55C2591059bBA0';
 const registryGetPairsAbi =
   'function getTokenConfidentialTokenPairs() view returns (tuple(address tokenAddress, address confidentialTokenAddress, bool isValid)[])';
 
+/**
+ * Coerce a multicall return value to BigInt.
+ * @param {bigint|number|string} v
+ * @returns {bigint}
+ */
 function toBigInt(v) {
   if (typeof v === 'bigint') return v;
   if (typeof v === 'number') return BigInt(Math.trunc(v));
   return BigInt(String(v));
 }
 
-/** underlying smallest units = supply * 10^uDec / 10^wDec */
+/**
+ * Convert wrapper totalSupply (wrapper decimals) to underlying raw units.
+ * @param {bigint} supply
+ * @param {bigint} wrapperDecimals
+ * @param {bigint} underlyingDecimals
+ * @returns {bigint}
+ */
 function toUnderlyingRawAmount(supply, wrapperDecimals, underlyingDecimals) {
   const w = BigInt(wrapperDecimals);
   const u = BigInt(underlyingDecimals);
@@ -28,6 +39,11 @@ function toUnderlyingRawAmount(supply, wrapperDecimals, underlyingDecimals) {
   return (supply * 10n ** u) / 10n ** w;
 }
 
+/**
+ * Sum TVS: for each valid registry pair, add underlying amount implied by wrapper totalSupply.
+ * Fail-fast if any registry-listed pair cannot be read (no silent understatement of TVL).
+ * @param {import('@defillama/sdk').ChainApi} api
+ */
 async function tvl(api) {
   const pairs = await api.call({
     target: REGISTRY,
@@ -49,24 +65,23 @@ async function tvl(api) {
   const totalSupplies = await api.multiCall({
     abi: 'erc20:totalSupply',
     calls: wrappers.map((target) => ({ target })),
-    permitFailure: true,
   });
 
   const wrapperDecimals = await api.multiCall({
     abi: 'erc20:decimals',
     calls: wrappers.map((target) => ({ target })),
-    permitFailure: true,
   });
 
   const underlyingDecimals = await api.multiCall({
     abi: 'erc20:decimals',
     calls: underlyings.map((target) => ({ target })),
-    permitFailure: true,
   });
 
   for (let i = 0; i < valid.length; i++) {
-    if (totalSupplies[i] === null || wrapperDecimals[i] === null || underlyingDecimals[i] === null) {
-      continue;
+    if (totalSupplies[i] == null || wrapperDecimals[i] == null || underlyingDecimals[i] == null) {
+      throw new Error(
+        `zama-protocol-tvs: missing multicall result for valid registry pair index=${i} underlying=${underlyings[i]} wrapper=${wrappers[i]}`,
+      );
     }
     const supply = toBigInt(totalSupplies[i]);
     if (supply === 0n) continue;


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR. ✅

**Contributor disclosure:** I am an independent community contributor and **not** an employee or official representative of Zama. This adapter only reads **public on-chain** state (Wrappers Registry + wrappers) documented by Zama. Any links to Zama’s website or X are **for protocol identification and documentation**, not an endorsement or claim of affiliation.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).

2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with collecting the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** It is a different repo, you can find your listing in [this file](https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts), you can edit it there and put up a PR
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes — this PR adds only `projects/zama-protocol-tvs/index.js` (no lockfile changes).

---
## PR summary

- **Adapter:** `projects/zama-protocol-tvs/index.js`
- **Chain:** Ethereum
- **Source of truth (on-chain only):** Zama Wrappers Registry `0xeb5015fF021DB115aCe010f23F55C2591059bBA0` — `getTokenConfidentialTokenPairs()`, only pairs with `isValid == true`
- **TVL logic:** For each confidential wrapper, read `totalSupply` plus wrapper/underlying `decimals`, normalize to underlying raw units, `api.add(underlying, amount)` (USD via DefiLlama pricing)
- **Docs:** [Zama mainnet addresses](https://docs.zama.org/protocol/protocol-apps/addresses/mainnet/ethereum.md)

`node test.js projects/zama-protocol-tvs/index.js` run locally matched ~$28M TVL (figure moves with supply and prices).

---
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
Zama — Confidential tokens (TVS)

##### Twitter Link:
https://twitter.com/zama

##### List of audit links if any:


##### Website Link:
https://www.zama.ai/

##### Logo (High resolution, will be shown with rounded borders):
<img width="1200" height="1200" alt="z-square_yellow" src="https://github.com/user-attachments/assets/1ae2f013-3f2c-4fca-bb4d-1d7827553538" />


##### Current TVL:
~$28M Ethereum (approximate from local `test.js` run at PR time; not a guarantee of live UI.)

##### Treasury Addresses (if the protocol has treasury)
N/A

##### Chain:
Ethereum

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description (to be shown on DefiLlama):
TVL reflects value shielded in Zama’s Ethereum confidential (ERC-7984) wrappers: each valid registry pair contributes underlying token balances implied by the wrapper’s `totalSupply`, normalized to underlying decimals and priced in USD by DefiLlama.

##### Token address and ticker if any:
Multi-asset via registry-linked underlyings (e.g. USDC, USDT, WETH). Registry: `0xeb5015fF021DB115aCe010f23F55C2591059bBA0`.

##### Category (full list at https://defillama.com/categories) \*Please choose only one:
Privacy

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
N/A — balances from chain; USD from DefiLlama’s standard token pricing.

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
Not applicable.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
https://docs.zama.org/protocol/protocol-apps/addresses/mainnet/ethereum.md

##### forkedFrom (Does your project originate from another project):
No

##### methodology (what is being counted as tvl, how is tvl being calculated):
Total value shielded (TVS): sum over valid registry pairs of confidential wrapper `totalSupply`, converted to underlying token raw amounts (decimal normalization), aggregated and shown as TVL in USD through DefiLlama pricing. Same text as `methodology` in `projects/zama-protocol-tvs/index.js`.

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/zama-ai — adapter PR author: https://github.com/00Xchriswilder-fhevm-hub

##### Does this project have a referral program?
No

---
## Contributor references (optional)

Ecosystem analytics dashboard: https://zamadashboard.org/

Related integrations and demos (external links):

- **Gnosis Safe (zama protocol and ERC-7984 implementation):** https://x.com/realchriswilder/status/2036019295424004262
- **MetaMask (zama protocol and ERC-7984 implementation):** https://x.com/realchriswilder/status/2048335489707442457
- **Rabby (zama protocol and ERC-7984 implementation):** https://x.com/realchriswilder/status/2048741451354513523
- **Zpayy (iOS & Android) Private payments on Ethereum Public chain:** https://x.com/realchriswilder/status/2044784821487177800 — site: https://zpayy.app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVS tracking for Zama confidential wrapper tokens (ERC-7984) on Ethereum, enabling real-time visibility into total value held in wrapped positions.
  * Supports historical (time-travel) data for comprehensive trend analysis and retrospective reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->