### PR TITLE
Juris protocol mainnet update

### DIFF
--- a/projects/jurisprotocol/abi.json
+++ b/projects/jurisprotocol/abi.json
@@ -41,6 +41,10 @@
       "owner": false
     }
   },
+  "borrowed_pools": {
+    "terra1sppah23w9ta0lszdjyxgr2hgc3mdjhxnnnsr3jmxyzjraz60ct0s2ux9u2": "uluna",
+    "terra1j2duml67vl7rhzg43qapnm42n79lwy8a5yedt2taeryvw7a9r8tse6pvfp": "terra1vhgq25vwuhdhn9xjll0rhl2s67jzw78a4g2t78y5kz89q9lsdskq2pxcj2"
+  },
   "contracts": {
     "staking": [
       "terra1rta0rnaxz9ww6hnrj9347vdn66gkgxcmcwgpm2jj6qulv8adc52s95qa5y"

--- a/projects/jurisprotocol/abi.json
+++ b/projects/jurisprotocol/abi.json
@@ -39,11 +39,23 @@
       "coingeckoId": "terraport",
       "type": "cw20",
       "owner": false
+    },
+    "USDC": {
+      "name": "USD Coin",
+      "symbol": "USDC",
+      "decimals": 6,
+      "address": "ibc/0BB9D8513E8E8E9AE6A9D211D9136E6DA42288DDE6CFAA453A150A4566054DC5",
+      "coingeckoId": "usd-coin",
+      "type": "native",
+      "owner": false
     }
   },
   "borrowed_pools": {
     "terra1sppah23w9ta0lszdjyxgr2hgc3mdjhxnnnsr3jmxyzjraz60ct0s2ux9u2": "uluna",
-    "terra1j2duml67vl7rhzg43qapnm42n79lwy8a5yedt2taeryvw7a9r8tse6pvfp": "terra1vhgq25vwuhdhn9xjll0rhl2s67jzw78a4g2t78y5kz89q9lsdskq2pxcj2"
+    "terra1j2duml67vl7rhzg43qapnm42n79lwy8a5yedt2taeryvw7a9r8tse6pvfp": "terra1vhgq25vwuhdhn9xjll0rhl2s67jzw78a4g2t78y5kz89q9lsdskq2pxcj2",
+    "terra17twja6w2wc8z25t9ztj7ukcfzujsrrvk04uh4n0vkpfs79q5xvzqdhdpw9": "terra1ex0hjv3wurhj4wgup4jzlzaqj4av6xqd8le4etml7rg9rs207y4s8cdvrp",
+    "terra1n6wrrkma0vzt7akv7nqzfrsjsutlccue0l0d79jf87v93zd0kz8slra8ac": "uusd",
+    "terra1pe5v475qlz2twm20at3gyy63gdcgenajhzpwpkv506svmwgy70kq4v7k6c": "ibc/0BB9D8513E8E8E9AE6A9D211D9136E6DA42288DDE6CFAA453A150A4566054DC5"
   },
   "contracts": {
     "staking": [
@@ -51,7 +63,10 @@
     ],
     "lending": [
       "terra1sppah23w9ta0lszdjyxgr2hgc3mdjhxnnnsr3jmxyzjraz60ct0s2ux9u2",
-      "terra1j2duml67vl7rhzg43qapnm42n79lwy8a5yedt2taeryvw7a9r8tse6pvfp"
+      "terra1j2duml67vl7rhzg43qapnm42n79lwy8a5yedt2taeryvw7a9r8tse6pvfp",
+      "terra17twja6w2wc8z25t9ztj7ukcfzujsrrvk04uh4n0vkpfs79q5xvzqdhdpw9",
+      "terra1n6wrrkma0vzt7akv7nqzfrsjsutlccue0l0d79jf87v93zd0kz8slra8ac",
+      "terra1pe5v475qlz2twm20at3gyy63gdcgenajhzpwpkv506svmwgy70kq4v7k6c"
     ],
     "liquidation_queues": [
       "terra1rmlwqsf5u4u7qk3p7xrqspqyv9rqem3crrp3lrf8pl9nzhypnnjsdr8r84",

--- a/projects/jurisprotocol/abi.json
+++ b/projects/jurisprotocol/abi.json
@@ -13,7 +13,7 @@
       "address": "terra1vhgq25vwuhdhn9xjll0rhl2s67jzw78a4g2t78y5kz89q9lsdskq2pxcj2",
       "coingeckoId": "juris-protocol",
       "type": "cw20",
-      "owner": "true"
+      "owner": true
     },
     "LUNC": {
       "name": "Terra Luna Classic",
@@ -21,7 +21,7 @@
       "decimals": 6,
       "address": "uluna",
       "coingeckoId": "terra-luna-classic",
- "type": "native"
+      "type": "native"
     },
     "USTC": {
       "name": "TerraClassicUSD",
@@ -30,14 +30,39 @@
       "address": "uusd",
       "coingeckoId": "terraclassicusd",
       "type": "native"
+    },
+    "TERRA": {
+      "name": "Terraport",
+      "symbol": "TERRA",
+      "decimals": 6,
+      "address": "terra1ex0hjv3wurhj4wgup4jzlzaqj4av6xqd8le4etml7rg9rs207y4s8cdvrp",
+      "coingeckoId": "terraport",
+      "type": "cw20",
+      "owner": false
     }
   },
   "contracts": {
     "staking": [
       "terra1rta0rnaxz9ww6hnrj9347vdn66gkgxcmcwgpm2jj6qulv8adc52s95qa5y"
     ],
-    "lending": [],
+    "lending": [
+      "terra1sppah23w9ta0lszdjyxgr2hgc3mdjhxnnnsr3jmxyzjraz60ct0s2ux9u2",
+      "terra1j2duml67vl7rhzg43qapnm42n79lwy8a5yedt2taeryvw7a9r8tse6pvfp"
+    ],
+    "liquidation_queues": [
+      "terra1rmlwqsf5u4u7qk3p7xrqspqyv9rqem3crrp3lrf8pl9nzhypnnjsdr8r84",
+      "terra1vxqg6wze0m0p302yk0p2q6pu7lj9nmncuem5l4ap4s2w9cfu9ctqcqvkk4"
+    ],
+    "liquidation_vault": [
+      "terra12aw79gxugkc9ursykwcjv2swm5lekawyj4am5e627vsjgg47w5dqqx8xdd"
+    ],
+    "margin": [
+      "terra13f9wdux2xqag2w6qtqxdevwc9s5e0sfxxhz9ag9w44qq7ltu89aq6l4dy9"
+    ],
     "vesting": [
+      "terra1zgjnvza0zjz4j6dqu0uw4u8vqxzr5hc53amdsdkjfnrkacl0t2hqyfxcew",
+      "terra1jgpllpdcyccmprr7qvye0ur4m6zfva72rh3rqprj6ryypuntyvcqh4fgls",
+      "terra1mynqhdwsl0stew2vnt85cuuw4dp2sq3vmrfaej7pc5jejnudt7msc48y48",
       "terra1w89kclh6qd4ftyll4k0x4cyd23lzd9krsntds4y0z2x67kymtf3qj9fgrl",
       "terra14783nqrx4mjqfnymyqp88dsjf5c6axlt2m75wwt2supwkc0jxr0qyrhqtl",
       "terra1lejvcrgmhcuedemdetv6qrru7yu8qgwn6e070fq6q4kpda838kpsghwl2u",
@@ -56,7 +81,7 @@
       "terra12xq35pp48mwp7qep2tdlnt2jg8pxmsll0vtnygay7tgh0djdk34sw6qhdl"
     ],
     "reserve": [],
-    "pool2": [], 
+    "pool2": [],
     "ownTokens": [],
     "treasury": []
   }

