### PR TITLE
feat: add Virtuals Protocol TVL adapter (Base)

### DIFF
--- a/projects/virtuals-protocol/index.js
+++ b/projects/virtuals-protocol/index.js
@@ -1,0 +1,35 @@
+const { getLogs2 } = require('../helper/cache/getLogs')
+const { sumTokens2 } = require('../helper/unwrapLPs')
+
+const VIRTUAL = '0x0b3e328455c4059EEb9e3f84b5543F74E24e7E1b'
+const FFACTORY = '0x8909dc15e40173ff4699343b6eb8132c65e18ec6'
+const STAKING = '0x60a203ddcde45fbfb325bdeea93824b5726b4df8'
+
+const PAIR_CREATED = 'event PairCreated(address indexed token0, address indexed token1, address pair, uint256 pairId)'
+
+async function tvl(api) {
+  const logs = await getLogs2({
+    api,
+    target: FFACTORY,
+    fromBlock: 17130330,
+    eventAbi: PAIR_CREATED,
+  })
+
+  const pairs = logs
+    .filter(l => l.token0.toLowerCase() === VIRTUAL.toLowerCase() || l.token1.toLowerCase() === VIRTUAL.toLowerCase())
+    .map(l => l.pair)
+
+  return sumTokens2({ api, tokens: [VIRTUAL], owners: pairs })
+}
+
+async function staking(api) {
+  return sumTokens2({ api, tokens: [VIRTUAL], owners: [STAKING] })
+}
+
+module.exports = {
+  methodology: 'TVL counts VIRTUAL locked in pre-graduation agent bonding curve pools (FPair). Staking counts VIRTUAL locked in the Virtuals Protocol staking contract.',
+  base: {
+    tvl,
+    staking,
+  },
+}


### PR DESCRIPTION
## Summary

- Adds TVL adapter for [Virtuals Protocol](https://app.virtuals.io) on Base
- Tracks **pre-graduation bonding curve TVL**: VIRTUAL locked in FPair contracts deployed by FFactory (`0x8909dc15e40173ff4699343b6eb8132c65e18ec6`)
- Tracks **staking TVL**: VIRTUAL locked in the Virtuals staking contract (`0x60a203ddcde45fbfb325bdeea93824b5726b4df8`)

## Methodology

- `tvl()`: Fetches all `PairCreated` events from FFactory, filters to pairs involving VIRTUAL, then calls `sumTokens2` to aggregate VIRTUAL balances across all FPair contracts
- `staking()`: Calls `sumTokens2` for the staking contract
- No double-counting with Aerodrome: post-graduation agents' VIRTUAL moves from FPair to Aerodrome; the FPair balance drops to 0 naturally, so only pre-graduation TVL is counted

## Numbers (approximate at time of writing)

- ~25,800 FPairs total; ~1,250 with non-zero VIRTUAL balance
- Pre-graduation TVL: ~24.9M VIRTUAL (~$17.7M at $0.71)
- Staking: ~22.9M VIRTUAL (~$16.2M at $0.71)

## Test plan

- [ ] `node test.js projects/virtuals-protocol/index.js`
- [ ] Verify TVL ~$17M and staking ~$16M on the DefiLlama protocol page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Virtuals Protocol tracking capabilities, enabling visibility into total value locked across liquidity pairs and staking contract positions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19325?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->