### PR TITLE
Add Dusk native staking TVL adapter

### DIFF
--- a/projects/dusk/index.js
+++ b/projects/dusk/index.js
@@ -1,0 +1,33 @@
+const { post } = require('../helper/http')
+
+const DUSK_RPC = process.env.DUSK_RPC || 'https://nodes.dusk.network'
+const LUX_PER_DUSK = 1_000_000_000n
+const DUSK_COINGECKO_ID = 'dusk-network'
+
+function luxToDusk(lux) {
+  const whole = lux / LUX_PER_DUSK
+  const fractional = lux % LUX_PER_DUSK
+  return Number(whole) + Number(fractional) / 1e9
+}
+
+async function tvl(api) {
+  const provisioners = await post(`${DUSK_RPC}/on/node/provisioners`)
+
+  if (!Array.isArray(provisioners)) {
+    throw new Error('Expected /on/node/provisioners response to be an array')
+  }
+
+  const totalLux = provisioners.reduce(
+    (sum, provisioner) =>
+      sum + BigInt(provisioner.amount ?? 0) + BigInt(provisioner.locked_amt ?? 0),
+    0n
+  )
+
+  api.addCGToken(DUSK_COINGECKO_ID, luxToDusk(totalLux))
+}
+
+module.exports = {
+  timetravel: false,
+  methodology: 'Counts native DUSK staked by provisioners from Rusk chain state exposed by /on/node/provisioners. Sums stake amount plus locked stake, converts from LUX to DUSK, and excludes pending rewards.',
+  dusk: { tvl },
+}

--- a/projects/helper/chains.json
+++ b/projects/helper/chains.json
@@ -124,6 +124,7 @@
   "doma",
   "dsc",
   "duckchain",
+  "dusk",
   "dydx",
   "dymension",
   "echelon",


### PR DESCRIPTION
## Summary
- Adds the `dusk` chain slug.
- Adds a current-state native staking TVL adapter for Dusk provisioners.
- Counts `amount + locked_amt`, converts from LUX to DUSK, and excludes pending rewards.

## Project notes
Name: Dusk
Website: https://dusk.network/
Docs: https://docs.dusk.network/
Twitter/X: https://x.com/DuskFoundation
Chain: Dusk
Category: Staking
GitHub org: dusk-network
Token: DUSK
CoinGecko ID: dusk-network
Current TVL: 28.04 M DUSK from `DUSK_RPC=https://nodes.dusk.network node test.js projects/dusk/index.js`
Methodology: Counts native DUSK staked by provisioners from /on/node/provisioners, sums amount + locked_amt, converts LUX to DUSK, excludes pending rewards.
Open question: confirm with Dusk/DefiLlama whether pending rewards should stay excluded.

## Validation
- `DUSK_RPC=https://nodes.dusk.network node test.js projects/dusk/index.js`
- CoinGecko `coins/list` returned one DUSK match: `dusk-network`; the detail endpoint links to https://dusk.network/ and Dusk GitHub repos.
