### PR TITLE
fix(maverick): tolerate failed token balance calls

### DIFF
--- a/projects/maverick/index.js
+++ b/projects/maverick/index.js
@@ -29,6 +29,7 @@ function maverickTVL(config) {
         return sumTokens2({
           api,
           ownerTokens: logs.map((i) => [[i.tokenA, i.tokenB], i.poolAddress]),
+          permitFailure: true,
         });
       },
     };


### PR DESCRIPTION
## Summary

   Closes #19029
- Fixes Maverick V1 TVL adapter failures caused by individual token `balanceOf` calls reverting.
- Enables `permitFailure` when summing balances from pools discovered through Maverick factory events.
- Keeps the existing on-chain factory/event-based TVL calculation unchanged.

## Testing

```bash
node test.js projects/maverick/index.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during token summation calculations to increase robustness and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->