### PR TITLE
Fix : Hebeswap ETC TVL

### DIFF
--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -41,6 +41,9 @@ const ibcMappings = {
 }
 
 const fixBalancesTokens = {
+  ethereumclassic: {
+    [ADDRESSES.ethereumclassic.WETC]: { coingeckoId: 'ethereum-classic', decimals: 18 },
+  },
   ozone: {
     // '0x83048f0bf34feed8ced419455a4320a735a92e9d': { coingeckoId: "ozonechain", decimals: 18 }, // was mapped to wrong chain
   },

--- a/registries/uniswapV2.js
+++ b/registries/uniswapV2.js
@@ -827,7 +827,10 @@ const uniV2Configs = {
     arbitrum: '0x989CF6bFA8997E8A01Fa07F3009392d1C734c719',
   },
   'hebeswap': {
-    ethereumclassic: '0x09fafa5eecbc11C3e5d30369e51B7D9aab2f3F53',
+    ethereumclassic: {
+      factory: '0x09fafa5eecbc11C3e5d30369e51B7D9aab2f3F53',
+      permitFailure: true,
+    },
   },
   'heraswap': {
     onus: '0x6CD368495D90b9Ba81660e2b35f7Ea2AcE2B8cD6',


### PR DESCRIPTION
Closes #19257

Fixes Hebeswap TVL returning 0 on Ethereum Classic.

Changes:
- Enables `permitFailure` for the Hebeswap UniV2 factory so a few broken pair contracts do not fail the entire TVL calculation.
- Maps Ethereum Classic WETC to the `ethereum-classic` CoinGecko id so the WETC liquidity found by the adapter is priced correctly.

Tested with:

```bash
NODE_PATH=/Users/alenalex/Desktop/OSS/Defillama/DefiLlama-Adapters/node_modules node test.js hebeswap
Result:

--- ethereumclassic ---
ETC                       56.15 k
Total: 56.15 k

--- tvl ---
ETC                       56.15 k
Total: 56.15 k

------ TVL ------
ethereumclassic           56.15 k

total                    56.15 k

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded Ethereum Classic support by adding WETC (Wrapped Ethereum Classic) token with proper exchange rate mapping and decimal configuration
  * Enhanced Hebeswap decentralized exchange configuration for Ethereum Classic with improved transaction handling capabilities

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19259)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->