### PR TITLE
fix: correct TVL decimal normalization in ssi-protocol adapter

### DIFF
--- a/projects/ssi-protocol/index.js
+++ b/projects/ssi-protocol/index.js
@@ -1,67 +1,64 @@
 const sdk = require('@defillama/sdk')
-const { getBlock } = require('../helper/http');
 
 const abi = {
-  getBasket: 'function getBasket() view returns ((string chain, string symbol, string addr, uint8 decimals, uint256 amount)[])'
+  getBasket: 'function getBasket() view returns ((string chain, string symbol, string addr, uint8 decimals, uint256 amount)[])',
 }
 
 const ssi_tokens = [
-  // MAG7.ssi
-  '0x9E6A46f294bB67c20F1D1E7AfB0bBEf614403B55',
-  // DEFI.ssi
-  '0x164ffdaE2fe3891714bc2968f1875ca4fA1079D0',
-  // MEME.ssi
-  '0xdd3acDBDc7b358Df453a6CB6bCA56C92aA5743aA'
+  '0x9E6A46f294bB67c20F1D1E7AfB0bBEf614403B55',  // MAG7.ssi
+  '0x164ffdaE2fe3891714bc2968f1875ca4fA1079D0',  // DEFI.ssi
+  '0xdd3acDBDc7b358Df453a6CB6bCA56C92aA5743aA',  // MEME.ssi
 ]
 
-function underlyingExports(chains) {
-  const exportObj = {};
-  Object.entries(chains).forEach(([chain, [chain_name, native_token]]) => {
-    exportObj[chain] = {
-      tvl: async (api, ethBlock, chainBlocks) => {
-        const balances = {};
-        const base_block = await getBlock(api.timestamp, 'base', chainBlocks);
-        const baskets = await Promise.all(ssi_tokens.map(async (ssi_token) => {
-          const res = await sdk.api.abi.call({
-            abi: abi.getBasket,
-            target: ssi_token,
-            chain: 'base',
-            block: base_block,
-          });
-          return res.output;
-        }));
-        baskets.forEach(basket => {
-          basket.forEach(token => {
-            if (token.chain == chain_name) {
-              let token_addr;
-              let token_amount;
-              if (token.addr != '') {
-                token_addr = chain + ':' + token.addr;
-                token_amount = token.amount;
-              } else {
-                token_addr = native_token;
-                token_amount = token.amount / 10 ** token.decimals;
-              }
-              sdk.util.sumSingleBalance(balances, token_addr, token_amount);
-            }
-          });
-        });
-        return balances;
-      }
-    }
-  });
-  return exportObj;
+const CHAIN_MAP = {
+  ethereum: 'ETH',
+  bsc: 'BSC_BNB',
+  solana: 'SOL',
+  bitcoin: 'BTC',
+  cardano: 'ADA',
+  ripple: 'XRP',
+  doge: 'DOGE',
 }
 
+const NATIVE_CG_IDS = {
+  ETH:     'ethereum',
+  BSC_BNB: 'binancecoin',
+  SOL:     'solana',
+  BTC:     'bitcoin',
+  ADA:     'cardano',
+  XRP:     'ripple',
+  DOGE:    'dogecoin',
+}
+
+async function getBaskets(timestamp) {
+  const baseApi = new sdk.ChainApi({ chain: 'base', timestamp })
+  return baseApi.multiCall({ abi: abi.getBasket, calls: ssi_tokens })
+}
+
+function buildTvl(chainName) {
+  return async (api) => {
+    const baskets = await getBaskets(api.timestamp)
+    baskets.forEach((basket) => {
+      basket.forEach((token) => {
+        if (token.chain !== chainName) return
+        const amount = Number(token.amount) / 10 ** Number(token.decimals)
+        if (token.addr !== '') {
+          api.add(api.chain + ':' + token.addr, amount)
+        } else {
+          const cgId = NATIVE_CG_IDS[chainName]
+          if (cgId) api.addCGToken(cgId, amount)
+        }
+      })
+    })
+  }
+}
+
+const chains = {}
+Object.entries(CHAIN_MAP).forEach(([chain, chainName]) => {
+  chains[chain] = { tvl: buildTvl(chainName) }
+})
+
 module.exports = {
-  methodology: 'TVL counts the underlying tokens in the baskets of the SSI tokens.',
-  ...underlyingExports({
-    ethereum: ['ETH', 'ethereum'],
-    bsc: ['BSC_BNB', 'binancecoin'],
-    doge: ['DOGE', 'dogecoin'],
-    solana: ['SOL', 'solana'],
-    bitcoin: ['BTC', 'bitcoin'],
-    cardano: ['ADA', 'cardano'],
-    ripple: ['XRP', 'ripple'],
-  })
-};
+  methodology: 'TVL counts the underlying tokens held in the baskets of all SoSoValue SSI index tokens (MAG7.ssi, DEFI.ssi, MEME.ssi). Basket composition is read directly from on-chain getBasket() calls on Base.',
+  ...chains,
+}

