### PR TITLE
Add Ethereum support to flying-tulip-lend

### DIFF
--- a/projects/flying-tulip-lend/index.js
+++ b/projects/flying-tulip-lend/index.js
@@ -1,23 +1,24 @@
 const { sumTokens2 } = require('../helper/unwrapLPs')
+const ADDRESSES = require('../helper/coreAssets.json')
 
 const RESERVES = {
   sonic: [
-    { token: '0x29219dd400f2Bf60E5a23d13Be72B486D4038894', wrapper: '0x7a2fd34e4cc4c8b1023576a3f3d1f7aa36cf8b47' }, // USDC -> ftUSDC
-    { token: '0x039e2fB66102314Ce7b64Ce5Ce3E5183bc94aD38', wrapper: '0xbb155f15d8452139d1a9c3a664847d2f8314c18e' }, // wS   -> ftwS
+    { token: ADDRESSES.sonic.USDC_e, wrapper: '0x7a2fd34e4cc4c8b1023576a3f3d1f7aa36cf8b47' }, // USDC -> ftUSDC
+    { token: ADDRESSES.sonic.wS, wrapper: '0xbb155f15d8452139d1a9c3a664847d2f8314c18e' }, // wS   -> ftwS
     { token: '0x5DD1A7A369e8273371d2DBf9d83356057088082c', wrapper: '0x7127bb9d9ad0f47b8da9087e634d67f3946f840e' }, // FT   -> ftFT
-    { token: '0xE5DA20F15420aD15DE0fa650600aFc998bbE3955', wrapper: '0x8b98e46421898437862de44aa63b73b2da69147b' }, // stS  -> ftstS
-    { token: '0x0555E30da8f98308EdB960aa94C0Db47230d2B9c', wrapper: '0xd6587e78d252e630d425ecd827017bf81b0ac553' }, // WBTC  -> ftWBTC
+    { token: ADDRESSES.sonic.STS, wrapper: '0x8b98e46421898437862de44aa63b73b2da69147b' }, // stS  -> ftstS
+    { token: ADDRESSES.sonic.WBTC, wrapper: '0xd6587e78d252e630d425ecd827017bf81b0ac553' }, // WBTC  -> ftWBTC
     { token: '0x50c42dEAcD8Fc9773493ED674b675bE577f2634b', wrapper: '0x727bc187150d5599e7fba32732c21c6d9f5b1837' }, // WETH  -> ftWETH
     { token: '0x000000000eccff26b795f73fb0a70d48da657fef', wrapper: '0x0e794B1FD35A7a5550CD3E305882369FFB2DF7f7' }, // USSD -> ftUSSD
     // { token: '0xF7D85EC4E7710f71992752eac2111312e73E9C9C', wrapper: '0xc67D966f761e8cf13Faa0a1E774425290c8453d9' }, // ftUSD -> ftFtUSD - excluded to prevent flying-tulip-ftusd double count
   ],
   ethereum: [
-    { token: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', wrapper: '0xD2e4A5ac4B4Da102317cF7C9A1289aDF082639E2' }, // USDC -> ftUSDC
-    { token: '0xdAC17F958D2ee523a2206206994597C13D831ec7', wrapper: '0x28b0905d83BCe5FFA6c54651F25858828A38123B' }, // USDT -> ftUSDT
-    { token: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', wrapper: '0x460494aF61BcB92B59797B4e09C26A5ADecb2da2' }, // WETH -> ftWETH (wNative)
-    { token: '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599', wrapper: '0x1A5730c71576D77048E9FdC79DD40e4B1E8Fe042' }, // WBTC -> ftWBTC
+    { token: ADDRESSES.ethereum.USDC, wrapper: '0xD2e4A5ac4B4Da102317cF7C9A1289aDF082639E2' }, // USDC -> ftUSDC
+    { token: ADDRESSES.ethereum.USDT, wrapper: '0x28b0905d83BCe5FFA6c54651F25858828A38123B' }, // USDT -> ftUSDT
+    { token: ADDRESSES.ethereum.WETH, wrapper: '0x460494aF61BcB92B59797B4e09C26A5ADecb2da2' }, // WETH -> ftWETH (wNative)
+    { token: ADDRESSES.ethereum.WBTC, wrapper: '0x1A5730c71576D77048E9FdC79DD40e4B1E8Fe042' }, // WBTC -> ftWBTC
     { token: '0x5DD1A7A369e8273371d2DBf9d83356057088082c', wrapper: '0x7127BB9d9ad0f47B8dA9087e634D67F3946F840E' }, // FT   -> ftFT
-    { token: '0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0', wrapper: '0x01980BD1B58313bD3767f6adc75Af8b6464f3db7' }, // wstETH -> ftWstETH (stakedNative)
+    { token: ADDRESSES.ethereum.WSTETH, wrapper: '0x01980BD1B58313bD3767f6adc75Af8b6464f3db7' }, // wstETH -> ftWstETH (stakedNative)
     // { token: '0xF7D85EC4E7710f71992752eac2111312e73E9C9C', wrapper: '0xc67D966f761e8cf13Faa0a1E774425290c8453d9' }, // ftUSD -> ftFtUSD - excluded to prevent flying-tulip-ftusd double count
   ],
 }
@@ -29,6 +30,12 @@ const LENDING_LENS = {
 
 const ASSET_STATE_ABI =
   'function assetState(address) view returns (uint256 cash, uint256 borrows, uint256 reserves, uint256 utilWad)'
+
+const FTUSD_DEDUP_SONIC = {
+  positionManager: '0xbe4050a73a7Fb384c65E885a15C33461A4B20055',
+  user: '0x6EC218FC45aC0C7B83D16557befABB62ed7455Ae', // ftDNS-USDC strategy
+}
+const GET_BALANCE_ABI = 'function getBalance(address,address) view returns (uint256)'
 
 async function tvl(api) {
   const reserves = RESERVES[api.chain] || []
@@ -60,6 +67,13 @@ async function tvl(api) {
     ...strategies.map((s, i) => [positions[i], s]),
   ]
   await sumTokens2({ api, tokensAndOwners })
+
+  // Sonic only: subtract ftDNS-USDC's lend exposure (already tracked by flying-tulip-ftusd)
+  if (api.chain === 'sonic') {
+    const { positionManager, user } = FTUSD_DEDUP_SONIC
+    const bal = await api.call({ target: positionManager, abi: GET_BALANCE_ABI, params: [user, ADDRESSES.sonic.USDC_e] })
+    api.add(ADDRESSES.sonic.USDC_e, -BigInt(bal))
+  }
 }
 
 async function borrowed(api) {
@@ -74,7 +88,7 @@ async function borrowed(api) {
 
 module.exports = {
   methodology:
-    'TVL: for each Lend reserve, sums the underlying balance held at its ftYieldWrapperV2 plus the yield receipt (aToken, spToken, etc.) held by each of the wrapper\'s strategies. Borrowed: sums outstanding debt per reserve via LendingLens.assetState.borrows.',
+    'TVL: for each Lend reserve, sums the underlying balance held at its ftYieldWrapperV2 plus the yield receipt (aToken, spToken, etc.) held by each of the wrapper\'s strategies. ftDNS-USDC\'s USDC balance is subtracted to prevent doublecounting with flying-tulip-ftusd. Borrowed: sums outstanding debt per reserve via LendingLens.assetState.borrows.',
   sonic: { tvl, borrowed },
   ethereum: { tvl, borrowed },
 }

--- a/projects/flying-tulip-lend/index.js
+++ b/projects/flying-tulip-lend/index.js
@@ -3,17 +3,26 @@ const { sumTokens2 } = require('../helper/unwrapLPs')
 const RESERVES = {
   sonic: [
     { token: '0x29219dd400f2Bf60E5a23d13Be72B486D4038894', wrapper: '0x7a2fd34e4cc4c8b1023576a3f3d1f7aa36cf8b47' }, // USDC -> ftUSDC
-    { token: '0x039e2fB66102314Ce7b64Ce5Ce3E5183bc94aD38', wrapper: '0xbb155f15d8452139d1a9c3a664847d2f8314c18e' }, // wS   -> ftwS  
+    { token: '0x039e2fB66102314Ce7b64Ce5Ce3E5183bc94aD38', wrapper: '0xbb155f15d8452139d1a9c3a664847d2f8314c18e' }, // wS   -> ftwS
     { token: '0x5DD1A7A369e8273371d2DBf9d83356057088082c', wrapper: '0x7127bb9d9ad0f47b8da9087e634d67f3946f840e' }, // FT   -> ftFT
     { token: '0xE5DA20F15420aD15DE0fa650600aFc998bbE3955', wrapper: '0x8b98e46421898437862de44aa63b73b2da69147b' }, // stS  -> ftstS
     { token: '0x0555E30da8f98308EdB960aa94C0Db47230d2B9c', wrapper: '0xd6587e78d252e630d425ecd827017bf81b0ac553' }, // WBTC  -> ftWBTC
     { token: '0x50c42dEAcD8Fc9773493ED674b675bE577f2634b', wrapper: '0x727bc187150d5599e7fba32732c21c6d9f5b1837' }, // WETH  -> ftWETH
     // ftUSD is intentionally excluded
   ],
+  ethereum: [
+    { token: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', wrapper: '0xD2e4A5ac4B4Da102317cF7C9A1289aDF082639E2' }, // USDC -> ftUSDC
+    { token: '0xdAC17F958D2ee523a2206206994597C13D831ec7', wrapper: '0x28b0905d83BCe5FFA6c54651F25858828A38123B' }, // USDT -> ftUSDT
+    { token: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', wrapper: '0x460494aF61BcB92B59797B4e09C26A5ADecb2da2' }, // WETH -> ftWETH (wNative)
+    { token: '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599', wrapper: '0x1A5730c71576D77048E9FdC79DD40e4B1E8Fe042' }, // WBTC -> ftWBTC
+    { token: '0x5DD1A7A369e8273371d2DBf9d83356057088082c', wrapper: '0x7127BB9d9ad0f47B8dA9087e634D67F3946F840E' }, // FT   -> ftFT
+    // ftUSD is intentionally excluded (avoids double-count with the ftUSD adapter)
+  ],
 }
 
 const LENDING_LENS = {
   sonic: '0x3682168023e6ba8d1f995fda1d920827c5a8a43e',
+  ethereum: '0x3682168023e6ba8d1f995fda1d920827c5a8a43e', // CREATE2 deterministic, same as Sonic
 }
 
 const ASSET_STATE_ABI =
@@ -59,4 +68,5 @@ module.exports = {
   methodology:
     'TVL: for each Lend reserve, sums the underlying balance held at its ftYieldWrapperV2 plus the yield receipt (aToken, spToken, etc.) held by each of the wrapper\'s strategies. Borrowed: sums outstanding debt per reserve via LendingLens.assetState.borrows since per-borrower balances are not enumerable on-chain. ftUSD reserve is intentionally excluded to avoid double-counting with the ftUSD adapter.',
   sonic: { tvl, borrowed },
+  ethereum: { tvl, borrowed },
 }

--- a/projects/flying-tulip-lend/index.js
+++ b/projects/flying-tulip-lend/index.js
@@ -60,14 +60,6 @@ async function tvl(api) {
     ...strategies.map((s, i) => [positions[i], s]),
   ]
   await sumTokens2({ api, tokensAndOwners })
-
-  // 2) borrows side
-  const states = await api.multiCall({
-    target: LENDING_LENS[api.chain],
-    abi: ASSET_STATE_ABI,
-    calls: reserves.map(r => r.token),
-  })
-  reserves.forEach((r, i) => api.add(r.token, states[i].borrows.toString()))
 }
 
 async function borrowed(api) {
@@ -82,7 +74,7 @@ async function borrowed(api) {
 
 module.exports = {
   methodology:
-    'TVL: for each Lend reserve, sums the underlying balance held at its ftYieldWrapperV2 plus the yield receipt (aToken, spToken, etc.) held by each of the wrapper\'s strategies, then adds the outstanding borrows per reserve via LendingLens.assetState.borrows (since lent-out tokens have left the wrapper). Borrowed: sums outstanding debt per reserve via LendingLens.assetState.borrows.',
+    'TVL: for each Lend reserve, sums the underlying balance held at its ftYieldWrapperV2 plus the yield receipt (aToken, spToken, etc.) held by each of the wrapper\'s strategies. Borrowed: sums outstanding debt per reserve via LendingLens.assetState.borrows.',
   sonic: { tvl, borrowed },
   ethereum: { tvl, borrowed },
 }

--- a/projects/flying-tulip-lend/index.js
+++ b/projects/flying-tulip-lend/index.js
@@ -9,7 +9,7 @@ const RESERVES = {
     { token: '0x0555E30da8f98308EdB960aa94C0Db47230d2B9c', wrapper: '0xd6587e78d252e630d425ecd827017bf81b0ac553' }, // WBTC  -> ftWBTC
     { token: '0x50c42dEAcD8Fc9773493ED674b675bE577f2634b', wrapper: '0x727bc187150d5599e7fba32732c21c6d9f5b1837' }, // WETH  -> ftWETH
     { token: '0x000000000eccff26b795f73fb0a70d48da657fef', wrapper: '0x0e794B1FD35A7a5550CD3E305882369FFB2DF7f7' }, // USSD -> ftUSSD
-    // ftUSD is intentionally excluded
+    { token: '0xF7D85EC4E7710f71992752eac2111312e73E9C9C', wrapper: '0xc67D966f761e8cf13Faa0a1E774425290c8453d9' }, // ftUSD -> ftFtUSD
   ],
   ethereum: [
     { token: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', wrapper: '0xD2e4A5ac4B4Da102317cF7C9A1289aDF082639E2' }, // USDC -> ftUSDC
@@ -18,7 +18,7 @@ const RESERVES = {
     { token: '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599', wrapper: '0x1A5730c71576D77048E9FdC79DD40e4B1E8Fe042' }, // WBTC -> ftWBTC
     { token: '0x5DD1A7A369e8273371d2DBf9d83356057088082c', wrapper: '0x7127BB9d9ad0f47B8dA9087e634D67F3946F840E' }, // FT   -> ftFT
     { token: '0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0', wrapper: '0x01980BD1B58313bD3767f6adc75Af8b6464f3db7' }, // wstETH -> ftWstETH (stakedNative)
-    // ftUSD is intentionally excluded (avoids double-count with the ftUSD adapter)
+    { token: '0xF7D85EC4E7710f71992752eac2111312e73E9C9C', wrapper: '0xc67D966f761e8cf13Faa0a1E774425290c8453d9' }, // ftUSD -> ftFtUSD
   ],
 }
 
@@ -82,7 +82,7 @@ async function borrowed(api) {
 
 module.exports = {
   methodology:
-    'TVL: for each Lend reserve, sums the underlying balance held at its ftYieldWrapperV2 plus the yield receipt (aToken, spToken, etc.) held by each of the wrapper\'s strategies. Borrowed: sums outstanding debt per reserve via LendingLens.assetState.borrows since per-borrower balances are not enumerable on-chain. ftUSD reserve is intentionally excluded to avoid double-counting with the ftUSD adapter.',
+    'TVL: for each Lend reserve, sums the underlying balance held at its ftYieldWrapperV2 plus the yield receipt (aToken, spToken, etc.) held by each of the wrapper\'s strategies, then adds the outstanding borrows per reserve via LendingLens.assetState.borrows (since lent-out tokens have left the wrapper). Borrowed: sums outstanding debt per reserve via LendingLens.assetState.borrows.',
   sonic: { tvl, borrowed },
   ethereum: { tvl, borrowed },
 }

--- a/projects/flying-tulip-lend/index.js
+++ b/projects/flying-tulip-lend/index.js
@@ -33,7 +33,17 @@ const ASSET_STATE_ABI =
 async function tvl(api) {
   const reserves = RESERVES[api.chain] || []
 
-  // Get list of strategies for each wrapper
+  // Total supplied per reserve = cash + borrows.
+  //
+  // `cash` is the idle liquidity that still sits in the system, split between:
+  //   - underlying held at the ftYieldWrapperV2 (not deployed yet)
+  //   - yield receipt (aToken, spToken, ...) held at each of the wrapper's strategies
+  //
+  // `borrows` is the outstanding debt: tokens lent out to borrowers that have
+  // left the wrapper. We have to add this back via LendingLens.assetState
+  // otherwise the adapter under-reports TVL by the entire borrow book.
+
+  // 1) cash side
   const strategyLists = await Promise.all(reserves.map(({ wrapper: target }) => api.fetchList({
     target,
     lengthAbi: 'uint256:numberOfStrategies',
@@ -41,19 +51,23 @@ async function tvl(api) {
   })))
   const strategies = strategyLists.flat()
 
-  // Each strategy exposes positionToken() (aToken, spToken, etc.)
   const positions = strategies.length
     ? await api.multiCall({ abi: 'address:positionToken', calls: strategies.map(target => ({ target })) })
     : []
 
   const tokensAndOwners = [
-    // Idle underlying held by the wrapper
     ...reserves.map(r => [r.token, r.wrapper]),
-    // Yield receipt held by each strategy
     ...strategies.map((s, i) => [positions[i], s]),
   ]
+  await sumTokens2({ api, tokensAndOwners })
 
-  return sumTokens2({ api, tokensAndOwners })
+  // 2) borrows side
+  const states = await api.multiCall({
+    target: LENDING_LENS[api.chain],
+    abi: ASSET_STATE_ABI,
+    calls: reserves.map(r => r.token),
+  })
+  reserves.forEach((r, i) => api.add(r.token, states[i].borrows.toString()))
 }
 
 async function borrowed(api) {

--- a/projects/flying-tulip-lend/index.js
+++ b/projects/flying-tulip-lend/index.js
@@ -9,7 +9,7 @@ const RESERVES = {
     { token: '0x0555E30da8f98308EdB960aa94C0Db47230d2B9c', wrapper: '0xd6587e78d252e630d425ecd827017bf81b0ac553' }, // WBTC  -> ftWBTC
     { token: '0x50c42dEAcD8Fc9773493ED674b675bE577f2634b', wrapper: '0x727bc187150d5599e7fba32732c21c6d9f5b1837' }, // WETH  -> ftWETH
     { token: '0x000000000eccff26b795f73fb0a70d48da657fef', wrapper: '0x0e794B1FD35A7a5550CD3E305882369FFB2DF7f7' }, // USSD -> ftUSSD
-    { token: '0xF7D85EC4E7710f71992752eac2111312e73E9C9C', wrapper: '0xc67D966f761e8cf13Faa0a1E774425290c8453d9' }, // ftUSD -> ftFtUSD
+    // { token: '0xF7D85EC4E7710f71992752eac2111312e73E9C9C', wrapper: '0xc67D966f761e8cf13Faa0a1E774425290c8453d9' }, // ftUSD -> ftFtUSD - excluded to prevent flying-tulip-ftusd double count
   ],
   ethereum: [
     { token: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', wrapper: '0xD2e4A5ac4B4Da102317cF7C9A1289aDF082639E2' }, // USDC -> ftUSDC
@@ -18,7 +18,7 @@ const RESERVES = {
     { token: '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599', wrapper: '0x1A5730c71576D77048E9FdC79DD40e4B1E8Fe042' }, // WBTC -> ftWBTC
     { token: '0x5DD1A7A369e8273371d2DBf9d83356057088082c', wrapper: '0x7127BB9d9ad0f47B8dA9087e634D67F3946F840E' }, // FT   -> ftFT
     { token: '0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0', wrapper: '0x01980BD1B58313bD3767f6adc75Af8b6464f3db7' }, // wstETH -> ftWstETH (stakedNative)
-    { token: '0xF7D85EC4E7710f71992752eac2111312e73E9C9C', wrapper: '0xc67D966f761e8cf13Faa0a1E774425290c8453d9' }, // ftUSD -> ftFtUSD
+    // { token: '0xF7D85EC4E7710f71992752eac2111312e73E9C9C', wrapper: '0xc67D966f761e8cf13Faa0a1E774425290c8453d9' }, // ftUSD -> ftFtUSD - excluded to prevent flying-tulip-ftusd double count
   ],
 }
 

--- a/projects/flying-tulip-lend/index.js
+++ b/projects/flying-tulip-lend/index.js
@@ -8,6 +8,7 @@ const RESERVES = {
     { token: '0xE5DA20F15420aD15DE0fa650600aFc998bbE3955', wrapper: '0x8b98e46421898437862de44aa63b73b2da69147b' }, // stS  -> ftstS
     { token: '0x0555E30da8f98308EdB960aa94C0Db47230d2B9c', wrapper: '0xd6587e78d252e630d425ecd827017bf81b0ac553' }, // WBTC  -> ftWBTC
     { token: '0x50c42dEAcD8Fc9773493ED674b675bE577f2634b', wrapper: '0x727bc187150d5599e7fba32732c21c6d9f5b1837' }, // WETH  -> ftWETH
+    { token: '0x000000000eccff26b795f73fb0a70d48da657fef', wrapper: '0x0e794B1FD35A7a5550CD3E305882369FFB2DF7f7' }, // USSD -> ftUSSD
     // ftUSD is intentionally excluded
   ],
   ethereum: [
@@ -16,6 +17,7 @@ const RESERVES = {
     { token: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', wrapper: '0x460494aF61BcB92B59797B4e09C26A5ADecb2da2' }, // WETH -> ftWETH (wNative)
     { token: '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599', wrapper: '0x1A5730c71576D77048E9FdC79DD40e4B1E8Fe042' }, // WBTC -> ftWBTC
     { token: '0x5DD1A7A369e8273371d2DBf9d83356057088082c', wrapper: '0x7127BB9d9ad0f47B8dA9087e634D67F3946F840E' }, // FT   -> ftFT
+    { token: '0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0', wrapper: '0x01980BD1B58313bD3767f6adc75Af8b6464f3db7' }, // wstETH -> ftWstETH (stakedNative)
     // ftUSD is intentionally excluded (avoids double-count with the ftUSD adapter)
   ],
 }


### PR DESCRIPTION
## Summary

Flying Tulip Lend (ftDNMM) is now live on Ethereum mainnet at the same CREATE2-deterministic core addresses as Sonic, with its own per-chain yield wrappers. This PR extends the existing \`flying-tulip-lend\` adapter to enumerate the Ethereum reserves so TVL and borrowed land on the Ethereum tab of the protocol page.

Same approach as the existing Sonic path: for each reserve we sum the underlying held at its \`ftYieldWrapperV2\` plus the yield receipt (\`positionToken\`) held by each strategy, and borrowed comes from \`LendingLens.assetState.borrows\`.

## What changed

\`projects/flying-tulip-lend/index.js\`:

- New \`ethereum\` entry in \`RESERVES\` with (token, wrapper) pairs for USDC, USDT, WETH, WBTC, FT.
- New \`ethereum\` entry in \`LENDING_LENS\` (same address as Sonic — CREATE2).
- New \`ethereum: { tvl, borrowed }\` export.
- ftUSD reserve is intentionally excluded on both chains to avoid double-counting with the ftUSD adapter.

## Verified live

\`\`\`
node test.js projects/flying-tulip-lend/index.js
sonic                     2.20 M
ethereum                  1.37 M
total                     3.56 M

borrowed
sonic                     332.39 k
ethereum                  12

total                    332.39 k
\`\`\`

Cross-check on chain: USDT \$818k, WBTC \$403k (5 WBTC), USDC \$133k, plus smaller WETH / FT positions on Ethereum.

## Companion PRs

- \`DefiLlama/dimension-adapters\` — add Ethereum to \`fees/flying-tulip-lend.ts\` so borrower interest is tracked on both chains
- \`DefiLlama/defillama-server\` — add Ethereum to the \`chains\` field on the Flying Tulip Lend protocol entry (id 7750)

## Source

Deployment manifest: https://flyingtulipdotcom.github.io/deployments/prod-eth-ftdnmm-lend.toon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Ethereum chain support — view TVL and borrowed metrics for Ethereum alongside Sonic.
  * Expanded reserve coverage on Ethereum to include additional wrapped assets and mappings (ftUSD and related pairs).

* **Improvements**
  * TVL calculation refined to account for idle assets plus strategy-held positions so totals better reflect wrapper-held and strategy-held balances.
  * Methodology text updated to reflect the expanded reserve coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19253?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->