### PR TITLE
scripts/audit: structural sanity checks for coreAssets and adapter sources

### DIFF
--- a/scripts/audit/README.md
+++ b/scripts/audit/README.md
@@ -1,0 +1,44 @@
+# Structural audit scripts
+
+Complementary to DefiLlama's existing TVL spike detector (`defillama-server/defi/src/api2/scripts/tvlSpikeDetector.ts`). The spike detector watches for **changes** in TVL — anomalies relative to a protocol's recent history. These scripts watch for **shapes** — always-on data bugs that don't manifest as a spike because they were already present at day-zero.
+
+The class of bug each catches is the kind that survives until somebody manually finds it: a mistyped address checksum, a token whose on-chain `symbol()` no longer matches the key it's filed under, a whitelist option that fails closed because of a config-key typo, a DEX adapter that enumerates its token universe from an unfiltered source. Spike detector won't fire on any of these — they were always wrong.
+
+## Scripts
+
+| Script | What it checks | Network calls |
+|--------|----------------|---------------|
+| `core-assets.js` | Static checks against `projects/helper/coreAssets.json`: EIP-55 checksum sanity, placeholder addresses, suspicious symbol names, cross-chain symbol/address mismatch | None |
+| `onchain-symbols.js` | Reads on-chain `symbol()` for every EVM entry and compares to its key — finds renamed tokens, dead contracts, wrong-address bugs | RPC multicall per chain |
+| `dex-token-universe.js` | Greps adapter source for risky token-universe sources (explorer APIs, unfiltered factory enumeration, balance-of-anything loops) | None |
+| `uni-tvl-no-whitelist.js` | Finds `getUniTVL({...})` calls that don't enable `useDefaultCoreAssets` and don't pass a custom `coreAssets` array — DogePay-class contamination risk | None |
+
+## Usage
+
+```sh
+# Pure-static structural checks against coreAssets.json
+node scripts/audit/core-assets.js
+node scripts/audit/core-assets.js --chain=tempo --severity=high
+
+# On-chain symbol cross-check (needs RPC access)
+node scripts/audit/onchain-symbols.js                       # default chain set
+node scripts/audit/onchain-symbols.js --chain=ethereum
+node scripts/audit/onchain-symbols.js --chains=ethereum,bsc
+
+# Adapter-source scans (instant)
+node scripts/audit/dex-token-universe.js
+node scripts/audit/uni-tvl-no-whitelist.js
+```
+
+`AUDIT_JSON=1` on any script appends a JSON dump of the findings — convenient for piping into other tooling.
+
+## Findings these surfaced (cross-linked PRs)
+
+- `coreAssets.saga.tBTC` had an invalid EIP-55 checksum (a single character mis-cased). `ethers` v6 rejects this on `getAddress`/`encodeFunctionData`, which silently breaks any `multiCall` path that touches the address.
+- `projects/archly-finance/index.js` had `seDefaultCoreAssets: true` (missing the `u`) on two of its nine chain blocks. JavaScript silently dropped the unknown key, leaving `useDefaultCoreAssets` at its `false` default, and the core-asset whitelist was never applied for those chains.
+
+## What these scripts deliberately don't do
+
+These scripts catch *shape* bugs, not *value* bugs. Detecting that a TVL number is wrong by 30 % is the spike detector's job — it has access to historical series and protocol-level baselines. These scripts can only tell you when something looks structurally implausible (wrong type, wrong format, wrong link) and let the human follow up.
+
+False-positive triage matters. The cross-chain symbol-mismatch and suspicious-name checks in particular surface a lot of *renamed tokens* (Polygon's MATIC→POL, Mento's cUSD→USDm, Tether's USDT→USD₮) where the address is correct and the only thing wrong is that the registry key now confuses readers. These are still findings worth knowing about, but they aren't TVL bugs — they're naming-debt.

--- a/scripts/audit/core-assets.js
+++ b/scripts/audit/core-assets.js
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+/**
+ * Structural audit of projects/helper/coreAssets.json.
+ *
+ * Catches "always-on" data bugs that DefiLlama's TVL spike detector cannot —
+ * because they don't manifest as a time-series anomaly, they're just wrong
+ * from day one (e.g. a wrong-decimals constant, a stale address, a copy-
+ * pasted entry from another chain). Spike detector watches for changes;
+ * this watches for shapes.
+ *
+ * Phase 1 (this script, no RPC): JSON-only structural checks.
+ *   - Address checksum sanity (EIP-55 + length)
+ *   - Address re-use across chains via the same key (suspicious copy-paste)
+ *   - Symbol shadowing (same symbol mapped to different addresses on the
+ *     same chain via aliasing)
+ *   - Suspicious naming patterns (joke / scam / TEST / MOCK)
+ *   - Empty / placeholder addresses
+ *
+ * Phase 2 (separate script, optional RPC): on-chain reconciliation.
+ *   - balanceOf + decimals + symbol against on-chain truth
+ *
+ * Usage:
+ *   node scripts/audit-core-assets.js
+ *   node scripts/audit-core-assets.js --severity=high
+ *   node scripts/audit-core-assets.js --chain=tempo
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const CORE_ASSETS_PATH = path.join(__dirname, '..', '..', 'projects', 'helper', 'coreAssets.json');
+const data = JSON.parse(fs.readFileSync(CORE_ASSETS_PATH, 'utf-8'));
+
+// CLI flags
+const args = process.argv.slice(2);
+const filterChain = args.find(a => a.startsWith('--chain='))?.split('=')[1];
+const minSeverity = args.find(a => a.startsWith('--severity='))?.split('=')[1] || 'low';
+const SEVERITY_RANK = { low: 0, medium: 1, high: 2 };
+
+const findings = [];
+
+const flag = (severity, kind, chain, symbol, detail, evidence = {}) => {
+  findings.push({ severity, kind, chain, symbol, detail, evidence });
+};
+
+// ── EIP-55 checksum validation ─────────────────────────────────────────────
+// Lightweight EIP-55 re-implementation; avoids requiring ethers at script
+// load time. Returns the canonical checksummed form, or null on bad shape.
+const { keccak256 } = require('ethers');
+function checksum(addr) {
+  if (typeof addr !== 'string' || !/^0x[0-9a-fA-F]{40}$/.test(addr)) return null;
+  const lower = addr.toLowerCase().slice(2);
+  const hash = keccak256(Buffer.from(lower, 'utf-8')).slice(2);
+  let out = '0x';
+  for (let i = 0; i < lower.length; i++) {
+    out += parseInt(hash[i], 16) >= 8 ? lower[i].toUpperCase() : lower[i];
+  }
+  return out;
+}
+
+// ── EVM-only chain heuristic ───────────────────────────────────────────────
+// coreAssets contains both EVM and non-EVM (Solana, Sui, Cosmos, …). Only
+// run EIP-55 checks on EVM-shaped entries. Non-EVM addresses don't follow
+// 0x40-hex layout, so the regex above already filters them out — but we
+// also skip checksum reporting on them to avoid noise.
+const isEvmAddress = a => typeof a === 'string' && /^0x[0-9a-fA-F]{40}$/.test(a);
+
+const SUSPICIOUS_NAME_PATTERNS = [
+  /^TEST_?/i, /^MOCK_?/i, /^FAKE_?/i, /^DEMO_?/i,
+  /DOGE/i, /SHIB/i, /PEPE/i, /INU(?!ity)/i,
+  /EXPLOIT/i, /SCAM/i, /HACK/i,
+  /^XYZ/i, /^ABC/i, /^123/i,
+];
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+const PLACEHOLDER_PATTERNS = [
+  /^0x0{40}$/, /^0x[fF]{40}$/, /^0xdead/i, /^0xbeef0{36}$/i,
+];
+
+// ── Cross-chain address re-use index ───────────────────────────────────────
+// Same address appearing on multiple chains under the same logical symbol
+// is OK for tokens that are deployed deterministically (CREATE2). Same
+// address under DIFFERENT symbols across chains is a copy-paste smell.
+const addressIndex = new Map(); // lowercased address → [{chain, symbol}]
+
+// ── Run checks per chain ──────────────────────────────────────────────────
+for (const [chainOrKey, value] of Object.entries(data)) {
+  // Top-level non-chain keys (null, GAS_TOKEN_2 …) are sentinels, skip.
+  if (typeof value !== 'object' || value === null) continue;
+  if (filterChain && chainOrKey !== filterChain) continue;
+
+  const chain = chainOrKey;
+  const symbolsOnThisChain = new Map(); // canonical address → [symbol1, symbol2…]
+
+  for (const [symbol, address] of Object.entries(value)) {
+    // 1. Suspicious naming pattern in the symbol itself
+    for (const pat of SUSPICIOUS_NAME_PATTERNS) {
+      if (pat.test(symbol)) {
+        flag('medium', 'suspicious-symbol-name', chain, symbol,
+          `symbol matches suspicious pattern ${pat}`,
+          { address, pattern: pat.toString() });
+        break;
+      }
+    }
+
+    // 2. Placeholder / dead-default address values
+    if (typeof address === 'string') {
+      for (const pat of PLACEHOLDER_PATTERNS) {
+        if (pat.test(address) && symbol !== 'NULL' && symbol !== 'NULL_ADDRESS') {
+          flag('medium', 'placeholder-address', chain, symbol,
+            `address matches placeholder pattern ${pat}`,
+            { address });
+          break;
+        }
+      }
+    }
+
+    // 3. EVM EIP-55 checksum (skip non-EVM)
+    if (isEvmAddress(address)) {
+      const expected = checksum(address);
+      // Allow either checksummed or all-lowercase (the established
+      // convention in coreAssets.json — most entries are lowercase).
+      const isAllLower = address === address.toLowerCase();
+      const isProperChecksum = address === expected;
+      if (!isAllLower && !isProperChecksum) {
+        flag('high', 'bad-checksum', chain, symbol,
+          'EIP-55 checksum is invalid (mixed case but does not validate)',
+          { address, expected });
+      }
+
+      // 4. Cross-chain address re-use bookkeeping
+      const lower = address.toLowerCase();
+      if (!addressIndex.has(lower)) addressIndex.set(lower, []);
+      addressIndex.get(lower).push({ chain, symbol });
+
+      // 5. Same address mapped to multiple symbols on the SAME chain
+      const sameAddrEntries = symbolsOnThisChain.get(lower) || [];
+      sameAddrEntries.push(symbol);
+      symbolsOnThisChain.set(lower, sameAddrEntries);
+    }
+  }
+
+  // Emit "duplicate within chain" findings after the per-chain loop
+  for (const [addr, syms] of symbolsOnThisChain) {
+    if (syms.length > 1) {
+      flag('low', 'duplicate-within-chain', chain, syms.join(','),
+        `${syms.length} symbols on ${chain} all point to ${addr}`,
+        { address: addr, symbols: syms });
+    }
+  }
+}
+
+// ── Cross-chain duplicate analysis ────────────────────────────────────────
+for (const [addr, entries] of addressIndex) {
+  if (entries.length <= 1) continue;
+  const distinctSymbols = new Set(entries.map(e => e.symbol));
+  if (distinctSymbols.size > 1) {
+    // Same address on multiple chains carrying DIFFERENT symbols —
+    // copy-paste smell.
+    flag('medium', 'cross-chain-symbol-mismatch',
+      entries.map(e => e.chain).join(','),
+      [...distinctSymbols].join(' / '),
+      `address ${addr} appears under ${distinctSymbols.size} distinct symbols across chains`,
+      { address: addr, occurrences: entries });
+  }
+}
+
+// ── Output ────────────────────────────────────────────────────────────────
+const ranked = findings
+  .filter(f => SEVERITY_RANK[f.severity] >= SEVERITY_RANK[minSeverity])
+  .sort((a, b) => SEVERITY_RANK[b.severity] - SEVERITY_RANK[a.severity]);
+
+console.log(`Scanned ${Object.keys(data).length} top-level keys, ${addressIndex.size} unique EVM addresses`);
+console.log(`Findings: ${ranked.length} (filtered to severity >= ${minSeverity})`);
+console.log();
+
+const grouped = {};
+for (const f of ranked) {
+  grouped[f.kind] ??= [];
+  grouped[f.kind].push(f);
+}
+for (const [kind, items] of Object.entries(grouped)) {
+  console.log(`── ${kind} (${items.length}) ──`);
+  for (const f of items.slice(0, 20)) {
+    console.log(`  [${f.severity}] ${f.chain} :: ${f.symbol}`);
+    console.log(`     ${f.detail}`);
+    if (f.evidence.address) console.log(`     address: ${f.evidence.address}`);
+    if (f.evidence.expected) console.log(`     expected: ${f.evidence.expected}`);
+  }
+  if (items.length > 20) console.log(`  … +${items.length - 20} more`);
+  console.log();
+}
+
+if (process.env.AUDIT_JSON) {
+  console.log('--- JSON OUTPUT ---');
+  console.log(JSON.stringify(ranked, null, 2));
+}
+
+process.exit(ranked.some(f => f.severity === 'high') ? 1 : 0);

--- a/scripts/audit/dex-token-universe.js
+++ b/scripts/audit/dex-token-universe.js
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+/**
+ * Phase 3: DEX/AMM token-universe contamination scan.
+ *
+ * The DogePay class of bug: an adapter enumerates its token universe from
+ * a chain's *explorer* API (or factory event scrape) rather than a curated
+ * tokenlist registry, ends up summing TVL contributions from joke / scam /
+ * exploit tokens whose `totalSupply()` is huge but whose price is null,
+ * and over-states protocol TVL by orders of magnitude.
+ *
+ * This script flags candidate adapters for manual review:
+ *   - reads each project file under projects/
+ *   - searches for explorer / scan / api3 token-list fetches as the
+ *     SOURCE of the token universe (not just metadata enrichment)
+ *   - notes patterns that historically corresponded to bug findings:
+ *       * fetching from explorer.<chain>.{xyz,fun,io}/api?...
+ *       * iterating factory createPair logs and counting all returned tokens
+ *       * "use any token with non-zero balance" loops
+ *
+ * Heuristics, not proofs — output is a triage list, not auto-bug-reports.
+ *
+ * Usage:
+ *   node scripts/audit-dex-token-universe.js
+ *   node scripts/audit-dex-token-universe.js --pattern=explorer
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const PROJECTS_ROOT = path.join(__dirname, '..', '..', 'projects');
+
+const SUSPICIOUS_PATTERNS = [
+  {
+    name: 'explorer-token-list-fetch',
+    severity: 'high',
+    description: 'adapter sources its token universe from a generic explorer API — this enumerates EVERY token on the chain, including joke/scam tokens',
+    regexes: [
+      /explorer\.[a-z0-9._-]+\.(xyz|com|io|fun|app)\/api[?\/]/i,
+      /scan\.[a-z0-9._-]+\.(xyz|com|io|fun|app)\/api[?\/]/i,
+      /\/api\?module=account&action=tokenlist/i,
+      /\/api\/v[12]\/tokens(?!\/list\/)/i,
+    ],
+  },
+  {
+    name: 'factory-pair-enumeration',
+    severity: 'medium',
+    description: 'pair/pool universe sourced by enumerating ALL factory events (no whitelist) — incoming joke pairs leak into TVL',
+    regexes: [
+      /allPairs\(.*\)/,
+      /allPairsLength/,
+      /getPair\([^)]*\)\.flat/,
+    ],
+  },
+  {
+    name: 'balance-of-anything',
+    severity: 'medium',
+    description: 'sums every token a treasury/operator address holds via off-chain index (any token whose `balanceOf` is non-zero) — junk dust tokens contribute',
+    regexes: [
+      /balance.*any\s*token/i,
+      /(?:portfolio|holdings)\s*:\s*await/i,
+      /tokens\s*=.*Set\(.*balances/i,
+    ],
+  },
+  {
+    name: 'unfiltered-multicall-totalSupply',
+    severity: 'medium',
+    description: 'reads totalSupply across a bulk token list with no decimals/name validation — bad-decimals tokens can over-contribute',
+    regexes: [
+      /erc20:totalSupply.*\.flat/,
+      /tokens\.map.*\{.*totalSupply.*decimals.*18/i,
+    ],
+  },
+];
+
+const OFFICIAL_TOKENLIST_HINTS = [
+  /tokenlist\.[a-z0-9.-]+\.(xyz|com|io)\/list\//i,
+  /tokens\.coingecko\.com/i,
+  /raw\.githubusercontent\.com.*tokenlist/i,
+  /tokens\.uniswap\.org/i,
+];
+
+const PROJECT_FILE_BLACKLIST = new Set([
+  'helper', 'sumTokens', // not project dirs in the proper sense
+]);
+
+const args = process.argv.slice(2);
+const filterPattern = args.find(a => a.startsWith('--pattern='))?.split('=')[1];
+
+function* walk(dir) {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) {
+      if (PROJECT_FILE_BLACKLIST.has(e.name)) continue;
+      yield* walk(full);
+    } else if (e.isFile() && /\.(js|ts)$/.test(e.name)) {
+      yield full;
+    }
+  }
+}
+
+const findings = [];
+let scanned = 0;
+
+for (const file of walk(PROJECTS_ROOT)) {
+  scanned++;
+  let content;
+  try { content = fs.readFileSync(file, 'utf-8'); } catch { continue; }
+  if (content.length > 200_000) continue; // skip very large generated bundles
+
+  // What we're looking for: an adapter that PULLS its token universe from
+  // an unsafe source. False-positive guard: if the same file ALSO references
+  // a curated tokenlist registry, treat it as already mitigated.
+  const usesCuratedSource = OFFICIAL_TOKENLIST_HINTS.some(h => h.test(content));
+
+  for (const pat of SUSPICIOUS_PATTERNS) {
+    if (filterPattern && pat.name !== filterPattern) continue;
+
+    for (const rx of pat.regexes) {
+      const m = content.match(rx);
+      if (!m) continue;
+
+      // Hint: which line
+      const idx = content.indexOf(m[0]);
+      const line = content.slice(0, idx).split('\n').length;
+      const projectName = path.relative(PROJECTS_ROOT, file).split(path.sep).slice(0, 2).join('/');
+
+      findings.push({
+        severity: pat.severity,
+        kind: pat.name,
+        description: pat.description,
+        project: projectName,
+        file: path.relative(PROJECTS_ROOT, file),
+        line,
+        match: m[0].slice(0, 120),
+        usesCuratedSource,
+      });
+      break; // one match per pattern per file
+    }
+  }
+}
+
+console.log(`Scanned ${scanned} adapter files`);
+console.log(`Findings: ${findings.length}`);
+console.log();
+
+const grouped = {};
+for (const f of findings) {
+  grouped[f.kind] ??= [];
+  grouped[f.kind].push(f);
+}
+
+const SEV = { high: 2, medium: 1, low: 0 };
+const sortedKinds = Object.entries(grouped).sort(
+  (a, b) => SEV[b[1][0].severity] - SEV[a[1][0].severity]);
+
+for (const [kind, items] of sortedKinds) {
+  console.log(`── ${kind} (${items.length}) ──`);
+  console.log(`   ${items[0].description}`);
+  console.log();
+  // sort: those WITHOUT curated-source mitigation first
+  items.sort((a, b) => Number(a.usesCuratedSource) - Number(b.usesCuratedSource));
+  for (const f of items) {
+    const flag = f.usesCuratedSource ? '  ⚠ ' : '  ✗ ';
+    console.log(`${flag}[${f.severity}] ${f.project}  →  ${f.file}:${f.line}`);
+    console.log(`     ${f.match}`);
+    if (f.usesCuratedSource) {
+      console.log(`     (also references a curated tokenlist — likely already mitigated)`);
+    }
+  }
+  console.log();
+}
+
+if (process.env.AUDIT_JSON) {
+  console.log('--- JSON ---');
+  console.log(JSON.stringify(findings, null, 2));
+}

--- a/scripts/audit/onchain-symbols.js
+++ b/scripts/audit/onchain-symbols.js
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+/**
+ * Phase 2 audit: cross-checks coreAssets.json entries against on-chain
+ * `symbol()` calls.
+ *
+ * For each EVM chain in coreAssets, multicalls every entry's address for
+ * its on-chain `symbol()` and compares against the key. Flags:
+ *
+ *   - mismatch  : on-chain symbol differs (e.g. coreAssets says "USDC" but
+ *                 the contract is actually "USDT" — wrong-address bug)
+ *   - dead      : address has no contract code
+ *   - reverts   : contract has code but `symbol()` reverts (suspicious)
+ *
+ * Designed to run on a curated chain set (default top-by-TVL); pass
+ * --chain=<name> to scope. RPC reads via @defillama/sdk.
+ *
+ * Usage:
+ *   node scripts/audit-onchain-symbols.js
+ *   node scripts/audit-onchain-symbols.js --chain=ethereum
+ *   node scripts/audit-onchain-symbols.js --chains=ethereum,bsc,polygon
+ *   node scripts/audit-onchain-symbols.js --address=0x...   # single check
+ */
+
+const fs = require('fs');
+const path = require('path');
+const sdk = require('@defillama/sdk');
+
+const CORE_ASSETS_PATH = path.join(__dirname, '..', '..', 'projects', 'helper', 'coreAssets.json');
+const data = JSON.parse(fs.readFileSync(CORE_ASSETS_PATH, 'utf-8'));
+
+const args = process.argv.slice(2);
+const chainArg = args.find(a => a.startsWith('--chain='))?.split('=')[1];
+const chainsArg = args.find(a => a.startsWith('--chains='))?.split('=')[1];
+const singleAddress = args.find(a => a.startsWith('--address='))?.split('=')[1];
+
+// Curated default set: chains where bugs would have the highest impact.
+const DEFAULT_CHAINS = [
+  'ethereum', 'bsc', 'polygon', 'arbitrum', 'optimism', 'base',
+  'avax', 'fantom', 'gnosis', 'linea', 'scroll', 'mode',
+  'metis', 'celo', 'mantle', 'blast', 'manta', 'sei',
+];
+
+let chainsToCheck;
+if (singleAddress) {
+  chainsToCheck = [chainArg || 'ethereum'];
+} else if (chainArg) {
+  chainsToCheck = [chainArg];
+} else if (chainsArg) {
+  chainsToCheck = chainsArg.split(',').map(s => s.trim());
+} else {
+  chainsToCheck = DEFAULT_CHAINS;
+}
+
+// Symbols whose key shape we should NOT compare strictly against on-chain
+// `symbol()` — naming conventions in coreAssets diverge from contract names
+// for legitimate reasons (e.g. "WETH_1" in fuse, "ceUSDC" in moonbeam, "USDC_e").
+const KEY_NORMALIZE = key => key
+  .replace(/_OFT$/i, '')
+  .replace(/_e$/i, '.e')
+  .replace(/^ce/, '')
+  .replace(/_\d+$/i, '')
+  .replace(/_OLD$/i, '')
+  .replace(/_NEW$/i, '')
+  .toUpperCase();
+
+const isEvmAddress = a => typeof a === 'string' && /^0x[0-9a-fA-F]{40}$/.test(a) && !/^0x[0fF]{40}$/.test(a);
+
+const findings = [];
+
+async function auditChain(chain) {
+  const entries = data[chain];
+  if (!entries || typeof entries !== 'object') return;
+
+  const items = Object.entries(entries)
+    .filter(([_, v]) => isEvmAddress(v))
+    .map(([k, v]) => ({ key: k, address: v }));
+
+  if (singleAddress) {
+    items.length = 0;
+    items.push({ key: '?', address: singleAddress });
+  }
+
+  if (!items.length) return;
+
+  console.log(`▸ ${chain}: ${items.length} EVM tokens to audit…`);
+
+  // Read symbol() with permitFailure so reverts surface
+  let res;
+  try {
+    res = await sdk.api.abi.multiCall({
+      chain,
+      abi: 'erc20:symbol',
+      calls: items.map(i => ({ target: i.address })),
+      permitFailure: true,
+    });
+  } catch (e) {
+    console.log(`  ✗ ${chain}: multiCall failed: ${e.message?.slice(0, 100)}`);
+    return;
+  }
+
+  // Also read code presence in batches via getCodeBatch (sdk has eth.getCode)
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    const result = res.output[i];
+    if (!result.success) {
+      // Could be no-code (dead) or reverting symbol(). Distinguish by getting code.
+      let isDead = false;
+      try {
+        const code = await sdk.api.eth.getCode({ chain, target: item.address });
+        isDead = !code || code === '0x';
+      } catch (_) {}
+      findings.push({
+        severity: 'high',
+        kind: isDead ? 'dead-contract' : 'symbol-reverts',
+        chain,
+        key: item.key,
+        address: item.address,
+        detail: isDead
+          ? 'address has no contract code on-chain'
+          : 'contract exists but symbol() reverts',
+      });
+      continue;
+    }
+    const onChainSymbol = String(result.output || '').trim();
+    if (!onChainSymbol) {
+      findings.push({
+        severity: 'medium', kind: 'empty-symbol', chain,
+        key: item.key, address: item.address,
+        detail: 'symbol() returned empty string',
+      });
+      continue;
+    }
+    const normalizedKey = KEY_NORMALIZE(item.key);
+    const normalizedSym = onChainSymbol.toUpperCase().replace(/^W/, '').replace(/\.E$/, '');
+    const looselyMatches =
+      normalizedKey === onChainSymbol.toUpperCase() ||
+      normalizedKey === normalizedSym ||
+      ('W' + normalizedKey) === onChainSymbol.toUpperCase() ||
+      normalizedKey.includes(onChainSymbol.toUpperCase()) ||
+      onChainSymbol.toUpperCase().includes(normalizedKey);
+
+    if (!looselyMatches) {
+      findings.push({
+        severity: 'high', kind: 'symbol-mismatch', chain,
+        key: item.key, address: item.address,
+        detail: `coreAssets key "${item.key}" but on-chain symbol() returns "${onChainSymbol}"`,
+        evidence: { keyNormalized: normalizedKey, onChainSymbol },
+      });
+    }
+  }
+}
+
+(async () => {
+  for (const chain of chainsToCheck) {
+    await auditChain(chain).catch(e =>
+      console.log(`  ✗ ${chain}: ${e.message?.slice(0, 200)}`));
+  }
+
+  console.log();
+  console.log(`Findings: ${findings.length}`);
+  console.log();
+  const grouped = {};
+  for (const f of findings) {
+    grouped[f.kind] ??= [];
+    grouped[f.kind].push(f);
+  }
+  for (const [kind, items] of Object.entries(grouped)) {
+    console.log(`── ${kind} (${items.length}) ──`);
+    for (const f of items) {
+      console.log(`  [${f.severity}] ${f.chain} :: ${f.key}`);
+      console.log(`     ${f.detail}`);
+      console.log(`     address: ${f.address}`);
+    }
+    console.log();
+  }
+  if (process.env.AUDIT_JSON) {
+    console.log('--- JSON ---');
+    console.log(JSON.stringify(findings, null, 2));
+  }
+})();

