### PR TITLE
fix olympus treasury (refactor)

### DIFF
--- a/projects/olympus/index.js
+++ b/projects/olympus/index.js
@@ -1,183 +1,351 @@
-// projects/olympus/index.js
-
-const ADDRESSES = require('../helper/coreAssets.json')
-const { blockQuery } = require("../helper/http");
+const BigNumber = require('bignumber.js');
+const ADDRESSES = require('../helper/coreAssets.json');
 const { staking } = require('../helper/staking');
-const { sumTokens2 } = require("../helper/unwrapLPs");
+const { sumTokens2 } = require('../helper/unwrapLPs');
 
+const OHM_V1 = '0x383518188c0c6d7730d91b2c03a03c837814a899';
+const OHM = '0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5';
+const GOHM = '0x0ab87046fBb341D058F17CBC4c1133F25a20a52f';
+const SOHM_V1 = '0x31932e6e45012476ba3a3a4953cba62aee77fbbe';
+const SOHM_V2 = '0x04f2694c8fcee23e8fd0dfea1d4f5bb8c352111f';
+const SOHM_V3 = '0x04906695D6D12CF5459975d7C3C03356E4Ccd460';
+const WSOHM = '0xCa76543Cf381ebBB277bE79574059e32108e3E65';
+const AURA = '0xC0c293ce456fF0ED870ADd98a0828Dd4d2903DBF';
+const VEFXS = '0xc8418af6358ffdda74e09ca9cc3fe03ca6adc5b0';
+
+// Address list: https://docs.olympusdao.finance/main/contracts/addresses
 const OlympusStakings = [
   "0x0822F3C03dcc24d200AFF33493Dc08d0e1f274A2", // Old Staking Contract
-  "0xFd31c7d00Ca47653c6Ce64Af53c1571f9C36566a", // New Staking Contract
-  "0xb63cac384247597756545b500253ff8e607a8020",
+  "0xFd31c7d00Ca47653c6Ce64Af53c1571f9C36566a", // V1 Staking Contract
+  "0xb63cac384247597756545b500253ff8e607a8020", // V2 Staking Contract
 ];
 
-const OHM_V1 = "0x383518188c0c6d7730d91b2c03a03c837814a899"
-const OHM = "0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5"
-const GOHM = "0x0ab87046fBb341D058F17CBC4c1133F25a20a52f"
+// Olympus-controlled multisigs, custodian wallets and yield-farming MSes on Ethereum.
+// Augmented at runtime via the Bophades Kernel TRSRY + CHREG modules.
+const ethereumOwners = [
+  '0x0d33c811d0fcc711bcb388dfb3a152de445be66f',
+  '0x0e1177e47151Be72e5992E0975000E73Ab5fd9D4',
+  '0x8CaF91A6bb38D55fB530dEc0faB535FA78d98FaD',
+  '0x872ebDd8129Aa328C89f6BF032bBD77a4c4BaC7e',
+  '0xa9b52a2d0ffdbabdb2cb23ebb7cd879cac6618a6',
+  '0x9025046c6fb25Fb39e720d97a8FD881ED69a1Ef6',
+  '0xBA42BE149e5260EbA4B82418A6306f55D532eA47',
+  '0xf7deb867e65306be0cb33918ac1b8f89a72109db',
+  '0x3dF5A355457dB3A4B5C744B8623A7721BF56dF78',
+  '0x408a9A09d97103022F53300A3A14Ca6c3FF867E8',
+  '0xDbf0683fC4FC8Ac11e64a6817d3285ec4f2Fc42d',
+  '0xdfc95aaf0a107daae2b350458ded4b7906e7f728',
+  '0x2d643df5de4e9ba063760d475beaa62821c71681',
+  '0x943C1dfA7dA96e54242bD2c78DD3eF5C7b24b18C',
+  '0x75E7f7D871F4B5db0fA9B0f01B7422352Ec9618f',
+  '0x245cc372c84b3645bf0ffe6538620b04a217988b',
+  '0xF65A665D650B5De224F46D729e2bD0885EeA9dA5',
+  '0x97b3ef4c558ec456d59cb95c65bfb79046e31fca',
+  '0x5db0761487e26B555F5Bfd5E40F4CBC3E1a7d11E',
+  '0x0EA26319836fF05B8C5C5afD83b8aB17dd46d063',
+  '0xe3312c3f1ab30878d9686452f7205ebe11e965eb',
+  '0x061C8610A784b8A1599De5B1157631e35180d818',
+  '0x886CE997aa9ee4F8c2282E182aB72A705762399D',
+  '0x31f8cc382c9898b273eff4e0b7626a6987c846e8',
+  '0x9A315BdF513367C0377FB36545857d12e85813Ef',
+  '0xa8687A15D4BE32CC8F0a8a7B9704a4C3993D9613',
+  '0xde7b85f52577b113181921a7aa8fc0c22e309475',
+  '0xd6a6e8d9e82534bd65821142fccd91ec9cf31880',
+  '0xe6343ad0675c9b8d3f32679ae6adba0766a2ab4c',
+  '0x1e094fe00e13fd06d64eea4fb3cd912893606fe0',
+  '0xdb591Ea2e5Db886dA872654D58f6cc584b68e7cC',
+  '0x2075e3b46470cfcE124Daaf52b46Dcf965727Dd1',
+];
 
-const olympusTokens = [GOHM, OHM];
+const ethereumTreasuryTokens = [
+  ADDRESSES.null,
+  ADDRESSES.ethereum.DAI,
+  '0x028171bca77440897b824ca71d1c56cac55b68a3', // aDAI
+  '0x4579a27af00a62c0eb156349f31b345c08386419', // aLUSD
+  '0x4f5923fc5fd4a93352581b38b7cd26943012decf', // aEthUSDe
+  '0x6df1c1e379bc5a00a7b4c6e67a203333772f45a8', // Aave V3 variableDebt USDT — yield-farming loop liability (excluded, subtracted via liabilityTokens)
+  '0x72e95b8931767c79ba4eee721354d6e99a61d004', // Aave V3 variableDebt USDC — yield-farming loop liability (excluded, subtracted via liabilityTokens)
+  '0x853d955acef822db058eb8505911ed77f175b99e', // FRAX
+  '0x5f98805a4e8be255a32880fdec7f6728c6568ba0', // LUSD
+  ADDRESSES.ethereum.USDC,
+  '0xdAC17F958D2ee523a2206206994597C13D831ec7', // USDT
+  '0x4c9EDD5852cd905f086C759E8383e09bff1E68B3', // USDe
+  '0xdC035D45d973E3EC169d2276DDab16f1e407384F', // USDS
+  '0x83F20F44975D03b1b09e64809B757c47f942BEeA', // sDAI
+  '0x9D39A5DE30e57443BfF2A8307A4256c8797A3497', // sUSDe
+  '0xa3931d71877C0E7a3148CB7Eb4463524FEc27fbD', // sUSDS
+  ADDRESSES.ethereum.WBTC,
+  ADDRESSES.ethereum.WETH,
+  ADDRESSES.ethereum.WSTETH,
+  '0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee', // weETH
+  AURA,
+  '0x616e8BfA43F920657B3497DBf40D6b1A02D4608d', // auraBAL
+  '0xba100000625a3754423978a60c9317c58a424e3D', // BAL
+  ADDRESSES.ethereum.CVX,
+  ADDRESSES.ethereum.vlCVX,                    // priced server-side as CVX
+  '0xd18140b4b819b895a3dba5442f959fa44994af50', // vlCVX v1 (unpriced; add server pricing if balance grows)
+  '0x3Fa73f1E5d8A792C80F426fc8F84FBF7Ce9bBCAC', // vlAURA   (unpriced; add server pricing if balance grows)
+  '0x62b9c7356a2dc64a1969e19c23e4f579f9810aa7',
+  '0x3432b6a60d23ca0dfca7761b7ab56459d9c964d0',
+  '0x6dea81c8171d0ba574754ef6f8b412f2ed88c54d',
+  '0x5a98fcbea516cf06857215779fd812ca3bef1b32', // LDO
+  '0x6B3595068778DD592e39A122f4f5a5cF09C90fE2', // SUSHI
+  '0x8798249c2e607446efb7ad49ec89dd1865ff4272', // xSUSHI
+  '0x2e9d63788249371f1dfc918a52f8d799f4a38c94',
+  '0xc7283b66Eb1EB5FB86327f08e1B5816b0720212B',
+  '0xdbdb4d16eda451d0503b854cf79d55697f90c8df', // ALCX
+  '0xc55126051b22ebb829d00368f4b12bde432de5da', // BTRFLY v2
+  '0x742B70151cd3Bc7ab598aAFF1d54B90c3ebC6027', // rlBTRFLY
+  '0xEd1480d12bE41d92F36f5f7bDd88212E381A3677',
+  '0xc770eefad204b5180df6a14ee197d99d808ee52d',
+  '0xc2544a32872a91f4a553b404c6950e89de901fdb',
+  '0x43d4a3cd90ddd2f8f4f693170c9c8098163502ad',
+];
 
