### PR TITLE
quell: clarify methodology to reflect Base→Arbitrum migration

### DIFF
--- a/registries/erc4626.js
+++ b/registries/erc4626.js
@@ -198,7 +198,7 @@ const configs = {
   },
   'quell': {
     doublecounted: true,
-    methodology: "TVL is the total USDC deposited in the Quell ERC4626 RWAVaults, which route USDC to external vaults such as Spark sUSDC and Steakhouse USDC MetaMorpho for RWA yield.",
+    methodology: "TVL is the total USDC deposited in the Quell ERC4626 RWAVaults, measured via totalAssets(). The protocol launched on Base in 2025 routing into the Steakhouse USDC MetaMorpho vault, then migrated to Arbitrum One in March 2026 where it routes into Spark sUSDC. Historical Base + early Arbitrum vaults are retained for chain TVL history; the live yield route on the current Arbitrum RWAVault is Spark sUSDC.",
     base: ['0xd85A4301706124699CbA8d0b59E5ED635360868b'],
     arbitrum: ['0x25cf6D8BacCFbF66DC0567844182F063b8BD0051', '0x82bDeB9239d33AAE4b8c38C0C0ef3B088b0Fc791'],
   },


### PR DESCRIPTION
Smaller follow-up to closed PR #19074.

@g1nt0ki — thanks for the quick feedback on #19074. Got it: the registry preserves historical chain entries so TVL history isn't truncated when a protocol migrates. Keeping the addresses in place.

This PR is methodology-only. The current string says the vaults route into "Spark sUSDC and Steakhouse USDC MetaMorpho" — that phrasing reads as if both are part of the live yield path, but Steakhouse MetaMorpho was the V1 (Base) route and is no longer active. Spark sUSDC is the only live route on the current Arbitrum RWAVault `0x82bDeB9239d33AAE4b8c38C0C0ef3B088b0Fc791`.

New methodology preserves the historical context (Base launch + Steakhouse) while making the live state explicit:

> "TVL is the total USDC deposited in the Quell ERC4626 RWAVaults, measured via totalAssets(). The protocol launched on Base in 2025 routing into the Steakhouse USDC MetaMorpho vault, then migrated to Arbitrum One in March 2026 where it routes into Spark sUSDC. Historical Base + early Arbitrum vaults are retained for chain TVL history; the live yield route on the current Arbitrum RWAVault is Spark sUSDC."

Vault list and `doublecounted: true` are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated registry documentation with enhanced details on protocol routing history, including launch and migrations across multiple networks, and current yield route configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->