### PR TITLE
Track Morpheus AI Builders TVL

### DIFF
--- a/projects/morpheus-ai/index.js
+++ b/projects/morpheus-ai/index.js
@@ -1,6 +1,12 @@
 const ADDRESSES = require('../helper/coreAssets.json')
 const PROJECT_CONTRACT = '0x47176B2Af9885dC6C4575d4eFd63895f7Aaa4790';
 const PROJECT_CONTRACT_V2 = '0xDf1AC1AC255d91F5f4B1E3B4Aef57c5350F64C7A';
+const MOR_ARBITRUM = '0x092bAaDB7DEf4C3981454dD9c0A0D7FF07bCFc86'
+const MOR_BASE = '0x7431ada8a591c955a994a21710752ef9b882b8e3'
+const BUILDERS_ARBITRUM = '0xC0eD68f163d44B6e9985F0041fDf6f67c6BCFF3f'
+const BUILDERS_BASE = '0x42BB446eAE6dca7723a9eBdb81EA88aFe77eF4B9'
+const BUILDERS_ARBITRUM_START = +new Date('2025-08-17') / 1e3
+const BUILDERS_BASE_START = +new Date('2025-08-16') / 1e3
 
 async function tvl(api) {
   const v2Deployment = +new Date('2025-09-17') / 1e3
@@ -23,12 +29,19 @@ const abi = {
   "getAllReservesTokens": "function getAllReservesTokens() view returns ((string symbol, address tokenAddress)[])",
 }
 
+const builderTvl = (token, owner, start) => api => {
+  if (api.timestamp < start) return {}
+  return api.sumTokens({ owner, tokens: [token] })
+}
+
 module.exports = {
   timetravel: true,
   misrepresentedTokens: false,
-  methodology: 'Calculates TVL based on stETH deposits in the project contract.',
+  methodology: 'Calculates TVL from stETH deposits in the capital contracts and MOR staked in Builders contracts.',
   start: '2024-02-08',  // Feb-08-2024 07:33:35 AM UTC in Unix timestamp
   ethereum: { tvl },
+  arbitrum: { tvl: builderTvl(MOR_ARBITRUM, BUILDERS_ARBITRUM, BUILDERS_ARBITRUM_START) },
+  base: { tvl: builderTvl(MOR_BASE, BUILDERS_BASE, BUILDERS_BASE_START) },
   hallmarks: [
     ['2024-04-06', "MOR token launch"],  // May-08-2024 12:00:00 AM UTC in Unix timestamp
   ],


### PR DESCRIPTION
Adds Morpheus AI Builders TVL on Arbitrum and Base by summing MOR held in the documented Builders contracts.\n\nThis addresses #18908, where Morpheus AI currently only reports Ethereum capital contract TVL and misses MOR deposited into Builders on Arbitrum. Base Builders TVL is included as well because Morpheus documents the same Builders protocol deployment there.\n\nChanges:\n- Rename `projects/MorpheusAI` to lowercase `projects/morpheus-ai` so the repo test harness accepts the adapter without `LLAMA_RUN_LOCAL`.\n- Add Arbitrum and Base Builders contracts as TVL sources.\n- Add start-date guards so historical runs before the Builders deployments do not call undeployed MOR contracts.\n\nValidation:\n- `node test.js projects/morpheus-ai/index.js`\n- `node test.js projects/morpheus-ai/index.js 2024-02-09`\n- `npx eslint -c eslint.config.js projects/morpheus-ai/index.js`\n- `npm run lint` (passes with the existing unrelated warning in `registries/erc4626.js`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Arbitrum and Base networks
  * Updated TVL calculation to include stETH deposits and MOR staked assets

<!-- end of auto-generated comment: release notes by coderabbit.ai -->