### PR TITLE
Fix(Beefy): switch to /vaults/all endpoint and dedup CLM exposures

### DIFF
--- a/projects/beefy/index.js
+++ b/projects/beefy/index.js
@@ -127,7 +127,7 @@ const beefyChainNameMapping = {
 };
 
 async function fetchVaultData() {
-  const vaultsResponse = await utils.fetchURL('https://api.beefy.finance/vaults');
+  const vaultsResponse = await utils.fetchURL('https://api.beefy.finance/vaults/all');
   const vaults = vaultsResponse.data;
 
   // sdk.log('Raw API response sample:', JSON.stringify(vaults[0], null, 2));
@@ -173,9 +173,10 @@ async function fetchVaultData() {
         id: vault.id,
         address: vault.earnContractAddress,
         token: vault.tokenAddress,
+        type: vault.type,
         isBIFI: vault.id.toLowerCase().includes('bifi'),
         status: vault.status,
-        chain: ourChainName
+        chain: ourChainName,
       });
       mappedVaults++;
     }
@@ -213,6 +214,18 @@ async function tvl(api, isStaking = false) {
 
   if (!isStaking)
     activeVaults = vaults.filter(v => !v.isBIFI && !blaclistedVaultSet.has(v.address.toLowerCase()));
+
+  // Dedup CLM exposures: standard "-vault" wrappers and gov "-rp" reward pools can both reference
+  // the same CLM cow* share. The downstream isConcLP branch reads the CLM's full underlying balances()
+  // off the cow* token, so any vault that resolves to that cow* token contributes the FULL CLM TVL.
+  // When a CLM has both a wrapper and an RP, we'd add the same CLM balances twice. Skip the RP in
+  // that case — the wrapper already covers it.
+  const wrapperTokens = new Set(
+    activeVaults
+      .filter(v => v.type === 'standard' && v.token)
+      .map(v => v.token.toLowerCase())
+  );
+  activeVaults = activeVaults.filter(v => !(v.type === 'gov' && v.token && wrapperTokens.has(v.token.toLowerCase())));
 
   // sdk.log(`Active non-BIFI vaults: ${activeVaults.length}`);
   const vaultAddresses = activeVaults.map(v => v.address);

--- a/projects/beefy/index.js
+++ b/projects/beefy/index.js
@@ -215,17 +215,24 @@ async function tvl(api, isStaking = false) {
   if (!isStaking)
     activeVaults = vaults.filter(v => !v.isBIFI && !blaclistedVaultSet.has(v.address.toLowerCase()));
 
-  // Dedup CLM exposures: standard "-vault" wrappers and gov "-rp" reward pools can both reference
-  // the same CLM cow* share. The downstream isConcLP branch reads the CLM's full underlying balances()
-  // off the cow* token, so any vault that resolves to that cow* token contributes the FULL CLM TVL.
-  // When a CLM has both a wrapper and an RP, we'd add the same CLM balances twice. Skip the RP in
-  // that case — the wrapper already covers it.
-  const wrapperTokens = new Set(
-    activeVaults
-      .filter(v => v.type === 'standard' && v.token)
-      .map(v => v.token.toLowerCase())
-  );
-  activeVaults = activeVaults.filter(v => !(v.type === 'gov' && v.token && wrapperTokens.has(v.token.toLowerCase())));
+  // CLM exposures are surfaced by multiple entries in /vaults/all: the cowcentrated CLM itself,
+  // its standard "-vault" wrapper, and its gov "-rp" reward pool. They all map back to the same
+  // underlying tokens, so to avoid double counting we ignore wrappers/RPs and query the CLM directly.
+  const clmVaults = activeVaults.filter(v => v.type === 'cowcentrated');
+  activeVaults = activeVaults.filter(v => v.type !== 'cowcentrated' && v.type !== 'gov');
+
+  if (clmVaults.length) {
+    const clmAddresses = clmVaults.map(v => v.address);
+    const clmWants = await api.multiCall({ abi: 'function wants() view returns (address token0, address token1)', calls: clmAddresses, permitFailure: true, });
+    const clmBalances = await api.multiCall({ abi: 'function balances() view returns (uint256 balance0, uint256 balance1)', calls: clmAddresses, permitFailure: true, });
+    clmWants.forEach((w, i) => {
+      const b = clmBalances[i];
+      if (w && b) {
+        api.add(w.token0, b.balance0);
+        api.add(w.token1, b.balance1);
+      }
+    });
+  }
 
   // sdk.log(`Active non-BIFI vaults: ${activeVaults.length}`);
   const vaultAddresses = activeVaults.map(v => v.address);
@@ -244,26 +251,11 @@ async function tvl(api, isStaking = false) {
     }
   })
 
