### PR TITLE
add apyx protocol (apyUSD ERC-4626 vault)

### DIFF
--- a/registries/erc4626.js
+++ b/registries/erc4626.js
@@ -267,7 +267,11 @@ const configs = {
       pCreditVault: '0x39976f3Ef143a5824d4E4c28c204d556113dCF7f',
     }),
     methodology: "TVL represents the total value of assets held within the vault. Each vault token is minted using USDC and appreciates in line with the performance of the underlying asset.",
-  }
+  },
+  'apyx-protocol': {
+    methodology: "TVL is totalAssets() of the apyUSD ERC-4626 savings vault, denominated in apxUSD (Apyx Protocol's synthetic dollar).",
+    ethereum: ['0x38EEb52F0771140d10c4E9A9a72349A329Fe8a6A'],
+  },
 }
 
 module.exports = buildProtocolExports(configs, erc4626ExportFn)


### PR DESCRIPTION
**Summary**

Adds a TVL adapter for Apyx Protocol via the existing `registries/erc4626.js` registry.

Apyx Protocol issues apxUSD (a synthetic dollar on Ethereum) and apyUSD (an ERC-4626 savings vault that holds apxUSD).

**Methodology**

Reads `totalAssets()` on the apyUSD ERC-4626 vault and credits the result under apxUSD, which is priced via `coins.llama.fi`.

**Contracts**

- apyUSD vault (ERC-4626): `0x38EEb52F0771140d10c4E9A9a72349A329Fe8a6A`
- apxUSD (underlying): `0x98A878b1Cd98131B271883B390f68D2c90674665`
- Chain: Ethereum

**Validation**

```
node test.js apyx-protocol

Loaded module apyx-protocol from registry
--- ethereum ---
apxUSD                    76.45 M
Total: 76.45 M

------ TVL ------
ethereum                  76.45 M

total                    76.45 M
```

This matches the yields-server adapter for the same vault (~$76M, pool `cb6139f9-4a68-4efd-8245-0312a92aee55`).

**Listing details**

- Name: Apyx Protocol
- Website: https://apyx.fi
- Twitter: https://twitter.com/apyx_fi
- Chain: Ethereum
- Category: RWA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added protocol registry configuration with TVL support for a new Ethereum-based savings vault.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->