### PR TITLE
Add Sour Finance — Solana perp DEX with batch clearing

### DIFF
--- a/projects/sour.js
+++ b/projects/sour.js
@@ -1,0 +1,28 @@
+const { sumTokens2 } = require("./helper/solana");
+
+// Sour LP vault PDA — derived deterministically from the program ID:
+//   findProgramAddressSync([utf8('sour_vault')], 'souryQgnM1xiNuGcmVYLPGT3MKqnGN8QTqP8zk8eape')
+//   → 'F6aMk3z9TVEuGJ2DQ7uBFrDwJUK88gBxVLnXMSZraGD' (bump 254)
+//
+// The vault holds the LP-side USDC that backs trader PnL on Sour. Trader
+// collateral is custodied per-trader inside the program but is not counted
+// toward protocol TVL by convention (it's user funds, not LP funds), so
+// `sumTokens2` aggregating only the vault's token accounts is the correct
+// scope.
+const SOUR_VAULT_PDA = 'F6aMk3z9TVEuGJ2DQ7uBFrDwJUK88gBxVLnXMSZraGD';
+
+async function tvl() {
+  return sumTokens2({ owner: SOUR_VAULT_PDA });
+}
+
+module.exports = {
+  hallmarks: [
+    ['2026-05-06', 'launch Sour mainnet v1.0.0'],
+  ],
+  timetravel: false,
+  methodology:
+    "TVL is the USDC balance of the SOUR LP vault — a program-derived account holding LP collateral for the Solana perpetuals program at souryQgnM1xiNuGcmVYLPGT3MKqnGN8QTqP8zk8eape. Vault PDA derived from [utf8('sour_vault'), program_id]. Trader collateral is excluded.",
+  solana: {
+    tvl,
+  },
+};

--- a/projects/sour/index.js
+++ b/projects/sour/index.js
@@ -1,4 +1,5 @@
-const { sumTokens2 } = require("./helper/solana");
+const { sumTokens2 } = require("../helper/solana");
+const ADDRESSES = require('../helper/coreAssets.json')
 
 // Sour LP vault PDA — derived deterministically from the program ID:
 //   findProgramAddressSync([utf8('sour_vault')], 'souryQgnM1xiNuGcmVYLPGT3MKqnGN8QTqP8zk8eape')
@@ -12,7 +13,7 @@ const { sumTokens2 } = require("./helper/solana");
 const SOUR_VAULT_PDA = 'F6aMk3z9TVEuGJ2DQ7uBFrDwJUK88gBxVLnXMSZraGD';
 
 async function tvl() {
-  return sumTokens2({ owner: SOUR_VAULT_PDA });
+  return sumTokens2({ owner: SOUR_VAULT_PDA, tokens: [ADDRESSES.solana.USDC] });
 }
 
 module.exports = {


### PR DESCRIPTION
Adds Sour Finance to the protocols dashboard.

**What:** Sour is a perpetual futures DEX on Solana mainnet. Live since 2026-05-06 (program ID `souryQgnM1xiNuGcmVYLPGT3MKqnGN8QTqP8zk8eape`). Three markets at launch: SOL-USD, BTC-USD, ETH-USD, all USDC-quoted.

**Methodology:** TVL is the USDC balance of the SOUR LP vault — a program-derived account holding LP collateral for the program. Vault PDA is derived from `[utf8('sour_vault'), program_id]` and resolves to `F6aMk3z9TVEuGJ2DQ7uBFrDwJUK88gBxVLnXMSZraGD` (bump 254). Trader collateral is custodied per-trader inside the program and excluded by convention.

**Mechanism:** Sour clears every 1.8 seconds at one uniform clearing price, with funding computed inside every batch (no off-chain cron). Flat 3 bps fee per fill, 100% routes to the LP vault.

**Verification:** the program is open-source and formally verified for settlement and aggregate-budget invariants — 18 Kani proofs + Lean specification + 15 property tests at https://github.com/GageBachik/sour-verification. No third-party security audit yet.

**Links:**
- Marketing: https://sour.finance
- App: https://app.sour.finance
- Source: https://github.com/GageBachik/sour
- Verification: https://github.com/GageBachik/sour-verification

Will follow with a separate PR to dimension-adapters for daily volume + fees.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tracking Total Value Locked (TVL) for the Sour project on Solana. TVL data now reflects USDC holdings in the protocol's vault, providing real-time visibility into locked capital.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19184?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->