-  const tokenSymbols = await api.multiCall({ abi: 'string:symbol', calls: wants, permitFailure: true, });
-  const wantTokens = await api.multiCall({ abi: 'function wants() view returns (address token0, address token1)', calls: wants, permitFailure: true, });
-  const wantBalances = await api.multiCall({ abi: 'function balances() view returns  (uint256 balance0, uint256 balance1)', calls: wants, permitFailure: true, });
-
   const balances = await api.multiCall({ abi: vaultABI.balance, calls: filteredVaults, permitFailure: true, });
 
   wants.forEach((token, i) => {
     const balance = balances[i]
-    const tokenSymbol = tokenSymbols[i] ?? ''
-    const multiTokens = wantTokens[i]
-    const multiBalances = wantBalances[i]
-
-    // check if this is a token for a concentrated LP (uni v3 style)
-    const isConcLP = tokenSymbol.startsWith('cow') && tokenSymbol.includes('-') && multiTokens && multiBalances
-
-    if (isConcLP) {
-      api.add(multiTokens.token0, multiBalances.balance0);
-      api.add(multiTokens.token1, multiBalances.balance1);
-    }
-    else if (token && balance) api.add(token, balance);
+    if (token && balance) api.add(token, balance);
   });
 
   await sumTokens2({ api, resolveLP: true, resolveIchiVault: true, });

--- a/projects/beefy/index.js
+++ b/projects/beefy/index.js
@@ -219,7 +219,12 @@ async function tvl(api, isStaking = false) {
   // its standard "-vault" wrapper, and its gov "-rp" reward pool. They all map back to the same
   // underlying tokens, so to avoid double counting we ignore wrappers/RPs and query the CLM directly.
   const clmVaults = activeVaults.filter(v => v.type === 'cowcentrated');
-  activeVaults = activeVaults.filter(v => v.type !== 'cowcentrated' && v.type !== 'gov');
+  const clmAddressSet = new Set(clmVaults.map(v => v.address.toLowerCase()));
+  activeVaults = activeVaults.filter(v =>
+    v.type !== 'cowcentrated' &&
+    v.type !== 'gov' &&
+    !clmAddressSet.has((v.token || '').toLowerCase())
+  );
 
   if (clmVaults.length) {
     const clmAddresses = clmVaults.map(v => v.address);


### PR DESCRIPTION
**Summary**

- Switch the Beefy vault list source from `https://api.beefy.finance/vaults` to `https://api.beefy.finance/vaults/all`. The previous endpoint returns only `type: standard` vaults (~3,976), excluding `cowcentrated` (CLM) and `gov` (reward pool) entries entirely. `/vaults/all` exposes the full set (~5,482), letting the adapter see CLMs and their reward pools.

- Skip gov reward pools (`-rp`) whose `tokenAddress` is already referenced by a standard wrapper vault (`-vault`). Both reference the same CLM cow* share, and the existing `isConcLP` symbol-based branch resolves either reference to the CLM's full `balances()` — so when both exist they double-count the same underlying. The wrapper already covers the CLM TVL; dropping the duplicate RP entries removes ~$8M of double-counted TVL across 241 CLMs.

**Test plan**

- [ ] `node test.js projects/beefy/index.js` runs cleanly
- [ ] Total TVL: $134.92M (down from $143.15M pre-dedup; gap vs Beefy app driven by ~$9M of standard-vault underlying tokens DefiLlama can't price)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Vault data retrieval now includes vault type to enable more accurate filtering.
  * TVL calculations updated to correctly account for concentrated-style vault exposures by adding their underlying token amounts and excluding specific vault types from standard aggregation.
  * Non-staking token balance aggregation simplified to pair each vault’s primary token with its reported balance, reducing double-counting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19249?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->