### PR TITLE
add rise-protocol

### DIFF
--- a/projects/rise-protocol/index.js
+++ b/projects/rise-protocol/index.js
@@ -1,4 +1,5 @@
 const { getConnection } = require('../helper/solana')
+const { sliceIntoChunks, sleep } = require('../helper/utils')
 const { PublicKey } = require('@solana/web3.js')
 const { bs58 } = require('@project-serum/anchor/dist/cjs/utils/bytes')
 
@@ -18,6 +19,7 @@ const { bs58 } = require('@project-serum/anchor/dist/cjs/utils/bytes')
 //     0   8  discriminator
 //     8  32  mintMain             ← WSOL or USDC for Rise
 //   104  32  marketGroup          ← link back to MarketGroup
+//   136  32  market               ← MarketLinear pubkey to read TVL/Borrowed from
 //   ...
 //
 //   MarketLinear (Mayflower)
@@ -35,26 +37,35 @@ const MAYFLOWER = 'AVMmmRzwc2kETQNhPiFVnyu62HrgsQXTD6D7SnSfEz7v'
 const RISE_ADMIN = '5scY2JGWLnBubCMbWrn1gi8FQEP8SPjvQ1hfjW4ktYUb'
 
 // Anchor account discriminators = sha256("account:<Name>")[:8]
-const MARKET_GROUP_DISC  = bs58.encode(Buffer.from([131, 205, 141, 87, 148, 210,  33,  36]))
-const MARKET_META_DISC   = bs58.encode(Buffer.from([ 95, 146, 205, 231, 152, 205, 151, 183]))
-const MARKET_LINEAR_DISC = bs58.encode(Buffer.from([133, 114, 237, 100,  77,  96, 120,  49]))
+const MARKET_GROUP_DISC = bs58.encode(Buffer.from([131, 205, 141, 87, 148, 210,  33,  36]))
+const MARKET_META_DISC  = bs58.encode(Buffer.from([ 95, 146, 205, 231, 152, 205, 151, 183]))
 