--- a/scripts/audit/uni-tvl-no-whitelist.js
+++ b/scripts/audit/uni-tvl-no-whitelist.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/**
+ * Phase 4: find DEX/AMM adapters built on `getUniTVL` that DO NOT enable the
+ * core-asset whitelist. Default is `useDefaultCoreAssets = false`, which means
+ * EVERY pair token's balance contributes to TVL — same wide-open shape that
+ * caused the DogePay over-state on Tempo's stable-dex.
+ *
+ * Heuristic: adapter calls `getUniTVL({...})` AND we cannot find a sibling
+ * `useDefaultCoreAssets: true` AND a custom `coreAssets:` array isn't passed
+ * either. False positives possible (some adapters supply a custom whitelist
+ * that's hard to detect statically) — output is for triage.
+ */
+const fs = require('fs');
+const path = require('path');
+const PROJECTS_ROOT = path.join(__dirname, '..', '..', 'projects');
+
+function* walk(dir) {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) yield* walk(full);
+    else if (/\.(js|ts)$/.test(e.name)) yield full;
+  }
+}
+
+const findings = [];
+
+for (const file of walk(PROJECTS_ROOT)) {
+  let c;
+  try { c = fs.readFileSync(file, 'utf-8'); } catch { continue; }
+  if (!/getUniTVL\s*\(/.test(c)) continue;
+
+  // For each getUniTVL call, capture the argument block and check
+  const re = /getUniTVL\s*\(\s*\{([^}]+)\}\s*\)/g;
+  let m;
+  while ((m = re.exec(c))) {
+    const args = m[1];
+    const hasWhitelist = /useDefaultCoreAssets\s*:\s*true/.test(args);
+    const hasCustomCoreAssets = /\bcoreAssets\s*:/.test(args);
+    if (!hasWhitelist && !hasCustomCoreAssets) {
+      const idx = m.index;
+      const line = c.slice(0, idx).split('\n').length;
+      const project = path.relative(PROJECTS_ROOT, file).split(path.sep).slice(0, 1)[0];
+      findings.push({
+        project, file: path.relative(PROJECTS_ROOT, file), line,
+        snippet: m[0].slice(0, 200),
+      });
+    }
+  }
+}
+
+console.log(`Adapters with getUniTVL but no whitelist: ${findings.length}`);
+console.log();
+for (const f of findings) {
+  console.log(`✗ ${f.project}  →  ${f.file}:${f.line}`);
+  console.log(`   ${f.snippet}`);
+  console.log();
+}


