### PR TITLE
feat: add Kittenswap (HyperEVM) TVL adapter

### DIFF
--- a/projects/kittenswap/index.js
+++ b/projects/kittenswap/index.js
@@ -1,0 +1,25 @@
+const { sumTokens2 } = require('../helper/unwrapLPs')
+const { getLogs } = require('../helper/cache/getLogs')
+
+// Kittenswap is an Algebra-based concentrated-liquidity DEX on HyperEVM.
+// TVL = sum of token balances in every liquidity pool ever created by the AlgebraFactory.
+// We discover pools by scanning `Pool` events emitted at deployment time.
+const FACTORY = '0x5f95E92c338e6453111Fc55ee66D4AafccE661A7'
+
+async function tvl(api) {
+  const logs = await getLogs({
+    api,
+    target: FACTORY,
+    eventAbi: 'event Pool(address indexed token0, address indexed token1, address pool)',
+    onlyArgs: true,
+    fromBlock: 1,
+  })
+  const ownerTokens = logs.map((log) => [[log.token0, log.token1], log.pool])
+  return sumTokens2({ api, ownerTokens, permitFailure: true })
+}
+
+module.exports = {
+  methodology:
+    'TVL is the sum of token balances held in all liquidity pools deployed by the Kittenswap AlgebraFactory on HyperEVM.',
+  hyperliquid: { tvl },
+}


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
Kittenswap

##### Twitter Link:
https://x.com/KittenswapHype

##### List of audit links if any:


##### Website Link:
https://kittenswap.finance

##### Logo (High resolution, will be shown with rounded borders):
https://kittenswap.finance/kitten-logo.png

##### Current TVL:
~$1.10M (per adapter), ~$1.23M (per Kittenswap UI at https://kittenswap.finance). The ~10% gap is expected price-feed and timing drift across 37 priced tokens.

##### Treasury Addresses (if the protocol has treasury):


##### Chain:
HyperEVM (Hyperliquid)

##### Coingecko ID:
https://www.coingecko.com/en/coins/kittenswap

##### Coinmarketcap ID:


##### Short Description (to be shown on DefiLlama):
Community-owned concentrated-liquidity DEX on HyperEVM, built on the Algebra framework.

##### Token address and ticker if any:
KITTEN — 0x618275f8efe54c2afa87bfb9f210a52f0ff89364

##### Category:
Dexes

##### Oracle Provider(s):
N/A — TVL is computed from on-chain token balances, no oracle dependency.

##### Implementation Details:
N/A.

##### Documentation/Proof:
https://docs.kittenswap.finance/tokenomics/deployed-contracts

##### forkedFrom:
Algebra

##### methodology:
Discovers every pool ever deployed by the AlgebraFactory (0x5f95E92c338e6453111Fc55ee66D4AafccE661A7) by scanning Pool events via DefiLlama-Adapters' cached getLogs helper, then sums on-chain balances of token0 and token1 held by each pool. permitFailure is enabled to tolerate non-standard tokens whose balanceOf reverts (their on-chain contribution is zero by definition).

##### Github org/user:


##### Does this project have a referral program?
No

---

### Validation
Tested locally with `node test.js projects/kittenswap/index.js`. Adapter discovers all pools and sums balances across 37 priced tokens (top: WHYPE $604k, USDC $138k, KITTEN $132k, USDT0 $66k, LHYPE $54k, UETH $40k…).

Local total: $1.10M  
UI total: $1.23M  
Drift: ~10% (price-feed and timing variance, expected)