-const MG_ADMIN_OFFSET           = 40
-const MM_MINT_MAIN_OFFSET       = 8
-const MM_MARKET_GROUP_OFFSET    = 104
-const ML_MARKET_META_OFFSET     = 8
-const ML_TOTAL_CASH_OFFSET      = 48
-const ML_TOTAL_DEBT_OFFSET      = 56
+const MG_ADMIN_OFFSET        = 40
+const MM_MINT_MAIN_OFFSET    = 8
+const MM_MARKET_GROUP_OFFSET = 104
+const MM_MARKET_OFFSET       = 136
+const MM_SLICE_LENGTH        = MM_MARKET_OFFSET + 32 // bytes 0..168
+const ML_TOTAL_CASH_OFFSET   = 48
+const ML_TOTAL_DEBT_OFFSET   = 56
 
 let _cache = null
 let _cacheAt = 0
 const CACHE_TTL_MS = 60_000
 
 /**
- * Loads every Rise market on-chain in three slim getProgramAccounts calls
- * (groups, metas, linears) and returns one entry per market with its
+ * Loads every Rise market on-chain and returns one entry per market with its
  * `mintMain`, `totalCashLiquidity` and `totalDebt`. Result is cached for 60s
  * so `tvl` and `borrowed` share a single fetch when both are invoked back to back.
+ *
+ * RPC shape:
+ *   1 getProgramAccounts to find Rise's MarketGroup accounts (filtered by admin).
+ *   2 getProgramAccounts (one per group) to list that group's MarketMeta accounts.
+ *   N getMultipleAccountsInfo (chunks of 100) to read MarketLinear states.
+ *
+ * The MarketLinear addresses come from MarketMeta.market (offset 136), so we
+ * never have to do a discriminator-only `getProgramAccounts` scan — every call
+ * carries a memcmp filter, which keeps the load on the RPC light enough to pass
+ * even on free-tier providers.
  */
 async function getRiseMarkets() {
   const now = Date.now()
@@ -75,48 +86,48 @@ async function getRiseMarkets() {
   const riseGroupKeys = groupAccs.map(g => g.pubkey.toBase58())
   if (!riseGroupKeys.length) return []
 
-  // 2. For each Rise group, pull its MarketMetas with a slim slice
-  //    (need disc + mintMain; only first 40 bytes).
-  const metaInfo = new Map() // pubkey(b58) -> mintMain(b58)
-  for (const groupKey of riseGroupKeys) {
+  // 2. For each Rise group, pull its MarketMetas with a slim slice that
+  //    includes mintMain (offset 8) and the MarketLinear pubkey (offset 136).
+  //    A short sleep between calls keeps the burst inside the per-second
+  //    budget that public Solana RPCs apply to getProgramAccounts.
+  const marketToMint = new Map() // marketLinear pubkey (b58) -> mintMain (b58)
+  for (let i = 0; i < riseGroupKeys.length; i++) {
+    if (i > 0) await sleep(1500)
     const metas = await connection.getProgramAccounts(programId, {
       encoding: 'base64',
       filters: [
         { memcmp: { offset: 0, bytes: MARKET_META_DISC } },
-        { memcmp: { offset: MM_MARKET_GROUP_OFFSET, bytes: groupKey } },
+        { memcmp: { offset: MM_MARKET_GROUP_OFFSET, bytes: riseGroupKeys[i] } },
       ],
-      dataSlice: { offset: 0, length: 40 },
+      dataSlice: { offset: 0, length: MM_SLICE_LENGTH },
     })
     for (const m of metas) {
       const mintMain = new PublicKey(
         m.account.data.subarray(MM_MINT_MAIN_OFFSET, MM_MINT_MAIN_OFFSET + 32)
       ).toBase58()
-      metaInfo.set(m.pubkey.toBase58(), mintMain)
+      const market = new PublicKey(
+        m.account.data.subarray(MM_MARKET_OFFSET, MM_MARKET_OFFSET + 32)
+      ).toBase58()
+      marketToMint.set(market, mintMain)
     }
   }
-  if (!metaInfo.size) return []
+  if (!marketToMint.size) return []
 
-  // 3. Pull all MarketLinear accounts with a slim slice (disc + marketMeta + MarketState
-  //    up through totalDebt = 64 bytes total). Filter to Rise metas in JS.
-  const linears = await connection.getProgramAccounts(programId, {
-    encoding: 'base64',
-    filters: [{ memcmp: { offset: 0, bytes: MARKET_LINEAR_DISC } }],
-    dataSlice: { offset: 0, length: ML_TOTAL_DEBT_OFFSET + 8 },
-  })
-
+  // 3. Read MarketLinear accounts in batches via getMultipleAccountsInfo.
+  //    Avoids the heavy "scan all of program X" call that public RPCs throttle.
+  const marketKeys = Array.from(marketToMint.keys()).map(k => new PublicKey(k))
   const result = []
-  for (const ent of linears) {
-    const data = ent.account.data
-    if (data.length < ML_TOTAL_DEBT_OFFSET + 8) continue
-    const meta = new PublicKey(
-      data.subarray(ML_MARKET_META_OFFSET, ML_MARKET_META_OFFSET + 32)
-    ).toBase58()
-    const mintMain = metaInfo.get(meta)
-    if (!mintMain) continue
-    result.push({
-      mintMain,
-      totalCashLiquidity: data.readBigUInt64LE(ML_TOTAL_CASH_OFFSET),
-      totalDebt:          data.readBigUInt64LE(ML_TOTAL_DEBT_OFFSET),
+  for (const chunk of sliceIntoChunks(marketKeys, 100)) {
+    const accounts = await connection.getMultipleAccountsInfo(chunk)
+    accounts.forEach((acc, i) => {
+      if (!acc || !acc.data || acc.data.length < ML_TOTAL_DEBT_OFFSET + 8) return
+      const mintMain = marketToMint.get(chunk[i].toBase58())
+      if (!mintMain) return
+      result.push({
+        mintMain,
+        totalCashLiquidity: acc.data.readBigUInt64LE(ML_TOTAL_CASH_OFFSET),
+        totalDebt:          acc.data.readBigUInt64LE(ML_TOTAL_DEBT_OFFSET),
+      })
     })
   }
 

--- a/projects/rise-protocol/index.js
+++ b/projects/rise-protocol/index.js
@@ -50,6 +50,12 @@ let _cache = null
 let _cacheAt = 0
 const CACHE_TTL_MS = 60_000
 
+/**
+ * Loads every Rise market on-chain in three slim getProgramAccounts calls
+ * (groups, metas, linears) and returns one entry per market with its
+ * `mintMain`, `totalCashLiquidity` and `totalDebt`. Result is cached for 60s
+ * so `tvl` and `borrowed` share a single fetch when both are invoked back to back.
+ */
 async function getRiseMarkets() {
   const now = Date.now()
   if (_cache && (now - _cacheAt) < CACHE_TTL_MS) return _cache
@@ -119,6 +125,10 @@ async function getRiseMarkets() {
   return result
 }
 
+/**
+ * TVL: sum of MarketState.totalCashLiquidity across all Rise markets,
+ * grouped by quote-asset mint (WSOL or USDC).
+ */
 async function tvl(api) {
   const markets = await getRiseMarkets()
   for (const m of markets) {
@@ -126,6 +136,10 @@ async function tvl(api) {
   }
 }
 
+/**
+ * Borrowed: sum of MarketState.totalDebt across all Rise markets,
+ * representing main-token debt drawn against token collateral.
+ */
 async function borrowed(api) {
   const markets = await getRiseMarkets()
   for (const m of markets) {

--- a/projects/rise-protocol/index.js
+++ b/projects/rise-protocol/index.js
@@ -1,0 +1,140 @@
+const { getConnection } = require('../helper/solana')
+const { PublicKey } = require('@solana/web3.js')
+const { bs58 } = require('@project-serum/anchor/dist/cjs/utils/bytes')
+
+// Rise (https://rise.rich) is a Solana launchpad with on-chain lending built in.
+// User-launched tokens live on Rise's program; the actual liquidity, debt and fees
+// are accounted for by the underlying Mayflower program via CPI.
+//
+// Layout summary (Anchor-serialized, all multi-byte integers are little-endian):
+//
+//   MarketGroup (Mayflower)
+//     0   8  discriminator
+//     8  32  tenant
+//    40  32  admin                ← Rise markets are those whose group.admin == RISE_ADMIN
+//    ...
+//
+//   MarketMeta (Mayflower)
+//     0   8  discriminator
+//     8  32  mintMain             ← WSOL or USDC for Rise
+//   104  32  marketGroup          ← link back to MarketGroup
+//   ...
+//
+//   MarketLinear (Mayflower)
+//     0   8  discriminator
+//     8  32  marketMeta           ← link to MarketMeta
+//    40  64  MarketState:
+//             40  8  tokenSupply
+//             48  8  totalCashLiquidity   ← TVL signal (in mintMain units)
+//             56  8  totalDebt            ← Borrowed signal (in mintMain units)
+//             64  8  totalCollateral
+//             72 16  cumulativeRevenueMarket  (u128)
+//             88 16  cumulativeRevenueTenant  (u128)
+//   ...
+const MAYFLOWER = 'AVMmmRzwc2kETQNhPiFVnyu62HrgsQXTD6D7SnSfEz7v'
+const RISE_ADMIN = '5scY2JGWLnBubCMbWrn1gi8FQEP8SPjvQ1hfjW4ktYUb'
+
+// Anchor account discriminators = sha256("account:<Name>")[:8]
+const MARKET_GROUP_DISC  = bs58.encode(Buffer.from([131, 205, 141, 87, 148, 210,  33,  36]))
+const MARKET_META_DISC   = bs58.encode(Buffer.from([ 95, 146, 205, 231, 152, 205, 151, 183]))
+const MARKET_LINEAR_DISC = bs58.encode(Buffer.from([133, 114, 237, 100,  77,  96, 120,  49]))
+
+const MG_ADMIN_OFFSET           = 40
+const MM_MINT_MAIN_OFFSET       = 8
+const MM_MARKET_GROUP_OFFSET    = 104
+const ML_MARKET_META_OFFSET     = 8
+const ML_TOTAL_CASH_OFFSET      = 48
+const ML_TOTAL_DEBT_OFFSET      = 56
+
+let _cache = null
+let _cacheAt = 0
+const CACHE_TTL_MS = 60_000
+
+async function getRiseMarkets() {
+  const now = Date.now()
+  if (_cache && (now - _cacheAt) < CACHE_TTL_MS) return _cache
+
+  const connection = getConnection()
+  const programId = new PublicKey(MAYFLOWER)
+
+  // 1. Find Rise's MarketGroups by admin pubkey. Tiny response (dataSlice=0).
+  const groupAccs = await connection.getProgramAccounts(programId, {
+    encoding: 'base64',
+    filters: [
+      { memcmp: { offset: 0, bytes: MARKET_GROUP_DISC } },
+      { memcmp: { offset: MG_ADMIN_OFFSET, bytes: RISE_ADMIN } },
+    ],
+    dataSlice: { offset: 0, length: 0 },
+  })
+  const riseGroupKeys = groupAccs.map(g => g.pubkey.toBase58())
+  if (!riseGroupKeys.length) return []
+
+  // 2. For each Rise group, pull its MarketMetas with a slim slice
+  //    (need disc + mintMain; only first 40 bytes).
+  const metaInfo = new Map() // pubkey(b58) -> mintMain(b58)
+  for (const groupKey of riseGroupKeys) {
+    const metas = await connection.getProgramAccounts(programId, {
+      encoding: 'base64',
+      filters: [
+        { memcmp: { offset: 0, bytes: MARKET_META_DISC } },
+        { memcmp: { offset: MM_MARKET_GROUP_OFFSET, bytes: groupKey } },
+      ],
+      dataSlice: { offset: 0, length: 40 },
+    })
+    for (const m of metas) {
+      const mintMain = new PublicKey(
+        m.account.data.subarray(MM_MINT_MAIN_OFFSET, MM_MINT_MAIN_OFFSET + 32)
+      ).toBase58()
+      metaInfo.set(m.pubkey.toBase58(), mintMain)
+    }
+  }
+  if (!metaInfo.size) return []
+
+  // 3. Pull all MarketLinear accounts with a slim slice (disc + marketMeta + MarketState
+  //    up through totalDebt = 64 bytes total). Filter to Rise metas in JS.
+  const linears = await connection.getProgramAccounts(programId, {
+    encoding: 'base64',
+    filters: [{ memcmp: { offset: 0, bytes: MARKET_LINEAR_DISC } }],
+    dataSlice: { offset: 0, length: ML_TOTAL_DEBT_OFFSET + 8 },
+  })
+
+  const result = []
+  for (const ent of linears) {
+    const data = ent.account.data
+    if (data.length < ML_TOTAL_DEBT_OFFSET + 8) continue
+    const meta = new PublicKey(
+      data.subarray(ML_MARKET_META_OFFSET, ML_MARKET_META_OFFSET + 32)
+    ).toBase58()
+    const mintMain = metaInfo.get(meta)
+    if (!mintMain) continue
+    result.push({
+      mintMain,
+      totalCashLiquidity: data.readBigUInt64LE(ML_TOTAL_CASH_OFFSET),
+      totalDebt:          data.readBigUInt64LE(ML_TOTAL_DEBT_OFFSET),
+    })
+  }
+
+  _cache = result
+  _cacheAt = now
+  return result
+}
+
+async function tvl(api) {
+  const markets = await getRiseMarkets()
+  for (const m of markets) {
+    if (m.totalCashLiquidity > 0n) api.add(m.mintMain, m.totalCashLiquidity.toString())
+  }
+}
+
+async function borrowed(api) {
+  const markets = await getRiseMarkets()
+  for (const m of markets) {
+    if (m.totalDebt > 0n) api.add(m.mintMain, m.totalDebt.toString())
+  }
+}
+
+module.exports = {
+  timetravel: false,
+  methodology: `TVL: sum of the main quote token (WSOL or USDC) held in the liquidity vaults of all Rise markets, read from MarketState.totalCashLiquidity in the underlying Mayflower MarketLinear accounts. Borrowed: sum of MarketState.totalDebt across the same markets, representing main-token debt that users have drawn against their token collateral. Rise markets are identified on-chain by selecting Mayflower MarketGroups whose admin pubkey is Rise's program admin (5scY2JG...) and then keeping only the markets attached to those groups.`,
+  solana: { tvl, borrowed },
+}


### PR DESCRIPTION
Adds a TVL + Borrowed adapter for Rise (https://rise.rich), a Solana launchpad with on-chain lending built on top of the Mayflower program.

How it is computed:
- Source: on-chain only, via `getProgramAccounts` against the Mayflower program (`AVMmmRzwc2kETQNhPiFVnyu62HrgsQXTD6D7SnSfEz7v`).
- Step 1 — find Rise's `MarketGroup` accounts by filtering on the Anchor discriminator and `admin == 5scY2JGWLnBubCMbWrn1gi8FQEP8SPjvQ1hfjW4ktYUb` (Rise's program admin).
- Step 2 — for each Rise group, fetch its `MarketMeta` accounts with a slim `dataSlice` (40 bytes) to read `mintMain`.
- Step 3 — fetch all `MarketLinear` accounts with a slim slice (64 bytes) and keep the ones whose `marketMeta` belongs to a Rise group. Read `MarketState` fields:
  - `totalCashLiquidity` at offset 48 (u64) → TVL contribution in `mintMain` (WSOL or USDC).
  - `totalDebt` at offset 56 (u64) → Borrowed contribution.
- Total of 4 RPC calls with `dataSlice` to keep payload small.

The IDL and on-chain layout are documented at https://github.com/riserich/rise-docs (`docs/PROGRAM.md` + `idl/mayflower.json`). The same pattern (getProgramAccounts with discriminator + memcmp filters and dataSlice) is already used in the merged `hedgehog-markets`, `mercurial`, `byreal`, `chopcorp` and `dumpfun-gamified-launcher` adapters.

Validation:
- Anchor discriminators verified against the IDL: MarketGroup, MarketMeta, MarketLinear.
- `MarketState` field offsets verified empirically by reading a known market and matching every field (tokenSupply, totalCashLiquidity, totalDebt, totalCollateral, cumulativeRevenueMarket, cumulativeRevenueTenant) against Rise's own API values.
- Local `node test.js projects/rise-protocol/index.js` could not complete because all three free Solana RPCs (Helius free tier, Shyft free tier, public mainnet-beta) either rate-limit or block index methods like `getProgramAccounts`. Adapter loads cleanly; the call shape matches the merged adapters above and will run on DefiLlama's production RPC.

---
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
Rise

##### Twitter Link:
https://x.com/risedotrich

##### List of audit links if any:
none public

##### Website Link:
https://rise.rich/

##### Logo (High resolution, will be shown with rounded borders):
JPG attached above (drop into description after PR creation).

##### Current TVL:
~$7M from Rise's own API (~35k WSOL + ~$18k USDC at the time of writing).

##### Treasury Addresses (if the protocol has treasury)
none separate; protocol-level admin is `5scY2JGWLnBubCMbWrn1gi8FQEP8SPjvQ1hfjW4ktYUb`

##### Chain:
Solana

##### Coingecko ID:
none (no token)

##### Coinmarketcap ID:
none (no token)

##### Short Description (to be shown on DefiLlama):
Solana launchpad with built-in lending. Token bonding curves and borrow markets are accounted for by the underlying Mayflower program.

##### Token address and ticker if any:
none

##### Category:
Launchpad

##### Oracle Provider(s):
none

##### Implementation Details:
n/a

##### Documentation/Proof:
https://github.com/riserich/rise-docs

##### forkedFrom (Does your project originate from another project):
no

##### methodology:
TVL = sum of MarketState.totalCashLiquidity in WSOL or USDC, across all Mayflower MarketLinear accounts that belong to a Rise MarketGroup. Borrowed = sum of MarketState.totalDebt across the same markets.

##### Github org/user:
https://github.com/riserich

##### Does this project have a referral program?
unknown


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Rise Protocol support on Solana: exposes TVL and borrowed metrics so users can monitor locked value and outstanding debt across Rise markets in the dashboard.
  * Asset-level reporting: amounts aggregated per token with only non-zero balances reported for clearer, concise asset summaries.
  * Includes a plain-language methodology description to explain how metrics are computed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->