### PR TITLE
Docs: README cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Follow [this guide](https://docs.llama.fi/submit-a-project) to create an adapter
 
 Also, don't hesitate to send a message on [our discord](https://discord.defillama.com/) if we're late to merge your PR.
 
-> If you would like to add a `volume` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters)
+> This repo is for **TVL** adapters.
+> For other metrics such as `volume`, `fees`, `revenue`, `aggregators`, `open-interest`, `active-users`, etc. submit the PR to [DefiLlama/dimension-adapters](https://github.com/DefiLlama/dimension-adapters).
 
 1. PLEASE PLEASE **enable "Allow edits by maintainers" while putting up the PR.**
 2. Once your adapter has been merged, it takes time to show on the UI. No need to notify us on Discord.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Follow [this guide](https://docs.llama.fi/submit-a-project) to create an adapter
 
 Also, don't hesitate to send a message on [our discord](https://discord.defillama.com/) if we're late to merge your PR.
 
-> If you would like to add a `volume` adapter please submit the PR [here](https://github.com/DefiLlama/adapters)
+> If you would like to add a `volume` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters)
 
 1. PLEASE PLEASE **enable "Allow edits by maintainers" while putting up the PR.**
 2. Once your adapter has been merged, it takes time to show on the UI. No need to notify us on Discord.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Also, don't hesitate to send a message on [our discord](https://discord.defillam
 2. Once your adapter has been merged, it takes time to show on the UI. No need to notify us on Discord.
 3. TVL must be computed from blockchain data (reason: https://github.com/DefiLlama/DefiLlama-Adapters/discussions/432), if you have trouble with creating the adapter, please hop onto our discord, we are happy to assist you.
 4. **For updating listing info** It is a different repo, you can find your listing in this file: https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts, you can  edit it there and put up a PR
-5. Do not edit/push `package-lock.json` file as part of your changes, we use lockfileVersion 2, and most use v1 and using that messes up our CI
+5. Do not edit/push `pnpm-lock.yaml` or `pnpm-workspace.yaml` files as part of your changes, that messes up our CI.
 6. No need to go to our discord and announce that you've created a PR, we monitor all PRs and will review it asap
 
 ## Getting listed

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ Follow [this guide](https://docs.llama.fi/submit-a-project) to create an adapter
 Also, don't hesitate to send a message on [our discord](https://discord.defillama.com/) if we're late to merge your PR.
 
 > If you would like to add a `volume` adapter please submit the PR [here](https://github.com/DefiLlama/adapters)
-> - If you would like to add a `liquidations` adapter, please refer to [this readme document](https://github.com/DefiLlama/DefiLlama-Adapters/tree/main/liquidations) for details.
 
 1. PLEASE PLEASE **enable "Allow edits by maintainers" while putting up the PR.**
 2. Once your adapter has been merged, it takes time to show on the UI. No need to notify us on Discord.


### PR DESCRIPTION
# Summary
Readme had some old, stale refs. Fixed all and improved wording.

- `package-lock.json` is now `pnpm-lock.yaml`
- `DefiLlama/adapters` is now `DefiLlama/dimension-adapters``
- No code/content changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the repository is specifically for TVL adapters, with other metrics belonging to a separate repository.
  * Updated contribution guidelines regarding pnpm lockfile management.
  * Reemphasized the policy on pull request announcements.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19216)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->