-// Updated subgraph IDs - removed dead chains (Fantom, Polygon), added Base
-const subgraphUrls = {
-  ethereum: "7jeChfyUTWRyp2JxPGuuzxvGt3fDKMkC9rLjm7sfLcNp",
-  arbitrum: "8Zxb1kVv9ZBChHXEPSgtC5u5gjCijMn5k8ErpzRYWNgH",
-  base: "3YAC1Gj2AUFCQ8wd4DaBQmqU3DJZjKyr45dQykAtXuMU",
+// Protocol-Owned Liquidity LP tokens — tracked by the Uniswap V3 adapter, not counted here.
+const ethereumPolTokens = [
+  '0xb23dfc0c4502a271976f1ee65321c51be2529640',
+  '0x622a725a79c7fe37ad839c640cd62d546712b3a9',
+  '0xc45d42f801105e861e86658648e3678ad7aa70f9',
+  '0x76fcf0e8c7ff37a47a799fa2cd4c13cde0d981c9',
+  '0xa02d8861fbfd0ba3d8ebafa447fe7680a3fa9a93',
+  '0xd1ec5e215e8148d76f4460e4097fd3d5ae0a3558',
+  '0x0ef97ef0e20f84e82ec2d79cbd9eda923c3daf09',
+  '0xd4f79ca0ac83192693bce4699d0c10c66aa6cf0f',
+  '0x32296969ef14eb0c6d29669c550d4a0449130230',
+  '0xfc1e8bf3e81383ef07be24c3fd146745719de48d',
+  '0x6ec38b3228251a0c5d491faf66858e2e23d7728b',
+  '0x38633ed142bcc8128b45ab04a2e4a6e53774699f',
+  '0x5769071665eb8db80e7e9226f92336bb2897dcfa',
+  '0x055475920a8c93cffb64d039a8205f7acc7722d3',
+  '0x34d7d7aaf50ad4944b70b320acb24c95fa2def7c',
+  '0x69b81152c5a8d35a67b32a4d3772795d96cae4da',
+  '0xfffae4a0f4ac251f4705717cd24cadccc9f33e06',
+  '0x46e4d8a1322b9448905225e52f914094dbd6dddf',
+  '0xfdf12d1f85b5082877a6e070524f50f6c84faa6b',
+  '0xe9ab8038ee6dd4fcc7612997fe28d4e22019c4b4',
+  '0x88051b0eea095007d3bef21ab287be961f3d8598',
+  '0x0858e2b0f9d75f7300b38d64482ac2c8df06a755',
+];
+
+const chains = {
+  ethereum: {
+    owners: ethereumOwners,
+    treasuryTokens: ethereumTreasuryTokens,
+    // Aave V3 variable debt tokens for Olympus's yield-farming leverage loop.
+    // Tracked as liabilities so the borrowed USDT/USDC net against the reinvested position.
+    // Currently $0 (loop inactive); sourced from Olympus's own subgraph Constants.ts.
+    liabilityTokens: [
+      '0x6df1c1e379bc5a00a7b4c6e67a203333772f45a8', // variableDebtEthUSDT
+      '0x72e95b8931767c79ba4eee721354d6e99a61d004', // variableDebtEthUSDC
+    ],
+    ownTokens: [OHM_V1, OHM, GOHM, SOHM_V1, SOHM_V2, SOHM_V3, WSOHM],
+    polTokens: ethereumPolTokens,
+    special: {
+      bophadesKernel: '0x2286d7f9639e8158FaD1169e76d1FbC38247f54b',
+      keycodes: { TRSRY: '0x5452535259', CHREG: '0x4348524547' },
+      makerDsr: '0x197E90f9FAD81970bA7976f33CbD77088E5D7cf7',
+      veFxs: {
+        token: VEFXS,
+        underlying: ADDRESSES.ethereum.FXS,
+        owners: ['0xde7b85f52577b113181921a7aa8fc0c22e309475'],
+      },
+      convexRewardPools: [
+        '0x3fe65692bfcd0e6cf84cb1e7d24108e434a7587e',
+        '0xB900EF131301B307dB5eFcbed9DBb50A3e209B2e',
+        '0x7e880867363A7e321f5d260Cade2B0Bb2F717B02',
+        '0xd683C7051a28fA150EB3F4BD92263865D4a67778',
+        '0x27A8c58e3DE84280826d615D80ddb33930383fE9',
+      ],
+      fraxLocks: [
+        { target: '0x963f487796d54d2f27bA6F3Fbe91154cA103b199', token: '0x3175Df0976dFA876431C2E9eE6Bc45b65d3473CC' },
+        { target: '0xc96e1a26264D965078bd01eaceB129A65C09FFE7', token: '0x5271045F7B73c17825A7A7aee6917eE46b0B7520' },
+      ],
+    },
+  },
+  arbitrum: {
+    owners: [...ethereumOwners, '0x012BBf0481b97170577745D2167ee14f63E2aD4C'],
+    treasuryTokens: [
+      ADDRESSES.arbitrum.ARB,
+      '0x17FC002b466eEc40DaE837Fc4bE5c67993ddBd6F',
+      '0x10393c20975cf177a3513071bc110f7962cd67da',
+      '0xfb9E5D956D889D91a82737B9bFCDaC1DCE3e1449',
+      '0x93b346b6bc2548da6a1e7d98e9a421b42541425b',
+      '0x539bde0d7dbd336b79148aa742883198bbf60342',
+      ADDRESSES.arbitrum.USDC,
+      '0xa684cd057951541187f288294a1e1c2646aa2d24',
+      ADDRESSES.arbitrum.WETH,
+    ],
+    ownTokens: [
+      '0xf0cb2dc0db5e6c66B9a70Ac27B06b878da017028', // OHM (Arb)
+      '0x8D9bA570D6cb60C7e3e0F31343Efe75AB8E65FB1', // gOHM (Arb)
+    ],
+    polTokens: [
+      '0xb3028ca124b80cfe6e9ca57b70ef2f0ccc41ebd40002000000000000000000ba',
+      '0xc61ff48f94d801c1ceface0289085197b5ec44f000020000000000000000004d',
+      '0x89dc7e71e362faf88d92288fe2311d25c6a1b5e0000200000000000000000423',
+      '0xce6195089b302633ed60f3f427d1380f6a2bfbc7000200000000000000000424',
+      '0xaa5bd49f2162ffdc15634c87a77ac67bd51c6a6d',
+      '0x292d1587a6bb37e34574c9ad5993f221d8a5616c',
+      '0xe8ee01ae5959d3231506fcdef2d5f3e85987a39c',
+      '0xb7e50106a5bd3cf21af210a755f9c8740890a8c9',
+      '0x8aCd42e4B5A5750B44A28C5fb50906eBfF145359',
+      '0xc6f780497a95e246eb9449f5e4770916dcd6396a',
+      '0xc31e54c7a869b9fcbecc14363cf510d1c41fa443',
+    ],
+  },
+  base: {
+    owners: ['0x18a390bD45bCc92652b9A91AD51Aed7f1c1358f5'],
+    treasuryTokens: [ADDRESSES.base.USDC, ADDRESSES.base.WETH],
+    ownTokens: ['0x060cb087a9730E13aa191f31A6d86bFF8DfcdCC0'], // OHM (Base)
+    polTokens: [
+      '0x5ab4b9e96aeed4820e4be267f42411d722985482',
+      '0x183ea22691c54806FE96555436dd312b6BeFAc2F',
+    ],
+  },
+  berachain: {
+    owners: [
+      '0x91494D1BC2286343D51c55E46AE80C9356D099b5',
+      '0xb1fA0Ac44d399b778B14af0AAF4bCF8af3437ad1',
+      '0xe22b2d431838528BcaD52d11C4744EfCdc907a1c',
+      '0x082689241b09c600b3eaf3812b1d09791e7ded5a', // THJ Custodian
+      '0xb65e74f6b2c0633e30ba1be75db818bb9522a81a',
+    ],
+    treasuryTokens: [
+      ADDRESSES.null,
+      '0x9b6761bf2397Bb5a6624a856cC84A3A14Dcd3fe5', // iBERA
+      '0xac03CABA51e17c86c921E1f6CBFBdC91F8BB2E6b',
+      '0xBaadCC2962417C01Af99fb2B7C75706B9bd6Babe',
+      ADDRESSES.berachain.USDC,
+      ADDRESSES.berachain.HONEY,
+      ADDRESSES.berachain.WBERA,
+    ],
+    ownTokens: ['0x18878Df23e2a36f81e820e4b47b4A40576D3159C'], // OHM (Berachain)
+    polTokens: [
+      '0x98bDEEde9A45C28d229285d9d6e9139e9F505391',
+      '0x555BAd9EC18dB19dED0057D2517242399d1c5D87',
+      '0xa57Cb177Beebc35A1A26A286951a306d9B752524',
+      '0x815596fa7c4d983d1ca5304e5b48978424c1b448',
+    ],
+  },
 };
 
-/** Map staked assets without price feeds to those with price feeds (1:1) */
-const addressMap = {
-  "0xb23dfc0c4502a271976f1ee65321c51be2529640": "0x76fcf0e8c7ff37a47a799fa2cd4c13cde0d981c9", // aura50OHM-50DAI -> 50OHM-50DAI
-  "0xc8418af6358ffdda74e09ca9cc3fe03ca6adc5b0": ADDRESSES.ethereum.FXS, // veFXS -> FXS
-  "0x3fa73f1e5d8a792c80f426fc8f84fbf7ce9bbcac": "0xc0c293ce456ff0ed870add98a0828dd4d2903dbf", // vlAURA -> AURA
-  [ADDRESSES.ethereum.vlCVX]: ADDRESSES.ethereum.CVX, // vlCVX -> CVX
-  "0xa02d8861fbfd0ba3d8ebafa447fe7680a3fa9a93": "0xd1ec5e215e8148d76f4460e4097fd3d5ae0a3558", // aura50OHM-50WETH -> 50OHM-50WETH
-  "0x0ef97ef0e20f84e82ec2d79cbd9eda923c3daf09": "0xd4f79ca0ac83192693bce4699d0c10c66aa6cf0f", // auraOHM-wstETH -> OHM-wstETH
-  "0x81b0dcda53482a2ea9eb496342dc787643323e95": "0x5271045f7b73c17825a7a7aee6917ee46b0b7520", // stkcvxOHMFRAXBP-f-frax -> OHMFRAXBP-f
-  "0x8a53ee42fb458d4897e15cc7dea3f75d0f1c3475": "0x3175df0976dfa876431c2e9ee6bc45b65d3473cc", // stkcvxcrvFRAX-frax -> crvFRAX-frax
-  "0xb0c22d8d350c67420f06f48936654f567c73e8c8": "0x4e78011ce80ee02d2c3e649fb657e45898257815", // sKLIMA -> KLIMA
-  "0x742b70151cd3bc7ab598aaff1d54b90c3ebc6027": "0xc55126051B22eBb829D00368f4B12Bde432de5Da", // rlBTRFLY -> BTRFLY V2
-  "0xc0d4ceb216b3ba9c3701b291766fdcba977cec3a": "0xc55126051B22eBb829D00368f4B12Bde432de5Da", // BTRFLY -> BTRFLY V2
-};
+const normalize = a => a && a.toLowerCase();
+const isAddress = a => !!a && /^0x[a-f0-9]{40}$/.test(normalize(a)) && normalize(a) !== ADDRESSES.null;
+const addressSet = (arr = []) => new Set(arr.filter(Boolean).map(normalize));
+const uniqueAddresses = arr => [...new Set(arr.filter(isAddress).map(a => a.toLowerCase()))];
 
-const poolsWithoutDecimals = ["0x88051b0eea095007d3bef21ab287be961f3d8598"];
+// Discover the live TRSRY and cross-chain treasury contracts from the Bophades Kernel.
+// Olympus can upgrade the TRSRY module via Kernel migration — never hardcode it.
+async function discoverOwners(api, chainConfig) {
+  const owners = [...(chainConfig.owners || [])];
+  const special = chainConfig.special || {};
 
-const getLatestBlockIndexed = `
-query {
-  lastBlock: tokenRecords(first: 1, orderBy: block, orderDirection: desc) {
-    block
-    timestamp
+  if (api.chain === 'ethereum' && special.bophadesKernel) {
+    const keycodeAbi = 'function getModuleForKeycode(bytes5 keycode_) view returns (address)';
+    const trsry = await api.call({ target: special.bophadesKernel, abi: keycodeAbi, params: [special.keycodes.TRSRY] });
+    if (isAddress(trsry)) owners.push(trsry);
+
+    const chreg = await api.call({ target: special.bophadesKernel, abi: keycodeAbi, params: [special.keycodes.CHREG] });
+    if (isAddress(chreg)) {
+      const count = await api.call({ target: chreg, abi: 'uint256:registryCount' });
+      if (count) {
+        const addrs = await api.multiCall({
+          target: chreg,
+          calls: Array.from({ length: Number(count) }, (_, i) => i),
+          abi: 'function registry(uint256) view returns (address)',
+          permitFailure: true,
+        });
+        owners.push(...addrs.filter(isAddress));
+      }
+    }
   }
-}`;
 
-/**
- * Builds a GraphQL query to fetch tokenRecords at a specific block.
- * @param {number} block - The block number to query at.
- * @returns {string} GraphQL query string.
- */
-const protocolQuery = (block) => `
-query {
-  tokenRecords(orderDirection: desc, orderBy: block, where: {block: ${block}}) {
-    block
-    timestamp
-    category
-    tokenAddress
-    token
-    balance
+  return uniqueAddresses(owners);
+}
+
+async function addLiabilities(api, owners, liabilityTokens) {
+  if (!liabilityTokens.length || !owners.length) return;
+  const calls = liabilityTokens.flatMap(t => owners.map(o => ({ target: t, params: [o] })));
+  const balances = await api.multiCall({ calls, abi: 'erc20:balanceOf', permitFailure: true });
+  balances.forEach((balance, i) => {
+    if (balance) api.add(calls[i].target, new BigNumber(balance).times(-1).toFixed(0));
+  });
+}
+
+async function addMakerDsr(api, owners, special) {
+  if (!special.makerDsr) return;
+  const [pies, chi] = await Promise.all([
+    api.multiCall({ target: special.makerDsr, calls: owners, abi: 'function pie(address) view returns (uint256)', permitFailure: true }),
+    api.call({ target: special.makerDsr, abi: 'uint256:chi' }),
+  ]);
+  if (!chi) return;
+  const dai = pies.reduce((sum, pie) => sum.plus(new BigNumber(pie || 0).times(chi).div(1e27)), new BigNumber(0));
+  if (dai.gt(0)) api.add(ADDRESSES.ethereum.DAI, dai.toFixed(0));
+}
+
+async function addVeFxs(api, special) {
+  if (!special.veFxs) return;
+  const { token, underlying, owners } = special.veFxs;
+  const locks = await api.multiCall({
+    target: token,
+    calls: owners,
+    abi: 'function locked(address) view returns (int128 amount, uint256 end)',
+    permitFailure: true,
+  });
+  locks.forEach(lock => {
+    const amount = lock && (lock.amount ?? lock[0]);
+    if (amount && new BigNumber(amount).gt(0)) api.add(underlying, amount.toString());
+  });
+}
+
+async function addFraxLocks(api, owners, special) {
+  for (const lock of special.fraxLocks || []) {
+    const balances = await api.multiCall({
+      target: lock.target,
+      calls: owners,
+      abi: 'function lockedLiquidityOf(address account) view returns (uint256)',
+      permitFailure: true,
+    });
+    balances.forEach(b => { if (b) api.add(lock.token, b); });
   }
 }
-`;
 
-/**
- * Aggregates token records by tokenAddress, summing balances for duplicate entries.
- * Used to collapse multiple subgraph rows for the same token into a single balance.
- * @param {Array<{tokenAddress: string, balance: string|number, category: string, token: string}>} arr
- * @returns {Array<{tokenAddress: string, balance: number, category: string, token: string}>}
- */
-function sumBalancesByTokenAddress(arr) {
-  const map = new Map();
-  for (const curr of arr) {
-    const existing = map.get(curr.tokenAddress);
-    if (existing) {
-      existing.balance += +curr.balance;
-    } else {
-      map.set(curr.tokenAddress, {
-        tokenAddress: curr.tokenAddress,
-        balance: +curr.balance,
-        category: curr.category,
-        token: curr.token,
+function buildTvl(mode) {
+  return async function(api) {
+    const chainConfig = chains[api.chain];
+    if (!chainConfig) return {};
+
+    const owners = await discoverOwners(api, chainConfig);
+    const ownSet = addressSet(chainConfig.ownTokens);
+    const polSet = addressSet(chainConfig.polTokens);
+    const liabilitySet = addressSet(chainConfig.liabilityTokens);
+    const blacklist = mode === 'ownTokens' ? [...polSet] : [...ownSet, ...polSet];
+
+    const sourceTokens = mode === 'ownTokens' ? chainConfig.ownTokens : chainConfig.treasuryTokens;
+    const tokens = (sourceTokens || []).filter(t => !liabilitySet.has(normalize(t)));
+
+    const convexRewardPools = mode === 'tvl' ? chainConfig.special?.convexRewardPools : undefined;
+    if ((tokens.length || convexRewardPools?.length) && owners.length) {
+      await sumTokens2({
+        api,
+        owners,
+        tokens,
+        convexRewardPools,
+        resolveLP: true,
+        permitFailure: true,
+        blacklistedTokens: blacklist,
       });
     }
-  }
-  return Array.from(map.values());
-}
 
-/**
- * Factory that returns an async TVL function for the given mode.
- *
- * Modes:
- * - 'tvl'       : Treasury assets excluding OHM/gOHM and Protocol-Owned Liquidity.
- *                 POL is tracked in Olympus treasury dashboards and excluded here
- *                 to avoid double-counting with the Uniswap V3 adapter.
- * - 'ownTokens' : Protocol-owned OHM and gOHM only.
- *
- * Note: 'borrowed' (Cooler Loans) is intentionally omitted — tracked separately
- * by the projects/cooler-loans adapter to avoid double-counting.
- *
- * @param {'tvl'|'ownTokens'} mode - Which subset of treasury records to return.
- * @returns {function(api: object): Promise<object>} Async TVL function for DeFiLlama.
- */
-function buildTvl(mode = 'tvl') {
-  return async function(api) {
-    if (!subgraphUrls[api.chain]) return {};
-
-    const indexedBlockForEndpoint = await blockQuery(subgraphUrls[api.chain], getLatestBlockIndexed, { api });
-    const latest = indexedBlockForEndpoint?.lastBlock?.[0];
-    if (!latest) throw new Error('no-indexed-block');
-
-    const blockNum = latest.block;
-    const lastTs = Number(latest.timestamp);
-
-    // Staleness guard (3 days)
-    const aDay = 24 * 3600;
-    const now = Date.now() / 1e3;
-    if (!Number.isFinite(lastTs) || now - lastTs > 3 * aDay) {
-      throw new Error("outdated");
+    if (mode === 'tvl' && chainConfig.special) {
+      await addLiabilities(api, owners, chainConfig.liabilityTokens || []);
+      await addMakerDsr(api, owners, chainConfig.special);
+      await addVeFxs(api, chainConfig.special);
+      await addFraxLocks(api, owners, chainConfig.special);
     }
 
-    const trResp = await blockQuery(subgraphUrls[api.chain], protocolQuery(blockNum), { api });
-    const tokenRecords = trResp?.tokenRecords || [];
-
-    // Exclude Protocol-Owned Liquidity and problematic pools from TVL.
-    // POL (Uniswap V3 LP positions) is tracked separately in Olympus treasury dashboards
-    // and is intentionally excluded here to avoid double-counting with the Uniswap V3 adapter.
-    const filteredTokenRecords = tokenRecords.filter(
-      (t) => t.category !== 'Protocol-Owned Liquidity' &&
-             !poolsWithoutDecimals.includes(t.tokenAddress)
-    );
-
-    // Normalize addresses for pricing
-    const normalizedRecords = filteredTokenRecords.map((token) => ({
-      ...token,
-      tokenAddress: addressMap[token.tokenAddress] || token.tokenAddress,
-    }));
-
-    const ownTokens = new Set(olympusTokens.map(i => i.toLowerCase()));
-
-    // Exclude borrowed records (Cooler Loans) from TVL/ownTokens — tracked separately.
-    const recordsToProcess = normalizedRecords.filter(t =>
-      !t.token?.includes('Borrowed Through Cooler Loans')
-    );
-
-    // Exclude specific arbitrum pool IDs that break pricing/decimals
-    let finalRecords = recordsToProcess;
-    if (api.chain === 'arbitrum') {
-      finalRecords = recordsToProcess.filter(i => ![
-        '0x89dc7e71e362faf88d92288fe2311d25c6a1b5e0000200000000000000000423',
-        '0xce6195089b302633ed60f3f427d1380f6a2bfbc7000200000000000000000424',
-      ].includes(i.tokenAddress));
-    }
-
-    const tokensToBalances = sumBalancesByTokenAddress(finalRecords);
-    const tokens = tokensToBalances.map(i => i.tokenAddress);
-    const decimals = await api.multiCall({ abi: 'erc20:decimals', calls: tokens, permitFailure: true });
-
-    tokensToBalances.forEach((token, i) => {
-      if (decimals[i] == null) return; // skip failed multiCall lookups; null-check avoids dropping 0-decimal tokens
-      const isOwn = ownTokens.has(token.tokenAddress.toLowerCase());
-
-      if (mode === 'ownTokens' && !isOwn) return;
-      if (mode === 'tvl' && isOwn) return;
-
-      if (token.balance < 0) {
-        // Cooler Loans debt records are filtered upstream; a negative here signals unexpected subgraph data.
-        console.warn(`[olympus] unexpected negative balance for ${token.tokenAddress}: ${token.balance} (mode=${mode}, chain=${api.chain})`);
-        return;
-      }
-
-      api.add(token.tokenAddress, token.balance * 10 ** decimals[i]);
-    });
-
-    return await sumTokens2({ api, resolveLP: true });
+    api.deleteTokens(blacklist);
   };
 }
 
@@ -185,20 +353,20 @@ module.exports = {
   start: '2021-03-24',
   timetravel: false,
   hallmarks: [
-    ["2021-03-24", "Olympus Launch"],
-    ["2021-10-19", "OHM v2 Migration begins"],
-    ["2022-01-21", "Inverse Bonds"],
-    ["2022-04-30", "Fei Protocol Hack"],
-    ["2022-11-17", "Range-Bound Stability Launch"],
-    ["2023-07-23", "Cooler Loans Launch"],
-    ["2024-09-20", "Yield Repurchase Facility"],
-    ["2024-10-01", "On-Chain Governance"],
-    ["2024-11-20", "Emissions Manager Launch"],
-    ["2025-01-15", "Cooler v2 Launch"],
-    ["2025-12-01", "Convertible Deposits Launch"],
-    ["2026-01-08", "CD Lending and Limit Orders"],
+    ['2021-03-24', 'Olympus Launch'],
+    ['2021-10-19', 'OHM v2 Migration begins'],
+    ['2022-01-21', 'Inverse Bonds'],
+    ['2022-04-30', 'Fei Protocol Hack'],
+    ['2022-11-17', 'Range-Bound Stability Launch'],
+    ['2023-07-23', 'Cooler Loans Launch'],
+    ['2024-09-20', 'Yield Repurchase Facility'],
+    ['2024-10-01', 'On-Chain Governance'],
+    ['2024-11-20', 'Emissions Manager Launch'],
+    ['2025-01-15', 'Cooler v2 Launch'],
+    ['2025-12-01', 'Convertible Deposits Launch'],
+    ['2026-01-08', 'CD Lending and Limit Orders'],
   ],
-  methodology: "Treasury value from subgraph excluding protocol-owned OHM and Protocol-Owned Liquidity. POL (Uniswap V3 LP positions) is tracked in Olympus treasury dashboards and excluded here to avoid double-counting with the Uniswap V3 adapter. Cooler Loans debt is tracked by the dedicated cooler-loans adapter.",
+  methodology: "Treasury balances are read directly on-chain. Owners include the Olympus DAO/policy/yield-farming multisigs plus the live TRSRY and cross-chain custodians discovered via the Bophades Kernel TRSRY + CHREG modules. Aave V3 yield-farming-loop debt (USDT/USDC) is subtracted as a liability. Cooler Loans funds are naturally excluded — lent USDS/DAI has left treasury wallets and is tracked by the dedicated cooler-loans adapter. Protocol-Owned Liquidity is excluded (counted by the Uniswap V3 adapter). OHM/sOHM/gOHM holdings in the treasury are reported under ownTokens.",
   ethereum: {
     tvl: buildTvl('tvl'),
     staking: staking(OlympusStakings, [OHM, OHM_V1]),
@@ -208,6 +376,9 @@ module.exports = {
     tvl: buildTvl('tvl'),
   },
   base: {
+    tvl: buildTvl('tvl'),
+  },
+  berachain: {
     tvl: buildTvl('tvl'),
   },
 };

--- a/projects/olympus/index.js
+++ b/projects/olympus/index.js
@@ -10,8 +10,10 @@ const SOHM_V1 = '0x31932e6e45012476ba3a3a4953cba62aee77fbbe';
 const SOHM_V2 = '0x04f2694c8fcee23e8fd0dfea1d4f5bb8c352111f';
 const SOHM_V3 = '0x04906695D6D12CF5459975d7C3C03356E4Ccd460';
 const WSOHM = '0xCa76543Cf381ebBB277bE79574059e32108e3E65';
+
 const AURA = '0xC0c293ce456fF0ED870ADd98a0828Dd4d2903DBF';
 const VEFXS = '0xc8418af6358ffdda74e09ca9cc3fe03ca6adc5b0';
+const JONES = '0x10393c20975cF177a3513071bC110f7962CD67da';
 
 // Address lists: https://docs.olympusdao.finance/main/contracts/addresses 
 // https://github.com/OlympusDAO/olympus-protocol-metrics-subgraph/blob/120b50a82d5f4be476201965ee3762710778eb92/subgraphs/ethereum/src/utils/Constants.ts
@@ -51,10 +53,6 @@ const ethereumOwners = [
   '0x9A315BdF513367C0377FB36545857d12e85813Ef',
   '0xa8687A15D4BE32CC8F0a8a7B9704a4C3993D9613',
   '0xde7b85f52577b113181921a7aa8fc0c22e309475',
-  '0xd6a6e8d9e82534bd65821142fccd91ec9cf31880',
-  '0xe6343ad0675c9b8d3f32679ae6adba0766a2ab4c',
-  '0x1e094fe00e13fd06d64eea4fb3cd912893606fe0',
-  '0xdb591Ea2e5Db886dA872654D58f6cc584b68e7cC',
   '0x2075e3b46470cfcE124Daaf52b46Dcf965727Dd1',
 ];
 
@@ -138,7 +136,6 @@ const chains = {
     special: {
       bophadesKernel: '0x2286d7f9639e8158FaD1169e76d1FbC38247f54b',
       keycodes: { TRSRY: '0x5452535259', CHREG: '0x4348524547' },
-      makerDsr: '0x197E90f9FAD81970bA7976f33CbD77088E5D7cf7',
       veFxs: {
         token: VEFXS,
         underlying: ADDRESSES.ethereum.FXS,
@@ -158,11 +155,12 @@ const chains = {
     },
   },
   arbitrum: {
-    owners: [...ethereumOwners, '0x012BBf0481b97170577745D2167ee14f63E2aD4C'],
+    owners: [ '0x012BBf0481b97170577745D2167ee14f63E2aD4C'],
     treasuryTokens: [
+      ADDRESSES.null,
       ADDRESSES.arbitrum.ARB,
       ADDRESSES.arbitrum.FRAX,
-      '0x10393c20975cf177a3513071bc110f7962cd67da', // JONES
+      JONES,
       '0xfb9E5D956D889D91a82737B9bFCDaC1DCE3e1449', // LQTY
       '0x93b346b6bc2548da6a1e7d98e9a421b42541425b', // LUSD
       '0x539bde0d7dbd336b79148aa742883198bbf60342', // MAGIC
@@ -175,10 +173,10 @@ const chains = {
       '0x8D9bA570D6cb60C7e3e0F31343Efe75AB8E65FB1', // gOHM (Arb)
     ],
     polTokens: [
-      '0xb3028ca124b80cfe6e9ca57b70ef2f0ccc41ebd40002000000000000000000ba',
-      '0xc61ff48f94d801c1ceface0289085197b5ec44f000020000000000000000004d',
-      '0x89dc7e71e362faf88d92288fe2311d25c6a1b5e0000200000000000000000423',
-      '0xce6195089b302633ed60f3f427d1380f6a2bfbc7000200000000000000000424',
+      '0xb3028ca124b80cfe6e9ca57b70ef2f0ccc41ebd4',
+      '0xc61ff48f94d801c1ceface0289085197b5ec44f0',
+      '0x89dc7e71e362faf88d92288fe2311d25c6a1b5e0',
+      '0xce6195089b302633ed60f3f427d1380f6a2bfbc7',
       '0xaa5bd49f2162ffdc15634c87a77ac67bd51c6a6d',
       '0x292d1587a6bb37e34574c9ad5993f221d8a5616c',
       '0xe8ee01ae5959d3231506fcdef2d5f3e85987a39c',
@@ -187,6 +185,9 @@ const chains = {
       '0xc6f780497a95e246eb9449f5e4770916dcd6396a',
       '0xc31e54c7a869b9fcbecc14363cf510d1c41fa443',
     ],
+    special: {
+      jonesStaking: '0xb94d1959084081c5a11C460012Ab522F5a0FD756'
+    },
   },
   base: {
     owners: ['0x18a390bD45bCc92652b9A91AD51Aed7f1c1358f5'],
@@ -220,6 +221,29 @@ const chains = {
       '0x555BAd9EC18dB19dED0057D2517242399d1c5D87',
       '0xa57Cb177Beebc35A1A26A286951a306d9B752524',
       '0x815596fa7c4d983d1ca5304e5b48978424c1b448',
+    ],
+  },
+  fantom: {
+    owners: ['0x2bc001ffeb862d843e0a02a7163c7d4828e5fb10'], // Cross-Chain Fantom custodian
+    treasuryTokens: [
+      ADDRESSES.fantom.WFTM,
+      '0x74b23882a30290451a17c44f4f05243b6b58c76d', // wETH (multichain bridge)
+      '0x10b620b2dbac4faa7d7ffd71da486f5d44cd86f9', // LQDR
+      '0xdc301622e621166bd8e82f2ca0a26c13ad0be355', // FRAX (multichain)
+      '0x841fad6eae12c286d1fd18d1d525dffa75c7effe', // BOO
+      '0xf24bcf4d1e507740041c9cfd2dddb29585adce1e', // BEETS
+      ADDRESSES.fantom.DAI,
+      ADDRESSES.fantom.USDC,
+    ],
+    ownTokens: ['0x91fa20244fb509e8289ca630e5db3e9166233fdc'], // gOHM (Fantom)
+    polTokens: [
+      '0xec7178f4c41f346b2721907f5cf7628e388a7a58', // BOO-WFTM
+      '0x4fe6f19031239f105f753d1df8a0d24857d0caa2', // LQDR-WFTM
+      '0x648a7452da25b4fb4bdb79badf374a8f8a5ea2b5', // WFTM-BEETS
+      '0xf0702249f4d3a25cd3ded7859a165693685ab577', // WFTM-ETH
+      '0xae9bba22e87866e48ccacff0689afaa41eb94995', // WFTM-gOHM
+      '0xcb6eab779780c7fd6d014ab90d8b10e97a1227e2', // WFTM-OXD
+      '0x2b4c76d0dc16be1c31d4c1dc53bf9b45987fc75c', // WFTM-USDC
     ],
   },
 };
@@ -257,17 +281,6 @@ async function discoverOwners(api, chainConfig) {
   return [...addressSet(owners)];
 }
 
-async function addMakerDsr(api, owners, special) {
-  if (!special.makerDsr) return;
-  const [pies, chi] = await Promise.all([
-    api.multiCall({ target: special.makerDsr, calls: owners, abi: 'function pie(address) view returns (uint256)', permitFailure: true }),
-    api.call({ target: special.makerDsr, abi: 'uint256:chi' }),
-  ]);
-  if (!chi) return;
-  const dai = pies.reduce((sum, pie) => sum.plus(new BigNumber(pie || 0).times(chi).div(1e27)), new BigNumber(0));
-  if (dai.gt(0)) api.add(ADDRESSES.ethereum.DAI, dai.toFixed(0));
-}
-
 async function addVeFxs(api, special) {
   if (!special.veFxs) return;
   const { token, underlying, owners } = special.veFxs;
@@ -283,16 +296,12 @@ async function addVeFxs(api, special) {
   });
 }
 
-async function addFraxLocks(api, owners, special) {
-  for (const lock of special.fraxLocks || []) {
-    const balances = await api.multiCall({
-      target: lock.target,
-      calls: owners,
-      abi: 'function lockedLiquidityOf(address account) view returns (uint256)',
-      permitFailure: true,
-    });
-    balances.forEach(b => { if (b) api.add(lock.token, b); });
-  }
+async function addJonesStaking(api, special, owners) {
+  if (!special.jonesStaking) return;
+
+  const calls = owners.map(o => {return {target: special.jonesStaking, params: [0, o]}})
+  const balances = await api.multiCall({owners, calls, abi: 'function userInfo(uint,address) returns(uint,int)'})
+  balances.forEach(b => { if (b) api.add(JONES, b.amount ?? b[0]) });
 }
 
 function buildTvl(mode) {
@@ -304,10 +313,9 @@ function buildTvl(mode) {
     const ownSet = addressSet(chainConfig.ownTokens);
     const polSet = addressSet(chainConfig.polTokens);
     const blacklist = mode === 'ownTokens' ? [...polSet] : [...ownSet, ...polSet];
-
     const tokens = mode === 'ownTokens' ? chainConfig.ownTokens : chainConfig.treasuryTokens;
-
     const convexRewardPools = mode === 'tvl' ? chainConfig.special?.convexRewardPools : undefined;
+    
     if ((tokens?.length || convexRewardPools?.length) && owners.length) {
       await sumTokens2({
         api,
@@ -321,12 +329,9 @@ function buildTvl(mode) {
     }
 
     if (mode === 'tvl' && chainConfig.special) {
-      await addMakerDsr(api, owners, chainConfig.special);
       await addVeFxs(api, chainConfig.special);
-      await addFraxLocks(api, owners, chainConfig.special);
+      await addJonesStaking(api, chainConfig.special, owners);
     }
-
-    api.deleteTokens(blacklist);
   };
 }
 
@@ -353,13 +358,8 @@ module.exports = {
     staking: staking(OlympusStakings, [OHM, OHM_V1]),
     ownTokens: buildTvl('ownTokens'),
   },
-  arbitrum: {
-    tvl: buildTvl('tvl'),
-  },
-  base: {
-    tvl: buildTvl('tvl'),
-  },
-  berachain: {
-    tvl: buildTvl('tvl'),
-  },
+  arbitrum: { tvl: buildTvl('tvl') },
+  base: { tvl: buildTvl('tvl') },
+  berachain: { tvl: buildTvl('tvl') },
+  fantom: { tvl: buildTvl('tvl') },
 };

--- a/projects/olympus/index.js
+++ b/projects/olympus/index.js
@@ -148,10 +148,6 @@ const chains = {
         '0xd683C7051a28fA150EB3F4BD92263865D4a67778',
         '0x27A8c58e3DE84280826d615D80ddb33930383fE9',
       ],
-      fraxLocks: [
-        { target: '0x963f487796d54d2f27bA6F3Fbe91154cA103b199', token: '0x3175Df0976dFA876431C2E9eE6Bc45b65d3473CC' },
-        { target: '0xc96e1a26264D965078bd01eaceB129A65C09FFE7', token: '0x5271045F7B73c17825A7A7aee6917eE46b0B7520' },
-      ],
     },
   },
   arbitrum: {

--- a/projects/olympus/index.js
+++ b/projects/olympus/index.js
@@ -101,38 +101,11 @@ const ethereumTreasuryTokens = [
   '0x43d4a3cd90ddd2f8f4f693170c9c8098163502ad',
 ];
 
-// Protocol-Owned Liquidity LP tokens.
-const ethereumPolTokens = [
-  '0xb23dfc0c4502a271976f1ee65321c51be2529640',
-  '0x622a725a79c7fe37ad839c640cd62d546712b3a9',
-  '0xc45d42f801105e861e86658648e3678ad7aa70f9',
-  '0x76fcf0e8c7ff37a47a799fa2cd4c13cde0d981c9',
-  '0xa02d8861fbfd0ba3d8ebafa447fe7680a3fa9a93',
-  '0xd1ec5e215e8148d76f4460e4097fd3d5ae0a3558',
-  '0x0ef97ef0e20f84e82ec2d79cbd9eda923c3daf09',
-  '0xd4f79ca0ac83192693bce4699d0c10c66aa6cf0f',
-  '0x32296969ef14eb0c6d29669c550d4a0449130230',
-  '0xfc1e8bf3e81383ef07be24c3fd146745719de48d',
-  '0x6ec38b3228251a0c5d491faf66858e2e23d7728b',
-  '0x38633ed142bcc8128b45ab04a2e4a6e53774699f',
-  '0x5769071665eb8db80e7e9226f92336bb2897dcfa',
-  '0x055475920a8c93cffb64d039a8205f7acc7722d3',
-  '0x34d7d7aaf50ad4944b70b320acb24c95fa2def7c',
-  '0x69b81152c5a8d35a67b32a4d3772795d96cae4da',
-  '0xfffae4a0f4ac251f4705717cd24cadccc9f33e06',
-  '0x46e4d8a1322b9448905225e52f914094dbd6dddf',
-  '0xfdf12d1f85b5082877a6e070524f50f6c84faa6b',
-  '0xe9ab8038ee6dd4fcc7612997fe28d4e22019c4b4',
-  '0x88051b0eea095007d3bef21ab287be961f3d8598',
-  '0x0858e2b0f9d75f7300b38d64482ac2c8df06a755',
-];
-
 const chains = {
   ethereum: {
     owners: ethereumOwners,
     treasuryTokens: ethereumTreasuryTokens,
     ownTokens: [OHM_V1, OHM, GOHM, SOHM_V1, SOHM_V2, SOHM_V3, WSOHM],
-    polTokens: ethereumPolTokens,
     special: {
       bophadesKernel: '0x2286d7f9639e8158FaD1169e76d1FbC38247f54b',
       keycodes: { TRSRY: '0x5452535259', CHREG: '0x4348524547' },
@@ -168,19 +141,6 @@ const chains = {
       '0xf0cb2dc0db5e6c66B9a70Ac27B06b878da017028', // OHM (Arb)
       '0x8D9bA570D6cb60C7e3e0F31343Efe75AB8E65FB1', // gOHM (Arb)
     ],
-    polTokens: [
-      '0xb3028ca124b80cfe6e9ca57b70ef2f0ccc41ebd4',
-      '0xc61ff48f94d801c1ceface0289085197b5ec44f0',
-      '0x89dc7e71e362faf88d92288fe2311d25c6a1b5e0',
-      '0xce6195089b302633ed60f3f427d1380f6a2bfbc7',
-      '0xaa5bd49f2162ffdc15634c87a77ac67bd51c6a6d',
-      '0x292d1587a6bb37e34574c9ad5993f221d8a5616c',
-      '0xe8ee01ae5959d3231506fcdef2d5f3e85987a39c',
-      '0xb7e50106a5bd3cf21af210a755f9c8740890a8c9',
-      '0x8aCd42e4B5A5750B44A28C5fb50906eBfF145359',
-      '0xc6f780497a95e246eb9449f5e4770916dcd6396a',
-      '0xc31e54c7a869b9fcbecc14363cf510d1c41fa443',
-    ],
     special: {
       jonesStaking: '0xb94d1959084081c5a11C460012Ab522F5a0FD756'
     },
@@ -189,10 +149,6 @@ const chains = {
     owners: ['0x18a390bD45bCc92652b9A91AD51Aed7f1c1358f5'],
     treasuryTokens: [ADDRESSES.base.USDC, ADDRESSES.base.WETH],
     ownTokens: ['0x060cb087a9730E13aa191f31A6d86bFF8DfcdCC0'], // OHM (Base)
-    polTokens: [
-      '0x5ab4b9e96aeed4820e4be267f42411d722985482',
-      '0x183ea22691c54806FE96555436dd312b6BeFAc2F',
-    ],
   },
   berachain: {
     owners: [
@@ -212,12 +168,6 @@ const chains = {
       ADDRESSES.berachain.WBERA,
     ],
     ownTokens: ['0x18878Df23e2a36f81e820e4b47b4A40576D3159C'], // OHM (Berachain)
-    polTokens: [
-      '0x98bDEEde9A45C28d229285d9d6e9139e9F505391',
-      '0x555BAd9EC18dB19dED0057D2517242399d1c5D87',
-      '0xa57Cb177Beebc35A1A26A286951a306d9B752524',
-      '0x815596fa7c4d983d1ca5304e5b48978424c1b448',
-    ],
   },
   fantom: {
     owners: ['0x2bc001ffeb862d843e0a02a7163c7d4828e5fb10'], // Cross-Chain Fantom custodian
@@ -232,15 +182,6 @@ const chains = {
       ADDRESSES.fantom.USDC,
     ],
     ownTokens: ['0x91fa20244fb509e8289ca630e5db3e9166233fdc'], // gOHM (Fantom)
-    polTokens: [
-      '0xec7178f4c41f346b2721907f5cf7628e388a7a58', // BOO-WFTM
-      '0x4fe6f19031239f105f753d1df8a0d24857d0caa2', // LQDR-WFTM
-      '0x648a7452da25b4fb4bdb79badf374a8f8a5ea2b5', // WFTM-BEETS
-      '0xf0702249f4d3a25cd3ded7859a165693685ab577', // WFTM-ETH
-      '0xae9bba22e87866e48ccacff0689afaa41eb94995', // WFTM-gOHM
-      '0xcb6eab779780c7fd6d014ab90d8b10e97a1227e2', // WFTM-OXD
-      '0x2b4c76d0dc16be1c31d4c1dc53bf9b45987fc75c', // WFTM-USDC
-    ],
   },
 };
 
@@ -307,8 +248,7 @@ function buildTvl(mode) {
 
     const owners = await discoverOwners(api, chainConfig);
     const ownSet = addressSet(chainConfig.ownTokens);
-    const polSet = addressSet(chainConfig.polTokens);
-    const blacklist = mode === 'ownTokens' ? [...polSet] : [...ownSet, ...polSet];
+    const blacklist = mode === 'ownTokens' ? [] : [...ownSet];
     const tokens = mode === 'ownTokens' ? chainConfig.ownTokens : chainConfig.treasuryTokens;
     const convexRewardPools = mode === 'tvl' ? chainConfig.special?.convexRewardPools : undefined;
     
@@ -348,7 +288,7 @@ module.exports = {
     ["2025-12-01", "Convertible Deposits Launch"],
     ["2026-01-08", "CD Lending and Limit Orders"],
   ],
-  methodology: "Treasury value from subgraph excluding protocol-owned OHM and Protocol-Owned Liquidity. POL (Uniswap V3 LP positions) is tracked in Olympus treasury dashboards and excluded here to avoid double-counting with the Uniswap V3 adapter. Cooler Loans debt is tracked by the dedicated cooler-loans adapter.",
+  methodology: "Total value held by treasury addresses and staking contracts excluding protocol-owned OHM and Protocol-Owned Liquidity. Cooler Loans debt is tracked by the dedicated cooler-loans adapter.",
   ethereum: {
     tvl: buildTvl('tvl'),
     staking: staking(OlympusStakings, [OHM, OHM_V1]),

--- a/projects/olympus/index.js
+++ b/projects/olympus/index.js
@@ -64,36 +64,36 @@ const ethereumTreasuryTokens = [
   '0x028171bca77440897b824ca71d1c56cac55b68a3', // aDAI
   '0x4579a27af00a62c0eb156349f31b345c08386419', // aLUSD
   '0x4f5923fc5fd4a93352581b38b7cd26943012decf', // aEthUSDe
-  '0x6df1c1e379bc5a00a7b4c6e67a203333772f45a8', // Aave V3 variableDebt USDT — yield-farming loop liability (excluded, subtracted via liabilityTokens)
-  '0x72e95b8931767c79ba4eee721354d6e99a61d004', // Aave V3 variableDebt USDC — yield-farming loop liability (excluded, subtracted via liabilityTokens)
-  '0x853d955acef822db058eb8505911ed77f175b99e', // FRAX
-  '0x5f98805a4e8be255a32880fdec7f6728c6568ba0', // LUSD
+  '0x6df1c1e379bc5a00a7b4c6e67a203333772f45a8', // variableDebtEthUSDT — yield-farming loop liability
+  '0x72e95b8931767c79ba4eee721354d6e99a61d004', // variableDebtEthUSDC — yield-farming loop liability
+  ADDRESSES.ethereum.FRAX,
+  ADDRESSES.ethereum.LUSD,
   ADDRESSES.ethereum.USDC,
-  '0xdAC17F958D2ee523a2206206994597C13D831ec7', // USDT
-  '0x4c9EDD5852cd905f086C759E8383e09bff1E68B3', // USDe
-  '0xdC035D45d973E3EC169d2276DDab16f1e407384F', // USDS
-  '0x83F20F44975D03b1b09e64809B757c47f942BEeA', // sDAI
-  '0x9D39A5DE30e57443BfF2A8307A4256c8797A3497', // sUSDe
-  '0xa3931d71877C0E7a3148CB7Eb4463524FEc27fbD', // sUSDS
+  ADDRESSES.ethereum.USDT,
+  ADDRESSES.ethereum.USDe,
+  ADDRESSES.ethereum.USDS, 
+  ADDRESSES.ethereum.SDAI, 
+  ADDRESSES.ethereum.sUSDe, 
+  ADDRESSES.ethereum.sUSDS,
   ADDRESSES.ethereum.WBTC,
   ADDRESSES.ethereum.WETH,
   ADDRESSES.ethereum.WSTETH,
-  '0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee', // weETH
+  ADDRESSES.ethereum.WEETH,
   AURA,
   '0x616e8BfA43F920657B3497DBf40D6b1A02D4608d', // auraBAL
   '0xba100000625a3754423978a60c9317c58a424e3D', // BAL
   ADDRESSES.ethereum.CVX,
-  ADDRESSES.ethereum.vlCVX,                    // priced server-side as CVX
-  '0xd18140b4b819b895a3dba5442f959fa44994af50', // vlCVX v1 (unpriced; add server pricing if balance grows)
-  '0x3Fa73f1E5d8A792C80F426fc8F84FBF7Ce9bBCAC', // vlAURA   (unpriced; add server pricing if balance grows)
-  '0x62b9c7356a2dc64a1969e19c23e4f579f9810aa7',
-  '0x3432b6a60d23ca0dfca7761b7ab56459d9c964d0',
-  '0x6dea81c8171d0ba574754ef6f8b412f2ed88c54d',
-  '0x5a98fcbea516cf06857215779fd812ca3bef1b32', // LDO
-  '0x6B3595068778DD592e39A122f4f5a5cF09C90fE2', // SUSHI
+  ADDRESSES.ethereum.vlCVX,                  
+  '0xd18140b4b819b895a3dba5442f959fa44994af50', // vlCVX v1
+  '0x3Fa73f1E5d8A792C80F426fc8F84FBF7Ce9bBCAC', // vlAURA 
+  ADDRESSES.ethereum.cvxCRV,
+  ADDRESSES.ethereum.FXS,
+  '0x6dea81c8171d0ba574754ef6f8b412f2ed88c54d', // LQTY
+  ADDRESSES.ethereum.LIDO,
+  ADDRESSES.ethereum.SUSHI, 
   '0x8798249c2e607446efb7ad49ec89dd1865ff4272', // xSUSHI
-  '0x2e9d63788249371f1dfc918a52f8d799f4a38c94',
-  '0xc7283b66Eb1EB5FB86327f08e1B5816b0720212B',
+  ADDRESSES.ethereum.TOKE,
+  '0xc7283b66Eb1EB5FB86327f08e1B5816b0720212B', // TRIBE
   '0xdbdb4d16eda451d0503b854cf79d55697f90c8df', // ALCX
   '0xc55126051b22ebb829d00368f4b12bde432de5da', // BTRFLY v2
   '0x742B70151cd3Bc7ab598aAFF1d54B90c3ebC6027', // rlBTRFLY
@@ -133,11 +133,6 @@ const chains = {
   ethereum: {
     owners: ethereumOwners,
     treasuryTokens: ethereumTreasuryTokens,
-    // Aave V3 variable debt tokens for Olympus's yield-farming leverage loop.
-    liabilityTokens: [
-      '0x6df1c1e379bc5a00a7b4c6e67a203333772f45a8', // variableDebtEthUSDT
-      '0x72e95b8931767c79ba4eee721354d6e99a61d004', // variableDebtEthUSDC
-    ],
     ownTokens: [OHM_V1, OHM, GOHM, SOHM_V1, SOHM_V2, SOHM_V3, WSOHM],
     polTokens: ethereumPolTokens,
     special: {
@@ -166,13 +161,13 @@ const chains = {
     owners: [...ethereumOwners, '0x012BBf0481b97170577745D2167ee14f63E2aD4C'],
     treasuryTokens: [
       ADDRESSES.arbitrum.ARB,
-      '0x17FC002b466eEc40DaE837Fc4bE5c67993ddBd6F',
-      '0x10393c20975cf177a3513071bc110f7962cd67da',
-      '0xfb9E5D956D889D91a82737B9bFCDaC1DCE3e1449',
-      '0x93b346b6bc2548da6a1e7d98e9a421b42541425b',
-      '0x539bde0d7dbd336b79148aa742883198bbf60342',
+      ADDRESSES.arbitrum.FRAX,
+      '0x10393c20975cf177a3513071bc110f7962cd67da', // JONES
+      '0xfb9E5D956D889D91a82737B9bFCDaC1DCE3e1449', // LQTY
+      '0x93b346b6bc2548da6a1e7d98e9a421b42541425b', // LUSD
+      '0x539bde0d7dbd336b79148aa742883198bbf60342', // MAGIC
       ADDRESSES.arbitrum.USDC,
-      '0xa684cd057951541187f288294a1e1c2646aa2d24',
+      '0xa684cd057951541187f288294a1e1c2646aa2d24', // VSTA
       ADDRESSES.arbitrum.WETH,
     ],
     ownTokens: [
@@ -262,15 +257,6 @@ async function discoverOwners(api, chainConfig) {
   return [...addressSet(owners)];
 }
 
-async function addLiabilities(api, owners, liabilityTokens) {
-  if (!liabilityTokens.length || !owners.length) return;
-  const calls = liabilityTokens.flatMap(t => owners.map(o => ({ target: t, params: [o] })));
-  const balances = await api.multiCall({ calls, abi: 'erc20:balanceOf', permitFailure: true });
-  balances.forEach((balance, i) => {
-    if (balance) api.add(calls[i].target, new BigNumber(balance).times(-1).toFixed(0));
-  });
-}
-
 async function addMakerDsr(api, owners, special) {
   if (!special.makerDsr) return;
   const [pies, chi] = await Promise.all([
@@ -317,14 +303,12 @@ function buildTvl(mode) {
     const owners = await discoverOwners(api, chainConfig);
     const ownSet = addressSet(chainConfig.ownTokens);
     const polSet = addressSet(chainConfig.polTokens);
-    const liabilitySet = addressSet(chainConfig.liabilityTokens);
     const blacklist = mode === 'ownTokens' ? [...polSet] : [...ownSet, ...polSet];
 
-    const sourceTokens = mode === 'ownTokens' ? chainConfig.ownTokens : chainConfig.treasuryTokens;
-    const tokens = (sourceTokens || []).filter(t => !liabilitySet.has(normalize(t)));
+    const tokens = mode === 'ownTokens' ? chainConfig.ownTokens : chainConfig.treasuryTokens;
 
     const convexRewardPools = mode === 'tvl' ? chainConfig.special?.convexRewardPools : undefined;
-    if ((tokens.length || convexRewardPools?.length) && owners.length) {
+    if ((tokens?.length || convexRewardPools?.length) && owners.length) {
       await sumTokens2({
         api,
         owners,
@@ -337,7 +321,6 @@ function buildTvl(mode) {
     }
 
     if (mode === 'tvl' && chainConfig.special) {
-      await addLiabilities(api, owners, chainConfig.liabilityTokens || []);
       await addMakerDsr(api, owners, chainConfig.special);
       await addVeFxs(api, chainConfig.special);
       await addFraxLocks(api, owners, chainConfig.special);

--- a/projects/olympus/index.js
+++ b/projects/olympus/index.js
@@ -13,7 +13,8 @@ const WSOHM = '0xCa76543Cf381ebBB277bE79574059e32108e3E65';
 const AURA = '0xC0c293ce456fF0ED870ADd98a0828Dd4d2903DBF';
 const VEFXS = '0xc8418af6358ffdda74e09ca9cc3fe03ca6adc5b0';
 
-// Address list: https://docs.olympusdao.finance/main/contracts/addresses
+// Address lists: https://docs.olympusdao.finance/main/contracts/addresses 
+// https://github.com/OlympusDAO/olympus-protocol-metrics-subgraph/blob/120b50a82d5f4be476201965ee3762710778eb92/subgraphs/ethereum/src/utils/Constants.ts
 const OlympusStakings = [
   "0x0822F3C03dcc24d200AFF33493Dc08d0e1f274A2", // Old Staking Contract
   "0xFd31c7d00Ca47653c6Ce64Af53c1571f9C36566a", // V1 Staking Contract
@@ -102,7 +103,7 @@ const ethereumTreasuryTokens = [
   '0x43d4a3cd90ddd2f8f4f693170c9c8098163502ad',
 ];
 
-// Protocol-Owned Liquidity LP tokens — tracked by the Uniswap V3 adapter, not counted here.
+// Protocol-Owned Liquidity LP tokens.
 const ethereumPolTokens = [
   '0xb23dfc0c4502a271976f1ee65321c51be2529640',
   '0x622a725a79c7fe37ad839c640cd62d546712b3a9',
@@ -133,8 +134,6 @@ const chains = {
     owners: ethereumOwners,
     treasuryTokens: ethereumTreasuryTokens,
     // Aave V3 variable debt tokens for Olympus's yield-farming leverage loop.
-    // Tracked as liabilities so the borrowed USDT/USDC net against the reinvested position.
-    // Currently $0 (loop inactive); sourced from Olympus's own subgraph Constants.ts.
     liabilityTokens: [
       '0x6df1c1e379bc5a00a7b4c6e67a203333772f45a8', // variableDebtEthUSDT
       '0x72e95b8931767c79ba4eee721354d6e99a61d004', // variableDebtEthUSDC
@@ -233,7 +232,6 @@ const chains = {
 const normalize = a => a && a.toLowerCase();
 const isAddress = a => !!a && /^0x[a-f0-9]{40}$/.test(normalize(a)) && normalize(a) !== ADDRESSES.null;
 const addressSet = (arr = []) => new Set(arr.filter(Boolean).map(normalize));
-const uniqueAddresses = arr => [...new Set(arr.filter(isAddress).map(a => a.toLowerCase()))];
 
 // Discover the live TRSRY and cross-chain treasury contracts from the Bophades Kernel.
 // Olympus can upgrade the TRSRY module via Kernel migration — never hardcode it.
@@ -261,7 +259,7 @@ async function discoverOwners(api, chainConfig) {
     }
   }
 
-  return uniqueAddresses(owners);
+  return [...addressSet(owners)];
 }
 
 async function addLiabilities(api, owners, liabilityTokens) {
@@ -353,20 +351,20 @@ module.exports = {
   start: '2021-03-24',
   timetravel: false,
   hallmarks: [
-    ['2021-03-24', 'Olympus Launch'],
-    ['2021-10-19', 'OHM v2 Migration begins'],
-    ['2022-01-21', 'Inverse Bonds'],
-    ['2022-04-30', 'Fei Protocol Hack'],
-    ['2022-11-17', 'Range-Bound Stability Launch'],
-    ['2023-07-23', 'Cooler Loans Launch'],
-    ['2024-09-20', 'Yield Repurchase Facility'],
-    ['2024-10-01', 'On-Chain Governance'],
-    ['2024-11-20', 'Emissions Manager Launch'],
-    ['2025-01-15', 'Cooler v2 Launch'],
-    ['2025-12-01', 'Convertible Deposits Launch'],
-    ['2026-01-08', 'CD Lending and Limit Orders'],
+    ["2021-03-24", "Olympus Launch"],
+    ["2021-10-19", "OHM v2 Migration begins"],
+    ["2022-01-21", "Inverse Bonds"],
+    ["2022-04-30", "Fei Protocol Hack"],
+    ["2022-11-17", "Range-Bound Stability Launch"],
+    ["2023-07-23", "Cooler Loans Launch"],
+    ["2024-09-20", "Yield Repurchase Facility"],
+    ["2024-10-01", "On-Chain Governance"],
+    ["2024-11-20", "Emissions Manager Launch"],
+    ["2025-01-15", "Cooler v2 Launch"],
+    ["2025-12-01", "Convertible Deposits Launch"],
+    ["2026-01-08", "CD Lending and Limit Orders"],
   ],
-  methodology: "Treasury balances are read directly on-chain. Owners include the Olympus DAO/policy/yield-farming multisigs plus the live TRSRY and cross-chain custodians discovered via the Bophades Kernel TRSRY + CHREG modules. Aave V3 yield-farming-loop debt (USDT/USDC) is subtracted as a liability. Cooler Loans funds are naturally excluded — lent USDS/DAI has left treasury wallets and is tracked by the dedicated cooler-loans adapter. Protocol-Owned Liquidity is excluded (counted by the Uniswap V3 adapter). OHM/sOHM/gOHM holdings in the treasury are reported under ownTokens.",
+  methodology: "Treasury value from subgraph excluding protocol-owned OHM and Protocol-Owned Liquidity. POL (Uniswap V3 LP positions) is tracked in Olympus treasury dashboards and excluded here to avoid double-counting with the Uniswap V3 adapter. Cooler Loans debt is tracked by the dedicated cooler-loans adapter.",
   ethereum: {
     tvl: buildTvl('tvl'),
     staking: staking(OlympusStakings, [OHM, OHM_V1]),

--- a/projects/treasury/olympus-dao.js
+++ b/projects/treasury/olympus-dao.js
@@ -1,4 +1,7 @@
-module.exports = require("../olympus/index");
+const index = require("../olympus/index");
+const ethereum = { ...index.ethereum };
 
-delete module.exports.ethereum.staking
-delete module.exports.ethereum.borrowed
+delete ethereum.staking
+delete ethereum.borrowed
+
+module.exports = { ...index, ethereum };


### PR DESCRIPTION
resolves #19033

- refactors #19194
- resolves #19054, #19121

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Berachain and Fantom TVL exports.
  * Switched TVL to config-driven, on-chain per-network computation.

* **Enhancements**
  * Dynamic owner discovery for improved treasury coverage.
  * Include veFXS underlying credits and JONES staking balances in TVL.
  * Stronger protection against double-counting between treasury and protocol-owned liquidity.

* **Bug Fixes**
  * Ethereum treasury export no longer exposes staking/borrowed fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19273?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->