--- a/projects/ssi-protocol/index.js
+++ b/projects/ssi-protocol/index.js
@@ -60,7 +60,9 @@ function buildTvl(chainName) {
         } else {
           const cgId = NATIVE_CG_IDS[chainName]
           if (cgId) {
-            api.addCGToken(cgId, amount)
+            const decimals = Number(token.decimals)
+            const normalizedAmount = Number(BigInt(amount) * BigInt(1e9) / BigInt(10 ** decimals)) / 1e9
+            api.addCGToken(cgId, normalizedAmount)
           } else {
             console.warn(`[ssi-protocol] No CoinGecko ID mapped for native chain "${chainName}" — skipping`)
           }

--- a/projects/ssi-protocol/index.js
+++ b/projects/ssi-protocol/index.js
@@ -33,8 +33,14 @@ const NATIVE_CG_IDS = {
 const _basketCache = new Map()
 async function getBaskets(timestamp) {
   if (!_basketCache.has(timestamp)) {
-    const baseApi = new sdk.ChainApi({ chain: 'base', timestamp })
-    _basketCache.set(timestamp, baseApi.multiCall({ abi: abi.getBasket, calls: ssi_tokens }))
+    const request = (async () => {
+      const baseApi = new sdk.ChainApi({ chain: 'base', timestamp })
+      return baseApi.multiCall({ abi: abi.getBasket, calls: ssi_tokens })
+    })().catch((e) => {
+      _basketCache.delete(timestamp)
+      throw e
+    })
+    _basketCache.set(timestamp, request)
   }
   return _basketCache.get(timestamp)
 }

--- a/projects/ssi-protocol/index.js
+++ b/projects/ssi-protocol/index.js
@@ -43,7 +43,10 @@ function buildTvl(chainName) {
         if (token.chain !== chainName) return
         const amount = token.amount
         if (token.addr !== '') {
-          api.add(api.chain + ':' + token.addr, amount)
+          const tokenAddress = ['ethereum', 'bsc'].includes(api.chain)
+            ? token.addr.toLowerCase()
+            : token.addr
+          api.add(`${api.chain}:${tokenAddress}`, amount)
         } else {
           const cgId = NATIVE_CG_IDS[chainName]
           if (cgId) api.addCGToken(cgId, amount)

--- a/projects/ssi-protocol/index.js
+++ b/projects/ssi-protocol/index.js
@@ -30,9 +30,13 @@ const NATIVE_CG_IDS = {
   DOGE:    'dogecoin',
 }
 
+const _basketCache = new Map()
 async function getBaskets(timestamp) {
-  const baseApi = new sdk.ChainApi({ chain: 'base', timestamp })
-  return baseApi.multiCall({ abi: abi.getBasket, calls: ssi_tokens })
+  if (!_basketCache.has(timestamp)) {
+    const baseApi = new sdk.ChainApi({ chain: 'base', timestamp })
+    _basketCache.set(timestamp, baseApi.multiCall({ abi: abi.getBasket, calls: ssi_tokens }))
+  }
+  return _basketCache.get(timestamp)
 }
 
 function buildTvl(chainName) {
@@ -49,7 +53,11 @@ function buildTvl(chainName) {
           api.add(`${api.chain}:${tokenAddress}`, amount)
         } else {
           const cgId = NATIVE_CG_IDS[chainName]
-          if (cgId) api.addCGToken(cgId, amount)
+          if (cgId) {
+            api.addCGToken(cgId, amount)
+          } else {
+            console.warn(`[ssi-protocol] No CoinGecko ID mapped for native chain "${chainName}" — skipping`)
+          }
         }
       })
     })

--- a/projects/ssi-protocol/index.js
+++ b/projects/ssi-protocol/index.js
@@ -41,7 +41,7 @@ function buildTvl(chainName) {
     baskets.forEach((basket) => {
       basket.forEach((token) => {
         if (token.chain !== chainName) return
-        const amount = Number(token.amount) / 10 ** Number(token.decimals)
+        const amount = token.amount
         if (token.addr !== '') {
           api.add(api.chain + ':' + token.addr, amount)
         } else {


### PR DESCRIPTION
Closes #17720 

The previous adapter had a critical bug where ERC-20 token amounts from getBasket() were stored as raw integer values without dividing by 10^decimals, causing TVL to be massively inflated.

Changes:
- Fix token amount normalization: always divide by 10^decimals regardless of whether the token has a contract address or is a native asset
- Replace deprecated sdk.api.abi.call + getBlock pattern with modern sdk.ChainApi for Base-chain reads from cross-chain TVL functions
- Remove unused getBlock import from ../helper/http
- Improve code clarity with named constants and extracted getBaskets()

**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).

2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** It is a different repo, you can find your listing in [this file](https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts), you can edit it there and put up a PR
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized TVL computation by reading basket compositions from a single, centralized source and exposing per-chain TVL endpoints.
  * Implemented batch fetching and cache-by-timestamp to improve efficiency and consistency across chains.
  * Standardized aggregation for ERC‑20 and native underlyings with consistent address normalization and native coin ID mapping; unmapped natives are skipped with a warning.
  * Updated methodology text to reflect the new centralized approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->