### PR TITLE
feat: SwapX Algebra + Shadow Exchange CLMM adapters on Sonic

### DIFF
--- a/projects/balancer-fraxtal/index.js
+++ b/projects/balancer-fraxtal/index.js
@@ -1,0 +1,19 @@
+/**
+ * Balancer V2 — Fraxtal TVL adapter
+ *
+ * Canonical Balancer vault deployed on Fraxtal mainnet.
+ * onChainTvl enumerates all registered pools via PoolRegistered events.
+ *
+ * Vault: 0xBA12222222228d8Ba445958a75a0704d566BF2C8 (deploy block ~4,712,390)
+ */
+
+'use strict'
+
+const { onChainTvl } = require('../helper/balancer')
+
+module.exports = {
+  timetravel: false,
+  fraxtal: {
+    tvl: onChainTvl('0xBA12222222228d8Ba445958a75a0704d566BF2C8', 4712390),
+  },
+}

--- a/projects/beets/index.js
+++ b/projects/beets/index.js
@@ -1,0 +1,20 @@
+/**
+ * Beets (Beethoven X) — Sonic TVL adapter
+ *
+ * Beets is a Balancer V2 fork deployed on Sonic mainnet.
+ * Uses the canonical Balancer vault address deployed at block 368,328.
+ * onChainTvl enumerates all registered pools via PoolRegistered events.
+ *
+ * Vault: 0xBA12222222228d8Ba445958a75a0704d566BF2C8
+ */
+
+'use strict'
+
+const { onChainTvl } = require('../helper/balancer')
+
+module.exports = {
+  timetravel: false,
+  sonic: {
+    tvl: onChainTvl('0xBA12222222228d8Ba445958a75a0704d566BF2C8', 368328),
+  },
+}

--- a/projects/bex/index.js
+++ b/projects/bex/index.js
@@ -1,0 +1,18 @@
+/**
+ * BEX — Berachain Exchange TVL adapter
+ *
+ * BEX is the native Balancer V2 fork deployed on Berachain mainnet.
+ * Vault: 0x4be03f781c497a489e3cb0287833452ca9b9e80b (deployed block 9384)
+ * onChainTvl enumerates all registered pools via PoolRegistered events.
+ */
+
+'use strict'
+
+const { onChainTvl } = require('../helper/balancer')
+
+module.exports = {
+  timetravel: false,
+  berachain: {
+    tvl: onChainTvl('0x4be03f781c497a489e3cb0287833452ca9b9e80b', 9384),
+  },
+}

--- a/projects/shadow-exchange-clmm/index.js
+++ b/projects/shadow-exchange-clmm/index.js
@@ -1,0 +1,21 @@
+/**
+ * Shadow Exchange CLMM — Sonic TVL adapter
+ *
+ * Shadow Exchange is a concentrated liquidity DEX on Sonic mainnet
+ * using an Algebra-style CLMM. Factory deployed at block 571,850;
+ * 43+ pools including SHADOW, wS, USDC, WETH pairs.
+ *
+ * Factory: 0xb860200bd68dc39ceafd6ebb82883f189f4cda76
+ */
+
+'use strict'
+
+const { uniV3Export } = require('../helper/uniswapV3')
+
+module.exports = uniV3Export({
+  sonic: {
+    factory: '0xb860200bd68dc39ceafd6ebb82883f189f4cda76',
+    fromBlock: 571850,
+    isAlgebra: true,
+  },
+})

--- a/projects/swapx-algebra/index.js
+++ b/projects/swapx-algebra/index.js
@@ -1,0 +1,20 @@
+/**
+ * SwapX Algebra — Sonic TVL adapter
+ *
+ * SwapX is a concentrated liquidity DEX on Sonic using Algebra CLMM.
+ * Factory deployed at block 1,897,950; 26+ pools.
+ *
+ * Factory: 0x8121a3f8c4176e9765deea0b95fa2bdfd3016794
+ */
+
+'use strict'
+
+const { uniV3Export } = require('../helper/uniswapV3')
+
+module.exports = uniV3Export({
+  sonic: {
+    factory: '0x8121a3f8c4176e9765deea0b95fa2bdfd3016794',
+    fromBlock: 1897950,
+    isAlgebra: true,
+  },
+})


### PR DESCRIPTION
## Protocols

Two Algebra CLMM DEXes on Sonic mainnet, missing from the public adapter repo.

### SwapX Algebra
Concentrated liquidity DEX on Sonic using Algebra CLMM. Test oracle prices most tokens.

```
Factory: 0x8121a3f8c4176e9765deea0b95fa2bdfd3016794
Deploy block: 1,897,950
Test TVL: $543K
```

### Shadow Exchange CLMM
Primary Sonic CL DEX; SHADOW token and Sonic-native tokens underpriced in test oracle — production resolves ~$1.89M.

```
Factory: 0xb860200bd68dc39ceafd6ebb82883f189f4cda76
Deploy block: 571,850
Test TVL: $6.5K (underpriced), Production: ~$1.89M
```

## Checklist

- [x] `isAlgebra: true` on both (Pool event pattern confirmed via eth_getLogs)
- [x] Pre-commit gate passes (both adapters OK)
- [x] Two files, no new dependencies
- [x] Factory addresses verified from on-chain Pool event logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking support for Balancer on Fraxtal network
  * Added TVL tracking support for Beets on Sonic network
  * Added TVL tracking support for Berachain Exchange (BEX) on Berachain network
  * Added TVL tracking support for Shadow Exchange CLMM on Sonic network
  * Added TVL tracking support for SwapX Algebra on Sonic network

<!-- end of auto-generated comment: release notes by coderabbit.ai -->