### PR TITLE
phoenix: add USDe (sUSDe) yield strategy

### DIFF
--- a/projects/phoenix-protocol/index.js
+++ b/projects/phoenix-protocol/index.js
@@ -3,6 +3,7 @@ const { sumTokensExport } = require("../helper/unwrapLPs");
 const tokensAndOwners = [
     ['0x79eB84B5E30Ef2481c8f00fD0Aa7aAd6Ac0AA54d', '0xE7aEC21BF6420FF483107adCB9360C4b31d69D78'], // autoDOLA in YieldStrategyDola
     ['0xa7569A44f348d3D70d8ad5889e50F78E33d80D35', '0x8b4A75290A1C4935eC1dfd990374AC4BD4D33952'], // autoUSDC in YieldStrategyUSDC
+    ['0x9D39A5DE30e57443BfF2A8307A4256c8797A3497', '0xFc629bC5F6339F77635f4F656FBb114A31F7bCB3'], // sUSDe in YieldStrategyUSDe
 ]
 
 module.exports = {


### PR DESCRIPTION
Adds the third yield strategy in the Phoenix Protocol minter — USDe held via Ethena's sUSDe (ERC4626 vault) — to the TVL adapter.

- `YieldStrategyUSDe`: `0xFc629bC5F6339F77635f4F656FBb114A31F7bCB3`
- `sUSDe` (vault held by the strategy): `0x9D39A5DE30e57443BfF2A8307A4256c8797A3497`

Unlike the DOLA / USDC strategies (which use Tokemak `AutoDOLA` / `AutoUSDC`), the USDe strategy holds Ethena's `sUSDe` directly. `doublecounted: true` is already set on the adapter, so this correctly avoids inflating aggregate TVL where Ethena already counts the underlying.

Local test:

```
--- ethereum ---
autoDOLA   11.96 k
autoUSD    10.29 k
sUSDe       3.77 k
Total:     26.01 k
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sUSDe (YieldStrategyUSDe) to TVL tracking, expanding yield strategy asset coverage and improving total value lock calculations across the protocol.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19281)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->