### PR TITLE
feat(ci): show TVL diff vs main on adapter PR comments

### DIFF
--- a/.github/workflows/__tests__/computeDiff.test.js
+++ b/.github/workflows/__tests__/computeDiff.test.js
@@ -1,0 +1,149 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  computeDiff,
+  formatUsd,
+  formatSignedUsd,
+  formatPct,
+  classifyDelta,
+  partitionRows,
+} = require('../computeDiff');
+
+const SCHEMA = 'tvl-baseline-v1';
+const baseline = (totals = {}, extras = {}) => ({ schema: SCHEMA, errored: false, totals, ...extras });
+
+test('formatUsd: scales by suffix and handles edge cases', () => {
+  const cases = [
+    [0, '$0'],
+    [123.45, '$123.45'],
+    [1_500, '$1.50k'],
+    [12_500_000, '$12.50M'],
+    [2_500_000_000, '$2.50B'],
+    [3_000_000_000_000, '$3.00T'],
+    [-1_500_000, '-$1.50M'],
+    [null, '—'],
+    [undefined, '—'],
+    [NaN, '—'],
+    [Infinity, '—'],
+  ];
+  for (const [input, expected] of cases) {
+    assert.equal(formatUsd(input), expected, `formatUsd(${input})`);
+  }
+});
+
+test('formatSignedUsd: + prefix for positive, no prefix for negative', () => {
+  assert.equal(formatSignedUsd(100_000), '+$100.00k');
+  assert.equal(formatSignedUsd(-200_000), '-$200.00k');
+  assert.equal(formatSignedUsd(0), '$0');
+  assert.equal(formatSignedUsd(null), '—');
+});
+
+test('formatPct: standard, edge, and negligible cases', () => {
+  assert.equal(formatPct(100, 110), '+10.00%');
+  assert.equal(formatPct(100, 90), '-10.00%');
+  assert.equal(formatPct(100, 100), '0%');
+  assert.equal(formatPct(0, 100), 'new');
+  assert.equal(formatPct(null, 100), 'new');
+  assert.equal(formatPct(100, null), 'removed');
+  assert.equal(formatPct(0, 0), '0%');
+  assert.equal(formatPct(null, null), '—');
+  assert.equal(formatPct(1_000_000, 1_000_001), '0%');
+});
+
+test('classifyDelta: covers add/remove/changed/unchanged', () => {
+  assert.equal(classifyDelta(null, 100), 'added');
+  assert.equal(classifyDelta(100, null), 'removed');
+  assert.equal(classifyDelta(100, 200), 'changed');
+  assert.equal(classifyDelta(100, 100.5), 'unchanged');
+  assert.equal(classifyDelta(null, null), 'unchanged');
+});
+
+test('partitionRows: 0.1% threshold; added/removed always significant', () => {
+  const rows = [
+    { label: 'a', baseline: 1_000_000, current: 1_000_500, classification: 'unchanged' },
+    { label: 'b', baseline: 1_000_000, current: 1_002_000, classification: 'changed' },
+    { label: 'c', baseline: null,      current: 50,        classification: 'added' },
+    { label: 'd', baseline: 50,        current: null,      classification: 'removed' },
+    { label: 'e', baseline: 0,         current: 0,         classification: 'unchanged' },
+    { label: 'f', baseline: 1_000_000, current: 1_001_000, classification: 'changed' },
+  ];
+  const { significant, quiet } = partitionRows(rows);
+  assert.deepEqual(significant.map(r => r.label).sort(), ['b', 'c', 'd', 'e', 'f']);
+  assert.deepEqual(quiet.map(r => r.label), ['a']);
+});
+
+test('computeDiff: throws on missing schema', () => {
+  assert.throws(() => computeDiff({ baseline: {}, current: baseline(), adapterPath: 'p' }), /baseline missing or wrong schema/);
+  assert.throws(() => computeDiff({ baseline: baseline(), current: {}, adapterPath: 'p' }), /current missing or wrong schema/);
+});
+
+test('computeDiff: renders headline diff with totals and per-chain', () => {
+  const md = computeDiff({
+    baseline: baseline({ tvl: 12_750_000, ethereum: 12_750_000 }),
+    current: baseline({ tvl: 13_500_000, ethereum: 13_500_000 }),
+    adapterPath: 'projects/aave/v3.js',
+  });
+  assert.match(md, /TVL diff for `projects\/aave\/v3.js`/);
+  assert.match(md, /\| \*\*total\*\* \| \$12.75M \| \$13.50M \| \+\$750.00k \| \+5.88% \|/);
+  assert.match(md, /\| ethereum \| \$12.75M \| \$13.50M \| \+\$750.00k \| \+5.88% \|/);
+});
+
+test('computeDiff: marks added and removed chains', () => {
+  const md = computeDiff({
+    baseline: baseline({ tvl: 13_000_000, ethereum: 12_000_000, optimism: 1_000_000 }),
+    current: baseline({ tvl: 12_400_000, ethereum: 12_000_000, polygon: 400_000 }),
+    adapterPath: 'p',
+  });
+  assert.match(md, /\| polygon \| — \| \$400.00k \| \+\$400.00k \| new \|/);
+  assert.match(md, /\| optimism \| \$1.00M \| — \| -\$1.00M \| removed \|/);
+});
+
+test('computeDiff: includes capture metadata footer when present', () => {
+  const md = computeDiff({
+    baseline: baseline({ tvl: 1_000_000 }, { capturedAt: '2026-04-26T14:32:00Z', fileSha: 'abcdef1234567890' }),
+    current: baseline({ tvl: 1_100_000 }),
+    adapterPath: 'p',
+  });
+  assert.match(md, /Baseline captured 2026-04-26T14:32:00Z from main@`abcdef1`/);
+});
+
+test('computeDiff: collapses ≥3 quiet chains; significant + added/removed always above the fold', () => {
+  const baselineTotals = { tvl: 50_000_000, ethereum: 50_000_000 };
+  const currentTotals = { tvl: 50_400_000, ethereum: 50_500_000, polygon: 400_000 };
+  for (let i = 0; i < 4; i++) {
+    baselineTotals[`q${i}`] = 5_000_000;
+    currentTotals[`q${i}`] = 5_000_500;
+  }
+  const md = computeDiff({
+    baseline: baseline(baselineTotals),
+    current: baseline(currentTotals),
+    adapterPath: 'p',
+  });
+  const aboveFold = md.split('<details>')[0];
+  assert.match(aboveFold, /\| ethereum \|.*\+1.00% \|/);
+  assert.match(aboveFold, /\| polygon \|.*new \|/);
+  assert.match(aboveFold, /_4 other chains_.*_no significant change_/);
+  assert.match(md, /<details><summary>Full per-chain table<\/summary>/);
+  for (let i = 0; i < 4; i++) assert.match(md, new RegExp(`\\| q${i} \\|`));
+});
+
+test('computeDiff: does not collapse when fewer than 3 quiet rows', () => {
+  const md = computeDiff({
+    baseline: baseline({ tvl: 30_000_000, a: 10_000_000, b: 10_000_000 }),
+    current: baseline({ tvl: 30_000_300, a: 10_000_100, b: 10_000_200 }),
+    adapterPath: 'p',
+  });
+  assert.doesNotMatch(md, /other chains/);
+  assert.doesNotMatch(md, /<details><summary>Full per-chain table/);
+  assert.match(md, /\| a \|/);
+  assert.match(md, /\| b \|/);
+});
+
+test('computeDiff: zero-delta shows $0 / 0%', () => {
+  const md = computeDiff({
+    baseline: baseline({ tvl: 1_000_000, ethereum: 1_000_000 }),
+    current: baseline({ tvl: 1_000_000, ethereum: 1_000_000 }),
+    adapterPath: 'p',
+  });
+  assert.match(md, /\| \*\*total\*\* \| \$1.00M \| \$1.00M \| \$0 \| 0% \|/);
+});

