### PR TITLE
royco-v2: update factory address and add arbitrum support

### DIFF
--- a/projects/royco-v2/index.js
+++ b/projects/royco-v2/index.js
@@ -1,4 +1,4 @@
-const { getLogs } = require("../helper/cache/getLogs");
+const { getLogs2 } = require("../helper/cache/getLogs");
 
 const config = {
     "ethereum": {
@@ -19,12 +19,10 @@ const tvl = async (api) => {
     // Market Vaults
     const { factoryFromBlock, factoryAddress } = config[api.chain];
 
-    const marketDeployedLogs = await getLogs({
+    const marketDeployedLogs = await getLogs2({
         api,
         target: factoryAddress,
         eventAbi: "event MarketDeployed((address seniorTranche, address juniorTranche, address kernel, address accountant) roycoMarket, (string seniorTrancheName, string seniorTrancheSymbol, string juniorTrancheName, string juniorTrancheSymbol, address seniorTrancheImplementation, address juniorTrancheImplementation, address kernelImplementation, address accountantImplementation, bytes seniorTrancheInitializationData, bytes juniorTrancheInitializationData, bytes kernelInitializationData, bytes accountantInitializationData, bytes32 seniorTrancheProxyDeploymentSalt, bytes32 juniorTrancheProxyDeploymentSalt, bytes32 kernelProxyDeploymentSalt, bytes32 accountantProxyDeploymentSalt, (address target, bytes4[] selectors, uint64[] roles)[] roles) params)",
-        onlyArgs: true,
-        extraKey: 'v2',
         fromBlock: factoryFromBlock,
     });
 

--- a/projects/royco-v2/index.js
+++ b/projects/royco-v2/index.js
@@ -1,34 +1,18 @@
-const ADDRESSES = require('../helper/coreAssets.json')
 const { getLogs } = require("../helper/cache/getLogs");
 
 const config = {
     "ethereum": {
-        factoryAddress: "0xD567cCbb336Eb71eC2537057E2bCF6DB840bB71d",
-        factoryFromBlock: 24385420,
+        factoryAddress: "0x7cc6fb28ec7b5e7afc3cb3986141797ffc27253c",
+        factoryFromBlock: 24650849,
     },
     "avax": {
-        factoryAddress: "0xD567cCbb336Eb71eC2537057E2bCF6DB840bB71d",
-        factoryFromBlock: 77273727,
+        factoryAddress: "0x7cc6fb28ec7b5e7afc3cb3986141797ffc27253c",
+        factoryFromBlock: 80312789,
     },
-};
-
-// Reserve addresses -- balances held by multisigs and earn vaults
-// that are not deposited into Royco Market Vaults
-const reserves = {
-    "ethereum": [
-        {
-            owner: "0x170ff06326ebb64bf609a848fc143143994af6c8", // Multisig
-            tokens: [
-                "0x98c23e9d8f34fefb1b7bd6a91b7ff122f4e16f5c", // aaveUSDC (Aave v3)
-            ],
-        },
-        {
-            owner: "0xcd9f5907f92818bc06c9ad70217f089e190d2a32", // Earn vault
-            tokens: [
-                ADDRESSES.ethereum.USDC, // USDC
-            ],
-        },
-    ],
+    "arbitrum": {
+        factoryAddress: "0x7cc6fb28ec7b5e7afc3cb3986141797ffc27253c",
+        factoryFromBlock: 441493793,
+    },
 };
 
 const tvl = async (api) => {
@@ -38,8 +22,9 @@ const tvl = async (api) => {
     const marketDeployedLogs = await getLogs({
         api,
         target: factoryAddress,
-        eventAbi: "event MarketDeployed((address seniorTranche, address juniorTranche, address kernel, address accountant) roycoMarket, (string seniorTrancheName, string seniorTrancheSymbol, string juniorTrancheName, string juniorTrancheSymbol, bytes32 marketId, address seniorTrancheImplementation, address juniorTrancheImplementation, address kernelImplementation, address accountantImplementation, bytes seniorTrancheInitializationData, bytes juniorTrancheInitializationData, bytes kernelInitializationData, bytes accountantInitializationData, bytes32 seniorTrancheProxyDeploymentSalt, bytes32 juniorTrancheProxyDeploymentSalt, bytes32 kernelProxyDeploymentSalt, bytes32 accountantProxyDeploymentSalt, (address target, bytes4[] selectors, uint64[] roles)[] roles) params)",
+        eventAbi: "event MarketDeployed((address seniorTranche, address juniorTranche, address kernel, address accountant) roycoMarket, (string seniorTrancheName, string seniorTrancheSymbol, string juniorTrancheName, string juniorTrancheSymbol, address seniorTrancheImplementation, address juniorTrancheImplementation, address kernelImplementation, address accountantImplementation, bytes seniorTrancheInitializationData, bytes juniorTrancheInitializationData, bytes kernelInitializationData, bytes accountantInitializationData, bytes32 seniorTrancheProxyDeploymentSalt, bytes32 juniorTrancheProxyDeploymentSalt, bytes32 kernelProxyDeploymentSalt, bytes32 accountantProxyDeploymentSalt, (address target, bytes4[] selectors, uint64[] roles)[] roles) params)",
         onlyArgs: true,
+        extraKey: 'v2',
         fromBlock: factoryFromBlock,
     });
 
@@ -60,20 +45,11 @@ const tvl = async (api) => {
     jtTotalAssets.forEach((result, i) => {
         api.add(juniorAssets[i], BigInt(result.jtAssets));
     });
-
-    // Reserves — multisig and earn vaults
-    const chainReserves = reserves[api.chain];
-    if (chainReserves) {
-        await api.sumTokens({
-            tokensAndOwners: chainReserves.flatMap(({ owner, tokens }) =>
-                tokens.map(token => [token, owner])
-            ),
-        });
-    }
 };
 
 module.exports = {
     methodology: "TVL is computed by reading MarketDeployed events from the Royco V2 factory and summing totalAssets() across senior and junior tranches.",
     ethereum: { tvl },
     avax: { tvl },
+    arbitrum: { tvl },
 }


### PR DESCRIPTION
## Summary
- Update factory address on ethereum and avax to v2 factory (`0x7cc6fb28ec7b5e7afc3cb3986141797ffc27253c`) with refreshed `fromBlock`
- Add arbitrum chain support
- Update `MarketDeployed` event ABI (drop `marketId` field)

## Test plan
- [x] `node test.js projects/royco-v2/index.js` returns TVL on ethereum, avax, and arbitrum

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Arbitrum network support for TVL tracking.

* **Updates**
  * Updated factory/configuration for Ethereum and Avalanche networks.
  * Improved log ingestion and event parsing for more accurate market detection.

* **Behavior Changes**
  * TVL computation now excludes reserves, multisig, and earn-vault token sums (affects reported totals).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19315?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->