### PR TITLE
Fix Aeria: typo `doublecouted` -> `doublecounted` in module.exports

### DIFF
--- a/projects/aeria/index.js
+++ b/projects/aeria/index.js
@@ -22,7 +22,7 @@ async function tvl(api) {
 }
 
 module.exports = {
-  doublecouted: true,
+  doublecounted: true,
   base: {
     tvl,
   },


### PR DESCRIPTION
## What

\`projects/aeria/index.js\` declared \`module.exports.doublecouted = true\` (typo). The framework rejects unrecognized export keys, so \`node test.js\` aborted with:

\`\`\`
Error: Found export keys that were not part of specification: doublecouted
\`\`\`

The framework's accepted-keys list (printed in the error) includes \`doublecounted\` but not \`doublecouted\`.

## Why

Two effects:
1. The adapter currently throws on every test run.
2. The author's intent — to flag this protocol's TVL as double-counted — was silently lost. Aeria appears to be a vault layered on top of an underlying yield source, so the flag is meaningful.

## Test

After this 1-character change:

\`\`\`
$ LLAMA_RUN_LOCAL=1 node test.js projects/aeria/index.js
Building prices get queries for 1 tokens
--- base ---
USDC                      365.11
Total: 365.11

------ TVL ------
base                      365.00

total                    365.11
\`\`\`

No external API, no new packages, no \`package-lock.json\` change. Diff is one character.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a configuration flag name to ensure the proper setting is correctly exposed and available for use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->