### PR TITLE
Create index.js

### DIFF
--- a/projects/mixymon/index.js
+++ b/projects/mixymon/index.js
@@ -1,0 +1,34 @@
+// MixyMon — privacy pool dApp on Monad mainnet (chainId 143).
+//
+// Each pool is a fixed-denomination, Tornado-style shielded pool that holds
+// only native MON: deposits require msg.value == denomination, withdrawals
+// pay out via low-level call{value: ...}. There are no ERC-20s, LP tokens,
+// or derivatives in any pool, so TVL is the sum of native MON held by the
+// four pool contracts.
+
+const POOLS = [
+  '0xE5f5d328f8C4e46578011F88B5c6a52c914e4f80', //     200 MON pool
+  '0xDb51fe0b98928E52F7C4a928C24F43823D2450CA', //   2,000 MON pool
+  '0xb714968DBf9662c9eAbD556dABf6B1c50d4b0e0e', //  20,000 MON pool
+  '0xEF724039825DE7D9E71081C0663E2A73554c904B', // 200,000 MON pool
+];
+
+async function tvl(api) {
+  const balances = await Promise.all(
+    POOLS.map((target) => api.getBalance({ target }))
+  );
+  balances.forEach((bal) => api.addGasToken(bal));
+}
+
+module.exports = {
+  methodology:
+    'Sum of native MON held by the four MixyMon privacy pool contracts on Monad mainnet (200, 2,000, 20,000, and 200,000 MON fixed-denomination shielded pools).',
+  // Earliest pool deploy: block 71,965,516 on Monad mainnet
+  // (2026-05-02T14:46:32Z). Before this timestamp every pool balance is 0.
+  start: 1777733192,
+  timetravel: true,
+  misrepresentedTokens: false,
+  monad: {
+    tvl,
+  },
+};


### PR DESCRIPTION
Adds a TVL adapter for MixyMon, a Tornado-style native-MON privacy pool dApp on Monad mainnet (chainId 143). Each of the 4 pool contracts holds only native MON, so TVL is computed as the sum of address(pool).balance across the four pools, on the monad chain key, via api.getBalance({ target }) + api.addGasToken(...) — same pattern as the existing Kintsu adapter.

I have enabled "Allow edits by maintainers" on this PR.

The adapter has no npm dependencies and pnpm-lock.yaml is unchanged.

## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):

MixyMon

##### Twitter Link:

https://x.com/MixyMonCom
https://x.com/MixyMonad

##### List of audit links if any:

None at this time. Will be added once an audit is complete.

##### Website Link:

https://mixymon.com

##### Logo (High resolution, will be shown with rounded borders):

https://mixymon.com/logo.png

##### Current TVL:

~600 MON at the time of submission. This will fluctuate continuously as users deposit and withdraw — the adapter computes it live from chain state.

##### Treasury Addresses (if the protocol has treasury)

Monad mainnet treasury (receives the 0.5% protocol fee on each withdrawal): 0xef0f9E681e79Bc1260A2d6D6a8713d455062010f

Note: this address holds protocol fee revenue, not locked user deposits. It is intentionally excluded from TVL — only native MON inside the four pool contracts is counted.

##### Chain:

Monad

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):

(leave empty — MixyMon does not have its own token)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):

(leave empty — MixyMon does not have its own token)

##### Short Description (to be shown on DefiLlama):

MixyMon is a Tornado-style privacy pool on Monad mainnet. Users deposit native MON in fixed denominations (200, 2,000, 20,000, or 200,000 MON) and withdraw to a fresh address using a zk-SNARK (Groth16) proof, with an optional relayer for first-withdrawal anonymity. A 0.5% protocol fee is routed to a treasury at withdrawal time.

##### Token address and ticker if any:

(none — MixyMon has no protocol token)

##### Category (full list at https://defillama.com/categories) *Please choose only one:

Privacy

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

None. The pools have no price-dependent logic — denominations are fixed at the contract level in native MON.

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

N/A — no oracle.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

N/A — no oracle.

##### forkedFrom (Does your project originate from another project):

Architecturally inspired by Tornado Cash but built as an independent codebase: fresh Solidity contracts, fresh circuits + trusted setup, fresh deployment. Not a literal fork of any existing repo.

##### methodology (what is being counted as tvl, how is tvl being calculated):

TVL = sum of native MON held by the four MixyMon pool contracts on Monad mainnet:

- 200 MON pool: 0xE5f5d328f8C4e46578011F88B5c6a52c914e4f80
- 2,000 MON pool: 0xDb51fe0b98928E52F7C4a928C24F43823D2450CA
- 20,000 MON pool: 0xb714968DBf9662c9eAbD556dABf6B1c50d4b0e0e
- 200,000 MON pool: 0xEF724039825DE7D9E71081C0663E2A73554c904B

Computed via api.getBalance per pool, summed via api.addGasToken. No ERC-20 balances, LP tokens, derivatives, staking positions, or treasury balances are included — only native deposits actively locked in the shielded pools.

Earliest pool deploy timestamp (start field in adapter): 1777733192 = 2026-05-02T14:46:32Z (Monad mainnet block 71,965,516).

##### Github org/user (Optional, if your code is open source, we can track activity):

(closed source for now)

##### Does this project have a referral program?

No.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MixyMon privacy pool dApp support for Monad mainnet with TVL calculation capabilities across multiple pool contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->