### PR TITLE
fix: hermetica usdh tvl (#19035)

### DIFF
--- a/projects/hermetica/index.js
+++ b/projects/hermetica/index.js
@@ -8,10 +8,10 @@ module.exports = {
   timetravel: false,
   stacks: {
     tvl: async () => {
-      const supplyOnStacksuUsdh = await call({ target: USDhContract, abi: 'get-total-supply' });
+      const supplyResult = await call({ target: USDhContract, abi: 'get-total-supply' });
+      const supply = Number(supplyResult.value) / 1e8;
 
-      return { 'hermetica-usdh': Number(supplyOnStacksuUsdh.value) / (10 ** 8) }
+      return { tether: supply }
     }
   },
-  misrepresentedTokens: true
 }


### PR DESCRIPTION
Closes #19035

## Changes
- Map USDh supply to `tether` instead of `hermetica-usdh` CoinGecko ID
- USDh is a $1-pegged stablecoin, so using `tether` gives correct TVL pricing
- Remove `misrepresentedTokens` flag (no longer needed with standard stablecoin mapping)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of TVL calculations through enhanced supply data processing, conversion, and mathematical normalization to ensure precise and reliable metrics.
  * Corrected token identification and mapping in TVL output to ensure accurate classification and improved user-facing reporting.
  * Updated module configuration by removing deprecated flags to streamline exports and better align with current system requirements and standards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->