--- a/projects/jurisprotocol/index.js
+++ b/projects/jurisprotocol/index.js
@@ -1,3 +1,4 @@
+const BigNumber = require('bignumber.js');
 const abi = require('./abi.json');
 const { queryContract, queryV1Beta1 } = require('../helper/chain/cosmos');
 
@@ -44,7 +45,8 @@ function addToken(api, tokenAddress, amount) {
   const info = TOKEN_BY_ADDR[tokenAddress] || {};
   if (tokenAddress.startsWith('ibc/') && info.coingeckoId) {
     const decimals = info.decimals ?? 6;
-    api.addCGToken(info.coingeckoId, Number(amount) / (10 ** decimals));
+    const balance = new BigNumber(amount).div(10 ** decimals).toNumber();
+    api.addCGToken(info.coingeckoId, balance);
   } else {
     api.add(tokenAddress, amount);
   }
@@ -117,7 +119,8 @@ if (abi.borrowed_pools) {
     await Promise.all(
       Object.entries(abi.borrowed_pools).map(async ([pool, token]) => {
         const borrowedRaw = await smartQuery(pool, { total_borrowed: {} });
-        const borrowed = String(borrowedRaw).replace(/[^0-9]/g, '') || '0';
+        const rawVal = borrowedRaw?.total_borrowed ?? borrowedRaw?.amount ?? borrowedRaw;
+        const borrowed = String(rawVal ?? '0').replace(/[^0-9]/g, '') || '0';
         if (+borrowed > 0) {
           addToken(api, token, borrowed);
         }

--- a/projects/jurisprotocol/index.js
+++ b/projects/jurisprotocol/index.js
@@ -101,9 +101,19 @@ if (contracts.pool2?.length) {
   terraExport.pool2 = (api) => fetchBalances('pool2', api, { excludeOwnedCw20: false, logTag: 'pool2' });
 }
 
-// Borrowed (in case they have it later)
-if (contracts.borrowed?.length) {
-  terraExport.borrowed = (api) => fetchBalances('borrowed', api, { excludeOwnedCw20: false, logTag: 'borrowed' });
+// Borrowed
+if (abi.borrowed_pools) {
+  terraExport.borrowed = async (api) => {
+    await Promise.all(
+      Object.entries(abi.borrowed_pools).map(async ([pool, token]) => {
+        const borrowedRaw = await smartQuery(pool, { total_borrowed: {} });
+        const borrowed = String(borrowedRaw).replace(/[^0-9]/g, '') || '0';
+        if (+borrowed > 0) {
+          api.add(token, borrowed);
+        }
+      })
+    );
+  };
 }
 
 module.exports = {

--- a/projects/jurisprotocol/index.js
+++ b/projects/jurisprotocol/index.js
@@ -48,7 +48,6 @@ async function fetchBalances(moduleName, api, { excludeOwnedCw20 = false, logTag
   }
 
   await Promise.all(owners.map(async owner => {
-
     const bank = await bankBalances(owner);
 
     // Natives
@@ -70,30 +69,46 @@ async function fetchBalances(moduleName, api, { excludeOwnedCw20 = false, logTag
       const isOwned = OWNED_CW20_SET.has(t.address);
       const excluded = excludeOwnedCw20 && isOwned;
 
-
       if (!excluded) api.add(t.address, bal);
     }
-
   }));
 }
 
-// Build category fns from abi.json (default: no exclusions)
+// Build category fns from abi.json
 const terraExport = {};
-Object.keys(contracts).forEach(key => {
-  if (contracts[key]?.length) {
-    terraExport[key] = (api) => fetchBalances(key, api, { excludeOwnedCw20: false, logTag: key });
-  }
-});
 
-// TVL: include all desired categories but exclude owner CW20s (e.g., JURIS) everywhere
+// TVL categories to sum
+const TVL_CATEGORIES = ['lending', 'liquidation_queues', 'liquidation_vault', 'margin', 'reserve', 'ownTokens', 'treasury'];
+
 terraExport.tvl = async (api) => {
-  const cats = Object.keys(contracts).filter(k => k !== 'tvl');
-  await Promise.all(cats.map((k) => fetchBalances(k, api, { excludeOwnedCw20: true, logTag: `TVL:${k}` })));
+  await Promise.all(
+    TVL_CATEGORIES.map((k) => fetchBalances(k, api, { excludeOwnedCw20: true, logTag: `TVL:${k}` }))
+  );
 };
- 
+
+// Staking (holds native LUNC or CW20s, owner CW20 JURIS is allowed here)
+if (contracts.staking?.length) {
+  terraExport.staking = (api) => fetchBalances('staking', api, { excludeOwnedCw20: false, logTag: 'staking' });
+}
+
+// Vesting (holds JURIS for vesting, owner CW20 JURIS is allowed here)
+if (contracts.vesting?.length) {
+  terraExport.vesting = (api) => fetchBalances('vesting', api, { excludeOwnedCw20: false, logTag: 'vesting' });
+}
+
+// Pool2 (in case they have it later)
+if (contracts.pool2?.length) {
+  terraExport.pool2 = (api) => fetchBalances('pool2', api, { excludeOwnedCw20: false, logTag: 'pool2' });
+}
+
+// Borrowed (in case they have it later)
+if (contracts.borrowed?.length) {
+  terraExport.borrowed = (api) => fetchBalances('borrowed', api, { excludeOwnedCw20: false, logTag: 'borrowed' });
+}
+
 module.exports = {
   methodology:
-    'TVL sums native denoms and non-owned CW20s across configured contract owners; any CW20 with owner=true in abi.json (e.g., JURIS) is excluded from TVL but still logged for visibility.',
+    'TVL sums native denoms and non-owned CW20s across configured lending pools, liquidation queues, liquidation vault, and margin account contracts. JURIS token is counted in staking and vesting but excluded from TVL.',
   timetravel: false,
   terra: terraExport,
 };

--- a/projects/jurisprotocol/index.js
+++ b/projects/jurisprotocol/index.js
@@ -40,6 +40,16 @@ function nativeBalance(balances, denom) {
   return String(row?.amount ?? '0').replace(/[^0-9]/g, '') || '0';
 }
 
+function addToken(api, tokenAddress, amount) {
+  const info = TOKEN_BY_ADDR[tokenAddress] || {};
+  if (tokenAddress.startsWith('ibc/') && info.coingeckoId) {
+    const decimals = info.decimals ?? 6;
+    api.addCGToken(info.coingeckoId, Number(amount) / (10 ** decimals));
+  } else {
+    api.add(tokenAddress, amount);
+  }
+}
+
 // Core worker: optional exclusion for protocol-owned CW20s, with verbose logging
 async function fetchBalances(moduleName, api, { excludeOwnedCw20 = false, logTag = '' } = {}) {
   const owners = (contracts[moduleName] || []).filter(Boolean);
@@ -54,7 +64,7 @@ async function fetchBalances(moduleName, api, { excludeOwnedCw20 = false, logTag
     for (const denom of NATIVE_DENOMS) {
       const bal = nativeBalance(bank, denom);
       if (+bal > 0) {
-        api.add(denom, bal);
+        addToken(api, denom, bal);
       }
     }
 
@@ -69,7 +79,7 @@ async function fetchBalances(moduleName, api, { excludeOwnedCw20 = false, logTag
       const isOwned = OWNED_CW20_SET.has(t.address);
       const excluded = excludeOwnedCw20 && isOwned;
 
-      if (!excluded) api.add(t.address, bal);
+      if (!excluded) addToken(api, t.address, bal);
     }
   }));
 }
@@ -109,7 +119,7 @@ if (abi.borrowed_pools) {
         const borrowedRaw = await smartQuery(pool, { total_borrowed: {} });
         const borrowed = String(borrowedRaw).replace(/[^0-9]/g, '') || '0';
         if (+borrowed > 0) {
-          api.add(token, borrowed);
+          addToken(api, token, borrowed);
         }
       })
     );


### PR DESCRIPTION
This PR updates the Juris Protocol adapter with live mainnet contract addresses on Terra Classic and adds support for:
- Mainnet TVL (LUNC pools, liquidation vault, margin accounts, and liquidation queues)
- JURIS Staking
- Vesting contracts (Lockdrop, Private Investors)
- Dynamic 'Borrowed' metric using the `{ total_borrowed: {} }` query message from lending pools.

Verified locally:
- Local tests pass cleanly with no errors.
- JURIS token (protocol token) is successfully excluded from the main TVL calculation but counted correctly under staking and vesting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Refined token registry format, converted owner flags to booleans, added a Terra token, and populated multiple contract address lists (lending, liquidation, margin, vesting, borrowed pools).
  * Improved balance handling to optionally exclude owned tokens and unified token-add logic for native, CW20, and IBC tokens.
  * Revised TVL methodology and documentation to use a fixed set of TVL categories and updated counting rules for owner tokens.

* **New Features**
  * Added a conditional "borrowed" metric and conditional exports for staking, vesting, and pool2.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19363?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->