### PR TITLE
Add KrokoSwap adapter for Kasplex

### DIFF
--- a/projects/krokoswap/index.js
+++ b/projects/krokoswap/index.js
@@ -1,0 +1,20 @@
+const { getUniTVL } = require('../helper/unknownTokens')
+const { uniV3Export } = require('../helper/uniswapV3')
+
+const V2_FACTORY = '0x4373b7Fcf5059A785843cD224129e01d243Aef71'
+const V3_FACTORY = '0x0dfb1Bb755d872EA1fa4d95E4ad0c2E6317Ce9B9'
+const V3_FROM_BLOCK = 14294547
+
+module.exports = {
+  misrepresentedTokens: true,
+  methodology: `Counts the tokens locked on AMM pools, pulling the data from the KrokoSwap V2 factory (for V2 pools) and V3 factory (for V3 pools).`,
+  kasplex: {
+    tvl: getUniTVL({ factory: V2_FACTORY, useDefaultCoreAssets: true, permitFailure: true }),
+  },
+  ...uniV3Export({
+    kasplex: {
+      factory: V3_FACTORY,
+      fromBlock: V3_FROM_BLOCK,
+    }
+  }),
+}


### PR DESCRIPTION
KrokoSwap is a decentralized exchange on Kasplex (chainId: 202555) supporting both V2 and V3 AMM pools.

**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).

2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** It is a different repo, you can find your listing in [this file](https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts), you can edit it there and put up a PR
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes

---
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama): KrokoSwap

##### Twitter Link: https://x.com/Kroko_Swap

##### List of audit links if any: / 

##### Website Link: krokoswap.io

##### Logo (High resolution, will be shown with rounded borders): 
<img width="1490" height="259" alt="logo-dark dda19e9b" src="https://github.com/user-attachments/assets/74c5c74f-3c01-4fc7-9dc4-6fa568f31374" />
<img width="300" height="52" alt="logo-dark dda19e9b" src="https://github.com/user-attachments/assets/4eddc2f5-405d-4367-aa73-197f54b60d34" />

##### Current TVL: 365.16k

##### Treasury Addresses (if the protocol has treasury) /

##### Chain: Kasplex

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): 
krokoswap-v3
https://www.coingecko.com/en/exchanges/krokoswap-v3
(https://api.coingecko.com/api/v3/coins/list)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): /
(https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama):  Kroko is a decentralized exchange built on the [Kasplex](https://kasplex.org/) blockchain, supporting both V2 (constant product) and V3 (concentrated liquidity) protocols with a Universal Router for unified swap execution.

##### Token address and ticker if any: / 

##### Category (full list at https://defillama.com/categories) \*Please choose only one: DEXs

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.): No oracle used

##### Implementation Details: Briefly describe how the oracle is integrated into your project: No oracle used

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage: /

##### forkedFrom (Does your project originate from another project): Uniswap V3

##### methodology (what is being counted as tvl, how is tvl being calculated): TVL is calculated by summing token balances locked in all V2 pairs and V3 pools. V2 pairs are fetched from the Factory contract (0x4373b7Fcf5059A785843cD224129e01d243Aef71), V3 pools are discovered via PoolCreated events from the V3 Factory (0x0dfb1Bb755d872EA1fa4d95E4ad0c2E6317Ce9B).

##### Github org/user (Optional, if your code is open source, we can track activity): /

##### Does this project have a referral program? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added KrokoSwap project adapter to the platform for tracking total value locked across automated market maker pools
  * Support for both V2 and V3 AMM pools with independent TVL calculations
  * Includes historical block-based data processing to analyze pool evolution from genesis
  * Configured with safeguards for token representation accuracy and failed lookups

<!-- end of auto-generated comment: release notes by coderabbit.ai -->