### PR TITLE
fix ssi-protocol on-chain tvl computation (fixes #17720)

### DIFF
--- a/projects/ssi-protocol/index.js
+++ b/projects/ssi-protocol/index.js
@@ -63,5 +63,6 @@ module.exports = {
     bitcoin: ['BTC', 'bitcoin'],
     cardano: ['ADA', 'cardano'],
     ripple: ['XRP', 'ripple'],
+    hyperliquid: ['HYPEREVM_HYPE', 'hyperliquid'],
   })
 };


### PR DESCRIPTION
Fixes #17720

## What was wrong
The `DEFI.ssi` basket on Base now includes native HYPE on HyperLiquid (returned by `getBasket()` as `chain: "HYPEREVM_HYPE"`, ~75,466 HYPE). The `underlyingExports` chain map in `projects/ssi-protocol/index.js` had no entry for HyperLiquid, so every TVL call silently skipped those tokens.

## What changed
Added one entry to `underlyingExports`:

```js
hyperliquid: ['HYPEREVM_HYPE', 'hyperliquid'],
```

- `'HYPEREVM_HYPE'` — exact `token.chain` string returned by `getBasket()`
- `'hyperliquid'` — DefiLlama chain slug + CoinGecko ID for native HYPE

## Before / after

`node test.js projects/ssi-protocol/index.js`:

```
                   Before        After
hyperliquid        (missing)     HYPE $3.04M
total TVL          $94.05M       $97.26M
```

Historical check `node test.js projects/ssi-protocol/index.js 2026-04-01`: passes, hyperliquid reports HYPE $2.77M.

## Notes
- No new npm packages
- No `package.json` / `pnpm-lock.yaml` changes
- TVL still computed from on-chain data only (`getBasket()` view call on Base)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Hyperliquid chain support now available. Users can monitor Total Value Locked (TVL) metrics for the Hyperliquid blockchain, gaining visibility into liquidity distribution and asset positions within the ecosystem. This addition expands platform coverage and enables comprehensive analysis of Hyperliquid activity and value metrics across the network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->