### PR TITLE
Add VisionBoard Vault

### DIFF
--- a/projects/visionboard-vault/index.js
+++ b/projects/visionboard-vault/index.js
@@ -1,0 +1,19 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+
+const VISIONBOARD_VAULT = '0x0a5e236425aca07fd087904F8863CAd554675E06'
+
+async function tvl(api) {
+  const [asset, totalAssets] = await Promise.all([
+    api.call({ abi: 'address:asset', target: VISIONBOARD_VAULT }),
+    api.call({ abi: 'uint256:totalAssets', target: VISIONBOARD_VAULT }),
+  ])
+
+  api.add(asset || ADDRESSES.hyperliquid.USDC, totalAssets)
+}
+
+module.exports = {
+  timetravel: false,
+  methodology:
+    'TVL is calculated from VisionBoard Vault totalAssets() on HyperEVM. Deposits mint VBV vault shares backed by the vault asset, currently USDC.',
+  hyperliquid: { tvl },
+}


### PR DESCRIPTION
Adds a DefiLlama TVL adapter for VisionBoard Vault on HyperEVM.

Name: VisionBoard Vault
Website: https://vault.visionboardfinance.com
App: https://vault.visionboardfinance.com
Chain: Hyperliquid / HyperEVM
Category: Onchain Capital Allocator
Vault contract: 0x0a5e236425aca07fd087904F8863CAd554675E06
Underlying asset: USDC on HyperEVM
Methodology: reads asset() and totalAssets() from the vault contract and reports TVL in the underlying vault asset. Deposits mint VBV vault shares backed by vault assets.
Current local adapter output: approximately 5.35k TVL on hyperliquid at test time.
Logo: https://visionboardfinance.com/vbv-logo.png

Local test:
```bash
node test.js projects/visionboard-vault/index.js
```