### PR TITLE
fix: remove duplicate AlphaFi Bluefin pool

### DIFF
--- a/projects/alphafi/index.js
+++ b/projects/alphafi/index.js
@@ -279,13 +279,6 @@ const ALPHAFI_BLUEFIN_TVL_IDS = [
     token0Type: "0xd1b72982e40348d069bb1ff701e634c117bb5f741f44dff91e472d3b01461e55::stsui::STSUI",
     token1Type: ADDRESSES.sui.SUI
   },
-  { //suibtc usdc
-    poolID: "0x4043b9e628d0cc6c2e3f322e6a7bddf603a3bcc084992355b55f4c23516bb6ba",
-    parentPoolID: "0xf0e4772e80800550368973d1f8ab2c9a7241ace8df8770452ee2bf3e3e67b8a1",
-    investorID: "0x6876c4b19075ee774ca368a4a782c9425cca97251093dafa7ff239a846b3ee30",
-    token0Type: ADDRESSES.sui.BTC,
-    token1Type: ADDRESSES.sui.USDC_CIRCLE
-  },
   { //lbtc suibtc
     poolID: "0xd30d849bbddd0c1bc0e2eb552c2dacdf4ae998cc03cd485640eb3db7f456e295",
     parentPoolID: "0x7df346f8ef98ad20869ff6d2fc7c43c00403a524987509091b39ce61dde00957",


### PR DESCRIPTION
Removes a duplicated AlphaFi Bluefin pool entry from the Sui adapter.

## Context

`ALPHAFI_BLUEFIN_TVL_IDS` contains the same `wBTC-USDC` Bluefin position twice with identical pool, parent pool, investor, and token pair values. Keeping both entries can double-count that position in AlphaFi TVL.

## Changes

- Remove the duplicate `suibtc usdc` entry
- Keep the original `wBTC-USDC` entry

## Tests

```bash
node test.js projects/alphafi/index.js
npx eslint -c eslint.config.js projects/alphafi/index.js
```

Draft PR for review before marking ready.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Corrected structural formatting in the AlphaFi module exports to ensure proper code organization. No functional changes to TVL, pool, or staking handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->