### PR TITLE
K613: add Aave V3 lending market on Monad

### DIFF
--- a/projects/k613/index.js
+++ b/projects/k613/index.js
@@ -1,0 +1,13 @@
+const { aaveV3Export } = require("../helper/aave");
+
+// K613 — Aave v3 fork lending market on Monad
+// POOL_ADDRESSES_PROVIDER: 0x1f6E754C6F7A49e2d69e5341d65EcB8f8506C69c
+// ProtocolDataProvider:    0xfc87bE7f3657AAD69baDb6247A88E924D1F8bc53
+module.exports = {
+  methodology:
+    "K613 is an Aave v3-based lending market on Monad. TVL counts tokens " +
+    "supplied to all reserves via aTokens; borrowed counts variable + stable debt.",
+  ...aaveV3Export({
+    monad: ["0xfc87bE7f3657AAD69baDb6247A88E924D1F8bc53"],
+  }),
+};


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).

2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** It is a different repo, you can find your listing in [this file](https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts), you can edit it there and put up a PR
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes

---
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama): K613

##### Twitter Link: https://x.com/k613_official

##### List of audit links if any:

##### Website Link: https://k613.net/

##### Logo (High resolution, will be shown with rounded borders): https://github.com/user-attachments/assets/79276db2-2023-4b6c-a38d-9a044d4d4361

##### Current TVL: $101.58 (live, freshly launched market)

##### Treasury Addresses (if the protocol has treasury) 0xF689bB846eE7DD51947c3368cc3ee26713D3ED83

##### Chain: Monad

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama): K613 is an over-collateralized lending protocol on Monad, forked from Aave V3. The market lists 11 assets — stablecoins, ETH/BTC and major Monad liquid staking tokens — and rewards both suppliers and borrowers with xK613 emissions through a dedicated incentives controller.

#####Token address and ticker if any:

#####Category (full list at https://defillama.com/categories) *Please choose only one: Lending

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.): Chainlink

##### Implementation Details: Briefly describe how the oracle is integrated into your project: The protocol uses an Aave V3 AaveOracle contract (0x0dFfb00A751a74ac8CF8B022Bf86b1ECd9D7ae6F) wired into the Pool via 
PoolAddressesProvider.setPriceOracle(). For each reserve asset, the oracle routes price queries to a dedicated Chainlink USD-denominated price feed via getSourceOfAsset(asset). Prices are reported in USD with 8 decimals (BASE_CURRENCY_UNIT = 1e8). All 11 markets are backed by individual Chainlink feeds; no fallback or TWAP is used.

#####Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
AaveOracle (verifiable on-chain via getSourceOfAsset): 0x0dFfb00A751a74ac8CF8B022Bf86b1ECd9D7ae6F

Per-asset Chainlink feeds (asset -> feed -> description):
USDC -> 0xf5F15f188AbCB0d165D1Edb7f37F7d6fA2fCebec "USDC / USD"
AUSD -> 0xE20751C7B5867bCBef815ffc1b284c3f412a9e13 "AUSD / USD"
USDT0 -> 0x1a1Be4c184923a6BFF8c27cfDf6ac8bDE4DE00FC "USDT / USD"
wsrUSD -> 0xceD82ddEac78A77500F2969B6e902bdB869a6641 "WSRUSD / USD"
WETH -> 0x1B1414782B859871781bA3E4B0979b9ca57A0A04 "ETH / USD"
wstETH -> 0xe6cd21b31948503dB54A07875999979722504B9A "WSTETH / USD"
WBTC -> 0x2D1Df1bD061AAc38C22407AD69d69bCC3C62edBD "WBTC / USD"
WMON -> 0xBcD78f76005B7515837af6b50c7C52BCf73822fb "MON / USD"
shMON -> 0x7A496d8ba15F82E35F3c633b6292eE75c4F5EDDB "shMON / USD"
sMON -> 0x23164e7B0D502E1EeB67C1b05201315372e7516E "sMON / USD"
gMON -> 0xdF3B3317974b2BA329377C7242C6A8e99A99E993 "gMON / USD"

Each feed exposes the standard Chainlink AggregatorV3Interface (description(), latestRoundData()).

##### forkedFrom (Does your project originate from another project): Aave V3

##### methodology (what is being counted as tvl, how is tvl being calculated): K613 is an Aave V3-based lending market on Monad. TVL counts the underlying tokens supplied by users to all reserves, measured as the balance of each underlying asset held by its corresponding aToken contract. Borrowed counts the sum of variable + stable debt token total supplies, denominated in their underlying assets. Rewards (paid in xK613) are emitted by an incentives controller and are NOT included in TVL.

##### Github org/user (Optional, if your code is open source, we can track activity): https://github.com/K613-Official

##### Does this project have a referral program? No
