### PR TITLE
fix rocket-vault: replace dead fetch with on-chain balance reads

### DIFF
--- a/projects/rocket-vault/index.js
+++ b/projects/rocket-vault/index.js
@@ -1,25 +1,25 @@
-const axios = require('axios')
+const ADDRESSES = require('../helper/coreAssets.json')
+const { sumTokensExport } = require('../helper/unwrapLPs')
 
-const ROCKET_API = "https://beta.rocket-cluster-1.com";
-const VAULT_ADDRESS = "0x6BC2179a284CB2A2857C379391E0158524de7cA0";
-
-const tvl = async (api) => {
-  const { data } = await axios.get(`${ROCKET_API}/vaults`)
-  let vaults = data.vaults.map(({ address }) => address)
-  if (!vaults.length) vaults = [VAULT_ADDRESS]
-
-  let total = 0
-  for (const vault of vaults) {
-    const { data } = await axios.get(`${ROCKET_API}/collateral?account=${encodeURIComponent(vault)}`)
-    total += Object.values(data.collaterals).reduce((sum, v) => sum + Number(v), 0)
-  }
-  api.addUSDValue(total)
-}
+// Rocket Liquidity Provider main vault on Arbitrum.
+// On-chain replacement for the previous fetch from `beta.rocket-cluster-1.com`,
+// which is unreachable.
+const VAULT = '0x6BC2179a284CB2A2857C379391E0158524de7cA0'
 
 module.exports = {
   timetravel: false,
   misrepresentedTokens: false,
   doublecounted: true,
-  methodology: "TVL is calculated by summing all USDC collateral deposited in Rocket Liquidity Provider vaults",
-  arbitrum: { tvl },
-};
+  methodology: 'TVL is the on-chain stablecoin balance held at the Rocket Liquidity Provider vault on Arbitrum.',
+  arbitrum: {
+    tvl: sumTokensExport({
+      owners: [VAULT],
+      tokens: [
+        ADDRESSES.arbitrum.USDC_CIRCLE,
+        ADDRESSES.arbitrum.USDC,
+        ADDRESSES.arbitrum.USDT,
+        ADDRESSES.arbitrum.DAI,
+      ],
+    }),
+  },
+}


### PR DESCRIPTION
The adapter previously fetched TVL from `https://beta.rocket-cluster-1.com` (vault list + per-vault collateral). That host is unreachable, so the adapter has been silently broken.

This PR replaces the fetch with direct on-chain reads of the Rocket Liquidity Provider vault `0x6BC2179a284CB2A2857C379391E0158524de7cA0` on Arbitrum, summing balances of the common stablecoins (USDC, USDC.e, USDT, DAI).

Local \`node test.js projects/rocket-vault/index.js\`:

\`\`\`
------ TVL ------
arbitrum                  0.00
total                     0.00
\`\`\`

Direct on-chain spot-check at the vault address confirms 0 for each token (USDC, USDC.e, USDT, DAI, WETH, WBTC). The vault is currently empty / the protocol appears dormant — if it fills up again, the new accounting will pick it up. If the team prefers to retire the listing entirely, happy to follow up with a removal PR.

Aligned with the maintainer guidance in #16930 (TVL must be computed from on-chain calls, not closed APIs). \`doublecounted: true\` preserved from the original.

Allow edits by maintainers: enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Rocket Vault TVL calculation to derive directly from on-chain stablecoin balances instead of external API calls.
  * Refreshed methodology documentation to reflect the new on-chain data source.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19292)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->