### PR TITLE
feat: add EticaHub adapter

### DIFF
--- a/projects/eticahub/index.js
+++ b/projects/eticahub/index.js
@@ -1,0 +1,104 @@
+const { Interface, formatUnits } = require("ethers");
+const http = require("../helper/http");
+
+const RPC = "https://eticamainnet.eticascan.org";
+const CG_ID = "etica";
+
+const FACTORY = "0xfc8dE5A5087c8825AA54E2C57B3FFe0e23784bc3";
+const ETI = "0x34c61EA91bAcdA647269d4e310A86b875c09946f";
+const ETX = "0xa5A1Bc6307b0b87989B8456D4b35F88a68650044";
+const STETX = "0x75d81d03a98CD9195593b8963aF17E13fAa70334";
+
+const iface = new Interface([
+  "function allPairs(uint256) view returns (address)",
+  "function allPairsLength() view returns (uint256)",
+  "function token0() view returns (address)",
+  "function token1() view returns (address)",
+  "function getReserves() view returns (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast)",
+  "function totalAssets() view returns (uint256)",
+  "function totalSupply() view returns (uint256)",
+]);
+
+async function call(target, method, params = []) {
+  const { result, error } = await http.post(RPC, {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "eth_call",
+    params: [{ to: target, data: iface.encodeFunctionData(method, params) }, "latest"],
+  });
+  if (error) throw new Error(error.message);
+  return iface.decodeFunctionResult(method, result);
+}
+
+function toNumber(value) {
+  return Number(formatUnits(value, 18));
+}
+
+async function getETXPriceInETI() {
+  const length = (await call(FACTORY, "allPairsLength"))[0];
+
+  for (let i = 0n; i < length; i++) {
+    const pair = (await call(FACTORY, "allPairs", [i]))[0];
+    const [[token0], [token1], [reserve0, reserve1]] = await Promise.all([
+      call(pair, "token0"),
+      call(pair, "token1"),
+      call(pair, "getReserves"),
+    ]);
+
+    if (token0 === ETI && token1 === ETX) return toNumber(reserve0) / toNumber(reserve1);
+    if (token0 === ETX && token1 === ETI) return toNumber(reserve1) / toNumber(reserve0);
+  }
+}
+
+async function getStETXPriceInETX() {
+  const [[totalAssets], [totalSupply]] = await Promise.all([
+    call(STETX, "totalAssets"),
+    call(STETX, "totalSupply"),
+  ]);
+  return toNumber(totalAssets) / toNumber(totalSupply);
+}
+
+async function tvl(api) {
+  const length = (await call(FACTORY, "allPairsLength"))[0];
+  const etxPriceInETI = await getETXPriceInETI();
+  const stETXPriceInETX = await getStETXPriceInETX();
+  let tvlInETI = 0;
+
+  for (let i = 0n; i < length; i++) {
+    const pair = (await call(FACTORY, "allPairs", [i]))[0];
+    const [[token0], [token1], [reserve0, reserve1]] = await Promise.all([
+      call(pair, "token0"),
+      call(pair, "token1"),
+      call(pair, "getReserves"),
+    ]);
+
+    const reserve0Amount = toNumber(reserve0);
+    const reserve1Amount = toNumber(reserve1);
+
+    if (token0 === ETI && token1 === ETX) tvlInETI += reserve0Amount + reserve1Amount * etxPriceInETI;
+    else if (token0 === ETX && token1 === ETI) tvlInETI += reserve0Amount * etxPriceInETI + reserve1Amount;
+    else if (token0 === STETX && token1 === ETX) tvlInETI += (reserve0Amount * stETXPriceInETX + reserve1Amount) * etxPriceInETI;
+    else if (token0 === ETX && token1 === STETX) tvlInETI += (reserve0Amount + reserve1Amount * stETXPriceInETX) * etxPriceInETI;
+    else if (token0 === ETX || token1 === ETX) {
+      const etxReserve = token0 === ETX ? reserve0Amount : reserve1Amount;
+      tvlInETI += etxReserve * etxPriceInETI * 2;
+    }
+  }
+
+  api.addCGToken(CG_ID, tvlInETI);
+}
+
+async function staking(api) {
+  const etxPriceInETI = await getETXPriceInETI();
+  const [totalAssets] = await call(STETX, "totalAssets");
+  api.addCGToken(CG_ID, toNumber(totalAssets) * etxPriceInETI);
+}
+
+module.exports = {
+  timetravel: false,
+  methodology: "Counts EticaSwap liquidity and prices ETX-denominated pools through the live ETI/ETX pool. Staking counts ETX deposited in the stETX ERC-4626 vault.",
+  etica: {
+    tvl,
+    staking,
+  },
+};

