### PR TITLE
Add DIEM Relay adapter (Base)

### DIFF
--- a/projects/diem-relay/index.js
+++ b/projects/diem-relay/index.js
@@ -1,0 +1,38 @@
+const ADDRESSES = require('../helper/coreAssets.json');
+const { sumTokens2 } = require('../helper/unwrapLPs');
+
+// DIEM Relay — Base
+const DIEM = '0xF4d97F2da56e8c3098f3a8D538DB630A2606a024';
+const DIEM_VAULT = '0xdc9625b026f6Dd17F9d96e608592A9C592e27eEF';
+const SDIEM = '0xdbF05AF4fdAA518AC9c4dc5aA49399b8dd0B4be2';
+const CSDIEM = '0x4899f5fBA1bf43C8Bea483bE6342e55Bc16e045a';
+const REVENUE_SPLITTER = '0xd185138CEA135E60CA6E567BE53DEC81D89Ce7D6';
+
+const STAKED_INFOS_ABI =
+  'function stakedInfos(address) view returns (uint256 amount, uint256 cooldownEnd, uint256 pendingUnstake)';
+
+async function tvl(api) {
+  return sumTokens2({
+    api,
+    tokens: [ADDRESSES.base.USDC],
+    owners: [DIEM_VAULT, SDIEM, CSDIEM, REVENUE_SPLITTER],
+  });
+}
+
+async function staking(api) {
+  const [veniceStaked] = await api.call({
+    target: DIEM,
+    params: SDIEM,
+    abi: STAKED_INFOS_ABI,
+  });
+  api.add(DIEM, veniceStaked);
+  return sumTokens2({ api, tokens: [DIEM], owners: [CSDIEM] });
+}
+
+module.exports = {
+  methodology:
+    'TVL is USDC held by the DIEM Relay vault, the sDIEM rewards-stream contract, ' +
+    'csDIEM, and the RevenueSplitter. Staking is DIEM forward-staked on Venice via sDIEM ' +
+    "plus any liquid DIEM held by csDIEM between harvest cycles.",
+  base: { tvl, staking },
+};


### PR DESCRIPTION
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
DIEM Relay

##### Twitter Link:
N/A

##### List of audit links if any:
Internal audit notes: https://github.com/Figu3/diem-relay/blob/main/contracts/AUDIT.md

##### Website Link:
https://diem-relay.com

##### Logo (High resolution, will be shown with rounded borders):
N/A — happy to add via the defillama-server repo follow-up.

##### Current TVL:
~\$50 USDC across the Relay contracts (DIEMVault, sDIEM, csDIEM, RevenueSplitter), plus ~16 DIEM forward-staked on Venice via sDIEM. The DIEM token's own native staking (separate from the Relay contracts) holds ~30k DIEM and is intentionally excluded.

##### Treasury Addresses (if the protocol has treasury)
2/2 Safe on Base: \`0x01Ea790410D9863A57771D992D2A72ea326DD7C9\`

##### Chain:
Base

##### Coingecko ID:
N/A

##### Coinmarketcap ID:
N/A

##### Short Description (to be shown on DefiLlama):
Stake DIEM to earn USDC yield from Venice AI compute revenue. Synthetix-style staking with a 24h reward stream, plus an optional ERC-4626 auto-compounding wrapper (csDIEM).

##### Token address and ticker if any:
DIEM — \`0xF4d97F2da56e8c3098f3a8D538DB630A2606a024\` (Base)

##### Category:
Yield

##### Oracle Provider(s):
TWAP — Aerodrome Slipstream CL pool \`0xBc3231036Ee1ECa03E5F67FEceDC640D21610823\` (USDC/DIEM, tickSpacing=100). Used only by csDIEM to bound USDC→DIEM swap slippage during \`harvest()\`.

##### Implementation Details:
csDIEM uses Uniswap V3 \`OracleLibrary.consult\` over a configurable TWAP window (≥30 min minimum, default 30 min). The TWAP price is enforced as a minimum out-amount on the Slipstream router swap, with a configurable slippage cap (≤10% hard cap). Mandatory \`minDiemPerUsdc\` floor pinned at deploy = 50% of TWAP.

##### Documentation/Proof:
- csDIEM source: https://github.com/Figu3/diem-relay/blob/main/contracts/src/csDIEM.sol
- OracleLibrary: https://github.com/Figu3/diem-relay/blob/main/contracts/src/libraries/OracleLibrary.sol

##### forkedFrom:
sDIEM forks Synthetix StakingRewards. csDIEM is built on OpenZeppelin ERC-4626 (with virtual shares/assets, async withdrawal pattern).

##### methodology:
**TVL** is the USDC balance held by the four DIEM Relay contracts: DIEMVault (USDC borrower deposits for the credit-gated relay), sDIEM (in-flight USDC rewards being streamed over 24h), csDIEM, and RevenueSplitter (transient USDC awaiting permissionless \`distribute()\`).

**Staking** is DIEM forward-staked on the Venice compute marketplace via sDIEM (queried via \`DIEM.stakedInfos(sDIEM)\`), plus any liquid DIEM held by csDIEM between harvest cycles.

##### Github org/user:
Figu3 — https://github.com/Figu3/diem-relay (MIT license, open source)

##### Does this project have a referral program?
No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added DIEM Relay adapter for computing Total Value Locked by aggregating USDC balances across vault, staking, and revenue distribution contracts.
  * Introduced DIEM staking metrics functionality enabling tracking of staked token amounts and calculation of total DIEM ownership across protocol positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->