### PR TITLE
fix: include WBTC collateral in Linx TVL

### DIFF
--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -44,6 +44,10 @@ const fixBalancesTokens = {
   ozone: {
     // '0x83048f0bf34feed8ced419455a4320a735a92e9d': { coingeckoId: "ozonechain", decimals: 18 }, // was mapped to wrong chain
   },
+  taiko: {
+    '0xff12470a969dd362eb6595ffb44c82c959fe9acc': { coingeckoId: 'usda', decimals: 18 },
+    '0x5d5c8aec46661f029a5136a4411c73647a5714a7': { coingeckoId: 'susda', decimals: 18 },
+  },
   provenance: {
     'ueurc.figure.se': { coingeckoId: 'euro-coin', decimals: 6 },
     'pm.pool.asset.3hjz8rcr3pejdc3msntlvy': { coingeckoId: 'usd-coin', decimals: 0 },

--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -48,6 +48,10 @@ const fixBalancesTokens = {
     '0xff12470a969dd362eb6595ffb44c82c959fe9acc': { coingeckoId: 'usda', decimals: 18 },
     '0x5d5c8aec46661f029a5136a4411c73647a5714a7': { coingeckoId: 'susda', decimals: 18 },
   },
+  alephium: {
+    '383bc735a4de6722af80546ec9eeb3cff508f2f68e97da19489ce69f3e703200': { coingeckoId: 'wrapped-bitcoin', decimals: 8 },
+    '556d9582463fe44fbd108aedc9f409f69086dc78d994b88ea6c9e65f8bf98e00': { coingeckoId: 'tether', decimals: 6 },
+  },
   provenance: {
     'ueurc.figure.se': { coingeckoId: 'euro-coin', decimals: 6 },
     'pm.pool.asset.3hjz8rcr3pejdc3msntlvy': { coingeckoId: 'usd-coin', decimals: 0 },


### PR DESCRIPTION
Fixes #18029

## Problem
WBTC used as collateral in Linx's WBTC/USDT pool on Alephium was 
being silently excluded from TVL calculations.

## Root Cause
A cleanup commit removed alephium token mappings from tokenMapping.js 
without migrating them, leaving WBTC with no coingeckoId/decimals 
mapping.

## Fix
Restored the alephium fixBalancesTokens entries in tokenMapping.js:
- WBTC (383bc735...) → wrapped-bitcoin, 8 decimals
- USDT (556d958...) → tether, 6 decimals

## Testing
Ran `node test.js projects/linx/index.js`
Result: ALPH $346k + USDT $8.23k + WBTC $6.51k = $361k total TVL ✓

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Token configuration for taiko and alephium blockchains has been enhanced with updated token identifiers and decimal precision values for more accurate asset recognition and balance calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->