### PR TITLE
Add ClawdStrategy

### DIFF
--- a/projects/clawdstrategy/index.js
+++ b/projects/clawdstrategy/index.js
@@ -1,0 +1,26 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+
+// ClawdStrategy STRI token on Base.
+// Each STRI is permanently minted at the immutable on-chain MINT_PRICE
+// (50 USDC, 6 decimals) and represents capital under management by the
+// protocol's AI trading agents. STRI itself is not redeemable for the
+// underlying USDC — the deposited capital is deployed into income
+// strategies that distribute Bitcoin (cbBTC) weekly to holders.
+const STRI = '0x014b5195DF372AFF57D7182c2A0fd3b202F707c3'
+
+async function tvl(api) {
+  const [totalSupply, mintPrice] = await Promise.all([
+    api.call({ abi: 'erc20:totalSupply', target: STRI }),
+    api.call({ abi: 'uint256:MINT_PRICE', target: STRI }),
+  ])
+  // STRI has 18 decimals, MINT_PRICE returns USDC raw (6 decimals).
+  // USDC equivalent (raw, 6 decimals) = totalSupply * MINT_PRICE / 1e18
+  const usdcAmount = (BigInt(totalSupply) * BigInt(mintPrice)) / (10n ** 18n)
+  api.add(ADDRESSES.base.USDC, usdcAmount.toString())
+}
+
+module.exports = {
+  methodology:
+    "TVL is calculated on-chain as STRI totalSupply() multiplied by the immutable MINT_PRICE() constant on the STRI contract (50 USDC, hardcoded in the smart contract). Each STRI token represents $50 of capital permanently committed to ClawdStrategy's AI income strategies on Base. Both values are read directly from the STRI contract at 0x014b5195DF372AFF57D7182c2A0fd3b202F707c3.",
+  base: { tvl },
+}


### PR DESCRIPTION
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
ClawdStrategy

##### Twitter Link:
https://x.com/ClawdStrategy

##### List of audit links if any:
None yet

##### Website Link:
https://clawdstrategy.com

##### Logo (High resolution, will be shown with rounded borders):
https://clawdstrategy.com/crab-logo.png

##### Current TVL:
~$14 (early launch, currently 0.28 STRI minted out of a 500,000 max supply; TVL grows by $50 per new STRI mint)

##### Treasury Addresses (if the protocol has treasury)
Base: \`0x0A5703883BB4983886212B7b32edCb526e68E847\`

##### Chain:
Base

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):
(not listed)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):
(not listed)

##### Short Description (to be shown on DefiLlama):
AI-powered Bitcoin income protocol on Base. Holders of STRI tokens receive cbBTC every week, distributed pro-rata from revenue generated by ClawdStrategy's AI trading agents. STRI mints at a fixed on-chain price of 50 USDC; max supply is 500,000.

##### Token address and ticker if any:
STRI — \`0x014b5195DF372AFF57D7182c2A0fd3b202F707c3\` (Base)

##### Category (full list at https://defillama.com/categories) *Please choose only one:
AI Agents

##### Oracle Provider(s):
None. STRI's mint price is a hardcoded immutable constant in the smart contract (\`MINT_PRICE = 50_000_000\` raw USDC). No external oracle is used for TVL computation.

##### Implementation Details:
TVL is derived from two on-chain reads on the STRI contract: \`totalSupply()\` and the immutable \`MINT_PRICE\` constant. Both are returned by view functions on the deployed contract — no oracle, no off-chain feed, no API.

##### Documentation/Proof:
- Contract on BaseScan (read \`totalSupply\` and \`MINT_PRICE\` directly): https://basescan.org/address/0x014b5195DF372AFF57D7182c2A0fd3b202F707c3#readContract
- What is STRI: https://clawdstrategy.com/insights/what-is-stri
- What is ClawdStrategy: https://clawdstrategy.com/insights/what-is-clawdstrategy

##### forkedFrom (Does your project originate from another project):
No, original protocol.

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL is computed on-chain as STRI \`totalSupply()\` × \`MINT_PRICE()\` on the STRI contract. \`MINT_PRICE\` is an immutable constant hardcoded at 50 USDC (50_000_000 raw with 6 decimals); \`totalSupply\` returns STRI in 18 decimals. Each STRI token represents \$50 of capital permanently committed to ClawdStrategy's AI income strategies on Base — no team allocation, no vesting, no pre-mine. The deposited capital is deployed by AI trading agents that generate weekly cbBTC distributions to all STRI holders pro-rata.

This represents AUM (Assets Under Management) by AI agents rather than traditional collateral-locked TVL: STRI is not redeemable for the underlying USDC — capital is permanently committed in exchange for the right to receive weekly cbBTC distributions for life.

##### Github org/user (Optional, if your code is open source, we can track activity):
N/A (private)

##### Does this project have a referral program?
No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ClawdStrategy STRI token TVL tracking on Base network, enabling real-time value calculations based on on-chain data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19274)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->