### PR TITLE
Exclude Ethena deposits from TVL calculation

### DIFF
--- a/projects/aave-v3/index.js
+++ b/projects/aave-v3/index.js
@@ -48,6 +48,7 @@ const CONFIG = {
   },
   megaeth: {
     poolDatas: ['0x9588b453A4EE24a420830CB3302195cA7aA3b403'],
+    blacklist_lenders: ETHENA_BLACKLIST,
   },
   mantle: {
     poolDatas: ['0x487c5c669D9eee6057C44973207101276cf73b68'],

--- a/projects/jupiter-lend/index.js
+++ b/projects/jupiter-lend/index.js
@@ -1,5 +1,5 @@
 const { getConfig } = require('../helper/cache')
-const { getProvider, sumTokens2 } = require('../helper/solana')
+const { getProvider, sumTokens2, getTokenAccountBalances } = require('../helper/solana')
 const { Program } = require("@coral-xyz/anchor");
 
 const LIQUIDITY_IDL_URL = "https://raw.githubusercontent.com/jup-ag/jupiter-lend/refs/heads/main/target/idl/liquidity.json";
@@ -22,10 +22,25 @@ async function getData() {
 }
 
 const EXCHANGE_PRICE_PRECISION = 1e12
-async function tvl() {
+// aTokens held by ethena's wallet, mapped to the underlying mint — subtracted since
+// these deposits are already counted in ethena's TVL
+const ETHENA_ATOKEN_ACCOUNTS = {
+  '6ZaKSZfYLUvbWqDmHKWWZ7wtUo8aMidvE6k8U2oMXvjf': '2u1tszSeqZ3qBWF3uNGPFc8TzMk2tdiwknnRMWGWjGWH', // jUSDG -> USDG
+}
+async function tvl(api) {
   const tokenReserves = await getData();
   const tokenAccounts = tokenReserves.map(i => i.vault.toBase58())
-  return sumTokens2({ tokenAccounts })
+  await sumTokens2({ api, tokenAccounts })
+  const reserveByMint = {}
+  tokenReserves.forEach(r => { reserveByMint[r.mint.toBase58()] = r })
+  const accounts = Object.keys(ETHENA_ATOKEN_ACCOUNTS)
+  const balances = await getTokenAccountBalances(accounts, { individual: true, allowError: true })
+  balances.forEach((b, i) => {
+    const underlyingMint = ETHENA_ATOKEN_ACCOUNTS[accounts[i]]
+    const reserve = reserveByMint[underlyingMint]
+    const underlying = +b.amount * (+reserve.supplyExchangePrice.toString()) / EXCHANGE_PRICE_PRECISION
+    api.add(underlyingMint, -underlying)
+  })
 }
 async function borrowed(api) {
   const tokenReserves = await getData()

--- a/projects/kamino-lending/index.js
+++ b/projects/kamino-lending/index.js
@@ -1,11 +1,26 @@
 const { PublicKey } = require('@solana/web3.js');
-const { getConnection, sumTokens2 } = require('../helper/solana');
+const { getConnection, sumTokens2, getTokenAccountBalances } = require('../helper/solana');
 const { Program } = require('@project-serum/anchor');
 const kaminoIdl = require('./kamino-lending-idl.json');
+const kaminoFarmsIdl = require('./kamino-farms-idl.json');
 const { MintLayout } = require("../helper/utils/solana/layouts/mixed-layout");
 const { getConfig } = require('../helper/cache')
 
-async function tvl() {
+const KAMINO_FARMS_PROGRAM_ID = 'FarmsPZpWu9i7Kky8tPN37rs2TpmMrAZrC7S7vJa91Hr';
+
+// Ethena positions held via Kamino KVaults — subtracted since these deposits are already counted in ethena's TVL.
+// Ethena holds the KVault receipt token, mostly staked in a Kamino farm. We compute Ethena's pro-rata share of the
+// KVault's kToken holdings (farm stake / farm total stake + any unstaked wallet balance) and treat 1:1 with the underlying.
+const ETHENA_KVAULT_POSITIONS = [
+  {
+    farmUserState: '1um6KRX6XodwZ7bgsArLx4aMDx1EvDePJMLK289ZCWn', // tracks ethena's stake in the KVault receipt farm
+    walletReceiptAccounts: ['Bh92ZZuYoJfeRxnn3hohpQXwRdAZYxw7o2eu3zDCCY4g'], // any unstaked receipt held by ethena
+    kTokenVault: 'GwHpfLMCcScMtXpuLJ6E2a4ANHdHHRZypNnnMVgkH8Zf', // KVault's kUSDG holding
+    underlying: '2u1tszSeqZ3qBWF3uNGPFc8TzMk2tdiwknnRMWGWjGWH', // USDG
+  },
+]
+
+async function tvl(api) {
   const connection = getConnection();
   const programId = new PublicKey('KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD');
   const markets = (await getConfig('kamino-lending', 'https://api.kamino.finance/v2/kamino-market')).map(x => x.lendingMarket);
@@ -37,7 +52,33 @@ async function tvl() {
       }
     }
   }
-  return sumTokens2({ tokensAndOwners })
+  await sumTokens2({ api, tokensAndOwners })
+  await subtractEthenaKVaultDeposits(api, connection)
+}
+
+async function subtractEthenaKVaultDeposits(api, connection) {
+  const farmsProgram = new Program(kaminoFarmsIdl, new PublicKey(KAMINO_FARMS_PROGRAM_ID), { connection, publicKey: PublicKey.unique() });
+  for (const p of ETHENA_KVAULT_POSITIONS) {
+    const userState = await farmsProgram.account.userState.fetch(new PublicKey(p.farmUserState));
+    const farmState = await farmsProgram.account.farmState.fetch(userState.farmState);
+    const totalStakeScaled = farmState.totalActiveStakeScaled.add(farmState.totalPendingStakeScaled);
+    if (totalStakeScaled.isZero()) continue;
+    const userStakeScaled = userState.activeStakeScaled.add(userState.pendingDepositStakeScaled);
+    const stakeFraction = +userStakeScaled.toString() / +totalStakeScaled.toString();
+
+    const accounts = [p.kTokenVault, ...(p.walletReceiptAccounts || [])];
+    const balances = await getTokenAccountBalances(accounts, { individual: true, allowError: true });
+    const kTokenInVault = +balances[0].amount;
+    const unstakedReceipt = balances.slice(1).reduce((a, b) => a + +b.amount, 0);
+    const farmReceiptAmount = +farmState.totalStakedAmount.toString();
+    const ethenaReceiptAmount = stakeFraction * farmReceiptAmount + unstakedReceipt;
+
+    const totalReceiptSupply = +(await connection.getTokenSupply(farmState.token.mint)).value.amount;
+    if (!totalReceiptSupply) continue;
+    // ethena's underlying share = (ethena receipts / total receipts) * kVault's kToken holdings, treated 1:1 with underlying
+    const underlyingToSubtract = (ethenaReceiptAmount / totalReceiptSupply) * kTokenInVault;
+    api.add(p.underlying, -underlyingToSubtract);
+  }
 }
 
 async function isKToken(mint, connection) {

--- a/projects/kamino-lending/kamino-farms-idl.json
+++ b/projects/kamino-lending/kamino-farms-idl.json
@@ -1,0 +1,215 @@
+{
+  "version": "1.6.5",
+  "name": "farms",
+  "instructions": [],
+  "accounts": [
+    {
+      "name": "FarmState",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {"name": "farmAdmin", "type": "publicKey"},
+          {"name": "globalConfig", "type": "publicKey"},
+          {"name": "token", "type": {"defined": "TokenInfo"}},
+          {"name": "rewardInfos", "type": {"array": [{"defined": "RewardInfo"}, 10]}},
+          {"name": "numRewardTokens", "type": "u64"},
+          {"name": "numUsers", "docs": ["Data used to calculate the rewards of the user"], "type": "u64"},
+          {
+            "name": "totalStakedAmount",
+            "docs": [
+              "The number of token in the `farm_vault` staked (getting rewards and fees)",
+              "Set such as `farm_vault.amount = total_staked_amount + total_pending_amount`"
+            ],
+            "type": "u64"
+          },
+          {"name": "farmVault", "type": "publicKey"},
+          {"name": "farmVaultsAuthority", "type": "publicKey"},
+          {"name": "farmVaultsAuthorityBump", "type": "u64"},
+          {"name": "delegateAuthority", "docs": ["Only used for delegate farms", "Set to `default()` otherwise"], "type": "publicKey"},
+          {"name": "timeUnit", "docs": ["Raw representation of a `TimeUnit`", "Seconds = 0, Slots = 1"], "type": "u8"},
+          {
+            "name": "isFarmFrozen",
+            "docs": ["Automatically set to true in case of a full authority withdrawal", "If true, the farm is frozen and no more deposits are allowed"],
+            "type": "u8"
+          },
+          {
+            "name": "isFarmDelegated",
+            "docs": ["Indicates if the farm is a delegate farm", "If true, the farm is a delegate farm and the `delegate_authority` is set*"],
+            "type": "u8"
+          },
+          {"name": "isRewardUserOnceEnabled", "docs": ["If set to 1, indicates that the \"reward user once\" feature is enabled"], "type": "u8"},
+          {"name": "isHarvestingPermissionless", "type": "u8"},
+          {"name": "padding0", "type": {"array": ["u8", 3]}},
+          {
+            "name": "withdrawAuthority",
+            "docs": [
+              "Withdraw authority for the farm, allowed to lock deposited funds and withdraw them",
+              "Set to `default()` if unused (only the depositors can withdraw their funds)"
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "depositWarmupPeriod",
+            "docs": ["Delay between a user deposit and the moment it is considered as staked", "0 if unused"],
+            "type": "u32"
+          },
+          {"name": "withdrawalCooldownPeriod", "docs": ["Delay between a user unstake and the ability to withdraw his deposit."], "type": "u32"},
+          {
+            "name": "totalActiveStakeScaled",
+            "docs": ["Total active stake of tokens in the farm (scaled from `Decimal` representation)."],
+            "type": "u128"
+          },
+          {
+            "name": "totalPendingStakeScaled",
+            "docs": [
+              "Total pending stake of tokens in the farm (scaled from `Decimal` representation).",
+              "(can be used by `withdraw_authority` but don't get rewards or fees)"
+            ],
+            "type": "u128"
+          },
+          {"name": "totalPendingAmount", "docs": ["Total pending amount of tokens in the farm"], "type": "u64"},
+          {"name": "slashedAmountCurrent", "docs": ["Slashed amounts from early withdrawal"], "type": "u64"},
+          {"name": "slashedAmountCumulative", "type": "u64"},
+          {"name": "slashedAmountSpillAddress", "type": "publicKey"},
+          {"name": "lockingMode", "docs": ["Locking stake"], "type": "u64"},
+          {"name": "lockingStartTimestamp", "type": "u64"},
+          {"name": "lockingDuration", "type": "u64"},
+          {"name": "lockingEarlyWithdrawalPenaltyBps", "type": "u64"},
+          {"name": "depositCapAmount", "type": "u64"},
+          {"name": "scopePrices", "type": "publicKey"},
+          {"name": "scopeOraclePriceId", "type": "u64"},
+          {"name": "scopeOracleMaxAge", "type": "u64"},
+          {"name": "pendingFarmAdmin", "type": "publicKey"},
+          {"name": "strategyId", "type": "publicKey"},
+          {"name": "delegatedRpsAdmin", "type": "publicKey"},
+          {"name": "vaultId", "type": "publicKey"},
+          {"name": "secondDelegatedAuthority", "type": "publicKey"},
+          {"name": "padding", "type": {"array": ["u64", 74]}}
+        ]
+      }
+    },
+    {
+      "name": "UserState",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {"name": "userId", "type": "u64"},
+          {"name": "farmState", "type": "publicKey"},
+          {"name": "owner", "type": "publicKey"},
+          {"name": "isFarmDelegated", "docs": ["Indicate if this user state is part of a delegated farm"], "type": "u8"},
+          {"name": "padding0", "type": {"array": ["u8", 7]}},
+          {
+            "name": "rewardsTallyScaled",
+            "docs": ["Rewards tally used for computation of gained rewards", "(scaled from `Decimal` representation)."],
+            "type": {"array": ["u128", 10]}
+          },
+          {"name": "rewardsIssuedUnclaimed", "docs": ["Number of reward tokens ready for claim"], "type": {"array": ["u64", 10]}},
+          {"name": "lastClaimTs", "type": {"array": ["u64", 10]}},
+          {
+            "name": "activeStakeScaled",
+            "docs": ["User stake deposited and usable, generating rewards and fees.", "(scaled from `Decimal` representation)."],
+            "type": "u128"
+          },
+          {
+            "name": "pendingDepositStakeScaled",
+            "docs": ["User stake deposited but not usable and not generating rewards yet.", "(scaled from `Decimal` representation)."],
+            "type": "u128"
+          },
+          {
+            "name": "pendingDepositStakeTs",
+            "docs": ["After this timestamp, pending user stake can be moved to user stake", "Initialized to now() + delayed user stake period"],
+            "type": "u64"
+          },
+          {
+            "name": "pendingWithdrawalUnstakeScaled",
+            "docs": [
+              "User deposits unstaked, pending for withdrawal, not usable and not generating rewards.",
+              "(scaled from `Decimal` representation)."
+            ],
+            "type": "u128"
+          },
+          {"name": "pendingWithdrawalUnstakeTs", "docs": ["After this timestamp, user can withdraw their deposit."], "type": "u64"},
+          {"name": "bump", "docs": ["User bump used for account address validation"], "type": "u64"},
+          {"name": "delegatee", "docs": ["Delegatee used for initialisation - useful to check against"], "type": "publicKey"},
+          {"name": "lastStakeTs", "type": "u64"},
+          {
+            "name": "rewardsIssuedCumulative",
+            "docs": [
+              "Cumulative rewards issued to the user - ONLY used for stats/analytics",
+              "DO NOT USE IN ANY CALCULATIONS",
+              "Old userStates will have this field populated only from the point of release",
+              "not reflecting any historical data before this was released"
+            ],
+            "type": {"array": ["u64", 10]}
+          },
+          {"name": "padding1", "type": {"array": ["u64", 40]}}
+        ]
+      }
+    }
+  ],
+  "types": [
+    {
+      "name": "TokenInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {"name": "mint", "type": "publicKey"},
+          {"name": "decimals", "type": "u64"},
+          {"name": "tokenProgram", "type": "publicKey"},
+          {"name": "padding", "type": {"array": ["u64", 6]}}
+        ]
+      }
+    },
+    {
+      "name": "RewardInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {"name": "token", "type": {"defined": "TokenInfo"}},
+          {"name": "rewardsVault", "type": "publicKey"},
+          {"name": "rewardsAvailable", "type": "u64"},
+          {"name": "rewardScheduleCurve", "type": {"defined": "RewardScheduleCurve"}},
+          {"name": "minClaimDurationSeconds", "type": "u64"},
+          {"name": "lastIssuanceTs", "type": "u64"},
+          {"name": "rewardsIssuedUnclaimed", "type": "u64"},
+          {"name": "rewardsIssuedCumulative", "type": "u64"},
+          {"name": "rewardPerShareScaled", "type": "u128"},
+          {"name": "placeholder0", "type": "u64"},
+          {"name": "rewardType", "type": "u8"},
+          {"name": "rewardsPerSecondDecimals", "type": "u8"},
+          {"name": "padding0", "type": {"array": ["u8", 6]}},
+          {"name": "padding1", "type": {"array": ["u64", 20]}}
+        ]
+      }
+    },
+    {
+      "name": "RewardScheduleCurve",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "points",
+            "docs": [
+              "This is a stepwise function, meaning that each point represents",
+              "how many rewards are issued per time unit since the beginning",
+              "of that point until the beginning of the next point.",
+              "This is not a linear curve, there is no interpolation going on.",
+              "A curve can be [[t0, 100], [t1, 50], [t2, 0]]",
+              "meaning that from t0 to t1, 100 rewards are issued per time unit,",
+              "from t1 to t2, 50 rewards are issued per time unit, and after t2 it stops",
+              "Another curve, can be [[t0, 100], [u64::max, 0]]",
+              "meaning that from t0 to u64::max, 100 rewards are issued per time unit"
+            ],
+            "type": {"array": [{"defined": "RewardPerTimeUnitPoint"}, 20]}
+          }
+        ]
+      }
+    },
+    {
+      "name": "RewardPerTimeUnitPoint",
+      "type": {"kind": "struct", "fields": [{"name": "tsStart", "type": "u64"}, {"name": "rewardPerTimeUnit", "type": "u64"}]}
+    }
+  ],
+  "errors": [],
+  "events": []
+}

