### PR TITLE
Track: PRED total TVL on Base

### DIFF
--- a/projects/pred/index.js
+++ b/projects/pred/index.js
@@ -1,0 +1,120 @@
+/**
+ * DeFiLlama adapter for PRED — TOTAL TVL (single chart).
+ *
+ * TVL = USDC.balanceOf(WrappedCollateral)
+ *     + USDC.balanceOf(NegRiskVault)
+ *     + Σ USDC.balanceOf(w) for every user trading wallet w
+ *
+ * User wallets: any address that sent/received USDC with PRED trade endpoints
+ * (USDC.Transfer log scan — includes Safe + ProxyWallet clones).
+ *
+ * Copy to projects/pred/index.js in DefiLlama-Adapters when submitting.
+ */
+
+const { getLogs } = require("../helper/cache/getLogs");
+
+const BASE_USDC = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913";
+const TRANSFER_ABI =
+  "event Transfer(address indexed from, address indexed to, uint256 value)";
+const TRANSFER_TOPIC =
+  "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+
+const PROTOCOL_CONTRACTS = [
+  "0x4e9608d5cf77f22b2d5543b6c65a8c5417e8122c", // wrappedCollateral
+  "0x3aa5a591f79ae2a9790b7335fab875bb0625a5bc", // negRiskVault
+];
+
+const TRADE_ENDPOINTS = [
+  "0x4e9608d5cf77f22b2d5543b6c65a8c5417e8122c",
+  "0x6b64b468bbd5a9166347bf47015763cfe8ff5d82",
+  "0x1938af63b717b80ea62ccb4ccbf799f8a28defb0",
+  "0xc574a05e622a769e6ab14293070cdf6cadb55f98",
+  "0xb0a1306a6bced14f00dacfae3043f173f72e126c",
+  "0x3aa5a591f79ae2a9790b7335fab875bb0625a5bc",
+];
+
+const RESERVED = new Set(
+  [
+    BASE_USDC,
+    "0xc83c5cca746d213d9cf63fe668e7eb8dee35314b",
+    "0x6b64b468bbd5a9166347bf47015763cfe8ff5d82",
+    "0x1938af63b717b80ea62ccb4ccbf799f8a28defb0",
+    "0x6bca0aad6096ea7ecba93b5efcf8ebd58dd9cdad",
+    "0xc574a05e622a769e6ab14293070cdf6cadb55f98",
+    "0xb0a1306a6bced14f00dacfae3043f173f72e126c",
+    "0x3aa5a591f79ae2a9790b7335fab875bb0625a5bc",
+    "0x4e9608d5cf77f22b2d5543b6c65a8c5417e8122c",
+    "0x6c0f43d5f6355b0500e0cbc368fb25e3a7825e06",
+    "0xfb425b95b5b3a4fb96cd036f47ca1774c7063f52",
+    "0xa077e7aabf2e3c0155f83789e95f46602d03f7f0",
+    "0x0000000000000000000000000000000000000000",
+    ...TRADE_ENDPOINTS,
+    ...PROTOCOL_CONTRACTS,
+  ].map((a) => a.toLowerCase()),
+);
+
+const WALLET_DISCOVERY_FROM_BLOCK = 45890000;
+
+function topicAddress(addr) {
+  return "0x" + addr.toLowerCase().replace(/^0x/, "").padStart(64, "0");
+}
+
+function addWallet(wallets, addr) {
+  if (!addr) return;
+  const lower = String(addr).toLowerCase();
+  if (!lower.startsWith("0x") || lower.length !== 42) return;
+  if (RESERVED.has(lower)) return;
+  wallets.add(lower);
+}
+
+async function discoverUserWallets(api) {
+  const wallets = new Set();
+
+  for (const endpoint of TRADE_ENDPOINTS) {
+    const toTopic = topicAddress(endpoint);
+
+    const deposits = await getLogs({
+      api,
+      target: BASE_USDC,
+      eventAbi: TRANSFER_ABI,
+      onlyArgs: true,
+      fromBlock: WALLET_DISCOVERY_FROM_BLOCK,
+      topics: [TRANSFER_TOPIC, null, toTopic],
+    });
+    for (const log of deposits) {
+      addWallet(wallets, log.from);
+    }
+
+    const withdrawals = await getLogs({
+      api,
+      target: BASE_USDC,
+      eventAbi: TRANSFER_ABI,
+      onlyArgs: true,
+      fromBlock: WALLET_DISCOVERY_FROM_BLOCK,
+      topics: [TRANSFER_TOPIC, toTopic, null],
+    });
+    for (const log of withdrawals) {
+      addWallet(wallets, log.to);
+    }
+  }
+
+  return [...wallets];
+}
+
+async function tvl(api) {
+  const userWallets = await discoverUserWallets(api);
+  const owners = [...PROTOCOL_CONTRACTS, ...userWallets];
+
+  await api.sumTokens({
+    owners,
+    tokens: [BASE_USDC],
+  });
+  return api.getBalances();
+}
+
+module.exports = {
+  methodology:
+    "Total TVL = USDC in WrappedCollateral + USDC in NegRiskVault + USDC in all user trading wallets that have interacted with PRED protocol contracts (discovered via USDC transfer logs).",
+  start: 1778583703,
+  base: { tvl },
+};

