### PR TITLE
feat(camelot-v2): add Plume mainnet Orbit chain

### DIFF
--- a/projects/camelot-v2/index.js
+++ b/projects/camelot-v2/index.js
@@ -17,7 +17,8 @@ const export2 = uniV3Export({
   duckchain: { factory: '0xCf4062Ee235BbeB4C7c0336ada689ed1c17547b6', fromBlock: 1530060, isAlgebra: true, },
   occ: { factory: '0xCf4062Ee235BbeB4C7c0336ada689ed1c17547b6', fromBlock: 21053, isAlgebra: true, },
   spn: { factory: '0xCf4062Ee235BbeB4C7c0336ada689ed1c17547b6', fromBlock: 1, isAlgebra: true, },
-  winr: { factory: '0x10aA510d94E094Bd643677bd2964c3EE085Daffc', fromBlock: 1258618, isAlgebra: true }
+  winr: { factory: '0x10aA510d94E094Bd643677bd2964c3EE085Daffc', fromBlock: 1258618, isAlgebra: true },
+  plume_mainnet: { factory: '0x1eb9822d5176c88b1d4eec353fa956c896d77df9', fromBlock: 21656475, isAlgebra: true },
 })
 
 module.exports = mergeExports([export1, export2])


### PR DESCRIPTION
## Summary

Adds Camelot DEX (Orbit) coverage for Plume mainnet (Chain ID 98866).

- **Factory:** `0x1eb9822d5176c88b1d4eec353fa956c896d77df9` — verified as `AlgebraFactory` on Plume explorer
- **Deploy block:** 21,656,475 (binary search confirmed: no code at 21,656,474, deployed at 21,656,475)
- **Pools discovered:** 296 (via `Pool(address,address,address)` event scan, full history)
- **Owner:** GnosisSafeProxy (Camelot team multisig — `0x54fe8AfAc3ca2AB1e20D94AEE00C81fC35693C69`)
- **Source:** [docs.camelot.exchange/contracts/orbit-chains/plume](https://docs.camelot.exchange/contracts/orbit-chains/plume)

Primary pairs include USDC.e/WPLUME (0.1% fee, tickSpacing=60) and USDC/WPLUME. Pattern matches all other Camelot Orbit deployments already in this file (`isAlgebra: true`).

Pre-commit TVL gate: ✅ passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Plume Mainnet chain in the protocol configuration, enabling interactions on this newly supported blockchain network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->