### PR TITLE
feat: add MyRxWallet DEX TVL adapter (MYRX-MAINNET Chain 8472)

### DIFF
--- a/projects/helper/chains.json
+++ b/projects/helper/chains.json
@@ -291,6 +291,7 @@
   "muuchain",
   "mvc",
   "mxczkevm",
+  "myrx",
   "nahmii",
   "naka",
   "namada",

--- a/projects/myrxwallet/index.js
+++ b/projects/myrxwallet/index.js
@@ -1,0 +1,61 @@
+// DefiLlama TVL Adapter -- MyRxWallet DEX (MYRX-MAINNET, Chain 8472)
+// Tracks liquidity in WMRT/WBTC and WMRT/MUSD pairs
+
+const RPC = 'https://rpc.myrxwallet.io'
+
+const WMRT_WBTC_PAIR = '0x16Bf6e74B9feE4306a7D268468Fc4d45C2F4B0C3'
+const WMRT_MUSD_PAIR = '0xf1946991eA67CdBB8d74b3124003D55A2069bd2e'
+const WMRT           = '0x00e69754c21090d69D29a2abe3B6CF153D3F1dF7'
+
+async function ethCall(target, data) {
+  const res = await fetch(RPC, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', method: 'eth_call', params: [{ to: target, data }, 'latest'], id: 1 }),
+  })
+  const json = await res.json()
+  if (json.error) throw new Error(json.error.message)
+  return json.result
+}
+
+function parseReserves(raw) {
+  return [BigInt('0x' + raw.slice(2, 66)), BigInt('0x' + raw.slice(66, 130))]
+}
+
+async function tvl(api) {
+  const [raw0, tok0r0] = await Promise.all([
+    ethCall(WMRT_WBTC_PAIR, '0x0902f1ac'),
+    ethCall(WMRT_WBTC_PAIR, '0x0dfe1681'),
+  ])
+  const [r0a, r0b] = parseReserves(raw0)
+  const tok0_wbtc = ('0x' + tok0r0.slice(-40)).toLowerCase()
+  const [wmrt0, wbtc0] = tok0_wbtc === WMRT.toLowerCase() ? [r0a, r0b] : [r0b, r0a]
+
+  api.add('bitcoin', Number(wbtc0) / 1e8)
+  if (wmrt0 > 0n && wbtc0 > 0n) {
+    const wmrtPriceBtc = Number(wbtc0) / 1e8 / (Number(wmrt0) / 1e18)
+    api.add('bitcoin', (Number(wmrt0) / 1e18) * wmrtPriceBtc)
+  }
+
+  const [raw1, tok0r1] = await Promise.all([
+    ethCall(WMRT_MUSD_PAIR, '0x0902f1ac'),
+    ethCall(WMRT_MUSD_PAIR, '0x0dfe1681'),
+  ])
+  const [r1a, r1b] = parseReserves(raw1)
+  const tok0_musd = ('0x' + tok0r1.slice(-40)).toLowerCase()
+  const [wmrt1, musd1] = tok0_musd === WMRT.toLowerCase() ? [r1a, r1b] : [r1b, r1a]
+
+  api.add('usd-coin', Number(musd1) / 1e8)
+  if (wmrt1 > 0n && musd1 > 0n) {
+    const wmrtPriceUsd = (Number(musd1) / 1e8) / (Number(wmrt1) / 1e18)
+    api.add('usd-coin', (Number(wmrt1) / 1e18) * wmrtPriceUsd)
+  }
+}
+
+module.exports = {
+  timetravel: false,
+  misrepresentedTokens: false,
+  methodology: 'Sums token reserves in WMRT/WBTC and WMRT/MUSD DEX pairs on MYRX-MAINNET (Chain 8472). WBTC valued as BTC. MUSD is a USD-pegged stablecoin at 1 USD.',
+  start: 1747267200,
+  myrx: { tvl },
+}

--- a/projects/myrxwallet/index.js
+++ b/projects/myrxwallet/index.js
@@ -1,61 +1,65 @@
 // DefiLlama TVL Adapter -- MyRxWallet DEX (MYRX-MAINNET, Chain 8472)
-// Tracks liquidity in WMRT/WBTC and WMRT/MUSD pairs
+// Healthcare-native blockchain rails: payment layer for patients, providers, and pharmacies.
 
-const RPC = 'https://rpc.myrxwallet.io'
-
-const WMRT_WBTC_PAIR = '0x16Bf6e74B9feE4306a7D268468Fc4d45C2F4B0C3'
-const WMRT_MUSD_PAIR = '0xf1946991eA67CdBB8d74b3124003D55A2069bd2e'
-const WMRT           = '0x00e69754c21090d69D29a2abe3B6CF153D3F1dF7'
+const RPC            = "https://rpc.myrxwallet.io";
+const WMRT_WBTC_PAIR = "0x16Bf6e74B9feE4306a7D268468Fc4d45C2F4B0C3";
+const WMRT_MUSD_PAIR = "0xf1946991eA67CdBB8d74b3124003D55A2069bd2e";
+const WMRT           = "0x00e69754c21090d69d29a2abe3b6cf153d3f1df7";
 
 async function ethCall(target, data) {
   const res = await fetch(RPC, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ jsonrpc: '2.0', method: 'eth_call', params: [{ to: target, data }, 'latest'], id: 1 }),
