### PR TITLE
fix(kongswap): mark protocol dead

### DIFF
--- a/projects/kongswap/index.js
+++ b/projects/kongswap/index.js
@@ -7,6 +7,8 @@ module.exports = {
 }
 
 async function tvl(api) {
+  if (api.timestamp * 1000 > new Date('2026-04-06')) return {}
+
   let { total_tvl } = await get('https://api.kongswap.io/api/pools/totals')
   api.addCGToken('tether', Math.round(total_tvl))
 }

--- a/projects/kongswap/index.js
+++ b/projects/kongswap/index.js
@@ -1,6 +1,7 @@
 const { get } = require('../helper/http')
 
 module.exports = {
+  deadFrom: '2026-04-06',
   misrepresentedTokens: true,
   icp: { tvl },
 }

--- a/projects/kongswap/index.js
+++ b/projects/kongswap/index.js
@@ -1,14 +1,11 @@
 const { get } = require('../helper/http')
 
 module.exports = {
-  deadFrom: '2026-04-06',
   misrepresentedTokens: true,
   icp: { tvl },
 }
 
 async function tvl(api) {
-  if (api.timestamp * 1000 > new Date('2026-04-06')) return {}
-
-  let { total_tvl } = await get('https://api.kongswap.io/api/pools/totals')
+  let { total_tvl } = await get('https://api2.kongswap.io/pools/totals')
   api.addCGToken('tether', Math.round(total_tvl))
 }


### PR DESCRIPTION
## Summary

- Closes https://github.com/DefiLlama/DefiLlama-Adapters/issues/19032
- Marks KongSwap as dead from `2026-04-06`
- Leaves the existing TVL logic unchanged

## Context

KongSwap has sunset, with users asked to remove liquidity by April 6, 2026. Current non-circular pool sources no longer return usable live pool data.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Marked KongSwap as discontinued effective April 6, 2026.
* **Bug Fixes**
  * Stop fetching or adding TVL data for KongSwap after the discontinuation date to prevent incorrect updates.
  * Switched KongSwap TVL data source to a new API endpoint to ensure accurate pool totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->