### PR TITLE
Add ParyonUSD (Bitcoin Cash, CDP)

### DIFF
--- a/projects/paryonusd/index.js
+++ b/projects/paryonusd/index.js
@@ -11,6 +11,9 @@ const REQUEST_TIMEOUT_MS = 10000;
 
 let requestIdCounter = 1;
 
+/**
+ * Create a JSON-RPC 2.0 request object for Electrum
+ */
 const createElectrumRequest = (method, params = [], id) => ({
   jsonrpc: '2.0',
   method,
@@ -18,6 +21,9 @@ const createElectrumRequest = (method, params = [], id) => ({
   id: id ?? requestIdCounter++,
 });
 
+/**
+ * Open a WebSocket connection to the Electrum server, resolving with the live socket.
+ */
 const connectElectrum = async () =>
   new Promise((resolve, reject) => {
     const ws = new WebSocket(ELECTRUM_WSS);
@@ -25,6 +31,9 @@ const connectElectrum = async () =>
     ws.on('error', (err) => reject(err));
   });
 
+/**
+ * Send an Electrum JSON-RPC request over the socket and resolve with its result, with a timeout.
+ */
 const sendElectrumRequest = (ws, request) =>
   new Promise((resolve, reject) => {
     const timeout = setTimeout(() => {
@@ -33,14 +42,20 @@ const sendElectrumRequest = (ws, request) =>
     }, REQUEST_TIMEOUT_MS);
 
     const messageHandler = (raw) => {
-      const response = JSON.parse(raw);
-      if (response.id !== request.id) return;
-      clearTimeout(timeout);
-      ws.off('message', messageHandler);
-      if (response.error) {
-        reject(new Error(`Electrum RPC error: ${response.error.message || JSON.stringify(response.error)}`));
-      } else {
-        resolve(response.result);
+      try {
+        const response = JSON.parse(raw);
+        if (response.id !== request.id) return;
+        clearTimeout(timeout);
+        ws.off('message', messageHandler);
+        if (response.error) {
+          reject(new Error(`Electrum RPC error: ${response.error.message || JSON.stringify(response.error)}`));
+        } else {
+          resolve(response.result);
+        }
+      } catch (err) {
+        clearTimeout(timeout);
+        ws.off('message', messageHandler);
+        reject(err);
       }
     };
     ws.on('message', messageHandler);
@@ -48,6 +63,9 @@ const sendElectrumRequest = (ws, request) =>
     ws.send(JSON.stringify(request) + '\n');
   });
 
+/**
+ * Sum BCH satoshis locked across all active loan UTXOs at the loan contract address.
+ */
 const fetchCollateralSats = async (ws) => {
   // Fulcrum: "include_tokens" populates token_data on returned UTXOs
   const request = createElectrumRequest('blockchain.address.listunspent', [LOAN_CONTRACT_ADDRESS, 'include_tokens']);
@@ -62,6 +80,9 @@ const fetchCollateralSats = async (ws) => {
   return loanUtxos.reduce((sum, utxo) => sum + utxo.value, 0);
 };
 
+/**
+ * DefiLlama TVL entrypoint: returns total BCH collateral locked in ParyonUSD.
+ */
 async function tvl() {
   let ws = null;
   try {

--- a/projects/paryonusd/index.js
+++ b/projects/paryonusd/index.js
@@ -1,0 +1,87 @@
+const WebSocket = require('ws');
+
+// ParyonUSD mainnet-v1 deployment constants
+// Each active loan UTXO holds a mutable-capability NFT with the paryonUSD tokenID category together with the BCH collateral
+const LOAN_CONTRACT_ADDRESS = 'bitcoincash:pv8zrfxplp50apvppy5ku5mjp3gqgkp94dvwf82lg0st4ptk5agfyrtpjvf8a';
+const PARYON_TOKEN_ID = '2469acc5afa4b10cb5b5c04afb89c3a3ffd61c5da9c01e26d00951cae2a02544';
+
+// Public Fulcrum Electrum server with CashTokens support
+const ELECTRUM_WSS = 'wss://electrum.imaginary.cash:50004';
+const REQUEST_TIMEOUT_MS = 10000;
+
+let requestIdCounter = 1;
+
+const createElectrumRequest = (method, params = [], id) => ({
+  jsonrpc: '2.0',
+  method,
+  params,
+  id: id ?? requestIdCounter++,
+});
+
+const connectElectrum = async () =>
+  new Promise((resolve, reject) => {
+    const ws = new WebSocket(ELECTRUM_WSS);
+    ws.on('open', () => resolve(ws));
+    ws.on('error', (err) => reject(err));
+  });
+
+const sendElectrumRequest = (ws, request) =>
+  new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      ws.off('message', messageHandler);
+      reject(new Error(`Electrum RPC timed out for id ${request.id}`));
+    }, REQUEST_TIMEOUT_MS);
+
+    const messageHandler = (raw) => {
+      const response = JSON.parse(raw);
+      if (response.id !== request.id) return;
+      clearTimeout(timeout);
+      ws.off('message', messageHandler);
+      if (response.error) {
+        reject(new Error(`Electrum RPC error: ${response.error.message || JSON.stringify(response.error)}`));
+      } else {
+        resolve(response.result);
+      }
+    };
+    ws.on('message', messageHandler);
+
+    ws.send(JSON.stringify(request) + '\n');
+  });
+
+const fetchCollateralSats = async (ws) => {
+  // Fulcrum: "include_tokens" populates token_data on returned UTXOs
+  const request = createElectrumRequest('blockchain.address.listunspent', [LOAN_CONTRACT_ADDRESS, 'include_tokens']);
+  const utxos = await sendElectrumRequest(ws, request);
+
+  // Active loans are marked by a mutable-capability NFT with the paryonUSD TokenID
+  const loanUtxos = utxos.filter(
+    (utxo) =>
+      utxo.token_data?.category === PARYON_TOKEN_ID &&
+      utxo.token_data?.nft?.capability === 'mutable'
+  );
+  return loanUtxos.reduce((sum, utxo) => sum + utxo.value, 0);
+};
+
+async function tvl() {
+  let ws = null;
+  try {
+    ws = await connectElectrum();
+    const collateralSats = await fetchCollateralSats(ws);
+    const totalCollateralBCH = collateralSats / 100_000_000;
+
+    return {
+      'bitcoin-cash': totalCollateralBCH,
+    };
+  } finally {
+    if (ws) ws.close();
+  }
+}
+
+module.exports = {
+  methodology:
+    'Sum BCH collateral across all active loan UTXOs at the ParyonUSD mainnet-v1 loan contract address (UTXOs holding a mutable-capability NFT with the paryonUSD tokenID category), via the Electrum protocol.',
+  timetravel: false,
+  bitcoincash: {
+    tvl,
+  },
+};

--- a/projects/paryonusd/index.js
+++ b/projects/paryonusd/index.js
@@ -1,108 +1,40 @@
 const WebSocket = require('ws');
 
-// ParyonUSD mainnet-v1 deployment constants
 // Each active loan UTXO holds a mutable-capability NFT with the paryonUSD tokenID category together with the BCH collateral
-const LOAN_CONTRACT_ADDRESS = 'bitcoincash:pv8zrfxplp50apvppy5ku5mjp3gqgkp94dvwf82lg0st4ptk5agfyrtpjvf8a';
+const LOAN_CONTRACT = 'bitcoincash:pv8zrfxplp50apvppy5ku5mjp3gqgkp94dvwf82lg0st4ptk5agfyrtpjvf8a';
 const PARYON_TOKEN_ID = '2469acc5afa4b10cb5b5c04afb89c3a3ffd61c5da9c01e26d00951cae2a02544';
-
-// Public Fulcrum Electrum server with CashTokens support
 const ELECTRUM_WSS = 'wss://electrum.imaginary.cash:50004';
-const REQUEST_TIMEOUT_MS = 10000;
+const TIMEOUT_MS = 10000;
 
-let requestIdCounter = 1;
-
-/**
- * Create a JSON-RPC 2.0 request object for Electrum
- */
-const createElectrumRequest = (method, params = [], id) => ({
-  jsonrpc: '2.0',
-  method,
-  params,
-  id: id ?? requestIdCounter++,
-});
-
-/**
- * Open a WebSocket connection to the Electrum server, resolving with the live socket.
- */
-const connectElectrum = async () =>
-  new Promise((resolve, reject) => {
+function electrumCall(method, params) {
+  return new Promise((resolve, reject) => {
     const ws = new WebSocket(ELECTRUM_WSS);
-    ws.on('open', () => resolve(ws));
-    ws.on('error', (err) => reject(err));
-  });
-
-/**
- * Send an Electrum JSON-RPC request over the socket and resolve with its result, with a timeout.
- */
-const sendElectrumRequest = (ws, request) =>
-  new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      ws.off('message', messageHandler);
-      reject(new Error(`Electrum RPC timed out for id ${request.id}`));
-    }, REQUEST_TIMEOUT_MS);
-
-    const messageHandler = (raw) => {
+    const timer = setTimeout(() => { ws.close(); reject(new Error(`Electrum timeout: ${method}`)); }, TIMEOUT_MS);
+    ws.on('open', () => ws.send(JSON.stringify({ jsonrpc: '2.0', method, params, id: 1 }) + '\n'));
+    ws.on('message', (raw) => {
+      clearTimeout(timer);
+      ws.close();
       try {
-        const response = JSON.parse(raw);
-        if (response.id !== request.id) return;
-        clearTimeout(timeout);
-        ws.off('message', messageHandler);
-        if (response.error) {
-          reject(new Error(`Electrum RPC error: ${response.error.message || JSON.stringify(response.error)}`));
-        } else {
-          resolve(response.result);
-        }
-      } catch (err) {
-        clearTimeout(timeout);
-        ws.off('message', messageHandler);
-        reject(err);
-      }
-    };
-    ws.on('message', messageHandler);
-
-    ws.send(JSON.stringify(request) + '\n');
+        const res = JSON.parse(raw);
+        res.error ? reject(new Error(res.error.message)) : resolve(res.result);
+      } catch (e) { reject(e); }
+    });
+    ws.on('error', (e) => { clearTimeout(timer); reject(e); });
   });
