### PR TITLE
Add AquaFlux TVL adapter

### DIFF
--- a/projects/aquaflux/index.js
+++ b/projects/aquaflux/index.js
@@ -1,0 +1,48 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+
+const CORE = '0x0da98a8447b6B4aDD9733011A812922954d3e127'
+const WAD = 10n ** 18n
+
+const ASSETS = [
+  {
+    name: 'pAlpha',
+    assetId: '0xbb48f16cbb1bf38267d547b2edc8d0994aca6925ab0ec264f38d6db4ca10fcb2',
+    underlying: '0xE47E9bA4EA2320A6ed87246d02Fd5C38485Ed7d1',
+    swapHook: '0x958a6E98203FE71Ae3A30c515D4705cb73C2Aa88',
+    token0: '0x34fD642Fa9fDc6Ce4013d4F3cde575C6dac904f9',
+    token1: '0xe150A72352a189dCe0D671C08F721B458104a2Af',
+    fee: 3000,
+    tickSpacing: 60,
+  },
+]
+
+async function tvl(api) {
+  const balances = await api.multiCall({
+    abi: 'function getAssetUnderlyingBalance(bytes32 assetId) view returns (uint256 balance)',
+    calls: ASSETS.map(({ assetId }) => ({
+      target: CORE,
+      params: [assetId],
+    })),
+  })
+
+  const underlyingValues = await api.multiCall({
+    abi: 'function underlyingValue((address currency0, address currency1, uint24 fee, int24 tickSpacing, address hooks) key) view returns (uint256)',
+    calls: ASSETS.map(({ swapHook, token0, token1, fee, tickSpacing }) => ({
+      target: swapHook,
+      params: [[token0, token1, fee, tickSpacing, swapHook]],
+    })),
+  })
+
+  balances.forEach((balance, i) => {
+    const usdBalance = BigInt(balance) * BigInt(underlyingValues[i]) / WAD
+    api.add(ADDRESSES.pharos.USDC, usdBalance)
+  })
+}
+
+module.exports = {
+  methodology:
+    'Counts active assets locked in AquaFluxCore contracts.',
+  pharos: {
+    tvl,
+  },
+}


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).

2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** It is a different repo, you can find your listing in [this file](https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts), you can edit it there and put up a PR
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes

---
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
AquaFlux

##### Twitter Link:
https://x.com/AquaFluxPro

##### List of audit links if any:
https://docs.aquaflux.pro/developers/audits

##### Website Link:
https://app.aquaflux.pro/

##### Logo (High resolution, will be shown with rounded borders):
<img width="400" height="401" alt="AquaFlux_400px" src="https://github.com/user-attachments/assets/a6299df9-e04f-47dc-99a9-6e3bf1b3df06" />


##### Current TVL: 
~$24680

##### Treasury Addresses (if the protocol has treasury) 
N/A

##### Chain: Pharos

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama):
AquaFlux is a structured protocol for yield assets, splitting asset exposure into senior principal(PT) and junior shield tranches(ST) with fixed-rate AMM liquidity.

##### Token address and ticker if any:

##### Category (full list at https://defillama.com/categories) \*Please choose only one: Yield

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.): Chainlink

##### Implementation Details: Briefly describe how the oracle is integrated into your project: 
Using oracles setup by Pharos via the Chainlink Runtime Environment that pull prices from Chainlink datastreams to make them available on-chain as push data feeds.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
https://docs.pharos.xyz/tooling-and-infrastructure/oracles/chainlink-pe

##### forkedFrom (Does your project originate from another project):

##### methodology (what is being counted as tvl, how is tvl being calculated):
Counts active underlying asset backing locked in AquaFluxCore on Pharos. The adapter reads AquaFluxCore.getAssetUnderlyingBalance(assetId), values the locked backing using AquaFlux Rate Hook underlyingValue for the corresponding market, and reports it as USDC-equivalent. 

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/AquafluxPro

##### Does this project have a referral program?
No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AquaFlux decentralized finance protocol integration with total value locked tracking, enabling users to monitor asset positions and valuations within the platform.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19371?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->