### PR TITLE
Fix: Backpack (Solana TVL + Eclipse)

### DIFF
--- a/projects/backpack/index.js
+++ b/projects/backpack/index.js
@@ -38,6 +38,7 @@ const CHAINS = [
   'ripple',
   'plasma',
   'fogo',
+  'eclipse',
   'stable',
   'monad',
   'hyperliquid',
@@ -68,8 +69,10 @@ CHAINS.forEach((chain) => {
 
       switch (chain) {
         case 'solana':
+          options.solOwners = options.owners;
           options.includeStakedSol = true;
           options.onlyTrustedTokens = true;
+          break;
         case 'fogo':
         case 'eclipse':
           options.solOwners = options.owners;


### PR DESCRIPTION
Fixes Backpack TVL undercounting reported by the Backpack team.

### Issues fixed

1. **Solana switch case was missing a `break`** — execution fell through into the Fogo/Eclipse branch which sets `options.tokens = undefined`, bypassing the `onlyTrustedTokens` filter on Solana.
2. **Solana case never set `solOwners`** — so native SOL (and staked SOL via `includeStakedSol`) was not being counted across the 18 Solana wallets returned by Backpack's `/api/v1/wallets` API. This matches the existing pattern in `helper/cex.js`.
3. **Eclipse was missing from `CHAINS`** — the switch already had a case for it but the chain was never iterated, so its 3 wallets were silently skipped.

### Methodology unchanged

Wallets are still fetched from `https://api.backpack.exchange/api/v1/wallets` and balances summed via `sumTokensExport`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Eclipse blockchain.

* **Improvements**
  * Improved Solana configuration mapping to avoid unintended behavior between chain handlers.
  * Clarified handling for Fogo and Eclipse so owner and token options are set consistently before balance aggregation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->