--- a/projects/morpho-blue/index.js
+++ b/projects/morpho-blue/index.js
@@ -15,7 +15,7 @@ const config = {
     fromBlock: 18883124,
     blacklistedMarketIds: [
       "0x1dca6989b0d2b0a546530b3a739e91402eee2e1536a2d3ded4f5ce589a9cd1c2",
-      
+
       // bad debt due to resolv hack
       "0xd9e34b1eed46d123ac1b69b224de1881dbc88798bc7b70f504920f62f58f28cc",
       "0xe1b65304edd8ceaea9b629df4c3c926a37d1216e27900505c04f14b2ed279f33",
@@ -214,7 +214,7 @@ const getMarket = async (api) => {
   } else {
     logs = await getLogs({ api, target: morphoBlue, eventAbi: eventAbis.createMarket, fromBlock, onlyArgs: true, extraKey, onlyUseExistingCache, useIndexer })
   }
-  
+
   if (api.chain === 'sei') {
     const existingIds = new Set(logs.map(i => i.id.toLowerCase()))
     logs.push(...[
@@ -234,6 +234,16 @@ const getMarket = async (api) => {
   return logs.map((i) => i.id.toLowerCase()).filter((id) => !blacklistedMarketIds.includes(id))
 }
 
+// exclude ethena deposits into markets where collateral is USDe
+const ethenaBlacklist = {
+  ethereum: {
+    wallets: ['0x2Bf5d9a2326Ad3C5Ef8208F91Af79C3ca1F0F67c'],
+    vaults: [
+      '0xBeEFC1CDAfc5b4a649b54D07AFc6bF0f75C6F4E2',   // USDtB vault
+    ],
+  }
+}
+
 const tvl = async (api) => {
   const { morphoBlue, blackList = [] } = config[api.chain]
   const markets = await getMarket(api)
@@ -246,7 +256,20 @@ const tvl = async (api) => {
     return wql == null || wql > 30 || wql < 0;
   });
   const tokens = filterMarkets.flatMap(({ collateralToken, loanToken }) => [collateralToken, loanToken])
-  
+
+  if (ethenaBlacklist[api.chain]) {
+    const { wallets = [], vaults = [] } = ethenaBlacklist[api.chain]
+    const balanceCalls = wallets.map((wallet) => vaults.map((vault) => ({ target: vault, params: wallet }))).flat()
+    const balances = await api.multiCall({ calls: balanceCalls, abi: 'erc20:balanceOf', permitFailure: true })
+    const assets = await api.multiCall({ calls: balanceCalls.map(c => c.target), abi: 'address:asset', permitFailure: true })
+    const assetBalances = await api.multiCall({ calls: balanceCalls.map((c, i) => ({ ...c, params: balances[i] })), abi: 'function convertToAssets(uint256) view returns (uint256)' })
+    assetBalances.forEach((balance, i) => {
+      const token = assets[i]
+      console.log(`Ethena blacklist - subtracting ${balance / 1e18} of ${token} from TVL`)
+      api.add(token, balance * -1)
+    })
+  }
+
   if (api.chain === 'stable' && tokens.includes(ADDRESSES.null))
     blackList.push(ADDRESSES.stable.USDT0)  // USDT0 and gas token on stable are the same thing
   return sumTokens2({ api, owner: morphoBlue, tokens, blacklistedTokens: blackList, permitFailure: true })

--- a/test.js
+++ b/test.js
@@ -252,6 +252,11 @@ function validateHallmarks(hallmark) {
     );
   }
 
+  if (warningTable.length) {
+    console.log(`WARNING: Found ${warningTable.length} tokens with a very high USD value, please check the following table for more details: `)
+    console.table(warningTable)
+  }
+
   Object.entries(usdTokenBalances).forEach(([chain, balances]) => {
     console.log(`--- ${chain} ---`);
     let entries = Object.entries(balances)
@@ -398,6 +403,8 @@ function fixBalances(balances) {
   })
 }
 
+const warningTable = []
+
 const confidenceThreshold = 0.5
 async function computeTVL(balances, timestamp) {
   fixBalances(balances)
@@ -493,12 +500,12 @@ async function computeTVL(balances, timestamp) {
         usdAmount = amount * data.price;
       }
 
-      if (usdAmount > 1e8) {
-        console.log(`-------------------
-Warning: `)
-        console.log(`Token ${address} has more than 100M in value (${usdAmount / 1e6} M) , price data: `, data)
-        console.log(`-------------------`)
+      if (Math.abs(usdAmount) > 1e8) {
+        const chain = address.split(':')[0]
+        warningTable.push({ chain, symbol: data.symbol, usdAmount: humanizeNumber(usdAmount), amount: humanizeNumber(amount), price: data.price, address, confidence: data.confidence, decimals: data.decimals, })
       }
+
+
       tokenBalances[data.symbol] = (tokenBalances[data.symbol] ?? 0) + amount;
       usdTokenBalances[data.symbol] = (usdTokenBalances[data.symbol] ?? 0) + usdAmount;
       usdTvl += usdAmount;


### PR DESCRIPTION
Implement logic to exclude Ethena deposits from the total value locked (TVL) calculation across multiple projects


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected TVL for Aave v3, Jupiter Lend, Morpho Blue, and Kamino Lending by excluding specific Ethena-held deposits so protocol totals reflect public liquidity.

* **Improvements**
  * TVL reporting now collects and displays high-value token warnings with richer context and an absolute-value threshold for alerting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19366?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->