### PR TITLE
primefi fix

### DIFF
--- a/projects/helper/utils.js
+++ b/projects/helper/utils.js
@@ -92,6 +92,7 @@ function isLP(symbol, token, chain) {
   if (chain === 'shibarium' && ['SSLP', 'ChewyLP'].includes(symbol)) return true
   if (chain === 'omax' && ['OSWAP-V2'].includes(symbol)) return true
   if (chain === 'sonic' && symbol.endsWith(' spLP')) return true
+  if (chain === 'xdc' && ['XSP2'].includes(symbol)) return true // xspswap LP
   let label
 
   if (symbol.startsWith('ZLK-LP') || symbol.includes('DMM-LP') || (chain === 'avax' && 'DLP' === symbol) || symbol === 'fChe-LP')

--- a/projects/primefi-xyz/index.js
+++ b/projects/primefi-xyz/index.js
@@ -1,52 +1,17 @@
-const { staking } = require("../helper/staking");
-const { aaveExports, methodology, aaveV2Export, } = require("../helper/aave");
-const { mergeExports } = require('../helper/utils');
+const { sumTokensExport } = require("../helper/unwrapLPs");
 
-const coreMarkets = {
-  methodology,
+module.exports = {
+  methodology: 'Counts collateral in PRFI/wrapped-native LP tokens.',
   base: {
-    ...aaveExports(undefined, '0xBfeE735e3868f8990787CCEAA4B920C9Ed162b07'),
-    pool2: staking("0x5b6D95545750f1bb1812F5c564d9a401D3DeBd80", "0x87B417AF600312df37F551a05ae14bCC3d55bC36")
+    tvl: sumTokensExport({ owner: "0x87B417AF600312df37F551a05ae14bCC3d55bC36", tokens: ["0x4200000000000000000000000000000000000006"] }),  // WETH
+    staking: sumTokensExport({ owner: "0x87B417AF600312df37F551a05ae14bCC3d55bC36", tokens: ["0x7BBCf1B600565AE023a1806ef637Af4739dE3255"] })  // PRFI
   },
   hyperliquid: {
-    ...aaveExports(undefined, '0x69A3c30A85aA1E22791466a08819c1080f0Aab7f'),
-    pool2: staking("0x33cd734739c6DeD500fD080d476D93135cB813Ef", "0x981F145a71Da6DF4A7cBe892807782c9CC9a5515")
+    tvl: sumTokensExport({ owner: "0x981F145a71Da6DF4A7cBe892807782c9CC9a5515", tokens: ["0x5555555555555555555555555555555555555555"] }),  // WHYPE
+    staking: sumTokensExport({ owner: "0x981F145a71Da6DF4A7cBe892807782c9CC9a5515", tokens: ["0x7BBCf1B600565AE023a1806ef637Af4739dE3255"] })  // PRFI
   },
   xdc: {
-    ...aaveExports(undefined, '0xBfeE735e3868f8990787CCEAA4B920C9Ed162b07'),
-    pool2: staking("0x01E7cd81D3d7A4907815877e0C937a77dE537e99", "0xffA04F091128fb89D3B1eCd0149DC677dfAe1C69")
+    tvl: sumTokensExport({ owner: "0xffA04F091128fb89D3B1eCd0149DC677dfAe1C69", tokens: ["0x951857744785E80e2De051c32EE7b25f9c458C42"] }),  // WXDC
+    staking: sumTokensExport({ owner: "0xffA04F091128fb89D3B1eCd0149DC677dfAe1C69", tokens: ["0x81B244d0be055EF3BEF1b09B7826Cc2b108B2cBD"] })  // PRFI
   },
 };
-
-const primeMarketsConfig = {
-  base: [
-    '0x8a619D8E3BfAb54F7C30Ef39Ce16c53429c739C3',
-  ],
-  hyperliquid: [
-    '0xb339448E13E273f6F46e3390e0932Ab7fF9F113F',
-  ],
-  xdc: [
-    '0x8a619D8E3BfAb54F7C30Ef39Ce16c53429c739C3',
-  ],
-}
-const primeMarketExports = {}
-
-Object.keys(primeMarketsConfig).forEach(chain => {
-  const pools = primeMarketsConfig[chain]
-  primeMarketExports[chain] = {
-    tvl: async (api) => {
-      for (const pool of pools) {
-        await aaveV2Export(pool).tvl(api)
-      }
-      return api.getBalances()
-    },
-    borrowed: async (api) => {
-      for (const pool of pools) {
-        await aaveV2Export(pool).borrowed(api)
-      }
-      return api.getBalances()
-    }
-  }
-})
-
-module.exports = mergeExports([primeMarketExports, coreMarkets])

--- a/projects/primefi-xyz/index.js
+++ b/projects/primefi-xyz/index.js
@@ -1,17 +1,17 @@
 const { sumTokensExport } = require("../helper/unwrapLPs");
 
 module.exports = {
-  methodology: 'Counts collateral in PRFI/wrapped-native LP tokens.',
+  methodology: "PRFI/wrapped-native LP staked in PrimeFi staking contracts on each chain.",
   base: {
-    tvl: sumTokensExport({ owner: "0x87B417AF600312df37F551a05ae14bCC3d55bC36", tokens: ["0x4200000000000000000000000000000000000006"] }),  // WETH
-    staking: sumTokensExport({ owner: "0x87B417AF600312df37F551a05ae14bCC3d55bC36", tokens: ["0x7BBCf1B600565AE023a1806ef637Af4739dE3255"] })  // PRFI
+    tvl: () => ({}),
+    pool2: sumTokensExport({ owner: '0x5b6D95545750f1bb1812F5c564d9a401D3DeBd80', tokens: ['0x87B417AF600312df37F551a05ae14bCC3d55bC36'], resolveLP: true }),
   },
   hyperliquid: {
-    tvl: sumTokensExport({ owner: "0x981F145a71Da6DF4A7cBe892807782c9CC9a5515", tokens: ["0x5555555555555555555555555555555555555555"] }),  // WHYPE
-    staking: sumTokensExport({ owner: "0x981F145a71Da6DF4A7cBe892807782c9CC9a5515", tokens: ["0x7BBCf1B600565AE023a1806ef637Af4739dE3255"] })  // PRFI
+    tvl: () => ({}),
+    pool2: sumTokensExport({ owner: '0x33cd734739c6DeD500fD080d476D93135cB813Ef', tokens: ['0x981F145a71Da6DF4A7cBe892807782c9CC9a5515'], resolveLP: true }),
   },
   xdc: {
-    tvl: sumTokensExport({ owner: "0xffA04F091128fb89D3B1eCd0149DC677dfAe1C69", tokens: ["0x951857744785E80e2De051c32EE7b25f9c458C42"] }),  // WXDC
-    staking: sumTokensExport({ owner: "0xffA04F091128fb89D3B1eCd0149DC677dfAe1C69", tokens: ["0x81B244d0be055EF3BEF1b09B7826Cc2b108B2cBD"] })  // PRFI
+    tvl: () => ({}),
+    pool2: sumTokensExport({ owner: '0x01E7cd81D3d7A4907815877e0C937a77dE537e99', tokens: ['0xffA04F091128fb89D3B1eCd0149DC677dfAe1C69'], resolveLP: true }),
   },
 };

--- a/projects/primefi-xyz/index.js
+++ b/projects/primefi-xyz/index.js
@@ -1,17 +1,22 @@
 const { sumTokensExport } = require("../helper/unwrapLPs");
+const { aaveExports } = require("../helper/aave");
+const { staking } = require("../helper/staking");
 
 module.exports = {
   methodology: "PRFI/wrapped-native LP staked in PrimeFi staking contracts on each chain.",
   base: {
-    tvl: () => ({}),
+    ...aaveExports(undefined, '0xBfeE735e3868f8990787CCEAA4B920C9Ed162b07'),
+    staking: staking('0x5b6D95545750f1bb1812F5c564d9a401D3DeBd80', '0x7BBCf1B600565AE023a1806ef637Af4739dE3255'),
     pool2: sumTokensExport({ owner: '0x5b6D95545750f1bb1812F5c564d9a401D3DeBd80', tokens: ['0x87B417AF600312df37F551a05ae14bCC3d55bC36'], resolveLP: true }),
   },
   hyperliquid: {
-    tvl: () => ({}),
+    ...aaveExports(undefined, '0x69A3c30A85aA1E22791466a08819c1080f0Aab7f'),
+    staking: staking('0x33cd734739c6DeD500fD080d476D93135cB813Ef', '0x7BBCf1B600565AE023a1806ef637Af4739dE3255'),
     pool2: sumTokensExport({ owner: '0x33cd734739c6DeD500fD080d476D93135cB813Ef', tokens: ['0x981F145a71Da6DF4A7cBe892807782c9CC9a5515'], resolveLP: true }),
   },
   xdc: {
-    tvl: () => ({}),
+    ...aaveExports(undefined, '0xBfeE735e3868f8990787CCEAA4B920C9Ed162b07'),
+    staking: staking('0x01E7cd81D3d7A4907815877e0C937a77dE537e99', '0x81B244d0be055EF3BEF1b09B7826Cc2b108B2cBD'),
     pool2: sumTokensExport({ owner: '0x01E7cd81D3d7A4907815877e0C937a77dE537e99', tokens: ['0xffA04F091128fb89D3B1eCd0149DC677dfAe1C69'], resolveLP: true }),
   },
 };

--- a/projects/treasury/primefi-xyz.js
+++ b/projects/treasury/primefi-xyz.js
@@ -1,0 +1,13 @@
+
+
+const { treasuryExports } = require("../helper/treasury");
+const ADDRESSES = require('../helper/coreAssets.json')
+
+const treasury = '0xF2e2A49631927108086268c68C559c63c3C8f73d'
+
+module.exports = treasuryExports({
+  ethereum: { owners: [treasury] },
+  base: { owners: [treasury], ownTokens: ['0x7BBCf1B600565AE023a1806ef637Af4739dE3255'] },
+  hyperliquid: { owners: [treasury], ownTokens: ['0x7BBCf1B600565AE023a1806ef637Af4739dE3255']},
+  xdc: { owners: [treasury], tokens: [ADDRESSES.null, ADDRESSES.xdc.WXDC], ownTokens: ['0x81B244d0be055EF3BEF1b09B7826Cc2b108B2cBD'] },
+})

--- a/registries/aave.js
+++ b/registries/aave.js
@@ -554,20 +554,6 @@ const aaveConfigs = {
       },
     },
   },
