### PR TITLE
Add Death.fun TVL adapter

### DIFF
--- a/projects/death-fun/index.js
+++ b/projects/death-fun/index.js
@@ -1,0 +1,20 @@
+const { sumTokensExport } = require("../helper/unknownTokens");
+
+const DEATH_FUN_CONTRACT = "0x27EDd16eE56958fddCBA08947f12C43DDeC2B20C";
+
+// Native token placeholder used by DefiLlama helpers for native ETH-like balances.
+const NATIVE_TOKEN = "0x0000000000000000000000000000000000000000";
+
+module.exports = {
+  start: 1748022475, // 2025-05-23 17:47:55 UTC
+
+  methodology:
+    "Death.fun TVL is the native ETH held in the Death.fun game contract, which serves as the house bankroll used to pay player cashouts. Direct bankroll deposits and owner withdrawals affect TVL because they change the contract balance, but they are treasury movements rather than game outcomes.",
+
+  abstract: {
+    tvl: sumTokensExport({
+      owners: [DEATH_FUN_CONTRACT],
+      tokens: [NATIVE_TOKEN],
+    }),
+  },
+};


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).

2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** It is a different repo, you can find your listing in [this file](https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts), you can edit it there and put up a PR
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes

---
## (Needs to be filled only for new listings)
NOTE: I am not affiliated with death.fun. This adapter was built from public contract information, public docs, and on-chain events.

##### Name (to be shown on DefiLlama):
death.fun

##### Twitter Link:
https://x.com/deathfungame

##### List of audit links if any:
N/A
##### Website Link:
https://death.fun/
##### Logo (High resolution, will be shown with rounded borders):
https://pbs.twimg.com/profile_images/1928212506163695619/vBIpHtBp_400x400.jpg
##### Current TVL:
~$31.89k at local test time. Exact value changes with the ETH balance held by the contract.
##### Treasury Addresses (if the protocol has treasury)
N/A
##### Chain:
Abstract
##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama):
Bet ETH. Don’t die. Cash out. Repeat.
##### Token address and ticker if any:

##### Category (full list at https://defillama.com/categories) \*Please choose only one:
Luck Games
##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
N/A
##### Implementation Details: Briefly describe how the oracle is integrated into your project:
N/A
##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
https://death-fun.notion.site/
##### forkedFrom (Does your project originate from another project):
N/A
##### methodology (what is being counted as tvl, how is tvl being calculated):
Death.fun TVL is the native ETH held in the Death.fun game contract, which serves as the house bankroll used to pay player cashouts.

Direct bankroll deposits and owner withdrawals affect TVL because they change the ETH balance held by the contract. They are treasury/bankroll movements rather than game outcomes.

Volume, fees, and revenue are handled separately in the dimension-adapters PR: https://github.com/DefiLlama/dimension-adapters/pull/7101

Volume = total ETH wagered by players.
Fees = gross gaming revenue (GGR): wagers minus player payouts.
Revenue / ProtocolRevenue = GGR minus referral rewards.
SupplySideRevenue = referral rewards paid from contract funds.
##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/Death-fun/
##### Does this project have a referral program?
Yes. Referral rewards are handled in the dimension-adapters PR as SupplySideRevenue.