### PR TITLE
fix pool-party tvl parties

### DIFF
--- a/projects/pool-party/index.js
+++ b/projects/pool-party/index.js
@@ -1,41 +1,18 @@
-/*
- * Pool Party — Canton Network AMM
- *
- * Pool Party is the first AMM on Canton Network, built by Send Foundation.
- * Pairs at launch: CC/CUSD, CC/USDCx, USDCx/CUSD.
- *
- * TVL methodology:
- *   This adapter mirrors the existing `wcc` adapter
- *   (projects/wcc/index.js) — the only currently supported Canton TVL pattern.
- *   It queries the public Canton Lighthouse API for the CC balance held by
- *   Pool Party's Canton party and reports it as gas-token (CC) TVL.
- *
- *   The Lighthouse API exposes Canton Coin balances per party only; CUSD and
- *   USDCx (the stablecoin sides of Pool Party's pools) are not currently
- *   queryable through public Canton APIs. As a result this adapter
- *   underreports the full pool TVL by roughly the value of the stablecoin
- *   sides. Adding the stablecoin sides is tracked as Phase 2.
- *
- * Docs: https://info.send.it/docs/pool-party/overview
- * App:  https://cantonwallet.com/pools/
- */
-
 const { get } = require('../helper/http')
 
 const BASE_URL = 'https://lighthouse.cantonloop.com/api/parties/'
 
-// Pool Party's Canton party ID. Source:
-// https://info.send.it/docs/miscellaneous/send-contract-addresses
+// Per-pool operator parties that custody pool reserves. Only CC-containing
+// pools are listed; the USDCx/CUSD pool has no CC side and the Lighthouse API
+// does not expose non-CC balances per party.
 const parties = [
-  'poolparty::1220f1b0d7a83c7eaaf6d712d95d5952ea2c801238af9c342e8d83c87dfc45c999dc',
+  'mainnet-pool-party-amulet-cusd-operator::1220724bbd5179d9f5d19de90f31cfa0e99e4bf9cf815e3e5e669a40524725d9e98b',
+  'mainnet-pool-party-amulet-usdcx-operator::1220647009424eff86ef09493a366aa314e8533c0cd8070aa82a9b014e42daad03c3',
 ]
 
 async function tvl(api) {
   for (const party of parties) {
     const { balance } = await get(BASE_URL + party + '/balance')
-    // total_coin_holdings is a decimal-string CC balance.
-    // Convert to atomic units (CC has 18 decimals, matching the wcc adapter's
-    // 1e18 multiplier).
     api.addGasToken(Number(balance.total_coin_holdings) * 1e18)
   }
 }
@@ -44,10 +21,8 @@ module.exports = {
   timetravel: false,
   canton: { tvl },
   methodology:
-    "TVL is the total Canton Coin (CC) balance held by Pool Party's Canton " +
-    "party, fetched from the public Lighthouse API. Stablecoin sides of pools " +
-    "(CUSD, USDCx) are not yet queryable through public Canton APIs and are " +
-    "not included; this matches the methodology used by the existing wcc " +
-    "adapter and is expected to be expanded once Canton APIs surface " +
-    "non-CC token balances per party.",
+    "Sum of Canton Coin (CC) reserves held by Pool Party's CC/CUSD and " +
+    "CC/USDCx pool operator parties, via the Lighthouse API. Stablecoin " +
+    "sides (CUSD, USDCx) and the USDCx/CUSD pool are not included since " +
+    "non-CC balances are not currently queryable through public Canton APIs.",
 }


### PR DESCRIPTION
## Summary
- Updates Pool Party TVL to sum CC reserves from the CC/CUSD and CC/USDCx pool operator parties.
- Refreshes the methodology to clarify that stablecoin sides and the USDCx/CUSD pool are excluded until public Canton APIs expose non-CC balances.

## Test plan
- `node test.js projects/pool-party/index.js`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pool Party TVL calculation now aggregates data from multiple pool operators instead of a single operator.

* **Documentation**
  * Updated methodology description to reflect the expanded multi-operator approach.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19191)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->