### PR TITLE
fix(contango-v2) update subgraph endpoint and pagination

### DIFF
--- a/projects/contango-v2/index.js
+++ b/projects/contango-v2/index.js
@@ -1,8 +1,9 @@
-const axios = require('axios')
+const { request } = require('../helper/utils/graphql')
 
 const CONTANGO_PROXY = "0x6Cae28b3D09D8f8Fc74ccD496AC986FC84C0C24E";
 const CONTANGO_LENS_PROXY = "0xe03835Dfae2644F37049c1feF13E8ceD6b1Bb72a";
-const alchemyGraphUrl = (chain) => `https://subgraph.satsuma-prod.com/773bd6dfe1c6/egills-team/v2-${chain}/api`
+const goldskyGraphUrl = (chain) => `https://api.goldsky.com/api/public/project_cmgz86r3700015ep2fvxn0ipr/subgraphs/v2-${chain}/v0.0.24/gn`
+const PAGE_SIZE = 1000
 
 const excludedIds_arb = [
   "0x415242555344540000000000000000000bffffffff0000000000000000000623",
@@ -18,53 +19,53 @@ const config = {
   arbitrum: {
     contango: CONTANGO_PROXY,
     contango_lens: CONTANGO_LENS_PROXY,
-    graphUrl: alchemyGraphUrl('arbitrum'),
+    graphUrl: goldskyGraphUrl('arbitrum'),
     excludedIds: excludedIds_arb
   },
   optimism: {
     contango: CONTANGO_PROXY,
     contango_lens: CONTANGO_LENS_PROXY,
-    graphUrl: alchemyGraphUrl('optimism'),
+    graphUrl: goldskyGraphUrl('optimism'),
   },
   ethereum: {
     contango: CONTANGO_PROXY,
     contango_lens: CONTANGO_LENS_PROXY,
-    graphUrl: alchemyGraphUrl('mainnet'),
+    graphUrl: goldskyGraphUrl('mainnet'),
   },
   polygon: {
     contango: CONTANGO_PROXY,
     contango_lens: CONTANGO_LENS_PROXY,
-    graphUrl: alchemyGraphUrl('polygon'),
+    graphUrl: goldskyGraphUrl('polygon'),
   },
   xdai: {
     contango: CONTANGO_PROXY,
     contango_lens: CONTANGO_LENS_PROXY,
-    graphUrl: alchemyGraphUrl('gnosis'),
+    graphUrl: goldskyGraphUrl('gnosis'),
   },
   base: {
     contango: CONTANGO_PROXY,
     contango_lens: CONTANGO_LENS_PROXY,
-    graphUrl: alchemyGraphUrl('base'),
+    graphUrl: goldskyGraphUrl('base'),
   },
   avax: {
     contango: CONTANGO_PROXY,
     contango_lens: CONTANGO_LENS_PROXY,
-    graphUrl: alchemyGraphUrl('avalanche'),
+    graphUrl: goldskyGraphUrl('avalanche'),
   },
   bsc: {
     contango: CONTANGO_PROXY,
     contango_lens: CONTANGO_LENS_PROXY,
-    graphUrl: alchemyGraphUrl('bsc'),
+    graphUrl: goldskyGraphUrl('bsc'),
   },
   linea: {
     contango: CONTANGO_PROXY,
     contango_lens: CONTANGO_LENS_PROXY,
-    graphUrl: alchemyGraphUrl('linea'),
+    graphUrl: goldskyGraphUrl('linea'),
   },
   scroll: {
     contango: CONTANGO_PROXY,
     contango_lens: CONTANGO_LENS_PROXY,
-    graphUrl: alchemyGraphUrl('scroll'),
+    graphUrl: goldskyGraphUrl('scroll'),
   },
 };
 
@@ -74,13 +75,16 @@ const abis = {
 
 const graphQueries = {
   position: `
-    query MyQuery($lastId: BigInt, $block: Int) {
+    query MyQuery($lastNumber: BigInt, $block: Int) {
       positions(
         block: {number: $block}
-        where: {and: [{number_gt: $lastId}, {quantity_not: "0"}]}
-        first: 10000
+        where: {and: [{number_gt: $lastNumber}, {quantity_not: "0"}]}
+        first: ${PAGE_SIZE}
+        orderBy: number
+        orderDirection: asc
       ) {
         id
+        number
         instrument {
           base {
             id
@@ -92,20 +96,61 @@ const graphQueries = {
       }
     }`,
   asset: `
-    query MyQuery($block: Int) {
-      assets(block: {number: $block}, first: 10000) {
+    query MyQuery($lastId: String, $block: Int) {
+      assets(
+        block: {number: $block}
+        where: {id_gt: $lastId}
+        first: ${PAGE_SIZE}
+        orderBy: id
+        orderDirection: asc
+      ) {
         id
       }
     }`,
 };
 
+async function queryGraphPage(graphUrl, query, variables, key) {
+  const data = await request(graphUrl, query, { variables });
+
+  if (!Array.isArray(data?.[key])) throw new Error(`Missing Contango subgraph ${key} response`)
+
+  return data[key]
+}
+
+async function queryPositions(graphUrl, block) {
+  let positions = []
+  let lastNumber = "0"
+
+  while (true) {
+    const page = await queryGraphPage(graphUrl, graphQueries.position, { lastNumber, block }, 'positions')
+    positions = positions.concat(page)
+    if (page.length < PAGE_SIZE) break
+    lastNumber = page[page.length - 1].number
+  }
+
+  return positions
+}
+
+async function queryAssets(graphUrl, block) {
+  let assets = []
+  let lastId = ""
+
+  while (true) {
+    const page = await queryGraphPage(graphUrl, graphQueries.asset, { lastId, block }, 'assets')
+    assets = assets.concat(page)
+    if (page.length < PAGE_SIZE) break
+    lastId = page[page.length - 1].id
+  }
+
+  return assets
+}
 
 const getPositionsTvl = async (api, lens, graphUrl, borrowed, block, excludedIds) => {
-  const { data } = await axios.post(graphUrl, { query: graphQueries.position, variables: { lastId: "0", block } });
-  const parts = data.data.positions
+  const positions = await queryPositions(graphUrl, block)
+  const parts = positions
     .filter(({ id }) => !excludedIds.includes(id))
     .map(({ id, instrument: { base, quote } }) => [id, [base.id, quote.id]]);
-  
+
   const calls = parts.map(([id]) => ({ target: lens, params: [id] }))
   const balances = await api.multiCall({ calls, abi: abis.balances })
 
@@ -120,9 +165,9 @@ const getPositionsTvl = async (api, lens, graphUrl, borrowed, block, excludedIds
 }
 
 const getVaultTvl = async (api, contango, graphUrl, block) => {
-  const { data } = await axios.post(graphUrl, { query: graphQueries.asset, variables: { lastId: "0", block } });
+  const assets = await queryAssets(graphUrl, block)
   const vault = await api.call({ abi: "address:vault", target: contango });
-  await api.sumTokens({ owner: vault, tokens: data.data.assets.map(({ id }) => id) });
+  await api.sumTokens({ owner: vault, tokens: assets.map(({ id }) => id) });
 }
 
 const tvl = async (api) => {


### PR DESCRIPTION
Fixes #19022

The Contango V2 adapter was failing because it still used the old Satsuma subgraph URLs, like:
`https://subgraph.satsuma-prod.com/773bd6dfe1c6/egills-team/v2-arbitrum/api`

That host no longer resolves, so the adapter could not export TVL.

I found two things that needed changing:
- The subgraph URLs needed to move from the old Satsuma host to the public Goldsky endpoints.
- The old query asked the subgraph for 10,000 rows at once. Goldsky rejects that with `The first argument must be between 0 and 1000, but is 10000`, so I changed the positions/assets queries to page through results instead.

This keeps the calculation the same. The subgraph is still only used to discover positions/assets, and TVL/borrowed are still calculated from the Contango lens/vault calls.

Tested with:

```
node test.js projects/contango-v2/index.js
```

Local run:

```
total                    9.45 M
borrowed                 64.21 M
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated data fetching infrastructure to use shared request helper and Goldsky endpoints
  * Improved pagination approach for position and asset queries with reusable helpers
  * Enhanced data retrieval efficiency with updated pagination parameters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->