### PR TITLE
fix(resonatefinance): mark adapter dead

### DIFF
--- a/projects/resonatefinance/index.js
+++ b/projects/resonatefinance/index.js
@@ -1,22 +1,14 @@
 const { get } = require('../helper/http');
 
 
-//Full Calculations for computing TVL for Resonate Finance is done internally by Resonate and exposed via API
-//API Endpoint: https://api.resonate.finance/{chainId}/tvl
-//https://github.com/Revest-Finance/railway-monorepo/blob/main/src/api.ts",
 async function tvl(api) {
-  let usdValue = 0;
-  do {
-      const data = await get(`https://api.resonate.finance/${api.chainId}/tvl`);
-      usdValue = data;
-  } while (usdValue == 0)
-  
-  return { 
-    tether: usdValue,
-  };
+  if ((api.timestamp ?? Date.now() / 1000) * 1000 > new Date('2025-08-01')) return {}
+
+  api.addUSDValue(await get(`https://api.resonate.finance/${api.chainId}/tvl`));
 }
 
 module.exports = {
+    deadFrom: '2025-08-01',
     methodology: "We sum all the tokens deposited as principal and any unclaimed interest accrued on it.",
     hallmarks: [
       ['2023-04-25', "Launch of Regen Portal"],


### PR DESCRIPTION
Closes #19018

Resonate Finance’s current TVL adapter depends on `https://api.resonate.finance/{chainId}/tvl`, but that endpoint now returns `502` across the configured chains.

The app at `https://app.resonate.finance/pool-list` still serves the frontend shell, but the pool list is empty and the UI shows `not live`. DefiLlama also has no fresh Resonate TVL datapoints after `2025-07-31`.

Changes:
- Marks Resonate Finance inactive from `2025-08-01`
- Stops current adapter runs from calling the broken upstream TVL API after that date
- Removes the `do...while` retry loop that could keep retrying while the API returned `0`
- Keeps historical behavior before the cutoff date

Tested:
- `node test.js projects/resonatefinance/index.js`

Result:
- Ethereum: `0.00`
- Polygon: `0.00`
- Optimism: `0.00`
- Arbitrum: `0.00`
- Fantom: `0.00`
- Total: `0.00`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Resonance Finance TVL tracking will be disabled after August 1, 2025
* TVL data collection and processing mechanism has been updated

<!-- end of auto-generated comment: release notes by coderabbit.ai -->