--- a/.github/workflows/__tests__/parseTvl.test.js
+++ b/.github/workflows/__tests__/parseTvl.test.js
@@ -1,0 +1,72 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { parseTvl, parseHumanizedNumber } = require('../parseTvl');
+
+test('parseHumanizedNumber: humanizeNumber output forms', () => {
+  const cases = [
+    ['12.34 M', 12_340_000],
+    ['1.50 B', 1_500_000_000],
+    ['2.00 T', 2_000_000_000_000],
+    ['500.00 k', 500_000],
+    ['123.45', 123.45],
+    ['0.00', 0],
+    ['-1.23 M', -1_230_000],
+  ];
+  for (const [input, expected] of cases) {
+    assert.equal(parseHumanizedNumber(input), expected, `parse ${input}`);
+  }
+});
+
+test('parseHumanizedNumber: returns null for unparseable input', () => {
+  for (const input of ['', 'abc', '1.2.3', 'NaN', null, undefined]) {
+    assert.equal(parseHumanizedNumber(input), null, `null for ${JSON.stringify(input)}`);
+  }
+});
+
+test('parseTvl: throws on non-string input', () => {
+  assert.throws(() => parseTvl(null), /must be a string/);
+});
+
+test('parseTvl: returns errored shape when no TVL marker present', () => {
+  const result = parseTvl('preamble\n------ ERROR ------\nstack trace');
+  assert.equal(result.errored, true);
+  assert.match(result.errorTail, /stack trace/);
+  assert.deepEqual(result.totals, {});
+});
+
+test('parseTvl: errored shape with no markers at all', () => {
+  const result = parseTvl('nothing useful');
+  assert.equal(result.errored, true);
+  assert.equal(result.errorTail, null);
+});
+
+test('parseTvl: extracts totals from realistic stdout', () => {
+  const stdout = [
+    '--- ethereum ---',
+    'USDC                       12.30 M',
+    'Total: 12.30 M',
+    '',
+    '------ TVL ------',
+    'ethereum                   12.75 M',
+    'polygon                    3.00 M',
+    '',
+    'total                      15.75 M',
+  ].join('\n');
+
+  const result = parseTvl(stdout);
+  assert.equal(result.errored, false);
+  assert.equal(result.schema, 'tvl-baseline-v1');
+  assert.deepEqual(result.totals, { tvl: 15_750_000, ethereum: 12_750_000, polygon: 3_000_000 });
+});
+
+test('parseTvl: tolerates blank lines and trailing whitespace', () => {
+  const stdout = '\n\n------ TVL ------\n\nethereum                   1.00 M \n\ntotal                      1.00 M\n\n';
+  assert.equal(parseTvl(stdout).totals.ethereum, 1_000_000);
+});
+
+test('parseTvl: ignores totals rows with unparseable values', () => {
+  const stdout = '------ TVL ------\nweird   undefined\nethereum   1.00 M\ntotal   1.00 M\n';
+  const result = parseTvl(stdout);
+  assert.equal(result.totals.ethereum, 1_000_000);
+  assert.equal(result.totals.weird, undefined);
+});

