### PR TITLE
Add Tsunami V3 + Sentry (Ink)

### DIFF
--- a/projects/sentry/index.js
+++ b/projects/sentry/index.js
@@ -1,0 +1,43 @@
+const { request, gql } = require("graphql-request");
+const { sumTokens2 } = require("../helper/unwrapLPs");
+
+const SUBGRAPH =
+  "https://api.goldsky.com/api/public/project_cmm7vh5xwsa8m01qmdr7w7u62/subgraphs/tsunami-v3/2.4.0/gn";
+
+async function tvl(api) {
+  const pageSize = 1000;
+  let lastId = "";
+  const ownerTokens = [];
+
+  while (true) {
+    const query = gql`
+      query sentryPools($lastId: ID!, $first: Int!) {
+        pools(
+          first: $first
+          where: { isSentry: true, id_gt: $lastId }
+          orderBy: id
+          orderDirection: asc
+        ) {
+          id
+          token0 { id }
+          token1 { id }
+        }
+      }
+    `;
+    const { pools } = await request(SUBGRAPH, query, { lastId, first: pageSize });
+    if (pools.length === 0) break;
+    for (const p of pools) {
+      ownerTokens.push([[p.token0.id, p.token1.id], p.id]);
+    }
+    if (pools.length < pageSize) break;
+    lastId = pools[pools.length - 1].id;
+  }
+
+  return sumTokens2({ api, ownerTokens });
+}
+
+module.exports = {
+  methodology:
+    "TVL is the sum of token balances locked in Tsunami V3 pools created by the Sentry Launch Factory on Ink (chain ID 57073). Pools are filtered via Pool.isSentry == true in the Tsunami V3 subgraph, which covers both the V4 factory (0xDc37e11B68052d1539fa23386eE58Ac444bf5BE1) and the legacy agent factory (0x733733E8eAbB94832847AbF0E0EeD6031c3EB2E4). Tokens without DefiLlama pricing contribute 0, so reported USD TVL is dominated by the WETH/USDT0 side of each pool.",
+  ink: { tvl },
+};

--- a/projects/sentry/index.js
+++ b/projects/sentry/index.js
@@ -1,13 +1,43 @@
 const { request, gql } = require("graphql-request");
-const { sumTokens2 } = require("../helper/unwrapLPs");
+const { ethers } = require("ethers");
 
 const SUBGRAPH =
   "https://api.goldsky.com/api/public/project_cmm7vh5xwsa8m01qmdr7w7u62/subgraphs/tsunami-v3/2.4.0/gn";
 
