### PR TITLE
fix(archly-finance): correct seDefaultCoreAssets typo

### DIFF
--- a/projects/archly-finance/index.js
+++ b/projects/archly-finance/index.js
@@ -37,7 +37,7 @@ module.exports = {
         })
     },
     base: {
-        tvl: getUniTVL({ factory: ARCHLY_FACTORY_OTHER, seDefaultCoreAssets: true, hasStablePools: true, }),
+        tvl: getUniTVL({ factory: ARCHLY_FACTORY_OTHER, useDefaultCoreAssets: true, hasStablePools: true, }),
         staking: sumTokensExport({
             owner: "0x4c01dF6B9be381BA2a687D0ED5c40039dEEaf0a9",
             tokens: [ARCHLY_ARC_TOKEN_OTHER],
@@ -47,7 +47,7 @@ module.exports = {
         })
     },
     bsc: {
-        tvl: getUniTVL({ factory: ARCHLY_FACTORY_OTHER, seDefaultCoreAssets: true, hasStablePools: true, }),
+        tvl: getUniTVL({ factory: ARCHLY_FACTORY_OTHER, useDefaultCoreAssets: true, hasStablePools: true, }),
         staking: sumTokensExport({
             owner: ARCHLY_VE_TOKEN_OTHER,
             tokens: [ARCHLY_ARC_TOKEN_OTHER],


### PR DESCRIPTION
## Fix

Two-line typo correction in `projects/archly-finance/index.js`:

```diff
     base: {
-        tvl: getUniTVL({ factory: ARCHLY_FACTORY_OTHER, seDefaultCoreAssets: true, hasStablePools: true, }),
+        tvl: getUniTVL({ factory: ARCHLY_FACTORY_OTHER, useDefaultCoreAssets: true, hasStablePools: true, }),
…
     bsc: {
-        tvl: getUniTVL({ factory: ARCHLY_FACTORY_OTHER, seDefaultCoreAssets: true, hasStablePools: true, }),
+        tvl: getUniTVL({ factory: ARCHLY_FACTORY_OTHER, useDefaultCoreAssets: true, hasStablePools: true, }),
```

The `base` and `bsc` blocks were calling `getUniTVL` with a key spelt `seDefaultCoreAssets` (missing the leading `u`). The other seven chain blocks in the same file already use the correct `useDefaultCoreAssets`.

## Why it matters

`getUniTVL` (in `projects/helper/cache/uniswap.js`) destructures its options:

```js
function getUniTVL({ /*…*/ useDefaultCoreAssets = false, /*…*/ }) { … }
```

JavaScript silently discards the unknown key and `useDefaultCoreAssets` falls through to its `false` default. The branch in `getUniTVL` that resolves a whitelist becomes a no-op:

```js
if (!coreAssets && useDefaultCoreAssets)   // ← false, so skipped
  coreAssets = getCoreAssets(chain)
```

…which means TVL on Archly's `base` and `bsc` deployments was calculated by summing every pair token on those factories, not just core stablecoins / wrapped natives. This is the same wide-open shape that caused the DogePay $1B+ overstate on Tempo's stable-dex ([#19015](https://github.com/DefiLlama/DefiLlama-Adapters/pull/19015)).

## How it was found

[`scripts/audit/uni-tvl-no-whitelist.js`](https://github.com/DefiLlama/DefiLlama-Adapters/pull/19106) — a small static scan that finds every `getUniTVL({...})` call without `useDefaultCoreAssets: true` and without a custom `coreAssets:` array. Usually that's a deliberate choice (the adapter passes a `blacklistedTokens` array instead, or has a curated factory). The Archly hits stood out because the surrounding chain blocks in the same file passed the option correctly — only `base` and `bsc` had the typo.

```
$ node scripts/audit/uni-tvl-no-whitelist.js | head
Adapters with getUniTVL but no whitelist: 20

✗ archly-finance  →  archly-finance/index.js:40
   getUniTVL({ factory: ARCHLY_FACTORY_OTHER, seDefaultCoreAssets: true, hasStablePools: true, })

✗ archly-finance  →  archly-finance/index.js:50
   getUniTVL({ factory: ARCHLY_FACTORY_OTHER, seDefaultCoreAssets: true, hasStablePools: true, })
```

Audit framework: [#19106](https://github.com/DefiLlama/DefiLlama-Adapters/pull/19106). Companion fix: [`saga.tBTC` checksum](https://github.com/DefiLlama/DefiLlama-Adapters/pull/19107).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a TVL (Total Value Locked) computation configuration error affecting Base and BSC blockchain networks. This fix ensures accurate and reliable asset value calculations across these networks, improving the overall accuracy of TVL metrics and network statistics for better user visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->