### PR TITLE
Vena:  Add TVL

### DIFF
--- a/projects/vena/index.js
+++ b/projects/vena/index.js
@@ -16,20 +16,28 @@ const FLUENT_USDNR = `fluent:${USDNR_ADDRESS}`;
 //      key, which would have to live as an env var on DefiLlama's runner. We want
 //      this adapter to work out-of-the-box without secrets, so we price each reserve
 //      via DefiLlama's own coins API (and getSharePrice for sUSDnr) instead.
+function readPrice(pricesByToken, feed) {
+  const entry = pricesByToken[feed];
+  if (!entry) {
+    throw new Error(`vena: no price returned for "${feed}" from coins.llama.fi`);
+  }
+  return new BigNumber(entry.price);
+}
+
 const RESERVES = [
   {
     symbol: 'WETH',
     address: '0x927C469E58Daab257Ea60B2D8c37bEDD2a203A54',
     decimals: 18,
     priceFeed: MAINNET_WETH,
-    calculateUSDPrice: async (_, pricesByToken) => new BigNumber(pricesByToken[MAINNET_WETH].price),
+    calculateUSDPrice: async (_, pricesByToken) => readPrice(pricesByToken, MAINNET_WETH),
   },
   {
     symbol: 'USDnr',
     address: USDNR_ADDRESS,
     decimals: 6,
     priceFeed: FLUENT_USDNR,
-    calculateUSDPrice: async (_, pricesByToken) => new BigNumber(pricesByToken[FLUENT_USDNR].price),
+    calculateUSDPrice: async (_, pricesByToken) => readPrice(pricesByToken, FLUENT_USDNR),
   },
   {
     symbol: 'sUSDnr',
@@ -40,7 +48,7 @@ const RESERVES = [
     // USD price per sUSDnr = (sharePrice / 10^6) * USDnr_USD_price.
     calculateUSDPrice: async (api, pricesByToken) => {
       const sharePrice = await api.call({ target: SUSDNR_VAULT, abi: 'uint256:getSharePrice' });
-      const usdnrPrice = new BigNumber(pricesByToken[FLUENT_USDNR].price);
+      const usdnrPrice = readPrice(pricesByToken, FLUENT_USDNR);
       return new BigNumber(sharePrice.toString()).shiftedBy(-6).times(usdnrPrice);
     },
   },
@@ -80,6 +88,6 @@ async function tvl(api) {
 }
 
 module.exports = {
-  methodology: 'Total market size of the Vena lending pool on Fluent — sum of each reserve\'s aToken total supply (live, including accrued interest) priced via per-reserve calculateUSDPrice functions. WETH is priced via DefiLlama as mainnet WETH; USDnr is priced via the M^0 token on mainnet; sUSDnr is priced via getSharePrice() on its vault (denominated in USDnr) times the USDnr USD price.',
+  methodology: 'Total market size of the Vena lending pool on Fluent — sum of each reserve\'s aToken total supply (live, including accrued interest) priced via per-reserve calculateUSDPrice functions. WETH is priced via DefiLlama\'s coins API as mainnet WETH; USDnr is priced via DefiLlama\'s coins API directly on Fluent (fluent:USDNR_ADDRESS); sUSDnr is priced as getSharePrice() on its USDnr/sUSDnr vault (USDnr per share) times the USDnr USD price.',
   fluent: { tvl },
 };

--- a/projects/vena/index.js
+++ b/projects/vena/index.js
@@ -1,17 +1,21 @@
-// This adapter mirrors the shape of `aaveV3Export` in projects/helper/aave.js:
-// it discovers reserves via getAllReservesTokens, reads aTokenAddress per reserve
-// via getReserveTokensAddresses, and computes TVL as the underlying balance held
-// by each aToken plus a separate `borrowed` track from totalVariableDebt +
-// totalStableDebt. We can't use the helper directly because two of Vena's
-// reserves can't be priced by DefiLlama's coins API as `fluent:<address>`:
-//   - Fluent WETH is not listed (priced here as mainnet WETH instead)
+// This adapter is a thin wrapper over `aaveV3Export` from projects/helper/aave.js.
+// aaveV3Export handles all the AAVE V3 mechanics: discover reserves via
+// getAllReservesTokens, read aTokenAddress per reserve, sum balanceOf for TVL,
+// and sum totalVariableDebt + totalStableDebt for borrowed.
+//
+// We can't use the helper as-is because two of Vena's reserves can't be priced
+// by DefiLlama's coins API as `fluent:<address>`:
+//   - Fluent WETH is not listed (priced here as mainnet WETH instead).
 //   - sUSDnr is not listed and is not standard ERC4626 — no asset() /
-//     convertToAssets(); pricing requires a custom getSharePrice() * USDnr
-// So instead of delegating wholesale to aaveV3Export, we inline its mechanics
-// and add a PRICE_OVERRIDES dict that computes USD locally for those two
-// reserves while letting the remaining reserves flow through the default path.
+//     convertToAssets(); pricing requires a custom getSharePrice() * USDnr.
+// We avoid the protocol's AaveOracle directly: it's a Pyth Lazer pull oracle
+// that reverts whenever the on-chain payload is older than ~30s.
+//
+// Strategy: let aaveV3Export populate api.balances normally, then call
+// applyPriceOverrides() to swap the unpriceable raw balances for explicit
+// USD values computed from our own pricing.
 const { default: BigNumber } = require('bignumber.js');
-const { sumTokens2 } = require('../helper/unwrapLPs');
+const { aaveV3Export } = require('../helper/aave');
 const { fetchURL } = require('../helper/utils');
 
 const POOL_DATA_PROVIDER = '0xb6eEF266933382661827E36fE3f936396e80166E';
@@ -21,18 +25,8 @@ const USDNR_ADDRESS = '0xD48e565561416dE59DA1050ED70b8d75e8eF28f9';
 const MAINNET_WETH = 'ethereum:0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
 const FLUENT_USDNR = `fluent:${USDNR_ADDRESS}`;
 
-const abi = {
-  getAllReservesTokens: 'function getAllReservesTokens() view returns ((string symbol, address tokenAddress)[])',
-  getReserveTokensAddresses: 'function getReserveTokensAddresses(address asset) view returns (address aTokenAddress, address stableDebtTokenAddress, address variableDebtTokenAddress)',
-  getReserveData: 'function getReserveData(address asset) view returns (uint256 unbacked, uint256 accruedToTreasuryScaled, uint256 totalAToken, uint256 totalStableDebt, uint256 totalVariableDebt, uint256 liquidityRate, uint256 variableBorrowRate, uint256 stableBorrowRate, uint256 averageStableBorrowRate, uint256 liquidityIndex, uint256 variableBorrowIndex, uint40 lastUpdateTimestamp)',
-};
-
-// Reserves whose price cannot be resolved by DefiLlama's coins API as `fluent:<address>`.
-// For these we compute USD locally instead of feeding the raw balance into the price layer.
-// We avoid the protocol's AaveOracle directly: it is a Pyth Lazer pull oracle and reverts whenever
-// the on-chain payload is older than ~30s (most of the time, without an authenticated keeper).
 const PRICE_OVERRIDES = {
-  // Fluent WETH -> mainnet WETH price (Fluent WETH itself isn't listed on coins.llama.fi).
+  // Fluent WETH -> mainnet WETH price.
   ['0x927C469E58Daab257Ea60B2D8c37bEDD2a203A54'.toLowerCase()]: {
     decimals: 18,
     priceFeed: MAINNET_WETH,
@@ -49,78 +43,62 @@ const PRICE_OVERRIDES = {
   },
 };
 
-// Reserves that DefiLlama's coins API prices directly as fluent:<address>.
+// Reserves that DefiLlama's coins API can price directly as fluent:<address>.
 const DIRECTLY_PRICEABLE = new Set([USDNR_ADDRESS.toLowerCase()]);
 
-async function fetchReserveData(api, isBorrowed) {
-  const reserveTokens = await api.call({ target: POOL_DATA_PROVIDER, abi: abi.getAllReservesTokens });
+// aaveV3Export leaves balances keyed as `fluent:<reserve>`; DefiLlama can't price
+// Fluent WETH or sUSDnr that way, so we swap their raw balances for explicit USD.
+async function applyPriceOverrides(api) {
+  const balances = api.getBalances();
 
-  for (const { symbol, tokenAddress } of reserveTokens) {
-    const addr = tokenAddress.toLowerCase();
+  // Safety: any unrecognized reserve would silently drop from TVL. Throw instead.
+  for (const key of Object.keys(balances)) {
+    if (!key.startsWith('fluent:')) continue;
+    const addr = key.slice('fluent:'.length).toLowerCase();
     if (!PRICE_OVERRIDES[addr] && !DIRECTLY_PRICEABLE.has(addr)) {
-      throw new Error(`vena: reserve ${symbol} (${tokenAddress}) has no pricing configured`);
+      throw new Error(`vena: reserve ${addr} has no pricing configured`);
     }
   }
 
-  const calls = reserveTokens.map(({ tokenAddress }) => ({ target: POOL_DATA_PROVIDER, params: tokenAddress }));
-  const reserveData = await api.multiCall({
-    abi: isBorrowed ? abi.getReserveData : abi.getReserveTokensAddresses,
-    calls,
-  });
-
-  const feeds = [...new Set(reserveTokens
-    .map(t => PRICE_OVERRIDES[t.tokenAddress.toLowerCase()]?.priceFeed)
-    .filter(Boolean))];
-  const pricesByFeed = feeds.length
-    ? (await fetchURL(`https://coins.llama.fi/prices/current/${feeds.join(',')}`)).data.coins
-    : {};
+  const feeds = [...new Set(Object.values(PRICE_OVERRIDES).map(o => o.priceFeed))];
+  const pricesByFeed = (await fetchURL(`https://coins.llama.fi/prices/current/${feeds.join(',')}`)).data.coins;
   for (const feed of feeds) {
     if (!pricesByFeed[feed]) throw new Error(`vena: no price returned for "${feed}" from coins.llama.fi`);
   }
 
-  // TVL for override reserves needs balanceOf(underlying, aTokenAddress); batch into one multicall.
-  const tvlOverrideTargets = !isBorrowed
-    ? reserveTokens
-        .map((t, i) => ({ token: t.tokenAddress, aTokenAddress: reserveData[i].aTokenAddress }))
-        .filter(e => PRICE_OVERRIDES[e.token.toLowerCase()])
-    : [];
-  const tvlOverrideBalances = tvlOverrideTargets.length
-    ? await api.multiCall({
-        abi: 'erc20:balanceOf',
-        calls: tvlOverrideTargets.map(e => ({ target: e.token, params: e.aTokenAddress })),
-      })
-    : [];
-  const balanceByOverrideToken = Object.fromEntries(
-    tvlOverrideTargets.map((e, i) => [e.token.toLowerCase(), tvlOverrideBalances[i]]),
-  );
+  // Build a case-insensitive lookup over balances so we can find each override's entry
+  // regardless of the address casing aaveV3Export wrote.
+  const balanceKeyByAddr = {};
+  for (const key of Object.keys(balances)) {
+    if (!key.startsWith('fluent:')) continue;
+    balanceKeyByAddr[key.slice('fluent:'.length).toLowerCase()] = key;
+  }
 
-  const tokensAndOwners = [];
-  await Promise.all(reserveData.map(async (data, i) => {
-    const token = reserveTokens[i].tokenAddress;
-    const override = PRICE_OVERRIDES[token.toLowerCase()];
-
-    if (override) {
-      const rawAmount = isBorrowed
-        ? new BigNumber(data.totalVariableDebt.toString()).plus(data.totalStableDebt.toString())
-        : new BigNumber(balanceByOverrideToken[token.toLowerCase()].toString());
-      const usdPerToken = await override.usdPerToken(api, pricesByFeed);
-      api.addUSDValue(rawAmount.shiftedBy(-override.decimals).times(usdPerToken).toNumber());
-    } else if (isBorrowed) {
-      api.add(token, data.totalVariableDebt);
-      api.add(token, data.totalStableDebt);
-    } else {
-      tokensAndOwners.push([token, data.aTokenAddress]);
-    }
-  }));
-
-  await sumTokens2({ api, tokensAndOwners });
-  return api.getBalances();
+  for (const [addr, override] of Object.entries(PRICE_OVERRIDES)) {
+    const key = balanceKeyByAddr[addr];
+    const rawAmount = key && balances[key];
+    if (rawAmount == null || rawAmount === '0') continue;
+    // Zero out the unpriceable balance, then add its USD value explicitly.
+    api.add(addr, new BigNumber(rawAmount.toString()).negated().toFixed(0));
+    const usdPerToken = await override.usdPerToken(api, pricesByFeed);
+    api.addUSDValue(new BigNumber(rawAmount.toString()).shiftedBy(-override.decimals).times(usdPerToken).toNumber());
+  }
 }
 
+const base = aaveV3Export({ fluent: { poolDatas: [POOL_DATA_PROVIDER] } });
+
 module.exports = {
-  methodology: "AAVE V3 fork. TVL = each reserve's underlying balance held by its aToken (live liquidity); borrowed = totalVariableDebt + totalStableDebt. Fluent WETH is priced as mainnet WETH (not listed on coins.llama.fi directly); USDnr is priced via coins.llama.fi as fluent:USDnr; sUSDnr is priced via getSharePrice() (USDnr per share) times the USDnr USD price.",
+  methodology: "AAVE V3 fork. TVL = each reserve's underlying balance held by its aToken (live liquidity); borrowed = totalVariableDebt + totalStableDebt. Two reserves need off-protocol pricing: Fluent WETH is priced as mainnet WETH (not listed on coins.llama.fi); sUSDnr is priced as getSharePrice() (USDnr per share) times the USDnr USD price (vault is not ERC4626-conformant).",
   fluent: {
-    tvl: (api) => fetchReserveData(api, false),
-    borrowed: (api) => fetchReserveData(api, true),
+    tvl: async (api) => {
+      await base.fluent.tvl(api);
+      await applyPriceOverrides(api);
+      return api.getBalances();
+    },
+    borrowed: async (api) => {
+      await base.fluent.borrowed(api);
+      await applyPriceOverrides(api);
+      return api.getBalances();
+    },
   },
 };

--- a/projects/vena/index.js
+++ b/projects/vena/index.js
@@ -8,6 +8,14 @@ const USDNR_ADDRESS = '0xD48e565561416dE59DA1050ED70b8d75e8eF28f9';
 const MAINNET_WETH = 'ethereum:0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
 const FLUENT_USDNR = `fluent:${USDNR_ADDRESS}`;
 
+// Why we don't read the protocol's own oracle (AaveOracle.getAssetPrice) directly:
+//   1. It's a Pyth Lazer pull oracle — prices are only fresh on-chain right after a
+//      keeper pushes an update. Otherwise `latestAnswer()` reverts on the 30s
+//      staleness check and the oracle returns nothing usable.
+//   2. Pulling a fresh Lazer payload ourselves requires an authenticated Lazer API
+//      key, which would have to live as an env var on DefiLlama's runner. We want
+//      this adapter to work out-of-the-box without secrets, so we price each reserve
+//      via DefiLlama's own coins API (and getSharePrice for sUSDnr) instead.
 const RESERVES = [
   {
     symbol: 'WETH',

--- a/projects/vena/index.js
+++ b/projects/vena/index.js
@@ -1,0 +1,77 @@
+const { default: BigNumber } = require('bignumber.js');
+const { fetchURL } = require('../helper/utils');
+
+const POOL_DATA_PROVIDER = '0xb6eEF266933382661827E36fE3f936396e80166E';
+const SUSDNR_VAULT = '0x50AE83DBDC44208eDa1Ef722F87Bab0FFB195Eea';
+
+const USDNR_ADDRESS = '0xD48e565561416dE59DA1050ED70b8d75e8eF28f9';
+const MAINNET_WETH = 'ethereum:0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+const FLUENT_USDNR = `fluent:${USDNR_ADDRESS}`;
+
+const RESERVES = [
+  {
+    symbol: 'WETH',
+    address: '0x927C469E58Daab257Ea60B2D8c37bEDD2a203A54',
+    decimals: 18,
+    priceFeed: MAINNET_WETH,
+    calculateUSDPrice: async (_, pricesByToken) => new BigNumber(pricesByToken[MAINNET_WETH].price),
+  },
+  {
+    symbol: 'USDnr',
+    address: USDNR_ADDRESS,
+    decimals: 6,
+    priceFeed: FLUENT_USDNR,
+    calculateUSDPrice: async (_, pricesByToken) => new BigNumber(pricesByToken[FLUENT_USDNR].price),
+  },
+  {
+    symbol: 'sUSDnr',
+    address: '0xFa9b3B45587f9fcdE14759121C3868C2733DCbf4',
+    decimals: 6,
+    priceFeed: FLUENT_USDNR,
+    // sharePrice() returns USDnr per share scaled by USDnr decimals (6).
+    // USD price per sUSDnr = (sharePrice / 10^6) * USDnr_USD_price.
+    calculateUSDPrice: async (api, pricesByToken) => {
+      const sharePrice = await api.call({ target: SUSDNR_VAULT, abi: 'uint256:getSharePrice' });
+      const usdnrPrice = new BigNumber(pricesByToken[FLUENT_USDNR].price);
+      return new BigNumber(sharePrice.toString()).shiftedBy(-6).times(usdnrPrice);
+    },
+  },
+];
+
+const RESERVE_BY_ADDRESS = Object.fromEntries(
+  RESERVES.map(r => [r.address.toLowerCase(), r]),
+);
+
+const abi = {
+  getAllReservesTokens: 'function getAllReservesTokens() view returns ((string symbol, address tokenAddress)[])',
+  getReserveData: 'function getReserveData(address asset) view returns (uint256 unbacked, uint256 accruedToTreasuryScaled, uint256 totalAToken, uint256 totalStableDebt, uint256 totalVariableDebt, uint256 liquidityRate, uint256 variableBorrowRate, uint256 stableBorrowRate, uint256 averageStableBorrowRate, uint256 liquidityIndex, uint256 variableBorrowIndex, uint40 lastUpdateTimestamp)',
+};
+
+async function tvl(api) {
+  const onchainReserves = await api.call({ target: POOL_DATA_PROVIDER, abi: abi.getAllReservesTokens });
+  for (const r of onchainReserves) {
+    if (!RESERVE_BY_ADDRESS[r.tokenAddress.toLowerCase()]) {
+      throw new Error(`vena: unconfigured reserve ${r.symbol} (${r.tokenAddress})`);
+    }
+  }
+
+  const tokens = RESERVES.map(r => r.address);
+  const allFeeds = [...new Set(RESERVES.map(r => r.priceFeed))];
+
+  const [reserveData, priceResp] = await Promise.all([
+    api.multiCall({ target: POOL_DATA_PROVIDER, abi: abi.getReserveData, calls: tokens }),
+    fetchURL(`https://coins.llama.fi/prices/current/${allFeeds.join(',')}`),
+  ]);
+  const pricesByToken = priceResp.data.coins;
+
+  await Promise.all(RESERVES.map(async (reserve, i) => {
+    const usdPerToken = await reserve.calculateUSDPrice(api, pricesByToken);
+    const amtTokenSupplied = new BigNumber(reserveData[i].totalAToken.toString()).shiftedBy(-reserve.decimals);
+    api.addUSDValue(amtTokenSupplied.times(usdPerToken).toNumber());
+  }));
+}
+
+module.exports = {
+  methodology: 'Total market size of the Vena lending pool on Fluent — sum of each reserve\'s aToken total supply (live, including accrued interest) priced via per-reserve calculateUSDPrice functions. WETH is priced via DefiLlama as mainnet WETH; USDnr is priced via the M^0 token on mainnet; sUSDnr is priced via getSharePrice() on its vault (denominated in USDnr) times the USDnr USD price.',
+  fluent: { tvl },
+};

--- a/projects/vena/index.js
+++ b/projects/vena/index.js
@@ -1,4 +1,17 @@
+// This adapter mirrors the shape of `aaveV3Export` in projects/helper/aave.js:
+// it discovers reserves via getAllReservesTokens, reads aTokenAddress per reserve
+// via getReserveTokensAddresses, and computes TVL as the underlying balance held
+// by each aToken plus a separate `borrowed` track from totalVariableDebt +
+// totalStableDebt. We can't use the helper directly because two of Vena's
+// reserves can't be priced by DefiLlama's coins API as `fluent:<address>`:
+//   - Fluent WETH is not listed (priced here as mainnet WETH instead)
+//   - sUSDnr is not listed and is not standard ERC4626 — no asset() /
+//     convertToAssets(); pricing requires a custom getSharePrice() * USDnr
+// So instead of delegating wholesale to aaveV3Export, we inline its mechanics
+// and add a PRICE_OVERRIDES dict that computes USD locally for those two
+// reserves while letting the remaining reserves flow through the default path.
 const { default: BigNumber } = require('bignumber.js');
+const { sumTokens2 } = require('../helper/unwrapLPs');
 const { fetchURL } = require('../helper/utils');
 
 const POOL_DATA_PROVIDER = '0xb6eEF266933382661827E36fE3f936396e80166E';
@@ -8,86 +21,106 @@ const USDNR_ADDRESS = '0xD48e565561416dE59DA1050ED70b8d75e8eF28f9';
 const MAINNET_WETH = 'ethereum:0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
 const FLUENT_USDNR = `fluent:${USDNR_ADDRESS}`;
 
-// Why we don't read the protocol's own oracle (AaveOracle.getAssetPrice) directly:
-//   1. It's a Pyth Lazer pull oracle — prices are only fresh on-chain right after a
-//      keeper pushes an update. Otherwise `latestAnswer()` reverts on the 30s
-//      staleness check and the oracle returns nothing usable.
-//   2. Pulling a fresh Lazer payload ourselves requires an authenticated Lazer API
-//      key, which would have to live as an env var on DefiLlama's runner. We want
-//      this adapter to work out-of-the-box without secrets, so we price each reserve
-//      via DefiLlama's own coins API (and getSharePrice for sUSDnr) instead.
-function readPrice(pricesByToken, feed) {
-  const entry = pricesByToken[feed];
-  if (!entry) {
-    throw new Error(`vena: no price returned for "${feed}" from coins.llama.fi`);
-  }
-  return new BigNumber(entry.price);
-}
-
-const RESERVES = [
-  {
-    symbol: 'WETH',
-    address: '0x927C469E58Daab257Ea60B2D8c37bEDD2a203A54',
-    decimals: 18,
-    priceFeed: MAINNET_WETH,
-    calculateUSDPrice: async (_, pricesByToken) => readPrice(pricesByToken, MAINNET_WETH),
-  },
-  {
-    symbol: 'USDnr',
-    address: USDNR_ADDRESS,
-    decimals: 6,
-    priceFeed: FLUENT_USDNR,
-    calculateUSDPrice: async (_, pricesByToken) => readPrice(pricesByToken, FLUENT_USDNR),
-  },
-  {
-    symbol: 'sUSDnr',
-    address: '0xFa9b3B45587f9fcdE14759121C3868C2733DCbf4',
-    decimals: 6,
-    priceFeed: FLUENT_USDNR,
-    // sharePrice() returns USDnr per share scaled by USDnr decimals (6).
-    // USD price per sUSDnr = (sharePrice / 10^6) * USDnr_USD_price.
-    calculateUSDPrice: async (api, pricesByToken) => {
-      const sharePrice = await api.call({ target: SUSDNR_VAULT, abi: 'uint256:getSharePrice' });
-      const usdnrPrice = readPrice(pricesByToken, FLUENT_USDNR);
-      return new BigNumber(sharePrice.toString()).shiftedBy(-6).times(usdnrPrice);
-    },
-  },
-];
-
-const RESERVE_BY_ADDRESS = Object.fromEntries(
-  RESERVES.map(r => [r.address.toLowerCase(), r]),
-);
-
 const abi = {
   getAllReservesTokens: 'function getAllReservesTokens() view returns ((string symbol, address tokenAddress)[])',
+  getReserveTokensAddresses: 'function getReserveTokensAddresses(address asset) view returns (address aTokenAddress, address stableDebtTokenAddress, address variableDebtTokenAddress)',
   getReserveData: 'function getReserveData(address asset) view returns (uint256 unbacked, uint256 accruedToTreasuryScaled, uint256 totalAToken, uint256 totalStableDebt, uint256 totalVariableDebt, uint256 liquidityRate, uint256 variableBorrowRate, uint256 stableBorrowRate, uint256 averageStableBorrowRate, uint256 liquidityIndex, uint256 variableBorrowIndex, uint40 lastUpdateTimestamp)',
 };
 
-async function tvl(api) {
-  const onchainReserves = await api.call({ target: POOL_DATA_PROVIDER, abi: abi.getAllReservesTokens });
-  for (const r of onchainReserves) {
-    if (!RESERVE_BY_ADDRESS[r.tokenAddress.toLowerCase()]) {
-      throw new Error(`vena: unconfigured reserve ${r.symbol} (${r.tokenAddress})`);
+// Reserves whose price cannot be resolved by DefiLlama's coins API as `fluent:<address>`.
+// For these we compute USD locally instead of feeding the raw balance into the price layer.
+// We avoid the protocol's AaveOracle directly: it is a Pyth Lazer pull oracle and reverts whenever
+// the on-chain payload is older than ~30s (most of the time, without an authenticated keeper).
+const PRICE_OVERRIDES = {
+  // Fluent WETH -> mainnet WETH price (Fluent WETH itself isn't listed on coins.llama.fi).
+  ['0x927C469E58Daab257Ea60B2D8c37bEDD2a203A54'.toLowerCase()]: {
+    decimals: 18,
+    priceFeed: MAINNET_WETH,
+    usdPerToken: (_api, prices) => new BigNumber(prices[MAINNET_WETH].price),
+  },
+  // sUSDnr -> getSharePrice() (USDnr per share, scaled to USDnr's 6 decimals) * USDnr USD price.
+  ['0xFa9b3B45587f9fcdE14759121C3868C2733DCbf4'.toLowerCase()]: {
+    decimals: 6,
+    priceFeed: FLUENT_USDNR,
+    usdPerToken: async (api, prices) => {
+      const sharePrice = await api.call({ target: SUSDNR_VAULT, abi: 'uint256:getSharePrice' });
+      return new BigNumber(sharePrice.toString()).shiftedBy(-6).times(prices[FLUENT_USDNR].price);
+    },
+  },
+};
+
+// Reserves that DefiLlama's coins API prices directly as fluent:<address>.
+const DIRECTLY_PRICEABLE = new Set([USDNR_ADDRESS.toLowerCase()]);
+
+async function fetchReserveData(api, isBorrowed) {
+  const reserveTokens = await api.call({ target: POOL_DATA_PROVIDER, abi: abi.getAllReservesTokens });
+
+  for (const { symbol, tokenAddress } of reserveTokens) {
+    const addr = tokenAddress.toLowerCase();
+    if (!PRICE_OVERRIDES[addr] && !DIRECTLY_PRICEABLE.has(addr)) {
+      throw new Error(`vena: reserve ${symbol} (${tokenAddress}) has no pricing configured`);
     }
   }
 
-  const tokens = RESERVES.map(r => r.address);
-  const allFeeds = [...new Set(RESERVES.map(r => r.priceFeed))];
+  const calls = reserveTokens.map(({ tokenAddress }) => ({ target: POOL_DATA_PROVIDER, params: tokenAddress }));
+  const reserveData = await api.multiCall({
+    abi: isBorrowed ? abi.getReserveData : abi.getReserveTokensAddresses,
+    calls,
+  });
 
-  const [reserveData, priceResp] = await Promise.all([
-    api.multiCall({ target: POOL_DATA_PROVIDER, abi: abi.getReserveData, calls: tokens }),
-    fetchURL(`https://coins.llama.fi/prices/current/${allFeeds.join(',')}`),
-  ]);
-  const pricesByToken = priceResp.data.coins;
+  const feeds = [...new Set(reserveTokens
+    .map(t => PRICE_OVERRIDES[t.tokenAddress.toLowerCase()]?.priceFeed)
+    .filter(Boolean))];
+  const pricesByFeed = feeds.length
+    ? (await fetchURL(`https://coins.llama.fi/prices/current/${feeds.join(',')}`)).data.coins
+    : {};
+  for (const feed of feeds) {
+    if (!pricesByFeed[feed]) throw new Error(`vena: no price returned for "${feed}" from coins.llama.fi`);
+  }
 
-  await Promise.all(RESERVES.map(async (reserve, i) => {
-    const usdPerToken = await reserve.calculateUSDPrice(api, pricesByToken);
-    const amtTokenSupplied = new BigNumber(reserveData[i].totalAToken.toString()).shiftedBy(-reserve.decimals);
-    api.addUSDValue(amtTokenSupplied.times(usdPerToken).toNumber());
+  // TVL for override reserves needs balanceOf(underlying, aTokenAddress); batch into one multicall.
+  const tvlOverrideTargets = !isBorrowed
+    ? reserveTokens
+        .map((t, i) => ({ token: t.tokenAddress, aTokenAddress: reserveData[i].aTokenAddress }))
+        .filter(e => PRICE_OVERRIDES[e.token.toLowerCase()])
+    : [];
+  const tvlOverrideBalances = tvlOverrideTargets.length
+    ? await api.multiCall({
+        abi: 'erc20:balanceOf',
+        calls: tvlOverrideTargets.map(e => ({ target: e.token, params: e.aTokenAddress })),
+      })
+    : [];
+  const balanceByOverrideToken = Object.fromEntries(
+    tvlOverrideTargets.map((e, i) => [e.token.toLowerCase(), tvlOverrideBalances[i]]),
+  );
+
+  const tokensAndOwners = [];
+  await Promise.all(reserveData.map(async (data, i) => {
+    const token = reserveTokens[i].tokenAddress;
+    const override = PRICE_OVERRIDES[token.toLowerCase()];
+
+    if (override) {
+      const rawAmount = isBorrowed
+        ? new BigNumber(data.totalVariableDebt.toString()).plus(data.totalStableDebt.toString())
+        : new BigNumber(balanceByOverrideToken[token.toLowerCase()].toString());
+      const usdPerToken = await override.usdPerToken(api, pricesByFeed);
+      api.addUSDValue(rawAmount.shiftedBy(-override.decimals).times(usdPerToken).toNumber());
+    } else if (isBorrowed) {
+      api.add(token, data.totalVariableDebt);
+      api.add(token, data.totalStableDebt);
+    } else {
+      tokensAndOwners.push([token, data.aTokenAddress]);
+    }
   }));
+
+  await sumTokens2({ api, tokensAndOwners });
+  return api.getBalances();
 }
 
 module.exports = {
-  methodology: 'Total market size of the Vena lending pool on Fluent — sum of each reserve\'s aToken total supply (live, including accrued interest) priced via per-reserve calculateUSDPrice functions. WETH is priced via DefiLlama\'s coins API as mainnet WETH; USDnr is priced via DefiLlama\'s coins API directly on Fluent (fluent:USDNR_ADDRESS); sUSDnr is priced as getSharePrice() on its USDnr/sUSDnr vault (USDnr per share) times the USDnr USD price.',
-  fluent: { tvl },
+  methodology: "AAVE V3 fork. TVL = each reserve's underlying balance held by its aToken (live liquidity); borrowed = totalVariableDebt + totalStableDebt. Fluent WETH is priced as mainnet WETH (not listed on coins.llama.fi directly); USDnr is priced via coins.llama.fi as fluent:USDnr; sUSDnr is priced via getSharePrice() (USDnr per share) times the USDnr USD price.",
+  fluent: {
+    tvl: (api) => fetchReserveData(api, false),
+    borrowed: (api) => fetchReserveData(api, true),
+  },
 };


### PR DESCRIPTION
 ## (Needs to be filled only for new listings)                                                                                  
   
  ##### Name (to be shown on DefiLlama):                                                                                         
  Vena Finance                                                                                                                 
                                                                                                                                 
  ##### Twitter Link:                                       
  https://x.com/venafinance                                                                                                    

  ##### List of audit links if any:
  None

  ##### Website Link:                                                                                                            
  https://vena.finance
                                                                                                                                 
  ##### Logo (High resolution, will be shown with rounded borders):
  https://app.vena.finance/icon.svg?469566caf16228fe                                                                           
                                                                                                                                 
  ##### Current TVL:
  ~$19.9M                                                                                            
                                                            
  ##### Treasury Addresses (if the protocol has treasury)                                                                      
  N/A

  ##### Chain:                                                                                                                   
  Fluent
                                                                                                                                 
  ##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):
  (no token)                                                                                                                   

  ##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):                                   
  (no token)
                                                                                                                                 
  ##### Short Description (to be shown on DefiLlama):       
 Vena is the credit layer where reputation directly affects the value of capital. Vena is launching as the native money market of Fluent.                                                                               
  
  ##### Token address and ticker if any:                                                                                         
  (no token)                                                
                                                                                                                               
  ##### Category (full list at https://defillama.com/categories) *Please choose only one:
  Lending

  ##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
  Pyth (Pyth Lazer)                                                                                                              
  
  ##### Implementation Details: Briefly describe how the oracle is integrated into your project:                                 
  Each reserve's price feed is a `PythProAggregatorAdapter` contract that exposes the Chainlink `AggregatorInterface`            
  (`latestAnswer`, `latestRound`, `getAnswer`, etc.). It reads from a central `VenaPythPrices` contract, which is updated by     
  anyone calling `updatePrices(bytes)` with a signed Pyth Lazer payload (verified via `IPythLazer.verifyUpdate`). The standard   
  AAVE V3 `AaveOracle` consumes those adapters via `getSourceOfAsset` / `getAssetPrice` for both protocol logic and external     
  integrations.                                                                                                                
                                                                                                                               
  ##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
  - VenaPythPrices: https://fluentscan.xyz/address/0x3E0496df554596d5334BABD375eF7458E9E9462F                                    
  - Example PythProAggregatorAdapter (WETH): https://fluentscan.xyz/address/0xEb798dE22062AD9a7de32EfC5a1F6BA069903322           
  - AaveOracle: https://fluentscan.xyz/address/0xC3Be4DDD4354Cd83FcfB3bE67686387b42A353Db                                        
  - Pyth Lazer docs: https://docs.pyth.network/lazer                                                                             
                                                                                                                                 
  ##### forkedFrom (Does your project originate from another project):                                                           
  AAVE V3                                                                                                                      
                                                                                                                               
  ##### methodology (what is being counted as tvl, how is tvl being calculated):
 TVL = total market size of the lending pool = sum across all reserves of totalAToken (the live aToken supply, which already  
  includes interest accrued via the liquidity index), priced in USD.                                                             
  - WETH — priced via DefiLlama's coins API as mainnet WETH                                              
  - USDnr — priced via DefiLlama's coins API directly on Fluent                                            
  - sUSDnr — priced as getSharePrice() × USDnr_USD_price. The contract at 0x50AE83DBDC44208eDa1Ef722F87Bab0FFB195Eea is a USDnr →
   sUSDnr vault where sUSDnr represents the shares; getSharePrice() returns USDnr per share scaled by USDnr's 6 decimals.                                              
                                                                                                                               
  ##### Does this project have a referral program?                                                                             
  No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Vena (Fluent) TVL and borrowed reporting with explicit USD valuation for configured reserves, including pricing overrides for specific assets.

* **Bug Fixes / Validation**
  * Validates reserve listings and excludes unpriceable raw balances, ensuring only priceable/configured assets contribute to totals.

* **Documentation**
  * Published a methodology describing the valuation and override approach.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19132)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->