### PR DESCRIPTION
## Summary

Adds five small Node scripts under `scripts/audit/` that complement DefiLlama's existing TVL spike detector (`defillama-server/defi/src/api2/scripts/tvlSpikeDetector.ts`).

The spike detector watches for **changes** in TVL — anomalies relative to a protocol's recent history. These scripts watch for **shapes** — always-on data bugs that don't manifest as a spike because they were already present at day-zero. Two real bugs in this repo surfaced while developing them; fix PRs are cross-linked at the bottom.

## Scripts

| Script | What it checks | Network calls |
|--------|----------------|---------------|
| `core-assets.js` | Static checks against `projects/helper/coreAssets.json`: EIP-55 checksum sanity, placeholder addresses, suspicious symbol names, cross-chain symbol/address mismatch | None |
| `onchain-symbols.js` | RPC `symbol()` for every EVM entry vs its key — finds renamed tokens, dead contracts, wrong-address bugs | RPC multicall per chain |
| `dex-token-universe.js` | Greps adapter source for risky token-universe sources (explorer APIs, unfiltered factory enumeration, balance-of-anything loops) | None |
| `uni-tvl-no-whitelist.js` | `getUniTVL({...})` calls that don't enable `useDefaultCoreAssets` and don't pass a custom `coreAssets` array — the DogePay class | None |

