### PR TITLE
feat: add Virtuals Protocol TVL adapter (Base)

### DIFF
--- a/projects/virtuals-protocol/index.js
+++ b/projects/virtuals-protocol/index.js
@@ -1,0 +1,35 @@
+const { getLogs2 } = require('../helper/cache/getLogs')
+const { sumTokens2 } = require('../helper/unwrapLPs')
+
+const VIRTUAL = '0x0b3e328455c4059EEb9e3f84b5543F74E24e7E1b'
+const FFACTORY = '0x8909dc15e40173ff4699343b6eb8132c65e18ec6'
+const STAKING = '0x60a203ddcde45fbfb325bdeea93824b5726b4df8'
+
+const PAIR_CREATED = 'event PairCreated(address indexed token0, address indexed token1, address pair, uint256 pairId)'
+
+async function tvl(api) {
+  const logs = await getLogs2({
+    api,
+    target: FFACTORY,
+    fromBlock: 17130330,
+    eventAbi: PAIR_CREATED,
+  })
+
+  const pairs = logs
+    .filter(l => l.token0.toLowerCase() === VIRTUAL.toLowerCase() || l.token1.toLowerCase() === VIRTUAL.toLowerCase())
+    .map(l => l.pair)
+
+  return sumTokens2({ api, tokens: [VIRTUAL], owners: pairs })
+}
+
+async function staking(api) {
+  return sumTokens2({ api, tokens: [VIRTUAL], owners: [STAKING] })
+}
+
+module.exports = {
+  methodology: 'TVL counts VIRTUAL locked in pre-graduation agent bonding curve pools (FPair). Staking counts VIRTUAL locked in the Virtuals Protocol staking contract.',
+  base: {
+    tvl,
+    staking,
+  },
+}

--- a/projects/virtuals-protocol/index.js
+++ b/projects/virtuals-protocol/index.js
@@ -7,7 +7,7 @@ const STAKING = '0x60a203ddcde45fbfb325bdeea93824b5726b4df8'
 
 const PAIR_CREATED = 'event PairCreated(address indexed tokenA, address indexed tokenB, address pair, uint256)'
 
-async function tvl(api) {
+async function staking(api) {
   const logs = await getLogs2({
     api,
     target: FFACTORY,
@@ -19,17 +19,13 @@ async function tvl(api) {
     .filter(l => l.tokenA.toLowerCase() === VIRTUAL.toLowerCase() || l.tokenB.toLowerCase() === VIRTUAL.toLowerCase())
     .map(l => l.pair)
 
-  return sumTokens2({ api, tokens: [VIRTUAL], owners: pairs })
-}
-
-async function staking(api) {
-  return sumTokens2({ api, tokens: [VIRTUAL], owners: [STAKING] })
+  return sumTokens2({ api, tokens: [VIRTUAL], owners: [STAKING, ...pairs] })
 }
 
 module.exports = {
-  methodology: 'TVL counts VIRTUAL locked in pre-graduation agent bonding curve pools (FPair). Staking counts VIRTUAL locked in the Virtuals Protocol staking contract.',
+  methodology: 'Counts VIRTUAL locked in pre-graduation agent bonding curve pools (FPair) and VIRTUAL locked in the Virtuals Protocol staking contract.',
   base: {
-    tvl,
+    tvl: () => ({}),
     staking,
   },
 }

--- a/projects/virtuals-protocol/index.js
+++ b/projects/virtuals-protocol/index.js
@@ -2,21 +2,21 @@ const { getLogs2 } = require('../helper/cache/getLogs')
 const { sumTokens2 } = require('../helper/unwrapLPs')
 
 const VIRTUAL = '0x0b3e328455c4059EEb9e3f84b5543F74E24e7E1b'
-const FFACTORY = '0x8909dc15e40173ff4699343b6eb8132c65e18ec6'
+const FFACTORY = '0xD7D3C85B4f2e9bee1998cD2E98820e647792d284'
 const STAKING = '0x60a203ddcde45fbfb325bdeea93824b5726b4df8'
 
-const PAIR_CREATED = 'event PairCreated(address indexed token0, address indexed token1, address pair, uint256 pairId)'
+const PAIR_CREATED = 'event PairCreated(address indexed tokenA, address indexed tokenB, address pair, uint256)'
 
 async function tvl(api) {
   const logs = await getLogs2({
     api,
     target: FFACTORY,
-    fromBlock: 17130330,
+    fromBlock: 36529894,
     eventAbi: PAIR_CREATED,
   })
 
   const pairs = logs
-    .filter(l => l.token0.toLowerCase() === VIRTUAL.toLowerCase() || l.token1.toLowerCase() === VIRTUAL.toLowerCase())
+    .filter(l => l.tokenA.toLowerCase() === VIRTUAL.toLowerCase() || l.tokenB.toLowerCase() === VIRTUAL.toLowerCase())
     .map(l => l.pair)
 
   return sumTokens2({ api, tokens: [VIRTUAL], owners: pairs })


### PR DESCRIPTION
site: https://www.virtuals.io/
app: https://app.virtuals.io/
twitter: https://x.com/virtuals_io
cg: https://www.coingecko.com/en/coins/virtual-protocol

## Summary

Adds a TVL adapter for Virtuals Protocol on Base, tracking two buckets:

- **tvl**: VIRTUAL tokens held in pre-graduation bonding curve pools (FPairs) created by FFactory
- **staking**: VIRTUAL locked in the protocol staking contract

## Methodology

The FFactory (`0x8909dc15e40173ff4699343b6eb8132c65e18ec6`) emits a `PairCreated` event for each new agent token launch. Each FPair holds VIRTUAL as the reserve asset during the bonding curve phase. The adapter uses `getLogs2` to enumerate all FPairs from the factory and `sumTokens2` to aggregate VIRTUAL balances across all active pairs.

Staking is tracked separately via the dedicated staking contract (`0x60a203ddcde45fbfb325bdeea93824b5726b4df8`).

## Contracts

| Contract | Address |
|---|---|
| VIRTUAL token | `0x0b3e328455c4059EEb9e3f84b5543F74E24e7E1b` |
| FFactory | `0x8909dc15e40173ff4699343b6eb8132c65e18ec6` |
| Staking | `0x60a203ddcde45fbfb325bdeea93824b5726b4df8` |

## Verification

```
npm run test -- projects/virtuals-protocol
```

Expected: tvl ~$17M (bonding curves), staking ~$16M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Staking now aggregates VIRTUAL held by the staking contract and by relevant liquidity-pool pairs created by the protocol.
* **Bug Fixes**
  * TVL display replaced with an empty placeholder to avoid presenting outdated totals.
* **Documentation**
  * Updated methodology to describe how staking and pool token counts are calculated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19334?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->