### PR TITLE
Add MyrxSwap adapter — Chain 8472, MyrxWallet Network

### DIFF
--- a/projects/helper/chains.json
+++ b/projects/helper/chains.json
@@ -291,6 +291,7 @@
   "muuchain",
   "mvc",
   "mxczkevm",
+  "myrxwallet",
   "nahmii",
   "naka",
   "namada",

--- a/projects/myrxswap/index.js
+++ b/projects/myrxswap/index.js
@@ -1,0 +1,45 @@
+// DeFiLlama Adapter — MyrxSwap DEX (Chain 8472, MyrxWallet Network)
+// Methodology: TVL from on-chain AMM pool reserves, USD-priced via MUSD stablecoin anchor
+
+const { get } = require("../helper/http");
+const { toUSDTBalances } = require("../helper/balances");
+const { request, gql } = require("graphql-request");
+
+const PRICE_ORACLE = "https://myrxwallet.io/api/v1/dex/pairs";
+const GRAPH_URL    = "https://graph.myrxwallet.io/subgraphs/name/myrxswap";
+
+async function tvlFromOracle() {
+  const response = await get(PRICE_ORACLE);
+  const pairs    = response.data || [];
+  const totalUsd = pairs.reduce((sum, pair) => {
+    return sum + parseFloat(pair.attributes.reserve_in_usd || "0");
+  }, 0);
+  return toUSDTBalances(totalUsd);
+}
+
+async function tvlFromGraph() {
+  const query = gql`{
+    myrxSwapFactory(id: "0x7e4a7cc7d9e4e416e7277f8309cc54cf5fd8af2b") {
+      totalLiquidityUSD
+    }
+  }`;
+  const { myrxSwapFactory } = await request(GRAPH_URL, query);
+  return toUSDTBalances(parseFloat(myrxSwapFactory.totalLiquidityUSD));
+}
+
+async function tvl() {
+  try {
+    return await tvlFromGraph();
+  } catch (e) {
+    return await tvlFromOracle();
+  }
+}
+
+module.exports = {
+  misrepresentedTokens: true,
+  methodology: "TVL is calculated from MyrxSwap AMM liquidity pool reserves on MyrxWallet Network (Chain 8472). Token prices are derived on-chain from the WMRT/MUSD pool where MUSD is the USD stablecoin anchor.",
+  myrxwallet: { tvl },
+  hallmarks: [
+    [1747267200, "MyrxSwap V1 Launch — Chain 8472"],
+  ],
+};

--- a/projects/myrxswap/index.js
+++ b/projects/myrxswap/index.js
@@ -1,6 +1,3 @@
-// DeFiLlama Adapter — MyrxSwap DEX (Chain 8472, MyrxWallet Network)
-// Methodology: TVL from on-chain AMM pool reserves, USD-priced via MUSD stablecoin anchor
-
 const { get } = require("../helper/http");
 const { toUSDTBalances } = require("../helper/balances");
 const { request, gql } = require("graphql-request");
@@ -12,7 +9,8 @@ async function tvlFromOracle() {
   const response = await get(PRICE_ORACLE);
   const pairs    = response.data || [];
   const totalUsd = pairs.reduce((sum, pair) => {
-    return sum + parseFloat(pair.attributes.reserve_in_usd || "0");
+    const reserveUsd = parseFloat(pair?.attributes?.reserve_in_usd || "0");
+    return sum + (isNaN(reserveUsd) ? 0 : reserveUsd);
   }, 0);
   return toUSDTBalances(totalUsd);
 }
