### PR TITLE
Add Dusk native staking TVL adapter

### DIFF
--- a/projects/dusk/index.js
+++ b/projects/dusk/index.js
@@ -4,12 +4,18 @@ const DUSK_RPC = process.env.DUSK_RPC || 'https://nodes.dusk.network'
 const LUX_PER_DUSK = 1_000_000_000n
 const DUSK_COINGECKO_ID = 'dusk-network'
 
+/**
+ * Converts a LUX-denominated staking balance to DUSK.
+ */
 function luxToDusk(lux) {
   const whole = lux / LUX_PER_DUSK
   const fractional = lux % LUX_PER_DUSK
   return Number(whole) + Number(fractional) / 1e9
 }
 
+/**
+ * Fetches Dusk provisioner state and reports native DUSK staking TVL.
+ */
 async function tvl(api) {
   const provisioners = await post(`${DUSK_RPC}/on/node/provisioners`)
 

--- a/projects/dusk/index.js
+++ b/projects/dusk/index.js
@@ -1,0 +1,33 @@
+const { post } = require('../helper/http')
+
+const DUSK_RPC = process.env.DUSK_RPC || 'https://nodes.dusk.network'
+const LUX_PER_DUSK = 1_000_000_000n
+const DUSK_COINGECKO_ID = 'dusk-network'
+
+function luxToDusk(lux) {
+  const whole = lux / LUX_PER_DUSK
+  const fractional = lux % LUX_PER_DUSK
+  return Number(whole) + Number(fractional) / 1e9
+}
+
+async function tvl(api) {
+  const provisioners = await post(`${DUSK_RPC}/on/node/provisioners`)
+
+  if (!Array.isArray(provisioners)) {
+    throw new Error('Expected /on/node/provisioners response to be an array')
+  }
+
+  const totalLux = provisioners.reduce(
+    (sum, provisioner) =>
+      sum + BigInt(provisioner.amount ?? 0) + BigInt(provisioner.locked_amt ?? 0),
+    0n
+  )
+
+  api.addCGToken(DUSK_COINGECKO_ID, luxToDusk(totalLux))
+}
+
+module.exports = {
+  timetravel: false,
+  methodology: 'Counts native DUSK staked by provisioners from Rusk chain state exposed by /on/node/provisioners. Sums stake amount plus locked stake, converts from LUX to DUSK, and excludes pending rewards.',
+  dusk: { tvl },
+}

--- a/projects/helper/chains.json
+++ b/projects/helper/chains.json
@@ -124,6 +124,7 @@
   "doma",
   "dsc",
   "duckchain",
+  "dusk",
   "dydx",
   "dymension",
   "echelon",


### PR DESCRIPTION
## Summary
- Adds the `dusk` chain slug.
- Adds a current-state native staking TVL adapter for Dusk provisioners.
- Counts `amount + locked_amt`, converts from LUX to DUSK, and excludes pending rewards.

## Project notes
Name: Dusk
Logo: https://dusk.network/media-kit/
Short description: Privacy-focused Layer 1 blockchain for regulated finance and smart contracts
Audit links: https://github.com/dusk-network/audits
Website: https://dusk.network/
Docs: https://docs.dusk.network/
Twitter/X: https://x.com/DuskFoundation
Chain: Dusk
Category: Staking
GitHub org: https://github.com/dusk-network
Token: DUSK
CoinGecko ID: dusk-network
Current TVL: 28.04 M DUSK from `DUSK_RPC=https://nodes.dusk.network node test.js projects/dusk/index.js`
Methodology: Counts native DUSK staked by provisioners from /on/node/provisioners, sums amount + locked_amt, converts LUX to DUSK, excludes pending rewards.
ForkedFrom: No
Does this project have a referral program?: No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DUSK chain support with a TVL adapter to track and display assets secured on the network.
  * Registered DUSK in the supported chains list so it appears alongside other networks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19215)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->