+}
 
-/**
- * Sum BCH satoshis locked across all active loan UTXOs at the loan contract address.
- */
-const fetchCollateralSats = async (ws) => {
-  // Fulcrum: "include_tokens" populates token_data on returned UTXOs
-  const request = createElectrumRequest('blockchain.address.listunspent', [LOAN_CONTRACT_ADDRESS, 'include_tokens']);
-  const utxos = await sendElectrumRequest(ws, request);
-
-  // Active loans are marked by a mutable-capability NFT with the paryonUSD TokenID
-  const loanUtxos = utxos.filter(
-    (utxo) =>
-      utxo.token_data?.category === PARYON_TOKEN_ID &&
-      utxo.token_data?.nft?.capability === 'mutable'
-  );
-  return loanUtxos.reduce((sum, utxo) => sum + utxo.value, 0);
-};
-
-/**
- * DefiLlama TVL entrypoint: returns total BCH collateral locked in ParyonUSD.
- */
 async function tvl() {
-  let ws = null;
-  try {
-    ws = await connectElectrum();
-    const collateralSats = await fetchCollateralSats(ws);
-    const totalCollateralBCH = collateralSats / 100_000_000;
-
-    return {
-      'bitcoin-cash': totalCollateralBCH,
-    };
-  } finally {
-    if (ws) ws.close();
-  }
+  // Active loans = UTXOs holding a mutable-capability NFT with the paryonUSD tokenID category
+  const utxos = await electrumCall('blockchain.address.listunspent', [LOAN_CONTRACT, 'include_tokens']);
+  if (!Array.isArray(utxos)) throw new Error('Electrum returned non-array UTXO list');
+  const loanSats = utxos
+    .filter(u => u.token_data?.category === PARYON_TOKEN_ID && u.token_data?.nft?.capability === 'mutable')
+    .reduce((sum, u) => sum + u.value, 0);
+  return { 'bitcoin-cash': loanSats / 1e8 };
 }
 
 module.exports = {
-  methodology:
-    'Sum BCH collateral across all active loan UTXOs at the ParyonUSD mainnet-v1 loan contract address (UTXOs holding a mutable-capability NFT with the paryonUSD tokenID category), via the Electrum protocol.',
+  methodology: 'Sum BCH collateral across all active loan UTXOs at the ParyonUSD mainnet-v1 loan contract (UTXOs marked by a mutable-capability NFT with the paryonUSD tokenID category), via the Electrum protocol.',
   timetravel: false,
-  bitcoincash: {
-    tvl,
-  },
+  bitcoincash: { tvl },
 };


