### PR TITLE
feat: add Brix (iTRY) TVL adapter

### DIFF
--- a/projects/brix/index.js
+++ b/projects/brix/index.js
@@ -1,0 +1,13 @@
+const ITRY_TOKEN = '0xb492B4aFD9658093694CF9452D5C272e8230F3B0';
+
+async function tvl(api) {
+  const totalSupply = await api.call({ abi: 'erc20:totalSupply', target: ITRY_TOKEN });
+  api.add(ITRY_TOKEN, totalSupply);
+}
+
+module.exports = {
+  methodology: 'TVL is the total iTRY supply on Ethereum. iTRY is a TRY-pegged stablecoin backed 1:1 by fund shares of the Digital Liquidity Fund (BVI professional fund). Cross-chain iTRY is locked in the LayerZero OFT adapter on Ethereum, so Ethereum totalSupply covers all chains.',
+  ethereum: {
+    tvl,
+  },
+};


### PR DESCRIPTION
## Summary

Adds a TVL adapter for Brix, a TRY-pegged stablecoin protocol operated by Almagest Labs (Switzerland).

## Methodology

```
TVL = totalSupply(iTRY) on Ethereum
```

iTRY is a TRY-pegged stablecoin backed 1:1 by fund shares of the Digital Liquidity Fund (BVI professional fund, fund-managed by Inverter Approved Manager Ltd).

- **Ethereum only.** LayerZero OFT locks tokens on Ethereum when bridging to MegaETH, so Ethereum `totalSupply()` covers all chains. Adding MegaETH would double-count.
- **No separate staking bucket.** Staked iTRY in the wiTRY contract is not broken out — the product does not present staking as a user-facing TVL primitive yet. wiTRY shows up as a separate pool in the yield adapter PR submitted in parallel to yield-server.

## Contracts (Ethereum mainnet)

- iTRY: `0xb492B4aFD9658093694CF9452D5C272e8230F3B0`

## Local test

```bash
$ node test.js projects/brix/index.js
--- ethereum ---
Total: 0.00 

--- tvl ---
Total: 0.00 

------ TVL ------
ethereum                  0.00

total                     0.00
```

USD value reads `0` because iTRY does not yet have a price source in `coins.llama.fi`. A parallel price adapter PR is being submitted to `DefiLlama/defillama-server` (`coins/src/adapters/rwa/brix.ts`); once it merges, TVL USD values populate.

## Project info

- App: https://app.brix.money
- Marketing: https://www.brix.money

I've ticked **Allow edits by maintainers**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added iTRY stablecoin total value locked (TVL) tracking on Ethereum network with support for cross-chain locked assets through LayerZero integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19278)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->