### PR TITLE
fix: fixed Fiamma TVL adapter using multi-chain FiammaBTC supply

### DIFF
--- a/projects/fiamma/index.js
+++ b/projects/fiamma/index.js
@@ -10,7 +10,7 @@ const FIAMMA_BTC_EVM = {
   core:        "0x60C230c38aF6d86b0277a98a1CAeAA345a7B061F",
   unichain:    "0x60C230c38aF6d86b0277a98a1CAeAA345a7B061F",
   plume_mainnet: "0x60C230c38aF6d86b0277a98a1CAeAA345a7B061F",
-  hyperliquid: "0x0CEDa114F533D540c8aF2AeB52942c1a4A0B1e86",  // HyperEVM slug
+  hyperliquid: "0x0CEDa114F533D540c8aF2AeB52942c1a4A0B1e86",
 };
 
 const APTOS_FIAMMA_BTC_METADATA =
@@ -19,32 +19,35 @@ const APTOS_FIAMMA_BTC_METADATA =
 const BTC_DECIMALS = 1e8;
 
 const evmTvl = (chain) => async (api) => {
-  try {
-    const supply = await api.call({
-      target: FIAMMA_BTC_EVM[chain],
-      abi:    "erc20:totalSupply",
-      chain,
-    });
-    if (!supply || supply === "0") return;
-    api.addCGToken("bitcoin", Number(supply) / BTC_DECIMALS);
-  } catch (_) {}
+  const supply = await api.call({
+    target: FIAMMA_BTC_EVM[chain],
+    abi: "erc20:totalSupply",
+    chain,
+  }).catch((e) => {
+    throw new Error(`fiamma:${chain} totalSupply failed: ${e.message}`);
+  });
+
+  if (!supply || supply === "0") return;
+  api.addCGToken("bitcoin", Number(supply) / BTC_DECIMALS);
 };
 
 const aptosTvl = async (api) => {
-  try {
-    const supply = await function_view({
-      functionStr:     "0x1::fungible_asset::supply",
-      type_arguments:  ["0x1::fungible_asset::Metadata"],
-      args:            [APTOS_FIAMMA_BTC_METADATA],
-      chain:           "aptos",
-    });
-    const raw = supply?.vec?.[0] ?? supply;
-    if (!raw) return;
-    api.addCGToken("bitcoin", Number(raw) / BTC_DECIMALS);
-  } catch (_) {}
+  const supply = await function_view({
+    functionStr: "0x1::fungible_asset::supply",
+    type_arguments: ["0x1::fungible_asset::Metadata"],
+    args: [APTOS_FIAMMA_BTC_METADATA],
+    chain: "aptos",
+  }).catch((e) => {
+    throw new Error(`fiamma:aptos supply failed: ${e.message}`);
+  });
+
+  const raw = supply?.vec?.[0] ?? supply;
+  if (!raw) return;
+  api.addCGToken("bitcoin", Number(raw) / BTC_DECIMALS);
 };
 
 module.exports = {
+  timetravel: false,
   methodology:
     "TVL = total supply of FiammaBTC tokens across all chains. " +
     "Each FiammaBTC token represents 1 satoshi of Bitcoin locked in the " +

--- a/projects/fiamma/index.js
+++ b/projects/fiamma/index.js
@@ -1,14 +1,64 @@
-const axios = require("axios")
+const { function_view } = require("../helper/chain/aptos");
 
-const btc_locked = async (api) => {
-    const response = (await axios.post('https://bridge-api.fiammachain.io', { "jsonrpc": "2.0", "id": 1, "method": "frontend_queryBridgeTVL", "params": {} })).data
-    const locked = response.result.total_tvl / 1e8
-    api.addCGToken('bitcoin', locked)
-}
+const FIAMMA_BTC_EVM = {
+  ethereum:    "0x22F0E0a4c97ff43546dad16d43Ef854C773F0e08",
+  arbitrum:    "0x60C230c38aF6d86b0277a98a1CAeAA345a7B061F",
+  base:        "0x60C230c38aF6d86b0277a98a1CAeAA345a7B061F",
+  polygon:     "0x60C230c38aF6d86b0277a98a1CAeAA345a7B061F",
+  bsc:         "0xafB253A80CEb3d1a5eeF3994C0d1C92c2f027524",
+  sei:         "0x60C230c38aF6d86b0277a98a1CAeAA345a7B061F",
+  core:        "0x60C230c38aF6d86b0277a98a1CAeAA345a7B061F",
+  unichain:    "0x60C230c38aF6d86b0277a98a1CAeAA345a7B061F",
+  plume_mainnet: "0x60C230c38aF6d86b0277a98a1CAeAA345a7B061F",
+  hyperliquid: "0x0CEDa114F533D540c8aF2AeB52942c1a4A0B1e86",  // HyperEVM slug
+};
+
+const APTOS_FIAMMA_BTC_METADATA =
+  "0x75de592a7e62e6224d13763c392190fda8635ebb79c798a5e9dd0840102f3f93";
+
+const BTC_DECIMALS = 1e8;
+
+const evmTvl = (chain) => async (api) => {
+  try {
+    const supply = await api.call({
+      target: FIAMMA_BTC_EVM[chain],
+      abi:    "erc20:totalSupply",
+      chain,
+    });
+    if (!supply || supply === "0") return;
+    api.addCGToken("bitcoin", Number(supply) / BTC_DECIMALS);
+  } catch (_) {}
+};
+
+const aptosTvl = async (api) => {
+  try {
+    const supply = await function_view({
+      functionStr:     "0x1::fungible_asset::supply",
+      type_arguments:  ["0x1::fungible_asset::Metadata"],
+      args:            [APTOS_FIAMMA_BTC_METADATA],
+      chain:           "aptos",
+    });
+    const raw = supply?.vec?.[0] ?? supply;
+    if (!raw) return;
+    api.addCGToken("bitcoin", Number(raw) / BTC_DECIMALS);
+  } catch (_) {}
+};
 
 module.exports = {
-    methodology: "Fiamma BTC TVL represents the total amount of Bitcoin bridged across all chains through the Fiamma Bridge, a trust‑minimized bridge built on the BitVM2 protocol.",
-    bitcoin: {
-      tvl: btc_locked,
-    }
-  };
+  methodology:
+    "TVL = total supply of FiammaBTC tokens across all chains. " +
+    "Each FiammaBTC token represents 1 satoshi of Bitcoin locked in the " +
+    "Fiamma BitVM2 trust-minimized bridge.",
+
+  ethereum:      { tvl: evmTvl("ethereum")      },
+  arbitrum:      { tvl: evmTvl("arbitrum")      },
+  base:          { tvl: evmTvl("base")          },
+  polygon:       { tvl: evmTvl("polygon")       },
+  bsc:           { tvl: evmTvl("bsc")           },
+  sei:           { tvl: evmTvl("sei")           },
+  core:          { tvl: evmTvl("core")          },
+  unichain:      { tvl: evmTvl("unichain")      },
+  plume_mainnet: { tvl: evmTvl("plume_mainnet") },
+  hyperliquid:   { tvl: evmTvl("hyperliquid")   },
+  aptos:         { tvl: aptosTvl               },
+};

