### PR TITLE
feat(lighter-v2): add missing spot deposit tokens to Ethereum TVL

### DIFF
--- a/projects/lighter-v2/index.js
+++ b/projects/lighter-v2/index.js
@@ -11,11 +11,12 @@ const config = {
     tokens: [
       ADDRESSES.ethereum.USDC,
       ADDRESSES.null,
-      '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9',
-      '0x514910771af9ca656af840dff83e8264ecf986ca',
-      '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984',
-      '0x5a98fcbea516cf06857215779fd812ca3bef1b32',
+      ADDRESSES.ethereum.AAVE,
+      ADDRESSES.ethereum.LINK,
+      ADDRESSES.ethereum.UNI,
+      ADDRESSES.ethereum.LIDO,
       '0x56072C95FAA701256059aa122697B133aDEd9279',
+      '0xA27EC0006e59f245217Ff08CD52A7E8b169E62D2',
     ],
   },
 };

--- a/projects/lighter-v2/index.js
+++ b/projects/lighter-v2/index.js
@@ -8,7 +8,15 @@ const config = {
   },
   ethereum: {
     owners: ["0x3b4d794a66304f130a4db8f2551b0070dfcf5ca7"],
-    tokens: [ADDRESSES.ethereum.USDC, ADDRESSES.null],
+    tokens: [
+      ADDRESSES.ethereum.USDC,
+      ADDRESSES.null,
+      '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9',
+      '0x514910771af9ca656af840dff83e8264ecf986ca',
+      '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984',
+      '0x5a98fcbea516cf06857215779fd812ca3bef1b32',
+      '0x56072C95FAA701256059aa122697B133aDEd9279',
+    ],
   },
 };
 
@@ -19,4 +27,4 @@ Object.keys(config).forEach((chain) => {
 });
 
 module.exports.methodology =
-  "Counts tokens held in the Lighter system wallet on Ethereum and Arbitrum.";
+  "Counts tokens deposited by users into the Lighter ZK rollup contract on Ethereum and Arbitrum. Excludes Lighter's own LIT governance token.";


### PR DESCRIPTION
Extends Ethereum TVL tracking for Lighter ZK rollup to include all user-deposited spot trading tokens visible on-chain at the deposit contract.

Added tokens: AAVE, LINK, UNI, LDO, SKY
Excluded: LIT (Lighter's own governance token, per DefiLlama methodology)

Closes #17314


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Updates**
  * Expanded token support by adding several additional token contracts on Ethereum.

* **Documentation**
  * Clarified methodology: counts tokens deposited by users into the Lighter ZK rollup on Ethereum and Arbitrum, explicitly excluding the LIT governance token.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->