## Sample output

```sh
$ node scripts/audit/core-assets.js --severity=high
Scanned 357 top-level keys, 1464 unique EVM addresses
Findings: 1 (filtered to severity >= high)

── bad-checksum (1) ──
  [high] saga :: tBTC
     EIP-55 checksum is invalid (mixed case but does not validate)
     address: 0x7cF468a019C5bf734311D10C3a429bB504CAF3Ce
     expected: 0x7cF468a019C5bf734311D10C3a429bB504CAF3ce
```

```sh
$ node scripts/audit/uni-tvl-no-whitelist.js | head -5
Adapters with getUniTVL but no whitelist: 20

✗ archly-finance  →  archly-finance/index.js:40
   getUniTVL({ factory: ARCHLY_FACTORY_OTHER, seDefaultCoreAssets: true, hasStablePools: true, })
```

That second one is the kind of bug these scripts are aimed at — a single mistyped key (`seDefault…` instead of `useDefault…`) that JavaScript silently drops, causing the whitelist to fail closed for two of nine chain blocks. Spike detector won't fire because the value was always wrong; only a structural pass catches it.

## Why these and not just spike detection

| Anomaly shape | Spike detector catches? | Structural audit catches? | Example |
|---|---|---|---|
| TVL jumped 5× in one day | ✅ | ✅ | Polymarket V2 hallmark spike |
| Permanently overstates by 1e12 | ❌ | ✅ | A 6-decimal stable typed as 18 |
| Mixed-case checksum invalid | ❌ | ✅ | `saga.tBTC` (this repo) |
| Whitelist option mistyped | ❌ | ✅ | `archly-finance` (this repo) |
| Joke token in unfiltered universe | ❌ | ✅ | The Tempo `tempo-stable-dex` $1B+ DogePay overstate I fixed in #19015 |

