### PR TITLE
Add Thaw (HyperEVM casino)

### DIFF
--- a/projects/thaw.js
+++ b/projects/thaw.js
@@ -1,0 +1,14 @@
+const { sumTokensExport, nullAddress } = require('./helper/unwrapLPs')
+
+const ADDRESS_BANKROLL = "0xf2fe0D4D898fb934510b0128d2EA01564C5ED3F1"
+
+module.exports = {
+  methodology: 'Thaw TVL is the HYPE held in the BankrollAndStaking contract, which serves as the house liquidity pool for all casino games. Liquidity providers deposit HYPE to earn yield from game outcomes across 6 on-chain games including Coin Flip, Range, Slots, Plinko, Rock Paper Scissors, and Baccarat. All games use Pyth Entropy for provably fair randomness.',
+  start: '2026-04-25',
+  hyperliquid: {
+    tvl: sumTokensExport({
+      owner: ADDRESS_BANKROLL,
+      tokens: [nullAddress]
+    })
+  }
+}


### PR DESCRIPTION
## Summary
- Adds TVL adapter for **Thaw**, a provably fair on-chain casino on HyperEVM (Hyperliquid)
- Tracks HYPE held in the BankrollAndStaking contract (`0xf2fe0D4D898fb934510b0128d2EA01564C5ED3F1`)
- 6 games: Coin Flip, Range, Slots, Plinko, Rock Paper Scissors, Baccarat
- All games use Pyth Entropy for verifiable randomness

## Contracts
| Contract | Address |
|----------|---------|
| BankrollAndStaking | `0xf2fe0D4D898fb934510b0128d2EA01564C5ED3F1` |
| CoinFlip | `0xd9197Ac761FA45E2eD70b13D69A51A0D260730a3` |
| Range | `0xeb04F70DA33713C6F40eCB0d3Ec95a780369C602` |
| Slots | `0x9aCccdE1D9Ff315aD6ed41Ae52D451D2fF7baf5b` |
| Plinko | `0x7ff7eA59C2aee61989440cAbE883e3f91B71C11c` |
| RockPaperScissors | `0xC216867c9bf0C60131c00d9139e17118E05B0989` |
| Baccarat | `0x1D6a92De0738044378C3338bDD02643b5c37044A` |

**Chain:** HyperEVM (Hyperliquid) — Chain ID 999
**Website:** https://thaw.bet
**Twitter:** https://x.com/thawdotbet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Total Value Locked (TVL) tracking for the Thaw protocol, providing visibility into the protocol's asset holdings and financial metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->