### PR TITLE
Fix Aquarius Stellar TVL adapter

### DIFF
--- a/projects/aqua-network/index.js
+++ b/projects/aqua-network/index.js
@@ -35,10 +35,15 @@ function pickClosestRow(rows, targetDate) {
   const exactMatch = sortedRows.find((row) => row.date === targetDate)
   if (exactMatch) return exactMatch
 
-  const priorRows = sortedRows.filter((row) => row.date < targetDate)
-  if (priorRows.length) return priorRows[priorRows.length - 1]
+  return sortedRows.reduce((closestRow, currentRow) => {
+    if (!closestRow) return currentRow
 
-  return sortedRows[0]
+    const closestDistance = Math.abs(new Date(closestRow.date).getTime() - new Date(targetDate).getTime())
+    const currentDistance = Math.abs(new Date(currentRow.date).getTime() - new Date(targetDate).getTime())
+
+    if (currentDistance < closestDistance) return currentRow
+    return closestRow
+  }, null)
 }
 
 async function tvl(api) {

--- a/projects/aqua-network/index.js
+++ b/projects/aqua-network/index.js
@@ -12,7 +12,6 @@ async function getData() {
   }
 
   const data = await _dataPromise
-  _dataPromise = null
   return Array.isArray(data) ? data : data?.results ?? data?.data ?? []
 }
 

--- a/projects/aqua-network/index.js
+++ b/projects/aqua-network/index.js
@@ -12,7 +12,14 @@ async function getData() {
   }
 
   const data = await _dataPromise
