### PR TITLE
track Growi HF Hyperliquid native vault

### DIFF
--- a/projects/growihf/index.js
+++ b/projects/growihf/index.js
@@ -1,0 +1,17 @@
+const { post } = require('../helper/http')
+
+const VAULT = '0x1e37a337ed460039d1b15bd3bc489de789768d5e'
+
+async function tvl(api) {
+  const data = await post('https://api.hyperliquid.xyz/info', {
+    type: 'clearinghouseState',
+    user: VAULT,
+  })
+  api.addCGToken('usd-coin', parseFloat(data.marginSummary.accountValue))
+}
+
+module.exports = {
+  timetravel: false,
+  methodology: "TVL is the equity (accountValue) of the Growi HF Hyperliquid native vault, returned by the Hyperliquid info API's clearinghouseState. The vault holds USDC collateral and runs a quantitative perp strategy on HyperCore.",
+  hyperliquid: { tvl },
+}


### PR DESCRIPTION
**Summary**

Adds a TVL adapter for the Growi HF Hyperliquid native vault.

**Methodology**

TVL is the equity (`marginSummary.accountValue`) of the vault on HyperCore, queried via the Hyperliquid info API (`type: clearinghouseState`). The vault holds USDC collateral and runs a quantitative perp strategy. The reported value is denominated in USDC.

**Vault**

- Address: `0x1e37a337ed460039d1b15bd3bc489de789768d5e`
- Chain: Hyperliquid L1 (HyperCore)
- Leader: `growihf` (https://twitter.com/growihf)

**Validation**

```
node test.js projects/growihf/index.js

--- tvl ---
USDC                      7.72 M
Total: 7.72 M

------ TVL ------
hyperliquid               7.72 M

total                    7.72 M
```

This matches the value reported by DefiLlama's existing yields-server adapter for the same pool (~$7.69M, pool `90c0b5b5-6e92-47b8-b644-fcb4a4a0d708`).

**Listing details**

- Name: Growi HF
- Chain: Hyperliquid L1
- Category: Yield Aggregator
- Twitter: https://twitter.com/growihf
- Methodology: TVL is the equity (accountValue) of the Growi HF Hyperliquid native vault on HyperCore, denominated in USDC.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Hyperliquid TVL adapter for the GrowIHF project, enabling real-time reporting of vault account values to CoinGecko token metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->