### PR TITLE
feat: add MyrxSwap TVL adapter (MyrxWallet Network, Chain 8472)

### DIFF
--- a/projects/myrxswap/index.js
+++ b/projects/myrxswap/index.js
@@ -1,0 +1,30 @@
+const { get } = require("../helper/http");
+
+// MyrxSwap — Uniswap V2 AMM on MyrxWallet Network (Chain 8472)
+// Factory:  0x7E4A7CC7D9e4e416E7277F8309cC54cF5FD8AF2b
+// Router:   0xE0eAb9309910f7e0E60Fc637aF50B38A4B34aD2B
+// Explorer: https://explorer.myrxwallet.io
+
+const TICKERS_URL = "https://command.myrxwallet.io/api/v1/dex/tickers";
+
+async function tvl() {
+  const tickers = await get(TICKERS_URL);
+  let totalUsd = 0;
+  for (const t of tickers) {
+    totalUsd += parseFloat(t.liquidity_in_usd || "0");
+  }
+  // Express as tether so DeFiLlama prices at $1/unit
+  return { tether: totalUsd };
+}
+
+module.exports = {
+  myrxwallet: {
+    tvl,
+  },
+  timetravel: false,
+  misrepresentedTokens: true,
+  methodology:
+    "Sums USD liquidity across all MyrxSwap AMM pairs on MyrxWallet Network (Chain 8472). " +
+    "MUSD is a USD-pegged stablecoin; WMRT price derived from WMRT/MUSD pool ratio. " +
+    "WBTC is wrapped Bitcoin bridged to Chain 8472.",
+};


### PR DESCRIPTION
## Summary

**Protocol:** MyrxSwap
**Chain:** MyrxWallet Network (Chain ID 8472) - custom EVM, Reth-based
**Type:** Uniswap V2 AMM fork

### Contracts

| Role | Address |
|---|---|
| Factory | `0x7E4A7CC7D9e4e416E7277F8309cC54cF5FD8AF2b` |
| Router | `0xE0eAb9309910f7e0E60Fc637aF50B38A4B34aD2B` |
| WMRT/MUSD pair | `0xf1946991eA67CdBB8d74b3124003D55A2069bd2e` |
| WMRT/WBTC pair | `0x16Bf6e74B9feE4306a7D268468Fc4d45C2F4B0C3` |

### Chain Info

- RPC: https://rpc.myrxwallet.io
- Explorer: https://explorer.myrxwallet.io
- Block time: ~2 seconds
- EVM-compatible (EIP-155, EIP-1559)

### TVL Source

Fetched from the live DEX ticker API (https://command.myrxwallet.io/api/v1/dex/tickers), which reports liquidity_in_usd per pair summed across all active pairs.

### Notes

- misrepresentedTokens: true - WMRT not yet on CoinGecko/CMC; TVL expressed as USDT equivalent
- timetravel: false - no historical data endpoint
- ChainList PR for Chain 8472: https://github.com/ethereum-lists/chains/pull/8346

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added integration for MyxrxSwap, a decentralized exchange on MyrxWallet Network (chain 8472), enabling real-time liquidity tracking and USD valuation of trading pairs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19307?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->