### PR TITLE
Add Matrixdock Silver TVL adapter

### DIFF
--- a/projects/matrixdock-silver/index.js
+++ b/projects/matrixdock-silver/index.js
@@ -1,0 +1,9 @@
+const { getTvlOfSupplyAssets } = require("../matrixdock/getTvlOfSupplyAssets")
+
+const XAGM = "0x123ffe0a3C62878dcbee2742227dc8990058d9E1"
+
+const config = {
+  ethereum: [XAGM],
+}
+
+module.exports = getTvlOfSupplyAssets(config)


### PR DESCRIPTION
Adds a Matrixdock Silver TVL adapter that tracks the Ethereum XAGM token supply using the existing Matrixdock supply-based TVL helper.

https://defillama.com/protocol/matrixdock

Found new TVL venue while working on https://github.com/DefiLlama/dimension-adapters/issues/6694



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added XAGM token support for the Ethereum blockchain with automatic TVL (Total Value Locked) calculations for supply assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->