### PR TITLE
helper: add retry/timeout and fix correctness bugs

### DIFF
--- a/projects/helper/cache.js
+++ b/projects/helper/cache.js
@@ -1,7 +1,21 @@
 const sdk = require('@defillama/sdk')
+const crypto = require('crypto')
 const Bucket = "tvl-adapter-cache";
-const axios = require('axios')
 const graphql = require('./utils/graphql')
+const { get: httpGet, post: httpPost, withRetry } = require('./http')
+
+// Hash of the request shape (endpoint + body/variables). Used to disambiguate the in-memory
+// promise cache when multiple call sites share a `project` name but hit different endpoints.
+// Disk cache keys remain project-only so existing fallback semantics are preserved.
+function _requestHash(...parts) {
+  const h = crypto.createHash('md5')
+  for (const p of parts) {
+    if (p == null) continue
+    h.update(typeof p === 'string' ? p : JSON.stringify(p))
+    h.update('\0')
+  }
+  return h.digest('hex').slice(0, 12)
+}
 
 function getKey(project, chain) {
   return `cache/${project}/${chain}.json`
@@ -25,7 +39,7 @@ async function getCache(project, chain, { skipCompression } = {}) {
     return json
   } catch (e) {
     try {
-      const { data: json } = await axios.get(getLink(project, chain))
+      const json = await httpGet(getLink(project, chain))
       await sdk.cache.writeCache(fileKey, json)
       return json
     } catch (e) {
@@ -60,27 +74,40 @@ function resetCache() {
   }
 }
 
+function _isValidCachePayload(json) {
+  if (json == null) return false
+  if (json?.error?.message) return false
+  if (typeof json === 'string') return json.trim().length > 0
+  if (Array.isArray(json)) return json.length > 0
+  if (typeof json === 'object') return Object.keys(json).length > 0
+  // primitives (numbers/booleans) — treat as invalid; configs should be objects/arrays/strings
+  return false
+}
+
 async function _setCache(project, chain, json) {
-  if (!json || json?.error?.message) return;
-  const strData = typeof json === 'string' ? json : JSON.stringify(json)
-  let isValidData = strData.length > 42
-  if (isValidData) // sometimes we get bad data/empty object, we dont overwrite cache with it
-    await setCache(project, chain, json)
+  // Don't overwrite a good cache with empty/error payloads — but unlike the old length>42 heuristic,
+  // small-but-valid configs (e.g. {"a":1}) are now correctly persisted.
+  if (!_isValidCachePayload(json)) return
+  await setCache(project, chain, json)
 }
 
 async function getConfig(project, endpoint, { fetcher } = {}) {
   resetCache()
   if (!project || (!endpoint && !fetcher)) throw new Error('Missing parameters')
   const key = 'config-cache'
-  const cacheKey = getKey(key, project)
-  if (!configCache[cacheKey]) configCache[cacheKey] = _getConfig()
+  const cacheKey = getKey(key, project) + '#' + _requestHash(endpoint, fetcher && fetcher.toString())
+  if (!configCache[cacheKey]) {
+    const promise = _getConfig()
+    promise.catch(() => { if (configCache[cacheKey] === promise) delete configCache[cacheKey] })
+    configCache[cacheKey] = promise
+  }
   return configCache[cacheKey]
 
   async function _getConfig() {
     try {
       let json
       if (endpoint) {
-        json = (await axios.get(endpoint)).data
+        json = await httpGet(endpoint)
       } else {
         json = await fetcher()
       }
@@ -116,13 +143,17 @@ async function getConfig(project, endpoint, { fetcher } = {}) {
 async function configPost(project, endpoint, data) {
   if (!project || !endpoint) throw new Error('Missing parameters')
   const key = 'config-cache'
-  const cacheKey = getKey(key, project)
-  if (!configCache[cacheKey]) configCache[cacheKey] = _configPost()
+  const cacheKey = getKey(key, project) + '#' + _requestHash(endpoint, data)
+  if (!configCache[cacheKey]) {
+    const promise = _configPost()
+    promise.catch(() => { if (configCache[cacheKey] === promise) delete configCache[cacheKey] })
+    configCache[cacheKey] = promise
+  }
   return configCache[cacheKey]
 
   async function _configPost() {
     try {
-      const { data: json } = await axios.post(endpoint, data)
+      const json = await httpPost(endpoint, data)
       await _setCache(key, project, json)
       return json
     } catch (e) {
@@ -138,8 +169,12 @@ async function cachedGraphQuery(project, endpoint, query, { api, useBlock = fals
   if (!project || !endpoint) throw new Error('Missing parameters')
   endpoint = sdk.graph.modifyEndpoint(endpoint)
   const key = 'config-cache'
-  const cacheKey = getKey(key, project)
-  if (!configCache[cacheKey]) configCache[cacheKey] = _cachedGraphQuery()
+  const cacheKey = getKey(key, project) + '#' + _requestHash(endpoint, query, variables, !!fetchById)
+  if (!configCache[cacheKey]) {
+    const promise = _cachedGraphQuery()
+    promise.catch(() => { if (configCache[cacheKey] === promise) delete configCache[cacheKey] })
+    configCache[cacheKey] = promise
+  }
   return configCache[cacheKey]
 
   async function _cachedGraphQuery() {
@@ -150,7 +185,7 @@ async function cachedGraphQuery(project, endpoint, query, { api, useBlock = fals
         variables.block = await api.getBlock()
       }
       if (!fetchById)
-        json = await graphql.request(endpoint, query, { variables, headers })
+        json = await withRetry(() => graphql.request(endpoint, query, { variables, headers }))
       else
         json = await graphFetchById({ endpoint, query, params: variables, api, options: { useBlock, safeBlockLimit, headers } })
       if (!json) throw new Error('Empty JSON')
@@ -174,7 +209,7 @@ async function graphFetchById({ endpoint, query, params = {}, api, options: { us
   let lastId = ""
   let response;
   do {
-    const res = await graphql.request(endpoint, query, { variables: { ...params, lastId }, headers })
+    const res = await withRetry(() => graphql.request(endpoint, query, { variables: { ...params, lastId }, headers }))
     Object.keys(res).forEach(key => response = res[key])
     data.push(...response)
     lastId = response[response.length - 1]?.id

--- a/projects/helper/cache.js
+++ b/projects/helper/cache.js
@@ -77,10 +77,16 @@ function resetCache() {
 function _isValidCachePayload(json) {
   if (json == null) return false
   if (json?.error?.message) return false
-  if (typeof json === 'string') return json.trim().length > 0
+  if (typeof json === 'string') {
+    const s = json.trim()
+    if (!s) return false
+    if (s.length > 42) {
+      try { JSON.parse(s) } catch { return false }
+    }
+    return true
+  }  
   if (Array.isArray(json)) return json.length > 0
   if (typeof json === 'object') return Object.keys(json).length > 0
-  // primitives (numbers/booleans) — treat as invalid; configs should be objects/arrays/strings
   return false
 }
 

--- a/projects/helper/http.js
+++ b/projects/helper/http.js
@@ -88,8 +88,7 @@ async function get(endpoint, options = {}) {
   const { retries, retryDelay, timeout = DEFAULT_TIMEOUT_MS, ...axiosOpts } = options
   const tonApiKey = getEnv('TON_API_KEY')
   if (tonApiKey && endpoint.includes('tonapi.io')) {
-    if (!axiosOpts.headers) axiosOpts.headers = {}
-    axiosOpts.headers['Authorization'] = tonApiKey
+    axiosOpts.headers = { ...axiosOpts.headers, Authorization: tonApiKey }
   }
   try {
     return await withRetry(

--- a/projects/helper/http.js
+++ b/projects/helper/http.js
@@ -36,11 +36,17 @@ function _parseRetryAfter(e) {
   return Math.min(ms, 60_000)
 }
 
-async function withRetry(fn, { retries = DEFAULT_RETRIES, retryDelay = DEFAULT_RETRY_DELAY_MS } = {}) {
+async function withRetry(fn, { retries = DEFAULT_RETRIES, retryDelay = DEFAULT_RETRY_DELAY_MS, timeout = DEFAULT_TIMEOUT_MS } = {}) {  
   let lastErr
   for (let attempt = 0; attempt <= retries; attempt++) {
     try {
-      return await fn()
+      const op = timeout === 0  
+        ? fn()  
+        : Promise.race([  
+            fn(),  
+            new Promise((_, rej) => setTimeout(() => rej(new Error('Operation timed out')), timeout)),  
+          ])
+      return await op
     } catch (e) {
       lastErr = e
       if (attempt === retries || !_isRetryableError(e)) break
@@ -88,7 +94,7 @@ async function get(endpoint, options = {}) {
   try {
     return await withRetry(
       async () => (await axios.get(endpoint, { timeout, ...axiosOpts })).data,
-      { retries, retryDelay }
+      { retries, retryDelay, timeout }
     )
   } catch (e) {
     sdk.log(e.message)
@@ -100,7 +106,7 @@ async function getWithMetadata(endpoint, options = {}) {
   const { retries, retryDelay, timeout = DEFAULT_TIMEOUT_MS, ...axiosOpts } = options
   return withRetry(
     () => axios.get(endpoint, { timeout, ...axiosOpts }),
-    { retries, retryDelay }
+    { retries, retryDelay, timeout }
   )
 }
 
@@ -109,7 +115,7 @@ async function post(endpoint, body, options = {}) {
   try {
     return await withRetry(
       async () => (await axios.post(endpoint, body, { timeout, ...axiosOpts })).data,
-      { retries, retryDelay }
+      { retries, retryDelay, timeout }
     )
   } catch (e) {
     sdk.log(e.message)

--- a/projects/helper/http.js
+++ b/projects/helper/http.js
@@ -40,13 +40,18 @@ async function withRetry(fn, { retries = DEFAULT_RETRIES, retryDelay = DEFAULT_R
   let lastErr
   for (let attempt = 0; attempt <= retries; attempt++) {
     try {
-      const op = timeout === 0  
-        ? fn()  
-        : Promise.race([  
-            fn(),  
-            new Promise((_, rej) => setTimeout(() => rej(new Error('Operation timed out')), timeout)),  
-          ])
-      return await op
+      if (timeout === 0) return await fn()
+      let timer
+      try {
+        return await Promise.race([
+          fn(),
+          new Promise((_, rej) => {
+            timer = setTimeout(() => rej(new Error('Operation timed out')), timeout)
+          }),
+        ])
+      } finally {
+        if (timer) clearTimeout(timer)
+      }
     } catch (e) {
       lastErr = e
       if (attempt === retries || !_isRetryableError(e)) break

--- a/projects/helper/http.js
+++ b/projects/helper/http.js
@@ -5,8 +5,62 @@ const { getEnv } = require('./env')
 
 const getCacheData = {}
 
+const DEFAULT_TIMEOUT_MS = 60_000
+const DEFAULT_RETRIES = 3
+const DEFAULT_RETRY_DELAY_MS = 500
+
+function _isRetryableError(e) {
+  const status = e?.response?.status
+  if (status === 429) return true
+  if (status >= 500 && status < 600) return true
+  if (status) return false // other 4xx are not retryable
+  // No response → network/timeout/DNS/abort errors
+  return true
+}
+
+// Parse a Retry-After header value (RFC 7231): either delta-seconds or an HTTP-date.
+// Returns delay in ms, or null if the header is absent/unparseable. Caps at 60s to avoid
+// pathological waits from misbehaving servers.
+function _parseRetryAfter(e) {
+  const header = e?.response?.headers?.['retry-after'] ?? e?.response?.headers?.['Retry-After']
+  if (header == null) return null
+  const seconds = Number(header)
+  let ms
+  if (Number.isFinite(seconds)) ms = seconds * 1000
+  else {
+    const ts = Date.parse(header)
+    if (Number.isNaN(ts)) return null
+    ms = ts - Date.now()
+  }
+  if (ms <= 0) return 0
+  return Math.min(ms, 60_000)
+}
+
+async function withRetry(fn, { retries = DEFAULT_RETRIES, retryDelay = DEFAULT_RETRY_DELAY_MS } = {}) {
+  let lastErr
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      return await fn()
+    } catch (e) {
+      lastErr = e
+      if (attempt === retries || !_isRetryableError(e)) break
+      const hinted = _parseRetryAfter(e)
+      const backoff = retryDelay * Math.pow(2, attempt) + Math.floor(Math.random() * 250)
+      const delay = hinted != null ? hinted : backoff
+      await new Promise(r => setTimeout(r, delay))
+    }
+  }
+  throw lastErr
+}
+
 async function getCache(endpoint) {
-  if (!getCacheData[endpoint]) getCacheData[endpoint] = get(endpoint)
+  if (!getCacheData[endpoint]) {
+    const promise = get(endpoint)
+    // Don't memoize a rejection forever — a single transient failure would otherwise poison
+    // every subsequent caller in this process. Drop the entry on failure so the next call retries.
+    promise.catch(() => { if (getCacheData[endpoint] === promise) delete getCacheData[endpoint] })
+    getCacheData[endpoint] = promise
+  }
   return getCacheData[endpoint]
 }
 
@@ -25,28 +79,38 @@ async function getBlock(timestamp, chain, chainBlocks, undefinedOk = false) {
 }
 
 async function get(endpoint, options = {}) {
+  const { retries, retryDelay, timeout = DEFAULT_TIMEOUT_MS, ...axiosOpts } = options
   const tonApiKey = getEnv('TON_API_KEY')
+  if (tonApiKey && endpoint.includes('tonapi.io')) {
+    if (!axiosOpts.headers) axiosOpts.headers = {}
+    axiosOpts.headers['Authorization'] = tonApiKey
+  }
   try {
-    if (tonApiKey && endpoint.includes('tonapi.io')) {
-      if (!options.headers) options.headers = {}
-      options.headers['Authorization'] = tonApiKey
-    }
-    const data = (await axios.get(endpoint, options)).data
-    return data
+    return await withRetry(
+      async () => (await axios.get(endpoint, { timeout, ...axiosOpts })).data,
+      { retries, retryDelay }
+    )
   } catch (e) {
     sdk.log(e.message)
     throw new Error(`Failed to get ${endpoint}`)
   }
 }
 
-async function getWithMetadata(endpoint) {
-  return axios.get(endpoint)
+async function getWithMetadata(endpoint, options = {}) {
+  const { retries, retryDelay, timeout = DEFAULT_TIMEOUT_MS, ...axiosOpts } = options
+  return withRetry(
+    () => axios.get(endpoint, { timeout, ...axiosOpts }),
+    { retries, retryDelay }
+  )
 }
 
-async function post(endpoint, body, options) {
+async function post(endpoint, body, options = {}) {
+  const { retries, retryDelay, timeout = DEFAULT_TIMEOUT_MS, ...axiosOpts } = options
   try {
-    const data = (await axios.post(endpoint, body, options)).data
-    return data
+    return await withRetry(
+      async () => (await axios.post(endpoint, body, { timeout, ...axiosOpts })).data,
+      { retries, retryDelay }
+    )
   } catch (e) {
     sdk.log(e.message)
     throw new Error(`Failed to post ${endpoint}`)
@@ -89,7 +153,7 @@ async function blockQuery(endpoint, query, { api, blockCatchupLimit = 500, }) {
   await api.getBlock()
   const block = api.block
   try {
-    const results = await graphQLClient.request(query, { block })
+    const results = await withRetry(() => graphQLClient.request(query, { block }))
     return results
   } catch (e) {
     e.chain = api.chain
@@ -100,7 +164,7 @@ async function blockQuery(endpoint, query, { api, blockCatchupLimit = 500, }) {
     sdk.log('Block catchup detected: subgraph indexed up to', indexedBlockNumber, 'but requested block was', block, 'falling back to indexed block')
     if (block - blockCatchupLimit > indexedBlockNumber)
       throw e
-    return graphQLClient.request(query, { block: indexedBlockNumber })
+    return withRetry(() => graphQLClient.request(query, { block: indexedBlockNumber }))
   }
 }
 
@@ -137,4 +201,5 @@ module.exports = {
   getBlock,
   getWithMetadata,
   proxiedFetch,
+  withRetry,
 }


### PR DESCRIPTION
Hardens the two helpers that mediate every off-chain HTTP call (`helper/http.js`, `helper/cache.js`) and fixes a silent LP under-counting bug in `helper/unwrapLPs.js`.

### Reliability
- Added `withRetry` (exp backoff + jitter, honors `Retry-After`, retries 429/5xx/network errors). Defaults: 3 retries, 60s timeout. Opt out via `{ retries: 0, timeout: 0 }`.
- Applied to `get`, `post`, `getWithMetadata`, `blockQuery`, and the GraphQL paths in `cachedGraphQuery` / `graphFetchById`.
- `cache.js` now routes through the resilient `httpGet` / `httpPost` instead of raw axios.

### Correctness fixes
- **`http.getCache` poisoned promise**: a transient rejection no longer poisons the in-memory cache for the rest of the process — the entry is evicted on failure.
- **`cache.js` key collision**: in-memory `configCache` is now keyed by `project + hash(endpoint, vars/body)`. Previously two `getConfig` sites sharing a project name silently shared one promise. Disk key is unchanged so existing fallback files still work.
- **`_setCache` validity check**: replaces the `length > 42` heuristic — small valid configs are now persisted, garbage strings >42 chars are no longer accepted.
- **`unwrapLPsAuto` LP detection**: `erc20:symbol` returning `null` on a transient RPC blip used to silently mis-classify the LP as a plain ERC20. One-shot retry resolves it before classification.

### Risk
Failure path is bounded but slower (up to ~3.7s extra per failed call before fallback). Failures stay strictly per-call-site — no new cross-adapter coupling. Adapters needing >60s for a single call should pass `{ timeout: 0 }`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic retries with exponential backoff, jitter, Retry-After respect, and per-request timeout controls.
  * Per-request retry/timeouts and improved request de-duplication to reduce redundant calls and speed responses.

* **Bug Fixes**
  * Stricter cache validation to avoid storing empty or error payloads while preserving small valid responses.
  * In-flight failures no longer leave stale cache entries; concurrent requests are de-duplicated and cleaned up on error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->