### PR TITLE
remove bprotocol owner address 

### DIFF
--- a/projects/anthias/index.js
+++ b/projects/anthias/index.js
@@ -2,6 +2,7 @@ const { getCuratorExport } = require("../helper/curators");
 
 const configs = {
   methodology: 'Count all assets deposited in all vaults curated by Anthias Labs.',
+  start: '2025-05-27', // https://snapshot.box/#/s:moonwell-governance.eth/proposal/0x38bba3ecc2c5421f7660e124a8d874c70485aec16b2097520cf8fd217efca86d
   blockchains: {
     base: {
       morpho: [

--- a/projects/b-protocol/index.js
+++ b/projects/b-protocol/index.js
@@ -7,12 +7,12 @@ const configs = {
       morphoVaultOwners: [
         '0xf7D44D5a28d5AF27a7F9c8fc6eFe0129e554d7c4',
         '0x2566f66f68ed438726AD904524FB306A03FdB80B',
-        '0x17e7bB9fe7983947FdCf02c1E3d8e6C92C21da54',
+        // '0x17e7bB9fe7983947FdCf02c1E3d8e6C92C21da54', // Anthias is now curator for Moonwell's Morpho vaults
       ],
     },
     base: {
       morphoVaultOwners: [
-        '0x17e7bB9fe7983947FdCf02c1E3d8e6C92C21da54',
+        // '0x17e7bB9fe7983947FdCf02c1E3d8e6C92C21da54', // Anthias is now curator for Moonwell's Morpho vaults: https://x.com/MoonwellDeFi/status/1928491680031969510
       ],
     },
   }

--- a/projects/helper/curators/index.js
+++ b/projects/helper/curators/index.js
@@ -563,8 +563,7 @@ function getCuratorExport(configs) {
     // methodology
     methodology: configs.methodology ? configs.methodology : 'Count all deposited assets in curated vaults.',
 
-    // start
-    ...(configs.start !== undefined ? { start: configs.start } : {}),
+    start: configs.start
   }
 
   for (const [chain, vaultConfigs] of Object.entries(configs.blockchains)) {

--- a/projects/helper/curators/index.js
+++ b/projects/helper/curators/index.js
@@ -552,17 +552,26 @@ async function getCuratorTvl(api, vaults) {
 }
 
 function getCuratorExport(configs) {
+  const startTs = configs.start
+    ? (typeof configs.start === 'number' ? configs.start : Math.floor(new Date(configs.start).getTime() / 1000))
+    : 0;
+
   const exportObjects = {
     // these tvl are double count
     doublecounted: true,
 
     // methodology
     methodology: configs.methodology ? configs.methodology : 'Count all deposited assets in curated vaults.',
+
+    // start
+    ...(configs.start !== undefined ? { start: configs.start } : {}),
   }
 
   for (const [chain, vaultConfigs] of Object.entries(configs.blockchains)) {
     exportObjects[chain] = {
       tvl: async (api) => {
+        // prevent attributing tvl to curators before they began curating
+        if (startTs && api.timestamp && api.timestamp < startTs) return {};
         return getCuratorTvl(api, vaultConfigs)
       }
     }


### PR DESCRIPTION
B.Protocol is no longer the curator for the Moonwell Morpho vaults: https://x.com/MoonwellDeFi/status/1928491680031969510


Anthias: https://app.morpho.org/vaults?v2=false&curators=anthias-labs
B.Protocol: https://app.morpho.org/vaults?v2=false&curators=b-protocol

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Changes**
  * B protocol curator settings updated to exclude the Anthias curator as an active owner for Ethereum and Base, so associated vault assets are no longer included in exports.

* **New Features**
  * Curator exports now honor a configured start date, preventing TVL attribution before that date.

* **Documentation**
  * Anthias project now documents a configured start date for its data window.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->