### PR DESCRIPTION
## New Listing: ParyonUSD (Bitcoin Cash, CDP)
##### Name (to be shown on DefiLlama):

ParyonUSD

##### Twitter Link:

https://x.com/ParyonUSD

##### List of audit links if any:

https://sighash.xyz/audits/paryonusd.pdf (Sighash Labs, three-pass audit, final pass clean)

##### Website Link:

https://paryonusd.com/

##### Logo (High resolution, will be shown with rounded borders):

https://paryonusd.com/logo.svg (vector)
https://paryonusd.com/android-chrome-512x512.png (512×512 PNG, if a raster is preferred)

##### Current TVL:

~1,383 BCH (can cross-reference https://tokenaut.cash/defi for the live BCH TVL figure)

##### Treasury Addresses (if the protocol has treasury)

N/A

##### Chain:

Bitcoin Cash

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): 

N/A

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): 

N/A

##### Short Description (to be shown on DefiLlama):

ParyonUSD is a decentralized BCH-collateralized stablecoin protocol on Bitcoin Cash. Users borrow PUSD against BCH collateral, with delegated interest management, a stability pool for liquidations, and native staking on collected interest.

##### Token address and ticker if any:

`2469acc5afa4b10cb5b5c04afb89c3a3ffd61c5da9c01e26d00951cae2a02544` / PUSD

