### PR TITLE
Add MegaChad adapter

### DIFF
--- a/projects/megachad/index.js
+++ b/projects/megachad/index.js
@@ -16,6 +16,21 @@ const MC_MG_PAIR = '0x437a433534FF6e7712D7e0A03Fa6CE577EeA1fef';
 const MOGGER_STAKING = '0xfd820E6189Eb3396dA71cB072643A0E1e1239853';
 const JESTERGOONER = '0x2695965Dd283e2425fab5C4c1E0955656802569c';
 
+/**
+ * Compute base TVL for MegaChad on MegaETH.
+ *
+ * Sums two non-overlapping pools of value:
+ *   1. MEGACHAD + MEGAGOONER token reserves held by the MC/MG AMM pair.
+ *   2. MEGACHAD locked in MoggerStaking (single-asset staking vault that
+ *      drips MEGAGOONER rewards Synthetix-style).
+ *
+ * LP tokens staked in JESTERGOONER are intentionally excluded here — they
+ * are accounted for separately under `pool2` to avoid double-counting
+ * (the LP's underlying reserves are already inside `MC_MG_PAIR`).
+ *
+ * @param {Object} api - DefiLlama SDK chain api bound to `megaeth`.
+ * @returns {Promise<Object>} Token balance map returned by `api.sumTokens`.
+ */
 async function tvl(api) {
   return api.sumTokens({
     ownerTokens: [
@@ -25,6 +40,20 @@ async function tvl(api) {
   });
 }
 
+/**
+ * Compute pool2 TVL: MC/MG LP tokens locked in JESTERGOONER V4, unwrapped
+ * into their underlying MEGACHAD + MEGAGOONER reserves.
+ *
+ * Because MegaChadLP exposes `reserveA` / `reserveB` (not the standard V2
+ * `getReserves`), the LP is unwrapped manually:
+ *     amountToken = reserve * (lpHeld / lpTotalSupply)
+ *
+ * Returns early when the pair has zero supply so a freshly deployed pool
+ * does not divide by zero.
+ *
+ * @param {Object} api - DefiLlama SDK chain api bound to `megaeth`.
+ * @returns {Promise<void>} Mutates `api` via `api.add` for each underlying token.
+ */
 async function pool2(api) {
   const [lpHeld, lpTotalSupply, reserveA, reserveB] = await Promise.all([
     api.call({ abi: 'erc20:balanceOf', target: MC_MG_PAIR, params: [JESTERGOONER] }),

--- a/projects/megachad/index.js
+++ b/projects/megachad/index.js
@@ -1,44 +1,10 @@
-// MegaChad — meme-burn + governance protocol on MegaETH (chain 4326)
-//
-// TVL components:
-//   tvl   → reserves of the MEGACHAD/MEGAGOONER AMM pair (MegaChadLP) PLUS
-//           MEGACHAD locked in MoggerStaking (Synthetix-style drip rewards)
-//   pool2 → MC/MG LP tokens locked in JESTERGOONER V4 (LP staking),
-//           unwrapped to their underlying MEGACHAD + MEGAGOONER reserves
-//
-// The AMM pair (MegaChadLP) uses tokenA/tokenB naming instead of the standard
-// Uniswap V2 token0/token1, so pool2 resolves LP holdings manually rather
-// than via the generic resolveLP helper.
+const { staking } = require("../helper/staking.js");
 
 const MEGACHAD = '0x374A17bd16B5cD76aaeFC9EAF76aE07e9aF3d888';
 const MEGAGOONER = '0x11d819Dbd6e9aF0b13A54e88EA411155764e3F46';
 const MC_MG_PAIR = '0x437a433534FF6e7712D7e0A03Fa6CE577EeA1fef';
 const MOGGER_STAKING = '0xfd820E6189Eb3396dA71cB072643A0E1e1239853';
 const JESTERGOONER = '0x2695965Dd283e2425fab5C4c1E0955656802569c';
-
-/**
- * Compute base TVL for MegaChad on MegaETH.
- *
- * Sums two non-overlapping pools of value:
- *   1. MEGACHAD + MEGAGOONER token reserves held by the MC/MG AMM pair.
- *   2. MEGACHAD locked in MoggerStaking (single-asset staking vault that
- *      drips MEGAGOONER rewards Synthetix-style).
- *
- * LP tokens staked in JESTERGOONER are intentionally excluded here — they
- * are accounted for separately under `pool2` to avoid double-counting
- * (the LP's underlying reserves are already inside `MC_MG_PAIR`).
- *
- * @param {Object} api - DefiLlama SDK chain api bound to `megaeth`.
- * @returns {Promise<Object>} Token balance map returned by `api.sumTokens`.
- */
-async function tvl(api) {
-  return api.sumTokens({
-    ownerTokens: [
-      [[MEGACHAD, MEGAGOONER], MC_MG_PAIR],
-      [[MEGACHAD], MOGGER_STAKING],
-    ],
-  });
-}
 
 /**
  * Compute pool2 TVL: MC/MG LP tokens locked in JESTERGOONER V4, unwrapped
@@ -70,10 +36,10 @@ async function pool2(api) {
 
 module.exports = {
   methodology:
-    'TVL = reserves of the MEGACHAD/MEGAGOONER AMM pair plus MEGACHAD locked in MoggerStaking. Pool2 = MC/MG LP tokens locked in JESTERGOONER V4 (LP staking), resolved to their underlying MEGACHAD + MEGAGOONER reserves.',
-  misrepresentedTokens: true,
+    'Staking counts MEGACHAD locked in MoggerStaking and Pool2 counts MC/MG LP tokens locked in JESTERGOONER V4 (LP staking), resolved to their underlying MEGACHAD + MEGAGOONER reserves.',
   megaeth: {
-    tvl,
+    tvl: () => ({}),
+    staking: staking(MOGGER_STAKING, MEGACHAD),
     pool2,
   },
 };

--- a/projects/megachad/index.js
+++ b/projects/megachad/index.js
@@ -1,0 +1,50 @@
+// MegaChad — meme-burn + governance protocol on MegaETH (chain 4326)
+//
+// TVL components:
+//   tvl   → reserves of the MEGACHAD/MEGAGOONER AMM pair (MegaChadLP) PLUS
+//           MEGACHAD locked in MoggerStaking (Synthetix-style drip rewards)
+//   pool2 → MC/MG LP tokens locked in JESTERGOONER V4 (LP staking),
+//           unwrapped to their underlying MEGACHAD + MEGAGOONER reserves
+//
+// The AMM pair (MegaChadLP) uses tokenA/tokenB naming instead of the standard
+// Uniswap V2 token0/token1, so pool2 resolves LP holdings manually rather
+// than via the generic resolveLP helper.
+
+const MEGACHAD = '0x374A17bd16B5cD76aaeFC9EAF76aE07e9aF3d888';
+const MEGAGOONER = '0x11d819Dbd6e9aF0b13A54e88EA411155764e3F46';
+const MC_MG_PAIR = '0x437a433534FF6e7712D7e0A03Fa6CE577EeA1fef';
+const MOGGER_STAKING = '0xfd820E6189Eb3396dA71cB072643A0E1e1239853';
+const JESTERGOONER = '0x2695965Dd283e2425fab5C4c1E0955656802569c';
+
+async function tvl(api) {
+  return api.sumTokens({
+    ownerTokens: [
+      [[MEGACHAD, MEGAGOONER], MC_MG_PAIR],
+      [[MEGACHAD], MOGGER_STAKING],
+    ],
+  });
+}
+
+async function pool2(api) {
+  const [lpHeld, lpTotalSupply, reserveA, reserveB] = await Promise.all([
+    api.call({ abi: 'erc20:balanceOf', target: MC_MG_PAIR, params: [JESTERGOONER] }),
+    api.call({ abi: 'erc20:totalSupply', target: MC_MG_PAIR }),
+    api.call({ abi: 'uint256:reserveA', target: MC_MG_PAIR }),
+    api.call({ abi: 'uint256:reserveB', target: MC_MG_PAIR }),
+  ]);
+  if (lpTotalSupply === '0' || lpTotalSupply === 0n) return;
+  const supply = BigInt(lpTotalSupply);
+  const held = BigInt(lpHeld);
+  api.add(MEGACHAD, (BigInt(reserveA) * held) / supply);
+  api.add(MEGAGOONER, (BigInt(reserveB) * held) / supply);
+}
+
+module.exports = {
+  methodology:
+    'TVL = reserves of the MEGACHAD/MEGAGOONER AMM pair plus MEGACHAD locked in MoggerStaking. Pool2 = MC/MG LP tokens locked in JESTERGOONER V4 (LP staking), resolved to their underlying MEGACHAD + MEGAGOONER reserves.',
+  misrepresentedTokens: true,
+  megaeth: {
+    tvl,
+    pool2,
+  },
+};


### PR DESCRIPTION
## Project

**MegaChad** — meme-burn + governance protocol on MegaETH (chain 4326).

- Website: https://megachad.xyz
- Docs: https://megachad.xyz/docs
- Twitter/X: https://x.com/megachadxyz

## TVL Methodology

Adapter at \`projects/megachad/index.js\`:

| Bucket | Source |
| --- | --- |
| \`tvl\` | Reserves of the MEGACHAD/MEGAGOONER AMM pair (MegaChadLP) **+** MEGACHAD locked in MoggerStaking (Synthetix-style drip rewards) |
| \`pool2\` | MC/MG LP tokens locked in JESTERGOONER V4 (LP staking), unwrapped to their underlying MEGACHAD + MEGAGOONER reserves |

## Contracts

- MEGACHAD (ERC20): \`0x374A17bd16B5cD76aaeFC9EAF76aE07e9aF3d888\`
- MEGAGOONER (ERC20): \`0x11d819Dbd6e9aF0b13A54e88EA411155764e3F46\`
- MC/MG AMM pair: \`0x437a433534FF6e7712D7e0A03Fa6CE577EeA1fef\`
- MoggerStaking: \`0xfd820E6189Eb3396dA71cB072643A0E1e1239853\`
- JESTERGOONER (LP staking): \`0x2695965Dd283e2425fab5C4c1E0955656802569c\`

## Pricing

The custom MegaChadLP AMM uses \`tokenA\`/\`tokenB\` naming instead of Uniswap V2's \`token0\`/\`token1\`, so \`pool2\` resolves LP holdings manually with reserve calls + the standard \`balanceOf / totalSupply\` proration.

MEGACHAD pricing is available through the existing Kumbaya adapter, which indexes the MEGACHAD/WETH pool at \`0x1C08A462E50532640441B4fC64385E610BA3a78D\`. MEGAGOONER will derive from the MEGACHAD/MEGAGOONER pair reserves once MEGACHAD prices through. \`misrepresentedTokens: true\` is set since not every token will be priced on day one.

## Tests

\`node test.js projects/megachad/index.js\` runs cleanly and returns the expected bucket structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added liquidity pool valuation for staked LP tokens (pool2) on MegaETH.
* **Staking**
  * Exposed staking balances via the shared staking integration for MEGACHAD.
* **Changes**
  * Overall TVL aggregation is currently disabled and will return an empty result until restored.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19310?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->