### PR TITLE
xstocks: extend AppLovin xStock (APPx) coverage

### DIFF
--- a/projects/xstocks/index.js
+++ b/projects/xstocks/index.js
@@ -1,3 +1,27 @@
+/**
+ * xstocks — Backed Finance's tokenised-equity adapter.
+ *
+ * Each entry in `data` represents one xStock (the on-chain wrapper for a
+ * traditional equity such as AAPLx or NVDAx). The `p` object maps each
+ * supported chain to that token's deployed address on that chain; the
+ * `chainMapping` table tells the generic EVM `tvl` function which key
+ * inside `p` corresponds to its DeFiLlama `api.chain` value
+ * (arbitrum → arbitrum-one is the canonical example; most others are
+ * identity mappings).
+ *
+ * Two TVL paths are exposed:
+ *   - `tvl(api)` — generic EVM handler, used for every EVM chain in
+ *     `chainMapping`. Sums `totalSupply` across every xStock deployed
+ *     on `api.chain`, then subtracts the issuer-held pre-mint balance
+ *     so the published TVL reflects circulating supply only.
+ *   - `solTvl(api)` — Solana handler (Token-2022 mints). Mirrors the
+ *     EVM logic via `getTokenSupplies` + `sumTokens2` from the
+ *     Solana helper module.
+ *
+ * Non-EVM chains (Tron, TON) are recorded in `data.p` for
+ * discoverability but do not yet have a dedicated handler — those are
+ * tracked as follow-up work (see project_xstocks_listing.md upstream).
+ */
 const { getTokenSupplies, sumTokens2 } = require('../helper/solana')
 
 const data = [
@@ -73,6 +97,18 @@ const chainMapping = {
   mantle: 'mantle',
 }
 
+/**
+ * EVM TVL handler — generic over every chain in `chainMapping`.
+ *
+ * Picks the right key inside each `data[i].p` object via
+ * `chainMapping[api.chain]`, fetches the on-chain `totalSupply` for
+ * every xStock that has a deployment on this chain, then subtracts the
+ * issuer-held pre-mint balance so reported TVL reflects user-held
+ * (circulating) supply only.
+ *
+ * @param {object} api — DeFiLlama EVM helper. Provides `api.chain`,
+ *   `api.multiCall`, and `api.add`.
+ */
 async function tvl(api) {
   const chainKey = chainMapping[api.chain]
   const tokens = data.map(stock => stock.p[chainKey]).filter(Boolean)
@@ -91,6 +127,15 @@ Object.keys(chainMapping).forEach(chain => {
   module.exports[chain] = { tvl }
 })
 
+/**
+ * Solana TVL handler — Token-2022 mints under the xStocks program.
+ *
+ * Mirrors `tvl` but uses the Solana helper module
+ * (`getTokenSupplies` + `sumTokens2`) instead of the EVM multicall.
+ * Subtracts the issuer-held pre-mint balance the same way.
+ *
+ * @param {object} api — DeFiLlama Solana helper. Provides `api.add`.
+ */
 async function solTvl(api) {
   const tokens = data.map(stock => stock.p.solana).filter(Boolean)
   const supplies = await getTokenSupplies(tokens)

--- a/projects/xstocks/index.js
+++ b/projects/xstocks/index.js
@@ -41,7 +41,7 @@ const data = [
   { "name": "Abbott xStock", "p": { "solana": "XsHtf5RpxsQ7jeJ9ivNewouZKJHbPxhPoEy6yYvULr7", "arbitrum-one": "0x89233399708c18ac6887f90a2b4cd8ba5fedd06e" } },
   { "name": "CrowdStrike xStock", "p": { "arbitrum-one": "0x214151022c2a5e380ab80cdac31f23ae554a7345" } },
   { "name": "AstraZeneca xStock", "p": { "arbitrum-one": "0x5d642505fe1a28897eb3baba665f454755d8daa2" } },
-  { "name": "AppLovin xStock", "p": { "arbitrum-one": "0x50a1291f69d9d3853def8209cfb1af0b46927be1" } },
+  { "name": "AppLovin xStock", "p": { "arbitrum-one": "0x50a1291f69d9d3853def8209cfb1af0b46927be1", "hyperliquid": "0x50a1291f69d9d3853def8209cfb1af0b46927be1", "ink": "0x50a1291f69d9d3853def8209cfb1af0b46927be1", "bsc": "0x50a1291f69d9d3853def8209cfb1af0b46927be1", "tron": "TTCNHD9tFLDSB3Ryn9MjtEv5bkwT6zya42", "ton": "EQCGJ7KuKsFu3w-VmgGVUu5qHgxH0kQee3b9j5HTWi7QEko4", "ethereum": "0x50a1291f69d9d3853def8209cfb1af0b46927be1", "mantle": "0x50a1291f69d9d3853def8209cfb1af0b46927be1", "solana": "XsPdAVBi8Zc1xvv53k4JcMrQaEDTgkGqKYeh7AYgPHV" } },
   { "name": "Netflix xStock", "p": { "arbitrum-one": "0xa6a65ac27e76cd53cb790473e4345c46e5ebf961" } },
   { "name": "Palantir xStock", "p": { "arbitrum-one": "0x6d482cec5f9dd1f05ccee9fd3ff79b246170f8e2" } },
   { "name": "Salesforce xStock", "p": { "arbitrum-one": "0x4a4073f2eaf299a1be22254dcd2c41727f6f54a2" } },
@@ -66,6 +66,11 @@ const data = [
 
 const chainMapping = {
   arbitrum: 'arbitrum-one',
+  hyperliquid: 'hyperliquid',
+  ink: 'ink',
+  bsc: 'bsc',
+  ethereum: 'ethereum',
+  mantle: 'mantle',
 }
 
 async function tvl(api) {


### PR DESCRIPTION
Adding APPx (AppLovin xStock) — issued by Backed Finance.

Deployments:
- arbitrum/token: 0x50a1291f69d9d3853def8209cfb1af0b46927be1
- hyperevm/token: 0x50a1291f69d9d3853def8209cfb1af0b46927be1
- ink/token: 0x50a1291f69d9d3853def8209cfb1af0b46927be1
- bsc/token: 0x50a1291f69d9d3853def8209cfb1af0b46927be1
- tron/token: TTCNHD9tFLDSB3Ryn9MjtEv5bkwT6zya42
- ton/token: EQCGJ7KuKsFu3w-VmgGVUu5qHgxH0kQee3b9j5HTWi7QEko4
- ethereum/token: 0x50a1291f69d9d3853def8209cfb1af0b46927be1
- mantle/token: 0x50a1291f69d9d3853def8209cfb1af0b46927be1
- solana/token: XsPdAVBi8Zc1xvv53k4JcMrQaEDTgkGqKYeh7AYgPHV

**This PR updates an existing adapter entry.** `AppLovin xStock` is already listed in `projects/xstocks/index.js`; this change only extends its multi-chain coverage. The new-listing template fields (Name / Website / Short Description / Category) do not apply — those were set when xstocks was first listed.

Added 8 chain keys to the token's `data` entry: hyperliquid, ink, bsc, tron, ton, ethereum, mantle, solana.
New `chainMapping` entries (so the existing EVM `tvl` function picks them up): hyperliquid, ink, bsc, ethereum, mantle.
Note: tron, ton addresses are recorded in `data.p` but need a custom TVL handler (analogous to `solTvl`). Out of scope for this PR — flagged for follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for tracking AppLovin xStock assets across multiple new blockchain networks including Hyperliquid, Ink, Binance Smart Chain, Ethereum, Mantle, Tron, Ton, and Solana. This expansion significantly enhances the user experience by enabling comprehensive cross-chain portfolio monitoring and total asset tracking across diverse blockchain ecosystems and decentralized platforms.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19241)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->