### PR TITLE
Add dexr.finance dex aggregator on Base

### DIFF
--- a/projects/dexr/index.js
+++ b/projects/dexr/index.js
@@ -1,118 +1,87 @@
-const { request } = require("graphql-request");
-
-// ─── Constants ───────────────────────────────────────────────────────────────
-
 const CHAIN = "base";
 const CONTRACT = "0x4859608579D0f01605F6824ea173072a7Cc206c5";
+const WETH_BASE = "0x4200000000000000000000000000000000000006";
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
-// SwapExecuted(address user, uint8 adapterId, address tokenIn, address tokenOut,
-//              uint256 amountIn, uint256 amountOut, uint256 feeAmount)
-const SWAP_EXECUTED_TOPIC =
+// SwapExecuted event topic
+const SWAP_TOPIC =
   "0xdd4c67c6f3ac40c1172614cde8156b024bd3d41f6891c92bf6c04ad9c83ffd95";
 
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-/**
- * Fetch swap logs from a public RPC for a given block range.
- * Returns an array of parsed log objects.
- */
 async function fetchSwapLogs(fromBlock, toBlock) {
-  const rpc = "https://mainnet.base.org";
+  try {
+    const res = await fetch("https://mainnet.base.org", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "eth_getLogs",
+        params: [
+          {
+            address: CONTRACT,
+            topics: [SWAP_TOPIC],
+            fromBlock: "0x" + fromBlock.toString(16),
+            toBlock: "0x" + toBlock.toString(16),
+          },
+        ],
+      }),
+    });
 
-  const body = JSON.stringify({
-    jsonrpc: "2.0",
-    id: 1,
-    method: "eth_getLogs",
-    params: [
-      {
-        address: CONTRACT,
-        topics: [SWAP_EXECUTED_TOPIC],
-        fromBlock: "0x" + fromBlock.toString(16),
-        toBlock: "0x" + toBlock.toString(16),
-      },
-    ],
-  });
+    const json = await res.json();
 
-  const res = await fetch(rpc, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body,
-  });
+    // Handle RPC errors gracefully (rate limit, upstream issue, etc.)
+    if (json.error || !Array.isArray(json.result)) {
+      console.error("RPC error:", json.error);
+      return [];
+    }
 
-  const json = await res.json();
-  return json.result ?? [];
+    return json.result;
+  } catch (e) {
+    console.error("fetchSwapLogs failed:", e);
+    return [];
+  }
 }
 
-/**
- * Decode a SwapExecuted log.
- * Non-indexed data layout (each 32 bytes):
- *   [0] tokenIn   [1] tokenOut   [2] amountIn   [3] amountOut   [4] feeAmount
- */
 function decodeSwapLog(log) {
-  const data = log.data.slice(2); // strip 0x
+  const data = log.data.slice(2);
   const chunk = (i) => data.slice(i * 64, (i + 1) * 64);
-
-  const tokenIn  = "0x" + chunk(0).slice(24);   // address (last 20 bytes)
-  const tokenOut = "0x" + chunk(1).slice(24);
+  const tokenIn = "0x" + chunk(0).slice(24);
   const amountIn = BigInt("0x" + chunk(2));
-
-  return { tokenIn, tokenOut, amountIn };
+  return { tokenIn, amountIn };
 }
 
