### PR TITLE
fix layerbank mphBTC tvl drop on morph (#14580)

### DIFF
--- a/projects/lineabank/index.js
+++ b/projects/lineabank/index.js
@@ -26,9 +26,35 @@ const abis = {
   totalBorrows: "uint256:totalBorrow",
 }
 
+// mphBTC has no on-chain liquidity, so DefiLlama's internal pricing path occasionally
+// returns no price and drops Morph TVL to 0 (issue #14580). The token is pegged 1:1 to
+// BTC, so we read its balance directly and emit it as coingecko:bitcoin.
+const MPHBTC = '0x950e7FB62398C3CcaBaBc0e3e0de3137fb0daCd2'
+const MPHBTC_DECIMALS = 10
+
+async function addMphBtcAsBitcoin(api, comptroller, borrowed) {
+  const cTokens = await api.call({ abi: abis.getAllMarkets, target: comptroller })
+  const underlyings = await api.multiCall({ abi: 'address:underlying', calls: cTokens, permitFailure: true })
+  const idx = underlyings.findIndex(u => u && u.toLowerCase() === MPHBTC.toLowerCase())
+  if (idx === -1) return
+  const cToken = cTokens[idx]
+  const raw = borrowed
+    ? await api.call({ abi: abis.totalBorrows, target: cToken })
+    : await api.call({ abi: 'erc20:balanceOf', target: MPHBTC, params: [cToken] })
+  api.add('coingecko:bitcoin', Number(raw) / 10 ** MPHBTC_DECIMALS)
+}
+
 Object.keys(v2Config).forEach(chain => {
   const comptroller = v2Config[chain]
-  module.exports[chain] = compoundExports2({ comptroller, abis, })
+  if (chain === 'morph') {
+    const base = compoundExports2({ comptroller, abis, blacklistedTokens: [MPHBTC] })
+    module.exports.morph = {
+      tvl: async (api) => { await base.tvl(api); await addMphBtcAsBitcoin(api, comptroller, false) },
+      borrowed: async (api) => { await base.borrowed(api); await addMphBtcAsBitcoin(api, comptroller, true) },
+    }
+  } else {
+    module.exports[chain] = compoundExports2({ comptroller, abis, })
+  }
 })
 
 const compoundExports = {


### PR DESCRIPTION
## Summary
- Fixes #14580 — LayerBank Morph TVL randomly drops to 0 because mphBTC has no on-chain liquidity, so DefiLlama's internal pricing path occasionally returns no price for it.
- mphBTC is pegged 1:1 to BTC (price API consistently returns BTC-based prices, confidence 0.99). Read its balance and borrows directly from the LayerBank cToken on morph and emit them as `coingecko:bitcoin` (10 decimals → BTC units).
- All other chains in `projects/lineabank/index.js` are untouched; only the `morph` entry is wrapped.

## Why this is the right shape
- `compoundExports2` is reused unchanged with `blacklistedTokens: [MPHBTC]` so every other market on morph keeps its existing pricing path.
- mphBTC supply / borrow figures are read from the same cToken `compoundExports2` would have hit, just remapped to a stable price source.
- Verified historical impact: 11 single-day zero-spikes for mphBTC on LayerBank Morph between 2025-04-30 and 2025-10-03 (sandwiched between non-zero days), matching the report.

## Test plan
- [x] `npx eslint -c eslint.config.js projects/lineabank/index.js` — clean.
- [x] `node test.js projects/lineabank/index.js` — morph fails with the same `allMarkets()` revert that occurs on `main` locally (upstream RPC/SDK incompatibility on the public Morph RPCs); behavior is unchanged on every other chain.
- [ ] Verify on DefiLlama infra that morph TVL no longer dips to 0 when mphBTC supply is non-zero.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Morph chain adapter to correctly calculate TVL and borrowed balances, with enhanced token-to-Bitcoin mapping for MPHBTC.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19196)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->