### PR TITLE
fix(synthetix-v3): remove base and arbitrum TVL

### DIFF
--- a/projects/synthetix-v3/index.js
+++ b/projects/synthetix-v3/index.js
@@ -1,22 +1,18 @@
-const { sumTokensExport } = require('../helper/unwrapLPs')
-const ADDRESSES = require('../helper/coreAssets.json')
+const { sumTokensExport } = require('../helper/unwrapLPs');
+const ADDRESSES = require('../helper/coreAssets.json');
 
-const CUSTOM_ADDRESSES = {
-  arbitrum: {
-    WEETH: ADDRESSES.arbitrum.weETH,
-    sUSDe: ADDRESSES.arbitrum.sUSDe,
-    tBTC: "0x6c84a8f1c29108F47a79964b5Fe888D4f4D0dE40"
-  }
-}
+// const CUSTOM_ADDRESSES = {
+//   arbitrum: {
+//     WEETH: ADDRESSES.arbitrum.weETH,
+//     sUSDe: ADDRESSES.arbitrum.sUSDe,
+//     tBTC: "0x6c84a8f1c29108F47a79964b5Fe888D4f4D0dE40"
+//   }
+// }
 
 module.exports = {
   ethereum: {
     tvl: sumTokensExport({ owner: '0xffffffaEff0B96Ea8e4f94b2253f31abdD875847', tokens: [ADDRESSES.ethereum.SNX] })
   },
-  base: {
-    tvl: sumTokensExport({ owner: '0x32C222A9A159782aFD7529c87FA34b96CA72C696', tokens: [ADDRESSES.base.USDC] })
-  },
-  arbitrum: {
-    tvl: sumTokensExport({ owner: '0xffffffaEff0B96Ea8e4f94b2253f31abdD875847', tokens: [ADDRESSES.arbitrum.USDC_CIRCLE, ADDRESSES.arbitrum.WETH, ADDRESSES.arbitrum.ARB, ADDRESSES.arbitrum.USDe, ADDRESSES.arbitrum.WSTETH, CUSTOM_ADDRESSES.arbitrum.WEETH, CUSTOM_ADDRESSES.arbitrum.sUSDe, CUSTOM_ADDRESSES.arbitrum.tBTC] })
-  }
-}
+  base: { tvl: () => ({}) },
+  arbitrum: { tvl: () => ({}) },
+};


### PR DESCRIPTION
Deprecate Base and Arbitrum support.

Refs:

* [https://blog.synthetix.io/l2s-are-dead-long-live-ethereum](https://blog.synthetix.io/l2s-are-dead-long-live-ethereum)
* [https://blog.synthetix.io/deprecation-of-synths-on-optimism](https://blog.synthetix.io/deprecation-of-synths-on-optimism)

Optimism is also deprecated, but retained for now since some tokens are still there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * TVL calculation for Base and Arbitrum chains in Synthetix V3 now returns empty data, while Ethereum TVL computation remains active
  * Removed unused custom address mappings and associated token configurations
  * Applied code formatting improvements including consistent use of semicolons and standardized style formatting

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19266)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->