### PR TITLE
feat(camelot-v2): add Corn chain Algebra CLMM

### DIFF
--- a/projects/camelot-v2/index.js
+++ b/projects/camelot-v2/index.js
@@ -13,7 +13,7 @@ const export2 = uniV3Export({
   reya: { factory: '0x10aA510d94E094Bd643677bd2964c3EE085Daffc', fromBlock: 2932166, isAlgebra: true, },
   gravity: { factory: '0x10aA510d94E094Bd643677bd2964c3EE085Daffc', fromBlock: 11988, isAlgebra: true, },
   apechain: { factory: '0x10aA510d94E094Bd643677bd2964c3EE085Daffc', fromBlock: 60224, isAlgebra: true, },
-  corn: { factory: '0xCf4062Ee235BbeB4C7c0336ada689ed1c17547b6', fromBlock: 21500, isAlgebra: true, },
+  corn: { factory: '0xCf4062Ee235BbeB4C7c0336ada689ed1c17547b6', fromBlock: 21580, isAlgebra: true, },
   duckchain: { factory: '0xCf4062Ee235BbeB4C7c0336ada689ed1c17547b6', fromBlock: 1530060, isAlgebra: true, },
   occ: { factory: '0xCf4062Ee235BbeB4C7c0336ada689ed1c17547b6', fromBlock: 21053, isAlgebra: true, },
   spn: { factory: '0xCf4062Ee235BbeB4C7c0336ada689ed1c17547b6', fromBlock: 1, isAlgebra: true, },

--- a/projects/camelot-v2/index.js
+++ b/projects/camelot-v2/index.js
@@ -13,6 +13,7 @@ const export2 = uniV3Export({
   reya: { factory: '0x10aA510d94E094Bd643677bd2964c3EE085Daffc', fromBlock: 2932166, isAlgebra: true, },
   gravity: { factory: '0x10aA510d94E094Bd643677bd2964c3EE085Daffc', fromBlock: 11988, isAlgebra: true, },
   apechain: { factory: '0x10aA510d94E094Bd643677bd2964c3EE085Daffc', fromBlock: 60224, isAlgebra: true, },
+  corn: { factory: '0xCf4062Ee235BbeB4C7c0336ada689ed1c17547b6', fromBlock: 21500, isAlgebra: true, },
   duckchain: { factory: '0xCf4062Ee235BbeB4C7c0336ada689ed1c17547b6', fromBlock: 1530060, isAlgebra: true, },
   occ: { factory: '0xCf4062Ee235BbeB4C7c0336ada689ed1c17547b6', fromBlock: 21053, isAlgebra: true, },
   spn: { factory: '0xCf4062Ee235BbeB4C7c0336ada689ed1c17547b6', fromBlock: 1, isAlgebra: true, },


### PR DESCRIPTION
## Summary

Adds Corn (chainId 21000000) to the Camelot V3 adapter.

- Factory: `0xCf4062Ee235BbeB4C7c0336ada689ed1c17547b6` (same contract as duckchain/occ/spn)
- `fromBlock: 21500` (factory deployed between blocks 21,500–22,000, confirmed via binary search on Corn RPC)
- CI reports: **corn $2.49K TVL**

Corn is not currently listed in the Camelot V3 protocol page on DeFiLlama. This is a one-line addition alongside the existing same-factory chain entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the corn network to Uniswap V3 exports, expanding decentralized exchange access and including corn-scoped exchange data in merged exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->