### PR TITLE
SoSoValue Indexes: count DEFI.ssi native HYPE on HyperEVM (fix soso index TVL)

### DIFF
--- a/projects/ssi-protocol/index.js
+++ b/projects/ssi-protocol/index.js
@@ -59,6 +59,7 @@ module.exports = {
     ethereum: ['ETH', 'ethereum'],
     bsc: ['BSC_BNB', 'binancecoin'],
     doge: ['DOGE', 'dogecoin'],
+    hyperliquid: ['HYPEREVM_HYPE', 'hyperliquid'],
     solana: ['SOL', 'solana'],
     bitcoin: ['BTC', 'bitcoin'],
     cardano: ['ADA', 'cardano'],


### PR DESCRIPTION
## Summary

`getBasket()` on Base for **DEFI.ssi** includes a row with `chain = HYPEREVM_HYPE` and empty `addr` (native HYPE). The SoSoValue Indexes adapter only mapped basket rows to the existing chain keys, so this balance was never attributed to any chain and was missing from TVL.

## Change

- Add `hyperliquid: ['HYPEREVM_HYPE', 'hyperliquid']` to the same `underlyingExports` map used in `projects/ssi-protocol/index.js` (same pattern as other native rows: `token.amount / 10 ** decimals` with CoinGecko id `hyperliquid` for pricing).

## Verification

```bash
node test.js projects/ssi-protocol/index.js
```

Shows a **hyperliquid** breakdown (~$3M HYPE at current prices) and increases total protocol TVL by that amount.


#### Please enable **Allow edits by maintainers** on this PR.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for the hyperliquid blockchain network in TVL export configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->