### PR TITLE
add LayerZero safety gate to USDT0

### DIFF
--- a/projects/helper/layerzero.js
+++ b/projects/helper/layerzero.js
@@ -28,11 +28,7 @@ async function getSendUlnConfig(api, { oapp, dstEid, endpoint = ENDPOINT_V2 }) {
 
   assertDvnArrayValid(requiredDVNs, requiredDVNCount, 'required');
   assertDvnArrayValid(optionalDVNs, optionalDVNCount, 'optional');
-
-  const combined = [...requiredDVNs, ...optionalDVNs].map(a => a.toLowerCase());
-  if (new Set(combined).size !== combined.length) {
-    throw new Error('LayerZero DVN config reuses a verifier across required/optional sets; quorum would overstate independent signers');
-  }
+  assertNoDuplicateDvns([...requiredDVNs, ...optionalDVNs]);
 
   return {
     confirmations: Number(config.confirmations),
@@ -52,9 +48,12 @@ function assertDvnArrayValid(dvns, declaredCount, label) {
   if (dvns.some(addr => addr.toLowerCase() === ZeroAddress.toLowerCase())) {
     throw new Error(`LayerZero ${label} DVN config contains zero-address verifier (KelpDAO-style spoof guard)`);
   }
+}
+
+function assertNoDuplicateDvns(dvns) {
   const lowered = dvns.map(a => a.toLowerCase());
   if (new Set(lowered).size !== lowered.length) {
-    throw new Error(`LayerZero ${label} DVN config contains duplicate verifier; quorum count would overstate independent signers`);
+    throw new Error('LayerZero DVN config contains duplicate verifier; quorum would overstate independent signers');
   }
 }
 
@@ -66,10 +65,15 @@ async function getIncludedEscrows(api, { escrows, minDvnQuorum }) {
   if (!Number.isInteger(minDvnQuorum) || minDvnQuorum < 1) {
     throw new Error('sumLayerZeroEscrows requires minDvnQuorum (>= 1). Opting out re-introduces post-KelpDAO risk; see issue #18926.');
   }
+  if (!Array.isArray(escrows)) {
+    throw new Error('sumLayerZeroEscrows requires escrows to be an array');
+  }
 
   const includedEscrows = [];
   for (const escrow of escrows) {
-    if (!escrow.oapp || !escrow.dstEid) throw new Error('LayerZero DVN gating requires oapp and dstEid per escrow');
+    if (!escrow?.oapp || !escrow?.token || !escrow?.owner || !escrow?.dstEid) {
+      throw new Error('LayerZero escrow entries require owner, token, oapp, and dstEid');
+    }
 
     const config = await getSendUlnConfig(api, escrow);
     if (getMinimumVerifierQuorum(config) >= minDvnQuorum) includedEscrows.push(escrow);

--- a/projects/helper/layerzero.js
+++ b/projects/helper/layerzero.js
@@ -61,6 +61,21 @@ function getMinimumVerifierQuorum(config) {
   return config.requiredDVNCount + config.optionalDVNThreshold;
 }
 
+function getEscrowDstEids(escrow) {
+  const rawEids = escrow.dstEids ?? (escrow.dstEid != null ? [escrow.dstEid] : null);
+  if (!Array.isArray(rawEids) || !rawEids.length) {
+    throw new Error('LayerZero escrow entries require dstEid or non-empty dstEids');
+  }
+  return [...new Set(rawEids)];
+}
+
+async function escrowMeetsQuorum(api, escrow, minDvnQuorum) {
+  const configs = await Promise.all(
+    getEscrowDstEids(escrow).map(dstEid => getSendUlnConfig(api, { ...escrow, dstEid }))
+  );
+  return configs.every(config => getMinimumVerifierQuorum(config) >= minDvnQuorum);
+}
+
 async function getIncludedEscrows(api, { escrows, minDvnQuorum }) {
   if (!Number.isInteger(minDvnQuorum) || minDvnQuorum < 1) {
     throw new Error('sumLayerZeroEscrows requires minDvnQuorum (>= 1). Opting out re-introduces post-KelpDAO risk; see issue #18926.');
@@ -71,12 +86,10 @@ async function getIncludedEscrows(api, { escrows, minDvnQuorum }) {
 
   const includedEscrows = [];
   for (const escrow of escrows) {
-    if (!escrow?.oapp || !escrow?.token || !escrow?.owner || !escrow?.dstEid) {
-      throw new Error('LayerZero escrow entries require owner, token, oapp, and dstEid');
+    if (!escrow?.oapp || !escrow?.token || !escrow?.owner) {
+      throw new Error('LayerZero escrow entries require owner, token, and oapp');
     }
-
-    const config = await getSendUlnConfig(api, escrow);
-    if (getMinimumVerifierQuorum(config) >= minDvnQuorum) includedEscrows.push(escrow);
+    if (await escrowMeetsQuorum(api, escrow, minDvnQuorum)) includedEscrows.push(escrow);
   }
 
   return includedEscrows;

--- a/projects/helper/layerzero.js
+++ b/projects/helper/layerzero.js
@@ -29,6 +29,11 @@ async function getSendUlnConfig(api, { oapp, dstEid, endpoint = ENDPOINT_V2 }) {
   assertDvnArrayValid(requiredDVNs, requiredDVNCount, 'required');
   assertDvnArrayValid(optionalDVNs, optionalDVNCount, 'optional');
 
+  const combined = [...requiredDVNs, ...optionalDVNs].map(a => a.toLowerCase());
+  if (new Set(combined).size !== combined.length) {
+    throw new Error('LayerZero DVN config reuses a verifier across required/optional sets; quorum would overstate independent signers');
+  }
+
   return {
     confirmations: Number(config.confirmations),
     requiredDVNCount,
@@ -58,7 +63,7 @@ function getMinimumVerifierQuorum(config) {
 }
 
 async function getIncludedEscrows(api, { escrows, minDvnQuorum }) {
-  if (typeof minDvnQuorum !== 'number' || minDvnQuorum < 1) {
+  if (!Number.isInteger(minDvnQuorum) || minDvnQuorum < 1) {
     throw new Error('sumLayerZeroEscrows requires minDvnQuorum (>= 1). Opting out re-introduces post-KelpDAO risk; see issue #18926.');
   }
 

--- a/projects/helper/layerzero.js
+++ b/projects/helper/layerzero.js
@@ -1,0 +1,89 @@
+const { AbiCoder, ZeroAddress } = require('ethers');
+
+const ENDPOINT_V2 = '0x1a44076050125825900e736c501f859c50fE728c';
+const ULN_CONFIG_TYPE = 2;
+
+const abiCoder = AbiCoder.defaultAbiCoder();
+const ulnConfigType = 'tuple(uint64 confirmations,uint8 requiredDVNCount,uint8 optionalDVNCount,uint8 optionalDVNThreshold,address[] requiredDVNs,address[] optionalDVNs)';
+
+async function getSendUlnConfig(api, { oapp, dstEid, endpoint = ENDPOINT_V2 }) {
+  const sendLib = await api.call({
+    target: endpoint,
+    abi: 'function getSendLibrary(address sender, uint32 eid) view returns (address)',
+    params: [oapp, dstEid],
+  });
+
+  const encodedConfig = await api.call({
+    target: endpoint,
+    abi: 'function getConfig(address oapp, address lib, uint32 eid, uint32 configType) view returns (bytes)',
+    params: [oapp, sendLib, dstEid, ULN_CONFIG_TYPE],
+  });
+
+  const [config] = abiCoder.decode([ulnConfigType], encodedConfig);
+
+  const requiredDVNCount = Number(config.requiredDVNCount);
+  const optionalDVNCount = Number(config.optionalDVNCount);
+  const requiredDVNs = Array.from(config.requiredDVNs);
+  const optionalDVNs = Array.from(config.optionalDVNs);
+
+  assertDvnArrayValid(requiredDVNs, requiredDVNCount, 'required');
+  assertDvnArrayValid(optionalDVNs, optionalDVNCount, 'optional');
+
+  return {
+    confirmations: Number(config.confirmations),
+    requiredDVNCount,
+    optionalDVNCount,
+    optionalDVNThreshold: Number(config.optionalDVNThreshold),
+    requiredDVNs,
+    optionalDVNs,
+    sendLib,
+  };
+}
+
+function assertDvnArrayValid(dvns, declaredCount, label) {
+  if (dvns.length !== declaredCount) {
+    throw new Error(`LayerZero ${label} DVN config malformed: declared count ${declaredCount}, actual length ${dvns.length}`);
+  }
+  if (dvns.some(addr => addr.toLowerCase() === ZeroAddress.toLowerCase())) {
+    throw new Error(`LayerZero ${label} DVN config contains zero-address verifier (KelpDAO-style spoof guard)`);
+  }
+  const lowered = dvns.map(a => a.toLowerCase());
+  if (new Set(lowered).size !== lowered.length) {
+    throw new Error(`LayerZero ${label} DVN config contains duplicate verifier; quorum count would overstate independent signers`);
+  }
+}
+
+function getMinimumVerifierQuorum(config) {
+  return config.requiredDVNCount + config.optionalDVNThreshold;
+}
+
+async function getIncludedEscrows(api, { escrows, minDvnQuorum }) {
+  if (typeof minDvnQuorum !== 'number' || minDvnQuorum < 1) {
+    throw new Error('sumLayerZeroEscrows requires minDvnQuorum (>= 1). Opting out re-introduces post-KelpDAO risk; see issue #18926.');
+  }
+
+  const includedEscrows = [];
+  for (const escrow of escrows) {
+    if (!escrow.oapp || !escrow.dstEid) throw new Error('LayerZero DVN gating requires oapp and dstEid per escrow');
+
+    const config = await getSendUlnConfig(api, escrow);
+    if (getMinimumVerifierQuorum(config) >= minDvnQuorum) includedEscrows.push(escrow);
+  }
+
+  return includedEscrows;
+}
+
+function sumLayerZeroEscrows({ escrows, minDvnQuorum } = {}) {
+  return async function tvl(api) {
+    const includedEscrows = await getIncludedEscrows(api, { escrows, minDvnQuorum });
+    return api.sumTokens({
+      tokensAndOwners: includedEscrows.map(({ token, owner }) => [token, owner]),
+    });
+  };
+}
+
+module.exports = {
+  getMinimumVerifierQuorum,
+  getSendUlnConfig,
+  sumLayerZeroEscrows,
+};

--- a/projects/layerzero-rise/index.js
+++ b/projects/layerzero-rise/index.js
@@ -21,5 +21,7 @@ Object.keys(bridgeContracts).forEach(chain => {
   };
 });
 
+module.exports.timetravel = false;
+
 module.exports.methodology =
   'Counts source-side USDC locked in RISE-specific LayerZero escrow contracts on Ethereum, Base, and Arbitrum. Destination minted OFT supply is excluded. Each escrow is included only if its LayerZero send-side ULN config meets the >=2 verifier quorum (requiredDVNCount + optionalDVNThreshold). Escrows whose OApps run a single-DVN setup (the KelpDAO failure mode) are excluded.';

--- a/projects/layerzero-rise/index.js
+++ b/projects/layerzero-rise/index.js
@@ -1,0 +1,25 @@
+const ADDRESSES = require('../helper/coreAssets.json');
+const { sumLayerZeroEscrows } = require('../helper/layerzero');
+
+const RISE_EID = 30401;
+
+const bridgeContracts = {
+  ethereum: [
+    { owner: '0xf43a70B250a86003a952af7A7986CcC243B89D81', token: ADDRESSES.ethereum.USDC, oapp: '0xf43a70B250a86003a952af7A7986CcC243B89D81', dstEid: RISE_EID },
+  ],
+  base: [
+    { owner: '0x82675d0553D802039e6776C006BEb1b820a69d55', token: ADDRESSES.base.USDC, oapp: '0x82675d0553D802039e6776C006BEb1b820a69d55', dstEid: RISE_EID },
+  ],
+  arbitrum: [
+    { owner: '0x82675d0553D802039e6776C006BEb1b820a69d55', token: ADDRESSES.arbitrum.USDC_CIRCLE, oapp: '0x82675d0553D802039e6776C006BEb1b820a69d55', dstEid: RISE_EID },
+  ],
+};
+
+Object.keys(bridgeContracts).forEach(chain => {
+  module.exports[chain] = {
+    tvl: sumLayerZeroEscrows({ escrows: bridgeContracts[chain], minDvnQuorum: 2 }),
+  };
+});
+
+module.exports.methodology =
+  'Counts source-side USDC locked in RISE-specific LayerZero escrow contracts on Ethereum, Base, and Arbitrum. Destination minted OFT supply is excluded. Each escrow is included only if its LayerZero send-side ULN config meets the >=2 verifier quorum (requiredDVNCount + optionalDVNThreshold). Escrows whose OApps run a single-DVN setup (the KelpDAO failure mode) are excluded.';

--- a/projects/usdt0/index.js
+++ b/projects/usdt0/index.js
@@ -1,20 +1,28 @@
 const coreAssets = require('../helper/coreAssets.json');
+const { sumLayerZeroEscrows } = require('../helper/layerzero');
 
 const ethereumOAdapterUpgradeable = "0x6C96dE32CEa08842dcc4058c14d3aaAD7Fa41dee";
-
-async function tvl(api) {
-  const balance = await api.call({
-    abi: 'erc20:balanceOf',
-    target: coreAssets.ethereum.USDT,
-    params: [ethereumOAdapterUpgradeable],
-  });
-
-  api.add(coreAssets.ethereum.USDT, balance);
-}
+const ethereumDstEids = [
+  30109, 30110, 30111, 30181, 30212, 30274, 30280, 30295, 30316, 30320,
+  30322, 30331, 30333, 30339, 30362, 30367, 30383, 30390, 30396, 30398, 30410,
+];
 
 module.exports = {
+  timetravel: false,
   start: 1736351639,
   ethereum: {
-    tvl,
+    tvl: sumLayerZeroEscrows({
+      escrows: [
+        {
+          oapp: ethereumOAdapterUpgradeable,
+          token: coreAssets.ethereum.USDT,
+          owner: ethereumOAdapterUpgradeable,
+          dstEids: ethereumDstEids,
+        },
+      ],
+      minDvnQuorum: 3,
+    }),
   },
+  methodology:
+    'Counts USDT locked in the Ethereum USDT0 OAdapter after validating all configured Ethereum send routes with the LayerZero helper. Each route must meet a 3-DVN quorum. Hedera and Tempo source-escrow OApps were observed but currently hold zero USDT0, so they are not included.',
 };


### PR DESCRIPTION
# Add LayerZero safety gate to USDT0

This PR depends on #19060.

Wires the existing single-address USDT0 adapter through the LayerZero TVL helper introduced in #19060. The current `projects/usdt0/index.js` reads the Ethereum source escrow balance directly, without checking the LayerZero DVN configuration on the routes secured by that escrow.

Because this PR is stacked on the #19060 branch, the diff against `main` includes the helper file from that PR. The meaningful new code is the `dstEids` extension to the helper and the USDT0 adapter rewrite. Once #19060 merges, this branch will rebase onto main and only the USDT0-relevant diff will remain.

This PR makes two changes:

1. `projects/helper/layerzero.js`: a backward-compatible extension to `sumLayerZeroEscrows`. Escrow entries can now declare `dstEids: [...]` instead of a single `dstEid`; the helper includes an escrow only when every route meets the quorum. The input is type-checked (must be an array) and deduplicated. RISE's existing single-route consumer continues to work unchanged.

2. `projects/usdt0/index.js`: switched from a raw `balanceOf` to `sumLayerZeroEscrows`, gated by `minDvnQuorum: 3` over the 21 destination EIDs configured on Ethereum's OApp.

The quorum is 3, not 2, because Ethereum's USDT0 OApp currently runs `requiredDVNCount=3, optionalDVNCount=0, optionalDVNThreshold=0` on every route (Tether Operations DVN, LayerZero Labs DVN, Nethermind DVN). A drop to 2-of-N would be a real safety reduction, so the threshold matches the current posture rather than allowing silent degradation.

The adapter is marked `timetravel: false` because the gate depends on the live LayerZero route configuration. Historical route configs were weaker before the current 3-DVN posture, so replaying this gate at old blocks would zero out historical escrow balances rather than reproduce the old raw-balance adapter.

I verified the scope on-chain:

- Ethereum is the only non-zero USDT source escrow counted by this adapter. Most destination OApps are mint-side OFTs; Hedera (EID 30316) and Tempo (EID 30410) source-escrow OApps were observed but currently hold zero USDT0.
- All 21 send-side routes from Ethereum return `req=3 opt=0 thr=0` quorum 3, via SendUln302 `0xbB2Ea70C9E858123480642Cf96acbcCE1372dCe1`.
- Hedera and Tempo can be added in a follow-up if their source escrow balances become non-zero.

Test:

```
$ node test.js projects/usdt0/index.js

--- ethereum ---
USDT                      3.68 B
Total: 3.68 B

------ TVL ------
ethereum                  3.68 B

total                    3.68 B
```

The number is identical to the pre-change adapter. This PR adds the gate, not new TVL.

Lint is clean. This PR adds no npm dependencies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added LayerZero RISE TVL tracking on Ethereum, Base, and Arbitrum
  * Introduced a helper to aggregate LayerZero escrows with verifier-quorum validation and escrow route filtering

* **Updates**
  * Switched USDT0 Ethereum TVL to LayerZero-based aggregation with a 3-DVN quorum requirement
  * Disabled timetravel and added methodology text for affected adapters
<!-- end of auto-generated comment: release notes by coderabbit.ai -->