### PR TITLE
fix: blacklist TURBO_RSETH cellar in Sommelier adapter

### DIFF
--- a/projects/sommelier/index.js
+++ b/projects/sommelier/index.js
@@ -10,7 +10,7 @@ const {
   optimismCellarsV2p5,
 } = require("./cellar-constants");
 
-const blacklistCellars = ['0x9a7b4980C6F0FCaa50CD5f288Ad7038f434c692e', '0x5195222f69c5821f8095ec565e71e18ab6a2298f', '0xdAdC82e26b3739750E036dFd9dEfd3eD459b877A']
+const blacklistCellars = ['0x9a7b4980C6F0FCaa50CD5f288Ad7038f434c692e', '0x5195222f69c5821f8095ec565e71e18ab6a2298f', '0xdAdC82e26b3739750E036dFd9dEfd3eD459b877A', '0x1dffb366b5c5A37A12af2C127F31e8e0ED86BDbe']
 
 async function ethereum_tvl(api) {
   const block = await api.getBlock();


### PR DESCRIPTION
## Summary

Fixes #19034

The Turbo rsETH cellar (`0x1dffb366b5c5A37A12af2C127F31e8e0ED86BDbe`) is no longer responding to `totalAssets()` calls, causing a multicall failure that breaks the entire Sommelier adapter.

Added it to the existing `blacklistCellars` array alongside the three other already-blacklisted cellars — same pattern already used in the codebase.

## Test output

```
ethereum   849.42k
arbitrum   156.57k
optimism    29.72k
total        1.04M
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated cellar filtering to exclude an inactive cellar from TVL calculations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19226)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->