### PR TITLE
fix(sablier-lockup) batch Envio config and restore Morph RPC

### DIFF
--- a/projects/helper/env.js
+++ b/projects/helper/env.js
@@ -47,7 +47,8 @@ const DEFAULTS = {
   KEETA_RPC: "https://rep1.main.network.api.keeta.com/api",
   CRYPTOAPIS_API_KEY: "35c1b8a" + "cd1119" + "b98dbe59e821ab734b87dfe6f84",
   PROPTECH_RPC: "https://mainnet.ptekcoin.com",
-  WHITELISTED_MORPH_RPC: 'https://explorer.morphl2.io/api/eth-rpc',
+  MORPH_RPC_CHAIN_ID: '2818',
+  MORPH_WHITELISTED_RPC: 'https://rpc.morphl2.io',
   BCYPHER_RPC: "https://mainapi.bchscan.io,https://datahub-asia01.bchscan.io,https://datahub-asia02.bchscan.io",
 }
 

--- a/projects/sablier-lockup/evm.js
+++ b/projects/sablier-lockup/evm.js
@@ -82,6 +82,10 @@ async function getEnvioConfig(chainId) {
 
         return { contractsByChain, assetsByChain }
       })
+      .catch(error => {
+        envioConfigPromise = undefined
+        throw error
+      })
   }
 
   const { contractsByChain, assetsByChain } = await envioConfigPromise

--- a/projects/sablier-lockup/evm.js
+++ b/projects/sablier-lockup/evm.js
@@ -26,6 +26,7 @@ const CHAIN_IDS_ENVIO = {
   optimism: 10,
   polygon: 137,
   scroll: 534352,
+  sei: 1329,
   sonic: 146,
   sophon: 50104,
   sseed: 5330,
@@ -37,7 +38,6 @@ const CHAIN_IDS_ENVIO = {
 
 // Chains that are not using the Envio indexer but using the Graph.
 const SUBGRAPH_ENDPOINTS = {
-  sei: 'AJU5rBfbuApuJpeZeaz6NYuYnnhAhEy4gFkqsSdAT6xb',
   // iotex: '2P3sxwmcWBjMUv1C79Jh4h6VopBaBZeTocYWDUQqwWFV',
 };
 
@@ -47,9 +47,9 @@ const config = {
 };
 
 const envioPayload = `
-query getChainData($chainId: numeric!) {
-  Contract(where: { _and: { chainId: { _eq: $chainId } , category: {_eq:"lockup"}}}) { id address category }
-  Asset(where: { _and: { chainId: { _eq: $chainId }, lockupStreams_aggregate: { count: { predicate: { _gt:0 }}}}}) { id chainId symbol }
+query getChainData($chainIds: [numeric!]!) {
+  Contract(where: { _and: { chainId: { _in: $chainIds } , category: {_eq:"lockup"}}}) { id address category chainId }
+  Asset(where: { _and: { chainId: { _in: $chainIds }, lockupStreams_aggregate: { count: { predicate: { _gt:0 }}}}}) { id chainId symbol }
 }
 `
 
@@ -60,6 +60,38 @@ const subgraphPayload = `
 }
 `
 
+let envioConfigPromise
+async function getEnvioConfig(chainId) {
+  if (!envioConfigPromise) {
+    envioConfigPromise = request(ENVIO_ENDPOINT, envioPayload, { chainIds: Object.values(CHAIN_IDS_ENVIO) })
+      .then(result => {
+        const contractsByChain = {}
+        const assetsByChain = {}
+
+        for (const contract of result.Contract || []) {
+          const id = String(contract.chainId)
+          contractsByChain[id] = contractsByChain[id] || []
+          contractsByChain[id].push(contract)
+        }
+
+        for (const asset of result.Asset || []) {
+          const id = String(asset.chainId)
+          assetsByChain[id] = assetsByChain[id] || []
+          assetsByChain[id].push(asset)
+        }
+
+        return { contractsByChain, assetsByChain }
+      })
+  }
+
+  const { contractsByChain, assetsByChain } = await envioConfigPromise
+  const id = String(chainId)
+  return {
+    contracts: contractsByChain[id] || [],
+    assets: assetsByChain[id] || [],
+  }
+}
+
 async function getTokensConfig(api, isVesting) {
   const endpoint = config[api.chain];
   if (!endpoint) return { ownerTokens: [] };
@@ -67,7 +99,7 @@ async function getTokensConfig(api, isVesting) {
   const isSubgraph = !!SUBGRAPH_ENDPOINTS[api.chain];
   const result = isSubgraph
     ? await request(sdk.graph.modifyEndpoint(endpoint), subgraphPayload)
-    : await request(ENVIO_ENDPOINT, envioPayload, { chainId: CHAIN_IDS_ENVIO[api.chain] });
+    : await getEnvioConfig(CHAIN_IDS_ENVIO[api.chain]);
 
   if (!result || (!isSubgraph && !CHAIN_IDS_ENVIO[api.chain])) return { ownerTokens: [] };
 


### PR DESCRIPTION
Fixes #19025

The Sablier Lockup adapter was failing in `node test.js projects/sablier-lockup/index.js`.

I found two issues:
- Morph was falling back to the SDK's Hoodi testnet RPC instead of Morph mainnet. The default env key was `WHITELISTED_MORPH_RPC`, but the SDK reads `{CHAIN}_WHITELISTED_RPC`, so this
changes it to `MORPH_WHITELISTED_RPC` and sets `MORPH_RPC_CHAIN_ID=2818`.
- After that, Sei was still using the Graph endpoint, which returned a paid API error. The Envio indexer already has Sei data, so this moves Sei to Envio.

I also changed the Envio request to fetch config for all Sablier chains once and reuse it instead of making the same query repeatedly for each chain/category.

Tested with:

```bash
node test.js projects/sablier-lockup/index.js
./node_modules/.bin/eslint -c eslint.config.js projects/helper/env.js projects/sablier-lockup/evm.js
git diff --check
```

This verifies the original failing adapter command now completes, while the calculation stays the same: balances are still read from Sablier Lockup contracts and split into `tvl` / `vesting`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Morph L2 RPC defaults: new chain ID and default RPC endpoint.
  * Migrated SEI blockchain indexing to Envio and consolidated requests into batched queries for improved efficiency and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->