### PR TITLE
Add Galaxy adapter

### DIFF
--- a/projects/galaxy/index.js
+++ b/projects/galaxy/index.js
@@ -1,0 +1,25 @@
+const { getMorphoVaultTvl } = require("../helper/morpoho");
+
+const ethereumConfig = {
+  vaults: [
+    "0x71ffB6a81786eC285D429d531Cf655107B9D878d",
+    "0x91600E31fBeDc72433d4a57F16639cfe661Be7d8",
+    "0x1878805799273d10aE96a58201A6f5254CF9824F"
+  ]
+}
+
+const baseConfig = {
+  vaults: [
+    "0x1e9e47583f15D45a10Df48c0b1846E0492c795D7"
+  ]
+}
+
+module.exports = {
+  methodology: "TVL is calculated by summing the assets deposited in Galaxy's Morpho vaults on each supported chain, using the ERC4626 balances of the listed vault contracts.",
+  ethereum: {
+    tvl: getMorphoVaultTvl(undefined, {vaults: ethereumConfig.vaults})
+  },
+  base: {
+    tvl: getMorphoVaultTvl(undefined, {vaults: baseConfig.vaults})
+  }
+}

--- a/projects/galaxy/index.js
+++ b/projects/galaxy/index.js
@@ -1,25 +1,17 @@
-const { getMorphoVaultTvl } = require("../helper/morpoho");
+const { getCuratorExport } = require("../helper/curators");
 
-const ethereumConfig = {
-  vaults: [
-    "0x71ffB6a81786eC285D429d531Cf655107B9D878d",
-    "0x91600E31fBeDc72433d4a57F16639cfe661Be7d8",
-    "0x1878805799273d10aE96a58201A6f5254CF9824F"
-  ]
-}
+const owners = ["0x42D510eDeb9257f8D920d5B9f5109D95cB22419d"]
 
-const baseConfig = {
-  vaults: [
-    "0x1e9e47583f15D45a10Df48c0b1846E0492c795D7"
-  ]
-}
-
-module.exports = {
-  methodology: "TVL is calculated by summing the assets deposited in Galaxy's Morpho vaults on each supported chain, using the ERC4626 balances of the listed vault contracts.",
-  ethereum: {
-    tvl: getMorphoVaultTvl(undefined, {vaults: ethereumConfig.vaults})
+const configs = {
+  methodology: "TVL is calculated by summing the assets deposited in all Morpho vaults curated by Galaxy on each supported chain.",
+  blockchains: {
+    ethereum: {
+      morphoVaultOwners: owners,
+    },
+    base: {
+      morphoVaultOwners: owners,
+    },
   },
-  base: {
-    tvl: getMorphoVaultTvl(undefined, {vaults: baseConfig.vaults})
-  }
 }
+
+module.exports = getCuratorExport(configs)


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

Adds a TVL adapter for Galaxy curator vaults on Morpho.

Methodology:
- Sum ERC4626 `totalAssets` for Galaxy's Morpho vaults on Ethereum and Base.
- Vault list is based on the current Galaxy curator page on Morpho.

Tested locally:
- `node test.js projects/galaxy/index.js`

Notes:
- This PR only adds the adapter.
- Listing info, if needed, should be handled separately in `defillama-server` per repository instructions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TVL tracking for Galaxy Morpho vaults across Ethereum and Base networks, enabling aggregated value monitoring.

* **Documentation**
  * Added a user-facing methodology summary explaining how Galaxy Morpho vault TVL is calculated.

* **Refactor**
  * Internal export and configuration consolidated to a curator-driven model for more consistent multi-chain reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19237?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->