### PR TITLE
mark primefi insolvent

### DIFF
--- a/projects/primefi-xyz/index.js
+++ b/projects/primefi-xyz/index.js
@@ -5,17 +5,17 @@ const { staking } = require("../helper/staking");
 module.exports = {
   methodology: "PRFI/wrapped-native LP staked in PrimeFi staking contracts on each chain.",
   base: {
-    ...aaveExports(undefined, '0xBfeE735e3868f8990787CCEAA4B920C9Ed162b07'),
+    ...aaveExports(undefined, '0xBfeE735e3868f8990787CCEAA4B920C9Ed162b07', undefined, undefined, {isInsolvent: true}),
     staking: staking('0x5b6D95545750f1bb1812F5c564d9a401D3DeBd80', '0x7BBCf1B600565AE023a1806ef637Af4739dE3255'),
     pool2: sumTokensExport({ owner: '0x5b6D95545750f1bb1812F5c564d9a401D3DeBd80', tokens: ['0x87B417AF600312df37F551a05ae14bCC3d55bC36'], resolveLP: true }),
   },
   hyperliquid: {
-    ...aaveExports(undefined, '0x69A3c30A85aA1E22791466a08819c1080f0Aab7f'),
+    ...aaveExports(undefined, '0x69A3c30A85aA1E22791466a08819c1080f0Aab7f', undefined, undefined, {isInsolvent: true}),
     staking: staking('0x33cd734739c6DeD500fD080d476D93135cB813Ef', '0x7BBCf1B600565AE023a1806ef637Af4739dE3255'),
     pool2: sumTokensExport({ owner: '0x33cd734739c6DeD500fD080d476D93135cB813Ef', tokens: ['0x981F145a71Da6DF4A7cBe892807782c9CC9a5515'], resolveLP: true }),
   },
   xdc: {
-    ...aaveExports(undefined, '0xBfeE735e3868f8990787CCEAA4B920C9Ed162b07'),
+    ...aaveExports(undefined, '0xBfeE735e3868f8990787CCEAA4B920C9Ed162b07', undefined, undefined, {isInsolvent: true}),
     staking: staking('0x01E7cd81D3d7A4907815877e0C937a77dE537e99', '0x81B244d0be055EF3BEF1b09B7826Cc2b108B2cBD'),
     pool2: sumTokensExport({ owner: '0x01E7cd81D3d7A4907815877e0C937a77dE537e99', tokens: ['0xffA04F091128fb89D3B1eCd0149DC677dfAe1C69'], resolveLP: true }),
   },


### PR DESCRIPTION
For example, `0x24bdd195378ab4ce4d353bb9f19dc36b30bb4540` has bad debt and <1 HF across all chains:

- XDC/Base pool: `0x8a619D8E3BfAb54F7C30Ef39Ce16c53429c739C3`
- HL pool: `0xb339448E13E273f6F46e3390e0932Ab7fF9F113F`

```
cast call --rpc-url <url> <pool> "getUserAccountData(address)(uint256,uint256,uint256,uint256,uint256,uint256)" 0x24bdd195378ab4ce4d353bb9f19dc36b30bb4540
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled insolvency tracking for Aave protocol data on Base, Hyperliquid, and XDC networks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19382?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->