### PR TITLE
Add W Chain RPC defaults for Wswap TVL

### DIFF
--- a/projects/helper/env.js
+++ b/projects/helper/env.js
@@ -50,6 +50,8 @@ const DEFAULTS = {
   WHITELISTED_MORPH_RPC: 'https://explorer.morphl2.io/api/eth-rpc',
   BCYPHER_RPC: "https://mainapi.bchscan.io,https://datahub-asia01.bchscan.io,https://datahub-asia02.bchscan.io",
   PHAROS_RPC_MULTICALL: "0xca11bde05977b3631167028862be2a173976ca11",  // v3
+  WCHAIN_RPC: "https://rpc.w-chain.com",
+  WCHAIN_RPC_CHAIN_ID: "171717",
 }
 
 const ENV_KEYS = [


### PR DESCRIPTION
## Summary

This PR adds default W Chain RPC configuration so the existing registry-backed Wswap adapter can run reliably.

This is **not a new protocol listing**. Wswap and Wswap Bridge are already listed, and this PR only fixes runtime RPC configuration for the existing Wswap TVL adapter.

## Existing Wswap Adapter

Wswap is already configured in `registries/uniswapV2.js` as a Uniswap V2-style DEX:

```js
'wswap': {
  wchain: '0x2A44f013aD7D6a1083d8F499605Cf1148fbaCE31',
  ethereum: '0x46B0B17Bb1f637CcfFA9fCc34bD591E3A0fF58F9',
  bsc: '0x5105989c863e801fC610396529BE9f2A6B95bF0A',
},
```

No `projects/wswap/index.js` file is needed because the registry exports this adapter as `wswap/index.js`.

## What Changed

Added W Chain RPC defaults in `projects/helper/env.js`:

```js
WCHAIN_RPC: "https://rpc.w-chain.com",
WCHAIN_RPC_CHAIN_ID: "171717",
```

## Why This Is Needed

The Wswap adapter reads pool data from the Wswap factory on W Chain. Without a default RPC for `wchain`, adapter execution can fail or return empty W Chain TVL data when no RPC is manually injected into the runtime.

After adding the default RPC values, the existing registry adapter successfully reads the W Chain factory and returns TVL.

## Validation

Ran:

```bash
node test.js wswap/index.js
```

Result summary:

```text
wchain:   ~136.99k
ethereum: ~4.00
bsc:      0.00
total:    ~136.99k
```

Also ran:

```bash
node test.js projects/wswap-bridge/index.js
```

Result summary:

```text
ethereum: ~20.98k
bsc:      ~6.74k
total:    ~27.72k
```

## Notes

- No new npm dependencies added.
- No lockfiles changed.
- No `projects/wswap` folder added because Wswap is intentionally registry-backed through `registries/uniswapV2.js`.
- This PR does not update listing metadata such as website, GitHub, Twitter, or description. Listing metadata is handled separately in `DefiLlama/defillama-server`.
- A separate PR will be raised in `defillama-server` to update the Wswap Bridge GitHub link.