-  'primefi': {
-    base: {
-      addressesProviderRegistry: '0xBfeE735e3868f8990787CCEAA4B920C9Ed162b07',
-      staking: ['0x5b6D95545750f1bb1812F5c564d9a401D3DeBd80', '0x7BBCf1B600565AE023a1806ef637Af4739dE3255']
-    },
-    hyperliquid: {
-      addressesProviderRegistry: '0x69A3c30A85aA1E22791466a08819c1080f0Aab7f',
-      staking: ['0x33cd734739c6DeD500fD080d476D93135cB813Ef', '0x7BBCf1B600565AE023a1806ef637Af4739dE3255']
-    },
-    xdc: {
-      addressesProviderRegistry: '0xBfeE735e3868f8990787CCEAA4B920C9Ed162b07',
-      staking: ['0x01E7cd81D3d7A4907815877e0C937a77dE537e99', '0x81B244d0be055EF3BEF1b09B7826Cc2b108B2cBD']
-    },
-  }
 }
 
 module.exports = {

--- a/registries/aave.js
+++ b/registries/aave.js
@@ -554,6 +554,20 @@ const aaveConfigs = {
       },
     },
   },
+  'primefi': {
+    base: {
+      addressesProviderRegistry: '0xBfeE735e3868f8990787CCEAA4B920C9Ed162b07',
+      staking: ['0x5b6D95545750f1bb1812F5c564d9a401D3DeBd80', '0x7BBCf1B600565AE023a1806ef637Af4739dE3255']
+    },
+    hyperliquid: {
+      addressesProviderRegistry: '0x69A3c30A85aA1E22791466a08819c1080f0Aab7f',
+      staking: ['0x33cd734739c6DeD500fD080d476D93135cB813Ef', '0x7BBCf1B600565AE023a1806ef637Af4739dE3255']
+    },
+    xdc: {
+      addressesProviderRegistry: '0xBfeE735e3868f8990787CCEAA4B920C9Ed162b07',
+      staking: ['0x01E7cd81D3d7A4907815877e0C937a77dE537e99', '0x81B244d0be055EF3BEF1b09B7826Cc2b108B2cBD']
+    },
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
1. prime markets and core markets were counting the same collateral. For example:
- prime market config on base `0x8a619D8E3BfAb54F7C30Ef39Ce16c53429c739C3` is a LendingPool and returns `0xBC2adF6bEE6E8468f9E60DFC017D4E2Ce682be0C` for `getAddressProvider()`
- core market passes `0xBfeE735e3868f8990787CCEAA4B920C9Ed162b07` to aaveExport as its LendingPoolAddressesProviderRegistry, and returns `0xBC2adF6bEE6E8468f9E60DFC017D4E2Ce682be0C` for `getAddressesProvidersList()`

2. swapped staking helper for sumTokensExport with resolveLP for univ2 lp tokens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added treasury configuration across multiple chains (Ethereum, Base, Hyperliquid, XDC)
  * Extended XSP2 token support as a liquidity pool on the XDC chain

* **Refactor**
  * Restructured PrimeFi market export configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19303?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->