### PR TITLE
add upshift curator helper

### DIFF
--- a/projects/clearstar/index.js
+++ b/projects/clearstar/index.js
@@ -21,10 +21,12 @@ const configs = {
         '0x829A13850b684A575C0580a83322890e19c5eFaa',
       ],
       erc4626: [
-        '0x18EE038C114a07f4B08b420fb1E4149a4F357249', // Upshift Wildcat USD
-        '0xb2FdA773822E5a04c8A70348d66257DD5Cf442DB', // Upshift LiquityV2
         '0xdd5eff0756db08bad0ff16b66f88f506e7318894', // YieldFi yPrism
         '0x87428d886F43068A44d7bDEeF106D3c42E1d6f23', // IPOR Fusion yoGOLD
+      ],
+      upshiftV2: [
+        '0x18EE038C114a07f4B08b420fb1E4149a4F357249', // Upshift Wildcat USD
+        '0xb2FdA773822E5a04c8A70348d66257DD5Cf442DB', // Upshift LiquityV2
       ],
     },
     polygon: {
@@ -76,26 +78,15 @@ const configs = {
         '0x1aEadA3C251215f1294720B80FcB3D1D005F3585', // Core wFLR Vault on Mystic
         '0x53184aDaBF312b490BF1EbcFdC896FEfF6019a14', // Core FXRP Vault on Mystic
       ],
+      upshiftV2: [
+        '0x373D7d201C8134D4a2f7b5c63560da217e3dEA28', // Upshift FXRP
+      ],
     },
   }
 }
 
-const exportObj = getCuratorExport(configs)
-const existingFlareTvl = exportObj.flare?.tvl
-
-// Flare vault uses non-standard getTotalAssets() instead of totalAssets()
-const FLARE_VAULT = '0x373D7d201C8134D4a2f7b5c63560da217e3dEA28' // Upshift FXRP
-exportObj.flare = {
-  tvl: async (api) => {
-    if (existingFlareTvl) await existingFlareTvl(api)
-    const asset = await api.call({ abi: 'address:asset', target: FLARE_VAULT })
-    const totalAssets = await api.call({ abi: 'uint256:getTotalAssets', target: FLARE_VAULT })
-    api.add(asset, totalAssets)
-  }
-}
-
 module.exports = {
-  ...exportObj,
+  ...getCuratorExport(configs),
 
   timetravel: false, // starknet doesn't support historical queries
   hallmarks: [

--- a/projects/helper/curators/index.js
+++ b/projects/helper/curators/index.js
@@ -443,6 +443,16 @@ async function getCuratorTvlBoringVault(api, vaults) {
   }
 }
 
+async function getCuratorTvlUpshiftV2(api, vaults) {
+  // Upshift multiAssetVault: non-ERC4626, exposes asset() + getTotalAssets()
+  await api.erc4626Sum({
+    calls: vaults,
+    tokenAbi: ABI.ERC4626.asset,
+    balanceAbi: 'uint256:getTotalAssets',
+    permitFailure: true,
+  })
+}
+
 async function getCuratorTvlSymbioticVault(api, vaults) {
   const assets = await api.multiCall({ abi: ABI.symbiotic.collateral, calls: vaults, permitFailure: true })
   const existedVaults = []
@@ -541,6 +551,11 @@ async function getCuratorTvl(api, vaults) {
   // symiotic.fi
   if (vaults.symbiotic) {
     await getCuratorTvlSymbioticVault(api, vaults.symbiotic)
+  }
+
+  // upshift.io multiAssetVault (V2)
+  if (vaults.upshiftV2) {
+    await getCuratorTvlUpshiftV2(api, vaults.upshiftV2)
   }
 
   // nested 4626 vaults

--- a/projects/rockawayx/index.js
+++ b/projects/rockawayx/index.js
@@ -13,12 +13,6 @@ const LISTA_VAULTS = {
   ],
 };
 
-const UPSHIFT_VAULTS = {
-  ethereum: [
-    '0xc87DBBB8C67e4F19fCD2E297c05937567b2572Ce',
-  ],
-};
-
 const MIDAS_VAULTS = {
   ethereum: [
     '0x030b69280892c888670EDCDCD8B69Fd8026A0BF3', // mMEV
@@ -41,6 +35,9 @@ const configs = {
         '0x5f829B1B473cBA86838E1B7BB7E144DbDE228e21',
         '0xE0181090c22579B6A217f1522cbf8c9f1F0C1965',
         '0x64C18DCC4Ccb3b8D27877a4aeBB4C3126CB39cB9',
+      ],
+      upshiftV2: [
+        '0xc87DBBB8C67e4F19fCD2E297c05937567b2572Ce', // Upshift Earn ctUSD
       ],
     },
     sei: {
@@ -94,25 +91,6 @@ for (const [chain, vaults] of Object.entries(LISTA_VAULTS)) {
     tvl: async (api) => {
       if (baseTvl) await baseTvl(api);
       await sumERC4626Vaults({ api, calls: vaults, isOG4626: true });
-    }
-  };
-}
-
-async function upshiftTvl(api, vaults) {
-  const assets = await api.multiCall({ abi: 'address:asset', calls: vaults, permitFailure: true });
-  const totalAssets = await api.multiCall({ abi: 'function getTotalAssets() view returns (uint256)', calls: vaults, permitFailure: true });
-  for (let i = 0; i < vaults.length; i++) {
-    if (!assets[i] || totalAssets[i] === null || totalAssets[i] === undefined) continue;
-    api.add(assets[i], totalAssets[i]);
-  }
-}
-
-for (const [chain, vaults] of Object.entries(UPSHIFT_VAULTS)) {
-  const baseTvl = adapterExport[chain]?.tvl;
-  adapterExport[chain] = {
-    tvl: async (api) => {
-      if (baseTvl) await baseTvl(api);
-      await upshiftTvl(api, vaults);
     }
   };
 }


### PR DESCRIPTION
- fixes 2 clearstar vaults that were silently dropped 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking Upshift V2 vaults across Ethereum and Flare networks.

* **Refactor**
  * Consolidated vault TVL calculation logic using standardized curator handlers.
  * Simplified Flare TVL computation by removing custom override implementations.
  * Unified Upshift vault tracking under Upshift V2 handler across adapters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->