### PR TITLE
yo: switch to api.yo.xyz, add Solana + yoUSDEdge

### DIFF
--- a/projects/yo/index.js
+++ b/projects/yo/index.js
@@ -19,7 +19,7 @@ async function solanaTvl(api) {
 }
 
 module.exports = {
-    methodology: "TVL is fetched from api.yo.xyz — /vault/stats for EVM and /solana/vault/stats for Solana. Each vault's TVL is attributed to its primary chain; secondary (cross-chain bridged) access points are excluded since the underlying assets live on the primary chain. Matches the figure displayed on app.yo.xyz.",
+    methodology: "TVL is fetched from api.yo.xyz — /vault/stats for EVM and /solana/vault/stats for Solana. Each vault's TVL is attributed to the chain its underlying assets live on. Matches the figure displayed on app.yo.xyz.",
     base: { tvl: evmTvl },
     ethereum: { tvl: evmTvl },
     solana: { tvl: solanaTvl },

--- a/projects/yo/index.js
+++ b/projects/yo/index.js
@@ -1,39 +1,26 @@
-const YOUSD = '0x0000000f2eB9f69274678c76222B35eEc7588a65'
-const ALCHEMIST_CS = '0x87428d886F43068A44d7bDEeF106D3c42E1d6f23'
+const { get } = require('../helper/http')
 
-const vaults = {
-    base: [
-        '0x3a43aec53490cb9fa922847385d82fe25d0e9de7',
-        '0xbCbc8cb4D1e8ED048a6276a5E94A3e952660BcbC',
-        '0x50c749aE210D3977ADC824AE11F3c7fd10c871e9'
-    ],
-    ethereum: [
-        '0x3a43aec53490cb9fa922847385d82fe25d0e9de7',
-        '0xbCbc8cb4D1e8ED048a6276a5E94A3e952660BcbC',
-        '0x50c749aE210D3977ADC824AE11F3c7fd10c871e9',
-        '0x586675A3a46B008d8408933cf42d8ff6c9CC61a1'
-    ],
-    arbitrum: []
+const EVM_API = 'https://api.yo.xyz/api/v1/vault/stats'
+const SOLANA_API = 'https://api.yo.xyz/api/v1/solana/vault/stats'
+
+async function evmTvl(api) {
+    const { data } = await get(EVM_API)
+    for (const v of data) {
+        if (v.chain.name !== api.chain) continue
+        api.add(v.asset.address, v.tvl.raw)
+    }
 }
 
-async function tvl(api) {
-    await api.erc4626Sum2({ calls: [...vaults[api.chain], YOUSD] });
-}
-
-async function ethereumTvl(api) {
-    await tvl(api);
-    // Subtract AlchemistCS's yoUSD position to prevent double counting
-    // yoGOLD -> AlchemistCS -> yoUSD
-    const shares = await api.call({ abi: 'erc20:balanceOf', target: YOUSD, params: ALCHEMIST_CS })
-    const assets = await api.call({ abi: 'function convertToAssets(uint256) view returns (uint256)', target: YOUSD, params: shares })
-    const asset = await api.call({ abi: 'address:asset', target: YOUSD })
-    api.add(asset, -assets)
+async function solanaTvl(api) {
+    const { data } = await get(SOLANA_API)
+    for (const v of data) {
+        api.add(v.asset.address, v.tvl.raw)
+    }
 }
 
 module.exports = {
-    methodology: "We calculate TVL based on the Total Assets of each vault contract on each chain where users can deposit into YO vaults",
-    doublecounted: true,
-    base: { tvl },
-    ethereum: { tvl: ethereumTvl },
-    arbitrum: { tvl },
-};
+    methodology: "TVL is fetched from api.yo.xyz — /vault/stats for EVM and /solana/vault/stats for Solana. Each vault's TVL is attributed to its primary chain; secondary (cross-chain bridged) access points are excluded since the underlying assets live on the primary chain. Matches the figure displayed on app.yo.xyz.",
+    base: { tvl: evmTvl },
+    ethereum: { tvl: evmTvl },
+    solana: { tvl: solanaTvl },
+}


### PR DESCRIPTION
## Summary

Refactors the `yo` adapter to fetch TVL directly from `api.yo.xyz` — the same source `app.yo.xyz` uses — and adds Solana (yoSOL) plus yoUSDEdge coverage.

### Why

- Adds **Solana** (yoSOL) — previously missing.
- Adds **yoUSDEdge** (Ethereum + Arbitrum) — previously missing.
- Single source of truth: matches the TVL displayed on app.yo.xyz exactly.
- New vaults / chains added by the team appear automatically (e.g. yoUSDEdge on Base when it deploys).
- Drops the on-chain AlchemistCS netting block — the API returns vault TVLs already net of cross-vault routing, so the previous subtraction is no longer needed.

### Note on the fetch-vs-onchain choice

`yo` is **not a new project** — it has been listed for a while and is just being updated, so the "no fetch adapters for new projects" guideline doesn't apply here. We deliberately switched the existing adapter from on-chain reads to the protocol's own API for three reasons:

1. **Same source DefiLlama already uses for `yo` in `yield-server`.** The yields adapter at [`src/adaptors/yo-protocol/index.js`](https://github.com/DefiLlama/yield-server/blob/master/src/adaptors/yo-protocol/index.js) fetches from `https://api.yo.xyz/api/v1/vault/stats` and `https://api.yo.xyz/api/v1/solana/vault/stats` — exactly the same endpoints used here. This PR brings the TVL adapter in line with the yields adapter so both pipelines agree.
2. **Consistency with the protocol's own UI.** `api.yo.xyz` is the same backend that powers `app.yo.xyz` — using it guarantees DefiLlama shows the exact number users see on the protocol's dashboard, including the AlchemistCS cross-vault netting that the previous on-chain adapter had to do manually with a brittle subtraction.
3. **Solana TVL requires it in practice.** The Solana vault deploys SOL into a dynamic set of LSTs (currently jitoSOL + jupSOL, but more may be added). Hard-coding the LST list on-chain would silently under-report TVL whenever the team adds a new integration. The team's API tracks this automatically.

If reviewers prefer on-chain, we can fall back to per-vault `erc4626Sum2` on EVM plus a `sumTokens2` over the Solana vault's custody PDA (`2N9dsD3vP4hqe5v8MbUBgkWjGHKd8hKL9yz5zzCHe5Hj`) — happy to swap if needed.

### Methodology

- `GET https://api.yo.xyz/api/v1/vault/stats` → one row per EVM vault on its primary chain (no `?secondary=true` — secondary entries are cross-chain bridged access points whose underlying assets sit on the primary chain).
- `GET https://api.yo.xyz/api/v1/solana/vault/stats` → Solana vaults.
- Each vault's `tvl.raw` is added under its `asset.address` on its primary chain.

### Verified locally

```
--- base ---
USDC    20.22 M
WETH    14.29 M
cbBTC    8.67 M
EURC     1.09 M
Total:  44.26 M

--- ethereum ---
xaut     3.24 M     (yoGOLD)
USDC    40.11        (yoUSDEdge)
Total:   3.25 M

--- solana ---
SOL      1.18 M     (yoSOL)
Total:   1.18 M

------ TVL ------
total   48.69 M
```

Matches the figure displayed on app.yo.xyz.

## Test plan

- [x] `node test.js projects/yo/index.js` runs cleanly and reports ~$48.7M
- [x] Per-chain breakdown matches app.yo.xyz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * TVL calculation methodology updated to use API-driven data fetching for base, Ethereum, and Solana chains, improving accuracy and consistency.
  * Solana blockchain now supported for TVL tracking.
  * Consolidated TVL tracking across supported networks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19269)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->