### PR TITLE
update aqua network and callSoroban helper

### DIFF
--- a/projects/aqua-network/index.js
+++ b/projects/aqua-network/index.js
@@ -6,12 +6,10 @@ const { callSoroban } = require('../helper/chain/stellar')
 const ROUTER = 'CBQDHNBFBZYE4MKPWBSJOPIYLW4SFSXAXUTSXJN76GNKYVYPCKWC6QUK'
 
 const TOKEN_SETS_PAGE = 25n
-const POOL_CONCURRENCY = 10  
 
 async function tvl(api) {
   const totalSets = await callSoroban(ROUTER, 'get_tokens_sets_count')
 
-  const pools = []
   for (let start = 0n; start < totalSets; start += TOKEN_SETS_PAGE) {
     const end = start + TOKEN_SETS_PAGE > totalSets ? totalSets : start + TOKEN_SETS_PAGE
     const batch = await callSoroban(ROUTER, 'get_pools_for_tokens_range', [
@@ -20,23 +18,13 @@ async function tvl(api) {
     ])
     for (const [tokens, poolsMap] of batch) {
       for (const poolAddr of Object.values(poolsMap)) {
-        pools.push({ tokens, poolAddr })
+        const reserves = await callSoroban(poolAddr, 'get_reserves').catch(() => null)
+        if (!reserves) continue
+        for (let j = 0; j < tokens.length; j++) {
+          if (reserves[j] && reserves[j] > 0n) api.add(tokens[j], reserves[j].toString())
+        }
       }
     }
-  }
-
-  for (let i = 0; i < pools.length; i += POOL_CONCURRENCY) {
-    const chunk = pools.slice(i, i + POOL_CONCURRENCY)
-    const reservesList = await Promise.all(
-      chunk.map(p => callSoroban(p.poolAddr, 'get_reserves').catch(() => null))
-    )
-    reservesList.forEach((reserves, idx) => {
-      if (!reserves) return
-      const { tokens } = chunk[idx]
-      for (let j = 0; j < tokens.length; j++) {
-        if (reserves[j] && reserves[j] > 0n) api.add(tokens[j], reserves[j].toString())
-      }
-    })
   }
 }
 

--- a/projects/aqua-network/index.js
+++ b/projects/aqua-network/index.js
@@ -1,40 +1,48 @@
-const { get } = require('../helper/http')
-const AQUA_STATS_URL = "https://amm-api.aqua.network/api/external/v1/statistics/totals/?size=all"
+const { callSoroban } = require('../helper/chain/stellar')
 
-let _data
+// Aqua Soroban AMM LiquidityPoolRouter contract. Retrieves all pools via the
+// router's get_tokens_sets_count + get_pools_for_tokens_range, then reads each
+// pool's get_reserves: https://github.com/AquaToken/soroban-amm
+const ROUTER = 'CBQDHNBFBZYE4MKPWBSJOPIYLW4SFSXAXUTSXJN76GNKYVYPCKWC6QUK'
 
-async function getData() {
-  if (!_data)
-    _data = get(AQUA_STATS_URL)
-  const data = await _data
-  const res = {}
-  data.forEach((item) => {
-    res[item.date] = item.tvl / 1e7
-  })
-  return res
-}
-
-function formatUnixTimestamp(unixTimestamp) {
-  const date = new Date(unixTimestamp * 1000); // Convert Unix timestamp to milliseconds
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0'); // Months are zero-based
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
-}
+const TOKEN_SETS_PAGE = 25n
+const POOL_CONCURRENCY = 10  
 
 async function tvl(api) {
-  const key = formatUnixTimestamp(api.timestamp)
-  const allData = await getData()
-  const usdValue = allData[key]
-  if (!usdValue)
-    throw new Error('No data found for current date');
-  api.addCGToken('tether', usdValue)
+  const totalSets = await callSoroban(ROUTER, 'get_tokens_sets_count')
+
+  const pools = []
+  for (let start = 0n; start < totalSets; start += TOKEN_SETS_PAGE) {
+    const end = start + TOKEN_SETS_PAGE > totalSets ? totalSets : start + TOKEN_SETS_PAGE
+    const batch = await callSoroban(ROUTER, 'get_pools_for_tokens_range', [
+      { type: 'u128', value: start },
+      { type: 'u128', value: end },
+    ])
+    for (const [tokens, poolsMap] of batch) {
+      for (const poolAddr of Object.values(poolsMap)) {
+        pools.push({ tokens, poolAddr })
+      }
+    }
+  }
+
+  for (let i = 0; i < pools.length; i += POOL_CONCURRENCY) {
+    const chunk = pools.slice(i, i + POOL_CONCURRENCY)
+    const reservesList = await Promise.all(
+      chunk.map(p => callSoroban(p.poolAddr, 'get_reserves').catch(() => null))
+    )
+    reservesList.forEach((reserves, idx) => {
+      if (!reserves) return
+      const { tokens } = chunk[idx]
+      for (let j = 0; j < tokens.length; j++) {
+        if (reserves[j] && reserves[j] > 0n) api.add(tokens[j], reserves[j].toString())
+      }
+    })
+  }
 }
 
 module.exports = {
-  start: '2024-07-01',
-  misrepresentedTokens: true,
+  timetravel: false,
   methodology:
-    'counts the liquidity of the Pools on AMM, data is pulled from the Aquarius API.',
+    'Counts liquidity locked in all Aqua AMM pools. Enumerates the full pool list on-chain via the LiquidityPoolRouter (get_tokens_sets_count + get_pools_for_tokens_range), then reads each pool contract\'s get_reserves directly.',
   stellar: { tvl },
-};
+}

