### PR TITLE
Fix CI file-list parsing for JSON output

### DIFF
--- a/.github/workflows/getFileList.js
+++ b/.github/workflows/getFileList.js
@@ -6,6 +6,7 @@ function getRunFiles({ modified, added, diffBase = 'HEAD~1', readDiff = readGitD
 
   changedFiles.forEach(file => {
     const [root, dir] = file.split('/')
+    if (!dir) return
     if (dir === 'treasury' || dir === 'entities') fileSet.add(file)
     else if (root === 'projects' && dir !== 'helper' && dir !== 'config') fileSet.add(root + '/' + dir)
     else if (root === 'registries' && file.endsWith('.js') && dir !== 'index.js' && dir !== 'utils.js') {
@@ -34,6 +35,7 @@ function parseFileList(data) {
   try {
     const parsed = JSON.parse(input)
     if (Array.isArray(parsed)) return parsed.map(normalizeFile).filter(Boolean)
+    // Some action outputs may arrive as JSON strings that still need parseFileList normalization.
     if (typeof parsed === 'string') return parseFileList(parsed)
   } catch {
     // Fall back to the legacy comma-delimited format.

--- a/.github/workflows/getFileList.js
+++ b/.github/workflows/getFileList.js
@@ -1,26 +1,62 @@
-const { execSync } = require('child_process')
+const { execFileSync } = require('child_process')
 
-const MODIFIED = parse(process.env.MODIFIED)
-const ADDED = parse(process.env.ADDED)
-const fileSet = new Set();
+function getRunFiles({ modified, added, diffBase = 'HEAD~1', readDiff = readGitDiff }) {
+  const fileSet = new Set()
+  const changedFiles = [...parseFileList(modified), ...parseFileList(added)]
 
-[...MODIFIED, ...ADDED].forEach(file => {
-  const [root, dir] = file.split('/')
-  if (dir === 'treasury' || dir === 'entities') fileSet.add(file)
-  else if (root === 'projects' && dir !=='helper' && dir !== 'config') fileSet.add(root + '/' + dir)
-  else if (root === 'registries' && file.endsWith('.js') && dir !== 'index.js' && dir !== 'utils.js') {
-    const diffBase = process.env.DIFF_BASE || 'HEAD~1'
-    const diff = execSync(`git diff ${diffBase} -- ${file}`).toString()
-    const lines = diff.split('\n').filter(l => l.startsWith('+') && !l.startsWith('+++'))
-    for (const line of lines) {
-      const match = line.match(/['"]([a-zA-Z0-9][a-zA-Z0-9_-]+)['"]\s*:/)
-      if (match) fileSet.add(match[1])
+  changedFiles.forEach(file => {
+    const [root, dir] = file.split('/')
+    if (dir === 'treasury' || dir === 'entities') fileSet.add(file)
+    else if (root === 'projects' && dir !== 'helper' && dir !== 'config') fileSet.add(root + '/' + dir)
+    else if (root === 'registries' && file.endsWith('.js') && dir !== 'index.js' && dir !== 'utils.js') {
+      const diff = readDiff(diffBase, file)
+      const lines = diff.split('\n').filter(l => l.startsWith('+') && !l.startsWith('+++'))
+      for (const line of lines) {
+        const match = line.match(/['"]([a-zA-Z0-9][a-zA-Z0-9_-]+)['"]\s*:/)
+        if (match) fileSet.add(match[1])
+      }
     }
-  }
-})
+  })
 
-console.log(JSON.stringify([...fileSet]))
-
-function parse(data) {
-  return data.replace('[', '').replace(']', '').split(',')
+  return [...fileSet]
 }
+
+function readGitDiff(diffBase, file) {
+  return execFileSync('git', ['diff', diffBase, '--', file], { encoding: 'utf8' })
+}
+
+function parseFileList(data) {
+  if (!data) return []
+
+  const input = String(data).trim()
+  if (!input) return []
+
+  try {
+    const parsed = JSON.parse(input)
+    if (Array.isArray(parsed)) return parsed.map(normalizeFile).filter(Boolean)
+    if (typeof parsed === 'string') return parseFileList(parsed)
+  } catch {
+    // Fall back to the legacy comma-delimited format.
+  }
+
+  return input
+    .replace(/^\[/, '')
+    .replace(/\]$/, '')
+    .split(',')
+    .map(normalizeFile)
+    .filter(Boolean)
+}
+
+function normalizeFile(file) {
+  return String(file).trim().replace(/^['"]+|['"]+$/g, '').trim()
+}
+
+if (require.main === module) {
+  console.log(JSON.stringify(getRunFiles({
+    modified: process.env.MODIFIED,
+    added: process.env.ADDED,
+    diffBase: process.env.DIFF_BASE || 'HEAD~1',
+  })))
+}
+
+module.exports = { getRunFiles, parseFileList }

--- a/.github/workflows/getFileList.test.js
+++ b/.github/workflows/getFileList.test.js
@@ -28,6 +28,11 @@ assert.deepStrictEqual(getRunFiles({
 }), [])
 
 assert.deepStrictEqual(getRunFiles({
+  modified: '["projects"]',
+  added: '[]',
+}), [])
+
+assert.deepStrictEqual(getRunFiles({
   modified: '["registries/yield.js"]',
   added: '[]',
   readDiff: () => `diff --git a/registries/yield.js b/registries/yield.js

--- a/.github/workflows/getFileList.test.js
+++ b/.github/workflows/getFileList.test.js
@@ -1,0 +1,46 @@
+const assert = require('assert')
+
+const { getRunFiles, parseFileList } = require('./getFileList')
+
+assert.deepStrictEqual(parseFileList(''), [])
+assert.deepStrictEqual(parseFileList('["projects/minswap/index.js"]'), ['projects/minswap/index.js'])
+assert.deepStrictEqual(parseFileList('[ projects/minswap/index.js, projects/velodrome/index.js ]'), ['projects/minswap/index.js', 'projects/velodrome/index.js'])
+assert.deepStrictEqual(parseFileList('["projects/minswap/index.js", "projects/velodrome/index.js"]'), ['projects/minswap/index.js', 'projects/velodrome/index.js'])
+
+assert.deepStrictEqual(getRunFiles({
+  modified: '["projects/minswap/index.js"]',
+  added: '[]',
+}), ['projects/minswap'])
+
+assert.deepStrictEqual(getRunFiles({
+  modified: '[]',
+  added: '["projects/new-adapter/index.js"]',
+}), ['projects/new-adapter'])
+
+assert.deepStrictEqual(getRunFiles({
+  modified: '["projects/treasury/olympus.js", "projects/entities/binance.js"]',
+  added: '[]',
+}), ['projects/treasury/olympus.js', 'projects/entities/binance.js'])
+
+assert.deepStrictEqual(getRunFiles({
+  modified: '["projects/helper/unwrapLPs.js", "projects/config/constants.js"]',
+  added: '[]',
+}), [])
+
+assert.deepStrictEqual(getRunFiles({
+  modified: '["registries/yield.js"]',
+  added: '[]',
+  readDiff: () => `diff --git a/registries/yield.js b/registries/yield.js
++  "beefy": {
++  'yearn-v2': {
++  symbol: "ignored",
+`,
+}), ['beefy', 'yearn-v2'])
+
+assert.deepStrictEqual(getRunFiles({
+  modified: '["registries/index.js", "registries/utils.js"]',
+  added: '[]',
+  readDiff: () => { throw new Error('should not read ignored registry files') },
+}), [])
+
+console.log('getFileList tests passed')

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ projects/binance/data.csv
 
 scripts/tvlModules.json
 .claude
+.my-claw-artifacts/


### PR DESCRIPTION
## Summary

Fix `.github/workflows/getFileList.js` so the PR test workflow can parse the JSON file lists emitted by `trilom/file-changes-action` before deciding which adapter tests to run.

## What was wrong

`.github/workflows/test.yml` configures the file-changes action with `output: "json"` and `fileOutput: "json"`. That means the action output is documented as a JSON string. A normal modified-file list can look like this:

```json
["projects/minswap/index.js", "projects/velodrome/index.js"]
```

The previous helper did not parse JSON. It only stripped the outer brackets and split on commas:

```js
data.replace("[", "").replace("]", "").split(",")
```

That can appear to work when the workflow injects the value into an unquoted shell assignment, because the shell may remove the double quotes before Node sees the value. In that case Node receives something closer to this:

```txt
[projects/minswap/index.js,projects/velodrome/index.js]
```

But if the helper receives the documented JSON string directly, the old parser leaves the quotes in place. The first path becomes `"projects/minswap/index.js"`, so `file.split("/")` sees the root as `"projects` instead of `projects`. That can make the helper miss a changed adapter and return no adapter test path.

Put another way: the workflow action is configured to emit JSON. The previous parser did not actually parse JSON; it only stripped brackets and split on commas. It may have worked in some CI cases because shell interpolation removed quotes before Node saw the value, but that was accidental. This PR makes the script handle the documented JSON output directly while preserving the old comma-style fallback.

## What changed

- Parse valid JSON arrays first.
- Keep support for the older shell-stripped comma format.
- Normalize quotes and whitespace around each file path.
- Preserve the existing adapter-selection rules:
  - `projects/<adapter>/...` still maps to `projects/<adapter>`.
  - `projects/treasury/...` and `projects/entities/...` still keep the exact file path.
  - changed registry files still scan added registry keys and run those adapters.
- Use `execFileSync` for registry diffs so file paths are passed to `git` as arguments instead of being interpolated into a shell command.
- Add focused regression tests for JSON input, legacy input, added adapters, treasury/entities files, ignored helper/config files, registry diffs, and ignored registry files.

## Safety notes

I rechecked the behavior against the existing workflow before updating this PR description. The adapter routing rules are unchanged after parsing. The old shell-stripped input format still works, and the documented JSON format now works too. Empty inputs now return `[]` instead of relying on string replacement. Registry diff behavior is the same, except the `git diff` call is now safer.

No adapter code, package files, or lockfiles are changed.

## Checks

- `git diff --check upstream/main...HEAD`
- `node .github/workflows/getFileList.test.js`
- Manual JSON input check: `MODIFIED="[\"projects/minswap/index.js\",\"projects/velodrome/index.js\"]" ADDED="[]" node .github/workflows/getFileList.js`
- Manual legacy input check: `MODIFIED="[projects/minswap/index.js,projects/velodrome/index.js]" ADDED="[]" node .github/workflows/getFileList.js`
- PR `Test_Change` checks are passing on GitHub.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Converted a top-level workflow script into a reusable module with clearer input parsing and safer diff handling.

* **Tests**
  * Added unit tests to validate input parsing and run-target derivation for workflow logic.

* **Chores**
  * Updated ignore rules to exclude new local/config artifacts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19213)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->