### PR TITLE
fix: replace dead SubQuery endpoint in Bittensor TVL helper with polkadot/api WebSocket

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@coral-xyz/anchor": "^0.30.1",
     "@defillama/sdk": "latest",
+    "@polkadot/api": "^16.5.6",
     "@project-serum/anchor": "^0.26.0",
     "@solana/web3.js": "^1.87.6",
     "@supercharge/promise-pool": "^2.1.0",
@@ -48,7 +49,7 @@
     "starknet": "^5.24.3",
     "ws": "^8.18.3"
   },
-  "overrides": {  },
+  "overrides": {},
   "description": "",
   "devDependencies": {
     "eslint": "^9.38.0"

--- a/projects/hatom-tao-bridge/index.js
+++ b/projects/hatom-tao-bridge/index.js
@@ -1,38 +1,14 @@
-const { post } = require('../helper/http')
+const { getBalance } = require('../helper/chain/bittensor')
 
 const TREASURY_ADDRESS = "5HZAAREPzwBc4EPWWeTHA2WRcJoCgy4UBk8mwYFWR5BTCNcT";
-
-const TAO_STATS_SUBQUERY = "https://api.subquery.network/sq/TaoStats/bittensor-indexer";
-
-const taoQuery = async () => {
-  const query = `{
-        query{
-            account(id: "${TREASURY_ADDRESS}"){
-                id
-                nodeId
-                balanceTotal
-                balanceStaked
-                balanceFree
-                address
-            }
-        }
-    }`;
-
-  const variables = {};
-
-  return post(TAO_STATS_SUBQUERY, {
-    query,
-    variables,
-  });
-};
 
 module.exports = {
   timetravel: false,
   bittensor: {
     tvl: async () => {
-      const { data: { query: { account: { balanceTotal } } } } = await taoQuery();
+      const balance = await getBalance(TREASURY_ADDRESS);
       return {
-        bittensor: balanceTotal / 1e9,
+        bittensor: balance,
       };
     },
   },

--- a/projects/helper/chain/bittensor.js
+++ b/projects/helper/chain/bittensor.js
@@ -1,27 +1,44 @@
 const sdk = require('@defillama/sdk')
-const { post } = require('../http')
+const { ApiPromise, WsProvider } = require("@polkadot/api");
 
-const TAO_STATS_SUBQUERY = "https://api.subquery.network/sq/TaoStats/bittensor-indexer";
+const WS_ENDPOINT = 'wss://entrypoint-finney.opentensor.ai:443'
+const TIMEOUT_MS = 30000
 
-async function getBalance(key) {
-  const query = `{
-        query{
-            account(id: "${key}"){
-                id
-                nodeId
-                balanceTotal
-                balanceStaked
-                balanceFree
-                address
-            }
-        }
-    }`;
-
-
-  const { data: { query: { account: { balanceTotal } } } } = await post(TAO_STATS_SUBQUERY, { query, variables: {}, });
-  return balanceTotal/1e9
+function withTimeout(promise, ms, onTimeout) {
+  let timer
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => {
+      onTimeout?.()
+      reject(new Error(`Timed out after ${ms}ms`))
+    }, ms)
+  })
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer))
 }
 
+async function getBalance(key) {
+  const wsProvider = new WsProvider(WS_ENDPOINT)
+  let bittensorApi
+
+  try {
+    bittensorApi = await withTimeout(
+      ApiPromise.create({ provider: wsProvider }),
+      TIMEOUT_MS,
+      () => wsProvider.disconnect()
+    )
+
+    const result = await withTimeout(
+      bittensorApi.query.system.account(key),
+      TIMEOUT_MS,
+      () => bittensorApi.disconnect()
+    )
+
+    const total = BigInt(result.data.free.toString()) + BigInt(result.data.reserved.toString())
+    return Number(total) / 1e9
+  } finally {
+    if (bittensorApi) await bittensorApi.disconnect()
+    else await wsProvider.disconnect()
+  }
+}
 
 async function sumTokens({ balances = {}, owners = [] }) {
   let total = 0
@@ -34,5 +51,6 @@ async function sumTokens({ balances = {}, owners = [] }) {
 }
 
 module.exports = {
-  sumTokens
+  getBalance,
+  sumTokens,
 }


### PR DESCRIPTION
## Problem

Fixes #19016

The TaoStats SubQuery endpoint used in `projects/helper/chain/bittensor.js` 
returns 404 and has been dead, breaking all Bittensor TVL adapters including 
`hatom-tao-bridge`.

## Fix

- Replaced the dead HTTP SubQuery call with a direct `@polkadot/api` 
  WebSocket connection to `wss://entrypoint-finney.opentensor.ai:443`
- Queries `system.account(address)` for `free + reserved` balance
- WebSocket disconnects cleanly after each query
- Simplified `hatom-tao-bridge/index.js` to use the updated helper

## Test Output

node test.js projects/hatom-tao-bridge/index.js

bittensor    23.00
total        23.27

Note: Current TVL is ~$23 (0.093 TAO actual on-chain balance). 
The $18M shown on DefiLlama is stale cached data from before 
the SubQuery endpoint broke. Asked @bheluga to confirm if the 
treasury address or staking query needs updating for the dTAO runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Dependencies**
  * Added Polkadot API library for chain interactions.

* **Refactor**
  * Switched TVL data source to direct on‑chain API calls instead of GraphQL.
  * TVL now uses on‑chain account balances with updated unit conversion, improving accuracy and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->