-  return Array.isArray(data) ? data : data?.results ?? data?.data ?? []
+  const rows = Array.isArray(data) ? data : data?.results ?? data?.data
+
+  if (!Array.isArray(rows)) {
+    _dataPromise = null
+    throw new Error(`Unexpected Aquarius API response shape: ${JSON.stringify(data).slice(0, 500)}`)
+  }
+
+  return rows
 }
 
 function formatUtcDate(unixTimestamp) {

--- a/projects/aqua-network/index.js
+++ b/projects/aqua-network/index.js
@@ -41,7 +41,12 @@ async function tvl(api) {
 
   if (!row) throw new Error('No Aquarius TVL rows returned by source API')
 
-  api.addCGToken('tether', Number(row.tvl) / 1e7)
+  const tvl = Number(row.tvl) / 1e7
+  if (!Number.isFinite(tvl)) {
+    throw new Error(`Invalid Aquarius TVL value for ${row.date}: ${row.tvl}`)
+  }
+
+  api.addCGToken('tether', tvl)
 }
 
 module.exports = {

--- a/projects/aqua-network/index.js
+++ b/projects/aqua-network/index.js
@@ -1,34 +1,48 @@
 const { get } = require('../helper/http')
 const AQUA_STATS_URL = "https://amm-api.aqua.network/api/external/v1/statistics/totals/?size=all"
 
-let _data
+let _dataPromise = null
 
 async function getData() {
-  if (!_data)
-    _data = get(AQUA_STATS_URL)
-  const data = await _data
-  const res = {}
-  data.forEach((item) => {
-    res[item.date] = item.tvl / 1e7
-  })
-  return res
+  if (_dataPromise === null) {
+    _dataPromise = get(AQUA_STATS_URL).catch((err) => {
+      _dataPromise = null
+      throw err
+    })
+  }
+
+  const data = await _dataPromise
+  _dataPromise = null
+  return Array.isArray(data) ? data : data?.results ?? data?.data ?? []
 }
 
-function formatUnixTimestamp(unixTimestamp) {
-  const date = new Date(unixTimestamp * 1000); // Convert Unix timestamp to milliseconds
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0'); // Months are zero-based
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
+function formatUtcDate(unixTimestamp) {
+  return new Date(unixTimestamp * 1000).toISOString().slice(0, 10)
+}
+
+function pickClosestRow(rows, targetDate) {
+  const sortedRows = rows
+    .filter((row) => row?.date && row?.tvl != null)
+    .slice()
+    .sort((a, b) => a.date.localeCompare(b.date))
+
+  const exactMatch = sortedRows.find((row) => row.date === targetDate)
+  if (exactMatch) return exactMatch
+
+  const priorRows = sortedRows.filter((row) => row.date < targetDate)
+  if (priorRows.length) return priorRows[priorRows.length - 1]
+
+  return sortedRows[0]
 }
 
 async function tvl(api) {
-  const key = formatUnixTimestamp(api.timestamp)
-  const allData = await getData()
-  const usdValue = allData[key]
-  if (!usdValue)
-    throw new Error('No data found for current date');
-  api.addCGToken('tether', usdValue)
+  const key = formatUtcDate(api.timestamp)
+  const rows = await getData()
+  const row = pickClosestRow(rows, key)
+
+  if (!row) throw new Error('No Aquarius TVL rows returned by source API')
+
+  api.addCGToken('tether', Number(row.tvl) / 1e7)
 }
 
 module.exports = {

--- a/projects/aqua-network/index.js
+++ b/projects/aqua-network/index.js
@@ -3,6 +3,26 @@ const AQUA_STATS_URL = "https://amm-api.aqua.network/api/external/v1/statistics/
 
 let _dataPromise = null
 
+const RESPONSE_PREVIEW_LIMIT = 500
+const RESPONSE_PREVIEW_KEY_LIMIT = 20
+const RESPONSE_PREVIEW_KEY_LENGTH = 40
+
+function getResponsePreview(data) {
+  if (typeof data === 'string') return data.slice(0, RESPONSE_PREVIEW_LIMIT)
+  if (data === null) return 'null'
+  if (Array.isArray(data)) return `array(length=${data.length})`
+  if (typeof data === 'object') {
+    const keys = []
+    for (const key in data) {
+      if (!Object.prototype.hasOwnProperty.call(data, key)) continue
+      keys.push(key.slice(0, RESPONSE_PREVIEW_KEY_LENGTH))
+      if (keys.length === RESPONSE_PREVIEW_KEY_LIMIT) break
+    }
+    return `object(keys=${keys})`
+  }
+  return String(data).slice(0, RESPONSE_PREVIEW_LIMIT)
+}
+
 async function getData() {
   if (_dataPromise === null) {
     _dataPromise = get(AQUA_STATS_URL).catch((err) => {
@@ -16,7 +36,7 @@ async function getData() {
 
   if (!Array.isArray(rows)) {
     _dataPromise = null
-    throw new Error(`Unexpected Aquarius API response shape: ${JSON.stringify(data).slice(0, 500)}`)
+    throw new Error(`Unexpected Aquarius API response shape: ${getResponsePreview(data)}`)
   }
 
   return rows

--- a/projects/aqua-network/index.js
+++ b/projects/aqua-network/index.js
@@ -26,32 +26,12 @@ function formatUtcDate(unixTimestamp) {
   return new Date(unixTimestamp * 1000).toISOString().slice(0, 10)
 }
 
-function pickClosestRow(rows, targetDate) {
-  const sortedRows = rows
-    .filter((row) => row?.date && row?.tvl != null)
-    .slice()
-    .sort((a, b) => a.date.localeCompare(b.date))
-
-  const exactMatch = sortedRows.find((row) => row.date === targetDate)
-  if (exactMatch) return exactMatch
-
-  return sortedRows.reduce((closestRow, currentRow) => {
-    if (!closestRow) return currentRow
-
-    const closestDistance = Math.abs(new Date(closestRow.date).getTime() - new Date(targetDate).getTime())
-    const currentDistance = Math.abs(new Date(currentRow.date).getTime() - new Date(targetDate).getTime())
-
-    if (currentDistance < closestDistance) return currentRow
-    return closestRow
-  }, null)
-}
-
 async function tvl(api) {
   const key = formatUtcDate(api.timestamp)
   const rows = await getData()
-  const row = pickClosestRow(rows, key)
+  const row = rows.find((entry) => entry?.date === key && entry?.tvl != null)
 
-  if (!row) throw new Error('No Aquarius TVL rows returned by source API')
+  if (!row) throw new Error(`No Aquarius TVL data found for ${key}`)
 
   const tvl = Number(row.tvl) / 1e7
   if (!Number.isFinite(tvl)) {


### PR DESCRIPTION
## Summary
Fix Aquarius Stellar TVL adapter to require an exact daily datapoint for the requested timestamp.

## Changes
- Keep UTC date formatting for daily key lookup
- Remove nearest-date fallback logic
- Throw an error when the current timestamp is missing from the source data
- Keep response-shape validation for Aquarius API payloads
- Keep TVL numeric validation before adding balances

## Validation
- Confirmed the adapter now uses exact-date matching only
- Confirmed missing daily data will throw instead of silently using an older/newer row
- Confirmed existing API response validation and finite TVL checks remain in place

Please enable "Allow edits by maintainers".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TVL fetching reliability by caching in-flight requests and resetting on HTTP failure
  * Stricter response validation, clearer errors for missing or non-finite TVL values
  * Fixed TVL parsing and scaling so reported values use the correct numeric conversion

* **New Features**
  * Accepts multiple server response shapes (top-level array or common wrappers) when reading TVL records

* **Chores**
  * Updated date formatting to match API UTC ISO format
<!-- end of auto-generated comment: release notes by coderabbit.ai -->