### PR TITLE
[fix] gold-dao - update TVL to use GLDT ledger canister

### DIFF
--- a/projects/gold-dao/index.js
+++ b/projects/gold-dao/index.js
@@ -1,16 +1,20 @@
-const { toUSDTBalances } = require("../helper/balances");
 const { get } = require('../helper/http')
+const { addCGToken } = require('../helper/tokenMapping')
 
-async function tvl() {
-  const url = 'https://teiwz-pqaaa-aaaap-ag7hq-cai.raw.icp0.io/gold_nft_metrics';
-  const data = await get(url);
-  return toUSDTBalances(data.tvl);
+const GLDT_METRICS_URL = 'https://6c7su-kiaaa-aaaar-qaira-cai.raw.icp0.io/metrics'
+
+async function tvl(api) {
+  const metrics = await get(GLDT_METRICS_URL, { responseType: 'text' })
+  const match = metrics.match(/ledger_total_supply\s+(\d+)/)
+  if (!match) throw new Error('Could not parse GLDT total supply')
+  const totalSupply = Number(match[1]) / 1e8  // 8 decimals
+  api.addCGToken('gold-token', totalSupply)
 }
 
 module.exports = {
   timetravel: false,
   misrepresentedTokens: true,
-  methodology: "TVL counts gold bar owned by gold dao and convert gram to usd price using Forex Public Data",
+  methodology: "TVL counts total GLDT supply (each GLDT = 0.01g of physical gold) priced via CoinGecko",
   icp: {
     tvl,
   },

--- a/projects/gold-dao/index.js
+++ b/projects/gold-dao/index.js
@@ -1,8 +1,13 @@
 const { get } = require('../helper/http')
-const { addCGToken } = require('../helper/tokenMapping')
 
 const GLDT_METRICS_URL = 'https://6c7su-kiaaa-aaaar-qaira-cai.raw.icp0.io/metrics'
 
+/**
+ * Fetches TVL for Gold DAO by reading total GLDT supply from the ICRC1 ledger canister.
+ * Each GLDT token represents 0.01g of physical gold stored in Switzerland.
+ * Priced via CoinGecko using the 'gold-token' id.
+ * @param {Object} api - DefiLlama API helper object
+ */
 async function tvl(api) {
   const metrics = await get(GLDT_METRICS_URL, { responseType: 'text' })
   const match = metrics.match(/ledger_total_supply\s+(\d+)/)


### PR DESCRIPTION
## Summary

Fixes #19020

The old metrics canister (teiwz-pqaaa-aaaap-ag7hq-cai) is stopped, 
causing TVL to fail since November 2025.

## Fix

Switch to the GLDT ledger canister metrics endpoint:
https://6c7su-kiaaa-aaaar-qaira-cai.raw.icp0.io/metrics

Parse ledger_total_supply and price via CoinGecko gold-token id.
Each GLDT = 0.01g of physical gold stored in Switzerland.

## Test Output

icp: GLDT $710.72k

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * TVL calculation updated to derive GLDT total supply directly and register token balances for more accurate valuation.

* **Documentation**
  * Methodology updated to explain counting total GLDT supply and pricing via CoinGecko.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->