--- a/projects/aqua-network/index.js
+++ b/projects/aqua-network/index.js
@@ -18,7 +18,7 @@ async function tvl(api) {
     ])
     for (const [tokens, poolsMap] of batch) {
       for (const poolAddr of Object.values(poolsMap)) {
-        const reserves = await callSoroban(poolAddr, 'get_reserves').catch(() => null)
+        const reserves = await callSoroban(poolAddr, 'get_reserves')
         if (!reserves) continue
         for (let j = 0; j < tokens.length; j++) {
           if (reserves[j] && reserves[j] > 0n) api.add(tokens[j], reserves[j].toString())

--- a/projects/helper/chain/stellar.js
+++ b/projects/helper/chain/stellar.js
@@ -152,8 +152,18 @@ function _parseScVal(buf, offset) {
     }
     case SC_VAL.ADDRESS: {
       const addrType = buf.readUInt32BE(offset); offset += 4
+      let version
+      if (addrType === SC_ADDR.CONTRACT) {
+        version = STRKEY_VERSION.CONTRACT
+      } else if (addrType === SC_ADDR.ACCOUNT) {
+        // AccountID is a PublicKey union; 40 bytes vs SAC's 36
+        const keyType = buf.readUInt32BE(offset); offset += 4
+        if (keyType !== 0) throw new Error(`Unsupported PublicKey type: ${keyType}`)
+        version = STRKEY_VERSION.ACCOUNT
+      } else {
+        throw new Error(`Unsupported SCAddressType: ${addrType}`)
+      }
       const addrBytes = Buffer.from(buf.slice(offset, offset + 32)); offset += 32
-      const version = addrType === SC_ADDR.CONTRACT ? STRKEY_VERSION.CONTRACT : STRKEY_VERSION.ACCOUNT
       return { value: _encodeStrKey(version, addrBytes), offset }
     }
     default: throw new Error(`Unsupported ScVal type: ${type}`)
@@ -204,7 +214,7 @@ function _writeTaggedArg(buf, o, type, v) {
     case 'u128': return _writeInt(buf, o, SC_VAL.U128, v, 16, false)
     case 'i128': return _writeInt(buf, o, SC_VAL.I128, v, 16, true)
     case 'address': {
-      if (typeof v !== 'string') throw new Error(`address expects string, got ${typeof v}`)
+      if (typeof v !== 'string' || !v.startsWith('C')) throw new Error(`address expects SAC string, got ${typeof v}`)
       buf.writeUInt32BE(SC_VAL.ADDRESS, o); o += 4
       buf.writeUInt32BE(SC_ADDR.CONTRACT, o); o += 4
       decodeStrKey(v).copy(buf, o); return o + 32

--- a/projects/helper/chain/stellar.js
+++ b/projects/helper/chain/stellar.js
@@ -54,6 +54,19 @@ async function getTokenBalance(token, address) {
 
 // Helpers for interacting with Soroban smart contracts via RPC without using @stellar/stellar-sdk.
 
+// Soroban ScVal type tags: https://github.com/stellar/stellar-xdr/blob/main/Stellar-contract.x
+const SC_VAL = {
+  BOOL: 0, VOID: 1, U32: 3, I32: 4, U64: 5, I64: 6,
+  U128: 9, I128: 10, BYTES: 13, STRING: 14, SYMBOL: 15,
+  VEC: 16, MAP: 17, ADDRESS: 18
+}
+
+// SC_ADDRESS sub-type tags (used inside ScVal::Address values).
+const SC_ADDR = { ACCOUNT: 0, CONTRACT: 1 }
+
+// StrKey version bytes:  https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0023.md#specification
+const STRKEY_VERSION = { ACCOUNT: 48, CONTRACT: 16 }
+
 
 function decodeStrKey(strKey) {
   const raw = Buffer.from(base32.decode.asBytes(strKey))
@@ -93,37 +106,31 @@ function _encodeStrKey(versionByte, rawBytes) {
  *
  * ScVal ("Smart Contract Value") is Stellar's universal type system for
  * Soroban return values—every contract function result is encoded as an ScVal.
- * The first 4 bytes are a type discriminator, then the payload follows.
- *
- * Supported types:
- *   0  = BOOL          3  = U32       4  = I32
- *   5  = U64           6  = I64       9  = U128      10 = I128
- *  13  = BYTES        14  = STRING   15  = SYMBOL
- *  16  = VEC (array)  17  = MAP      18  = ADDRESS
+ * The first 4 bytes are a type discriminator (list in SC_VAL), then the payload follows.
  */
 function _parseScVal(buf, offset) {
   const type = buf.readUInt32BE(offset); offset += 4
   switch (type) {
-    case 0: return { value: buf.readUInt32BE(offset) !== 0, offset: offset + 4 } // BOOL
-    case 1: return { value: null, offset } // VOID
-    case 3: return { value: buf.readUInt32BE(offset), offset: offset + 4 } // U32
-    case 4: return { value: buf.readInt32BE(offset), offset: offset + 4 } // I32
-    case 5: return { value: buf.readBigUInt64BE(offset), offset: offset + 8 } // U64
-    case 6: return { value: buf.readBigInt64BE(offset), offset: offset + 8 } // I64
-    case 9: { // U128
+    case SC_VAL.BOOL: return { value: buf.readUInt32BE(offset) !== 0, offset: offset + 4 }
+    case SC_VAL.VOID: return { value: null, offset }
+    case SC_VAL.U32:  return { value: buf.readUInt32BE(offset), offset: offset + 4 }
+    case SC_VAL.I32:  return { value: buf.readInt32BE(offset),  offset: offset + 4 }
+    case SC_VAL.U64:  return { value: buf.readBigUInt64BE(offset), offset: offset + 8 }
+    case SC_VAL.I64:  return { value: buf.readBigInt64BE(offset),  offset: offset + 8 }
+    case SC_VAL.U128: {
       const hi = buf.readBigUInt64BE(offset), lo = buf.readBigUInt64BE(offset + 8)
       return { value: (hi << 64n) + lo, offset: offset + 16 }
     }
-    case 10: { // I128
+    case SC_VAL.I128: {
       const hi = buf.readBigInt64BE(offset), lo = buf.readBigUInt64BE(offset + 8)
       return { value: (hi << 64n) | lo, offset: offset + 16 }
     }
-    case 13: case 14: case 15: { // BYTES, STRING, SYMBOL
+    case SC_VAL.BYTES: case SC_VAL.STRING: case SC_VAL.SYMBOL: {
       const len = buf.readUInt32BE(offset); offset += 4
       const str = buf.slice(offset, offset + len).toString('utf8')
       return { value: str, offset: offset + len + ((4 - (len % 4)) % 4) }
     }
-    case 16: { // VEC (optional)
+    case SC_VAL.VEC: {
       const present = buf.readUInt32BE(offset); offset += 4
       if (!present) return { value: null, offset }
       const len = buf.readUInt32BE(offset); offset += 4
@@ -131,7 +138,7 @@ function _parseScVal(buf, offset) {
       for (let i = 0; i < len; i++) { const e = _parseScVal(buf, offset); arr.push(e.value); offset = e.offset }
       return { value: arr, offset }
     }
-    case 17: { // MAP (optional)
+    case SC_VAL.MAP: {
       const present = buf.readUInt32BE(offset); offset += 4
       if (!present) return { value: null, offset }
       const len = buf.readUInt32BE(offset); offset += 4
@@ -143,61 +150,117 @@ function _parseScVal(buf, offset) {
       }
       return { value: map, offset }
     }
-    case 18: { // ADDRESS
+    case SC_VAL.ADDRESS: {
       const addrType = buf.readUInt32BE(offset); offset += 4
       const addrBytes = Buffer.from(buf.slice(offset, offset + 32)); offset += 32
-      return { value: _encodeStrKey(addrType === 1 ? 16 : 48, addrBytes), offset }
+      const version = addrType === SC_ADDR.CONTRACT ? STRKEY_VERSION.CONTRACT : STRKEY_VERSION.ACCOUNT
+      return { value: _encodeStrKey(version, addrBytes), offset }
     }
     default: throw new Error(`Unsupported ScVal type: ${type}`)
   }
 }
 
+// Size per tagged ScVal; derived from RFC-4506 (4.1, 4.3, 4.4) and Stellar-contract.x:
+// https://github.com/stellar/stellar-xdr/blob/main/Stellar-contract.x
+const TAGGED_SIZE = {
+  bool: 8, u32: 8, i32: 8, u64: 12, i64: 12, u128: 20, i128: 20, address: 40,
+}
+
+// Encodes an XDR int (i32/u32, i64/u64, i128/u128) into buf
+function _writeInt(buf, o, scValTag, value, byteWidth, signed) {
+  const n = BigInt(value)
+  const bits = BigInt(byteWidth * 8)
+  const min = signed ? -(1n << (bits - 1n)) : 0n
+  const max = signed ?  (1n << (bits - 1n)) - 1n : (1n << bits) - 1n
+  if (n < min || n > max) throw new Error(`${signed ? 'i' : 'u'}${bits} out of range: ${value}`)
+
+  buf.writeUInt32BE(scValTag, o); o += 4
+  if (byteWidth === 4) {
+    signed ? buf.writeInt32BE(Number(n), o) : buf.writeUInt32BE(Number(n), o)
+    return o + 4
+  }
+  if (byteWidth === 8) {
+    signed ? buf.writeBigInt64BE(n, o) : buf.writeBigUInt64BE(n, o)
+    return o + 8
+  }
+  
+  const u = signed && n < 0n ? n + (1n << 128n) : n
+  buf.writeBigUInt64BE(u >> 64n, o); o += 8
+  buf.writeBigUInt64BE(u & ((1n << 64n) - 1n), o)
+  return o + 8
+}
+
+function _writeTaggedArg(buf, o, type, v) {
+  switch (type) {
+    case 'bool': {
+      if (typeof v !== 'boolean') throw new Error(`bool expects boolean, got ${typeof v}`)
+      buf.writeUInt32BE(SC_VAL.BOOL, o); o += 4
+      buf.writeUInt32BE(v ? 1 : 0, o); return o + 4
+    }
+    case 'u32':  return _writeInt(buf, o, SC_VAL.U32,  v, 4,  false)
+    case 'i32':  return _writeInt(buf, o, SC_VAL.I32,  v, 4,  true)
+    case 'u64':  return _writeInt(buf, o, SC_VAL.U64,  v, 8,  false)
+    case 'i64':  return _writeInt(buf, o, SC_VAL.I64,  v, 8,  true)
+    case 'u128': return _writeInt(buf, o, SC_VAL.U128, v, 16, false)
+    case 'i128': return _writeInt(buf, o, SC_VAL.I128, v, 16, true)
+    case 'address': {
+      if (typeof v !== 'string') throw new Error(`address expects string, got ${typeof v}`)
+      buf.writeUInt32BE(SC_VAL.ADDRESS, o); o += 4
+      buf.writeUInt32BE(SC_ADDR.CONTRACT, o); o += 4
+      decodeStrKey(v).copy(buf, o); return o + 32
+    }
+    default: throw new Error(`Unsupported ScVal type: '${type}'`)
+  }
+}
+
 /**
  * Simulate a read-only Soroban contract call via RPC.
- * contractId - Stellar contract address
- * fnName - Contract function name
- * args - Optional args: number -> U32, string -> contract address
+ * @param {string} contractId  - Stellar contract address
+ * @param {string} fnName      - Contract function name
+ * @param {Array}  args        - Function args. Defaults string to ADDRESS and number to U32
+ * For other arg types, pass an object like: { type: 'u128', value: 100n } or { type: 'bool', value: true }
  */
 async function callSoroban(contractId, fnName, args = []) {
   const contractBytes = decodeStrKey(contractId)
   const fnPadLen = fnName.length + ((4 - (fnName.length % 4)) % 4)
 
-  // Calculate total size of serialized args
+  // Normalize each arg into [type, value]. Strings default to ADDRESS, numbers
+  // to U32. Tagged { type, value } objects pass through unchanged.
+  const normalizedArgs = args.map(arg => {
+    if (arg && typeof arg === 'object' && 'type' in arg) return [arg.type, arg.value]
+    if (typeof arg === 'string')                         return ['address', arg]
+    if (typeof arg === 'number')                         return ['u32', arg]
+    throw new Error(`Unsupported arg type: ${typeof arg}`)
+  })
+
   let argsSize = 0
-  for (const arg of args) {
-    if (typeof arg === 'number') argsSize += 8        // U32: type(4) + value(4)
-    else if (typeof arg === 'string') argsSize += 40  // ADDRESS: type(4) + addrType(4) + bytes(32)
-    else throw new Error(`Unsupported arg type: ${typeof arg}`)
+  for (const [type] of normalizedArgs) {
+    const size = TAGGED_SIZE[type]
+    if (size == null) throw new Error(`Unsupported tagged ScVal type: '${type}'`)
+    argsSize += size
   }
 
+  // TransactionV1Envelope: https://github.com/stellar/stellar-xdr/blob/main/Stellar-transaction.x#L1010
   const buf = Buffer.alloc(132 + fnPadLen + argsSize)
   let o = 0
   buf.writeUInt32BE(2, o); o += 4        // ENVELOPE_TYPE_TX
-  buf.writeUInt32BE(0, o); o += 4        // KEY_TYPE_ED25519
-  o += 32                                 // dummy source (zeros)
+  buf.writeUInt32BE(0, o); o += 4        // MuxedAccount.KEY_TYPE_ED25519
+  o += 32                                // dummy source (zeros)
   buf.writeUInt32BE(100, o); o += 4      // fee
   buf.writeBigUInt64BE(0n, o); o += 8    // seqNum
-  buf.writeUInt32BE(0, o); o += 4        // PRECOND_NONE
-  buf.writeUInt32BE(0, o); o += 4        // MEMO_NONE
+  buf.writeUInt32BE(0, o); o += 4        // Preconditions.PRECOND_NONE
+  buf.writeUInt32BE(0, o); o += 4        // Memo.MEMO_NONE
   buf.writeUInt32BE(1, o); o += 4        // 1 operation
   buf.writeUInt32BE(0, o); o += 4        // no sourceAccount on op
-  buf.writeUInt32BE(24, o); o += 4       // INVOKE_HOST_FUNCTION
-  buf.writeUInt32BE(0, o); o += 4        // HOST_FUNCTION_TYPE_INVOKE_CONTRACT
-  buf.writeUInt32BE(1, o); o += 4        // SC_ADDRESS_TYPE_CONTRACT
+  buf.writeUInt32BE(24, o); o += 4       // Operation.INVOKE_HOST_FUNCTION
+  buf.writeUInt32BE(0, o); o += 4        // HostFunctionType.HOST_FUNCTION_TYPE_INVOKE_CONTRACT
+  buf.writeUInt32BE(1, o); o += 4        // SCAddressType.SC_ADDRESS_TYPE_CONTRACT
   contractBytes.copy(buf, o); o += 32    // contractId bytes
   buf.writeUInt32BE(fnName.length, o); o += 4
   buf.write(fnName, o, 'utf8'); o += fnPadLen
   buf.writeUInt32BE(args.length, o); o += 4
-  for (const arg of args) {
-    if (typeof arg === 'number') {
-      buf.writeUInt32BE(3, o); o += 4    // SC_VAL_TYPE_U32
-      buf.writeUInt32BE(arg, o); o += 4
-    } else if (typeof arg === 'string') {
-      const argBytes = decodeStrKey(arg)
-      buf.writeUInt32BE(18, o); o += 4   // SC_VAL_TYPE_ADDRESS
-      buf.writeUInt32BE(1, o); o += 4    // SC_ADDRESS_TYPE_CONTRACT
-      argBytes.copy(buf, o); o += 32
-    }
+  for (const [type, value] of normalizedArgs) {
+    o = _writeTaggedArg(buf, o, type, value)
   }
   buf.writeUInt32BE(0, o); o += 4        // 0 auth
   buf.writeUInt32BE(0, o); o += 4        // ext v=0


### PR DESCRIPTION
resolves #19130


1. `aqua-network/index.js` - rewrites to use `callSoroban` helper instead of api
    - ~19M gap between what API reports due to token pricing, particularly solvBTC and xSolvBTC
2. `helper/chain/stellar.js` - adds support for additional arg types
    - aqua-network uses u128 for [get_pools_for_tokens_range](https://github.com/AquaToken/soroban-amm/blob/c4d842de3108a23a4a1107b7d54c357bae45f962/liquidity_pool_router/src/pool_interface.rs#L255)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Aqua Network TVL now enumerates on-chain liquidity pools for more reliable, real-time valuation.
  * Soroban simulation and argument encoding enhanced to support richer data types and improve contract interaction robustness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19328?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->