### PR TITLE
Fix CI file-list parsing for JSON output

### DIFF
--- a/.github/workflows/getFileList.js
+++ b/.github/workflows/getFileList.js
@@ -1,26 +1,62 @@
-const { execSync } = require('child_process')
+const { execFileSync } = require('child_process')
 
-const MODIFIED = parse(process.env.MODIFIED)
-const ADDED = parse(process.env.ADDED)
-const fileSet = new Set();
+function getRunFiles({ modified, added, diffBase = 'HEAD~1', readDiff = readGitDiff }) {
+  const fileSet = new Set()
+  const changedFiles = [...parseFileList(modified), ...parseFileList(added)]
 
-[...MODIFIED, ...ADDED].forEach(file => {
-  const [root, dir] = file.split('/')
-  if (dir === 'treasury' || dir === 'entities') fileSet.add(file)
-  else if (root === 'projects' && dir !=='helper' && dir !== 'config') fileSet.add(root + '/' + dir)
-  else if (root === 'registries' && file.endsWith('.js') && dir !== 'index.js' && dir !== 'utils.js') {
-    const diffBase = process.env.DIFF_BASE || 'HEAD~1'
-    const diff = execSync(`git diff ${diffBase} -- ${file}`).toString()
-    const lines = diff.split('\n').filter(l => l.startsWith('+') && !l.startsWith('+++'))
-    for (const line of lines) {
-      const match = line.match(/['"]([a-zA-Z0-9][a-zA-Z0-9_-]+)['"]\s*:/)
-      if (match) fileSet.add(match[1])
+  changedFiles.forEach(file => {
+    const [root, dir] = file.split('/')
+    if (dir === 'treasury' || dir === 'entities') fileSet.add(file)
+    else if (root === 'projects' && dir !== 'helper' && dir !== 'config') fileSet.add(root + '/' + dir)
+    else if (root === 'registries' && file.endsWith('.js') && dir !== 'index.js' && dir !== 'utils.js') {
+      const diff = readDiff(diffBase, file)
+      const lines = diff.split('\n').filter(l => l.startsWith('+') && !l.startsWith('+++'))
+      for (const line of lines) {
+        const match = line.match(/['"]([a-zA-Z0-9][a-zA-Z0-9_-]+)['"]\s*:/)
+        if (match) fileSet.add(match[1])
+      }
     }
-  }
-})
+  })
 
-console.log(JSON.stringify([...fileSet]))
-
-function parse(data) {
-  return data.replace('[', '').replace(']', '').split(',')
+  return [...fileSet]
 }
+
+function readGitDiff(diffBase, file) {
+  return execFileSync('git', ['diff', diffBase, '--', file], { encoding: 'utf8' })
+}
+
+function parseFileList(data) {
+  if (!data) return []
+
+  const input = String(data).trim()
+  if (!input) return []
+
+  try {
+    const parsed = JSON.parse(input)
+    if (Array.isArray(parsed)) return parsed.map(normalizeFile).filter(Boolean)
+    if (typeof parsed === 'string') return parseFileList(parsed)
+  } catch {
+    // Fall back to the legacy comma-delimited format.
+  }
+
+  return input
+    .replace(/^\[/, '')
+    .replace(/\]$/, '')
+    .split(',')
+    .map(normalizeFile)
+    .filter(Boolean)
+}
+
+function normalizeFile(file) {
+  return String(file).trim().replace(/^['"]+|['"]+$/g, '').trim()
+}
+
+if (require.main === module) {
+  console.log(JSON.stringify(getRunFiles({
+    modified: process.env.MODIFIED,
+    added: process.env.ADDED,
+    diffBase: process.env.DIFF_BASE || 'HEAD~1',
+  })))
+}
+
+module.exports = { getRunFiles, parseFileList }

--- a/.github/workflows/getFileList.test.js
+++ b/.github/workflows/getFileList.test.js
@@ -1,0 +1,46 @@
+const assert = require('assert')
+
+const { getRunFiles, parseFileList } = require('./getFileList')
+
+assert.deepStrictEqual(parseFileList(''), [])
+assert.deepStrictEqual(parseFileList('["projects/minswap/index.js"]'), ['projects/minswap/index.js'])
+assert.deepStrictEqual(parseFileList('[ projects/minswap/index.js, projects/velodrome/index.js ]'), ['projects/minswap/index.js', 'projects/velodrome/index.js'])
+assert.deepStrictEqual(parseFileList('["projects/minswap/index.js", "projects/velodrome/index.js"]'), ['projects/minswap/index.js', 'projects/velodrome/index.js'])
+
+assert.deepStrictEqual(getRunFiles({
+  modified: '["projects/minswap/index.js"]',
+  added: '[]',
+}), ['projects/minswap'])
+
+assert.deepStrictEqual(getRunFiles({
+  modified: '[]',
+  added: '["projects/new-adapter/index.js"]',
+}), ['projects/new-adapter'])
+
+assert.deepStrictEqual(getRunFiles({
+  modified: '["projects/treasury/olympus.js", "projects/entities/binance.js"]',
+  added: '[]',
+}), ['projects/treasury/olympus.js', 'projects/entities/binance.js'])
+
+assert.deepStrictEqual(getRunFiles({
+  modified: '["projects/helper/unwrapLPs.js", "projects/config/constants.js"]',
+  added: '[]',
+}), [])
+
+assert.deepStrictEqual(getRunFiles({
+  modified: '["registries/yield.js"]',
+  added: '[]',
+  readDiff: () => `diff --git a/registries/yield.js b/registries/yield.js
++  "beefy": {
++  'yearn-v2': {
++  symbol: "ignored",
+`,
+}), ['beefy', 'yearn-v2'])
+
+assert.deepStrictEqual(getRunFiles({
+  modified: '["registries/index.js", "registries/utils.js"]',
+  added: '[]',
+  readDiff: () => { throw new Error('should not read ignored registry files') },
+}), [])
+
+console.log('getFileList tests passed')

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ projects/binance/data.csv
 
 scripts/tvlModules.json
 .claude
+.my-claw-artifacts/


### PR DESCRIPTION
## Summary

Fixes the PR file-list helper so it correctly reads JSON arrays from `trilom/file-changes-action`.

## Why this matters

`test.yml` asks the file-changes action for JSON output. The helper was stripping brackets and splitting on commas, which left quoted paths like `"projects/minswap/index.js"`. Those paths did not match `projects/`, so adapter PRs could skip the changed-adapter test path and report no adapter files were modified.

## What changed

- Parse valid JSON arrays before falling back to the old comma-split format.
- Normalize quotes and whitespace around legacy file entries.
- Keep the existing adapter, treasury/entities, and registry-key selection behavior.
- Use `execFileSync` for registry diffs instead of interpolating the file path into a shell command.
- Add focused Node fixtures for modified adapters, added adapters, treasury/entities files, ignored helper/config files, registry diffs, and ignored registry files.

## Checks

- `node .github/workflows/getFileList.test.js`
- `MODIFIED='["projects/minswap/index.js"]' ADDED='[]' node .github/workflows/getFileList.js`
- `MODIFIED='[ projects/minswap/index.js, projects/velodrome/index.js ]' ADDED='[]' node .github/workflows/getFileList.js`
- `npx eslint -c eslint.config.js .github/workflows/getFileList.js .github/workflows/getFileList.test.js`
