### PR TITLE
  Add Base vaults to Aarna adapter

### DIFF
--- a/projects/aarna/index.js
+++ b/projects/aarna/index.js
@@ -17,6 +17,10 @@ const AARNA_CONFIG = {
     arbitrum: {
       'ATV-111': "0xe1a6bda42fbafae38607598386a1050613c1a64b"
     },
+    base: {
+      'ATV-101': "0x9dC3F0f25d793bee5eec75Da3058b0c919F71166",
+      'ATV-111': "0xB56aA0Cbee33C4b6b281027ebAa7697aad42a853",
+    },
     sonic: {
       'ATV-111': "0x1cb934e1f5acdb5b805c609a2c5a09aa8489f124"
     }
@@ -31,6 +35,10 @@ const AARNA_CONFIG = {
     },
     arbitrum: {
       'ATV-111': "0x4700bd9cc7232f243945b4a55834ab84563e4e9d"
+    },
+    base: {
+      'ATV-101': "0x6469D15333e7d6a8bDad18a18c251706570bc318",
+      'ATV-111': "0x6469D15333e7d6a8bDad18a18c251706570bc318",
     },
     sonic: {
       'ATV-111': "0x13da4847c80732cab3341f459a094e042af98691"
@@ -50,6 +58,10 @@ const AARNA_CONFIG = {
       ADDRESSES.arbitrum.USDC_CIRCLE, // USDC on Arbitrum
       ADDRESSES.arbitrum.USDC, // USDC.e on Arbitrum
     ],
+    base: [
+      ADDRESSES.base.USDC,
+      ADDRESSES.base.cbBTC,
+    ],
     sonic: [
       ADDRESSES.sonic.USDC_e, // usdc address on sonic
       "0x3F5EA53d1160177445B1898afbB16da111182418", // pendle lp token on sonic
@@ -57,7 +69,7 @@ const AARNA_CONFIG = {
   },
 
   // Multi-chain deployment
-  chains: ['ethereum', 'arbitrum', 'sonic']
+  chains: ['ethereum', 'arbitrum', 'base', 'sonic']
 };
 
 // Export the generated configuration

--- a/projects/helper/atv-helper.js
+++ b/projects/helper/atv-helper.js
@@ -36,17 +36,20 @@ async function getAtvCumulativeTvl(api, vaultConfigs) {
  */
 async function getAtvVaultTokens(api, vaultAddress, vaultType = 'ATV-111', additionalTokens = []) {
   // Always try to get dynamic tokens from vault contract
-  const [_, inputTokens] = await api.call({
+  const inputTokenResult = await api.call({
     abi: ATV_ABIS.getInputToken,
     target: vaultAddress,
     permitFailure: true,
   });
 
-  const uTokens = await api.call({
+  const uTokensResult = await api.call({
     abi: ATV_ABIS.getUTokens,
     target: vaultAddress,
     permitFailure: true,
   });
+
+  const inputTokens = Array.isArray(inputTokenResult) ? inputTokenResult[1] || [] : [];
+  const uTokens = Array.isArray(uTokensResult) ? uTokensResult : [];
 
   // Combine dynamic tokens
   const dynamicTokens = []


### PR DESCRIPTION
  ## Summary
  Add Base vault support to the Aarna adapter.

  ## What changed
  - Added Base vaults to `projects/aarna/index.js`
  - Added Base storage contract support for the new vault entries
  - Hardened `projects/helper/atv-helper.js` so failed vault token discovery calls do not crash the adapter

  ## Base contracts
  - ATV-101: `0x9dC3F0f25d793bee5eec75Da3058b0c919F71166`
  - ATV-111: `0xB56aA0Cbee33C4b6b281027ebAa7697aad42a853`
  - Storage: `0x6469D15333e7d6a8bDad18a18c251706570bc318`

  ## Verification
  Tested locally with: `node test.js projects/aarna/index.js`

  Base TVL now resolves successfully in the adapter output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Base blockchain network with corresponding vault and storage contract mappings, plus fallback token configuration.

* **Bug Fixes**
  * Enhanced robustness of token retrieval operations with improved error handling to gracefully handle unexpected API response formats and prevent aggregation failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->