### PR TITLE
Add LayerZero TVL helper and LayerZero RISE bridge adapter

### DIFF
--- a/projects/helper/layerzero.js
+++ b/projects/helper/layerzero.js
@@ -28,11 +28,7 @@ async function getSendUlnConfig(api, { oapp, dstEid, endpoint = ENDPOINT_V2 }) {
 
   assertDvnArrayValid(requiredDVNs, requiredDVNCount, 'required');
   assertDvnArrayValid(optionalDVNs, optionalDVNCount, 'optional');
-
-  const combined = [...requiredDVNs, ...optionalDVNs].map(a => a.toLowerCase());
-  if (new Set(combined).size !== combined.length) {
-    throw new Error('LayerZero DVN config reuses a verifier across required/optional sets; quorum would overstate independent signers');
-  }
+  assertNoDuplicateDvns([...requiredDVNs, ...optionalDVNs]);
 
   return {
     confirmations: Number(config.confirmations),
@@ -52,9 +48,12 @@ function assertDvnArrayValid(dvns, declaredCount, label) {
   if (dvns.some(addr => addr.toLowerCase() === ZeroAddress.toLowerCase())) {
     throw new Error(`LayerZero ${label} DVN config contains zero-address verifier (KelpDAO-style spoof guard)`);
   }
+}
+
+function assertNoDuplicateDvns(dvns) {
   const lowered = dvns.map(a => a.toLowerCase());
   if (new Set(lowered).size !== lowered.length) {
-    throw new Error(`LayerZero ${label} DVN config contains duplicate verifier; quorum count would overstate independent signers`);
+    throw new Error('LayerZero DVN config contains duplicate verifier; quorum would overstate independent signers');
   }
 }
 
@@ -66,10 +65,15 @@ async function getIncludedEscrows(api, { escrows, minDvnQuorum }) {
   if (!Number.isInteger(minDvnQuorum) || minDvnQuorum < 1) {
     throw new Error('sumLayerZeroEscrows requires minDvnQuorum (>= 1). Opting out re-introduces post-KelpDAO risk; see issue #18926.');
   }
+  if (!Array.isArray(escrows)) {
+    throw new Error('sumLayerZeroEscrows requires escrows to be an array');
+  }
 
   const includedEscrows = [];
   for (const escrow of escrows) {
-    if (!escrow.oapp || !escrow.dstEid) throw new Error('LayerZero DVN gating requires oapp and dstEid per escrow');
+    if (!escrow?.oapp || !escrow?.token || !escrow?.owner || !escrow?.dstEid) {
+      throw new Error('LayerZero escrow entries require owner, token, oapp, and dstEid');
+    }
 
     const config = await getSendUlnConfig(api, escrow);
     if (getMinimumVerifierQuorum(config) >= minDvnQuorum) includedEscrows.push(escrow);

--- a/projects/helper/layerzero.js
+++ b/projects/helper/layerzero.js
@@ -29,6 +29,11 @@ async function getSendUlnConfig(api, { oapp, dstEid, endpoint = ENDPOINT_V2 }) {
   assertDvnArrayValid(requiredDVNs, requiredDVNCount, 'required');
   assertDvnArrayValid(optionalDVNs, optionalDVNCount, 'optional');
 
+  const combined = [...requiredDVNs, ...optionalDVNs].map(a => a.toLowerCase());
+  if (new Set(combined).size !== combined.length) {
+    throw new Error('LayerZero DVN config reuses a verifier across required/optional sets; quorum would overstate independent signers');
+  }
+
   return {
     confirmations: Number(config.confirmations),
     requiredDVNCount,
@@ -58,7 +63,7 @@ function getMinimumVerifierQuorum(config) {
 }
 
 async function getIncludedEscrows(api, { escrows, minDvnQuorum }) {
-  if (typeof minDvnQuorum !== 'number' || minDvnQuorum < 1) {
+  if (!Number.isInteger(minDvnQuorum) || minDvnQuorum < 1) {
     throw new Error('sumLayerZeroEscrows requires minDvnQuorum (>= 1). Opting out re-introduces post-KelpDAO risk; see issue #18926.');
   }
 

--- a/projects/helper/layerzero.js
+++ b/projects/helper/layerzero.js
@@ -1,0 +1,89 @@
+const { AbiCoder, ZeroAddress } = require('ethers');
+
+const ENDPOINT_V2 = '0x1a44076050125825900e736c501f859c50fE728c';
+const ULN_CONFIG_TYPE = 2;
+
+const abiCoder = AbiCoder.defaultAbiCoder();
+const ulnConfigType = 'tuple(uint64 confirmations,uint8 requiredDVNCount,uint8 optionalDVNCount,uint8 optionalDVNThreshold,address[] requiredDVNs,address[] optionalDVNs)';
+
+async function getSendUlnConfig(api, { oapp, dstEid, endpoint = ENDPOINT_V2 }) {
+  const sendLib = await api.call({
+    target: endpoint,
+    abi: 'function getSendLibrary(address sender, uint32 eid) view returns (address)',
+    params: [oapp, dstEid],
+  });
+
+  const encodedConfig = await api.call({
+    target: endpoint,
+    abi: 'function getConfig(address oapp, address lib, uint32 eid, uint32 configType) view returns (bytes)',
+    params: [oapp, sendLib, dstEid, ULN_CONFIG_TYPE],
+  });
+
+  const [config] = abiCoder.decode([ulnConfigType], encodedConfig);
+
+  const requiredDVNCount = Number(config.requiredDVNCount);
+  const optionalDVNCount = Number(config.optionalDVNCount);
+  const requiredDVNs = Array.from(config.requiredDVNs);
+  const optionalDVNs = Array.from(config.optionalDVNs);
+
+  assertDvnArrayValid(requiredDVNs, requiredDVNCount, 'required');
+  assertDvnArrayValid(optionalDVNs, optionalDVNCount, 'optional');
+
+  return {
+    confirmations: Number(config.confirmations),
+    requiredDVNCount,
+    optionalDVNCount,
+    optionalDVNThreshold: Number(config.optionalDVNThreshold),
+    requiredDVNs,
+    optionalDVNs,
+    sendLib,
+  };
+}
+
+function assertDvnArrayValid(dvns, declaredCount, label) {
+  if (dvns.length !== declaredCount) {
+    throw new Error(`LayerZero ${label} DVN config malformed: declared count ${declaredCount}, actual length ${dvns.length}`);
+  }
+  if (dvns.some(addr => addr.toLowerCase() === ZeroAddress.toLowerCase())) {
+    throw new Error(`LayerZero ${label} DVN config contains zero-address verifier (KelpDAO-style spoof guard)`);
+  }
+  const lowered = dvns.map(a => a.toLowerCase());
+  if (new Set(lowered).size !== lowered.length) {
+    throw new Error(`LayerZero ${label} DVN config contains duplicate verifier; quorum count would overstate independent signers`);
+  }
+}
+
+function getMinimumVerifierQuorum(config) {
+  return config.requiredDVNCount + config.optionalDVNThreshold;
+}
+
+async function getIncludedEscrows(api, { escrows, minDvnQuorum }) {
+  if (typeof minDvnQuorum !== 'number' || minDvnQuorum < 1) {
+    throw new Error('sumLayerZeroEscrows requires minDvnQuorum (>= 1). Opting out re-introduces post-KelpDAO risk; see issue #18926.');
+  }
+
+  const includedEscrows = [];
+  for (const escrow of escrows) {
+    if (!escrow.oapp || !escrow.dstEid) throw new Error('LayerZero DVN gating requires oapp and dstEid per escrow');
+
+    const config = await getSendUlnConfig(api, escrow);
+    if (getMinimumVerifierQuorum(config) >= minDvnQuorum) includedEscrows.push(escrow);
+  }
+
+  return includedEscrows;
+}
+
+function sumLayerZeroEscrows({ escrows, minDvnQuorum } = {}) {
+  return async function tvl(api) {
+    const includedEscrows = await getIncludedEscrows(api, { escrows, minDvnQuorum });
+    return api.sumTokens({
+      tokensAndOwners: includedEscrows.map(({ token, owner }) => [token, owner]),
+    });
+  };
+}
+
+module.exports = {
+  getMinimumVerifierQuorum,
+  getSendUlnConfig,
+  sumLayerZeroEscrows,
+};

--- a/projects/layerzero-rise/index.js
+++ b/projects/layerzero-rise/index.js
@@ -21,5 +21,7 @@ Object.keys(bridgeContracts).forEach(chain => {
   };
 });
 
+module.exports.timetravel = false;
+
 module.exports.methodology =
   'Counts source-side USDC locked in RISE-specific LayerZero escrow contracts on Ethereum, Base, and Arbitrum. Destination minted OFT supply is excluded. Each escrow is included only if its LayerZero send-side ULN config meets the >=2 verifier quorum (requiredDVNCount + optionalDVNThreshold). Escrows whose OApps run a single-DVN setup (the KelpDAO failure mode) are excluded.';

--- a/projects/layerzero-rise/index.js
+++ b/projects/layerzero-rise/index.js
@@ -1,0 +1,25 @@
+const ADDRESSES = require('../helper/coreAssets.json');
+const { sumLayerZeroEscrows } = require('../helper/layerzero');
+
+const RISE_EID = 30401;
+
+const bridgeContracts = {
+  ethereum: [
+    { owner: '0xf43a70B250a86003a952af7A7986CcC243B89D81', token: ADDRESSES.ethereum.USDC, oapp: '0xf43a70B250a86003a952af7A7986CcC243B89D81', dstEid: RISE_EID },
+  ],
+  base: [
+    { owner: '0x82675d0553D802039e6776C006BEb1b820a69d55', token: ADDRESSES.base.USDC, oapp: '0x82675d0553D802039e6776C006BEb1b820a69d55', dstEid: RISE_EID },
+  ],
+  arbitrum: [
+    { owner: '0x82675d0553D802039e6776C006BEb1b820a69d55', token: ADDRESSES.arbitrum.USDC_CIRCLE, oapp: '0x82675d0553D802039e6776C006BEb1b820a69d55', dstEid: RISE_EID },
+  ],
+};
+
+Object.keys(bridgeContracts).forEach(chain => {
+  module.exports[chain] = {
+    tvl: sumLayerZeroEscrows({ escrows: bridgeContracts[chain], minDvnQuorum: 2 }),
+  };
+});
+
+module.exports.methodology =
+  'Counts source-side USDC locked in RISE-specific LayerZero escrow contracts on Ethereum, Base, and Arbitrum. Destination minted OFT supply is excluded. Each escrow is included only if its LayerZero send-side ULN config meets the >=2 verifier quorum (requiredDVNCount + optionalDVNThreshold). Escrows whose OApps run a single-DVN setup (the KelpDAO failure mode) are excluded.';


### PR DESCRIPTION
# Add LayerZero TVL helper and LayerZero RISE bridge adapter

Adds a LayerZero TVL helper at `projects/helper/layerzero.js` and a new adapter at `projects/layerzero-rise/index.js` for the LayerZero side of the RISE bridge.

The RISE team originally proposed parallel bridge tracking in PR #18838: an OP Stack `OptimismPortal2` adapter at `projects/rise/index.js` plus a separate LayerZero adapter at `projects/layerzero-rise/index.js`, with stated methodology "Canonical bridge TVL + LayerZero-enabled bridge TVL". PR #18850 landed the OP Stack portal but dropped the LayerZero half because all LayerZero TVL was paused after the April 2026 KelpDAO incident. Issue #18926 has been open since then asking for a safer way to count it. This PR adds the LayerZero half back, behind a small safety helper that other LayerZero adapters can reuse.

The existing `projects/rise/index.js` (OP Stack `OptimismPortal2` at `0xad92...c4C`, around $108k of L1 ETH escrow) is unchanged. The two adapters are independent and do not overlap: the portal escrows ETH for canonical L1-to-L2 deposits, the LayerZero contracts escrow USDC for OFT mints on RISE.

The helper counts source-side escrow balances only. It never reads destination OFT `totalSupply`.

For each escrow it reads the LayerZero V2 send-side ULN config and computes verifier quorum as `requiredDVNCount + optionalDVNThreshold`. Paths below `minDvnQuorum` are excluded. The helper throws if `minDvnQuorum` is missing, so a future adapter cannot silently opt out. The RISE adapter uses `minDvnQuorum: 2`.

`assertDvnArrayValid` rejects malformed configs: a DVN array shorter than its declared count, an `address(0)` entry (which would let `[realDVN, address(0)]` pass a naive count check), or duplicate addresses (which would overstate independent signers).

Scope is LayerZero V2 only (EndpointV2 at `0x1a44...728c`). V1 endpoints are not supported.

RISE escrows, all USDC, dstEid 30401:

- Ethereum `0xf43a70B250a86003a952af7A7986CcC243B89D81`
- Base `0x82675d0553D802039e6776C006BEb1b820a69d55`
- Arbitrum `0x82675d0553D802039e6776C006BEb1b820a69d55`

Each USDCLockReleaseOFT proxy is its own OApp, so `oapp == owner` per escrow. RISE Chain EID 30401 was confirmed via a PeerSet event on the Ethereum escrow at block 24772785, peer `0xa6ffe66379c34b85cd2ff4b3c8a73d3de7aba043`.

Live DVN configs (read via `EndpointV2.getConfig`):

- Ethereum: required=1, optional=2, threshold=1, effective quorum 2
- Base: required=1, optional=2, threshold=1, effective quorum 2
- Arbitrum: required=1, optional=2, threshold=1, effective quorum 2

All three pass.

Test:

```
$ node test.js projects/layerzero-rise/index.js

------ TVL ------
ethereum                  647.37 k
arbitrum                  195.18 k
base                      55.07 k

total                    897.62 k
```

Lint clean. No new npm dependencies; uses `ethers ^6.0.0` already in the repo.

A separate `defillama-server` PR is likely needed to add a listing entry for this adapter (data6.ts id 7737 currently maps "RISE Bridge" to `rise/index.js` only). Happy to file that follow-up under whatever naming maintainers prefer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added LayerZero RISE TVL adapter for Ethereum, Base, and Arbitrum.
  * Added a helper that computes LayerZero escrow TVL and includes only escrows meeting a verifier-quorum threshold.

* **Documentation**
  * Added methodology describing counting rules, quorum-based inclusion/exclusion, and exclusion of destination-minted supply.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->