### PR TITLE
Add Covenant (Monad) TVL adapter

### DIFF
--- a/projects/covenant/dataProvider.json
+++ b/projects/covenant/dataProvider.json
@@ -1,0 +1,770 @@
+[
+  {
+    "type": "function",
+    "name": "getMarketDetails",
+    "inputs": [
+      {
+        "name": "covenantLiquid",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "marketId",
+        "type": "bytes20",
+        "internalType": "MarketId"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "marketsDetails",
+        "type": "tuple",
+        "internalType": "struct MarketDetails",
+        "components": [
+          {
+            "name": "marketId",
+            "type": "bytes20",
+            "internalType": "MarketId"
+          },
+          {
+            "name": "baseToken",
+            "type": "tuple",
+            "internalType": "struct ERC20Details",
+            "components": [
+              {
+                "name": "tokenAddress",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "decimals",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "totalSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "name",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "symbol",
+                "type": "string",
+                "internalType": "string"
+              }
+            ]
+          },
+          {
+            "name": "quoteToken",
+            "type": "tuple",
+            "internalType": "struct ERC20Details",
+            "components": [
+              {
+                "name": "tokenAddress",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "decimals",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "totalSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "name",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "symbol",
+                "type": "string",
+                "internalType": "string"
+              }
+            ]
+          },
+          {
+            "name": "aToken",
+            "type": "tuple",
+            "internalType": "struct ERC20Details",
+            "components": [
+              {
+                "name": "tokenAddress",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "decimals",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "totalSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "name",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "symbol",
+                "type": "string",
+                "internalType": "string"
+              }
+            ]
+          },
+          {
+            "name": "zToken",
+            "type": "tuple",
+            "internalType": "struct ERC20Details",
+            "components": [
+              {
+                "name": "tokenAddress",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "decimals",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "totalSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "name",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "symbol",
+                "type": "string",
+                "internalType": "string"
+              }
+            ]
+          },
+          {
+            "name": "marketParams",
+            "type": "tuple",
+            "internalType": "struct MarketParams",
+            "components": [
+              {
+                "name": "baseToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "quoteToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "curator",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "lex",
+                "type": "address",
+                "internalType": "address"
+              }
+            ]
+          },
+          {
+            "name": "marketState",
+            "type": "tuple",
+            "internalType": "struct MarketState",
+            "components": [
+              {
+                "name": "baseSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "protocolFeeGrowth",
+                "type": "uint128",
+                "internalType": "uint128"
+              },
+              {
+                "name": "authorizedPauseAddress",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "statusFlag",
+                "type": "uint8",
+                "internalType": "uint8"
+              }
+            ]
+          },
+          {
+            "name": "lexState",
+            "type": "tuple",
+            "internalType": "struct LexState",
+            "components": [
+              {
+                "name": "lastDebtNotionalPrice",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "lastBaseTokenPrice",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "lastETWAPBaseSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "lastSqrtPriceX96",
+                "type": "uint160",
+                "internalType": "uint160"
+              },
+              {
+                "name": "lastUpdateTimestamp",
+                "type": "uint96",
+                "internalType": "uint96"
+              },
+              {
+                "name": "lastLnRateBias",
+                "type": "int64",
+                "internalType": "int64"
+              }
+            ]
+          },
+          {
+            "name": "lexConfig",
+            "type": "tuple",
+            "internalType": "struct LexConfig",
+            "components": [
+              {
+                "name": "protocolFee",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "aToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "zToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "noCapLimit",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "scaleDecimals",
+                "type": "int8",
+                "internalType": "int8"
+              },
+              {
+                "name": "adaptive",
+                "type": "bool",
+                "internalType": "bool"
+              }
+            ]
+          },
+          {
+            "name": "lexParams",
+            "type": "tuple",
+            "internalType": "struct LexParams",
+            "components": [
+              {
+                "name": "covenantCore",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "initLnRateBias",
+                "type": "int64",
+                "internalType": "int64"
+              },
+              {
+                "name": "edgeSqrtPriceX96_B",
+                "type": "uint160",
+                "internalType": "uint160"
+              },
+              {
+                "name": "edgeSqrtPriceX96_A",
+                "type": "uint160",
+                "internalType": "uint160"
+              },
+              {
+                "name": "limHighSqrtPriceX96",
+                "type": "uint160",
+                "internalType": "uint160"
+              },
+              {
+                "name": "limMaxSqrtPriceX96",
+                "type": "uint160",
+                "internalType": "uint160"
+              },
+              {
+                "name": "debtDuration",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "swapFee",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "targetXvsL",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "currentLTV",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "targetLTV",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "debtPriceDiscount",
+            "type": "uint128",
+            "internalType": "uint128"
+          },
+          {
+            "name": "tokenPrices",
+            "type": "tuple",
+            "internalType": "struct TokenPrices",
+            "components": [
+              {
+                "name": "baseTokenPrice",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "aTokenPrice",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "zTokenPrice",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getMarketsDetails",
+    "inputs": [
+      {
+        "name": "covenantLiquid",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "marketIds",
+        "type": "bytes20[]",
+        "internalType": "MarketId[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "marketsDetails",
+        "type": "tuple[]",
+        "internalType": "struct MarketDetails[]",
+        "components": [
+          {
+            "name": "marketId",
+            "type": "bytes20",
+            "internalType": "MarketId"
+          },
+          {
+            "name": "baseToken",
+            "type": "tuple",
+            "internalType": "struct ERC20Details",
+            "components": [
+              {
+                "name": "tokenAddress",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "decimals",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "totalSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "name",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "symbol",
+                "type": "string",
+                "internalType": "string"
+              }
+            ]
+          },
+          {
+            "name": "quoteToken",
+            "type": "tuple",
+            "internalType": "struct ERC20Details",
+            "components": [
+              {
+                "name": "tokenAddress",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "decimals",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "totalSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "name",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "symbol",
+                "type": "string",
+                "internalType": "string"
+              }
+            ]
+          },
+          {
+            "name": "aToken",
+            "type": "tuple",
+            "internalType": "struct ERC20Details",
+            "components": [
+              {
+                "name": "tokenAddress",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "decimals",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "totalSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "name",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "symbol",
+                "type": "string",
+                "internalType": "string"
+              }
+            ]
+          },
+          {
+            "name": "zToken",
+            "type": "tuple",
+            "internalType": "struct ERC20Details",
+            "components": [
+              {
+                "name": "tokenAddress",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "decimals",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "totalSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "name",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "symbol",
+                "type": "string",
+                "internalType": "string"
+              }
+            ]
+          },
+          {
+            "name": "marketParams",
+            "type": "tuple",
+            "internalType": "struct MarketParams",
+            "components": [
+              {
+                "name": "baseToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "quoteToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "curator",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "lex",
+                "type": "address",
+                "internalType": "address"
+              }
+            ]
+          },
+          {
+            "name": "marketState",
+            "type": "tuple",
+            "internalType": "struct MarketState",
+            "components": [
+              {
+                "name": "baseSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "protocolFeeGrowth",
+                "type": "uint128",
+                "internalType": "uint128"
+              },
+              {
+                "name": "authorizedPauseAddress",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "statusFlag",
+                "type": "uint8",
+                "internalType": "uint8"
+              }
+            ]
+          },
+          {
+            "name": "lexState",
+            "type": "tuple",
+            "internalType": "struct LexState",
+            "components": [
+              {
+                "name": "lastDebtNotionalPrice",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "lastBaseTokenPrice",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "lastETWAPBaseSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "lastSqrtPriceX96",
+                "type": "uint160",
+                "internalType": "uint160"
+              },
+              {
+                "name": "lastUpdateTimestamp",
+                "type": "uint96",
+                "internalType": "uint96"
+              },
+              {
+                "name": "lastLnRateBias",
+                "type": "int64",
+                "internalType": "int64"
+              }
+            ]
+          },
+          {
+            "name": "lexConfig",
+            "type": "tuple",
+            "internalType": "struct LexConfig",
+            "components": [
+              {
+                "name": "protocolFee",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "aToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "zToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "noCapLimit",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "scaleDecimals",
+                "type": "int8",
+                "internalType": "int8"
+              },
+              {
+                "name": "adaptive",
+                "type": "bool",
+                "internalType": "bool"
+              }
+            ]
+          },
+          {
+            "name": "lexParams",
+            "type": "tuple",
+            "internalType": "struct LexParams",
+            "components": [
+              {
+                "name": "covenantCore",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "initLnRateBias",
+                "type": "int64",
+                "internalType": "int64"
+              },
+              {
+                "name": "edgeSqrtPriceX96_B",
+                "type": "uint160",
+                "internalType": "uint160"
+              },
+              {
+                "name": "edgeSqrtPriceX96_A",
+                "type": "uint160",
+                "internalType": "uint160"
+              },
+              {
+                "name": "limHighSqrtPriceX96",
+                "type": "uint160",
+                "internalType": "uint160"
+              },
+              {
+                "name": "limMaxSqrtPriceX96",
+                "type": "uint160",
+                "internalType": "uint160"
+              },
+              {
+                "name": "debtDuration",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "swapFee",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "targetXvsL",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "currentLTV",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "targetLTV",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "debtPriceDiscount",
+            "type": "uint128",
+            "internalType": "uint128"
+          },
+          {
+            "name": "tokenPrices",
+            "type": "tuple",
+            "internalType": "struct TokenPrices",
+            "components": [
+              {
+                "name": "baseTokenPrice",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "aTokenPrice",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "zTokenPrice",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "error",
+    "name": "SafeCastOverflowedUintDowncast",
+    "inputs": [
+      {
+        "name": "bits",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  }
+]

--- a/projects/covenant/index.js
+++ b/projects/covenant/index.js
@@ -1,0 +1,72 @@
+const sdk = require('@defillama/sdk');
+
+const dataProviderAbi = require('./dataProvider.json');
+
+const COVENANT = '0x11a7ab0a9d7bd531dbcf0f0630bf7167f8f198f6';
+const DATA_PROVIDER = '0x3818a6d5018aa9eb69b6bce09e38a7c24bbe8c22';
+const DEPLOY_BLOCK = 35851140;
+const CHAIN = 'monad';
+
+const NATIVE_MON = '0x0000000000000000000000000000000000000000';
+const USD_CG_ID = 'usd-coin'; // attributed via api.addCGToken to skip chain prefix
+
+const createMarketEvent =
+  'event CreateMarket(bytes20 indexed marketId, (address baseToken, address quoteToken, address curator, address lex) marketParams, (address aToken, address zToken) synthTokens, bytes initData, bytes lexData)';
+
+const getMarketsDetailsAbi = dataProviderAbi.find(
+  (x) => x.name === 'getMarketsDetails'
+);
+
+// PRICE_DIVISOR = 1e36 = 10^(2 * 18). Mirrors covenant-interface
+// EVMBlockchainAdapter.ts:45 — synth and base prices are pre-scaled so that
+// (balance * price) / 1e36 yields value in quote whole units regardless of
+// token decimal mismatches.
+async function tvl(api) {
+  const toBlock = await api.getBlock();
+  const logs = await api.getLogs({
+    target: COVENANT,
+    fromBlock: DEPLOY_BLOCK,
+    toBlock,
+    eventAbi: createMarketEvent,
+    onlyArgs: true,
+  });
+  if (!logs.length) return;
+
+  const marketIds = logs.map((l) => l.marketId);
+
+  const { output: details } = await sdk.api.abi.call({
+    target: DATA_PROVIDER,
+    abi: getMarketsDetailsAbi,
+    params: [COVENANT, marketIds],
+    chain: CHAIN,
+  });
+
+  for (const d of details) {
+    if (Number(d.marketState.statusFlag) === 0) continue;
+    const baseSupply = BigInt(d.marketState.baseSupply.toString());
+    const basePrice = BigInt(d.tokenPrices.baseTokenPrice.toString());
+    if (basePrice === 0n || baseSupply === 0n) continue;
+
+    // (baseSupply * basePrice) is scaled to 1e36 over whole quote units.
+    // Divide by 1e18 once to get a 1e18-scaled quote value (quote-wei equivalent).
+    const valueInQuoteWei = (baseSupply * basePrice) / 10n ** 18n;
+
+    const quoteSym = d.quoteToken.symbol;
+    if (quoteSym === 'USD') {
+      // CoinGecko IDs have no associated decimals in DefiLlama's pricing
+      // layer, so balance is treated as whole tokens. Pass whole USD.
+      api.addCGToken(USD_CG_ID, valueInQuoteWei / 10n ** 18n);
+    } else if (quoteSym === 'MON') {
+      // Native MON has 18 decimals; valueInQuoteWei is already MON-wei.
+      api.add(NATIVE_MON, valueInQuoteWei);
+    }
+    // Unknown quote symbols are skipped intentionally; would need a new
+    // attribution mapping when Covenant adds non-USD/non-MON quote markets.
+  }
+}
+
+module.exports = {
+  methodology:
+    'For each Covenant market, the value of base-token collateral locked in the Covenant contract is computed from on-chain state: baseSupply (from Covenant.getMarketState) multiplied by the curator-routed oracle price (from DataProvider.tokenPrices.baseTokenPrice, denominated in the market\'s quote unit). USD-quote markets are attributed as USDC for DefiLlama pricing; MON-quote markets are attributed as native MON. Markets are enumerated from CreateMarket logs on Covenant.sol. The TVL amount comes entirely from on-chain reads; CoinGecko is used only to convert the well-known quote anchors (USDC, MON) to USD.',
+  monad: { tvl },
+};


### PR DESCRIPTION
Adds a TVL adapter for the Covenant credit protocol on Monad mainnet.

Methodology summary:
- Markets enumerated via `CreateMarket` logs on Covenant.sol (Monad mainnet
  deploy block 35,851,140).
- Per-market value = `baseSupply × curator on-chain price`, read in one
  batched `DataProvider.getMarketsDetails` call.
- USD-quote markets are attributed to `coingecko:usd-coin` (whole USD,
  CG IDs have no decimals); MON-quote markets are attributed to native MON.
  DefiLlama prices both anchors. This gives full coverage on day one even
  for Monad-native vault wrappers that aren't yet in DefiLlama's pricing
  layer.
- No npm dependencies added; no lockfile changes.

Workspace + methodology rationale:
https://github.com/covenant-labs/covenant-defillama

---

## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
Covenant

##### Twitter Link:
https://x.com/covenantFi

##### List of audit links if any:
https://docs.covenant.finance/resources/audits

##### Website Link:
https://covenant.finance

##### Logo (High resolution, will be shown with rounded borders):
https://docs.covenant.finance/~gitbook/image?url=https%3A%2F%2F3972845554-files.gitbook.io%2F%7E%2Ffiles%2Fv0%2Fb%2Fgitbook-x-prod.appspot.com%2Fo%2Fspaces%252FCHCjmUrjuPhzffSUl2eD%252Fuploads%252F2grJA9QORjBU4wcOLdtF%252FLogoGreen_AlphaBG_vector.svg%3Falt%3Dmedia%26token%3Dfa6fe139-5de7-4156-aa56-a2434aa0977b&width=300&dpr=3&quality=100&sign=d0ad321a&sv=2

##### Current TVL:
~$36,000 USD (Monad mainnet, at the time of submission)

##### Treasury Addresses (if the protocol has treasury):
N/A

##### Chain:
Monad

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):

##### Short Description (to be shown on DefiLlama):
Covenant is a tranching layer on Monad that converts any tokenized asset into
fully-backed leverage and yield markets. Each market mints two synthetic
tokens against the base collateral: a Yield Coin (fixed-rate, debt-side)
and a Leverage Coin (levered exposure to the underlying). 

##### Token address and ticker if any:
"N/A — no protocol token"

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Yield

##### Oracle Provider(s):
Chainlink, Pyth, plus protocol-specific oracle adapters for Kintsu (Monad
LSTs) and Upshift (vault wrappers). Some markets use direct ERC4626 convertToAssets() prices.

##### Implementation Details:
Each Covenant market specifies a `curator` address (a CovenantCurator
instance) which routes price requests for `(baseToken, quoteToken)` pairs
to a registered oracle adapter (ChainlinkOracle, PythOracle, KintsuOracle,
UpshiftVaultOracle, FixedRateOracle, or a CrossAdapter composing two
sources). Prices are queried via `IPriceOracle.getQuote(amount, base, quote)`.

##### Documentation/Proof:
https://docs.covenant.finance

##### forkedFrom (Does your project originate from another project):
No — built from scratch by Covenant Labs.

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL is the sum, across all live Covenant markets on Monad, of the
base-token collateral locked in the Covenant contract (`baseSupply` per
market). Each market's value is computed as `baseSupply × baseTokenPrice`,
where `baseTokenPrice` is the curator-routed on-chain oracle price
denominated in the market's quote unit (USD or MON). USD-quote markets
are attributed via `coingecko:usd-coin`, MON-quote markets as native MON;
DefiLlama prices both anchors to convert to USD. The TVL amount comes
entirely from on-chain reads (baseSupply and curator price); CoinGecko
is used only for the well-known quote-to-USD conversion.

##### Github org/user (Optional, if your code is open source, we can track activity):
covenant-labs

##### Does this project have a referral program?
yes.  https://rewards.covenant.finance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Covenant protocol Total Value Locked tracking now available on Monad chain
  * Market data provider interface queries detailed market information and collateral valuations
  * Support for both USD and native MON token denominated markets
  * Includes market activity validation and proper handling of zero-value edge cases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19271)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->