### PR TITLE
Update index.js

### DIFF
--- a/projects/blackhaven/index.js
+++ b/projects/blackhaven/index.js
@@ -1,9 +1,11 @@
 const { sumTokensExport } = require('../helper/unwrapLPs')
 
 module.exports = {
-  methodology: "Counts the RBT tokens staked in the bond contract.",
+  methodology: "USDM and Aave USDM held by the treasury, ensuring the backing of the RBT token",
   megaeth: {
-    tvl: () => ({}),
-    staking: sumTokensExport({ owner: '0x40f5F3654Db5F7F56cCe33caF0F7a0CAaaE57EAc', token: '0x8F77A685bDe702E6d32A103e9AeB41906317D7e5' }),
-  },
+    tvl: sumTokensExport({
+        owner: "0xb59126f8a13F907f63e67CFc248160698cE41918",
+        tokens: ["0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7", "0x5dF82810CB4B8f3e0Da3c031cCc9208ee9cF9500"]
+      })
+  }
 }


### PR DESCRIPTION
GM.
The current adapter for Blackhaven show incorrect data.

**Our TVL sit here :**
[0xb59126f8a13F907f63e67CFc248160698cE41918](https://mega.etherscan.io/address/0xb59126f8a13F907f63e67CFc248160698cE41918?utm_source=chatgpt.com)￼

It contains both **USDM** and **Aave USDM (aMegUSDM).**

Additionally, there is no staking.
Users deposit USDM, which is transferred to the treasury, and then receive RBT once the lock period has elapsed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated treasury holdings calculation for Blackhaven to accurately report USDM and Aave USDM tokens held by the treasury, replacing the previous bond-staking approach. This enhancement ensures precise representation of RBT token backing and provides clearer visibility into treasury asset composition and overall value.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19207)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->