### PR TITLE
add TVL adapter for Agridex Yield Aniseed

### DIFF
--- a/projects/ay-aniseed-vault/index.js
+++ b/projects/ay-aniseed-vault/index.js
@@ -1,0 +1,35 @@
+const { callSoroban } = require('../helper/chain/stellar')
+
+const AGVT_TOKEN = 'CDQDXYC42G4ODKZA7B3RARH6VEOGCCQAX2UXOZLDYBNGDEOWODTSQYAZ'
+const EXCHANGE = 'CATKU4CKIUVPTNTLBHUFWIE5NOXO6CUW7EZGJLNAOZBKTQGXFHFIRN5N'
+const USDC = 'CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75'
+
+/**
+ * Calculates TVL by fetching the total AGVT token supply and exchange rate from on-chain contracts,
+ * then converting to the equivalent USDC value using the contract's redeem formula.
+ */
+async function tvl(api) {
+  const [totalSupply, rate] = await Promise.all([
+    callSoroban(AGVT_TOKEN, 'total_supply'),
+    callSoroban(EXCHANGE, 'get_rate'),
+  ])
+
+  // Redeem formula from contract: usdc_amount = agvt_amount * 10_000_000 / exchange_rate
+  // totalSupply is in raw AGVT units (7 decimals), rate uses 7-decimal scaling
+  // Result is raw USDC units (6 decimals)
+  const rateBn = BigInt(rate)
+  if (rateBn === 0n) {
+    api.add(USDC, '0')
+    return
+  }
+
+  const usdcValue = BigInt(totalSupply) * 10_000_000n / rateBn
+
+  api.add(USDC, usdcValue.toString())
+}
+
+module.exports = {
+  methodology: 'TVL is calculated by converting the total AGVT vault token supply to USDC using the exchange contract redeem formula (supply * scale / rate), representing the total USDC value backing all vault tokens.',
+  timetravel: false,
+  stellar: { tvl },
+}


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
AY-Aniseed Vault

##### Twitter Link:
https://x.com/agridexplatform

##### List of audit links if any:
n/a

##### Website Link:
agridex.com

##### Logo (High resolution, will be shown with rounded borders):
https://i.tracxn.com/logo/company/ad_766bc486-d2db-41c2-ab4b-fef497caddc8.jpg

##### Current TVL:
$0.26

##### Treasury Addresses (if the protocol has treasury)
GDO6SXI6XKH3UVTSNRA2G3X727554WXNN4OZWAC5VWAEXGPUOPSX63PO
Treasury wallet used for deploying funds into lending, balance fluctuates as loans are issued and repaid.

##### Chain:
Stellar

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama):
Agridex's first tokenized lending vault, Aniseed, on Stellar. Users deposit USDC and receive vault tokens representing their share, while deposited funds are deployed into commodity trade finance lending.

##### Token address and ticker if any:
CDQDXYC42G4ODKZA7B3RARH6VEOGCCQAX2UXOZLDYBNGDEOWODTSQYAZ

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Lending

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
None, exchange rate is set manually by protocol admins

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
n/a

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
n/a

##### forkedFrom (Does your project originate from another project):
n/a

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL is calculated by multiplying the total AGVT vault token supply by the USDC exchange rate from the Agridex exchange contract, representing the total USDC value backing all vault tokens.

##### Github org/user (Optional, if your code is open source, we can track activity):

##### Does this project have a referral program?
No

---
Re-opens #18648 (auto-closed when the previous fork's GitHub account was deleted). Same single-file change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New Stellar TVL adapter added that queries vault contracts to calculate and display total asset value denominated in USDC.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->