### PR TITLE
fix multipli: replace fetch with on-chain accounting (#19200)

### DIFF
--- a/projects/multipli/index.js
+++ b/projects/multipli/index.js
@@ -1,11 +1,34 @@
-const axios = require('axios')
-const API = "https://api.multipli.fi/multipli/v1/external-aggregator/defillama/tvl/"
+const ADDRESSES = require('../helper/coreAssets.json')
+const { sumTokensExport } = require('../helper/unwrapLPs')
 
-const tvl = async (api) => {
-  const { data } = await axios.get(API)
-  return data.payload[api.chain]
+// On-chain accounting per issue #19200. Counts only on-chain balances of
+// underlying assets at verified Multipli vault and fund-manager addresses.
+// Self-issued shares (rwaUSDi) and off-chain/custodial claims are excluded.
+
+const avaxOwners = [
+  '0xCF0Eb4ac018C06a16ED5c63484823C7805e7599D', // xUSDC vault
+  '0x01e676EAA0C9780A88395c651349Cf08Fe52368e', // xUSDC fund manager
+  '0x468BbabAEf852C134b584382C0fef83F2954Cd5c', // xBTC.b vault
+  '0x62c2181618833b202e68b5addc4279542978Ef47', // xBTC.b fund manager
+]
+
+const monadOwners = [
+  '0xd74FB32112b1eF5b4C428Fead8dA8d85A0019009', // xUSDC vault
+  '0xE1824bF952bB2E8414d12de8A9fc2cBc666D6758', // xUSDC fund manager
+]
+
+module.exports = {
+  methodology: 'TVL is the on-chain balance of underlying assets (USDC, BTC.b) at verified Multipli vault and fund-manager addresses. Self-issued shares (rwaUSDi) and off-chain custodial claims are excluded.',
+  avax: {
+    tvl: sumTokensExport({
+      owners: avaxOwners,
+      tokens: [ADDRESSES.avax.USDC, ADDRESSES.avax.BTC_b],
+    }),
+  },
+  monad: {
+    tvl: sumTokensExport({
+      owners: monadOwners,
+      tokens: [ADDRESSES.monad.USDC],
+    }),
+  },
 }
-
-const chains = ['ethereum', 'bsc', 'avax', 'base', 'monad', 'arbitrum']
-module.exports.timetravel = false
-chains.forEach(chain => { module.exports[chain] = { tvl } })


### PR DESCRIPTION
Closes #19200.

## Summary

The Multipli adapter at `projects/multipli/index.js` was fetching TVL from `https://api.multipli.fi/.../defillama/tvl/` and returning the payload directly. As documented in #19200, that payload included:

- **Self-issued protocol tokens** (rwaUSDi at `0xd74F…9009` on Base and `0xa399…d0f4` on Ethereum) whose vaults' `asset()` is the same protocol-issued token.
- **Off-chain / custodial claims** (USDC/USDT/WBTC amounts not present at the reported contracts).

This PR replaces the fetch with on-chain balance accounting at verified vault and fund-manager addresses. Self-issued shares and off-chain claims are excluded.

## What's tracked now

| Chain | Addresses | Tokens |
|---|---|---|
| Avalanche | `0xCF0E…45AB` xUSDC vault, `0x01e6…68e` xUSDC FM, `0x468B…Cd5c` xBTC.b vault, `0x62c2…Ef47` xBTC.b FM | USDC, BTC.b |
| Monad | `0xd74F…9009` xUSDC vault, `0xE182…6758` xUSDC FM | USDC |

Local `node test.js projects/multipli/index.js`:

\`\`\`
--- monad ---
USDC                      7.85 k
--- avax ---
AvalancheUSDC             2.64 k
btc.b                     227.89
------ TVL ------
monad                     7.85 k
avax                      2.87 k
total                    10.72 k
\`\`\`

## What's intentionally dropped

The previous adapter listed `ethereum`, `bsc`, `base`, and `arbitrum`. None of those have verified on-chain backing per the investigation in #19200, so they're dropped. Multipli can reopen them by disclosing verified vault/fund-manager addresses for those chains.

Allow edits by maintainers: enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * TVL computation for Avalanche and Monad now uses on-chain token balances (verified owner addresses) instead of external API data; only underlying assets are counted and off-chain/custodial/self-issued claims are excluded.
  * PR also adds a clear methodology description alongside the chain-specific TVL outputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19283)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->