+const WETH = "0x4200000000000000000000000000000000000006";
+
+// Same exclusion list as the Tsunami DEX adapter — covers oracle helper,
+// dust pools, and developer test-token pools.
+const EXCLUDED_POOLS = new Set([
+  "0xd43839e216c40a9825132c8fb47dbcb0b20c3f72",
+  "0x075425ba32cd03e9a33bd059d5d2b92429f39552",
+  "0xa3d3fc7e5de722ed5e9706380988d5576c33ffd5",
+]);
+const TEST_SYMBOL = /^test\d*$/i;
+
+function isHidden(pool) {
+  if (EXCLUDED_POOLS.has(pool.id.toLowerCase())) return true;
+  if (TEST_SYMBOL.test(pool.token0.symbol || "")) return true;
+  if (TEST_SYMBOL.test(pool.token1.symbol || "")) return true;
+  return false;
+}
+
+function poolWethEquivalent(p) {
+  const isWeth0 = p.token0.id.toLowerCase() === WETH;
+  const isWeth1 = p.token1.id.toLowerCase() === WETH;
+  if (!isWeth0 && !isWeth1) return 0;
+  const tvl0 = parseFloat(p.totalValueLockedToken0) || 0;
+  const tvl1 = parseFloat(p.totalValueLockedToken1) || 0;
+  if (isWeth0) {
+    return tvl0 + tvl1 * (parseFloat(p.token0Price) || 0);
+  }
+  return tvl1 + tvl0 * (parseFloat(p.token1Price) || 0);
+}
+
 async function tvl(api) {
   const pageSize = 1000;
   let lastId = "";
-  const ownerTokens = [];
+  let totalWeth = 0;
 
   while (true) {
     const query = gql`
@@ -19,25 +49,32 @@ async function tvl(api) {
           orderDirection: asc
         ) {
           id
-          token0 { id }
-          token1 { id }
+          token0 { id symbol }
+          token1 { id symbol }
+          token0Price
+          token1Price
+          totalValueLockedToken0
+          totalValueLockedToken1
         }
       }
     `;
     const { pools } = await request(SUBGRAPH, query, { lastId, first: pageSize });
     if (pools.length === 0) break;
     for (const p of pools) {
-      ownerTokens.push([[p.token0.id, p.token1.id], p.id]);
+      if (isHidden(p)) continue;
+      totalWeth += poolWethEquivalent(p);
     }
     if (pools.length < pageSize) break;
     lastId = pools[pools.length - 1].id;
   }
 
-  return sumTokens2({ api, ownerTokens });
+  if (totalWeth > 0) {
+    api.add(WETH, ethers.parseUnits(totalWeth.toFixed(18), 18).toString());
+  }
 }
 
 module.exports = {
   methodology:
-    "TVL is the sum of token balances locked in Tsunami V3 pools created by the Sentry Launch Factory on Ink (chain ID 57073). Pools are filtered via Pool.isSentry == true in the Tsunami V3 subgraph, which covers both the V4 factory (0xDc37e11B68052d1539fa23386eE58Ac444bf5BE1) and the legacy agent factory (0x733733E8eAbB94832847AbF0E0EeD6031c3EB2E4). Tokens without DefiLlama pricing contribute 0, so reported USD TVL is dominated by the WETH/USDT0 side of each pool.",
+    "TVL is the sum of value locked in Tsunami V3 pools created by the Sentry Launch Factory (Pool.isSentry == true in the subgraph; covers both V4 factory 0xDc37e11B68052d1539fa23386eE58Ac444bf5BE1 and the legacy agent factory 0x733733E8eAbB94832847AbF0E0EeD6031c3EB2E4). Each pool contributes its WETH balance plus the paired token's value at the pool's own WETH ratio — same per-pool calculation as the Tsunami frontend.",
   ink: { tvl },
 };

--- a/projects/tsunami/index.js
+++ b/projects/tsunami/index.js
@@ -4,6 +4,7 @@ const config = uniV3Export({
   ink: {
     factory: "0xD8B0826150B7686D1F56d6F10E31E58e1BCF1193",
     fromBlock: 39943476,
+    permitFailure: true,
   },
 });
 

--- a/projects/tsunami/index.js
+++ b/projects/tsunami/index.js
@@ -1,0 +1,14 @@
+const { uniV3Export } = require("../helper/uniswapV3");
+
+const config = uniV3Export({
+  ink: {
+    factory: "0xD8B0826150B7686D1F56d6F10E31E58e1BCF1193",
+    fromBlock: 39943476,
+  },
+});
+
+module.exports = {
+  methodology:
+    "TVL is the sum of token balances locked across all Tsunami V3 pools. Pools are enumerated via PoolCreated events from the TsunamiV3Factory (0xD8B0826150B7686D1F56d6F10E31E58e1BCF1193) on Ink (chain ID 57073).",
+  ...config,
+};

--- a/projects/tsunami/index.js
+++ b/projects/tsunami/index.js
@@ -1,15 +1,95 @@
-const { uniV3Export } = require("../helper/uniswapV3");
+const { request, gql } = require("graphql-request");
+const { ethers } = require("ethers");
 
