### PR TITLE
feat: Ventuals vHYPE TVL on Hyperliquid ($20.29M)

### DIFF
--- a/projects/ventuals/index.js
+++ b/projects/ventuals/index.js
@@ -1,0 +1,16 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+const { getHypercoreStakedHype } = require('../helper/chain/hyperliquid')
+
+const stakingVault = '0x8888888192a4A0593c13532Ba48449FC24C3bEDA'
+
+const tvl = async (api) => {
+  await api.sumTokens({ owners: [stakingVault], tokens: [ADDRESSES.null] })
+  const staked = await getHypercoreStakedHype(stakingVault)
+  api.addGasToken(staked)
+}
+
+module.exports = {
+  timetravel: false,
+  methodology: 'Counts HYPE held by the Ventuals StakingVault on HyperEVM plus HYPE delegated on HyperCore that backs vHYPE.',
+  hyperliquid: { tvl },
+}


### PR DESCRIPTION
## Ventuals vHYPE — Hyperliquid

Adds a TVL adapter for Ventuals. The protocol already has a DefiLlama page (`/protocol/ventuals`) tracking fees, derivatives volume, and open interest, but `currentChainTvls` was empty — this fills in TVL for the vHYPE LST.

- **Protocol type:** HYPE liquid staking token backing a HIP-3 perp DEX
- **Chain:** hyperliquid
- **Methodology:** Sum of HYPE held by the StakingVault on HyperEVM + HYPE delegated on HyperCore for the same address
- **TVL (local test):** \$20.29M

### Contracts

| Contract | Address |
| --- | --- |
| vHYPE token | [`0x8888888FdAAc0E7CF8C6523c8955bF7954c216fa`](https://hyperevmscan.io/address/0x8888888FdAAc0E7CF8C6523c8955bF7954c216fa) |
| StakingVault | [`0x8888888192a4A0593c13532Ba48449FC24C3bEDA`](https://hyperevmscan.io/address/0x8888888192a4A0593c13532Ba48449FC24C3bEDA) |

The adapter mirrors the pattern already in `projects/kinetiq/index.js` (uses the existing `getHypercoreStakedHype` helper).

### Local test
```
$ node test.js projects/ventuals/index.js
--- hyperliquid ---
HYPE                      20.29 M
------ TVL ------
hyperliquid               20.29 M
```