### PR TITLE
  fix(sommelier): blacklist TURBO_RSETH cellar (totalAssets reverts)

### DIFF
--- a/projects/sommelier/index.js
+++ b/projects/sommelier/index.js
@@ -10,7 +10,7 @@ const {
   optimismCellarsV2p5,
 } = require("./cellar-constants");
 
-const blacklistCellars = ['0x9a7b4980C6F0FCaa50CD5f288Ad7038f434c692e', '0x5195222f69c5821f8095ec565e71e18ab6a2298f', '0xdAdC82e26b3739750E036dFd9dEfd3eD459b877A']
+const blacklistCellars = ['0x9a7b4980C6F0FCaa50CD5f288Ad7038f434c692e', '0x5195222f69c5821f8095ec565e71e18ab6a2298f', '0xdAdC82e26b3739750E036dFd9dEfd3eD459b877A', '0x1dffb366b5c5A37A12af2C127F31e8e0ED86BDbe']
 
 async function ethereum_tvl(api) {
   const block = await api.getBlock();


### PR DESCRIPTION
                                                         
  ## Problem                                                                                                                                                                          
  The sommelier adapter was returning $0 TVL on ethereum, arbitrum, and optimism.                                                                                                     
                                                                                                                                                                                      
  Root cause: `TURBO_RSETH` cellar (`0x1dffb366b5c5A37A12af2C127F31e8e0ED86BDbe`)                                                                                                     
  has a reverting `totalAssets()` call. The `v2.sumTvl` helper multiCalls                                                                                                             
  `totalAssets` across all cellars without `permitFailure`, so a single revert                                                                                                        
  poisons the entire batch and crashes the adapter on every chain that uses v2/v2.5                                                                                                   
  cellars.                                                                                                                                                                            
                                                                                                                                                                                      
  Other state on the cellar is healthy (`totalSupply()` ≈ 31e18, `asset()` returns                                                                                                    
  WETH, `isPaused()` returns false), suggesting an internal strategy/pricing issue
  rather than a redeployment.                                                                                                                                                         
                                                               
  ## Before                                                                                                                                                                           
  $ node test.js projects/sommelier                            
  ... ------ ERROR ------                                                                                                                                                             
  Error: Multicall failed!
  [chain: ethereum] [fail count: 1] [abi: uint256:totalAssets]                                                                                                                        
  target: 0x1dffb366b5c5A37A12af2C127F31e8e0ED86BDbe                                                                                                                                  
  Total TVL: **$0** (adapter crash)                                                                                                                                                   
                                                                                                                                                                                      
  ## After                                                                                                                                                                            
  ethereum    848.42 k                                         
  arbitrum    154.93 k                                                                                                                                                                
  optimism     29.29 k                                                                                                                                                                
  total       1.03 M
                                                                                                                                                                                      
  ## Fix                                                       
  Add TURBO_RSETH to `blacklistCellars` — same convention as the 3 previously-broken                                                                                                  
  cellars already excluded from query.    

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TVL calculation configuration to exclude a specific Ethereum cellar from metrics across all supported versions (v0.8.15, v0.8.16, v2, and v2.5).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->