### PR TITLE
fix(pool-party): source TVL from CCTools to include stablecoin pools

### DIFF
--- a/projects/pool-party/index.js
+++ b/projects/pool-party/index.js
@@ -2,6 +2,9 @@ const { get } = require('../helper/http')
 
 const POOLS_URL = 'https://api.cctools.network/api/markets/send/pools'
 
+// CCTools rejects axios's default User-Agent; identify ourselves explicitly.
+const FETCH_OPTS = { headers: { 'User-Agent': 'DefiLlama-Adapter (pool-party)' } }
+
 // Canonical Canton token IDs → CoinGecko slugs.
 // USDCx (bridged USDC) and CUSD (Send privacy stable) priced as USDC; neither
 // has its own CoinGecko listing.
@@ -12,7 +15,7 @@ const TOKEN_TO_CG = {
 }
 
 async function tvl(api) {
-  const pools = await get(POOLS_URL)
+  const pools = await get(POOLS_URL, FETCH_OPTS)
   for (const pool of pools) {
     if (pool.status !== 'live') continue
     for (const side of [pool.baseReserve, pool.quoteReserve]) {

--- a/projects/pool-party/index.js
+++ b/projects/pool-party/index.js
@@ -2,25 +2,21 @@ const { get } = require('../helper/http')
 
 const POOLS_URL = 'https://api.cctools.network/api/markets/send/pools'
 
+// const parties = [
+//   'mainnet-pool-party-amulet-cusd-operator::1220724bbd5179d9f5d19de90f31cfa0e99e4bf9cf815e3e5e669a40524725d9e98b',
+//   'mainnet-pool-party-amulet-usdcx-operator::1220647009424eff86ef09493a366aa314e8533c0cd8070aa82a9b014e42daad03c3',
+// ]
+
 // CCTools rejects axios's default User-Agent; identify ourselves explicitly.
 const FETCH_OPTS = { headers: { 'User-Agent': 'DefiLlama-Adapter (pool-party)' } }
-
-// Canonical Canton token IDs → CoinGecko slugs.
-// USDCx (bridged USDC) and CUSD (Send privacy stable) priced as USDC; neither
-// has its own CoinGecko listing.
-const TOKEN_TO_CG = {
-  'Amulet': 'canton-network',
-  'USDCx': 'usd-coin',
-  '481871d4-ca56-42a8-b2d3-4b7d28742946': 'usd-coin',
-}
 
 async function tvl(api) {
   const pools = await get(POOLS_URL, FETCH_OPTS)
   for (const pool of pools) {
     if (pool.status !== 'live') continue
     for (const side of [pool.baseReserve, pool.quoteReserve]) {
-      const cgId = TOKEN_TO_CG[side.tokenId]
-      if (cgId) api.addCGToken(cgId, Number(side.amount))
+      const m = side.tokenId == 'Amulet' ? 1e18 : 1e6
+      api.add(side.tokenId, Number(side.amount) * m)
     }
   }
 }
@@ -29,9 +25,7 @@ module.exports = {
   timetravel: false,
   canton: { tvl },
   methodology:
-    "Sum of raw token reserves across Pool Party's live pools " +
-    "(CC/USDCx, CC/CUSD, CUSD/USDCx), via the CCTools API — an independent " +
-    "Canton DeFi aggregator that exposes per-pool reserves with canonical " +
-    "token IDs. CC priced via coingecko:canton-network; USDCx (bridged USDC) " +
-    "and CUSD priced via coingecko:usd-coin (neither has its own listing).",
+    "Sum of raw token reserves across Pool Party's live pools (CC/USDCx, " +
+    "CC/CUSD, CUSD/USDCx), via the CCTools API — an independent Canton DeFi " +
+    "aggregator that exposes per-pool reserves with canonical token IDs."
 }

--- a/projects/pool-party/index.js
+++ b/projects/pool-party/index.js
@@ -1,14 +1,24 @@
 const { get } = require('../helper/http')
 
-// CCTools is an independent Canton DeFi aggregator. Its public API reports
-// per-pool USD TVL for every Pool Party pool, including the stablecoin sides
-// (USDCx, CUSD) that the Lighthouse API does not expose.
 const POOLS_URL = 'https://api.cctools.network/api/markets/send/pools'
+
+// Canonical Canton token IDs → CoinGecko slugs.
+// USDCx (bridged USDC) and CUSD (Send privacy stable) priced as USDC; neither
+// has its own CoinGecko listing.
+const TOKEN_TO_CG = {
+  'Amulet': 'canton-network',
+  'USDCx': 'usd-coin',
+  '481871d4-ca56-42a8-b2d3-4b7d28742946': 'usd-coin',
+}
 
 async function tvl(api) {
   const pools = await get(POOLS_URL)
   for (const pool of pools) {
-    if (pool.status === 'live') api.addUSDValue(Number(pool.tvlUsd))
+    if (pool.status !== 'live') continue
+    for (const side of [pool.baseReserve, pool.quoteReserve]) {
+      const cgId = TOKEN_TO_CG[side.tokenId]
+      if (cgId) api.addCGToken(cgId, Number(side.amount))
+    }
   }
 }
 
@@ -16,8 +26,9 @@ module.exports = {
   timetravel: false,
   canton: { tvl },
   methodology:
-    "Sum of USD-denominated liquidity across Pool Party's live pools " +
+    "Sum of raw token reserves across Pool Party's live pools " +
     "(CC/USDCx, CC/CUSD, CUSD/USDCx), via the CCTools API — an independent " +
-    "Canton DeFi aggregator that indexes the stablecoin sides (USDCx, CUSD) " +
-    "in addition to Canton Coin.",
+    "Canton DeFi aggregator that exposes per-pool reserves with canonical " +
+    "token IDs. CC priced via coingecko:canton-network; USDCx (bridged USDC) " +
+    "and CUSD priced via coingecko:usd-coin (neither has its own listing).",
 }

--- a/projects/pool-party/index.js
+++ b/projects/pool-party/index.js
@@ -1,19 +1,14 @@
 const { get } = require('../helper/http')
 
-const BASE_URL = 'https://lighthouse.cantonloop.com/api/parties/'
-
-// Per-pool operator parties that custody pool reserves. Only CC-containing
-// pools are listed; the USDCx/CUSD pool has no CC side and the Lighthouse API
-// does not expose non-CC balances per party.
-const parties = [
-  'mainnet-pool-party-amulet-cusd-operator::1220724bbd5179d9f5d19de90f31cfa0e99e4bf9cf815e3e5e669a40524725d9e98b',
-  'mainnet-pool-party-amulet-usdcx-operator::1220647009424eff86ef09493a366aa314e8533c0cd8070aa82a9b014e42daad03c3',
-]
+// CCTools is an independent Canton DeFi aggregator. Its public API reports
+// per-pool USD TVL for every Pool Party pool, including the stablecoin sides
+// (USDCx, CUSD) that the Lighthouse API does not expose.
+const POOLS_URL = 'https://api.cctools.network/api/markets/send/pools'
 
 async function tvl(api) {
-  for (const party of parties) {
-    const { balance } = await get(BASE_URL + party + '/balance')
-    api.addGasToken(Number(balance.total_coin_holdings) * 1e18)
+  const pools = await get(POOLS_URL)
+  for (const pool of pools) {
+    if (pool.status === 'live') api.addUSDValue(Number(pool.tvlUsd))
   }
 }
 
@@ -21,8 +16,8 @@ module.exports = {
   timetravel: false,
   canton: { tvl },
   methodology:
-    "Sum of Canton Coin (CC) reserves held by Pool Party's CC/CUSD and " +
-    "CC/USDCx pool operator parties, via the Lighthouse API. Stablecoin " +
-    "sides (CUSD, USDCx) and the USDCx/CUSD pool are not included since " +
-    "non-CC balances are not currently queryable through public Canton APIs.",
+    "Sum of USD-denominated liquidity across Pool Party's live pools " +
+    "(CC/USDCx, CC/CUSD, CUSD/USDCx), via the CCTools API — an independent " +
+    "Canton DeFi aggregator that indexes the stablecoin sides (USDCx, CUSD) " +
+    "in addition to Canton Coin.",
 }


### PR DESCRIPTION
Per @RohanNero's note on #19041 (option 2 — a neutral third-party indexer covering non-CC balances), this switches the Pool Party adapter to CCTools (`api.cctools.network`), an independent Canton DeFi aggregator not affiliated with Send.

CCTools indexes the stablecoin sides (USDCx, CUSD) that the Lighthouse API does not expose, so all three live pools are now counted: CC/USDCx, CC/CUSD, CUSD/USDCx.

TVL: ~$180k → ~$1.19M (current snapshot).

Note: CCTools serves pre-computed per-pool USD, so the adapter reports via `addUSDValue`. Happy to move to token-level balances if you'd prefer — the CCTools API would need a per-token-reserve endpoint for that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * TVL now aggregates reserves from all live pools via an external pools API, giving a more complete and accurate total value locked (now includes stablecoin sides).
  * Token pricing now maps pool tokens to market identifiers for correct USD valuation across assets.

* **Documentation**
  * Methodology updated to describe the live-pools raw-reserves data source and the new valuation approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->