### PR TITLE
jupiter-lend: include isolated Ethena-market deployment in TVL

### DIFF
--- a/projects/jupiter-lend/index.js
+++ b/projects/jupiter-lend/index.js
@@ -2,15 +2,23 @@ const { getConfig } = require('../helper/cache')
 const { getProvider, sumTokens2 } = require('../helper/solana')
 const { Program } = require("@coral-xyz/anchor");
 
-async function getData() {
-  const LIQUIDITY_IDL_URL = "https://raw.githubusercontent.com/jup-ag/jupiter-lend/refs/heads/main/target/idl/liquidity.json";
-  const LIQUIDITY_PROGRAM_ID = "jupeiUmn818Jg1ekPURTpr4mFo29p46vygyykFJ3wZC";
+const LIQUIDITY_IDL_URL = "https://raw.githubusercontent.com/jup-ag/jupiter-lend/refs/heads/main/target/idl/liquidity.json";
+const LIQUIDITY_PROGRAM_IDS = [
+  "jupeiUmn818Jg1ekPURTpr4mFo29p46vygyykFJ3wZC", // main deployment
+  "jup6QF1sNDGpkkcu6F4qaFHcRBmnSS1VgyB4uFbBvNS", // isolated Ethena market (shares the liquidity IDL)
+];
 
+async function getData() {
   const idl = await getConfig('jupiter-lend', LIQUIDITY_IDL_URL)
   const provider = getProvider();
-  idl.metadata.address = LIQUIDITY_PROGRAM_ID;
-  const program = new Program(idl, provider);
-  return ( await program.account.tokenReserve.all()).map(i => i.account)
+  const reserves = []
+  for (const programId of LIQUIDITY_PROGRAM_IDS) {
+    const localIdl = { ...idl, address: programId }
+    const program = new Program(localIdl, provider);
+    const accounts = await program.account.tokenReserve.all()
+    reserves.push(...accounts.map(i => i.account))
+  }
+  return reserves
 }
 
 const EXCHANGE_PRICE_PRECISION = 1e12


### PR DESCRIPTION
Jupiter Lend now operates a second isolated-market deployment for Ethena.

This PR rolls the new deployment into the existing `Jupiter Lend` line item rather than splitting it out.

- Main Liquidity program: `jupeiUmn818Jg1ekPURTpr4mFo29p46vygyykFJ3wZC` 
- Ethena Liquidity program: `jup6QF1sNDGpkkcu6F4qaFHcRBmnSS1VgyB4uFbBvNS` (fork)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended liquidity tracking to support multiple Jupiter Lend programs, enabling broader data aggregation for TVL and borrowed value calculations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19219)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->