### PR TITLE
Add Bond (Uniswap V3 fork on 0G)

### DIFF
--- a/registries/uniswapV3.js
+++ b/registries/uniswapV3.js
@@ -8,6 +8,7 @@ const uniV3Configs = {
   'warpx-v3': { megaeth: { factory: '0xf67cF9d6FC433e97Ec39Ae4b7E4451B56B171C8a', fromBlock: 4630394 } },
   'sailfish-v3': { occ: { factory: '0x963A7f4eB46967A9fd3dFbabD354fC294FA2BF5C', fromBlock: 142495 } },
   'tradegpt': { '0g': { factory: '0x6F3945Ab27296D1D66D8EEb042ff1B4fb2E0CE70', fromBlock: 5711733 } },
+  'bond': { '0g': { factory: '0xBDDB3aCF0A90029a1e7ebC3F82C7D9391C429A75', fromBlock: 32738449 } },
   'ultrasolid-v3': { hyperliquid: { factory: '0xD883a0B7889475d362CEA8fDf588266a3da554A1', fromBlock: 10742640 } },
   'juiceswap': { citrea: { factory: '0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82', fromBlock: 2651539 } },
   'weero-v3': { klaytn: { factory: '0x6603E53b4Ae1AdB1755bAF62BcbF206f90874178', fromBlock: 186673202 } },


### PR DESCRIPTION
  ## Summary
  Adds Bond, a Uniswap V3 fork DEX deployed on 0G Mainnet (chainId 16661).

  TVL is sourced via the standard `uniV3Export` helper against Bond's factory, so it scans `PoolCreated` events and sums pool reserves.

  ## Details
  - Protocol key: `bond`
  - Chain: 0G
  - Factory: `0xBDDB3aCF0A90029a1e7ebC3F82C7D9391C429A75`
  - fromBlock: `32738449` (first `PoolCreated` event emitted by the factory)
  - Added as a one-line entry to `registries/uniswapV3.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for bond protocol configuration in Uniswap V3.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19345?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->