### PR TITLE
Morpho Blue: blacklist sdeUSD/USDC market on Ethereum

### DIFF
--- a/projects/morpho-blue/index.js
+++ b/projects/morpho-blue/index.js
@@ -22,6 +22,8 @@ const config = {
       "0x8e7cc042d739a365c43d0a52d5f24160fa7ae9b7e7c9a479bd02a56041d4cf77",
       "0xcc39b6c92fd03ac608b9239618db8b80a4a2034b0450bdf47b404229571312da",
       "0x1cfdc0154ae6b9f1887a8250f2582d55606e1a2008e65108fb83dd50a928593e",
+
+      "0x0f9563442d64ab3bd3bcb27058db0b0d4046a4c46f0acd811dacae9551d2b129", // sdeUSD/USDC (91.5% LLTV) bad debt from sdeUSD exploit (Nov 2025)
     ],
   },
   base: {


### PR DESCRIPTION
## Summary
- Blacklists market `0x0f9563442d64ab3bd3bcb27058db0b0d4046a4c46f0acd811dacae9551d2b129` (sdeUSD/USDC, 91.5% LLTV) on Ethereum Morpho Blue
- This market accrued bad debt following the early-November 2025 sdeUSD exploit. Excluding it from the adapter keeps Ethereum Morpho Blue TVL accurate by avoiding artifacts from the stuck under-collateralised position and any subsequent `AccrueInterest` spikes (same pattern as the earlier Resolv / Kinto blacklists).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Excluded a Morpho Blue market affected by an sdeUSD exploit from market metrics calculations to prevent bad debt from impacting platform reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19290)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->