### PR TITLE
Ensuro: fix error in V3 launch

### DIFF
--- a/projects/ensuro/index.js
+++ b/projects/ensuro/index.js
@@ -98,6 +98,6 @@ module.exports = {
   start: '2022-02-01',
   hallmarks: [
     ['2022-12-01', "Ensuro V2 Launch"],
-    ['2025-03-18', "Ensuro V3 Launch"],
+    ['2026-03-18', "Ensuro V3 Launch"],
   ]
 };


### PR DESCRIPTION
Fix a small error in Hallmark; it's 2026 instead of 2025.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the V3 Launch milestone date for project planning records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->