Both passes are useful. They catch disjoint sets of bugs.

## Triage discipline

Many findings are not TVL bugs — they're naming-debt:

- Mento renamed Celo's cUSD to USDm at the same address; `coreAssets.celo.cUSD` still works but the on-chain `symbol()` returns `USDm`.
- Polygon's MATIC → POL rebrand left `WMATIC_2` resolving to a contract whose on-chain symbol is now `WPOL`.
- Tether started using `USD₮` / `USD₮0` for several bridged variants.

These show up in the symbol-mismatch report but the addresses are correct and adapters keep working. The README has a section explaining how to keep these out of triage.

## Fixes from these scripts (separate PRs)

- **`fix(coreAssets): correct saga.tBTC EIP-55 checksum`** — single character, but `ethers` v6 rejects the address from `getAddress` / `encodeFunctionData`, so any `multiCall` path touching it fails with the opaque `Bad encoding`. Surfaced by `core-assets.js`. (See [DefiLlama/defillama-sdk#217](https://github.com/DefiLlama/defillama-sdk/issues/217) for the SDK side of the same wrinkle.)
- **`fix(archly-finance): correct seDefaultCoreAssets typo`** — `seDefaultCoreAssets: true` (missing `u`) on the `base` and `bsc` blocks, which silently disabled the core-asset whitelist for those chains. Surfaced by `uni-tvl-no-whitelist.js`.

## Companion / context

- DogePay $1B+ overstate fix: [DefiLlama-Adapters#19015](https://github.com/DefiLlama/DefiLlama-Adapters/pull/19015) (the case that motivated the structural-audit angle)
- Tempo Mainnet integration set: [#19015](https://github.com/DefiLlama/DefiLlama-Adapters/pull/19015), [peggedassets-server#773](https://github.com/DefiLlama/peggedassets-server/pull/773), [dimension-adapters#6783](https://github.com/DefiLlama/dimension-adapters/pull/6783), [defillama-server#11916](https://github.com/DefiLlama/defillama-server/pull/11916)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive guide for structural audit scripts covering usage, examples, and findings from various validation checks.

* **New Features**
  * Four new audit scripts to detect address validation errors, on-chain symbol mismatches, unsafe token enumeration in DEX adapters, and missing configuration requirements across the protocol.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->