### PR TITLE
fix(stkd-scrt) compute TVL from Secret staking balances

### DIFF
--- a/projects/shadeprotocol-derivatives/index.js
+++ b/projects/shadeprotocol-derivatives/index.js
@@ -1,14 +1,58 @@
-const { get } = require("../helper/http")
+const { queryV1Beta1 } = require("../helper/chain/cosmos")
+const { queryContract } = require("../helper/chain/secret")
+
+const STKD_SCRT_CONTRACT = 'secret1k6u0cy4feepm6pehnz804zmwakuwdapm69tuc4'
+const DENOM = 'uscrt'
+
+function toBaseAmount(amount = 0) {
+  const [wholeAmount] = String(amount).split('.')
+  return BigInt(wholeAmount || 0)
+}
+
+function sumAmounts(amounts) {
+  return amounts.reduce((sum, amount) => sum + toBaseAmount(amount), 0n)
+}
+
+async function queryPaginated(url, listKey) {
+  let values = []
+  let key
+
+  do {
+    const query = `${url}?pagination.limit=1000${key ? `&pagination.key=${encodeURIComponent(key)}` : ''}`
+    const page = await queryV1Beta1({ chain: 'secret', url: query })
+    const pageValues = page[listKey]
+    if (!Array.isArray(pageValues)) throw new Error(`Missing ${listKey} response`)
+    values = values.concat(pageValues)
+    key = page.pagination?.next_key
+  } while (key)
+
+  return values
+}
 
 async function tvl(api) {
-  const data = await get('https://ruvzuawwz7.execute-api.us-east-1.amazonaws.com/prod-analytics-v1/derivatives')
-  return {
-    tether: data.totalUsd
-  }
+  const [{ staking_info: stakingInfo }, unbonding] = await Promise.all([
+    queryContract({ contract: STKD_SCRT_CONTRACT, data: { staking_info: { time: Math.floor(Date.now() / 1000) } } }),
+    queryPaginated(`staking/v1beta1/delegators/${STKD_SCRT_CONTRACT}/unbonding_delegations`, 'unbonding_responses'),
+  ])
+
+  if (!stakingInfo) throw new Error('Missing staking_info response')
+
+  let total = sumAmounts([
+    stakingInfo.bonded_scrt,
+    stakingInfo.reserved_scrt,
+    stakingInfo.available_scrt,
+    stakingInfo.rewards,
+  ])
+  total += unbonding.reduce((sum, item) => (
+    sum + (item.entries || []).reduce((entrySum, entry) => entrySum + toBaseAmount(entry.balance), 0n)
+  ), 0n)
+
+  api.add(DENOM, total.toString())
 }
 
 module.exports = {
-  misrepresentedTokens: true,
+  timetravel: false,
+  methodology: 'TVL counts SCRT backing stkd-SCRT using the staking contract accounting plus active unbonding SCRT.',
   secret: {
     tvl
   }


### PR DESCRIPTION
Fixes #19019

The stkd-SCRT adapter was failing because it depended on Shade's old hosted derivatives API:
`https://ruvzuawwz7.execute-api.us-east-1.amazonaws.com/prod-analytics-v1/derivatives` and that endpoint now returns a 500, so the adapter could not export TVL.

I checked the StakeEasy/dead-adapter precedent mentioned in the issue. StakeEasy is marked dead in `registries/deadAdapters.json`, but stkd-SCRT still has a current Shade staking derivative contract, and the contract/account state shows SCRT backing.

The current stkd-SCRT contract: 
`secret1k6u0cy4feepm6pehnz804zmwakuwdapm69tuc4` 

Proof/reference links:

  - ShadeJS contract registry lists stkd-scrt with the same mainnet contract: https://shadejs.dev/contracts
  - Mintscan explorer page for the contract/account: https://www.mintscan.io/secret/address/secret1k6u0cy4feepm6pehnz804zmwakuwdapm69tuc4
  - ShadeJS contract registry lists `stkd-SCRT` with the same mainnet contract: https://shadejs.dev/contracts
  - Contract SCRT bank balance: https://lcd-secret.keplr.app/cosmos/bank/v1beta1/balances/secret1k6u0cy4feepm6pehnz804zmwakuwdapm69tuc4
  - Contract active delegations: https://lcd-secret.keplr.app/cosmos/staking/v1beta1/delegations/secret1k6u0cy4feepm6pehnz804zmwakuwdapm69tuc4
  - Contract active unbonding: https://lcd-secret.keplr.app/cosmos/staking/v1beta1/delegators/secret1k6u0cy4feepm6pehnz804zmwakuwdapm69tuc4/unbonding_delegations

When I checked the current state locally:

```
stkd-SCRT supply:               2,858,010.901887
staking_info.bonded_scrt:       6,493,518.355761 SCRT
active delegated SCRT:          6,493,518.355761 SCRT

reserved + available SCRT:      285,217.440347 SCRT
contract bank balance:          285,217.440347 SCRT

active unbonding SCRT:          176,430.379892 SCRT
```

So this looks like a source/contract migration rather than a dead-adapter case. This updates the adapter to use the current stkd-SCRT contract instead of the old hosted API. The adapter reads the contract's staking_info for bonded, reserved, available, and reward SCRT, and adds active unbonding SCRT from the Secret staking module.

Tested with:
  ```bash
  node test.js projects/shadeprotocol-derivatives/index.js

  Local run:
secret                    715.76 k
total                    715.76 k