##### Category (full list at https://defillama.com/categories) \*Please choose only one:

CDP

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

General Protocols (USD/BCH price oracle, public key `02d09db08af1ff4e8453919cc866a4be427d7bfe18f2c05e5444c196fcf6fd2818`)

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

An on-chain price contract holds the current BCH/USD price as state. Anyone can update it by submitting a fresh signed oracle message from the General Protocols oracle, verified inside the contract via Schnorr signature checks against the oracle's public key (subject to heartbeat and deviation-threshold rules). Borrow, redeem, and liquidation transactions read the current price directly from the price contract's on-chain state.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

https://oracles.cash/oracles/02d09db08af1ff4e8453919cc866a4be427d7bfe18f2c05e5444c196fcf6fd2818
https://paryonusd.com/docs/technical/contract-verification

##### forkedFrom (Does your project originate from another project):

Not a fork. Liquity V2 is the closest design reference, but ParyonUSD is a from-scratch CashScript implementation adapted to Bitcoin Cash UTXOs and CashTokens.

##### methodology (what is being counted as tvl, how is tvl being calculated):

Sum BCH collateral across all active loan UTXOs at the ParyonUSD mainnet-v1 loan contract address (UTXOs holding a mutable-capability NFT with the paryonUSD tokenID category), via the Electrum protocol.

##### Github org/user (Optional, if your code is open source, we can track activity):

https://github.com/ParyonUSD

##### Does this project have a referral program?

No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Total Value Locked (TVL) tracking for ParyonUSD (mainnet-v1) on Bitcoin Cash, providing real-time visibility into protocol collateral holdings.
  * Aggregates collateral via an Electrum-based connection and reports totals in BCH.
  * Real-time only (no historical timetravel) and includes a methodology note explaining the aggregation approach.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19127?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->