### PR TITLE
fix: add USDa and sUSDa token mappings for Taiko chain - fixes #12510

### DIFF
--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -44,6 +44,10 @@ const fixBalancesTokens = {
   ozone: {
     // '0x83048f0bf34feed8ced419455a4320a735a92e9d': { coingeckoId: "ozonechain", decimals: 18 }, // was mapped to wrong chain
   },
+  taiko: {
+    '0xff12470a969dd362eb6595ffb44c82c959fe9acc': { coingeckoId: 'usda', decimals: 18 },
+    '0x5d5c8aec46661f029a5136a4411c73647a5714a7': { coingeckoId: 'susda', decimals: 18 },
+  },
   provenance: {
     'ueurc.figure.se': { coingeckoId: 'euro-coin', decimals: 6 },
     'pm.pool.asset.3hjz8rcr3pejdc3msntlvy': { coingeckoId: 'usd-coin', decimals: 0 },


### PR DESCRIPTION
Fixes #12510

## Problem
The avalon-finance-usdalend adapter was unable to price USDa and sUSDa 
tokens on Taiko chain, causing them to show as "Unrecognized tokens" 
and be excluded from TVL calculations.

## Fix
Added token mappings to `projects/helper/tokenMapping.js` for the 
Taiko chain:
- USDa (0xff12470a969dd362eb6595ffb44c82c959fe9acc) → coingeckoId: usda
- sUSDa (0x5d5c8aec46661f029a5136a4411c73647a5714a7) → coingeckoId: susda

## Testing
Ran `node test.js projects/avalon-finance-usdalend/index.js` — adapter 
runs cleanly with no errors and no unrecognized tokens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Taiko network token support with mappings for two token contracts, including proper identifier associations and decimal configuration for accurate balance tracking and asset recognition across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->