### PR TITLE
feat(balancer): add Balancer V2 vault to 6 missing chains

### DIFF
--- a/registries/balancer.js
+++ b/registries/balancer.js
@@ -78,6 +78,12 @@ const configs = {
     avax: balV2Chain(26386141),
     mode: balV2Chain(8110317),
     fraxtal: balV2Chain(4708596),
+    ink: balV2Chain(34313901),
+    cronos: balV2Chain(15251184),
+    soneium: balV2Chain(21420762),
+    manta: balV2Chain(3871299),
+    moonriver: balV2Chain(9453547),
+    moonbeam: balV2Chain(6942168),
   },
   'swaap-v2': {
     ethereum: { vault: '0xd315a9c38ec871068fec378e4ce78af528c76293', fromBlock: 17598578 },


### PR DESCRIPTION
Adds the canonical Balancer V2 vault (`0xBA12222222228d8Ba445958a75a0704d566BF2C8`) to six chains that have it deployed but are not yet tracked in `registries/balancer.js`:

| Chain | fromBlock | Chain TVL |
|---|---|---|
| ink | 34313901 | ~$309M |
| cronos | 15251184 | ~$295M |
| soneium | 21420762 | ~$8.9M |
| manta | 3871299 | ~$5.9M |
| moonriver | 9453547 | ~$1.9M |
| moonbeam | 6942168 | ~$1.8M |

**Verification method:** Binary-search RPC (`eth_getCode`) confirmed the vault bytecode is present at the canonical address on each chain. `fromBlock` values found via halving-search against `eth_getCode` returning non-empty.

Uses existing `balV2Chain(fromBlock)` helper — no new logic, just six registry entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Balancer V2 support for six additional blockchain networks: Ink, Cronos, Soneium, Manta, Moonriver, and Moonbeam.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->