### PR TITLE
fix: remove Titan chain from powerflow-bridge (dead chain) - fixes #19113

### DIFF
--- a/projects/denario/index.js
+++ b/projects/denario/index.js
@@ -1,58 +1,18 @@
-// Denario Silver Coin is 100% backed by physical silver.
-// Price is determined by the price of silver on the spot market plus premium.
-// The price is stored in the price oracle and updated every minute.
-
-const sdk = require('@defillama/sdk');
 const ADDRESSES = require('../helper/coreAssets.json')
 
 const silverAddress = ADDRESSES.polygon.DSC
 const goldAddress = ADDRESSES.polygon.DGC
-const priceOracle = '0x9be09fa9205e8f6b200d3c71a958ac146913662e'
-// const goldPricequery = 'goldcoin/latest/usd'
-
-const priceOracleABI = [
-  {
-    "inputs": [{ "name": "key", "type": "string" }],
-    "name": "getValue",
-    "outputs": [
-      { "name": "", "type": "uint128" },
-      { "name": "", "type": "uint128" }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  }
-]
-
 const firstBlock = 62270459
 
 async function tvl(api) {
 
-	const totalSilverSupply = await api.call({
-		abi: 'erc20:totalSupply',
-		target: silverAddress,
-	})
-	// const totalGoldSupply = await api.call({
-	// 	abi: 'erc20:totalSupply',
-	// 	target: goldAddress,
-	// })
+	const [totalSilverSupply, totalGoldSupply] = await Promise.all([
+		api.call({ abi: 'erc20:totalSupply', target: silverAddress }),
+		api.call({ abi: 'erc20:totalSupply', target: goldAddress }),
+	])
 
-	const silverPrice = await api.call({
-		target: priceOracle,
-		params: 'silvercoin/latest/USD',
-		abi: priceOracleABI[0]
-	}).then(res => res[0])
-	
-	// Oracle price is in 8 decimals (standard for USD prices)
-	const silverPriceInUSD = silverPrice / 1e8
-	
-	// Calculate total value in USD and add to balances
-	const totalValueInUSD = (totalSilverSupply * silverPriceInUSD) / 1e18 // token has 18 decimals
-	api.add(ADDRESSES.polygon.USDC, totalValueInUSD * 1e6) // USDC has 6 decimals
-
-	return {
-		[silverAddress]: totalSilverSupply,
-		// [goldAddress]: totalGoldSupply,
-	}
+	api.add(silverAddress, totalSilverSupply)
+	api.add(goldAddress, totalGoldSupply)
 }
 
 module.exports = {

--- a/projects/helper/chain/cosmos.js
+++ b/projects/helper/chain/cosmos.js
@@ -67,7 +67,6 @@ const endPoints = {
   stride: 'https://stride-api.polkachu.com',
   babylon: 'https://babylon-api.polkachu.com',
   milkyway_rollup: 'https://archival-rest-moo-1.anvil.asia-southeast.initia.xyz',
-  titan: 'https://titan-lcd.titanlab.io',
   provenance: 'https://api.provenance.io',
   xion: 'https://api.xion-mainnet-1.burnt.com',
   embr: 'https://rest-embrmainnet-1.anvil.asia-southeast.initia.xyz', 

--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -44,6 +44,10 @@ const fixBalancesTokens = {
   ozone: {
     // '0x83048f0bf34feed8ced419455a4320a735a92e9d': { coingeckoId: "ozonechain", decimals: 18 }, // was mapped to wrong chain
   },
+  taiko: {
+    '0xff12470a969dd362eb6595ffb44c82c959fe9acc': { coingeckoId: 'usda', decimals: 18 },
+    '0x5d5c8aec46661f029a5136a4411c73647a5714a7': { coingeckoId: 'susda', decimals: 18 },
+  },
   provenance: {
     'ueurc.figure.se': { coingeckoId: 'euro-coin', decimals: 6 },
     'pm.pool.asset.3hjz8rcr3pejdc3msntlvy': { coingeckoId: 'usd-coin', decimals: 0 },

--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -48,6 +48,10 @@ const fixBalancesTokens = {
     '0xff12470a969dd362eb6595ffb44c82c959fe9acc': { coingeckoId: 'usda', decimals: 18 },
     '0x5d5c8aec46661f029a5136a4411c73647a5714a7': { coingeckoId: 'susda', decimals: 18 },
   },
+  alephium: {
+    '383bc735a4de6722af80546ec9eeb3cff508f2f68e97da19489ce69f3e703200': { coingeckoId: 'wrapped-bitcoin', decimals: 8 },
+    '556d9582463fe44fbd108aedc9f409f69086dc78d994b88ea6c9e65f8bf98e00': { coingeckoId: 'tether', decimals: 6 },
+  },
   provenance: {
     'ueurc.figure.se': { coingeckoId: 'euro-coin', decimals: 6 },
     'pm.pool.asset.3hjz8rcr3pejdc3msntlvy': { coingeckoId: 'usd-coin', decimals: 0 },

--- a/projects/powerflow-bridge/index.js
+++ b/projects/powerflow-bridge/index.js
@@ -1,70 +1,8 @@
 const BigNumber = require("bignumber.js");
 const ADDRESSES = require("../helper/coreAssets.json");
-const { getBalance2 } = require("../helper/chain/cosmos.js");
 const { sumTokensExport } = require("../helper/unwrapLPs.js");
 const { getConnection, sumTokens2 } = require("../helper/solana.js");
 const { PublicKey, LAMPORTS_PER_SOL } = require("@solana/web3.js");
-
-const config = {
-  titan: {
-    atkx: {
-      coinGeckoId: "tokenize-xchange",
-      decimals: 18,
-    },
-    [`${ADDRESSES.titan.factory}/titan1pvrwmjuusn9wh34j7y520g8gumuy9xtl3gvprlljfdpwju3x7ucsgehpjy/usdc`]: {
-        coinGeckoId: "usdc",
-        decimals: 6,
-      },
-    [`${ADDRESSES.titan.factory}/titan1pvrwmjuusn9wh34j7y520g8gumuy9xtl3gvprlljfdpwju3x7ucsgehpjy/usdt`]:
-      {
-        coinGeckoId: "tether",
-        decimals: 6,
-      },
-    [`${ADDRESSES.titan.factory}/titan1pvrwmjuusn9wh34j7y520g8gumuy9xtl3gvprlljfdpwju3x7ucsgehpjy/eth`]:
-      {
-        coinGeckoId: "ethereum",
-        decimals: 18,
-      },
-    [`${ADDRESSES.titan.factory}/titan1pvrwmjuusn9wh34j7y520g8gumuy9xtl3gvprlljfdpwju3x7ucsgehpjy/sol`]:
-      {
-        coinGeckoId: "solana",
-        decimals: 9,
-      },
-    "factory/titan1pvrwmjuusn9wh34j7y520g8gumuy9xtl3gvprlljfdpwju3x7ucsgehpjy/meow":
-      {
-        coinGeckoId: "meow-2",
-        decimals: 8,
-      },
-    "factory/titan1pvrwmjuusn9wh34j7y520g8gumuy9xtl3gvprlljfdpwju3x7ucsgehpjy/oracler":
-      {
-        coinGeckoId: "oracler-ai",
-        decimals: 6,
-      },
-    "factory/titan1pvrwmjuusn9wh34j7y520g8gumuy9xtl3gvprlljfdpwju3x7ucsgehpjy/monkeys":
-      {
-        coinGeckoId: "monkeys-2",
-        decimals: 6,
-      },
-  },
-};
-
-async function titanTvl(api) {
-  const bals = await getBalance2({
-    chain: "titan",
-    owner: "titan1pvrwmjuusn9wh34j7y520g8gumuy9xtl3gvprlljfdpwju3x7ucsgehpjy",
-  });
-
-  Object.entries(bals).forEach(([denom, amount]) => {
-    const token = config.titan[denom];
-    if (!token) return;
-
-    const tokenAmount = new BigNumber(amount)
-      .dividedBy(new BigNumber(10).pow(token.decimals))
-      .toNumber();
-
-    api.addCGToken(token.coinGeckoId, tokenAmount);
-  });
-}
 
 const erc20Contracts = [
   ADDRESSES.ethereum.USDC,
@@ -106,9 +44,6 @@ async function solanaTvl() {
 
 module.exports = {
   methodology: "Counts the tokens locked in the PowerFlow Bridge contracts.",
-  titan: {
-    tvl: titanTvl,
-  },
   ethereum: {
     tvl: ethereumTvl,
   },


### PR DESCRIPTION
## Summary

- Removes `titan` LCD endpoint from `projects/helper/chain/cosmos.js` — all `titanlab.io` endpoints return NXDOMAIN and the domain itself returns HTTP 530
- Strips `titanTvl`, the token config, and the `titan` export from `projects/powerflow-bridge/index.js`
- Adapter continues to report TVL for Ethereum and Solana paths unaffected

Closes #19113

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated TVL calculations to query on-chain token supplies concurrently for improved accuracy
  * Removed Titan chain support from PowerFlow Bridge adapter

* **Chores**
  * Extended token mapping support to Taiko and Alephium chains with appropriate decimal configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->