-const config = uniV3Export({
-  ink: {
-    factory: "0xD8B0826150B7686D1F56d6F10E31E58e1BCF1193",
-    fromBlock: 39943476,
-    permitFailure: true,
-  },
-});
+const SUBGRAPH =
+  "https://api.goldsky.com/api/public/project_cmm7vh5xwsa8m01qmdr7w7u62/subgraphs/tsunami-v3/2.4.0/gn";
+
+const WETH = "0x4200000000000000000000000000000000000006";
+
+// Pools known to have skewed single-tick math that inflates subgraph TVL,
+// or dust pools that just clutter the listing. Mirrors the frontend's
+// EXCLUDED_POOLS in tsunami/frontend/src/config/contracts.ts.
+const EXCLUDED_POOLS = new Set([
+  "0xd43839e216c40a9825132c8fb47dbcb0b20c3f72", // USDT0/WETH 0.05% oracle helper
+  "0x075425ba32cd03e9a33bd059d5d2b92429f39552", // WETH/SENTRY 1% dust
+  "0xa3d3fc7e5de722ed5e9706380988d5576c33ffd5", // WETH/MOLTING 1% dust
+]);
+// Developer test tokens (TEST, TEST1, Test4, etc.) are hidden the same way.
+const TEST_SYMBOL = /^test\d*$/i;
+
+function isHidden(pool) {
+  if (EXCLUDED_POOLS.has(pool.id.toLowerCase())) return true;
+  if (TEST_SYMBOL.test(pool.token0.symbol || "")) return true;
+  if (TEST_SYMBOL.test(pool.token1.symbol || "")) return true;
+  return false;
+}
+
+// TVL is anchored to WETH the way the Tsunami frontend computes it: each
+// visible pool contributes its WETH side at face value plus the meme-token
+// side priced at the pool's own WETH ratio. Pools without a WETH side are
+// skipped — that automatically excludes the USDT0/NAMI peg pool whose
+// single-tick math reports $498T to the subgraph.
+function poolWethEquivalent(p) {
+  const isWeth0 = p.token0.id.toLowerCase() === WETH;
+  const isWeth1 = p.token1.id.toLowerCase() === WETH;
+  if (!isWeth0 && !isWeth1) return 0;
+  const tvl0 = parseFloat(p.totalValueLockedToken0) || 0;
+  const tvl1 = parseFloat(p.totalValueLockedToken1) || 0;
+  // Tsunami subgraph convention: token0Price = token0 per token1.
+  // So when WETH = token0, token0Price is WETH per (token1 unit) — the
+  // meme-token side multiplied by token0Price gives WETH-equivalent.
+  if (isWeth0) {
+    return tvl0 + tvl1 * (parseFloat(p.token0Price) || 0);
+  }
+  return tvl1 + tvl0 * (parseFloat(p.token1Price) || 0);
+}
+
+async function fetchAllPools(extraWhere = "") {
+  const pageSize = 1000;
+  let lastId = "";
+  const out = [];
+  while (true) {
+    const query = gql`
+      query pools($lastId: ID!, $first: Int!) {
+        pools(
+          first: $first
+          where: { id_gt: $lastId ${extraWhere} }
+          orderBy: id
+          orderDirection: asc
+        ) {
+          id
+          token0 { id symbol }
+          token1 { id symbol }
+          token0Price
+          token1Price
+          totalValueLockedToken0
+          totalValueLockedToken1
+        }
+      }
+    `;
+    const { pools } = await request(SUBGRAPH, query, { lastId, first: pageSize });
+    if (pools.length === 0) break;
+    out.push(...pools);
+    if (pools.length < pageSize) break;
+    lastId = pools[pools.length - 1].id;
+  }
+  return out;
+}
+
+async function tvl(api) {
+  const pools = await fetchAllPools();
+  let totalWeth = 0;
+  for (const p of pools) {
+    if (isHidden(p)) continue;
+    totalWeth += poolWethEquivalent(p);
+  }
+  if (totalWeth > 0) {
+    api.add(WETH, ethers.parseUnits(totalWeth.toFixed(18), 18).toString());
+  }
+}
 
 module.exports = {
   methodology:
-    "TVL is the sum of token balances locked across all Tsunami V3 pools. Pools are enumerated via PoolCreated events from the TsunamiV3Factory (0xD8B0826150B7686D1F56d6F10E31E58e1BCF1193) on Ink (chain ID 57073).",
-  ...config,
+    "TVL mirrors the Tsunami frontend: each visible pool contributes its WETH-side balance plus the paired token's value derived from the pool's own WETH ratio (subgraph token0Price/token1Price). Pools without a WETH side are skipped, which automatically excludes single-tick peg pools whose math is mechanically broken (e.g. USDT0/NAMI). Address blacklist and developer test-token pools are also excluded.",
+  ink: { tvl },
 };


