### PR TITLE
fix(onesec): read icp tvl from canister

### DIFF
--- a/projects/helper/chain/icp.js
+++ b/projects/helper/chain/icp.js
@@ -6,7 +6,9 @@ const CANDID_TYPE = {
   null: -1,
   bool: -2,
   nat: -3,
+  nat8: -5,
   nat64: -8,
+  float64: -14,
   text: -15,
   opt: -18,
   vec: -19,
@@ -322,9 +324,15 @@ function decodeCandid(bytes, labelHashMap) {
       return value === 1
     }
     if (typeRef === CANDID_TYPE.nat) return decodeUleb128(bytes, state)
+    if (typeRef === CANDID_TYPE.nat8) return bytes[state.i++]
     if (typeRef === CANDID_TYPE.nat64) {
       let out = 0n
       for (let i = 0; i < 8; i++) out |= BigInt(bytes[state.i++]) << BigInt(i * 8)
+      return out
+    }
+    if (typeRef === CANDID_TYPE.float64) {
+      const out = Buffer.from(bytes.slice(state.i, state.i + 8)).readDoubleLE()
+      state.i += 8
       return out
     }
     if (typeRef === CANDID_TYPE.text) {

--- a/projects/onesec/index.js
+++ b/projects/onesec/index.js
@@ -1,9 +1,29 @@
 const ADDRESSES = require('../helper/coreAssets.json')
 const { sumTokensExport } = require('../helper/unwrapLPs')
-const { getCache } = require('../helper/http')
+const { queryCanister, decodeCandid, hashCandidLabel } = require('../helper/chain/icp')
 
-const API_URL = 'https://1sec.to/api/balances'
+const ONESEC_CANISTER = '5okwm-giaaa-aaaar-qbn6a-cai'
 const LOCKER = '0x70AE25592209B57F62b3a3e832ab356228a2192C'
+const CANDID_LABELS = [
+  'Ok',
+  'Err',
+  'tokens',
+  'token',
+  'balance',
+  'chain',
+  'ICP',
+  'Base',
+  'Ethereum',
+  'Arbitrum',
+  'BOB',
+  'CHAT',
+  'GLDT',
+  'USDC',
+  'USDT',
+  'cbBTC',
+  'ckBTC',
+]
+const CANDID_LABELS_MAP = Object.fromEntries(CANDID_LABELS.map(label => [hashCandidLabel(label), label]))
 
 const icpTokens = {
   ICP: { decimals: 8, coingeckoId: 'internet-computer' },
@@ -13,19 +33,29 @@ const icpTokens = {
   GLDT: { decimals: 8, coingeckoId: 'gold-dao' },
 }
 
-function parseBalance(balanceStr) {
-  if (!balanceStr) return 0
-  return Number(balanceStr.toString().replace(/_/g, ''))
+function variantName(value) {
+  const variant = Array.isArray(value) ? value[0] : value
+  return variant && Object.keys(variant)[0]
 }
 
 async function icpTvl() {
-  const data = await getCache(API_URL)
+  const metadata = decodeCandid(
+    await queryCanister({ canisterId: ONESEC_CANISTER, methodName: 'get_metadata' }),
+    CANDID_LABELS_MAP
+  )[0]
+  if (metadata.Err) throw new Error(metadata.Err)
+
   const balances = {}
 
-  for (const [token, { decimals, coingeckoId }] of Object.entries(icpTokens)) {
-    const balance = parseBalance(data[token]?.icp)
+  for (const tokenMetadata of metadata.Ok.tokens) {
+    const token = variantName(tokenMetadata.token)
+    const chain = variantName(tokenMetadata.chain)
+    const tokenConfig = icpTokens[token]
+    if (!tokenConfig || chain !== 'ICP') continue
+
+    const balance = Number(tokenMetadata.balance)
     if (balance > 0) {
-      balances[`coingecko:${coingeckoId}`] = balance / 10 ** decimals
+      balances[`coingecko:${tokenConfig.coingeckoId}`] = balance / 10 ** tokenConfig.decimals
     }
   }
 
@@ -34,7 +64,7 @@ async function icpTvl() {
 
 module.exports = {
   timetravel: false,
-  methodology: 'TVL counts tokens where collateral is custodied: ICP-native tokens on ICP chain, and EVM-native tokens locked in the locker contract on their respective EVM chains.',
+  methodology: 'TVL counts tokens where collateral is custodied: ICP-native tokens reported by the OneSec canister, and EVM-native tokens locked in the locker contract on their respective EVM chains.',
   icp: { tvl: icpTvl },
   ethereum: {
     tvl: sumTokensExport({ owner: LOCKER, tokens: [ADDRESSES.ethereum.USDC, ADDRESSES.ethereum.cbBTC, ADDRESSES.ethereum.USDT] })

--- a/projects/onesec/index.js
+++ b/projects/onesec/index.js
@@ -55,7 +55,8 @@ async function icpTvl() {
 
     const balance = Number(tokenMetadata.balance)
     if (balance > 0) {
-      balances[`coingecko:${tokenConfig.coingeckoId}`] = balance / 10 ** tokenConfig.decimals
+      const key = `coingecko:${tokenConfig.coingeckoId}`
+      balances[key] = (balances[key] || 0) + balance / 10 ** tokenConfig.decimals
     }
   }
 


### PR DESCRIPTION
## Summary

Closes #19028

- Fixes the 1sec TVL adapter by removing the dependency on `https://1sec.to/api/balances`, which now returns a Cloudflare challenge / 403 in CI.
- Reads ICP-side token balances from the official OneSec canister `get_metadata` response instead.
- Keeps existing EVM TVL logic unchanged, using on-chain locker balances on Ethereum, Arbitrum, and Base.
- Adds minimal Candid decode support for `nat8` and `float64`, which are required to decode the OneSec canister metadata response.

## Testing

```bash
node test.js projects/onesec/index.js


------ TVL ------
icp                       1.67 M
ethereum                  22.55 k
base                      2.28 k
arbitrum                  7.00

total                    1.70 M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ICP TVL calculation now retrieves data directly from the on-chain OneSec canister, replacing the previous cached HTTP endpoint for improved accuracy.

* **Chores**
  * Extended Candid primitive type support for enhanced data decoding capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->