### PR TITLE
fix: replace self-reported API with on-chain USDC accounting in Multipli adapter

### DIFF
--- a/projects/multipli/index.js
+++ b/projects/multipli/index.js
@@ -2,7 +2,6 @@ const ADDRESSES = require('../helper/coreAssets.json');
 const { sumTokensExport } = require('../helper/unwrapLPs');
 
 module.exports = {
-  timetravel: false,
   methodology: 'Counts USDC deposited in Multipli vault and fund manager contracts.',
   avax: {
     tvl: sumTokensExport({

--- a/projects/multipli/index.js
+++ b/projects/multipli/index.js
@@ -1,11 +1,25 @@
-const axios = require('axios')
-const API = "https://api.multipli.fi/multipli/v1/external-aggregator/defillama/tvl/"
+const ADDRESSES = require('../helper/coreAssets.json');
+const { sumTokensExport } = require('../helper/unwrapLPs');
 
-const tvl = async (api) => {
-  const { data } = await axios.get(API)
-  return data.payload[api.chain]
-}
-
-const chains = ['ethereum', 'bsc', 'avax', 'base', 'monad', 'arbitrum']
-module.exports.timetravel = false
-chains.forEach(chain => { module.exports[chain] = { tvl } })
+module.exports = {
+  timetravel: false,
+  methodology: 'Counts USDC deposited in Multipli vault and fund manager contracts.',
+  avax: {
+    tvl: sumTokensExport({
+      owners: [
+        '0xCF0Eb4ac018C06a16ED5c63484823C7805e7599D', // xUSDC vault
+        '0x01e676EAA0C9780A88395c651349Cf08Fe52368e', // fund manager
+      ],
+      tokens: [ADDRESSES.avax.USDC],
+    }),
+  },
+  monad: {
+    tvl: sumTokensExport({
+      owners: [
+        '0xd74FB32112b1eF5b4C428Fead8dA8d85A0019009', // xUSDC vault
+        '0xE1824bF952bB2E8414d12de8A9fc2cBc666D6758', // fund manager
+      ],
+      tokens: [ADDRESSES.monad.USDC],
+    }),
+  },
+};


### PR DESCRIPTION
## Summary

Fixes #19200

The Multipli adapter was calling the protocol's own `/defillama/tvl/` API, which self-reported ~$175M+ TVL dominated by protocol-issued `rwaUSDi` tokens. These are unbacked by verifiable on-chain collateral, inflating TVL significantly.

This fix replaces the API call with direct on-chain USDC balance queries on the verified vault and fund manager contracts:

- **Avalanche**: xUSDC vault `0xCF0Eb4ac018C06a16ED5c63484823C7805e7599D` + fund manager `0x01e676EAA0C9780A88395c651349Cf08Fe52368e`
- **Monad**: xUSDC vault `0xd74FB32112b1eF5b4C428Fead8dA8d85A0019009` + fund manager `0xE1824bF952bB2E8414d12de8A9fc2cBc666D6758`

Chains with no verified collateral contracts (ethereum, bsc, base, arbitrum) are removed.

## Test output

```
avax    2.63k USDC
monad   7.85k USDC
total  10.48k
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * TVL calculation for Avax and Monad now uses on-chain USDC balance aggregation for specified custodial addresses.
  * TVL data is now provided only for Avax and Monad; other networks have been removed from the public exports.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19225)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->