### PR TITLE
anthias: add Morpho vault curator on Base

### DIFF
--- a/projects/anthias/index.js
+++ b/projects/anthias/index.js
@@ -1,0 +1,13 @@
+const { getCuratorExport } = require("../helper/curators");
+
+const configs = {
+  methodology: 'Count all assets deposited in all vaults curated by Anthias Labs.',
+  blockchains: {
+    base: {
+      morphoVaultOwners: [
+        '0x8b621804a7637b781e2BbD58e256a591F2dF7d51',
+      ],
+    },
+  }
+}
+module.exports = getCuratorExport(configs)

--- a/projects/anthias/index.js
+++ b/projects/anthias/index.js
@@ -4,8 +4,16 @@ const configs = {
   methodology: 'Count all assets deposited in all vaults curated by Anthias Labs.',
   blockchains: {
     base: {
-      morphoVaultOwners: [
-        '0x8b621804a7637b781e2BbD58e256a591F2dF7d51',
+      morpho: [
+        '0xa0E430870c4604CcfC7B38Ca7845B1FF653D0ff1',
+        '0xc1256Ae5FF1cf2719D4937adb3bbCCab2E00A2Ca',
+        '0x543257eF2161176D7C8cD90BA65C2d4CaEF5a796',
+        '0xf24608E0CCb972b0b0f4A6446a0BBf58c701a026',
+        '0xdbA76Bc542bb07538e046B40F2e8a215B409F7A8',
+        '0x89BeDBB1C4837444Da215A377275Ff96A84D6f53',
+        '0xbB2F06CeAE42CBcF5559Ed0713538c8892D977c9',
+        '0x5083b1387Ec3d4Ee6467B83890D98f1AF93F7c48',
+        '0x48a90E85be5C56b0A669985A12ee7C449fC79965',
       ],
     },
   }


### PR DESCRIPTION
Add a new TVL adapter for **Anthias Labs**, a DeFi risk management firm curating Morpho V2 vaults on Base.

---

##### Name (to be shown on DefiLlama):
Anthias Labs

##### Twitter Link:
https://x.com/anthiasxyz

##### List of audit links if any:

##### Website Link:
https://anthias.xyz

##### Logo (High resolution, will be shown with rounded borders):
https://avatars.githubusercontent.com/u/157551383?s=200&v=4

##### Current TVL:
~$25.93M (9 vaults on Base)

##### Treasury Addresses (if the protocol has treasury)

##### Chain:
Base

##### Coingecko ID:

##### Coinmarketcap ID:

##### Short Description (to be shown on DefiLlama):
Anthias Labs is a boutique on-chain advisory firm focused on DeFi risk management and system design.

##### Token address and ticker if any:

##### Category (full list at https://defillama.com/categories):
Risk Curators

##### Oracle Provider(s):

##### Implementation Details:

##### Documentation/Proof:

##### forkedFrom:

##### methodology:
Count all assets deposited in Morpho V2 vaults curated by Anthias Labs on Base.

##### Github org/user:
https://github.com/anthias-labs

##### Does this project have a referral program?
No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Anthias project configuration, including methodology metadata and Morpho network integration for vault/curator workflows, enabling the project to be surfaced and managed within the platform.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->