--- a/.github/workflows/__tests__/parseTvl.test.js
+++ b/.github/workflows/__tests__/parseTvl.test.js
@@ -40,6 +40,14 @@ test('parseTvl: errored shape with no markers at all', () => {
   assert.equal(result.errorTail, null);
 });
 
+test('parseTvl: errored when both TVL and ERROR markers present', () => {
+  const stdout = '------ TVL ------\nethereum 1.00 M\n------ ERROR ------\nboom';
+  const result = parseTvl(stdout);
+  assert.equal(result.errored, true);
+  assert.match(result.errorTail, /boom/);
+  assert.deepEqual(result.totals, {});
+});
+
 test('parseTvl: extracts totals from realistic stdout', () => {
   const stdout = [
     '--- ethereum ---',

--- a/.github/workflows/baseline-on-merge.yml
+++ b/.github/workflows/baseline-on-merge.yml
@@ -1,0 +1,97 @@
+name: Baseline_On_Merge
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'projects/**'
+
+concurrency:
+  group: tvl-baseline
+  cancel-in-progress: false
+
+jobs:
+  refresh-baselines:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          version: 10
+          run_install: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Restore baseline cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .tvl-baselines
+          key: tvl-baselines-v1-${{ github.sha }}
+          restore-keys: |
+            tvl-baselines-v1-
+
+      - name: Detect changed adapter files
+        id: changes
+        run: |
+          mkdir -p .tvl-baselines
+          BEFORE="${{ github.event.before }}"
+          AFTER="${{ github.sha }}"
+          if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            BEFORE="${AFTER}^"
+          fi
+          git diff --name-only "$BEFORE" "$AFTER" -- 'projects/**' \
+            | grep -E '\.(js|ts)$' \
+            | grep -v '^projects/helper/' \
+            | grep -v '^projects/config/' \
+            > changed.txt || true
+          echo "Changed files:"
+          cat changed.txt || true
+          echo "count=$(wc -l < changed.txt | tr -d ' ')" >> "$GITHUB_OUTPUT"
+
+      - name: Refresh baselines for changed adapters
+        if: steps.changes.outputs.count != '0'
+        env:
+          LLAMA_DEBUG_MODE: "true"
+        run: |
+          set -u
+          while IFS= read -r FILE; do
+            [ -z "$FILE" ] && continue
+            [ ! -f "$FILE" ] && continue
+
+            HASH=$(printf '%s' "$FILE" | sha256sum | cut -c1-16)
+            FILE_SHA=$(git log -1 --format=%H -- "$FILE" || echo "")
+            CAPTURED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+            OUT=".tvl-baselines/${HASH}.json"
+
+            echo "::group::Baseline ${FILE}"
+            if node test.js "$FILE" > baseline-output.txt 2>&1; then
+              ADAPTER_PATH="$FILE" FILE_SHA="$FILE_SHA" CAPTURED_AT="$CAPTURED_AT" \
+                node .github/workflows/parseTvl.js baseline-output.txt "$OUT"
+              echo "Wrote ${OUT}"
+            else
+              # Adapter errored on main: skip writing. Next PR sees a cache miss
+              # and falls back to today's behavior. The failing run is already
+              # visible in this workflow's logs.
+              echo "Skipped ${FILE} (test.js errored)"
+            fi
+            echo "::endgroup::"
+          done < changed.txt
+
+      - name: Save baseline cache
+        if: steps.changes.outputs.count != '0'
+        uses: actions/cache/save@v4
+        with:
+          path: .tvl-baselines
+          key: tvl-baselines-v1-${{ github.sha }}

--- a/.github/workflows/commentResult.js
+++ b/.github/workflows/commentResult.js
@@ -27,7 +27,10 @@ function buildDiffBody({ baseline, current, adapterPath, legacyBody }) {
     const { computeDiff } = require('./computeDiff');
     let diffMd;
     try { diffMd = computeDiff({ baseline, current, adapterPath }); }
-    catch { return null; }
+    catch (e) {
+        console.error('computeDiff failed:', e?.message || e);
+        return null;
+    }
     if (!legacyBody) return diffMd;
     return `${diffMd}\n\n<details><summary>Full PR-run output</summary>\n\n${legacyBody}\n\n</details>`;
 }

--- a/.github/workflows/commentResult.js
+++ b/.github/workflows/commentResult.js
@@ -1,24 +1,51 @@
-const { readFileSync, writeFileSync, mkdirSync } = require('fs');
+const { readFileSync, writeFileSync, mkdirSync, existsSync } = require('fs');
 const path = require('path');
 
-function main() {
-    const [, , log, outDir, adapterPath] = process.argv;
-    const file = readFileSync(log, 'utf-8');
+function safeReadJson(p) {
+    if (!p || !existsSync(p)) return null;
+    try { return JSON.parse(readFileSync(p, 'utf-8')); }
+    catch { return null; }
+}
 
+function buildLegacyBody(file, adapterPath) {
     const errorString = '------ ERROR ------';
     const summaryIndex = file.indexOf('------ TVL ------');
     const errorIndex = file.indexOf(errorString);
-    let body;
 
-    if (summaryIndex != -1) {
-        body = `The adapter at ${adapterPath} exports TVL:
+    if (summaryIndex !== -1) {
+        return `The adapter at ${adapterPath} exports TVL:
         \n \n ${file.substring(summaryIndex + 17).replaceAll('\n', '\n    ')}`;
-    } else if (errorIndex != -1) {
-        body = `Error while running adapter at ${adapterPath ?? ''}:
-        \n \n ${file.split(errorString)[1].replaceAll('\n', '\n    ')}`;
-    } else {
-        return;
     }
+    if (errorIndex !== -1) {
+        return `Error while running adapter at ${adapterPath ?? ''}:
+        \n \n ${file.split(errorString)[1].replaceAll('\n', '\n    ')}`;
+    }
+    return null;
+}
+
+function buildDiffBody({ baseline, current, adapterPath, legacyBody }) {
+    const { computeDiff } = require('./computeDiff');
+    let diffMd;
+    try { diffMd = computeDiff({ baseline, current, adapterPath }); }
+    catch { return null; }
+    if (!legacyBody) return diffMd;
+    return `${diffMd}\n\n<details><summary>Full PR-run output</summary>\n\n${legacyBody}\n\n</details>`;
+}
+
+function main() {
+    const [, , log, outDir, adapterPath, baselineJsonPath, currentJsonPath] = process.argv;
+    const file = readFileSync(log, 'utf-8');
+
+    const legacyBody = buildLegacyBody(file, adapterPath);
+    const baseline = safeReadJson(baselineJsonPath);
+    const current = safeReadJson(currentJsonPath);
+
+    let body = null;
+    if (baseline && current && !current.errored && !baseline.errored) {
+        body = buildDiffBody({ baseline, current, adapterPath, legacyBody });
+    }
+    if (!body) body = legacyBody;
+    if (!body) return;
 
     mkdirSync(outDir, { recursive: true });
     const safeName = (adapterPath || 'general').replace(/[^a-zA-Z0-9._-]/g, '_');

--- a/.github/workflows/computeDiff.js
+++ b/.github/workflows/computeDiff.js
@@ -1,0 +1,146 @@
+const SCHEMA = 'tvl-baseline-v1';
+const NEGLIGIBLE_USD = 1;
+const NEGLIGIBLE_PCT = 0.01;
+const SIGNIFICANT_PCT = 0.1;
+const COLLAPSE_MIN_QUIET = 3;
+
+function formatUsd(amount) {
+  if (amount == null || !Number.isFinite(amount)) return '—';
+  const sign = amount < 0 ? '-' : '';
+  const abs = Math.abs(amount);
+  if (abs === 0) return '$0';
+  if (abs >= 1e12) return `${sign}$${(abs / 1e12).toFixed(2)}T`;
+  if (abs >= 1e9) return `${sign}$${(abs / 1e9).toFixed(2)}B`;
+  if (abs >= 1e6) return `${sign}$${(abs / 1e6).toFixed(2)}M`;
+  if (abs >= 1e3) return `${sign}$${(abs / 1e3).toFixed(2)}k`;
+  return `${sign}$${abs.toFixed(2)}`;
+}
+
+function formatSignedUsd(amount) {
+  if (amount == null || !Number.isFinite(amount)) return '—';
+  if (amount === 0) return '$0';
+  if (amount > 0) return '+' + formatUsd(amount);
+  return formatUsd(amount);
+}
+
+function formatPct(baseline, current) {
+  if (baseline == null && current == null) return '—';
+  if (baseline == null || baseline === 0) {
+    if (current == null || current === 0) return '0%';
+    return 'new';
+  }
+  if (current == null) return 'removed';
+  const pct = ((current - baseline) / Math.abs(baseline)) * 100;
+  if (Math.abs(pct) < NEGLIGIBLE_PCT) return '0%';
+  const sign = pct > 0 ? '+' : '';
+  return `${sign}${pct.toFixed(2)}%`;
+}
+
+function classifyDelta(baseline, current) {
+  const b = baseline ?? null;
+  const c = current ?? null;
+  if (b == null && c != null) return 'added';
+  if (b != null && c == null) return 'removed';
+  if (b != null && c != null) {
+    if (Math.abs(c - b) < NEGLIGIBLE_USD) return 'unchanged';
+    return 'changed';
+  }
+  return 'unchanged';
+}
+
+function computeRows(baselineTotals, currentTotals) {
+  const keys = new Set([...Object.keys(baselineTotals || {}), ...Object.keys(currentTotals || {})]);
+  keys.delete('tvl');
+
+  const rows = [];
+  for (const key of keys) {
+    const baseline = baselineTotals?.[key] ?? null;
+    const current = currentTotals?.[key] ?? null;
+    rows.push({
+      label: key,
+      baseline,
+      current,
+      delta: baseline != null && current != null ? current - baseline : null,
+      classification: classifyDelta(baseline, current),
+    });
+  }
+
+  rows.sort((a, b) => {
+    const mag = r => Math.max(Math.abs(r.delta ?? 0), Math.abs(r.current ?? 0), Math.abs(r.baseline ?? 0));
+    return mag(b) - mag(a);
+  });
+
+  return rows;
+}
+
+function partitionRows(rows) {
+  const significant = [];
+  const quiet = [];
+  for (const row of rows) {
+    if (row.classification === 'added' || row.classification === 'removed') {
+      significant.push(row);
+    } else if (row.baseline == null || row.baseline === 0) {
+      significant.push(row);
+    } else {
+      const pct = Math.abs(((row.current ?? 0) - row.baseline) / row.baseline) * 100;
+      (pct >= SIGNIFICANT_PCT ? significant : quiet).push(row);
+    }
+  }
+  return { significant, quiet };
+}
+
+function renderTotalRow(baseline, current) {
+  const b = baseline?.totals?.tvl ?? null;
+  const c = current?.totals?.tvl ?? null;
+  const delta = b != null && c != null ? c - b : null;
+  return `| **total** | ${formatUsd(b)} | ${formatUsd(c)} | ${formatSignedUsd(delta)} | ${formatPct(b, c)} |`;
+}
+
+function renderChainRow(row) {
+  const deltaCell = row.classification === 'added' || row.classification === 'removed'
+    ? formatSignedUsd(row.classification === 'added' ? row.current : -row.baseline)
+    : formatSignedUsd(row.delta);
+  return `| ${row.label} | ${formatUsd(row.baseline)} | ${formatUsd(row.current)} | ${deltaCell} | ${formatPct(row.baseline, row.current)} |`;
+}
+
+function computeDiff({ baseline, current, adapterPath }) {
+  if (!baseline || baseline.schema !== SCHEMA) {
+    throw new Error(`computeDiff: baseline missing or wrong schema (got ${baseline?.schema})`);
+  }
+  if (!current || current.schema !== SCHEMA) {
+    throw new Error(`computeDiff: current missing or wrong schema (got ${current?.schema})`);
+  }
+
+  const { significant, quiet } = partitionRows(computeRows(baseline.totals, current.totals));
+  const collapse = quiet.length >= COLLAPSE_MIN_QUIET;
+
+  const lines = [
+    `### TVL diff for \`${adapterPath}\``,
+    '',
+    '| | Baseline | This PR | Δ | Δ% |',
+    '|---|---:|---:|---:|---:|',
+    renderTotalRow(baseline, current),
+    ...significant.map(renderChainRow),
+  ];
+
+  if (collapse) {
+    lines.push(`| _${quiet.length} other chains_ |  |  |  | _no significant change_ |`);
+    lines.push('', '<details><summary>Full per-chain table</summary>', '');
+    lines.push('| | Baseline | This PR | Δ | Δ% |', '|---|---:|---:|---:|---:|');
+    lines.push(...quiet.map(renderChainRow));
+    lines.push('', '</details>');
+  } else {
+    lines.push(...quiet.map(renderChainRow));
+  }
+
+  if (baseline.fileSha || baseline.capturedAt) {
+    const parts = [];
+    if (baseline.capturedAt) parts.push(baseline.capturedAt);
+    if (baseline.fileSha) parts.push(`main@\`${baseline.fileSha.slice(0, 7)}\``);
+    lines.push('', `_Baseline captured ${parts.join(' from ')}._`);
+  }
+
+  return lines.join('\n');
+}
+
+module.exports = { computeDiff, formatUsd, formatSignedUsd, formatPct, classifyDelta, partitionRows };

--- a/.github/workflows/parseTvl.js
+++ b/.github/workflows/parseTvl.js
@@ -24,7 +24,11 @@ function parseTvl(stdout) {
   const errorIdx = stdout.indexOf(ERROR_MARKER);
   const tvlIdx = stdout.indexOf(TVL_MARKER);
 
-  if (tvlIdx === -1) {
+  // If the run errored at any point, treat the whole output as errored even
+  // when a TVL block was already printed before the failure (e.g. late
+  // assertion, postExit hook throwing). Otherwise we'd render a diff against
+  // partially-broken output.
+  if (errorIdx !== -1 || tvlIdx === -1) {
     return {
       schema: 'tvl-baseline-v1',
       errored: true,

--- a/.github/workflows/parseTvl.js
+++ b/.github/workflows/parseTvl.js
@@ -1,0 +1,75 @@
+const SUFFIX_MULTIPLIER = { T: 1e12, B: 1e9, M: 1e6, k: 1e3 };
+const TVL_MARKER = '------ TVL ------';
+const ERROR_MARKER = '------ ERROR ------';
+const HUMANIZED_RE = /^(-?)(\d+(?:\.\d+)?)(?:\s+([TBMk]))?$/;
+
+function parseHumanizedNumber(raw) {
+  if (raw == null) return null;
+  const trimmed = String(raw).trim();
+  if (trimmed === '' || trimmed.toLowerCase() === 'nan') return null;
+  const m = trimmed.match(HUMANIZED_RE);
+  if (!m) return null;
+  const [, sign, digits, suffix] = m;
+  const base = Number(digits);
+  if (!Number.isFinite(base)) return null;
+  const multiplier = suffix ? SUFFIX_MULTIPLIER[suffix] : 1;
+  return (sign === '-' ? -1 : 1) * base * multiplier;
+}
+
+function parseTvl(stdout) {
+  if (typeof stdout !== 'string') {
+    throw new TypeError('parseTvl: stdout must be a string');
+  }
+
+  const errorIdx = stdout.indexOf(ERROR_MARKER);
+  const tvlIdx = stdout.indexOf(TVL_MARKER);
+
+  if (tvlIdx === -1) {
+    return {
+      schema: 'tvl-baseline-v1',
+      errored: true,
+      errorTail: errorIdx !== -1 ? stdout.slice(errorIdx).slice(0, 4000) : null,
+      totals: {},
+    };
+  }
+
+  return {
+    schema: 'tvl-baseline-v1',
+    errored: false,
+    totals: parseTotalsBlock(stdout.slice(tvlIdx + TVL_MARKER.length)),
+  };
+}
+
+function parseTotalsBlock(text) {
+  const totals = {};
+  for (const rawLine of text.split('\n')) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    if (line.startsWith('---')) break;
+    const match = line.match(/^(\S+)\s+(.+)$/);
+    if (!match) continue;
+    const value = parseHumanizedNumber(match[2].trim());
+    if (value === null) continue;
+    const key = match[1] === 'total' ? 'tvl' : match[1];
+    totals[key] = value;
+  }
+  return totals;
+}
+
+if (require.main === module) {
+  const fs = require('fs');
+  const [, , inputPath, outputPath] = process.argv;
+  if (!inputPath) {
+    console.error('usage: parseTvl.js <input.txt> [output.json]');
+    process.exit(1);
+  }
+  const parsed = parseTvl(fs.readFileSync(inputPath, 'utf-8'));
+  if (process.env.ADAPTER_PATH) parsed.adapter = process.env.ADAPTER_PATH;
+  if (process.env.FILE_SHA) parsed.fileSha = process.env.FILE_SHA;
+  if (process.env.CAPTURED_AT) parsed.capturedAt = process.env.CAPTURED_AT;
+  const json = JSON.stringify(parsed);
+  if (outputPath) fs.writeFileSync(outputPath, json);
+  else process.stdout.write(json + '\n');
+}
+
+module.exports = { parseTvl, parseHumanizedNumber };

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,15 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Restore TVL baselines
+        uses: actions/cache/restore@v4
+        continue-on-error: true
+        with:
+          path: .tvl-baselines
+          key: tvl-baselines-v1-none
+          restore-keys: |
+            tvl-baselines-v1-
+
       - name: Record PR number
         run: |
           mkdir -p pr-comments
@@ -65,7 +74,28 @@ jobs:
           do
             {
               node ${{ github.workspace }}/test.js ${{ github.workspace }}/${i} 2>&1 | tee output.txt
-              node ${{ github.workspace }}/.github/workflows/commentResult.js ${{ github.workspace }}/output.txt ${{ github.workspace }}/pr-comments ${i}
+
+              # Look for a baseline JSON for this adapter, only if it's a real
+              # file path (skip registry-derived virtual entries) and a cached
+              # baseline exists. Any failure here is non-fatal — we fall back
+              # to today's behavior by passing no baseline arg.
+              BASELINE_JSON=""
+              CURRENT_JSON=""
+              if [ -f "${{ github.workspace }}/${i}" ]; then
+                HASH=$(printf '%s' "${i}" | sha256sum | cut -c1-16)
+                CANDIDATE="${{ github.workspace }}/.tvl-baselines/${HASH}.json"
+                if [ -f "$CANDIDATE" ]; then
+                  CURRENT_JSON="${{ github.workspace }}/current-${HASH}.json"
+                  if node ${{ github.workspace }}/.github/workflows/parseTvl.js output.txt "$CURRENT_JSON"; then
+                    BASELINE_JSON="$CANDIDATE"
+                  else
+                    CURRENT_JSON=""
+                  fi
+                fi
+              fi
+
+              node ${{ github.workspace }}/.github/workflows/commentResult.js ${{ github.workspace }}/output.txt ${{ github.workspace }}/pr-comments ${i} "$BASELINE_JSON" "$CURRENT_JSON"
+
               if grep -q "\-\-\-\- ERROR \-\-\-\-" output.txt; then
                 exit 1;
               fi


### PR DESCRIPTION
Adds a per-chain TVL diff vs `main` to the existing PR-comment workflow.
Baselines are computed once per adapter on `push:main`, cached in GHA
Cache, and consumed on PR. Strictly additive, any failure (cold cache,
parse error, RPC flake) falls back byte-identical to today's output.

<img width="966" height="302" alt="screenshot-1" src="https://github.com/user-attachments/assets/bf7c03cd-df81-4ac1-a619-a80e506c32f7" />

<img width="963" height="263" alt="screenshot-2" src="https://github.com/user-attachments/assets/ddf91892-fdc7-484a-9dd2-887910175a5b" />

<img width="963" height="472" alt="screenshot-3" src="https://github.com/user-attachments/assets/e3ae7bda-c6ee-4325-bb10-a14409177bf1" />

Chains with |Δ%| < 0.1% collapse into a summary row with the full table
in a nested `<details>`; added/removed chains always shown above the fold.

No new npm deps, no lockfile changes, `test.js` untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PR comments now include TVL baseline vs. current diffs with total and per-chain deltas, significance-aware ordering, optional collapsing of quiet chains, and conditional capture metadata in the footer.

* **Tests**
  * Added end-to-end tests covering TVL parsing, humanized-number parsing/formatting, diff computation, classification, and markdown rendering/edge cases.

* **Chores**
  * CI updated to regenerate and cache TVL baselines on merge and to surface diff results in PR comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->