### PR TITLE
Add Morpho Spark Blue Chip USDT Vault

### DIFF
--- a/projects/spark-liquidity-layer/index.js
+++ b/projects/spark-liquidity-layer/index.js
@@ -34,7 +34,8 @@ const mainnetAllocatorToTokens = {
     '0xe7dF13b8e3d6740fe17CBE928C7334243d86c92f', // spUSDT
     '0x377C3bd93f2a2984E1E7bE6A5C22c525eD4A4815', // spUSDC
     '0x56A76b428244a50513ec81e225a293d128fd581D', // morpho Spark Blue Chip USDC Vault
-    '0xc7CDcFDEfC64631ED6799C95e3b110cd42F2bD22', // morpho Spark Blue Chip USDT Vault
+    '0xc7CDcFDEfC64631ED6799C95e3b110cd42F2bD22', // morpho Spark Blue Chip USDT Vault v1
+    '0xb0c424116172B55CbB6dD3136F5989F7959e5B91', // morpho Spark Blue Chip USDT Vault v2
     '0x14d60E7FDC0D71d8611742720E4C50E7a974020c', // Superstate's USCC
     '0x6c3ea9036406852006290770BEdFcAbA0e23A0e8', // pyUSD
     '0x23878914efe38d27c4d67ab83ed1b93a74d4086a', // aaveCoreUsdt


### PR DESCRIPTION
Adds Spark's Blue Chip USDT Vault on Morpho. Spark is going to use this one going forwards instead of v1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded token tracking for the Spark Liquidity Layer to include an additional USDT vault address alongside the existing vault, improving TVL data aggregation and calculation accuracy on Ethereum.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19206)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->