### PR TITLE
sky-money: add Morpho vault curator on Ethereum

### DIFF
--- a/projects/sky-money/index.js
+++ b/projects/sky-money/index.js
@@ -1,0 +1,20 @@
+const { getCuratorExport } = require("../helper/curators");
+
+const configs = {
+  methodology: 'Count all assets deposited in all vaults curated by Sky Money.',
+  blockchains: {
+    ethereum: {
+      morpho: [
+        '0x23f5E9c35820f4baB695Ac1F19c203cC3f8e1e11',
+        '0xE15fcC81118895b67b6647BBd393182dF44E11E0',
+        '0x56bfa6f53669B836D1E0Dfa5e99706b12c373ecf',
+        '0xf42bca228D9bd3e2F8EE65Fec3d21De1063882d4',
+        '0x2bD3A43863c07B6A01581FADa0E1614ca5DF0E3d'
+      ],
+      
+    },
+    
+  }
+}
+
+module.exports = getCuratorExport(configs)


### PR DESCRIPTION
## Track Sky Money as Morpho vault curator on Ethereum

Adds a TVL adapter for Sky Money, tracking assets deposited across all Morpho vaults curated by Sky Money on Ethereum.

### Vaults tracked (5)

| Address | Chain |
|---|---|
| `0x23f5E9c35820f4baB695Ac1F19c203cC3f8e1e11` | Ethereum |
| `0xE15fcC81118895b67b6647BBd393182dF44E11E0` | Ethereum |
| `0x56bfa6f53669B836D1E0Dfa5e99706b12c373ecf` | Ethereum |
| `0xf42bca228D9bd3e2F8EE65Fec3d21De1063882d4` | Ethereum |
| `0x2bD3A43863c07B6A01581FADa0E1614ca5DF0E3d` | Ethereum |

### Methodology

Count all assets deposited in all vaults curated by Sky Money, using the `getCuratorExport` helper with the Morpho protocol.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking Sky Money curated assets on Ethereum, including assets deposited in Morpho vaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->