### PR TITLE
gondi-v3: add v3.1 contracts and HypeEVM deployment

### DIFF
--- a/projects/gondi-v3/index.js
+++ b/projects/gondi-v3/index.js
@@ -1,12 +1,19 @@
 const { sumTokensExport, } = require('../helper/unwrapLPs');
 
-// https://docs.gondi.xyz/protocol-contracts
+// https://docs.gondi.xyz/gondi-v3/protocol-contracts
 const multiSourceLoan = "0xf65b99ce6dc5f6c556172bcc0ff27d3665a7d9a8";
 const userVault = "0x823de2c44369e94cac3da789ad4b6493e27e4bfe";
 
+// V3.1
+const multiSourceLoanV31 = "0xf41B389E0C1950dc0B16C9498eaE77131CC08A56";
+const multiSourceLoanV31Hype = "0x6ad675624ec8320e5806858cd5db101a0b927fd9";
+
 module.exports = {
-  methodology: `Counts the floor value of all deposited NFTs with Chainlink price feeds.`,
+  methodology: `Counts the floor value of all deposited NFTs with Chainlink price feeds. NFT floor pricing is only available on Ethereum; on HyperEVM only ERC20 collateral is counted.`,
   ethereum: {
-    tvl: sumTokensExport({ owners: [multiSourceLoan, userVault], resolveNFTs: true, }),
-  }
+    tvl: sumTokensExport({ owners: [multiSourceLoan, userVault, multiSourceLoanV31], resolveNFTs: true, }),
+  },
+  hyperliquid: {
+    tvl: sumTokensExport({ owners: [multiSourceLoanV31Hype], fetchCoValentTokens: true, tokenConfig: { ignoreMissingChain: true, }, }),
+  },
 }

--- a/projects/gondi-v3/index.js
+++ b/projects/gondi-v3/index.js
@@ -5,7 +5,7 @@ const multiSourceLoan = "0xf65b99ce6dc5f6c556172bcc0ff27d3665a7d9a8";
 const userVault = "0x823de2c44369e94cac3da789ad4b6493e27e4bfe";
 
 // V3.1
-const multiSourceLoanV31 = "0xf41B389E0C1950dc0B16C9498eaE77131CC08A56";
+const multiSourceLoanV31 = "0xf41b389e0c1950dc0b16c9498eae77131cc08a56";
 const multiSourceLoanV31Hype = "0x6ad675624ec8320e5806858cd5db101a0b927fd9";
 
 module.exports = {

--- a/projects/gondi-v3/index.js
+++ b/projects/gondi-v3/index.js
@@ -6,14 +6,10 @@ const userVault = "0x823de2c44369e94cac3da789ad4b6493e27e4bfe";
 
 // V3.1
 const multiSourceLoanV31 = "0xf41b389e0c1950dc0b16c9498eae77131cc08a56";
-const multiSourceLoanV31Hype = "0x6ad675624ec8320e5806858cd5db101a0b927fd9";
 
 module.exports = {
-  methodology: `Counts the floor value of all deposited NFTs with Chainlink price feeds. NFT floor pricing is only available on Ethereum; on HyperEVM only ERC20 collateral is counted.`,
+  methodology: `Counts the floor value of all deposited NFTs with Chainlink price feeds.`,
   ethereum: {
     tvl: sumTokensExport({ owners: [multiSourceLoan, userVault, multiSourceLoanV31], resolveNFTs: true, }),
-  },
-  hyperliquid: {
-    tvl: sumTokensExport({ owners: [multiSourceLoanV31Hype], fetchCoValentTokens: true, tokenConfig: { ignoreMissingChain: true, }, }),
-  },
+  }
 }


### PR DESCRIPTION
## Summary
- Adds the Gondi V3.1 `MultiSourceLoan` (`0xf41B389E0C1950dc0B16C9498eaE77131CC08A56`) to the existing ethereum owners list in `projects/gondi-v3/index.js`.
- Adds a `hyperliquid` block tracking the V3.1 HypeEVM `MultiSourceLoan` (`0x6ad675624ec8320e5806858cd5db101a0b927fd9`).
- Updates the docs URL comment and the methodology string.

V3.1 is a parallel deployment of V3 (it has its own MSL), so it's merged into the existing `gondi-v3` adapter rather than getting a new folder. V3's `UserVaults Factory` is unchanged; V3.1 doesn't introduce a separate factory, so we don't double-count.

Contract source: https://docs.gondi.xyz/gondi-v3/protocol-contracts

## Notes on HypeEVM
`resolveNFTs: true` is currently Ethereum-only (it calls into ArtBlocks contracts that don't exist on other chains, and Ankr's chain map doesn't include `hyperliquid`). Following the same pattern used in `projects/pwn/index.js`, the `hyperliquid` block uses `fetchCoValentTokens: true` with `tokenConfig: { ignoreMissingChain: true }`, which captures any ERC20 collateral held by the MSL on HypeEVM but cannot floor-price NFT collateral there. The methodology string was updated to reflect this.

## Test plan
- [x] `node test.js projects/gondi-v3/index.js` — ethereum reports its existing TVL plus any V3.1 contributions; hyperliquid reports a numeric TVL (currently $0 — no ERC20 collateral at the MSL right now); no errors.
- [x] `node test.js projects/gondi/index.js` — V1 adapter unaffected.
- [x] ESLint clean on the changed file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Gondi V3.1 on Ethereum; Ethereum TVL now includes the V3.1 contract.

* **Documentation**
  * Methodology remains unchanged (Ethereum TVL and cross-chain handling noted).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->