### PR TITLE
Add Coinshift USPC TVL adapter

### DIFF
--- a/projects/coinshift-uspc/index.js
+++ b/projects/coinshift-uspc/index.js
@@ -1,0 +1,18 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+
+const IUSPC = '0xdc807c3a618B6B1248481783def7ED76700B9eC6'
+const USPC_NAV_FEED = '0x02ae69C812DD749c32afb4F1723F6833EeF3d7a3'
+
+async function tvl(api) {
+  const supply = await api.call({ target: IUSPC, abi: 'erc20:totalSupply' })
+  const price = await api.call({ target: USPC_NAV_FEED, abi: 'int256:latestAnswer' })
+  const priceDecimals = await api.call({ target: USPC_NAV_FEED, abi: 'uint8:decimals' })
+  const value = (BigInt(supply) * BigInt(price)) / 10n ** BigInt(priceDecimals)
+  api.add(ADDRESSES.ethereum.USDC, value.toString())
+}
+
+module.exports = {
+  methodology:
+    "TVL is the iUSPC supply valued at NAV: iUSPC.totalSupply() multiplied by the Chainlink USPC NAV feed (uspc-nav.data.eth), reported as USDC. The USPC ERC-4626 vault wraps iUSPC 1:1, so its assets are already counted inside iUSPC.totalSupply().",
+  ethereum: { tvl },
+}

--- a/projects/coinshift-uspc/index.js
+++ b/projects/coinshift-uspc/index.js
@@ -4,9 +4,12 @@ const IUSPC = '0xdc807c3a618B6B1248481783def7ED76700B9eC6'
 const USPC_NAV_FEED = '0x02ae69C812DD749c32afb4F1723F6833EeF3d7a3'
 
 async function tvl(api) {
-  const supply = await api.call({ target: IUSPC, abi: 'erc20:totalSupply' })
-  const price = await api.call({ target: USPC_NAV_FEED, abi: 'int256:latestAnswer' })
-  const priceDecimals = await api.call({ target: USPC_NAV_FEED, abi: 'uint8:decimals' })
+  const [supply, price, priceDecimals] = await Promise.all([
+    api.call({ target: IUSPC, abi: 'erc20:totalSupply' }),
+    api.call({ target: USPC_NAV_FEED, abi: 'int256:latestAnswer' }),
+    api.call({ target: USPC_NAV_FEED, abi: 'uint8:decimals' }),
+  ])
+  if (BigInt(price) <= 0n) throw new Error('Invalid USPC NAV from Chainlink feed')
   const value = (BigInt(supply) * BigInt(price)) / 10n ** BigInt(priceDecimals)
   api.add(ADDRESSES.ethereum.USDC, value.toString())
 }


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):

**Coinshift USPC**

##### Twitter Link:

https://x.com/0xCoinshift

##### Website Link:

| | |
|---|---|
| Main site | https://www.coinshift.xyz/ |
| USPC app | https://app.coinshift.xyz/ |
| Analytics | https://analytics.coinshift.xyz/ |

##### Logo (High resolution, will be shown with rounded borders):

https://www.coinshift.xyz/images/iuspc-logo.svg

##### Current TVL:

**~$6.63M** (per the adapter, 2026-05-11)

##### Treasury Addresses:

| Label | Address |
|---|---|
| Treasury | `0x4768bed77edd27606803065c923af6d5ef6c5d75` |
| Strategy Wallet | `0x419b4866d2e5f57c74906405924ee7b935ae1405` |

##### Chain:

Ethereum

##### Coingecko ID:

_(not listed)_

##### Coinmarketcap ID:

_(not listed)_

##### Short Description:

Coinshift USPC (USD Private Credit) is an institutional NAV-based credit fund. Users deposit USDC into the `IUSPCHub`, receive `iUSPC` representing fund shares priced at NAV via a Chainlink feed, and can wrap into `USPC` (ERC-4626) for DeFi composability. Reserves are attested at [coinshift.accountable.capital](https://coinshift.accountable.capital/).

##### Token address and ticker:

| Ticker | Address |
|---|---|
| `iUSPC` | `0xdc807c3a618B6B1248481783def7ED76700B9eC6` |
| `USPC` _(ERC-4626 wrapper)_ | `0xbF4e3fbE8B60062A00C7a6B1D97d0d49c2971A19` |

##### Category:

**RWA**

##### Oracle Provider(s):

**Chainlink**

##### Implementation Details:

The fund's NAV is published to a dedicated Chainlink feed `uspc-nav.data.eth` (aggregator `0x02ae69C812DD749c32afb4F1723F6833EeF3d7a3`).

On-chain, the `Pricer` contract (`0x5eC0C20A83554eC1BBC0F1D3414BB8746a04acD4`) thin-wraps that feed with:

- **5%** round-over-round deviation cap
- **24h** staleness check

The `IUSPCHub` contract consumes it for subscription and redemption math:

```
shares     = collateral * 1e36 / price
collateral = shares     * price / 1e36
```

The DefiLlama adapter reads the Chainlink aggregator directly (no `Pricer` dependency, unaffected if the wrapper is paused).

##### Documentation/Proof:

- Chainlink feed: https://data.chain.link/feeds/ethereum/mainnet/uspc-nav
- Proof of Reserves: https://coinshift.accountable.capital/

##### forkedFrom:

_n/a — original implementation_

##### Methodology:

```
TVL = iUSPC.totalSupply() × ChainlinkUSPCNAV / 10^feedDecimals   (reported as USDC)
```

The `USPC` ERC-4626 vault wraps `iUSPC` 1:1, so its `totalAssets` are already counted inside `iUSPC.totalSupply()` — **no double-counting**.

##### Github org/user:

https://github.com/multisafe/

##### Referral program:

No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Ethereum TVL tracking for iUSPC tokens using a Chainlink NAV feed for valuation.
  * Validates NAV feed values and reports the computed TVL in USDC.
  * Includes a documented methodology describing the valuation approach.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19220)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->