### PR TITLE
add Nawa USDC vault TVL on ZigChain

### DIFF
--- a/projects/nawa/index.js
+++ b/projects/nawa/index.js
@@ -169,13 +169,13 @@ module.exports = {
   timetravel: false,            // ZigChain query is live-state only
   misrepresentedTokens: false,
   methodology:
-    'Core: TVL is calculated by 1) unwrapping Bitflux LP tokens held by Nawa Solv Vault V2 to their underlying assets ' +
-    '(e.g. SolvBTC.CORE, WBTC, SolvBTC.b) based on pool reserves and total supply, and 2) tracking dualCore token ' +
-    'holdings in the Core vault address. ' +
     'ZigChain: TVL is the sum of (1) the Nawa Zig vault AUM (in stZIG) converted to uZIG equivalent via ' +
     'Valdora’s reverse_st_zig_price oracle and reported as uZIG, and (2) the Nawa USDC vault AUM ' +
     '(oracle-reported USD value of capital deployed off-chain via Zignaly into a cross-chain ' +
-    'private credit position), reported as USDC.',
+    'private credit position), reported as USDC. ' +
+    'Core: TVL is calculated by 1) unwrapping Bitflux LP tokens held by Nawa Solv Vault V2 to their underlying assets ' +
+    '(e.g. SolvBTC.CORE, WBTC, SolvBTC.b) based on pool reserves and total supply, and 2) tracking dualCore token ' +
+    'holdings in the Core vault address.',
   core: {
     tvl: coreTvl,
   },

--- a/projects/nawa/index.js
+++ b/projects/nawa/index.js
@@ -62,6 +62,11 @@ const NAWA_ZIG_VAULT = 'zig1fqxfjv54zavyr9464vj6n2jgw9fxgdnxucf866spedunntw0skcs
 // Valdora Staker contract used as pricing oracle for stZIG → uZIG
 const VALDORA_STAKER_CONTRACT = 'zig18nnde5tpn76xj3wm53n0tmuf3q06nruj3p6kdemcllzxqwzkpqzqk7ue55';
 
+// Nawa USDC vault. Funds deposited here are forwarded off-chain to Zignaly
+// and bridged to ETH/BSC for a private credit strategy, so the only on-chain
+// handle on TVL is the vault's oracle-reported AUM (in USDC base units, 6 dp).
+const NAWA_USDC_VAULT = 'zig1fn4rrr5knlg93nf3wyme9fzmgve3fftxu5l7wv90llp77mwg7ctq2lfwtd';
+
 /**
  * Fetch TVL (AUM) from the Nawa Zig vault using:
  *   QueryMsg::TotalAum {}
@@ -106,15 +111,31 @@ async function fetchUzigPerStzig() {
   return (probeUzig * 1_000_000n) / BigInt(stzig_amount);
 }
 
+/**
+ * Fetch AUM (in USDC base units, 6 decimals) from the Nawa USDC vault using:
+ *   QueryMsg::Aum {} -> { "aum": "<uint256>" }
+ */
+async function fetchUsdcVaultAum() {
+  const res = await queryContract({
+    contract: NAWA_USDC_VAULT,
+    chain: 'zigchain',
+    data: { aum: {} },
+  });
+
+  const amount = res.aum;
+  if (!amount || amount === '0') return null;
+  return BigInt(amount);
+}
+
 async function zigchainTvl(api) {
     const balances = api.getBalances();
-  
+
     try {
       const [aumStzig, ratioScaled] = await Promise.all([
         fetchZigVaultTVL(),
         fetchUzigPerStzig(),
       ]);
-  
+
       if (aumStzig && ratioScaled) {
         const uzigEq = (aumStzig * ratioScaled) / 1_000_000n;
         const key = 'zigchain:uzig';
@@ -124,7 +145,22 @@ async function zigchainTvl(api) {
     } catch (e) {
       // If Zig part fails, we just skip it so Core TVL still works
     }
-  
+
+    try {
+      const aumUsdc = await fetchUsdcVaultAum();
+      if (aumUsdc) {
+        // Funds are deployed cross-chain via Zignaly; tag as USD value
+        // rather than a chain-specific denom. Aum is in USDC base units
+        // (6 decimals); convert to a USD float for addCGToken.
+        const usdValue = Number(aumUsdc) / 1e6;
+        if (Number.isFinite(usdValue) && usdValue > 0) {
+          api.addCGToken('usd-coin', usdValue);
+        }
+      }
+    } catch (e) {
+      // If USDC vault query fails, skip it so the rest of TVL still works
+    }
+
     return transformBalances('zigchain', balances);
   }
   
@@ -136,8 +172,10 @@ module.exports = {
     'Core: TVL is calculated by 1) unwrapping Bitflux LP tokens held by Nawa Solv Vault V2 to their underlying assets ' +
     '(e.g. SolvBTC.CORE, WBTC, SolvBTC.b) based on pool reserves and total supply, and 2) tracking dualCore token ' +
     'holdings in the Core vault address. ' +
-    'ZigChain: TVL is the total AUM returned by the Nawa Zig vault (in stZIG) converted to uZIG equivalent via ' +
-    'Valdora’s reverse_st_zig_price oracle, then reported as uZIG on ZigChain.',
+    'ZigChain: TVL is the sum of (1) the Nawa Zig vault AUM (in stZIG) converted to uZIG equivalent via ' +
+    'Valdora’s reverse_st_zig_price oracle and reported as uZIG, and (2) the Nawa USDC vault AUM ' +
+    '(oracle-reported USD value of capital deployed off-chain via Zignaly into a cross-chain ' +
+    'private credit position), reported as USDC.',
   core: {
     tvl: coreTvl,
   },

--- a/projects/nawa/index.js
+++ b/projects/nawa/index.js
@@ -59,8 +59,8 @@ async function coreTvl(api) {
 // Nawa Zig vault contract (CosmWasm)
 const NAWA_ZIG_VAULT = 'zig1fqxfjv54zavyr9464vj6n2jgw9fxgdnxucf866spedunntw0skcsq9gz33';
 
-// Valdora Staker contract used as pricing oracle for stZIG → uZIG
-const VALDORA_STAKER_CONTRACT = 'zig18nnde5tpn76xj3wm53n0tmuf3q06nruj3p6kdemcllzxqwzkpqzqk7ue55';
+// stZIG denom — priced server-side via Valdora oracle.
+const STZIG_DENOM = 'coin.zig109f7g2rzl2aqee7z6gffn8kfe9cpqx0mjkk7ethmx8m2hq4xpe9snmaam2.stzig';
 
 // Nawa USDC vault. Funds deposited here are forwarded off-chain to Zignaly
 // and bridged to ETH/BSC for a private credit strategy, so the only on-chain
@@ -87,31 +87,6 @@ async function fetchZigVaultTVL() {
 }
 
 /**
- * Fetches the conversion rate from stZIG to uZIG using the redeem-side quote
- * from the Valdora Staker contract.
- *
- * 1. We send a probe amount of 1,000 ZIG (1e9 uZIG) via reverse_st_zig_price.
- * 2. Contract returns stzig_amount (how much stZIG is received for that probe uZIG).
- * 3. We compute: uzig_per_stzig = probe_uzig / stzig_amount, scaled by 1e6.
- *
- * Returns BigInt ratioScaled = uZIG per 1 stZIG * 1e6, or null if it fails.
- */
-async function fetchUzigPerStzig() {
-  const probeUzig = 1_000_000_000n; // 1,000 ZIG in uZIG (assuming 6 decimals)
-
-  const { stzig_amount } = await queryContract({
-    contract: VALDORA_STAKER_CONTRACT,
-    chain: 'zigchain',
-    data: { reverse_st_zig_price: { amount: probeUzig.toString() } },
-  });
-
-  if (!stzig_amount || stzig_amount === '0') return null;
-
-  // ratioScaled = (probeUzig * 1e6) / stzig_amount
-  return (probeUzig * 1_000_000n) / BigInt(stzig_amount);
-}
-
-/**
  * Fetch AUM (in USDC base units, 6 decimals) from the Nawa USDC vault using:
  *   QueryMsg::Aum {} -> { "aum": "<uint256>" }
  */
@@ -128,51 +103,37 @@ async function fetchUsdcVaultAum() {
 }
 
 async function zigchainTvl(api) {
-    const balances = api.getBalances();
+  const balances = api.getBalances();
 
-    try {
-      const [aumStzig, ratioScaled] = await Promise.all([
-        fetchZigVaultTVL(),
-        fetchUzigPerStzig(),
-      ]);
-
-      if (aumStzig && ratioScaled) {
-        const uzigEq = (aumStzig * ratioScaled) / 1_000_000n;
-        const key = 'zigchain:uzig';
-        const current = balances[key] ? BigInt(balances[key]) : 0n;
-        balances[key] = (current + uzigEq).toString();
-      }
-    } catch (e) {
-      // If Zig part fails, we just skip it so Core TVL still works
-    }
-
-    try {
-      const aumUsdc = await fetchUsdcVaultAum();
-      if (aumUsdc) {
-        // Funds are deployed cross-chain via Zignaly; tag as USD value
-        // rather than a chain-specific denom. Aum is in USDC base units
-        // (6 decimals); convert to a USD float for addCGToken.
-        const usdValue = Number(aumUsdc) / 1e6;
-        if (Number.isFinite(usdValue) && usdValue > 0) {
-          api.addCGToken('usd-coin', usdValue);
-        }
-      }
-    } catch (e) {
-      // If USDC vault query fails, skip it so the rest of TVL still works
-    }
-
-    return transformBalances('zigchain', balances);
+  const aumStzig = await fetchZigVaultTVL();
+  if (aumStzig) {
+    const key = `zigchain:${STZIG_DENOM}`;
+    const current = balances[key] ? BigInt(balances[key]) : 0n;
+    balances[key] = (current + aumStzig).toString();
   }
-  
+
+  const aumUsdc = await fetchUsdcVaultAum();
+  if (aumUsdc) {
+    // Funds are deployed cross-chain via Zignaly; tag as USD value
+    // rather than a chain-specific denom. Aum is in USDC base units
+    // (6 decimals); convert to a USD float for addCGToken.
+    const usdValue = Number(aumUsdc) / 1e6;
+    if (Number.isFinite(usdValue) && usdValue > 0) {
+      api.addCGToken('usd-coin', usdValue);
+    }
+  }
+
+  return transformBalances('zigchain', balances);
+}
 
 module.exports = {
   timetravel: false,            // ZigChain query is live-state only
   misrepresentedTokens: false,
   methodology:
-    'ZigChain: TVL is the sum of (1) the Nawa Zig vault AUM (in stZIG) converted to uZIG equivalent via ' +
-    'Valdora’s reverse_st_zig_price oracle and reported as uZIG, and (2) the Nawa USDC vault AUM ' +
-    '(oracle-reported USD value of capital deployed off-chain via Zignaly into a cross-chain ' +
-    'private credit position), reported as USDC. ' +
+    'ZigChain: TVL is the sum of (1) the Nawa Zig vault AUM reported as stZIG, ' +
+    'and (2) the Nawa USDC vault AUM ' +
+    '(oracle-reported USD value of capital deployed off-chain via Zignaly into a ' +
+    'cross-chain private credit position), reported as USDC. ' +
     'Core: TVL is calculated by 1) unwrapping Bitflux LP tokens held by Nawa Solv Vault V2 to their underlying assets ' +
     '(e.g. SolvBTC.CORE, WBTC, SolvBTC.b) based on pool reserves and total supply, and 2) tracking dualCore token ' +
     'holdings in the Core vault address.',

--- a/projects/nawa/index.js
+++ b/projects/nawa/index.js
@@ -103,27 +103,16 @@ async function fetchUsdcVaultAum() {
 }
 
 async function zigchainTvl(api) {
-  const balances = api.getBalances();
+  const aumStzig = await fetchZigVaultTVL()
+  if (aumStzig) api.add(STZIG_DENOM, aumStzig.toString())
 
-  const aumStzig = await fetchZigVaultTVL();
-  if (aumStzig) {
-    const key = `zigchain:${STZIG_DENOM}`;
-    const current = balances[key] ? BigInt(balances[key]) : 0n;
-    balances[key] = (current + aumStzig).toString();
-  }
-
-  const aumUsdc = await fetchUsdcVaultAum();
+  const aumUsdc = await fetchUsdcVaultAum()
   if (aumUsdc) {
-    // Funds are deployed cross-chain via Zignaly; tag as USD value
-    // rather than a chain-specific denom. Aum is in USDC base units
-    // (6 decimals); convert to a USD float for addCGToken.
-    const usdValue = Number(aumUsdc) / 1e6;
+    const usdValue = Number(aumUsdc) / 1e6
     if (Number.isFinite(usdValue) && usdValue > 0) {
-      api.addCGToken('usd-coin', usdValue);
+      api.addCGToken('usd-coin', usdValue)
     }
   }
-
-  return transformBalances('zigchain', balances);
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
Extends the existing "nawa" adapter to include AUM from the Nawa USDC vault on ZigChain.

- Vault contract: "zig1fn4rrr5knlg93nf3wyme9fzmgve3fftxu5l7wv90llp77mwg7ctq2lfwtd"
- Asset: USDC (6 decimals)
- TVL source: on-chain `Aum {}` query → returns AUM in USDC base units
- Emitted via "api.addCGToken('usd-coin', usdValue)" (USD float, AUM pre-scaled from 6-decimal base units). Funds are forwarded off-chain via Zignaly and bridged to ETH/BSC for a private credit strategy, so no chain-native denom would faithfully represent them; the contract's oracle-reported AUM is the only on-chain handle on TVL.

## Methodology
ZigChain TVL is now the sum of:
1. Nawa Zig vault AUM (stZIG → uZIG via the Valdora `reverse_st_zig_price` oracle, reported as `uzig`), unchanged
2. Nawa USDC vault AUM, reported as USDC

The `methodology` string in the adapter has been updated accordingly.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TVL now reports the Nawa Zig vault value directly in stZIG and includes the Nawa USDC vault’s oracle-reported AUM as an additional USD-backed component (converted to USD).

* **Documentation**
  * Updated TVL methodology to reflect combined reporting of stZIG holdings plus the USDC-vault AUM as a USD value.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19144)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->