### PR TITLE
fix lending markets

### DIFF
--- a/projects/paraspace-v2/index.js
+++ b/projects/paraspace-v2/index.js
@@ -2,6 +2,7 @@ const { tvl, borrowed } = require("./helper/index");
 
 module.exports = {
   hallmarks: [],
+  deadFrom: '2026-05-15',
   methodology: `TVL includes ERC-20 and ERC-721 tokens that have been supplied as well as ERC-20 tokens that are supplied for lending.`,
   ethereum: {
     tvl,

--- a/projects/shoebillFinance-v2/index.js
+++ b/projects/shoebillFinance-v2/index.js
@@ -47,27 +47,32 @@ module.exports = mergeExports([
         bsquared: compoundExports2({
             comptroller: "0x80E81348D9386Eb4d10c2A32A7458638cD3308dF",
             cether: "0x8dbf84c93727c85DB09478C83a8621e765D20eC2",
+            isInsolvent: true
         }),
     },
     {
         bsquared: compoundExports2({
             comptroller: "0x9f53Cd350c3aC49cE6CE673abff647E5fe79A3CC",
+            isInsolvent: true
         }),
     },
     {
         bob: compoundExports2({
             comptroller: "0x9f53Cd350c3aC49cE6CE673abff647E5fe79A3CC",
             cether: "0xb4255533Ad74A25A83d17154cB48A287E8f6A811",
+            isInsolvent: true
         }),
     },
     {
         bob: compoundExports2({
             comptroller: "0xB7ed6c062caAaCb1A13f317E0A751289280FC306",
+            isInsolvent: true
         }),
     },    
     {
         bob: compoundExports2({
             comptroller: "0x1e514767F5cFe1ddE599dd39a79666E3BeEAaf7d",
+            isInsolvent: true
         }),
     },   
     {

--- a/projects/tarot/tarotHelper.js
+++ b/projects/tarot/tarotHelper.js
@@ -73,10 +73,13 @@ function tarotHelper(exportsObj, config, { tarotSymbol = 'vTAROT' } = {}) {
     const blacklistedBorrowables = new Set([
       '0x5990Ddc40b63D90d3B783207069F5b9A8b661C1C',
       '0xec51a9f0dc97563147fb89176047283b9ae4cca9',
+      '0x93e3AF1734fB1BfeCfcB07Ea574438f84C8f0f5E',
+      '0xfCF859324183DDBa27d3eAB78206eed1499511a5', 
     ].map(a => a.toLowerCase()))
 
     const blacklistedTokens = new Set([
       '0xC5e2B037D30a390e62180970B3aa4E91868764cD', // Tarot
+      '0xb7C2ddB1EBAc1056231ef22c1b0A13988537a274', // Tarot
       '0xfb98b335551a418cd0737375a2ea0ded62ea213b',// Lot of MAI pools have bad debt, ignoring it
     ].map(a => a.toLowerCase()))
 


### PR DESCRIPTION
1. mark shoebill markets insolvent
2. mark parallel lending v2 dead
3. blacklist tarot markets with bad debt and exclude 2nd TAROT token

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * ParaSpace V2: Set project inactivity date to May 15, 2026
  * Shoebill Finance V2: Marked multiple vault configurations as insolvent
  * Tarot: Updated borrowable pool filtering for improved TVL calculations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19312?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->