### PR TITLE
Add Feather Curator on Kaia

### DIFF
--- a/projects/feather/index.js
+++ b/projects/feather/index.js
@@ -17,6 +17,11 @@ const configs = {
         '0x81c76F62f7E05DEC75800150bA5A23f62e2f091F',
       ],
     },
+    klaytn: {
+      morphoVaultOwners: [
+        '0x6Ba8f7039bC7d79c1959cB8E409Dff2ba05A133E',
+      ],
+    },
   }
 }
 

--- a/projects/helper/curators/configs.js
+++ b/projects/helper/curators/configs.js
@@ -203,7 +203,7 @@ const MorphoConfigs = {
     vaultFactoriesV2: [
       {
         address: '0xf2Aecd4a4d4C21d08770e34F392C4C271aBD9144',
-        fromBlock: 208021118,
+        fromBlock: 213463014,
       }
     ]
   }

--- a/projects/helper/curators/configs.js
+++ b/projects/helper/curators/configs.js
@@ -198,6 +198,14 @@ const MorphoConfigs = {
         fromBlock: 40259931,
       }
     ]
+  },
+  klaytn: {
+    vaultFactoriesV2: [
+      {
+        address: '0xf2Aecd4a4d4C21d08770e34F392C4C271aBD9144',
+        fromBlock: 208021118,
+      }
+    ]
   }
 }
 


### PR DESCRIPTION
## Summary
- Add Kaia (chain key `klaytn`) support to the Feather curator adapter, dynamically discovering Morpho V2 vaults via the `VaultV2Factory`.
- Register Kaia under `MorphoConfigs` with the `VaultV2Factory` at `0xf2Aecd4a4d4C21d08770e34F392C4C271aBD9144` (fromBlock `208021118`).
- Track vaults owned by `0x6Ba8f7039bC7d79c1959cB8E409Dff2ba05A133E`.

Vaults on this market:
FeatherUSDT (USD₮): 0x32936d1bebDdB4B85018AAcb9b119748C65a76bb
FeatherKAIA (WKLAY): 0xA8d31bF381256d097FfFA3F1E6d57C1419741A9D

## Test plan
- [ ] Verify Kaia TVL includes both vaults
- [ ] Verify no regression on other chains (sei, celo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Klaytn blockchain support: Morpho vault and vault factory configurations were introduced to enable discovery and management of vaults on the Klaytn network. This expands the platform's blockchain coverage and lets users view and manage Klaytn-based vaults alongside existing networks, improving cross-chain asset visibility and operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19291)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->