--- a/projects/fiamma/index.js
+++ b/projects/fiamma/index.js
@@ -41,7 +41,7 @@ const aptosTvl = async (api) => {
     throw new Error(`fiamma:aptos supply failed: ${e.message}`);
   });
 
-  const raw = supply?.vec?.[0] ?? supply;
+  const raw = supply?.vec?.[0];
   if (!raw) return;
   api.addCGToken("bitcoin", Number(raw) / BTC_DECIMALS);
 };


### PR DESCRIPTION
### Overview

Fixes #19030 and fixes the TVL adapter for Fiamma Bridge.

### Methodology

TVL is currently computed as the total supply of FiammaBTC tokens across supported chains (EVM + Aptos). Each FiammaBTC token represents 1 satoshi of Bitcoin locked via the BitVM2 bridge.

### Notes / Limitations

* Ideally, TVL should be derived from BTC locked on the Bitcoin chain (source of collateral), in line with bridge methodology.
* The official bridge dApp is also down (`https://app.fiammalabs.io/bridge`)
* The official endpoint for BTC locked (`https://bridge-api.fiammachain.io`) is currently not responding:

  ```
  Error: Failed to post https://bridge-api.fiammachain.io (error code: 522)
  ```
* As a temporary approach, the issued supply is used as a proxy.

### Next Steps

* Update to source-chain (Bitcoin) TVL once a stable API or alternative data source is available.
* Happy to revise implementation based on reviewer feedback.

### Validation

```
node test.js projects/fiamma/index.js
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TVL now reads directly from each blockchain for improved accuracy.
  * TVL support expanded to 11 chains, including Aptos, Ethereum, Arbitrum, Base, Polygon, BSC and others.
  * TVL now reports total FiammaBTC token supply across supported networks.

* **Chores**
  * Timetravel disabled for these data sources.

* **Bug Fixes**
  * Improved per-chain error handling and empty-supply handling to prevent spurious TVL entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->