### PR TITLE
add yeet adapter (berachain)

### DIFF
--- a/projects/yeet/index.js
+++ b/projects/yeet/index.js
@@ -8,14 +8,14 @@ const POT_OWNERS = [
 ]
 
 const TRIFECTA_VAULT = '0xD3908dA797eCeC7ea0fBfbacF3118302E215556c'
-const BONDS_TELLER = '0x007F774351e541b8bc720018De0796c4BF5afE3D'
 
 async function tvl(api) {
   await api.sumTokens({
     owners: POT_OWNERS,
     tokens: [ADDRESSES.null, ADDRESSES.berachain.WBERA],
   })
-
+}
+async function pool2(api) {
   // Trifecta deposits its LP into an external strategy, so balanceOf(vault) reads 0.
   const lpToken = await api.call({ target: TRIFECTA_VAULT, abi: 'address:asset' })
   const lpHeld = await api.call({ target: TRIFECTA_VAULT, abi: 'uint256:totalAssets' })
@@ -36,19 +36,8 @@ async function tvl(api) {
     api.add(token0, share(underlying.amount0Current))
     api.add(token1, share(underlying.amount1Current))
   }
-
-  await api.sumTokens({
-    owner: BONDS_TELLER,
-    tokens: [
-      ADDRESSES.null,
-      ADDRESSES.berachain.WBERA,
-      ADDRESSES.berachain.HONEY,
-      ADDRESSES.berachain.USDC,
-    ],
-  })
 }
 
 module.exports = {
-  doublecounted: true,
-  berachain: { tvl },
+  berachain: { tvl, pool2 },
 }

--- a/projects/yeet/index.js
+++ b/projects/yeet/index.js
@@ -1,0 +1,54 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+
+const POT_OWNERS = [
+  '0xEe6f49Dc2f1D0d9567dDd3FD6D77D8F7edfe7379', // Yeet v1 Game
+  '0x9B84297A081903e79f7b449a5239244abEbBEbd5', // Yeet v1 Lottery
+  '0xF6977c3D5154Aa4510B16267761Da16fE6bb05e4', // BGT Auction Game
+  '0xd05A807eDD9710e9064BC2535995C4a9d2332B8c', // PrizeManager
+]
+
+const TRIFECTA_VAULT = '0xD3908dA797eCeC7ea0fBfbacF3118302E215556c'
+const BONDS_TELLER = '0x007F774351e541b8bc720018De0796c4BF5afE3D'
+
+async function tvl(api) {
+  await api.sumTokens({
+    owners: POT_OWNERS,
+    tokens: [ADDRESSES.null, ADDRESSES.berachain.WBERA],
+  })
+
+  // Trifecta deposits its LP into an external strategy, so balanceOf(vault) reads 0.
+  const lpToken = await api.call({ target: TRIFECTA_VAULT, abi: 'address:asset' })
+  const lpHeld = await api.call({ target: TRIFECTA_VAULT, abi: 'uint256:totalAssets' })
+  if (lpHeld > 0) {
+    const [token0, token1, lpSupply, underlying] = await Promise.all([
+      api.call({ target: lpToken, abi: 'address:token0' }),
+      api.call({ target: lpToken, abi: 'address:token1' }),
+      api.call({ target: lpToken, abi: 'erc20:totalSupply' }),
+      api.call({
+        target: lpToken,
+        abi: 'function getUnderlyingBalances() view returns (uint256 amount0Current, uint256 amount1Current)',
+      }),
+    ])
+    const supply = BigInt(lpSupply)
+    if (supply === 0n) return
+    const held = BigInt(lpHeld)
+    const share = (n) => (BigInt(n) * held) / supply
+    api.add(token0, share(underlying.amount0Current))
+    api.add(token1, share(underlying.amount1Current))
+  }
+
+  await api.sumTokens({
+    owner: BONDS_TELLER,
+    tokens: [
+      ADDRESSES.null,
+      ADDRESSES.berachain.WBERA,
+      ADDRESSES.berachain.HONEY,
+      ADDRESSES.berachain.USDC,
+    ],
+  })
+}
+
+module.exports = {
+  doublecounted: true,
+  berachain: { tvl },
+}


### PR DESCRIPTION
## (New listing)

##### Name (to be shown on DefiLlama):
Yeet

##### Twitter Link:
https://x.com/eatsleepyeet

##### List of audit links if any:
- Zellic, October 2024
- Immunefi audit competition: https://immunefi.com/audit-competition/audit-comp-yeet/scope/

##### Website Link:
https://www.yeetit.xyz/

##### Logo (High resolution, will be shown with rounded borders):
(to be added by maintainer / project team)

##### Current TVL:
~$2.6k at submission. Comes from BERA/WBERA in the v1 game, lottery, BGT-auction and PrizeManager pots, plus the YEET-wBERA Kodiak LP underlying the Trifecta vault. The YeetBonds Teller is empty right now but is included so it picks up automatically once active.

##### Treasury Addresses (if the protocol has treasury):
The YEET Buyback Vault (`0x366590179b477362adce1735419a38d574071b4c`) holds protocol-owned revenue. It's intentionally excluded from TVL.

##### Chain:
Berachain

##### Coingecko ID:
yeet

##### Coinmarketcap ID:
yeet-it

##### Short Description (to be shown on DefiLlama):
On-chain games on Berachain: a yeet-the-pot timer game, a BGT Dutch auction, OTC bond sales (YeetBonds), and a YEET-wBERA liquidity vault.

##### Token address and ticker if any:
$YEET, `0x08A38Caa631DE329FF2DAD1656CE789F31AF3142` (Berachain)

##### Category:
Gaming

##### Oracle Provider(s):
None. TVL reads directly from contract balances and ERC-4626 / Kodiak Island accounting.

##### Implementation Details:
N/A (no oracle dependency)

##### Documentation/Proof:
- https://docs.yeetit.xyz/
- Contracts dump: https://docs.yeetit.xyz/yeet/llms-full.txt

##### forkedFrom:
N/A

##### methodology:
TVL = native BERA / WBERA in the Yeet v1 Game, Yeet v1 Lottery, BGT Auction Game and PrizeManager pots, plus the YEET-wBERA Kodiak Island LP underlying the Liquidity Trifecta ERC-4626 vault, plus quote tokens held by the YeetBonds Fixed Term Teller.

The Trifecta vault parks its LP in an external strategy, so `balanceOf(vault)` reads 0. The adapter uses `totalAssets()` for the LP amount and unwraps it via `getUnderlyingBalances()` scaled by ownership share.

Excluded: the YEET Buyback Vault (protocol-owned revenue) and YEET Staking (own-token staking). Marked `doublecounted` because Trifecta wraps a Kodiak LP already counted by the kodiak-islands adapter.

##### Github org/user:
https://github.com/yeet-protocol

##### Does this project have a referral program?
Not advertised.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Total Value Locked (TVL) for Yeet on Berachain — aggregates native and wrapped token balances held by protocol owners.
  * Added Pool2/liquidity modeling for the vault — reads vault exposure, fetches LP metadata, and computes proportional underlying token balances.
  * Note: bond/teller aggregation is not included in this release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19185?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->