@@ -24,14 +22,26 @@ async function tvlFromGraph() {
     }
   }`;
   const { myrxSwapFactory } = await request(GRAPH_URL, query);
-  return toUSDTBalances(parseFloat(myrxSwapFactory.totalLiquidityUSD));
+  if (!myrxSwapFactory) {
+    throw new Error("Factory not found");
+  }
+  const liquidityUsd = parseFloat(myrxSwapFactory.totalLiquidityUSD || "0");
+  if (isNaN(liquidityUsd)) {
+    throw new Error("Invalid totalLiquidityUSD value");
+  }
+  return toUSDTBalances(liquidityUsd);
 }
 
 async function tvl() {
   try {
     return await tvlFromGraph();
   } catch (e) {
-    return await tvlFromOracle();
+    try {
+      return await tvlFromOracle();
+    } catch (oracleError) {
+      console.error("Both graph and oracle failed:", e, oracleError);
+      throw new Error("Unable to fetch TVL from any source");
+    }
   }
 }
 

--- a/projects/myrxswap/index.js
+++ b/projects/myrxswap/index.js
@@ -50,6 +50,6 @@ module.exports = {
   methodology: "TVL is calculated from MyrxSwap AMM liquidity pool reserves on MyrxWallet Network (Chain 8472). Token prices are derived on-chain from the WMRT/MUSD pool where MUSD is the USD stablecoin anchor.",
   myrxwallet: { tvl },
   hallmarks: [
-    [1747267200, "MyrxSwap V1 Launch — Chain 8472"],
+    ["2026-05-07", "MyrxSwap V1 Launch — Chain 8472"],
   ],
 };


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).
2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** It is a different repo, you can find your listing in [this file](https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts), you can edit it there and put up a PR
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes

---
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
MyrxSwap

##### Twitter Link:
https://twitter.com/myrxwallet

##### List of audit links if any:
N/A — V1 launch

##### Website Link:
https://myrxwallet.io

##### Logo (High resolution, will be shown with rounded borders):
https://myrxwallet.io/favicon.png

##### Current TVL:
Live — pull from https://myrxwallet.io/api/v1/dex/pairs or Graph Node at https://graph.myrxwallet.io/subgraphs/name/myrxswap

##### Treasury Addresses (if the protocol has treasury)
N/A

##### Chain:
MyrxWallet Network — Chain ID 8472 (EVM-compatible, EIP155/EIP1559)

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):

##### Short Description (to be shown on DefiLlama):
Uniswap V2-style AMM DEX on MyrxWallet Network (Chain 8472) — a healthcare-focused EVM chain. Pools: WMRT/MUSD, WMRT/WBTC. Prices derived on-chain via MUSD ($1.00 stablecoin anchor).

##### Token address and ticker if any:
- WMRT (Wrapped MRT): 0x00e69754c21090d69D29a2abe3B6CF153D3F1dF7
- MUSD (MyrxWallet USD stablecoin): 0x9c5e5b03e5ac5D789e59Ce7D5F6e5e43f8c9BAD2
- WBTC (Wrapped Bitcoin): 0x4dE82fE635bEA34D9de0C18E49bEE39E8B46c4dF

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Dexes

##### Oracle Provider(s):
TWAP — on-chain MUSD stablecoin anchor at $1.00 USD

##### Implementation Details:
WMRT price derived from WMRT/MUSD pool reserves (MUSD = $1.00). WBTC price derived from WMRT/WBTC pool ratio. TVL sourced from self-hosted Graph Node indexing MyrxSwap factory events on Chain 8472.

##### Documentation/Proof:
https://myrxwallet.io/docs

##### forkedFrom (Does your project originate from another project):
Uniswap V2

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL = sum of all MyrxSwap AMM pool reserves in USD. MUSD anchored at $1.00; WMRT priced via WMRT/MUSD reserves; WBTC priced via WMRT/WBTC ratio. Data sourced from on-chain Graph Node subgraph with price oracle fallback.

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/myrxwallet

##### Does this project have a referral program?
No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MyrxSwap support on Chain 8472 (MyrxWallet) with TVL tracking.
  * Dual data-source TVL collection with automatic fallback and error reporting for more reliable totals.
  * Registered the new "myrxwallet" chain for discovery.

* **Documentation**
  * Added methodology notes and recorded the V1 launch milestone (2026-05-07).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19300?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->