### PR TITLE
Fix Starknet multiCall: handle non-array response from single-element batches

### DIFF
--- a/projects/helper/chain/starknet.js
+++ b/projects/helper/chain/starknet.js
@@ -79,7 +79,11 @@ async function multiCall({ abi: rootAbi, target: rootTarget, calls = [], allAbi 
   for (const chunk of chunks) {
     await sleep(200)
     const { data } = await axios.post(STARKNET_RPC, chunk)
-    allData.push(...data)
+    // Some Starknet RPC providers (e.g. lava.build) return a single object
+    // instead of a one-element array when the batch contains exactly one
+    // request. Normalize so the spread below never gets a non-iterable.
+    const responses = Array.isArray(data) ? data : [data]
+    allData.push(...responses)
   }
 
   const response = []


### PR DESCRIPTION
## What

\`projects/helper/chain/starknet.js\`'s \`multiCall\` does \`allData.push(...data)\` on the response from \`axios.post(STARKNET_RPC, chunk)\`. When a chunk contains exactly one call, the default RPC (\`https://rpc.starknet.lava.build/\`) returns a single object instead of a one-element array, so the spread throws.

## Reproduce on current main

\`\`\`
$ LLAMA_RUN_LOCAL=1 node test.js projects/ekubo/index.js

 ------ ERROR ------ 

Error: Promise pool failed! 
 TypeError: Spread syntax requires ...iterable[Symbol.iterator] to be a function
\`\`\`

Direct check of the RPC behavior:

\`\`\`
$ curl -s -X POST 'https://rpc.starknet.lava.build/' -H 'Content-Type: application/json' \
       --data '[{\"jsonrpc\":\"2.0\",\"id\":0,\"method\":\"starknet_blockNumber\"}]'
{\"jsonrpc\":\"2.0\",\"id\":0,\"result\":9257820}      # ← single object, not [{…}]

$ curl -s -X POST 'https://rpc.starknet.lava.build/' -H 'Content-Type: application/json' \
       --data '[{\"jsonrpc\":\"2.0\",\"id\":0,\"method\":\"starknet_blockNumber\"},
                {\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"starknet_blockNumber\"}]'
[{…},{…}]                                            # ← array as expected for multi-element
\`\`\`

So the bug fires whenever an adapter's call set divides into a chunk of exactly one — which happens for any \`multiCall\` with a single request, or with a request count that's a multiple of 25 + 1.

## Fix

Two-line normalization that wraps a non-array response back into an array:

\`\`\`diff
   const { data } = await axios.post(STARKNET_RPC, chunk)
-  allData.push(...data)
+  const responses = Array.isArray(data) ? data : [data]
+  allData.push(...responses)
\`\`\`

## Test

\`\`\`
$ LLAMA_RUN_LOCAL=1 node test.js projects/ekubo/index.js

------ TVL ------
starknet                  29.79 M
ethereum                  8.01 M

total                    37.80 M
\`\`\`

\`projects/endur\` (which uses larger multi-element batches) reports its expected ~\$10.16M before and after — multi-batch path unchanged. No external API, no new packages, no \`package-lock.json\` change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of Starknet RPC responses to properly process single-item batch requests and prevent iteration errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->