--- a/projects/eticahub/index.js
+++ b/projects/eticahub/index.js
@@ -19,6 +19,8 @@ const iface = new Interface([
   "function totalSupply() view returns (uint256)",
 ]);
 
+let etxPriceInETIPromise;
+
 async function call(target, method, params = []) {
   const { result, error } = await http.post(RPC, {
     jsonrpc: "2.0",
@@ -35,6 +37,12 @@ function toNumber(value) {
 }
 
 async function getETXPriceInETI() {
+  if (etxPriceInETIPromise) return etxPriceInETIPromise;
+  etxPriceInETIPromise = findETXPriceInETI();
+  return etxPriceInETIPromise;
+}
+
+async function findETXPriceInETI() {
   const length = (await call(FACTORY, "allPairsLength"))[0];
 
   for (let i = 0n; i < length; i++) {
@@ -48,6 +56,7 @@ async function getETXPriceInETI() {
     if (token0 === ETI && token1 === ETX) return toNumber(reserve0) / toNumber(reserve1);
     if (token0 === ETX && token1 === ETI) return toNumber(reserve1) / toNumber(reserve0);
   }
+  throw new Error("ETI/ETX pair not found in EticaSwap factory");
 }
 
 async function getStETXPriceInETX() {
@@ -96,7 +105,7 @@ async function staking(api) {
 
 module.exports = {
   timetravel: false,
-  methodology: "Counts EticaSwap liquidity and prices ETX-denominated pools through the live ETI/ETX pool. Staking counts ETX deposited in the stETX ERC-4626 vault.",
+  methodology: "Counts EticaSwap liquidity and prices ETX-denominated pools through the live ETI/ETX pool. stETX pools are priced through the stETX ERC-4626 exchange rate. Other ETX pools are treated as balanced 50/50 AMM pools and estimated from the ETX reserve. Staking counts ETX deposited in the stETX ERC-4626 vault.",
   etica: {
     tvl,
     staking,

--- a/projects/helper/chains.json
+++ b/projects/helper/chains.json
@@ -153,6 +153,7 @@
   "ethereumclassic",
   "ethf",
   "ethpow",
+  "etica",
   "etlk",
   "etn",
   "europa",


### PR DESCRIPTION
Adds a TVL adapter for EticaHub on Etica mainnet.

## Context

EticaHub is live on Etica mainnet and exposes EticaSwap pools plus an stETX ERC-4626 staking vault. The adapter queries Etica mainnet RPC directly, prices ETX-denominated liquidity through the ETI/ETX pool, and reports ETI-denominated TVL via the CoinGecko `etica` id.

## Changes

- Add `projects/eticahub/index.js`
- Add `etica` to `projects/helper/chains.json`
- Track EticaSwap pool liquidity and stETX staking

## Tests

```bash
node test.js projects/eticahub/index.js
npx eslint -c eslint.config.js projects/eticahub/index.js
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ETICA DeFi protocol support, enabling TVL and staking position tracking across ETICA pools.
  * Added Etica chain to the list of supported networks for on-chain data collection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->