### PR TITLE
fix jpegd treasury 

### DIFF
--- a/projects/treasury/jpegd.js
+++ b/projects/treasury/jpegd.js
@@ -3,6 +3,7 @@ const ADDRESSES = require('../helper/coreAssets.json')
 const { treasuryExports, nullAddress } = require("../helper/treasury");
 
 const jpegd = "0xE80C0cd204D654CEbe8dd64A4857cAb6Be8345a3";
+const jpgd = "0xce722f60f35c37ab295adc4e6ba45bcc7ca89dd6";
 
 // Owners
 const multisig = "0x51C2cEF9efa48e08557A361B52DB34061c025a1B";
@@ -37,7 +38,7 @@ const treasuryTvl = treasuryExports({
       "0xdB06a76733528761Eda47d356647297bC35a98BD", // JPEGWETH SLP
     ],
     owners: [multisig, donationEvent, usdcVault, usdtVault, pethVault],
-    ownTokens: [jpegd],
+    ownTokens: [jpegd, jpgd],
     resolveUniV3: true,
   },
 });


### PR DESCRIPTION
Their new governance token wasn't listed inside `ownTokens` so it was being included in normal tvl export
- token: 0xce722f60f35c37ab295adc4e6ba45bcc7ca89dd6
- announcment: https://x.com/JPEGd_69/status/1752450450509418533

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded the set of tracked tokens in the treasury configuration to monitor an additional digital asset on the Ethereum network.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19256)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->