### PR TITLE
Add PiggyBank Protocol

### DIFF
--- a/projects/piggybank/index.js
+++ b/projects/piggybank/index.js
@@ -1,0 +1,76 @@
+const { PublicKey } = require('@solana/web3.js')
+const { getConnection } = require('../helper/solana')
+
+// PiggyBank Token vaults. Add a line here when a new vault is launched.
+const VAULTS = [
+  '91LYov1N1j62Q3ipuBi8w2e5GVqjVxWTdJ757roiWXdy', // pbUSDC    -> USDC
+  '5CgRTdywEQ7LK7SRM5NAgsuSWxnswREW6VeZ4i9jHCRf', // pbSPYx    -> SPYx (xStock)
+  '6mzgN6fyqap4Um7bNoH7DNCqtib3CU7TfGvVTMBhaDhf', // pbJITOSOL -> JitoSOL
+]
+
+const DISCRIMINATOR = Buffer.from('PBKTOKEN')
+const PBK_TOKEN_LEN = 210
+const SCALE = 10n ** 18n
+
+// PbkToken layout (#[repr(C)], all fields are byte arrays so no padding):
+//   0   discriminator [8]
+//   8   mint                   [32]   share/LST mint
+//   40  underlying_mint        [32]
+//   72  lst_supply             u128
+//   88  epoch                  u64
+//   96  prev_epoch_redemptions u128
+//   112 epoch_redemptions      u128
+//   128 epoch_deposits         u128
+//   144 pending_redemptions    u128
+//   160 pending_claims         u128
+//   176 managed                u128
+//   192 deposit_cap            u128
+//   208 state                  u8
+//   209 bump                   u8
+function readU128LE(data, offset) {
+  return data.readBigUInt64LE(offset) | (data.readBigUInt64LE(offset + 8) << 64n)
+}
+
+function decodePbkToken(data) {
+  if (!data || data.length !== PBK_TOKEN_LEN) return null
+  if (!data.slice(0, 8).equals(DISCRIMINATOR)) return null
+
+  const underlyingMint = new PublicKey(data.slice(40, 72)).toString()
+  const lstSupply = readU128LE(data, 72)
+  const prevEpochRedemptions = readU128LE(data, 96)
+  const epochRedemptions = readU128LE(data, 112)
+  const epochDeposits = readU128LE(data, 128)
+  const pendingRedemptions = readU128LE(data, 144)
+  const managed = readU128LE(data, 176)
+
+  // Mirrors on-chain underlying_represented_by_lst()
+  const underlying =
+    managed + epochDeposits - epochRedemptions - prevEpochRedemptions - pendingRedemptions
+
+  // Mirrors on-chain lst_price_in_underlying() (1e18-scaled)
+  const lstPrice = lstSupply === 0n ? SCALE : (underlying * SCALE) / lstSupply
+
+  return { underlyingMint, lstSupply, lstPrice }
+}
+
+async function tvl(api) {
+  const accounts = await getConnection().getMultipleAccountsInfo(
+    VAULTS.map((v) => new PublicKey(v)),
+  )
+
+  for (const account of accounts) {
+    const decoded = decodePbkToken(account?.data)
+    if (!decoded) continue
+    const { underlyingMint, lstSupply, lstPrice } = decoded
+    // share supply * share->underlying price (1e18-scaled) / 1e18
+    const underlyingAmount = (lstSupply * lstPrice) / SCALE
+    api.add(underlyingMint, underlyingAmount.toString())
+  }
+}
+
+module.exports = {
+  timetravel: false,
+  methodology:
+    'PiggyBank issues vault share tokens (e.g. pbUSDC, pbJitoSOL, pbSPYx) representing deposits in an underlying token. For each vault, the adapter reads the on-chain vault account, computes the total underlying represented by the share supply (share supply x on-chain share-to-underlying price), and adds it to TVL denominated in the underlying mint - USDC, JitoSOL, or an xStocks SPL mint such as SPYx. Underlying mints are priced by DefiLlama.',
+  solana: { tvl },
+}


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).
2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** It is a different repo, you can find your listing in [this file](https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts), you can edit it there and put up a PR
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes

---
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):

PiggyBank

##### Twitter Link:

https://x.com/piggybank_fi

##### List of audit links if any:

https://cdn.prod.website-files.com/68e7628180c5b014e78a46cc/6900fa6f3a2659fab4c7b728_piggy_bank.pdf

##### Website Link:

https://piggybank.fi

##### Logo (High resolution, will be shown with rounded borders):

https://app.piggybank.fi/web-app-manifest-512x512.png

##### Current TVL:

$4,601,723 on May 7th, 2026

##### Treasury Addresses (if the protocol has treasury)

C63SijJLVtiMmzosPmZ23mft4GxXXXTxjmuuu98owx8K

##### Chain:

Solana

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): 

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): 

##### Short Description (to be shown on DefiLlama):

PiggyBank offers extra yield on tokenized stocks. Earn additional yield on digital assets through systematic strategies, compounded every 48 hours.

##### Token address and ticker if any:

##### Category (full list at https://defillama.com/categories) \*Please choose only one:

Yield

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

 N/A — TVL is read directly from on-chain vault state; no oracle is used for TVL computation

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

##### forkedFrom (Does your project originate from another project):

##### methodology (what is being counted as tvl, how is tvl being calculated):

PiggyBank issues vault share tokens (e.g. pbUSDC, pbJitoSOL, pbSPYx) representing deposits in an underlying token. For each vault, the adapter reads the on-chain vault account, computes the total underlying represented by the share supply (share supply x on-chain share-to-underlying price), and adds it to TVL denominated in the underlying mint - USDC, JitoSOL, or an xStocks SPL mint such as SPYx. Underlying mints are priced by DefiLlama.

##### Github org/user (Optional, if your code is open source, we can track activity):

https://github.com/zsociety-io

##### Does this project have a referral program?

Yes: https://app.piggybank.fi/oinks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking PiggyBank vault share tokens on Solana, enabling TVL measurement across multiple vault assets including USDC, JitoSOL, and SPYx. The new adapter reads and aggregates on-chain vault data for comprehensive protocol coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->