### PR TITLE
Add aPriori liquid staking adapter for Monad

### DIFF
--- a/projects/apriori/index.js
+++ b/projects/apriori/index.js
@@ -1,0 +1,11 @@
+const VAULT = '0x0c65A0BC65a5D819235B71F554D210D3F80E0852'; // aprMON ERC-4626 vault
+
+async function tvl(api) {
+  const total = await api.call({ abi: 'uint256:totalAssets', target: VAULT });
+  api.addGasToken(total);
+}
+
+module.exports = {
+  methodology: 'Total MON staked in the aPriori liquid staking vault, represented as aprMON (ERC-4626).',
+  monad: { tvl },
+};


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).
2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** It is a different repo, you can find your listing in [this file](https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts), you can edit it there and put up a PR
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes

---

## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
aPriori

##### Twitter Link:
https://x.com/aPriori

##### List of audit links if any:
N/A (not published publicly)

##### Website Link:
https://www.apr.io

##### Logo (High resolution, will be shown with rounded borders):
https://www.apr.io/logo-with-name.svg

##### Current TVL:
28,199,161 MON (~$871k USD)

##### Treasury Addresses (if the protocol has treasury)
N/A

##### Chain:
Monad

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):
apriori

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):
38569

##### Short Description (to be shown on DefiLlama):
MEV-powered liquid staking on Monad. Stake MON, receive aprMON — a reward-bearing ERC-4626 token earning both PoS and MEV-boosted yields.

##### Token address and ticker if any:
APR — `0x0a332311633c0625f63cfc51ee33fc49826e0a3c` (Monad)

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Liquid Staking

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
N/A — TVL is derived directly from the ERC-4626 vault's `totalAssets()`, no external oracle used.

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
N/A

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
N/A

##### forkedFrom (Does your project originate from another project):
No

##### methodology (what is being counted as tvl, how is tvl being calculated):
Total MON staked in the aPriori aprMON vault (`0x0c65A0BC65a5D819235B71F554D210D3F80E0852`) via the standard ERC-4626 `totalAssets()` call.

##### Github org/user (Optional, if your code is open source, we can track activity):

##### Does this project have a referral program?
Unknown


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Total Value Locked (TVL) tracking for the aPriori vault, displaying the total amount of MON tokens staked within the protocol, represented as aprMON.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19243)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->