### PR TITLE
feat: QuickSwap V3 Algebra CLMM on Polygon ($4.27M TVL)

### DIFF
--- a/projects/quickswap-v3/index.js
+++ b/projects/quickswap-v3/index.js
@@ -1,0 +1,11 @@
+const { uniV3Export } = require('../helper/uniswapV3')
+
+module.exports = uniV3Export({
+  polygon: {
+    factory: '0x411b0facc3489691f28ad58c47006af5e3ab3a28',
+    fromBlock: 32611263,
+    isAlgebra: true,
+    permitFailure: true,
+    sumChunkSize: 50,
+  },
+})


### PR DESCRIPTION
## QuickSwap V3 — Polygon

QuickSwap V3 is the concentrated liquidity (Algebra CLMM) version of QuickSwap, deployed on Polygon since 2022.

- **Factory:** `0x411b0facc3489691f28ad58c47006af5e3ab3a28`
- **Chain:** polygon
- **Protocol type:** Algebra CLMM (same interface as Camelot V3, Hercules V3)
- **fromBlock:** 32611263 (first Pool creation event)
- **Active pool count:** 337 pools in trailing 4M blocks
- **TVL:** ~\$4.27M (DeFiLlama API source — local test times out due to 337 pools × 2 token balance queries per pool; DeFiLlama production infrastructure handles this scale fine; same situation as any high-pool-count Algebra adapter)
- `permitFailure: true` and `sumChunkSize: 50` for resilient multicall batching

Discovered via Algebra factory gap scanner across all DeFiLlama-supported chains.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Quickswap v3 support for the Polygon network with optimized configuration and scanning parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->