### PR TITLE
fix(idle): tolerate deprecated V3 vaults reverting tokenPrice (#19031)

### DIFF
--- a/projects/idle/index.js
+++ b/projects/idle/index.js
@@ -106,18 +106,18 @@ async function tvl(api) {
     tokenSafe,
   ] = await Promise.all([
     api.multiCall({ abi: 'uint256:totalSupply', calls: v1 }),
-    api.multiCall({ abi: 'uint256:totalSupply', calls: v3 }),
+    api.multiCall({ abi: 'uint256:totalSupply', calls: v3, permitFailure: true }),
     api.multiCall({ abi: 'uint256:totalSupply', calls: safe }),
     api.multiCall({ abi: 'uint256:tokenPrice', calls: v1 }),
-    api.multiCall({ abi: 'uint256:tokenPrice', calls: v3 }),
+    api.multiCall({ abi: 'uint256:tokenPrice', calls: v3, permitFailure: true }),
     api.multiCall({ abi: 'uint256:tokenPrice', calls: safe }),
     api.multiCall({ abi: 'address:token', calls: v1 }),
-    api.multiCall({ abi: 'address:token', calls: v3 }),
+    api.multiCall({ abi: 'address:token', calls: v3, permitFailure: true }),
     api.multiCall({ abi: 'address:token', calls: safe }),
   ])
 
   // Load tokens decimals
-  const callsDecimals = [...tokenV1, ...tokenV3, ...tokenSafe].map( t => ({ target: t, params: [] }) )
+  const callsDecimals = [...tokenV1, ...tokenV3, ...tokenSafe].filter(t => t != null).map( t => ({ target: t, params: [] }) )
   const decimalsResults = await api.multiCall({abi: 'erc20:decimals', calls: callsDecimals})
   const tokensDecimals = decimalsResults.reduce( (tokensDecimals, decimals, i) => {
     const call = callsDecimals[i]
@@ -135,6 +135,7 @@ async function tvl(api) {
   totalSupplyV3.map( (supply, i) => {
     const token = tokenV3[i]
     const tokenPrice = tokenPriceV3[i]
+    if (supply == null || tokenPrice == null || token == null) return
     const vaultTVL = BigNumber(supply).times(tokenPrice).div(1e18).toFixed(0)
     sdk.util.sumSingleBalance(balances, token, vaultTVL, api.chain)
   })


### PR DESCRIPTION
Fixes #19031 — `node test.js projects/idle/index.js` aborts with `Multicall failed! [chain: ethereum] [fail count: 7] [abi: uint256:tokenPrice]`, leaving the protocol stuck on a stale TVL.

## Root cause
Seven of the nine ethereum V3 vaults revert on `tokenPrice()` while still holding non-zero residual share supply (users have not withdrawn the dust). The `Promise.all` of multicalls aborts the moment one fails, so all of `tvl()` errors out — not just the V3 portion.

| V3 vault | tokenPrice | totalSupply |
|---|---|---|
| `0x78751b12...` idleDAIYieldV3 | **revert** | 994.48e18 |
| `0x12B98C62...` idleUSDCYieldV3 | **revert** | 622.60e6 |
| `0x63D27B3D...` idleUSDTYieldV3 | **revert** | 595.91e6 |
| `0xe79e177d...` idleSUSDYieldV3 | ok | 180.66e18 |
| `0x51C77689...` idleTUSDYieldV3 | ok | 9.24e18 |
| `0xD6f279B7...` idleWBTCYieldV3 | **revert** | 0.066e8 |
| `0x1846bdfD...` idleDAISafeV3 | **revert** | 484.08e18 |
| `0xcDdB1Bce...` idleUSDCSafeV3 | **revert** | 58.46e6 |
| `0x42740698...` idleUSDTSafeV3 | **revert** | 12.06e6 |

## Fix
Mark the three V3 multicalls (`totalSupply`, `tokenPrice`, `token`) as `permitFailure: true`, skip indexes where any of the three returns `null`, and filter nulls out of the decimals call. V1, Safe, and CDO paths are untouched (they work fine — no speculative guards).

## Verification
```
$ node test.js projects/idle/index.js
ethereum                  3.59 M
polygon                   27.27 k
optimism                  19.08 k
polygon_zkevm             4.36 k
arbitrum                  0.00
total                     3.64 M
```
Polygon / Optimism / Polygon zkEVM / Arbitrum match `api.llama.fi/protocol/idle` to the dollar. The two healthy V3 vaults (sUSD, TUSD) still contribute via the surviving entries.

## Notes
- "Allow edits by maintainers" enabled.
- No new npm deps; `pnpm-lock.yaml` untouched.
- Bug-fix only — no listing-form section needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of total value locked (TVL) calculations by enhancing error handling for contract interactions and implementing data validation to prevent calculation failures from invalid entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->