### PR TITLE
quell: drop dead Base+Arbitrum vaults from registries/erc4626

### DIFF
--- a/registries/erc4626.js
+++ b/registries/erc4626.js
@@ -197,9 +197,8 @@ const configs = {
   },
   'quell': {
     doublecounted: true,
-    methodology: "TVL is the total USDC deposited in the Quell ERC4626 RWAVaults, which route USDC to external vaults such as Spark sUSDC and Steakhouse USDC MetaMorpho for RWA yield.",
-    base: ['0xd85A4301706124699CbA8d0b59E5ED635360868b'],
-    arbitrum: ['0x25cf6D8BacCFbF66DC0567844182F063b8BD0051', '0x82bDeB9239d33AAE4b8c38C0C0ef3B088b0Fc791'],
+    methodology: "TVL is totalAssets() of the Quell RWAVault (ERC-4626) on Arbitrum One. Underlying asset is native USDC. Yield route: Spark sUSDC.",
+    arbitrum: ['0x82bDeB9239d33AAE4b8c38C0C0ef3B088b0Fc791'],
   },
   'zensats': {
     doublecounted: true,


### PR DESCRIPTION
## Cleanup follow-up to #18876

The Quell entry in `registries/erc4626.js` (added in #18876) currently lists three vaults across two chains, but two of them are dead:

| Address | Chain | Status |
|---|---|---|
| `0xd85A4301706124699CbA8d0b59E5ED635360868b` | Base | Pre-migration RWAVault. Protocol migrated off Base in March 2026 — vault no longer used. |
| `0x25cf6D8BacCFbF66DC0567844182F063b8BD0051` | Arbitrum | First-version Arbitrum vault, deprecated after a Pashov-skill audit pass. Internal runbooks instruct teams not to query it. |
| `0x82bDeB9239d33AAE4b8c38C0C0ef3B088b0Fc791` | Arbitrum | Current live RWAVault. USDC in / rvUSDC out. Yield routes to Spark sUSDC. |

This PR drops the dead two and rewrites the methodology so the protocol page no longer cites Steakhouse / MetaMorpho — neither is in the live yield path anymore (the only external venue today is Spark sUSDC).

`doublecounted: true` is preserved (Spark sUSDC TVL is tracked separately upstream by DefiLlama).

### Why now
Listing on `api.llama.fi/protocol/quell` currently shows methodology + chains that don't match production. We use the DefiLlama protocol page in marketing/aggregator copy, so a clean methodology + correct chain set matters. Sister PR DefiLlama/defillama-server#11813 covers the protocol-server metadata side (description / chains / hallmark / twitter / github).

### Verification
- Live RWAVault: [`0x82bDeB9239d33AAE4b8c38C0C0ef3B088b0Fc791`](https://arbiscan.io/address/0x82bDeB9239d33AAE4b8c38C0C0ef3B088b0Fc791) — ERC-4626 USDC vault, `totalAssets()` denominated in native Arbitrum USDC.
- Source repo: `thedelph/quell-contracts`.
- App: https://app.quell.fi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Quell vault registry configuration to reflect TVL calculation methodology using `totalAssets()` for the ERC-4626 vault on Arbitrum One with native USDC and Spark sUSDC yield routing. Modified the vault address list and removed Base network support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->