### PR TITLE
Add Aurum (BSC) TVL adapter

### DIFF
--- a/projects/aurum/index.js
+++ b/projects/aurum/index.js
@@ -1,0 +1,16 @@
+const ARM     = "0xAEb0EB3628eAE1B36Ac94FE1033530342ADE0E26";
+const STAKING = "0x02Ef1BAD5aac23366A94110517d46cE4EAb7351C";
+
+async function staking(api) {
+  const totalStaked = await api.call({ target: STAKING, abi: "uint256:totalStaked" });
+  api.add(ARM, totalStaked);
+}
+
+module.exports = {
+  methodology:
+    "TVL is the ARM principal staked by users in the Aurum staking pool. Read from the on-chain `totalStaked()` accumulator on the staking contract, which excludes the rewards bucket. ARM is the protocol's native token, so the figure is reported under the `staking` bucket.",
+  bsc: {
+    tvl: () => ({}),
+    staking,
+  },
+};


### PR DESCRIPTION
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
Aurum

##### Twitter Link:
https://x.com/AurumBSC

##### List of audit links if any:
None yet — independent audit scheduled for Q3 2026 (disclosed in whitepaper).

##### Website Link:
https://aurumswap.finance

##### Logo (High resolution, will be shown with rounded borders):
https://aurumswap.finance/arm-logo.png

##### Current TVL:
Live — read on-chain via `totalStaked()` on the staking contract. Currently bootstrapping after Q2 2026 mainnet redeploy.

##### Treasury Addresses (if the protocol has treasury)
None tracked yet — protocol uses a flat BNB fee model, no large stablecoin treasury.

##### Chain:
BNB Smart Chain (bsc)

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):
Not yet listed — application in progress.

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):
Not yet listed — application in progress.

##### Short Description (to be shown on DefiLlama):
Non-custodial, time-locked staking on BSC. Variable APR snapshotted per stake. Quadratic burn on early exit. Oracle-bounded one-click zap from USDT/BNB into a staked ARM position.

##### Token address and ticker if any:
ARM — `0xAEb0EB3628eAE1B36Ac94FE1033530342ADE0E26`

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Staking

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
Chainlink

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
The Zap contract reads Chainlink BNB/USD and USDT/USD price feeds and bounds every swap-and-stake output to ±5% of the oracle-implied fair price. If the PancakeSwap V3 pool drifts beyond that tolerance, the transaction reverts — protecting users from sandwich attacks. The staking pool itself does not use an oracle; APR is snapshotted at deposit time.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
- Whitepaper §09 (Zap & Liquidity) and §10 (Security Model): https://aurumswap.finance/whitepaper
- Verified Zap source on BscScan: https://bscscan.com/address/0x7f0eCd589D30FBF26bCD77a0394eb9C3E65925A6#code

##### forkedFrom (Does your project originate from another project):
No — original code.

##### methodology (what is being counted as tvl, how is tvl being calculated):
The adapter reads the on-chain `totalStaked` accumulator on the staking contract (`0x02Ef1BAD5aac23366A94110517d46cE4EAb7351C`). This value is updated atomically inside `stake()` (incremented) and `exit()` (decremented), and represents exactly the sum of user principal currently locked. It does **not** include the protocol's rewards bucket, even though that ARM is held by the same contract, because rewards are protocol-owned future-payout capital, not user TVL.

Reported under the `staking` bucket since ARM is the protocol's own token.

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/FerUrdanetaDev/AurumSwap (private during launch period; contracts publicly verified on BscScan)

Verified contracts:
- ARM Token: https://bscscan.com/address/0xAEb0EB3628eAE1B36Ac94FE1033530342ADE0E26#code
- Staking: https://bscscan.com/address/0x02Ef1BAD5aac23366A94110517d46cE4EAb7351C#code
- Zap: https://bscscan.com/address/0x7f0eCd589D30FBF26bCD77a0394eb9C3E65925A6#code

##### Does this project have a referral program?
Yes — 10% bonus on the referee's accrued rewards, paid in ARM, vested linearly over the referee's lock period. Self-referral is blocked at the contract level. Documented in whitepaper §08.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Aurum staking metrics for Binance Smart Chain are now integrated
  * Users can track and monitor Aurum staking activity with real-time total staked value data
  * Complete visibility into Aurum's BSC staking performance is now available

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19285)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->