-  })
-  const json = await res.json()
-  if (json.error) throw new Error(json.error.message)
-  return json.result
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", method: "eth_call", params: [{ to: target, data }, "latest"], id: 1 }),
+  });
+  const j = await res.json();
+  if (j.error) throw new Error(j.error.message);
+  return j.result;
 }
 
 function parseReserves(raw) {
-  return [BigInt('0x' + raw.slice(2, 66)), BigInt('0x' + raw.slice(66, 130))]
+  if (!raw || raw.length < 130) throw new Error("bad reserves");
+  return [BigInt("0x" + raw.slice(2, 66)), BigInt("0x" + raw.slice(66, 130))];
+}
+
+async function addPairTVL(api, pairAddr, label, coingeckoKey, otherDecimals) {
+  try {
+    const [resRaw, tok0Raw] = await Promise.all([
+      ethCall(pairAddr, "0x0902f1ac"),
+      ethCall(pairAddr, "0x0dfe1681"),
+    ]);
+    const [r0, r1] = parseReserves(resRaw);
+    if (r0 === 0n && r1 === 0n) return;
+    const tok0 = ("0x" + tok0Raw.slice(26)).toLowerCase();
+    const [wmrt, other] = tok0 === WMRT.toLowerCase() ? [r0, r1] : [r1, r0];
+    if (other === 0n || wmrt === 0n) return;
+
+    // BigInt-safe: keep 8 decimals of precision throughout
+    const PREC = 100_000_000n;
+    const otherDec = BigInt(10 ** otherDecimals);
+
+    // other-side TVL
+    const otherVal = Number(other * PREC / otherDec) / Number(PREC);
+    api.add(coingeckoKey, otherVal);
+
+    // WMRT-side TVL: price = other/wmrt adjusted for decimals
+    const priceNum = Number(other * PREC * (10n ** 18n) / (wmrt * otherDec)) / Number(PREC);
+    const wmrtVal = Number(wmrt) / 1e18 * priceNum;
+    api.add(coingeckoKey, wmrtVal);
+  } catch (err) {
+    console.error(`[myrxwallet] ${label} skipped:`, err.message);
+  }
 }
 
 async function tvl(api) {
-  const [raw0, tok0r0] = await Promise.all([
-    ethCall(WMRT_WBTC_PAIR, '0x0902f1ac'),
-    ethCall(WMRT_WBTC_PAIR, '0x0dfe1681'),
-  ])
-  const [r0a, r0b] = parseReserves(raw0)
-  const tok0_wbtc = ('0x' + tok0r0.slice(-40)).toLowerCase()
-  const [wmrt0, wbtc0] = tok0_wbtc === WMRT.toLowerCase() ? [r0a, r0b] : [r0b, r0a]
-
-  api.add('bitcoin', Number(wbtc0) / 1e8)
-  if (wmrt0 > 0n && wbtc0 > 0n) {
-    const wmrtPriceBtc = Number(wbtc0) / 1e8 / (Number(wmrt0) / 1e18)
-    api.add('bitcoin', (Number(wmrt0) / 1e18) * wmrtPriceBtc)
-  }
-
-  const [raw1, tok0r1] = await Promise.all([
-    ethCall(WMRT_MUSD_PAIR, '0x0902f1ac'),
-    ethCall(WMRT_MUSD_PAIR, '0x0dfe1681'),
-  ])
-  const [r1a, r1b] = parseReserves(raw1)
-  const tok0_musd = ('0x' + tok0r1.slice(-40)).toLowerCase()
-  const [wmrt1, musd1] = tok0_musd === WMRT.toLowerCase() ? [r1a, r1b] : [r1b, r1a]
-
-  api.add('usd-coin', Number(musd1) / 1e8)
-  if (wmrt1 > 0n && musd1 > 0n) {
-    const wmrtPriceUsd = (Number(musd1) / 1e8) / (Number(wmrt1) / 1e18)
-    api.add('usd-coin', (Number(wmrt1) / 1e18) * wmrtPriceUsd)
-  }
+  await addPairTVL(api, WMRT_WBTC_PAIR, "WMRT/WBTC", "bitcoin", 8);
+  await addPairTVL(api, WMRT_MUSD_PAIR, "WMRT/MUSD", "usd-coin", 8);
 }
 
 module.exports = {
   timetravel: false,
   misrepresentedTokens: false,
-  methodology: 'Sums token reserves in WMRT/WBTC and WMRT/MUSD DEX pairs on MYRX-MAINNET (Chain 8472). WBTC valued as BTC. MUSD is a USD-pegged stablecoin at 1 USD.',
+  methodology: "Sums reserves in WMRT/WBTC and WMRT/MUSD pairs on MYRX-MAINNET (Chain 8472). WBTC as BTC, MUSD as USD.",
   start: 1747267200,
   myrx: { tvl },
-}
+};


### PR DESCRIPTION
## MyRxWallet DEX — MYRX-MAINNET (Chain ID 8472)

Adds TVL tracking for the MyRxWallet DEX (UniswapV2-style AMM) on MYRX-MAINNET.

### Pairs tracked
- WMRT/WBTC  — Wrapped MRT vs Wrapped BTC
- WMRT/MUSD  — Wrapped MRT vs MyRx USD stablecoin

### Chain details
- Chain ID: 8472 | RPC: https://rpc.myrxwallet.io

### Valuation
- WBTC priced as bitcoin (coingecko)
- MUSD priced as usd-coin (.00 peg)
- WMRT derived via pair reserve ratios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MyRxWallet DEX TVL adapter for Chain 8472, exposing TVL under the myrx entry and enabling on-chain reserve-based valuation for WMRT/WBTC and WMRT/MUSD pairs.
* **Chores**
  * Registered "myrx" in the supported chains list to enable tracking for the new adapter.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19295)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->