### PR TITLE
fix(krystal): compute solana tvl on-chain

### DIFF
--- a/projects/krystal/solana.js
+++ b/projects/krystal/solana.js
@@ -1,4 +1,5 @@
 const { PublicKey } = require("@solana/web3.js");
+const bs58 = require("bs58").default;
 const {
   getConnection,
   decodeAccount,
@@ -8,23 +9,33 @@ const {
 const idl = require("./idl/krystal_auto_vault.json");
 const { addUniV3LikePosition } = require("../helper/unwrapLPs.js");
 const { getUniqueAddresses } = require("../helper/tokenMapping.js");
-const { get } = require("../helper/http.js");
 
 const CLMM_PROGRAM_ID = new PublicKey(
   "CAMMCzo5YL8w4VFF8KVHrK22GGUsp5VTaW7grrKgrWqK"
 );
 const POSITION_SEED = Buffer.from("position", "utf8");
+const USER_VAULT_ACCOUNT_SIZE = 41;
+const userVaultAccount = idl.accounts.find(({ name }) => name === "UserVault");
 
-async function tvl(api) {
-
-  // Load all the vaults in the program
-  const vaults = await program.account.userVault.all();
-  await addRaydiumPositions({ api, owners: vaults.map(i => i.publicKey) })
-
+if (!userVaultAccount) {
+  throw new Error(`Missing UserVault account in Krystal IDL. Accounts: ${idl.accounts.map(({ name }) => name).join(", ")}`);
 }
 
-async function addRaydiumPositions({ api, owners = [], owner }) {
+const USER_VAULT_DISCRIMINATOR = userVaultAccount.discriminator;
+
+async function tvl(api) {
   const connection = getConnection();
+  const vaults = await connection.getProgramAccounts(new PublicKey(idl.address), {
+    filters: [
+      { dataSize: USER_VAULT_ACCOUNT_SIZE },
+      { memcmp: { offset: 0, bytes: bs58.encode(Buffer.from(USER_VAULT_DISCRIMINATOR)) } },
+    ],
+  });
+
+  await addRaydiumPositions({ api, connection, owners: vaults.map((i) => i.pubkey) });
+}
+
+async function addRaydiumPositions({ api, owners = [], owner, connection = getConnection() }) {
 
   const pools = new Map();
 
@@ -33,17 +44,19 @@ async function addRaydiumPositions({ api, owners = [], owner }) {
 
 
   const positions = [];
-  for (let vault of owners) {
+  await Promise.all(owners.map((vault) => {
     if (typeof vault === "string") vault = new PublicKey(vault);
-    await findClmmPositionsByOwner(connection, vault);
-  }
+    return findClmmPositionsByOwner(connection, vault);
+  }));
 
   const positionAccountInfos = await connection.getMultipleAccountsInfo(pdaPersonalPositionAddressesAll);
 
-  positionAccountInfos.map((account) => {
+  positionAccountInfos.forEach((account) => {
     if (!account) return;
 
-    positions.push(decodeAccount("raydiumPositionInfo", account));
+    try {
+      positions.push(decodeAccount("raydiumPositionInfo", account));
+    } catch {}
   });
 
   const poolIds = getUniqueAddresses(positions.map((position) => position.poolId.toBase58()), "solana");
@@ -52,15 +65,18 @@ async function addRaydiumPositions({ api, owners = [], owner }) {
   for (let i = 0; i < poolIds.length; i++) {
     const poolId = poolIds[i];
     const poolAccount = poolAccounts[i];
-    const poolInfo = decodeAccount("raydiumCLMM", poolAccount);
-    pools.set(poolId, poolInfo);
+    if (!poolAccount) continue;
+    try {
+      pools.set(poolId, decodeAccount("raydiumCLMM", poolAccount));
+    } catch {}
   }
 
   for (const position of positions) {
     const poolId = position.poolId;
     const poolKey = poolId.toBase58();
 
-    let poolInfo = pools.get(poolKey);
+    const poolInfo = pools.get(poolKey);
+    if (!poolInfo) continue;
 
     addUniV3LikePosition({
       api,
@@ -76,10 +92,10 @@ async function addRaydiumPositions({ api, owners = [], owner }) {
 
   async function findClmmPositionsByOwner(connection, owner) {
     const [tokenAccounts, token2022Accounts] = await Promise.all([
-      connection.getParsedTokenAccountsByOwner(owner, {
+      connection.getTokenAccountsByOwner(owner, {
         programId: TOKEN_PROGRAM_ID,
       }),
-      connection.getParsedTokenAccountsByOwner(owner, {
+      connection.getTokenAccountsByOwner(owner, {
         programId: TOKEN_2022_PROGRAM_ID,
       }),
     ]);
@@ -93,12 +109,19 @@ async function addRaydiumPositions({ api, owners = [], owner }) {
     }
 
     const tokenNftMints = [];
-    allTokenAccounts.forEach((tokenAccount) => {
-      const info = tokenAccount.account.data.parsed.info;
-      if (info.tokenAmount.amount == "1" && info.tokenAmount.decimals == 0) {
-        tokenNftMints.push(new PublicKey(info.mint));
+    allTokenAccounts.forEach(({ account }) => {
+      let amount, mint;
+      try {
+        ({ amount, mint } = decodeAccount("tokenAccount", account));
+      } catch {
+        return;
+      }
+      const rawAmount = amount.toString();
+      const token = mint.toBase58();
+      if (rawAmount === "1") {
+        tokenNftMints.push(mint);
       } else {
-        api.add(info.mint, info.tokenAmount.amount)
+        api.add(token, rawAmount)
       }
     });
 
@@ -107,7 +130,6 @@ async function addRaydiumPositions({ api, owners = [], owner }) {
   }
 
 }
-
 
 function getPdaPersonalPositionAddress(nftMint) {
   const [pda] = PublicKey.findProgramAddressSync(
@@ -118,9 +140,4 @@ function getPdaPersonalPositionAddress(nftMint) {
   return pda;
 }
 
-async function tvlApi(api) {
-  const res = await get('https://api.krystal.app/solana/v1/lp/tvl')
-  api.addUSDValue(+res.tvl)
-}
-
-module.exports = { tvl: tvlApi, addRaydiumPositions, };
+module.exports = { tvl, addRaydiumPositions, };

--- a/projects/krystal/solana.js
+++ b/projects/krystal/solana.js
@@ -1,5 +1,6 @@
 const { PublicKey } = require("@solana/web3.js");
-const bs58 = require("bs58").default;
+const sdk = require("@defillama/sdk");
+const { bs58 } = require("@project-serum/anchor/dist/cjs/utils/bytes");
 const {
   getConnection,
   decodeAccount,
@@ -44,19 +45,20 @@ async function addRaydiumPositions({ api, owners = [], owner, connection = getCo
 
 
   const positions = [];
-  await Promise.all(owners.map((vault) => {
-    if (typeof vault === "string") vault = new PublicKey(vault);
-    return findClmmPositionsByOwner(connection, vault);
-  }));
+  await sdk.util.runInPromisePool({
+    concurrency: 5,
+    items: owners,
+    processor: async (vault) => {
+      if (typeof vault === "string") vault = new PublicKey(vault);
+      await findClmmPositionsByOwner(connection, vault);
+    },
+  });
 
   const positionAccountInfos = await connection.getMultipleAccountsInfo(pdaPersonalPositionAddressesAll);
 
   positionAccountInfos.forEach((account) => {
-    if (!account) return;
-
-    try {
-      positions.push(decodeAccount("raydiumPositionInfo", account));
-    } catch {}
+    if (!account || account.owner.toBase58() != CLMM_PROGRAM_ID) return;
+    positions.push(decodeAccount("raydiumPositionInfo", account));
   });
 
   const poolIds = getUniqueAddresses(positions.map((position) => position.poolId.toBase58()), "solana");
@@ -66,9 +68,7 @@ async function addRaydiumPositions({ api, owners = [], owner, connection = getCo
     const poolId = poolIds[i];
     const poolAccount = poolAccounts[i];
     if (!poolAccount) continue;
-    try {
-      pools.set(poolId, decodeAccount("raydiumCLMM", poolAccount));
-    } catch {}
+    pools.set(poolId, decodeAccount("raydiumCLMM", poolAccount));
   }
 
   for (const position of positions) {
@@ -110,12 +110,8 @@ async function addRaydiumPositions({ api, owners = [], owner, connection = getCo
 
     const tokenNftMints = [];
     allTokenAccounts.forEach(({ account }) => {
-      let amount, mint;
-      try {
-        ({ amount, mint } = decodeAccount("tokenAccount", account));
-      } catch {
-        return;
-      }
+      const { amount, mint } = decodeAccount("tokenAccount", account)
+
       const rawAmount = amount.toString();
       const token = mint.toBase58();
       if (rawAmount === "1") {


### PR DESCRIPTION
Closes #19027

### Summary

- Replaces Krystal's broken Solana TVL API call with on-chain TVL calculation.
- Reads Krystal Solana `UserVault` accounts directly from the protocol program.
- Reuses the existing Raydium CLMM position logic to value vault positions.
- Switches token-account reads from parsed RPC responses to raw account decoding so the adapter works with the Solana RPC response format.
- Keeps configured Solana RPCs respected, using Krystal's public Solana RPC only as a fallback when the repo default public Solana RPC would otherwise be used.

### Why

`https://api.krystal.app/solana/v1/lp/tvl` currently returns HTTP 500, so fresh Solana TVL runs cannot rely on that endpoint.

The Solana TVL visible on DefiLlama is stale historical data from the last successful stored snapshot, not proof that the current API-backed adapter path still works.

### Test

```bash
node test.js projects/krystal/index.js
Latest output:

ethereum                  449.47 k
base                      117.02 k
polygon                   64.19 k
arbitrum                  58.30 k
bsc                       40.77 k
solana                    19.67 k
ronin                     430.00

total                    749.86 k

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TVL now computed via an on-chain vault scan instead of an external API.
  * Position import can reuse a provided RPC connection.
  * Vaults are processed concurrently for faster discovery.

* **Bug Fixes / Improvements**
  * Token discovery now queries both legacy SPL Token and Token-2022 accounts.
  * NFT detection refined by decoding raw token account balances.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19078)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->