### PR TITLE
[fix] sushiswap-bentobox - mark dead from 2024-06-12

### DIFF
--- a/projects/sushiswap-bentobox/index.js
+++ b/projects/sushiswap-bentobox/index.js
@@ -15,9 +15,15 @@ const bentobox_chains = [
   //"metis",
   "celo",
 ];
+
+const DEAD_FROM = new Date('2024-06-12');
+
 bentobox_chains.forEach((chain) => {
   module.exports[chain] = {
-    tvl: chain === "fantom" || chain === "avax" ? () => ({ }) : (api) => bentobox(api),
+    tvl: chain === "fantom" || chain === "avax" ? () => ({}) : async (api) => {
+      if (new Date(api.timestamp * 1000) > DEAD_FROM) return {};
+      return bentobox(api);
+    },
   };
 });
 

--- a/projects/sushiswap-bentobox/index.js
+++ b/projects/sushiswap-bentobox/index.js
@@ -1,5 +1,4 @@
 const { bentobox } = require("./bentobox.js");
-
 const bentobox_chains = [
   "ethereum",
   "polygon",
@@ -16,9 +15,10 @@ const bentobox_chains = [
   //"metis",
   "celo",
 ];
-
 bentobox_chains.forEach((chain) => {
   module.exports[chain] = {
     tvl: chain === "fantom" || chain === "avax" ? () => ({ }) : (api) => bentobox(api),
   };
 });
+
+module.exports.deadFrom = '2024-06-12';

--- a/projects/sushiswap-bentobox/index.js
+++ b/projects/sushiswap-bentobox/index.js
@@ -21,7 +21,7 @@ const DEAD_FROM = new Date('2024-06-12');
 bentobox_chains.forEach((chain) => {
   module.exports[chain] = {
     tvl: chain === "fantom" || chain === "avax" ? () => ({}) : async (api) => {
-      if (new Date(api.timestamp * 1000) > DEAD_FROM) return {};
+      if (new Date(api.timestamp * 1000) >= DEAD_FROM) return {};
       return bentobox(api);
     },
   };


### PR DESCRIPTION
## Summary

Fixes #19026

Marks Sushi BentoBox as dead from June 12, 2024 — the date The Graph 
officially deprecated its hosted service.

The adapter relied on hosted service subgraphs which are no longer 
available, causing "payment required" errors on all chains.

## Root Cause

The Graph hosted service shutdown on 2024-06-12. BentoBox subgraphs 
were never migrated to the decentralized network, making historical 
TVL data inaccessible without payment.

## Fix

Added `deadFrom: '2024-06-12'` to stop fetching after the protocol's 
data became unavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Marked SushiSwap BentoBox integration inactive effective June 12, 2024 (cutoff date added).
  * Confirmed per-chain behavior: Fantom and Avalanche remain always disabled; all other chains switch to inactive status for timestamps on or after the cutoff, while preserving prior behavior for earlier timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->