### PR TITLE
Add defimarketplus

### DIFF
--- a/projects/defimarketplus/index.js
+++ b/projects/defimarketplus/index.js
@@ -1,0 +1,39 @@
+// defimarketplus — non-custodial USD yield vault on Arbitrum.
+// https://dmtp.io
+//
+// TVL = SafeUsdVault.totalAssets() + ProjectTreasury USDC balance.
+// The vault's totalAssets() already includes idle USDC + USDC supplied to all
+// active strategies (Aave V3 today; Compound V3 + others under governance
+// review). Treasury USDC is separately held and earmarked for curated yield
+// strategy deployment, so we count it toward TVL as well.
+
+const ADDRESSES = require('../helper/coreAssets.json');
+
+const VAULT = '0x07fF8bCe905CB285220e4D96d8443cfCF141af8b'; // SafeUsdVault (smUSD)
+const TREASURY = '0x68d60e869a77ae1ceB546c07F3351e7D899b0Ce3'; // ProjectTreasury
+
+async function tvl(api) {
+  const usdc = ADDRESSES.arbitrum.USDC; // canonical Circle USDC
+
+  // Vault's nominal-totalAssets-minus-locked-profit. Includes idle + strategy
+  // assets already.
+  const vaultAssets = await api.call({
+    target: VAULT,
+    abi: 'uint256:totalAssets',
+  });
+  api.add(usdc, vaultAssets);
+
+  // Treasury USDC waiting to be deployed.
+  const treasuryUsdc = await api.call({
+    target: usdc,
+    abi: 'function balanceOf(address) view returns (uint256)',
+    params: [TREASURY],
+  });
+  api.add(usdc, treasuryUsdc);
+}
+
+module.exports = {
+  methodology:
+    'TVL = SafeUsdVault.totalAssets() (idle USDC + USDC deployed to whitelisted lending strategies, minus unvested locked-profit) + USDC held in ProjectTreasury awaiting curated yield deployment.',
+  arbitrum: { tvl },
+};


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
defimarketplus

##### Twitter Link:
(not yet active — will follow up)

##### List of audit links if any:
No audit yet — V1 launch deployment 2026-04-30. Trail of Bits + OtterSec audit scheduled before scaling beyond bootstrap TVL.

##### Website Link:
https://dmtp.io

##### Logo (High resolution, will be shown with rounded borders):
https://www.dmtp.io/brand/dmtp.svg
(SVG, 100×100 viewBox, rounded-corner ready, brand teal #06D6A0 on deep dark #012B22)

##### Current TVL:
~$1.20k USDC (genesis state — submitting at v1 launch).

##### Treasury Addresses (if the protocol has treasury)
ProjectTreasury (Arbitrum): `0x68d60e869a77ae1ceB546c07F3351e7D899b0Ce3`

##### Chain:
Arbitrum

##### Coingecko ID:
(not yet listed — DMTp token will be submitted after a DMTp/USDC pool exists)

##### Coinmarketcap ID:
(not yet listed)

##### Short Description (to be shown on DefiLlama):
Non-custodial USD yield vault on Arbitrum. ERC-4626 vault routing USDC across whitelisted lending venues (Aave V3, with more under governance review). 0.15% deposit / 0.10% exit fees, no management or performance fee. Treasury yield routes 70% to vault PPS for depositors, 30% to DMTp buyback-and-burn via CoW Protocol.

##### Token address and ticker if any:
DMTp governance token: `0x09fd7e0d021D29106c534Edfb4Ea817AC0ea7F84` (Arbitrum)
smUSD share token: `0x07fF8bCe905CB285220e4D96d8443cfCF141af8b` (Arbitrum, ERC-4626)

##### Category (full list at https://defillama.com/categories):
Yield Aggregator

##### Oracle Provider(s):
None. Vault uses on-chain price discovery via ERC-4626 share/asset conversion math; no external oracle required.

##### Implementation Details:
N/A — no oracle integration.

##### Documentation/Proof:
N/A — no oracle dependency.

##### forkedFrom:
Original implementation. ERC-4626 base from OpenZeppelin upgradeable. Locked-profit math based on Yearn v2 pattern (slope-based vesting). Buyback-burn pattern inspired by MKR/BNB precedents.

##### methodology:
TVL = `SafeUsdVault.totalAssets()` + `IERC20(USDC).balanceOf(ProjectTreasury)`.
- `totalAssets()` returns idle USDC + USDC supplied to active strategies (Aave V3 today), minus unvested locked-profit. Calculated by the vault contract on-chain.
- ProjectTreasury USDC is held separately, awaiting curated yield strategy deployment via governance proposals.

Both reads are pure on-chain calls, no off-chain dependency.

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/fxspeiser
(Smart contracts source-verified on Arbiscan; full repo to open-source after audit.)

##### Does this project have a referral program?
No.

---

## Adapter notes

- All contracts source-verified on Arbiscan. Direct links + governance details in original PR description above.
- Local TVL test passes:
  ```
  $ node test.js projects/defimarketplus/index.js
  --- arbitrum ---
  USDC                      1.30 k
  Total: 1.30 k
  ```
- No external API dependencies. Pure on-chain reads via the standard `api` helper.
- "Allow edits by maintainers" is enabled.