### PR DESCRIPTION
## Summary

Two new TVL adapters on **Ink** (chain ID 57073):

1. **Tsunami V3** — Uniswap V3 fork (the underlying DEX)
2. **Sentry** — Token launchpad that atomically deploys an ERC20 + seeds a single Tsunami V3 LP position

Both adapters share the same Tsunami V3 subgraph; Sentry filters Tsunami pools by `Pool.isSentry == true` so the same liquidity isn't double-counted as a separate protocol — Sentry only reflects launchpad-launched markets.

TVL is anchored to WETH the way the Tsunami frontend computes it: each pool contributes its WETH-side balance plus the paired token's value at the pool's own WETH ratio (`token0Price` / `token1Price` from the subgraph). Pools without a WETH side are skipped, which auto-excludes the USDT0/NAMI single-tick peg pool whose subgraph TVL math overflows. An additional small blacklist (dust pools, dev test tokens) mirrors the frontend's hidden-pool list.

## Local test

```
$ node test.js projects/tsunami/index.js
--- ink ---
WETH                      103.65 k
Total: 103.65 k

$ node test.js projects/sentry/index.js
--- ink ---
WETH                       55.52 k
Total:                     55.52 k
```

Frontend Pools page total TVL (https://nami.ink/pools): $103,867. Adapter matches within timing/rounding.

Companion volume/fees adapter PR: https://github.com/DefiLlama/dimension-adapters/pull/6761

---

## Tsunami V3

##### Name (to be shown on DefiLlama):
Tsunami V3

##### List of audit links if any:
None — code is a Uniswap V3 fork.

##### Website Link:
https://nami.ink

##### Logo (High resolution, will be shown with rounded borders):
https://raw.githubusercontent.com/mavrkofficial/tsunami-public/main/assets/logos/tsunami/coin/nami-coin-logo-circle.png

##### Current TVL:
~$103.6k

##### Chain:
Ink (57073)

##### Short Description (to be shown on DefiLlama):
Concentrated liquidity DEX on Ink (Uniswap V3 fork). Standard 8-tier fee schedule and standard V3 pool math; no protocol-fee switch enabled.

##### Token address and ticker if any:
NAMI — `0x40f297b5a31fb7d28169ba75666bea38122860c2`

##### Category:
Dexes

##### forkedFrom:
Uniswap V3

##### methodology:
WETH-anchored TVL: each visible Tsunami V3 pool contributes its WETH-side balance plus the paired token's value derived from the pool's own WETH ratio. Pools without a WETH side are skipped. Address blacklist + developer test-token pools also excluded.

##### Github org/user:
https://github.com/mavrkofficial/tsunami-public

---

## Sentry

##### Name (to be shown on DefiLlama):
Sentry

##### Twitter Link:
https://x.com/sentrylauncher

##### List of audit links if any:
None.

##### Website Link:
https://sentry.trading

##### Logo (High resolution, will be shown with rounded borders):
https://raw.githubusercontent.com/mavrkofficial/tsunami-public/main/assets/logos/sentry/coin/sentry-coin-logo-circle-black.png

##### Current TVL:
~$55.5k

##### Chain:
Ink (57073)

##### Short Description (to be shown on DefiLlama):
Atomic token launchpad on Ink. One transaction deploys an ERC20, creates a Tsunami V3 pool, and mints the seed liquidity position; the launchpad self-custodies the LP NFT and routes a 25/75 creator/treasury split of the WETH-side fees.

##### Category:
Launchpad

##### forkedFrom:
None (custom contracts; uses the Tsunami V3 factory + position manager underneath).

##### methodology:
Same per-pool WETH-anchored calculation as the Tsunami V3 adapter, restricted to pools where Pool.isSentry == true in the subgraph. Covers both the V4 launch factory (0xDc37e11B68052d1539fa23386eE58Ac444bf5BE1) and the legacy agent factory (0x733733E8eAbB94832847AbF0E0EeD6031c3EB2E4).

##### Github org/user:
https://github.com/mavrkofficial/tsunami-public