### PR TITLE
Add xeno-money sISKe vault (Base)

### DIFF
--- a/registries/erc4626.js
+++ b/registries/erc4626.js
@@ -275,6 +275,10 @@ const configs = {
   'defimarketplus': {
     arbitrum: ['0x07fF8bCe905CB285220e4D96d8443cfCF141af8b'],
     methodology: 'TVL = SafeUsdVault.totalAssets() (idle USDC + USDC deployed to whitelisted lending strategies, minus unvested locked-profit).'
+  },
+  'xeno-money': {
+    base: ['0xC6Aad7c41c66bDC5E138fbd4180cDd3dB0F4fB3F'],
+    methodology: 'TVL is the total ISKe deposited in the sISKe ERC-4626 earn vault, measured via totalAssets().'
   }
 }
 


### PR DESCRIPTION
## Summary

Adds TVL tracking for Xeno Money's sISKe ERC-4626 earn vault on Base mainnet.

- **Vault:** `0xC6Aad7c41c66bDC5E138fbd4180cDd3dB0F4fB3F`
- **Underlying:** ISKe (Monerium MiCA-regulated ISK stablecoin)
- **Chain:** Base (8453)
- **Method:** `totalAssets()` via ERC-4626 registry
- **Website:** https://app.xeno.money

ISKe is the only MiCA-regulated Icelandic krona stablecoin, issued by Monerium (EMI-licensed). The sISKe vault passes reserve yield to depositors.

ISKe/USDC liquidity exists on Aerodrome (Base) at `0x8b910de6074cde39edddb5229f078bfbe4e992da` for pricing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the ERC-4626 protocol registry configuration
  * Closed the defimarketplus protocol entry
  * Added xeno-money protocol to the registry with vault configuration and methodology details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->