### PR TITLE
fix: add Alpha STETH vault to sommelier tvl

### DIFF
--- a/projects/sommelier/cellar-constants.js
+++ b/projects/sommelier/cellar-constants.js
@@ -57,6 +57,7 @@ const TURBO_ETHX = "0x19B8D8FC682fC56FbB42653F68c7d48Dd3fe597E";
 const TURBO_EETH_V2 = "0xdAdC82e26b3739750E036dFd9dEfd3eD459b877A";
 const TURBO_RSETH = "0x1dffb366b5c5A37A12af2C127F31e8e0ED86BDbe";
 const TURBO_EZETH = "0x27500De405a3212D57177A789E30bb88b0AdbeC5";
+const ALPHA_STETH = "0xef417fce1883c6653e7dc6af7c6f85ccde84aa09";
 
 const cellarsV2p5 = [
   // { id: TURBO_SWETH, startBlock: 17910374 },
@@ -72,6 +73,7 @@ const cellarsV2p5 = [
   { id: TURBO_EETH_V2, startBlock: 19163705 },
   { id: TURBO_RSETH, startBlock: 19338456 },
   { id: TURBO_EZETH, startBlock: 19260727 },
+  { id: ALPHA_STETH, startBlock: 22541007 },
 ];
 
 // v2.5 Cellars on Arbitrum


### PR DESCRIPTION
Closes #19034

## Changes
Add the new Somm-native **Alpha STETH** BoringVault (`0xef417fce1883c6653e7dc6af7c6f85ccde84aa09`) to the Sommelier adapter.

This vault holds ~$21.71M TVL and was missing from the cellar constants. It uses the same ERC-4626 interface (`totalAssets`/`asset`) as V2 cellars, so no logic changes are needed — just adding it to the `cellarsV2p5` list.

The vault was deployed at block `22541007` and is managed by Seven Seas under the BoringVault architecture.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new Staked Ethereum (STETH) based cellar, expanding available investment options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->