### PR TITLE
lagoon: add bsc, hemi, hyperliquid, sei + fix sonic beaconFactory

### DIFF
--- a/projects/lagoon/index.js
+++ b/projects/lagoon/index.js
@@ -159,17 +159,17 @@ const config = {
     },
   },
   
-  unichain: {
-    vaults: [],
-    optinProxyFactory:{
-      address: "0x6FC0F2320483fa03FBFdF626DDbAE2CC4B112b51",
-      fromBlock: 22021431
-    },
-    beaconFactory: {
-      address: "0xaba1A2e157Dae248f8630cA550bd826725Ff745c",
-      fromBlock: 14576623
-    },
-  },
+  // unichain: {
+  //   vaults: [],
+  //   optinProxyFactory:{
+  //     address: "0x6FC0F2320483fa03FBFdF626DDbAE2CC4B112b51",
+  //     fromBlock: 22021431
+  //   },
+  //   beaconFactory: {
+  //     address: "0xaba1A2e157Dae248f8630cA550bd826725Ff745c",
+  //     fromBlock: 14576623
+  //   },
+  // },
   wc: {
     optinProxyFactory:{
       address: "0xC094C224ce0406BC338E00837B96aD2e265F7287",

--- a/projects/lagoon/index.js
+++ b/projects/lagoon/index.js
@@ -204,6 +204,7 @@ Object.keys(config).forEach((chain) => {
           const beaconFactoryVaults = await getBeaconFactoryVaults({api, factory: beaconFactory?.address, fromBlock: beaconFactory?.fromBlock, useIndexer: beaconFactory?.useIndexer});
           const optinProxyFactoryVaults = await getOptinProxyFactoryVaults({ api, factory: optinProxyFactory?.address, fromBlock: optinProxyFactory?.fromBlock, useIndexer: optinProxyFactory?.useIndexer });
           vaults = [...beaconFactoryVaults, ...optinProxyFactoryVaults]
+            .filter((v) => keepVault(v, vaultsBlacklist))
         } catch (e) {
           vaults = config[chain].fallbackVaults;
         }

--- a/projects/lagoon/index.js
+++ b/projects/lagoon/index.js
@@ -139,6 +139,13 @@ const config = {
       fromBlock: 76939871
     },
   },
+  sei: {
+    optinProxyFactory:{
+      address: "0xDa1d1De87C4D90A07a6462cCD9bE651a0d074362",
+      fromBlock: 183102541,
+      useIndexer: true,
+    },
+  },
   sonic: {
     optinProxyFactory:{
       address: "0x6FC0F2320483fa03FBFdF626DDbAE2CC4B112b51",

--- a/projects/lagoon/index.js
+++ b/projects/lagoon/index.js
@@ -185,7 +185,8 @@ const config = {
 const vaultsBlacklist = [
   "0xDe7CFf032D453Ce6B0a796043E75d380Df258812", // vault tac 9S, used mostly by another vault: 9s flagship, on Eth mainnet
   "0xd6DaBAf70977a867Fa884844FC5DCb21DE81c498", // vault tac 9s. but on TAC chain
-  "0xd730f24d993398d29dbaa537b6e1bd71a55df775", // test vault with fake totalAssets 
+  "0xd730f24d993398d29dbaa537b6e1bd71a55df775", // test vault with fake totalAssets
+  "0xb114b5a99652a6f6e1e9c13da0a544dc634007b5", // hyperliquid (hyperevm)
 ]
 
 function keepVault(vault, vaultBlacklist) {

--- a/projects/lagoon/index.js
+++ b/projects/lagoon/index.js
@@ -190,7 +190,8 @@ const vaultsBlacklist = [
 ]
 
 function keepVault(vault, vaultBlacklist) {
-  return  vaultBlacklist.indexOf(vault) == -1;
+  const v = vault.toLowerCase();
+  return !vaultBlacklist.some((b) => b.toLowerCase() === v);
 }
 
 Object.keys(config).forEach((chain) => {

--- a/projects/lagoon/index.js
+++ b/projects/lagoon/index.js
@@ -53,7 +53,8 @@ const config = {
   bsc: {
     optinProxyFactory:{
       address: "0x3f680aB9E51EEED9381dE5275f4995611Ff884d5",
-      fromBlock: 56083879
+      fromBlock: 56083879,
+      useIndexer: true,
     },
   },
   ethereum: {
@@ -81,13 +82,15 @@ const config = {
   hemi: {
     optinProxyFactory:{
       address: "0xB457e9C025A8Af99E32b03668e34f80D20A71d2C",
-      fromBlock: 4091220
+      fromBlock: 4091220,
+      useIndexer: true,
     },
   },
   hyperliquid: {
     optinProxyFactory:{
       address: "0x90beB507A1BA7D64633540cbce615B574224CD84",
-      fromBlock: 12973305
+      fromBlock: 12973305,
+      useIndexer: true,
     },
   },
 
@@ -134,12 +137,6 @@ const config = {
     optinProxyFactory:{
       address: "0x0C0E287f6e4de685f4b44A5282A3ad4A29D05a91",
       fromBlock: 76939871
-    },
-  },
-  sei: {
-    optinProxyFactory:{
-      address: "0xDa1d1De87C4D90A07a6462cCD9bE651a0d074362",
-      fromBlock: 183102541
     },
   },
   sonic: {
@@ -216,8 +213,8 @@ Object.keys(config).forEach((chain) => {
     tvl: async (api) => {
       if (config[chain].fallbackVaults) {
         try {
-          const beaconFactoryVaults = await getBeaconFactoryVaults({api, factory: beaconFactory?.address, fromBlock: beaconFactory?.fromBlock});
-          const optinProxyFactoryVaults = await getOptinProxyFactoryVaults({ api, factory: optinProxyFactory?.address, fromBlock: optinProxyFactory?.fromBlock });
+          const beaconFactoryVaults = await getBeaconFactoryVaults({api, factory: beaconFactory?.address, fromBlock: beaconFactory?.fromBlock, useIndexer: beaconFactory?.useIndexer});
+          const optinProxyFactoryVaults = await getOptinProxyFactoryVaults({ api, factory: optinProxyFactory?.address, fromBlock: optinProxyFactory?.fromBlock, useIndexer: optinProxyFactory?.useIndexer });
           vaults = [...beaconFactoryVaults, ...optinProxyFactoryVaults]
         } catch (e) {
           vaults = config[chain].fallbackVaults;
@@ -225,8 +222,8 @@ Object.keys(config).forEach((chain) => {
         return await api.erc4626Sum2({ calls: vaults })
       } else {
         if (!vaults) vaults = [];
-        let beaconFactoryVaults = await getBeaconFactoryVaults({api, factory: beaconFactory?.address, fromBlock: beaconFactory?.fromBlock});
-        let optinProxyFactoryVaults = await getOptinProxyFactoryVaults({api, factory: optinProxyFactory?.address, fromBlock: optinProxyFactory?.fromBlock});
+        let beaconFactoryVaults = await getBeaconFactoryVaults({api, factory: beaconFactory?.address, fromBlock: beaconFactory?.fromBlock, useIndexer: beaconFactory?.useIndexer});
+        let optinProxyFactoryVaults = await getOptinProxyFactoryVaults({api, factory: optinProxyFactory?.address, fromBlock: optinProxyFactory?.fromBlock, useIndexer: optinProxyFactory?.useIndexer});
         beaconFactoryVaults = beaconFactoryVaults.filter((v) => keepVault(v, vaultsBlacklist));
         optinProxyFactoryVaults = optinProxyFactoryVaults.filter((v) => keepVault(v, vaultsBlacklist));
   
@@ -241,7 +238,7 @@ Object.keys(config).forEach((chain) => {
 
 
 const BeaconProxyDeployed = "0xfa8e336138457120a1572efbe25f72698abd5cca1c9be0bce42ad406ff350a2b";
-async function getBeaconFactoryVaults({api, factory, fromBlock})  {
+async function getBeaconFactoryVaults({api, factory, fromBlock, useIndexer})  {
   if (!api || !factory || !fromBlock) return [];
   const logs = await getLogs({
     api,
@@ -250,14 +247,13 @@ async function getBeaconFactoryVaults({api, factory, fromBlock})  {
     eventAbi: "event BeaconProxyDeployed(address proxy, address deployer)",
     onlyArgs: true,
     fromBlock: fromBlock,
-  
-
+    useIndexer,
   });
   if (!logs) return [];
   return logs.map((vault) => vault.proxy);
 }
 const ProxyDeployed = "0x8b5fd0eb1f997b4ecac1f234109294d6ace2519fc7abeab9f315fef38e2eb1dc";
-async function getOptinProxyFactoryVaults({api, factory, fromBlock})  {
+async function getOptinProxyFactoryVaults({api, factory, fromBlock, useIndexer})  {
   if (!api || !factory || !fromBlock) return [];
   const logs = await getLogs({
     api,
@@ -266,6 +262,7 @@ async function getOptinProxyFactoryVaults({api, factory, fromBlock})  {
     eventAbi: "event ProxyDeployed(address proxy, address deployer)",
     onlyArgs: true,
     fromBlock: fromBlock,
+    useIndexer,
   });
   if (!logs) return [];
   return logs.map((vault) => vault.proxy);

--- a/projects/lagoon/index.js
+++ b/projects/lagoon/index.js
@@ -50,6 +50,12 @@ const config = {
       fromBlock: 4061769
     },
   },
+  bsc: {
+    optinProxyFactory:{
+      address: "0x3f680aB9E51EEED9381dE5275f4995611Ff884d5",
+      fromBlock: 56083879
+    },
+  },
   ethereum: {
     vaults:
       [
@@ -72,7 +78,19 @@ const config = {
       fromBlock: 22218451
     },
   },
-  
+  hemi: {
+    optinProxyFactory:{
+      address: "0xB457e9C025A8Af99E32b03668e34f80D20A71d2C",
+      fromBlock: 4091220
+    },
+  },
+  hyperliquid: {
+    optinProxyFactory:{
+      address: "0x90beB507A1BA7D64633540cbce615B574224CD84",
+      fromBlock: 12973305
+    },
+  },
+
   katana: {
     vaults: [],
     optinProxyFactory:{
@@ -118,13 +136,19 @@ const config = {
       fromBlock: 76939871
     },
   },
+  sei: {
+    optinProxyFactory:{
+      address: "0xDa1d1De87C4D90A07a6462cCD9bE651a0d074362",
+      fromBlock: 183102541
+    },
+  },
   sonic: {
     optinProxyFactory:{
       address: "0x6FC0F2320483fa03FBFdF626DDbAE2CC4B112b51",
       fromBlock: 38968917
     },
     beaconFactory: {
-      address: "0x8846189A4E46997Dd30Fd9e8bE48C1fA1B846920",
+      address: "0x99CD0b8b32B15922f0754Fddc21323b5278c5261",
       fromBlock: 21645993,
     }
   },

--- a/projects/lagoon/index.js
+++ b/projects/lagoon/index.js
@@ -76,10 +76,8 @@ const config = {
     optinProxyFactory:{
       address: "0x90beB507A1BA7D64633540cbce615B574224CD84",
       fromBlock: 12973305,
-      useIndexer: true,
     },
   },
-
   katana: {
     vaults: [],
     optinProxyFactory:{
@@ -159,17 +157,17 @@ const config = {
     },
   },
   
-  // unichain: {
-  //   vaults: [],
-  //   optinProxyFactory:{
-  //     address: "0x6FC0F2320483fa03FBFdF626DDbAE2CC4B112b51",
-  //     fromBlock: 22021431
-  //   },
-  //   beaconFactory: {
-  //     address: "0xaba1A2e157Dae248f8630cA550bd826725Ff745c",
-  //     fromBlock: 14576623
-  //   },
-  // },
+  unichain: {
+    vaults: [],
+    optinProxyFactory:{
+      address: "0x6FC0F2320483fa03FBFdF626DDbAE2CC4B112b51",
+      fromBlock: 22021431
+    },
+    beaconFactory: {
+      address: "0xaba1A2e157Dae248f8630cA550bd826725Ff745c",
+      fromBlock: 14576623
+    },
+  },
   wc: {
     optinProxyFactory:{
       address: "0xC094C224ce0406BC338E00837B96aD2e265F7287",
@@ -185,42 +183,40 @@ const config = {
 const vaultsBlacklist = [
   "0xDe7CFf032D453Ce6B0a796043E75d380Df258812", // vault tac 9S, used mostly by another vault: 9s flagship, on Eth mainnet
   "0xd6DaBAf70977a867Fa884844FC5DCb21DE81c498", // vault tac 9s. but on TAC chain
+  "0xd730f24d993398d29dbaa537b6e1bd71a55df775", // test vault with fake totalAssets 
   "0xd730f24d993398d29dbaa537b6e1bd71a55df775", // test vault with fake totalAssets
   "0xb114b5a99652a6f6e1e9c13da0a544dc634007b5", // hyperliquid (hyperevm)
-  "0x17488aed11845d92f1f113e8df51f497465d715c", // base
+  "0x17488aed11845d92f1f113e8df51f497465d715c", // base test vault with fake totalAssets
 ]
 
 function keepVault(vault, vaultBlacklist) {
   const v = vault.toLowerCase();
-  return !vaultBlacklist.some((b) => b.toLowerCase() === v);
+  return !vaultBlacklist.some((b) => b.toLowerCase() === v)
 }
 
 Object.keys(config).forEach((chain) => {
-  const { beaconFactory, optinProxyFactory } = config[chain];
-
+  let { vaults, beaconFactory, optinProxyFactory } = config[chain];
+  
   module.exports[chain] = {
     tvl: async (api) => {
-      const staticVaults = config[chain].vaults ?? [];
       if (config[chain].fallbackVaults) {
-        let vaults;
         try {
-          const beaconFactoryVaults = await getBeaconFactoryVaults({api, factory: beaconFactory?.address, fromBlock: beaconFactory?.fromBlock, useIndexer: beaconFactory?.useIndexer});
-          const optinProxyFactoryVaults = await getOptinProxyFactoryVaults({ api, factory: optinProxyFactory?.address, fromBlock: optinProxyFactory?.fromBlock, useIndexer: optinProxyFactory?.useIndexer });
-          vaults = [...staticVaults, ...beaconFactoryVaults, ...optinProxyFactoryVaults]
-            .filter((v) => keepVault(v, vaultsBlacklist))
+          const beaconFactoryVaults = await getBeaconFactoryVaults({api, factory: beaconFactory?.address, fromBlock: beaconFactory?.fromBlock});
+          const optinProxyFactoryVaults = await getOptinProxyFactoryVaults({ api, factory: optinProxyFactory?.address, fromBlock: optinProxyFactory?.fromBlock });
+          vaults = [...beaconFactoryVaults, ...optinProxyFactoryVaults]
         } catch (e) {
-          vaults = [...staticVaults, ...config[chain].fallbackVaults]
-            .filter((v) => keepVault(v, vaultsBlacklist));
+          vaults = config[chain].fallbackVaults;
         }
         return await api.erc4626Sum2({ calls: vaults })
       } else {
-        let beaconFactoryVaults = await getBeaconFactoryVaults({api, factory: beaconFactory?.address, fromBlock: beaconFactory?.fromBlock, useIndexer: beaconFactory?.useIndexer});
-        let optinProxyFactoryVaults = await getOptinProxyFactoryVaults({api, factory: optinProxyFactory?.address, fromBlock: optinProxyFactory?.fromBlock, useIndexer: optinProxyFactory?.useIndexer});
+        if (!vaults) vaults = [];
+        let beaconFactoryVaults = await getBeaconFactoryVaults({api, factory: beaconFactory?.address, fromBlock: beaconFactory?.fromBlock});
+        let optinProxyFactoryVaults = await getOptinProxyFactoryVaults({api, factory: optinProxyFactory?.address, fromBlock: optinProxyFactory?.fromBlock});
         beaconFactoryVaults = beaconFactoryVaults.filter((v) => keepVault(v, vaultsBlacklist));
         optinProxyFactoryVaults = optinProxyFactoryVaults.filter((v) => keepVault(v, vaultsBlacklist));
-
+  
         return await api.erc4626Sum2({
-          calls: [...staticVaults, ...beaconFactoryVaults, ...optinProxyFactoryVaults],
+          calls: [...vaults, ...beaconFactoryVaults, ...optinProxyFactoryVaults],
         })
       }
     }
@@ -230,7 +226,7 @@ Object.keys(config).forEach((chain) => {
 
 
 const BeaconProxyDeployed = "0xfa8e336138457120a1572efbe25f72698abd5cca1c9be0bce42ad406ff350a2b";
-async function getBeaconFactoryVaults({api, factory, fromBlock, useIndexer})  {
+async function getBeaconFactoryVaults({api, factory, fromBlock})  {
   if (!api || !factory || !fromBlock) return [];
   const logs = await getLogs({
     api,
@@ -239,13 +235,14 @@ async function getBeaconFactoryVaults({api, factory, fromBlock, useIndexer})  {
     eventAbi: "event BeaconProxyDeployed(address proxy, address deployer)",
     onlyArgs: true,
     fromBlock: fromBlock,
-    useIndexer,
+  
+
   });
   if (!logs) return [];
   return logs.map((vault) => vault.proxy);
 }
 const ProxyDeployed = "0x8b5fd0eb1f997b4ecac1f234109294d6ace2519fc7abeab9f315fef38e2eb1dc";
-async function getOptinProxyFactoryVaults({api, factory, fromBlock, useIndexer})  {
+async function getOptinProxyFactoryVaults({api, factory, fromBlock})  {
   if (!api || !factory || !fromBlock) return [];
   const logs = await getLogs({
     api,
@@ -254,7 +251,6 @@ async function getOptinProxyFactoryVaults({api, factory, fromBlock, useIndexer})
     eventAbi: "event ProxyDeployed(address proxy, address deployer)",
     onlyArgs: true,
     fromBlock: fromBlock,
-    useIndexer,
   });
   if (!logs) return [];
   return logs.map((vault) => vault.proxy);

--- a/projects/lagoon/index.js
+++ b/projects/lagoon/index.js
@@ -187,6 +187,7 @@ const vaultsBlacklist = [
   "0xd6DaBAf70977a867Fa884844FC5DCb21DE81c498", // vault tac 9s. but on TAC chain
   "0xd730f24d993398d29dbaa537b6e1bd71a55df775", // test vault with fake totalAssets
   "0xb114b5a99652a6f6e1e9c13da0a544dc634007b5", // hyperliquid (hyperevm)
+  "0x17488aed11845d92f1f113e8df51f497465d715c", // base
 ]
 
 function keepVault(vault, vaultBlacklist) {

--- a/projects/lagoon/index.js
+++ b/projects/lagoon/index.js
@@ -50,13 +50,6 @@ const config = {
       fromBlock: 4061769
     },
   },
-  bsc: {
-    optinProxyFactory:{
-      address: "0x3f680aB9E51EEED9381dE5275f4995611Ff884d5",
-      fromBlock: 56083879,
-      useIndexer: true,
-    },
-  },
   ethereum: {
     vaults:
       [
@@ -77,13 +70,6 @@ const config = {
     beaconFactory: {
       address: "0x09C8803f7Dc251f9FaAE5f56E3B91f8A6d0b70ee",
       fromBlock: 22218451
-    },
-  },
-  hemi: {
-    optinProxyFactory:{
-      address: "0xB457e9C025A8Af99E32b03668e34f80D20A71d2C",
-      fromBlock: 4091220,
-      useIndexer: true,
     },
   },
   hyperliquid: {
@@ -137,13 +123,6 @@ const config = {
     optinProxyFactory:{
       address: "0x0C0E287f6e4de685f4b44A5282A3ad4A29D05a91",
       fromBlock: 76939871
-    },
-  },
-  sei: {
-    optinProxyFactory:{
-      address: "0xDa1d1De87C4D90A07a6462cCD9bE651a0d074362",
-      fromBlock: 183102541,
-      useIndexer: true,
     },
   },
   sonic: {

--- a/projects/lagoon/index.js
+++ b/projects/lagoon/index.js
@@ -195,29 +195,31 @@ function keepVault(vault, vaultBlacklist) {
 }
 
 Object.keys(config).forEach((chain) => {
-  let { vaults, beaconFactory, optinProxyFactory } = config[chain];
-  
+  const { beaconFactory, optinProxyFactory } = config[chain];
+
   module.exports[chain] = {
     tvl: async (api) => {
+      const staticVaults = config[chain].vaults ?? [];
       if (config[chain].fallbackVaults) {
+        let vaults;
         try {
           const beaconFactoryVaults = await getBeaconFactoryVaults({api, factory: beaconFactory?.address, fromBlock: beaconFactory?.fromBlock, useIndexer: beaconFactory?.useIndexer});
           const optinProxyFactoryVaults = await getOptinProxyFactoryVaults({ api, factory: optinProxyFactory?.address, fromBlock: optinProxyFactory?.fromBlock, useIndexer: optinProxyFactory?.useIndexer });
-          vaults = [...beaconFactoryVaults, ...optinProxyFactoryVaults]
+          vaults = [...staticVaults, ...beaconFactoryVaults, ...optinProxyFactoryVaults]
             .filter((v) => keepVault(v, vaultsBlacklist))
         } catch (e) {
-          vaults = config[chain].fallbackVaults;
+          vaults = [...staticVaults, ...config[chain].fallbackVaults]
+            .filter((v) => keepVault(v, vaultsBlacklist));
         }
         return await api.erc4626Sum2({ calls: vaults })
       } else {
-        if (!vaults) vaults = [];
         let beaconFactoryVaults = await getBeaconFactoryVaults({api, factory: beaconFactory?.address, fromBlock: beaconFactory?.fromBlock, useIndexer: beaconFactory?.useIndexer});
         let optinProxyFactoryVaults = await getOptinProxyFactoryVaults({api, factory: optinProxyFactory?.address, fromBlock: optinProxyFactory?.fromBlock, useIndexer: optinProxyFactory?.useIndexer});
         beaconFactoryVaults = beaconFactoryVaults.filter((v) => keepVault(v, vaultsBlacklist));
         optinProxyFactoryVaults = optinProxyFactoryVaults.filter((v) => keepVault(v, vaultsBlacklist));
-  
+
         return await api.erc4626Sum2({
-          calls: [...vaults, ...beaconFactoryVaults, ...optinProxyFactoryVaults],
+          calls: [...staticVaults, ...beaconFactoryVaults, ...optinProxyFactoryVaults],
         })
       }
     }


### PR DESCRIPTION
## Summary

Sync the Lagoon adapter with the SDK's authoritative chain/factory registry.

- Add `optinProxyFactory` entries for **bsc, hemi, hyperliquid, sei** — these chains are supported by the Lagoon protocol but were missing from the adapter, so their TVL was not reported.
- Update **sonic** `beaconFactory` address `0x8846189A4E46997Dd30Fd9e8bE48C1fA1B846920` → `0x99CD0b8b32B15922f0754Fddc21323b5278c5261` per the current Lagoon SDK. `fromBlock` is unchanged (21645993) because both contracts were deployed in the same block.

All factory addresses come from `@lagoon-protocol/v0-core` `addresses.ts`. Each deployment block was verified via the chain's RPC (`eth_getTransactionReceipt` on the creation tx) or the chain explorer.

| Chain | optinProxyFactory | fromBlock |
|---|---|---|
| bsc | `0x3f680aB9E51EEED9381dE5275f4995611Ff884d5` | 56083879 |
| hemi | `0xB457e9C025A8Af99E32b03668e34f80D20A71d2C` | 4091220 |
| hyperliquid | `0x90beB507A1BA7D64633540cbce615B574224CD84` | 12973305 |
| sei | `0xDa1d1De87C4D90A07a6462cCD9bE651a0d074362` | 183102541 |

## Test plan

- [x] `node -e "require('./projects/lagoon')"` loads cleanly with 20 chains
- [x] Sonic TVL verified locally with the new beaconFactory address
- [x] Hemi adapter runs cleanly (returns 0 vaults — none deployed yet)
- [ ] CI to run the full adapter (BSC / Hyperliquid require backend indexer or archive RPCs due to public-RPC `getLogs` payload limits over multi-million-block ranges)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vault-proxy discovery can optionally use an indexer for log-based detection.
  * Indexer-enabled log discovery activated for Hyperliquid.

* **Bug Fixes / Improvements**
  * Beacon-deployed vault discovery updated for Sonic to improve reliability.
  * Vault blacklist expanded with two addresses.
  * Blacklist filtering made case-insensitive to prevent missed matches.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19208?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->