### PR TITLE
[fix] DigiFT: track ultra tvl across arb,avax,solana

### DIFF
--- a/projects/DigiFT/index.js
+++ b/projects/DigiFT/index.js
@@ -1,10 +1,14 @@
 const sdk = require('@defillama/sdk');
 const { getLogs2 } = require('../helper/cache/getLogs')
+const { getTokenSupplies } = require('../helper/solana')
 //Polygon FeedPrice contract address
 const DFeedPriceAddress = "0x7d4d68f18d1be3410ab8d827fb7ebc690f938d2d"
 const tokenListAbi = "function getAllTokenRecords() view returns (tuple(uint256 chainId, address tokenAddress, uint64 tokenType)[])"
 const uMintAddress = '0xC06036793272219179F846eF6bfc3B16E820Df0B'
 const ULTRAAddress = '0x50293dd8889b931eb3441d2664dce8396640b419'
+const ULTRAArbitrum = '0xc26af85ede9cc25d449bcebef866bb85afd5d346'
+const ULTRAAvax = '0x51626db85482b2fa9901271c18627ebefa8875ac'
+const ULTRASolana = '9DRPPWYud8i6CaSsDsFESs1xyVr8dBCMtjPZji2xiZEa'
 const BurnAbi = "event Burn (address indexed from, uint256 value, string data)"
 const MintAbi = "event Mint (address indexed to, uint256 amount)"
 const SubRedManagement = '0x3797c46db697c24a983222c335f17ba28e8c5b69'
@@ -27,7 +31,12 @@ async function calculateTokenNetSupply(api, tokenAddress, managementAddress) {
   return MintAmount - BurnAmount;
 }
 
+async function solanaTvl(api) {
+  await getTokenSupplies([ULTRASolana], { api })
+}
+
 module.exports = {
+  timetravel: false,
   ethereum: {
     tvl: async (api) => {
       const tokenAPI = new sdk.ChainApi({ chain: 'polygon', timestamp: api.timestamp, });
@@ -39,6 +48,7 @@ module.exports = {
       //uMint amount
       const netUMintSupply = await calculateTokenNetSupply(api, uMintAddress, SubRedManagement)
       await api.addToken(uMintAddress, netUMintSupply)
+      await api.addToken(ULTRAAddress, await api.call({ abi: 'uint256:totalSupply', target: ULTRAAddress }))
       return api.getBalances()
     }
   },
@@ -48,9 +58,21 @@ module.exports = {
       const tokens = await getTokenList(tokenAPI, api.chainId)
       const tokenSupplies = await api.multiCall({ abi: 'uint256:totalSupply', calls: tokens })
       await api.addTokens(tokens, tokenSupplies)
+      await api.addToken(ULTRAArbitrum, await api.call({ abi: 'uint256:totalSupply', target: ULTRAArbitrum }))
       return api.getBalances()
     }
   },
+  avax: {
+    tvl: async (api) => {
+      const tokenAPI = new sdk.ChainApi({ chain: 'polygon', timestamp: api.timestamp, });
+      const tokens = await getTokenList(tokenAPI, api.chainId)
+      const tokenSupplies = await api.multiCall({ abi: 'uint256:totalSupply', calls: tokens })
+      await api.addTokens(tokens, tokenSupplies)
+      await api.addToken(ULTRAAvax, await api.call({ abi: 'uint256:totalSupply', target: ULTRAAvax }))
+      return api.getBalances()
+    }
+  },
+  solana: { tvl: solanaTvl },
   plume_mainnet: {
     tvl: async (api) => {
       const tokenAPI = new sdk.ChainApi({ chain: 'polygon', timestamp: api.timestamp, });


### PR DESCRIPTION
Source https://app.rwa.xyz/assets/ULTRA
Extends fees adapter at https://github.com/DefiLlama/dimension-adapters/pull/6901

## Summary
- Fixes DigiFT TVL by explicitly tracking ULTRA supply on Arbitrum, Avalanche, and Solana.
- Adds Avalanche to the DigiFT TVL adapter while preserving the existing DFeed token-list logic.
- Keeps the original adapter structure and layers the new ULTRA tracking on top.

## Changes
- Updated `projects/DigiFT/index.js`.
- Added ULTRA token addresses for Arbitrum, Avalanche, and Solana.
- Adds Arbitrum and Avalanche ULTRA `totalSupply` to TVL alongside existing DFeed-listed token supplies.
- Adds a new `avax` TVL export for DigiFT.
- Adds Solana ULTRA supply using the existing `getTokenSupplies` Solana helper.
- Preserves Ethereum `uMint` net-supply accounting from mint/burn logs.

## Methodology
- DigiFT EVM token TVL continues to use the Polygon DFeed token list and each token's `totalSupply`.
- ULTRA TVL is added explicitly from chain-specific token supply on Ethereum, Arbitrum, and Avalanche.
- Solana ULTRA TVL is counted from the SPL mint supply.
- The adapter is marked `timetravel: false` because Solana SPL mint supply is read through current-state Solana RPC.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Solana chain support for TVL calculations
  * Expanded ULTRA token tracking across Polygon, Arbitrum, and Avalanche
  * Enhanced TVL aggregation across multiple blockchain networks

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19201)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->