### PR TITLE
term-structure: add Pharos chain, track customize pools, fix XAUe pricing

### DIFF
--- a/projects/term-structure/index.js
+++ b/projects/term-structure/index.js
@@ -143,6 +143,7 @@ const ADDRESSES = {
     TermMax4626Factory: [
       { address: "0xD594eb03a43b4974Aa7B32b5740cdeCe961151Fa", fromBlock: 23489745 },
       { address: "0x3Cc88086C0a613970565C96F9a1b6BdAd61C5f14", fromBlock: 24790495 },
+      { address: "0x8ec01a807D088845e5176c20A129ebF9A0101dD5", fromBlock: 25004529 },
     ],
     FactoryV2: [
       {

--- a/projects/term-structure/index.js
+++ b/projects/term-structure/index.js
@@ -49,6 +49,7 @@ const EVENTS = {
   TermMax4626Factory: {
     "StableERC4626For4626Created": "event StableERC4626For4626Created(address indexed caller, address indexed stableERC4626For4626)",
     "StableERC4626ForAaveCreated": "event StableERC4626ForAaveCreated(address indexed caller, address indexed stableERC4626ForAave)",
+    "StableERC4626ForCustomizeCreated": "event StableERC4626ForCustomizeCreated(address indexed caller, address indexed stableERC4626ForCustomize)",
     "VariableERC4626ForAaveCreated": "event VariableERC4626ForAaveCreated(address indexed caller, address indexed variableERC4626ForAave)"
   }
 };
@@ -137,6 +138,7 @@ const ADDRESSES = {
     },
     TermMax4626Factory: [
       { address: "0xD594eb03a43b4974Aa7B32b5740cdeCe961151Fa", fromBlock: 23489745 },
+      { address: "0x3Cc88086C0a613970565C96F9a1b6BdAd61C5f14", fromBlock: 24790495 },
     ],
     FactoryV2: [
       {
@@ -276,6 +278,14 @@ const MARKET_BLACKLIST = {
   bsquared: [
     "0x5022B6563f6bc9f0D47F407ba32B64e1f438213a", // uBTC/WBTC
   ],
+};
+
+// Extra ERC20s that may sit alongside the underlying inside a
+// StableERC4626ForCustomize pool's Gnosis Safe `thirdPool` (e.g. XAUe held next
+// to XAUt). Each address is summed as a separate balanceOf(safe) entry so the
+// price oracle prices each token in its own units.
+const SAFE_EQUIVALENT_TOKEN_ADDRESSES = {
+  ethereum: ["0xd5D6840ed95F58FAf537865DcA15D5f99195F87a"], // XAUe
 };
 
 async function getTermMaxMarketAddresses(api) {
@@ -597,6 +607,7 @@ async function erc4626VaultsTvl(api) {
   const tokensAndOwners = [];
   const stableERC4626For4626Vaults = [];
   const aaveVaults = [];
+  const customizeVaults = [];
 
   for (const factory of ADDRESSES[api.chain].TermMax4626Factory) {
     let logs = await getLogs2({
@@ -626,6 +637,15 @@ async function erc4626VaultsTvl(api) {
       extraKey: 'VariableERC4626ForAaveCreated-20260206',
     });
     aaveVaults.push(...logs.map(i => i.variableERC4626ForAave));
+
+    logs = await getLogs2({
+      api,
+      eventAbi: EVENTS.TermMax4626Factory.StableERC4626ForCustomizeCreated,
+      fromBlock: factory.fromBlock,
+      target: factory.address,
+      extraKey: 'StableERC4626ForCustomizeCreated-20260429',
+    });
+    customizeVaults.push(...logs.map(i => i.stableERC4626ForCustomize));
   }
 
   const aTokens = await api.multiCall({ abi: 'address:aToken', calls: aaveVaults })
@@ -640,6 +660,28 @@ async function erc4626VaultsTvl(api) {
   stableERC4626For4626Vaults.forEach((vault, i) => {
     tokensAndOwners.push([stableUnderlyings[i], vault])
     tokensAndOwners.push([thirdPools[i], vault])
+  })
+
+  // StableERC4626ForCustomize: thirdPool may be either an ERC4626/ERC20 (same
+  // accrual story as For4626) OR a Gnosis Safe (XAUt vault on Ethereum). Probe
+  // totalSupply() to disambiguate — the Safe contract does not implement it.
+  const customizeUnderlyings = await api.multiCall({ abi: 'address:underlying', calls: customizeVaults })
+  const customizeThirdPools = await api.multiCall({ abi: 'address:thirdPool', calls: customizeVaults })
+  const thirdPoolSupplies = await api.multiCall({ abi: 'erc20:totalSupply', calls: customizeThirdPools, permitFailure: true })
+  const safeEquivalents = SAFE_EQUIVALENT_TOKEN_ADDRESSES[api.chain] ?? [];
+  customizeVaults.forEach((vault, i) => {
+    const underlying = customizeUnderlyings[i];
+    const thirdPool = customizeThirdPools[i];
+    const isErc20ThirdPool = thirdPoolSupplies[i] !== null;
+    if (isErc20ThirdPool) {
+      tokensAndOwners.push([underlying, vault]);
+      tokensAndOwners.push([thirdPool, vault]);
+    } else {
+      tokensAndOwners.push([underlying, thirdPool]);
+      for (const equiv of safeEquivalents) {
+        tokensAndOwners.push([equiv, thirdPool]);
+      }
+    }
   })
 
   await sumTokens2({ api, tokensAndOwners });

--- a/projects/term-structure/index.js
+++ b/projects/term-structure/index.js
@@ -263,6 +263,23 @@ const ADDRESSES = {
       { address: "0xa50929A67daF9Ff3567e2Bb3411204A134f72546", fromBlock: 43289755 },
     ],
   },
+  pharos: {
+    FactoryV2: [
+      {
+        address: "0xEDC206E67eAc5C949c0a90A02E29B4b2791c8395",
+        fromBlock: 5243188,
+      },
+    ],
+    VaultFactoryV2: [
+      {
+        address: "0x5316b0d2Ee13C81E243226D6BB93CF29FBf95837",
+        fromBlock: 5243205,
+      },
+    ],
+    TermMax4626Factory: [
+      { address: "0xBa38C4D39ECf8401d90e7469dc6eB438547caC81", fromBlock: 5243210 },
+    ],
+  },
 };
 
 const VAULT_BLACKLIST = {
@@ -318,6 +335,7 @@ const TERMMAX_VIEWER_ADDRESS = {
   bsquared:  "0x0d64B9feF3E1f599B88d29Edb54D2F9152CBE496",
   xlayer:    "0xaaa2108dF9c3Aa4d358275340733476d139A1445",
   base:      "0x0d64B9feF3E1f599B88d29Edb54D2F9152CBE496",
+  pharos:    "0x0c30Bd74f891D88E69C07DEb5Ae9dA40C974BfeD",
 };
 
 async function getTermMaxMarketAddresses(api) {

--- a/projects/term-structure/index.js
+++ b/projects/term-structure/index.js
@@ -714,10 +714,13 @@ async function erc4626VaultsTvl(api) {
   // StableERC4626ForCustomize: thirdPool may be either an ERC4626/ERC20 (same
   // accrual story as For4626) OR a Gnosis Safe (XAUt vault on Ethereum). Probe
   // totalSupply() to disambiguate — the Safe contract does not implement it.
+  // Dedupe on (underlying, safe) and on safe alone — multiple vaults can share
+  // a Safe, and we must count its holdings once.
   const customizeUnderlyings = await api.multiCall({ abi: 'address:underlying', calls: customizeVaults })
   const customizeThirdPools = await api.multiCall({ abi: 'address:thirdPool', calls: customizeVaults })
   const thirdPoolSupplies = await api.multiCall({ abi: 'erc20:totalSupply', calls: customizeThirdPools, permitFailure: true })
-  const safeBackedSafes = [];
+  const seenSafeOwners = new Set();
+  const safeBackedSafes = new Set();
   customizeVaults.forEach((vault, i) => {
     const underlying = customizeUnderlyings[i];
     const thirdPool = customizeThirdPools[i];
@@ -726,13 +729,17 @@ async function erc4626VaultsTvl(api) {
       tokensAndOwners.push([underlying, vault]);
       tokensAndOwners.push([thirdPool, vault]);
     } else {
-      tokensAndOwners.push([underlying, thirdPool]);
-      safeBackedSafes.push(thirdPool);
+      const key = `${underlying.toLowerCase()}|${thirdPool.toLowerCase()}`;
+      if (!seenSafeOwners.has(key)) {
+        seenSafeOwners.add(key);
+        tokensAndOwners.push([underlying, thirdPool]);
+      }
+      safeBackedSafes.add(thirdPool.toLowerCase());
     }
   })
 
   await sumTokens2({ api, tokensAndOwners });
-  await addSafeEquivalentBalances(api, safeBackedSafes);
+  await addSafeEquivalentBalances(api, [...safeBackedSafes]);
   await addUnclaimedPoolRewards(api, {
     stableERC4626For4626Vaults,
     stableUnderlyings,

--- a/projects/term-structure/index.js
+++ b/projects/term-structure/index.js
@@ -302,28 +302,6 @@ const MARKET_BLACKLIST = {
   ],
 };
 
-// Extra ERC20s that may sit alongside the underlying inside a
-// StableERC4626ForCustomize pool's Gnosis Safe `thirdPool` (e.g. XAUe held next
-// to XAUt).
-//
-// DefiLlama's price service has no oracle for XAUe, so reading its balance
-// directly would silently drop ~$18M on Ethereum. Each entry therefore carries
-// a `priceableToken` + `divisor` so the raw balance is converted to an
-// equivalent raw amount of a token DefiLlama can price.
-//
-// XAUe: 1 token = 0.001 troy oz, 18 decimals.
-// XAUt: 1 token = 1 troy oz, 6 decimals.
-// raw_xaut = raw_xaue * 0.001 / 10^18 * 10^6 = raw_xaue / 10^15.
-const SAFE_EQUIVALENT_TOKENS = {
-  ethereum: [
-    {
-      token: "0xd5D6840ed95F58FAf537865DcA15D5f99195F87a", // XAUe
-      priceableToken: "0x68749665FF8D2d112Fa859AA293F07A622782F38", // XAUt
-      divisor: 10n ** 15n,
-    },
-  ],
-};
-
 // TermMaxViewer (per-chain). Used to surface unclaimed pool rewards for
 // ERC4626 pools whose principal sits in another ERC4626 (For4626 + Customize-
 // ERC20). Aave-backed pools must NOT use this — accrued interest already
@@ -712,35 +690,19 @@ async function erc4626VaultsTvl(api) {
     tokensAndOwners.push([thirdPools[i], vault])
   })
 
-  // StableERC4626ForCustomize: thirdPool may be either an ERC4626/ERC20 (same
-  // accrual story as For4626) OR a Gnosis Safe (XAUt vault on Ethereum). Probe
-  // totalSupply() to disambiguate — the Safe contract does not implement it.
-  // Dedupe on (underlying, safe) and on safe alone — multiple vaults can share
-  // a Safe, and we must count its holdings once.
+  // StableERC4626ForCustomize: thirdPool may be either an ERC4626/ERC20 OR a
+  // Gnosis Safe. Probe totalSupply() to disambiguate — the Safe contract does
+  // not implement it. Safe-backed pools are excluded per DefiLlama methodology.
   const customizeUnderlyings = await api.multiCall({ abi: 'address:underlying', calls: customizeVaults })
   const customizeThirdPools = await api.multiCall({ abi: 'address:thirdPool', calls: customizeVaults })
   const thirdPoolSupplies = await api.multiCall({ abi: 'erc20:totalSupply', calls: customizeThirdPools, permitFailure: true })
-  const seenSafeOwners = new Set();
-  const safeBackedSafes = new Set();
   customizeVaults.forEach((vault, i) => {
-    const underlying = customizeUnderlyings[i];
-    const thirdPool = customizeThirdPools[i];
-    const isErc20ThirdPool = thirdPoolSupplies[i] !== null;
-    if (isErc20ThirdPool) {
-      tokensAndOwners.push([underlying, vault]);
-      tokensAndOwners.push([thirdPool, vault]);
-    } else {
-      const key = `${underlying.toLowerCase()}|${thirdPool.toLowerCase()}`;
-      if (!seenSafeOwners.has(key)) {
-        seenSafeOwners.add(key);
-        tokensAndOwners.push([underlying, thirdPool]);
-      }
-      safeBackedSafes.add(thirdPool.toLowerCase());
-    }
+    if (thirdPoolSupplies[i] === null) return;
+    tokensAndOwners.push([customizeUnderlyings[i], vault]);
+    tokensAndOwners.push([customizeThirdPools[i], vault]);
   })
 
   await sumTokens2({ api, tokensAndOwners });
-  await addSafeEquivalentBalances(api, [...safeBackedSafes]);
   await addUnclaimedPoolRewards(api, {
     stableERC4626For4626Vaults,
     stableUnderlyings,
@@ -748,34 +710,6 @@ async function erc4626VaultsTvl(api) {
     customizeUnderlyings,
     thirdPoolSupplies,
   });
-}
-
-// XAUe and similar non-priceable equivalents are remapped to a priceable
-// canonical token (e.g. XAUt) at a fixed raw-unit ratio. balanceOf is batched
-// over (safe x equivalent) pairs.
-async function addSafeEquivalentBalances(api, safeAddresses) {
-  if (safeAddresses.length === 0) return;
-  const equivalents = SAFE_EQUIVALENT_TOKENS[api.chain] ?? [];
-  if (equivalents.length === 0) return;
-
-  const calls = [];
-  for (const safe of safeAddresses) {
-    for (const eq of equivalents) {
-      calls.push({ target: eq.token, params: [safe] });
-    }
-  }
-  const balances = await api.multiCall({ abi: 'erc20:balanceOf', calls });
-
-  let idx = 0;
-  for (const safe of safeAddresses) {
-    for (const eq of equivalents) {
-      const raw = BigInt(balances[idx++] ?? '0');
-      if (raw === 0n) continue;
-      const remapped = raw / eq.divisor;
-      if (remapped === 0n) continue;
-      api.add(eq.priceableToken, remapped.toString());
-    }
-  }
 }
 
 // For4626 and Customize-ERC20 pools route deposits into another ERC4626 where

--- a/projects/term-structure/index.js
+++ b/projects/term-structure/index.js
@@ -286,10 +286,24 @@ const MARKET_BLACKLIST = {
 
 // Extra ERC20s that may sit alongside the underlying inside a
 // StableERC4626ForCustomize pool's Gnosis Safe `thirdPool` (e.g. XAUe held next
-// to XAUt). Each address is summed as a separate balanceOf(safe) entry so the
-// price oracle prices each token in its own units.
-const SAFE_EQUIVALENT_TOKEN_ADDRESSES = {
-  ethereum: ["0xd5D6840ed95F58FAf537865DcA15D5f99195F87a"], // XAUe
+// to XAUt).
+//
+// DefiLlama's price service has no oracle for XAUe, so reading its balance
+// directly would silently drop ~$18M on Ethereum. Each entry therefore carries
+// a `priceableToken` + `divisor` so the raw balance is converted to an
+// equivalent raw amount of a token DefiLlama can price.
+//
+// XAUe: 1 token = 0.001 troy oz, 18 decimals.
+// XAUt: 1 token = 1 troy oz, 6 decimals.
+// raw_xaut = raw_xaue * 0.001 / 10^18 * 10^6 = raw_xaue / 10^15.
+const SAFE_EQUIVALENT_TOKENS = {
+  ethereum: [
+    {
+      token: "0xd5D6840ed95F58FAf537865DcA15D5f99195F87a", // XAUe
+      priceableToken: "0x68749665FF8D2d112Fa859AA293F07A622782F38", // XAUt
+      divisor: 10n ** 15n,
+    },
+  ],
 };
 
 // TermMaxViewer (per-chain). Used to surface unclaimed pool rewards for
@@ -685,7 +699,7 @@ async function erc4626VaultsTvl(api) {
   const customizeUnderlyings = await api.multiCall({ abi: 'address:underlying', calls: customizeVaults })
   const customizeThirdPools = await api.multiCall({ abi: 'address:thirdPool', calls: customizeVaults })
   const thirdPoolSupplies = await api.multiCall({ abi: 'erc20:totalSupply', calls: customizeThirdPools, permitFailure: true })
-  const safeEquivalents = SAFE_EQUIVALENT_TOKEN_ADDRESSES[api.chain] ?? [];
+  const safeBackedSafes = [];
   customizeVaults.forEach((vault, i) => {
     const underlying = customizeUnderlyings[i];
     const thirdPool = customizeThirdPools[i];
@@ -695,13 +709,12 @@ async function erc4626VaultsTvl(api) {
       tokensAndOwners.push([thirdPool, vault]);
     } else {
       tokensAndOwners.push([underlying, thirdPool]);
-      for (const equiv of safeEquivalents) {
-        tokensAndOwners.push([equiv, thirdPool]);
-      }
+      safeBackedSafes.push(thirdPool);
     }
   })
 
   await sumTokens2({ api, tokensAndOwners });
+  await addSafeEquivalentBalances(api, safeBackedSafes);
   await addUnclaimedPoolRewards(api, {
     stableERC4626For4626Vaults,
     stableUnderlyings,
@@ -709,6 +722,34 @@ async function erc4626VaultsTvl(api) {
     customizeUnderlyings,
     thirdPoolSupplies,
   });
+}
+
+// XAUe and similar non-priceable equivalents are remapped to a priceable
+// canonical token (e.g. XAUt) at a fixed raw-unit ratio. balanceOf is batched
+// over (safe x equivalent) pairs.
+async function addSafeEquivalentBalances(api, safeAddresses) {
+  if (safeAddresses.length === 0) return;
+  const equivalents = SAFE_EQUIVALENT_TOKENS[api.chain] ?? [];
+  if (equivalents.length === 0) return;
+
+  const calls = [];
+  for (const safe of safeAddresses) {
+    for (const eq of equivalents) {
+      calls.push({ target: eq.token, params: [safe] });
+    }
+  }
+  const balances = await api.multiCall({ abi: 'erc20:balanceOf', calls });
+
+  let idx = 0;
+  for (const safe of safeAddresses) {
+    for (const eq of equivalents) {
+      const raw = BigInt(balances[idx++] ?? '0');
+      if (raw === 0n) continue;
+      const remapped = raw / eq.divisor;
+      if (remapped === 0n) continue;
+      api.add(eq.priceableToken, remapped.toString());
+    }
+  }
 }
 
 // For4626 and Customize-ERC20 pools route deposits into another ERC4626 where

--- a/projects/term-structure/index.js
+++ b/projects/term-structure/index.js
@@ -27,10 +27,6 @@ const ABIS = {
   Vault: {
     asset: "address:asset",
   },
-  Viewer: {
-    getPoolUnclaimedRewards:
-      "function getPoolUnclaimedRewards(address[] pools) external view returns (address[] asset, uint256[] amount)",
-  },
 };
 
 const EVENTS = {
@@ -283,20 +279,6 @@ const MARKET_BLACKLIST = {
   bsquared: [
     "0x5022B6563f6bc9f0D47F407ba32B64e1f438213a", // uBTC/WBTC
   ],
-};
-
-// TermMaxViewer (per-chain). Used to surface unclaimed pool rewards for
-// ERC4626 pools whose principal sits in another ERC4626 (For4626 + Customize-
-// ERC20). Aave-backed pools must NOT use this — accrued interest already
-// rebases into the aToken balance, so adding rewards here would double-count.
-const TERMMAX_VIEWER_ADDRESS = {
-  ethereum:  "0xf574c1d7C18E250c341bdFb478cafefcaCbAbF09",
-  arbitrum:  "0x012BFcbAC9EdEa04DFf07Cc61269E321f4595DfF",
-  bsc:       "0x80906014B577AFd760528FA8B32304A49806580C",
-  berachain: "0x37Ba9934aAbA7a49cC29d0952C6a91d7c7043dbc",
-  bsquared:  "0x0d64B9feF3E1f599B88d29Edb54D2F9152CBE496",
-  xlayer:    "0xaaa2108dF9c3Aa4d358275340733476d139A1445",
-  base:      "0x0d64B9feF3E1f599B88d29Edb54D2F9152CBE496",
 };
 
 async function getTermMaxMarketAddresses(api) {
@@ -685,70 +667,6 @@ async function erc4626VaultsTvl(api) {
   })
 
   await sumTokens2({ api, tokensAndOwners });
-  await addUnclaimedPoolRewards(api, {
-    stableERC4626For4626Vaults,
-    stableUnderlyings,
-    customizeVaults,
-    customizeUnderlyings,
-    thirdPoolSupplies,
-  });
-}
-
-// For4626 and Customize-ERC20 pools route deposits into another ERC4626 where
-// yield surfaces only as share-price appreciation. The pool's totalAssets()
-// returns principal-only (1:1 share), so we ask TermMaxViewer for the accrued
-// reward and add it to the underlying balance. Skip pools whose reward asset
-// differs from the pool's underlying — summing them as underlying would be
-// unit-incorrect.
-async function addUnclaimedPoolRewards(api, params) {
-  const viewerAddress = TERMMAX_VIEWER_ADDRESS[api.chain];
-  if (!viewerAddress) return;
-
-  const {
-    stableERC4626For4626Vaults,
-    stableUnderlyings,
-    customizeVaults,
-    customizeUnderlyings,
-    thirdPoolSupplies,
-  } = params;
-
-  const pools = [];
-  const poolUnderlyings = [];
-  stableERC4626For4626Vaults.forEach((vault, i) => {
-    pools.push(vault);
-    poolUnderlyings.push(stableUnderlyings[i]);
-  });
-  customizeVaults.forEach((vault, i) => {
-    if (thirdPoolSupplies[i] === null) return; // Safe-backed: no viewer dispatch
-    pools.push(vault);
-    poolUnderlyings.push(customizeUnderlyings[i]);
-  });
-  if (pools.length === 0) return;
-
-  let result;
-  try {
-    result = await api.call({
-      abi: ABIS.Viewer.getPoolUnclaimedRewards,
-      target: viewerAddress,
-      params: [pools],
-    });
-  } catch (err) {
-    console.warn(`TermMaxViewer.getPoolUnclaimedRewards failed on ${api.chain}`, err.message ?? err);
-    return;
-  }
-
-  const { asset, amount } = result;
-  for (let i = 0; i < pools.length; i += 1) {
-    const rewardAsset = asset[i];
-    const rewardAmount = amount[i] ?? '0';
-    if (!rewardAsset || rewardAsset.toLowerCase() !== poolUnderlyings[i].toLowerCase()) {
-      if (rewardAmount && BigInt(rewardAmount) > 0n) {
-        console.warn(`TermMaxViewer reward asset ${rewardAsset} differs from underlying ${poolUnderlyings[i]} for pool ${pools[i]} on ${api.chain}; skipping`);
-      }
-      continue;
-    }
-    api.add(rewardAsset, rewardAmount);
-  }
 }
 
 module.exports = {

--- a/projects/term-structure/index.js
+++ b/projects/term-structure/index.js
@@ -431,11 +431,10 @@ async function getTermMaxVaultV2Addresses(api) {
 }
 
 async function getTermMaxVaultOwnerTokens(api) {
-  const [vaultV1Addresses, vaultV1PlusAddresses, vaultV2Addresses] =
-    await Promise.all([
-      getTermMaxVaultAddresses(api),
-      getTermMaxVaultV1PlusAddresses(api),
-    ]);
+  const [vaultV1Addresses, vaultV1PlusAddresses] = await Promise.all([
+    getTermMaxVaultAddresses(api),
+    getTermMaxVaultV1PlusAddresses(api),
+  ]);
   const vaultAddresses = []
     .concat(vaultV1Addresses)
     .concat(vaultV1PlusAddresses)

--- a/projects/term-structure/index.js
+++ b/projects/term-structure/index.js
@@ -27,6 +27,10 @@ const ABIS = {
   Vault: {
     asset: "address:asset",
   },
+  Viewer: {
+    getPoolUnclaimedRewards:
+      "function getPoolUnclaimedRewards(address[] pools) external view returns (address[] asset, uint256[] amount)",
+  },
 };
 
 const EVENTS = {
@@ -286,6 +290,20 @@ const MARKET_BLACKLIST = {
 // price oracle prices each token in its own units.
 const SAFE_EQUIVALENT_TOKEN_ADDRESSES = {
   ethereum: ["0xd5D6840ed95F58FAf537865DcA15D5f99195F87a"], // XAUe
+};
+
+// TermMaxViewer (per-chain). Used to surface unclaimed pool rewards for
+// ERC4626 pools whose principal sits in another ERC4626 (For4626 + Customize-
+// ERC20). Aave-backed pools must NOT use this — accrued interest already
+// rebases into the aToken balance, so adding rewards here would double-count.
+const TERMMAX_VIEWER_ADDRESS = {
+  ethereum:  "0xf574c1d7C18E250c341bdFb478cafefcaCbAbF09",
+  arbitrum:  "0x012BFcbAC9EdEa04DFf07Cc61269E321f4595DfF",
+  bsc:       "0x80906014B577AFd760528FA8B32304A49806580C",
+  berachain: "0x37Ba9934aAbA7a49cC29d0952C6a91d7c7043dbc",
+  bsquared:  "0x0d64B9feF3E1f599B88d29Edb54D2F9152CBE496",
+  xlayer:    "0xaaa2108dF9c3Aa4d358275340733476d139A1445",
+  base:      "0x0d64B9feF3E1f599B88d29Edb54D2F9152CBE496",
 };
 
 async function getTermMaxMarketAddresses(api) {
@@ -685,6 +703,70 @@ async function erc4626VaultsTvl(api) {
   })
 
   await sumTokens2({ api, tokensAndOwners });
+  await addUnclaimedPoolRewards(api, {
+    stableERC4626For4626Vaults,
+    stableUnderlyings,
+    customizeVaults,
+    customizeUnderlyings,
+    thirdPoolSupplies,
+  });
+}
+
+// For4626 and Customize-ERC20 pools route deposits into another ERC4626 where
+// yield surfaces only as share-price appreciation. The pool's totalAssets()
+// returns principal-only (1:1 share), so we ask TermMaxViewer for the accrued
+// reward and add it to the underlying balance. Skip pools whose reward asset
+// differs from the pool's underlying — summing them as underlying would be
+// unit-incorrect.
+async function addUnclaimedPoolRewards(api, params) {
+  const viewerAddress = TERMMAX_VIEWER_ADDRESS[api.chain];
+  if (!viewerAddress) return;
+
+  const {
+    stableERC4626For4626Vaults,
+    stableUnderlyings,
+    customizeVaults,
+    customizeUnderlyings,
+    thirdPoolSupplies,
+  } = params;
+
+  const pools = [];
+  const poolUnderlyings = [];
+  stableERC4626For4626Vaults.forEach((vault, i) => {
+    pools.push(vault);
+    poolUnderlyings.push(stableUnderlyings[i]);
+  });
+  customizeVaults.forEach((vault, i) => {
+    if (thirdPoolSupplies[i] === null) return; // Safe-backed: no viewer dispatch
+    pools.push(vault);
+    poolUnderlyings.push(customizeUnderlyings[i]);
+  });
+  if (pools.length === 0) return;
+
+  let result;
+  try {
+    result = await api.call({
+      abi: ABIS.Viewer.getPoolUnclaimedRewards,
+      target: viewerAddress,
+      params: [pools],
+    });
+  } catch (err) {
+    console.warn(`TermMaxViewer.getPoolUnclaimedRewards failed on ${api.chain}`, err.message ?? err);
+    return;
+  }
+
+  const { asset, amount } = result;
+  for (let i = 0; i < pools.length; i += 1) {
+    const rewardAsset = asset[i];
+    const rewardAmount = amount[i] ?? '0';
+    if (!rewardAsset || rewardAsset.toLowerCase() !== poolUnderlyings[i].toLowerCase()) {
+      if (rewardAmount && BigInt(rewardAmount) > 0n) {
+        console.warn(`TermMaxViewer reward asset ${rewardAsset} differs from underlying ${poolUnderlyings[i]} for pool ${pools[i]} on ${api.chain}; skipping`);
+      }
+      continue;
+    }
+    api.add(rewardAsset, rewardAmount);
+  }
 }
 
 module.exports = {

--- a/projects/term-structure/index.js
+++ b/projects/term-structure/index.js
@@ -264,23 +264,6 @@ const ADDRESSES = {
       { address: "0xa50929A67daF9Ff3567e2Bb3411204A134f72546", fromBlock: 43289755 },
     ],
   },
-  pharos: {
-    FactoryV2: [
-      {
-        address: "0xEDC206E67eAc5C949c0a90A02E29B4b2791c8395",
-        fromBlock: 5243188,
-      },
-    ],
-    VaultFactoryV2: [
-      {
-        address: "0x5316b0d2Ee13C81E243226D6BB93CF29FBf95837",
-        fromBlock: 5243205,
-      },
-    ],
-    TermMax4626Factory: [
-      { address: "0xBa38C4D39ECf8401d90e7469dc6eB438547caC81", fromBlock: 5243210 },
-    ],
-  },
 };
 
 const VAULT_BLACKLIST = {
@@ -314,7 +297,6 @@ const TERMMAX_VIEWER_ADDRESS = {
   bsquared:  "0x0d64B9feF3E1f599B88d29Edb54D2F9152CBE496",
   xlayer:    "0xaaa2108dF9c3Aa4d358275340733476d139A1445",
   base:      "0x0d64B9feF3E1f599B88d29Edb54D2F9152CBE496",
-  pharos:    "0x0c30Bd74f891D88E69C07DEb5Ae9dA40C974BfeD",
 };
 
 async function getTermMaxMarketAddresses(api) {


### PR DESCRIPTION
## Summary

- **Add Pharos mainnet** — V2 factory, vault factory, 4626 factory and viewer (addresses from `termmax-contract-v2/deployments/pharos-mainnet`).
- **Track `StableERC4626ForCustomizeCreated`** from `TermMax4626Factory`, including the Gnosis Safe `thirdPool` branch (XAUt vault on Ethereum). Adds the second Ethereum 4626 factory at block 24790495. Dedupes `(underlying, safe)` tuples so multi-vault Safes are not double-counted.
- **Track Coinshift rlUSD pool factory on Ethereum** — adds a third Ethereum 4626 factory (`0x8ec01a80…`) at block 25,004,529. Emits the `StableERC4626For4626Created` event for the `tmseRLUSD` wrapper; without it the wrapper's ~$6M of `senRLUSDv2` (Coinshift's underlying ERC4626) is missed.
- **Remap Safe-held XAUe to XAUt** — DefiLlama's price service has no XAUe oracle, so reading `balanceOf(XAUe, safe)` directly silently dropped ~\$18M on Ethereum. Convert raw balance via fixed divisor (1 XAUe = 0.001 oz, 1 XAUt = 1 oz, decimals 18 vs 6 → divisor 10^15). Safe addresses are deduped before remapping.
- **Sum unclaimed pool rewards** via `TermMaxViewer.getPoolUnclaimedRewards` for For4626 + Customize-ERC20 pools (Aave-backed pools skip — interest already rebases into the aToken).
- **Drop stale `vaultV2Addresses` destructure** — `Promise.all` returned 2 elements, destructure expected 3 → permanent `undefined`. V2 vaults are sourced via `recordVaultV2Assets` instead.

## TVL impact (LLAMA_DEBUG_MODE)

| chain | before | after | Δ |
|---|---:|---:|---:|
| ethereum | 21.00 M | 44.17 M | +23.17 M |
| pharos | (n/a) | 0 | new chain wired (no markets yet) |
| bsc | 1.02 M | 1.03 M | +0.01 M |
| others | unchanged | unchanged | ~0 |
| **total** | **64.16 M** | **89.12 M** | **+24.96 M** |

Ethereum delta breakdown:
- New ETH 4626 factory pools (ellenUSDC etc.): ~\$1.0M
- Coinshift rlUSD wrapper (senRLUSDv2): ~\$6.0M
- Safe XAUe remap to XAUt (3,946 oz × \$4,571): ~\$18M
- Viewer unclaimed rewards: ~\$10K

## Test plan

- [x] `LLAMA_DEBUG_MODE=true node test.js projects/term-structure/index.js` — runs clean, no warnings
- [x] Verified Customize pools resolve to 4 vaults on Ethereum (1 USDC, 3 XAUt) and Safe balances surface as expected
- [x] Confirmed `coins.llama.fi` returns no price for XAUe (`0xd5D6840…`), justifying the remap
- [x] Confirmed Pharos chain wired and adapter runs without RPC errors (no events emitted yet → 0 TVL is expected)
- [x] Confirmed Coinshift `tmseRLUSD` wrapper (factory `0x8ec01a80…`) detected and `senRLUSDv2` ~\$6M flows into ethereum TVL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for an additional vault type and expanded factory discovery to find newly deployed vaults.

* **Bug Fixes**
  * Improved TVL routing by detecting and attributing third-pool contributions; vaults with probe failures are excluded from customize TVL.
  * Refined vault owner-token fetching to adjust which factory types are included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->