-// ─── Volume adapter ───────────────────────────────────────────────────────────
+async function fetch(timestamp, chainBlocks) {
+  const toBlock = chainBlocks[CHAIN];
+  const fromBlock = toBlock - 43200; // ~24h on Base (2s blocks)
 
-const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
-const WETH_BASE    = "0x4200000000000000000000000000000000000006";
-
-/**
- * Sum raw amountIn values per token for all swaps in the given block range.
- * Returns { dailyVolume: { [tokenAddress]: BigInt } }
- */
-async function getVolume(timestamp, fromBlock, toBlock) {
   const logs = await fetchSwapLogs(fromBlock, toBlock);
 
   const volumeByToken = {};
 
   for (const log of logs) {
     const { tokenIn, amountIn } = decodeSwapLog(log);
-
-    // Treat native ETH (address(0)) same as WETH for pricing
-    const token = tokenIn === ZERO_ADDRESS ? WETH_BASE : tokenIn.toLowerCase();
+    const token =
+      tokenIn.toLowerCase() === ZERO_ADDRESS
+        ? WETH_BASE.toLowerCase()
+        : tokenIn.toLowerCase();
 
     volumeByToken[token] = (volumeByToken[token] ?? BigInt(0)) + amountIn;
   }
 
-  return volumeByToken;
+  const dailyVolume = {};
+  for (const [token, amount] of Object.entries(volumeByToken)) {
+    dailyVolume[`${CHAIN}:${token}`] = amount.toString();
+  }
+
+  return { dailyVolume, timestamp };
 }
 
-// ─── DefiLlama export ─────────────────────────────────────────────────────────
-
 module.exports = {
-  // Metadata
-  version: 1,
-  methodology:
-    "Volume is calculated from the amountIn field of SwapExecuted events " +
-    "emitted by the FeeAggregatorMaster contract on Base.",
-
-  [CHAIN]: {
-    fetch: async (timestamp, chainBlocks) => {
-      // DefiLlama passes the current day's block range
-      const toBlock   = chainBlocks[CHAIN];
-      const fromBlock = toBlock - 43200; // ~24 h on Base (2-s blocks)
-
-      const volumeByToken = await getVolume(timestamp, fromBlock, toBlock);
-
-      // Convert to the format DefiLlama expects:
-      // { [chain:tokenAddress]: humanReadableAmount }
-      // We return raw BigInt strings here; DefiLlama SDK handles decimals/pricing.
-      const dailyVolume = {};
-      for (const [token, amount] of Object.entries(volumeByToken)) {
-        dailyVolume[`${CHAIN}:${token}`] = amount.toString();
-      }
-
-      return { dailyVolume, timestamp };
+  adapter: {
+    [CHAIN]: {
+      fetch,
+      start: async () => 1746316800, // 2026-05-04
+      runAtCurrTime: true,
     },
-
-    start: 1746316800, // 2025-05-04 (approx deploy date)
   },
 };

--- a/projects/dexr/index.js
+++ b/projects/dexr/index.js
@@ -1,0 +1,118 @@
+const { request } = require("graphql-request");
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const CHAIN = "base";
+const CONTRACT = "0x4859608579D0f01605F6824ea173072a7Cc206c5";
+
+// SwapExecuted(address user, uint8 adapterId, address tokenIn, address tokenOut,
+//              uint256 amountIn, uint256 amountOut, uint256 feeAmount)
+const SWAP_EXECUTED_TOPIC =
+  "0xdd4c67c6f3ac40c1172614cde8156b024bd3d41f6891c92bf6c04ad9c83ffd95";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Fetch swap logs from a public RPC for a given block range.
+ * Returns an array of parsed log objects.
+ */
+async function fetchSwapLogs(fromBlock, toBlock) {
+  const rpc = "https://mainnet.base.org";
+
+  const body = JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "eth_getLogs",
+    params: [
+      {
+        address: CONTRACT,
+        topics: [SWAP_EXECUTED_TOPIC],
+        fromBlock: "0x" + fromBlock.toString(16),
+        toBlock: "0x" + toBlock.toString(16),
+      },
+    ],
+  });
+
+  const res = await fetch(rpc, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body,
+  });
+
+  const json = await res.json();
+  return json.result ?? [];
+}
+
+/**
+ * Decode a SwapExecuted log.
+ * Non-indexed data layout (each 32 bytes):
+ *   [0] tokenIn   [1] tokenOut   [2] amountIn   [3] amountOut   [4] feeAmount
+ */
+function decodeSwapLog(log) {
+  const data = log.data.slice(2); // strip 0x
+  const chunk = (i) => data.slice(i * 64, (i + 1) * 64);
+
+  const tokenIn  = "0x" + chunk(0).slice(24);   // address (last 20 bytes)
+  const tokenOut = "0x" + chunk(1).slice(24);
+  const amountIn = BigInt("0x" + chunk(2));
+
+  return { tokenIn, tokenOut, amountIn };
+}
+
+// ─── Volume adapter ───────────────────────────────────────────────────────────
+
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+const WETH_BASE    = "0x4200000000000000000000000000000000000006";
+
+/**
+ * Sum raw amountIn values per token for all swaps in the given block range.
+ * Returns { dailyVolume: { [tokenAddress]: BigInt } }
+ */
+async function getVolume(timestamp, fromBlock, toBlock) {
+  const logs = await fetchSwapLogs(fromBlock, toBlock);
+
+  const volumeByToken = {};
+
+  for (const log of logs) {
+    const { tokenIn, amountIn } = decodeSwapLog(log);
+
+    // Treat native ETH (address(0)) same as WETH for pricing
+    const token = tokenIn === ZERO_ADDRESS ? WETH_BASE : tokenIn.toLowerCase();
+
+    volumeByToken[token] = (volumeByToken[token] ?? BigInt(0)) + amountIn;
+  }
+
+  return volumeByToken;
+}
+
+// ─── DefiLlama export ─────────────────────────────────────────────────────────
+
+module.exports = {
+  // Metadata
+  version: 1,
+  methodology:
+    "Volume is calculated from the amountIn field of SwapExecuted events " +
+    "emitted by the FeeAggregatorMaster contract on Base.",
+
+  [CHAIN]: {
+    fetch: async (timestamp, chainBlocks) => {
+      // DefiLlama passes the current day's block range
+      const toBlock   = chainBlocks[CHAIN];
+      const fromBlock = toBlock - 43200; // ~24 h on Base (2-s blocks)
+
+      const volumeByToken = await getVolume(timestamp, fromBlock, toBlock);
+
+      // Convert to the format DefiLlama expects:
+      // { [chain:tokenAddress]: humanReadableAmount }
+      // We return raw BigInt strings here; DefiLlama SDK handles decimals/pricing.
+      const dailyVolume = {};
+      for (const [token, amount] of Object.entries(volumeByToken)) {
+        dailyVolume[`${CHAIN}:${token}`] = amount.toString();
+      }
+
+      return { dailyVolume, timestamp };
+    },
+
+    start: 1746316800, // 2025-05-04 (approx deploy date)
+  },
+};


### PR DESCRIPTION
## Summary
- Protocol: dexr.finance
- Category: dex-aggregators  
- Chain: Base
- Contract: 0x4859608579D0f01605F6824ea173072a7Cc206c5

## Methodology
Volume is tracked from SwapExecuted events emitted by FeeAggregatorMaster contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Base mainnet dexr volume adapter that tracks and aggregates daily swap volumes per token and returns keyed dailyVolume plus the input timestamp.
  * Treats zero-address swaps as WETH_BASE and runs aggregation over ~24h intervals; adapter is scheduled to run at current time with a fixed start date.
* **Bug Fixes**
  * RPC error handling added to return empty results on failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->