--- a/projects/pred/index.js
+++ b/projects/pred/index.js
@@ -59,6 +59,11 @@ function topicAddress(addr) {
   return "0x" + addr.toLowerCase().replace(/^0x/, "").padStart(64, "0");
 }
 
+// Unique padded topics for eth_getLogs OR filter (dedupe shared addresses e.g. vault/wcol).
+const ENDPOINT_TOPICS = [
+  ...new Set(TRADE_ENDPOINTS.map((a) => topicAddress(a))),
+];
+
 function addWallet(wallets, addr) {
   if (!addr) return;
   const lower = String(addr).toLowerCase();
@@ -69,33 +74,32 @@ function addWallet(wallets, addr) {
 
 async function discoverUserWallets(api) {
   const wallets = new Set();
+  const logOpts = {
+    api,
+    target: BASE_USDC,
+    eventAbi: TRANSFER_ABI,
+    onlyArgs: true,
+    fromBlock: WALLET_DISCOVERY_FROM_BLOCK,
+  };
 
-  for (const endpoint of TRADE_ENDPOINTS) {
-    const toTopic = topicAddress(endpoint);
+  const [deposits, withdrawals] = await Promise.all([
+    getLogs({
+      ...logOpts,
+      extraKey: "pred-user-deposits",
+      topics: [TRANSFER_TOPIC, null, ENDPOINT_TOPICS],
+    }),
+    getLogs({
+      ...logOpts,
+      extraKey: "pred-user-withdrawals",
+      topics: [TRANSFER_TOPIC, ENDPOINT_TOPICS, null],
+    }),
+  ]);
 
-    const deposits = await getLogs({
-      api,
-      target: BASE_USDC,
-      eventAbi: TRANSFER_ABI,
-      onlyArgs: true,
-      fromBlock: WALLET_DISCOVERY_FROM_BLOCK,
-      topics: [TRANSFER_TOPIC, null, toTopic],
-    });
-    for (const log of deposits) {
-      addWallet(wallets, log.from);
-    }
-
-    const withdrawals = await getLogs({
-      api,
-      target: BASE_USDC,
-      eventAbi: TRANSFER_ABI,
-      onlyArgs: true,
-      fromBlock: WALLET_DISCOVERY_FROM_BLOCK,
-      topics: [TRANSFER_TOPIC, toTopic, null],
-    });
-    for (const log of withdrawals) {
-      addWallet(wallets, log.to);
-    }
+  for (const log of deposits) {
+    addWallet(wallets, log.from);
+  }
+  for (const log of withdrawals) {
+    addWallet(wallets, log.to);
   }
 
   return [...wallets];


### PR DESCRIPTION

Sum USDC in WrappedCollateral, NegRiskVault, and user trading wallets discovered via USDC transfer logs to protocol endpoints.

**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).

2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** It is a different repo, you can find your listing in [this file](https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts), you can edit it there and put up a PR
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes

---
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama): PRED

##### Twitter Link: https://x.com/predofficial

##### List of audit links if any:

##### Website Link: https://www.pred.app/

##### Logo (High resolution, will be shown with rounded borders): 
<img width="512" height="512" alt="Pred Icon" src="https://github.com/user-attachments/assets/2f87b076-80a3-4d3d-948b-f2c3499aac17" />


##### Current TVL:  $172,382.64

##### Treasury Addresses (if the protocol has treasury)

##### Chain: Base

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama): PRED is a decentralised exchange for trading on sports outcomes. It has implemented a CLOB (Central Limit Order Book) structure in a trading terminal design, where traders with differing views are matched with each other. PRED features a high-speed order matching and settlement platform, which is implemented onchain.

##### Token address and ticker if any:

##### Category (full list at https://defillama.com/categories) \*Please choose only one: Prediction Market

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

##### forkedFrom (Does your project originate from another project): 

##### methodology (what is being counted as tvl, how is tvl being calculated): TVL = USDC.balanceOf(WrappedCollateral)
    + USDC.balanceOf(NegRiskVault)
    + Σ USDC.balanceOf(user trading wallet)

##### Github org/user (Optional, if your code is open source, we can track activity): https://github.com/pred-org/

##### Does this project have a referral program? Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new DefiLlama adapter for PRED that reports Total Value Locked (TVL) denominated in USDC. It aggregates protocol reserves and active user trading wallets (discovered from on-chain USDC activity), and exposes TVL data along with a documented methodology and start timestamp for historical context.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19362?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->