### PR TITLE
refactor alkimi: use sui helper instead of raw axios

### DIFF
--- a/projects/alkimi/index.js
+++ b/projects/alkimi/index.js
@@ -1,33 +1,25 @@
-const axios = require("axios");
+const { getObject } = require('../helper/chain/sui')
 
-const STAKING_VAULT = "0xc92fe84368fc3ff40713792c750709501fcfc4869f120755fd0bea5cac1ead94";
-const ALKIMI_DECIMALS = 9n;
-const ALKIMI_COINGECKO_ID = "alkimi-2";
+const STAKING_VAULT = '0xc92fe84368fc3ff40713792c750709501fcfc4869f120755fd0bea5cac1ead94'
+const ALKIMI_DECIMALS = 9n
+const ALKIMI_COINGECKO_ID = 'alkimi-2'
+
+const staking = async () => {
+  const content = await getObject(STAKING_VAULT)
+  const fields = content?.fields
+  if (!fields) return {}
+
+  const total = BigInt(fields.balance || '0')
+  return {
+    [ALKIMI_COINGECKO_ID]: Number(total / 10n ** ALKIMI_DECIMALS),
+  }
+}
 
 module.exports = {
   timetravel: false,
-  methodology: "Staking counts all ALKIMI tokens locked in the StakingVault (user + admin)",
-
+  methodology: 'Staking counts all ALKIMI tokens locked in the StakingVault (user + admin)',
   sui: {
     tvl: async () => 0,
-    staking: async () => {
-      // fetch vault data from Sui fullnode
-      const resp = await axios.post("https://fullnode.mainnet.sui.io:443", {
-        jsonrpc: "2.0",
-        id: 1,
-        method: "sui_getObject",
-        params: [STAKING_VAULT, { showType: true, showOwner: true, showContent: true }],
-      });
-
-      const fields = resp.data.result?.data?.content?.fields;
-      if (!fields) return {};
-
-      const total = BigInt(fields.balance || "0");
-      const humanTotal = Number(total / 10n ** ALKIMI_DECIMALS);
-
-      return {
-        [ALKIMI_COINGECKO_ID]: humanTotal,
-      };
-    }
-  }
-};
+    staking,
+  },
+}


### PR DESCRIPTION
The `alkimi` staking adapter used raw `axios.post(...)` against the Sui fullnode with a hand-built JSON-RPC payload. This PR swaps it for `getObject(...)` from `projects/helper/chain/sui.js`, which already wraps the same `sui_getObject` call via the SDK's chain-aware RPC machinery (retries, fallbacks, env-overridable endpoint).

Behavior unchanged: same `STAKING_VAULT` object id, same field extraction (`fields.balance`), same Coingecko ID (`alkimi-2`).

Drops the `axios` dependency from this adapter and aligns with the maintainer guidance in #16930 (use repo helpers / on-chain reads over raw fetch).

Allow edits by maintainers: enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal data fetching mechanism for Sui staking vault information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19301?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->