### PR TITLE
feat: add lisAster TVL adapter

### DIFF
--- a/projects/lis-aster/index.js
+++ b/projects/lis-aster/index.js
@@ -1,0 +1,28 @@
+/**
+ * lisAster — Lista DAO's ASTER yield aggregator.
+ *
+ * Users deposit ASTER into AsterVault, which locks it permanently in
+ * veASTER (Aster's official staking) at the maximum 208-week duration
+ * with auto-relock to maintain full veASTER weight. lisAster is minted
+ * 1:1 on deposit, so its ERC20 total supply equals the underlying ASTER
+ * locked through the protocol.
+ *
+ * TVL = lisAster.totalSupply() priced as ASTER.
+ */
+
+const ASTER = '0x000Ae314E2A2172a039B26378814C252734f556A'
+const LIS_ASTER = '0xa17A497D20cC143508FE3b63578b13ba6b9c9f06'
+
+async function tvl(api) {
+  const supply = await api.call({
+    abi: 'erc20:totalSupply',
+    target: LIS_ASTER,
+  })
+  api.add(ASTER, supply)
+}
+
+module.exports = {
+  methodology:
+    'TVL is the ASTER permanently locked through lisAster — equal to lisAster ERC20 total supply (minted 1:1 on deposit).',
+  bsc: { tvl },
+}

--- a/projects/lis-aster/index.js
+++ b/projects/lis-aster/index.js
@@ -22,6 +22,7 @@ async function tvl(api) {
 }
 
 module.exports = {
+  doublecounted: true,
   methodology:
     'TVL is the ASTER permanently locked through lisAster — equal to lisAster ERC20 total supply (minted 1:1 on deposit).',
   bsc: { tvl },


### PR DESCRIPTION
## Summary

Add a TVL adapter for **lisAster**, Lista DAO's new ASTER yield aggregator on BSC mainnet.

Users deposit ASTER into AsterVault, which permanently locks it in veASTER (Aster's official staking) at the maximum 208-week duration with auto-relock, maintaining full veASTER weight. lisAster ERC20 is minted 1:1 on deposit, so its total supply equals the underlying ASTER locked through the protocol.

## TVL methodology

`lisAster.totalSupply()` priced as ASTER.

## Contracts (BSC mainnet)

| Contract | Address |
| --- | --- |
| ASTER (reward / underlying) | [`0x000Ae314E2A2172a039B26378814C252734f556A`](https://bscscan.com/address/0x000Ae314E2A2172a039B26378814C252734f556A) |
| LisAster (ERC20 receipt) | [`0xa17A497D20cC143508FE3b63578b13ba6b9c9f06`](https://bscscan.com/address/0xa17A497D20cC143508FE3b63578b13ba6b9c9f06) |
| AsterVault (deposit + veASTER lock manager) | [`0xb3Df1b695D720dDc5906005DD5448DB160687C42`](https://bscscan.com/address/0xb3Df1b695D720dDc5906005DD5448DB160687C42) |

## Suggested category

`Yield Aggregator` — within the Lista DAO family (sits alongside `lista-lending`, `lista-dex`, `lista-rwa`, `listapie`).

## Local test

\`\`\`
$ node test.js projects/lis-aster/index.js
--- bsc ---
ASTER                     8.04 k
Total: 8.04 k

------ TVL ------
bsc                       8.04 k
\`\`\`

## Notes

- App: https://lista.org/lis-aster
- Docs: https://docs.bsc.lista.org (lisAster section forthcoming)
- Twitter announcement: pending launch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for the lisAster ASTER yield aggregator on Binance Smart Chain.
  * TVL reflects locked ASTER supply and includes a methodology explaining the 1:1 relationship between lisAster tokens and permanently locked ASTER collateral for users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19372?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->