### PR TITLE
fix: disable timetravel for VisionBoard Vault

### DIFF
--- a/registries/erc4626.js
+++ b/registries/erc4626.js
@@ -269,6 +269,7 @@ const configs = {
     methodology: "TVL represents the total value of assets held within the vault. Each vault token is minted using USDC and appreciates in line with the performance of the underlying asset.",
   },
   'visionboard-vault': {
+    timetravel: false,
     hyperliquid: ['0x0a5e236425aca07fd087904F8863CAd554675E06'],
     methodology: 'TVL is calculated from VisionBoard Vault totalAssets() on HyperEVM. Deposits mint VBV vault shares backed by the vault asset, currently USDC.'
   },


### PR DESCRIPTION
VisionBoard Vault's ERC-4626 totalAssets() includes active HyperCore/HyperEVM vault accounting and needs to be read at latest state. The original custom adapter had timetravel disabled, but the registry refactor dropped that flag.\n\nCurrent behavior:\n- Latest local adapter run exports ~6.63k USDC TVL.\n- Historical/timestamped run at the API sample timestamp (2026-05-07 20:26:47 UTC / 1778185607) exports ~24.99 USDC, matching the stale DefiLlama API value.\n- On-chain latest totalAssets() currently returns ~6.63k USDC.\n\nThis adds timetravel: false back to the registry entry so DefiLlama uses the live/latest totalAssets() value rather than stale historical calls.\n\nTest:\n```bash\nrm -rf tvl-adapter-repo .cache cache\nnode test.js visionboard-vault\n# hyperliquid 6.63 k / total 6.63 k\n```\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TVL computation configuration for visionboard-vault protocol.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->