### PR TITLE
Add Showdown TVL adapter

### DIFF
--- a/projects/showdown/index.js
+++ b/projects/showdown/index.js
@@ -11,13 +11,15 @@ const REGISTERED_EVENT_ABI = "event Registered(bytes16 indexed tournamentId, add
 
 const USDM = ADDRESSES.megaeth.USDm;
 const LOG_CHUNK_SIZE = 100_000;
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
 async function getLogs2InChunks({ api, target, eventAbi, fromBlock, toBlock }) {
   const logs = [];
-  for (let start = fromBlock; start <= toBlock; start += LOG_CHUNK_SIZE + 1) {
-    const end = Math.min(start + LOG_CHUNK_SIZE, toBlock);
+  for (let start = fromBlock; start <= toBlock; start += LOG_CHUNK_SIZE) {
+    const end = Math.min(start + LOG_CHUNK_SIZE - 1, toBlock);
+    const endKey = end === toBlock ? "tail" : `${end}`;
     // Use a unique cache key per block chunk so each chunk is cached and reused independently
-    const extraKey = `showdown-${target.toLowerCase()}-${start}-${end}`;
+    const extraKey = `showdown-${target.toLowerCase()}-${start}-${endKey}`;
     const chunkLogs = await getLogs2({
       api,
       target,
@@ -56,7 +58,8 @@ async function getShowdownEmbeddedWallets(api) {
     ...tournamentLogs.map((log) => log.wallet),
   ]
     .filter(Boolean)
-    .map((wallet) => wallet.toLowerCase());
+    .map((wallet) => wallet.toLowerCase())
+    .filter((wallet) => wallet !== ZERO_ADDRESS);
 
   return [...new Set(wallets)];
 }

--- a/projects/showdown/index.js
+++ b/projects/showdown/index.js
@@ -1,0 +1,79 @@
+const { getLogs2 } = require("../helper/cache/getLogs");
+const ADDRESSES = require("../helper/coreAssets.json");
+
+const SHOWDOWN_CONTRACTS = {
+  MONEYGAMES: { address: "0x7B8DF4195eda5b193304eeCB5107DE18b6557D24", fromBlock: 6238852, },
+  TOURNAMENTS: { address: "0x130A8Da14C998C0fC23c5F5aDa64a318dFD6A805", fromBlock: 11578822, },
+};
+
+const MATCHFUNDED_EVENT_ABI = "event MatchFunded(bytes16 indexed matchId, address indexed player1, address indexed player2, uint128 amount)";
+const REGISTERED_EVENT_ABI = "event Registered(bytes16 indexed tournamentId, address indexed wallet, uint256 amount)";
+
+const USDM = ADDRESSES.megaeth.USDm;
+const LOG_CHUNK_SIZE = 100_000;
+
+async function getLogs2InChunks({ api, target, eventAbi, fromBlock, toBlock }) {
+  const logs = [];
+  for (let start = fromBlock; start <= toBlock; start += LOG_CHUNK_SIZE + 1) {
+    const end = Math.min(start + LOG_CHUNK_SIZE, toBlock);
+    // Use a unique cache key per block chunk so each chunk is cached and reused independently
+    const extraKey = `showdown-${target.toLowerCase()}-${start}-${end}`;
+    const chunkLogs = await getLogs2({
+      api,
+      target,
+      eventAbi,
+      fromBlock: start,
+      toBlock: end,
+      extraKey,
+    });
+    logs.push(...chunkLogs);
+  }
+  return logs;
+}
+
+async function getShowdownEmbeddedWallets(api) {
+  const toBlock = await api.getBlock();
+
+  const [gameLogs, tournamentLogs] = await Promise.all([
+    getLogs2InChunks({
+      api,
+      target: SHOWDOWN_CONTRACTS.MONEYGAMES.address,
+      eventAbi: MATCHFUNDED_EVENT_ABI,
+      fromBlock: SHOWDOWN_CONTRACTS.MONEYGAMES.fromBlock,
+      toBlock,
+    }),
+    getLogs2InChunks({
+      api,
+      target: SHOWDOWN_CONTRACTS.TOURNAMENTS.address,
+      eventAbi: REGISTERED_EVENT_ABI,
+      fromBlock: SHOWDOWN_CONTRACTS.TOURNAMENTS.fromBlock,
+      toBlock,
+    }),
+  ]);
+
+  const wallets = [
+    ...gameLogs.flatMap((log) => [log.player1, log.player2]),
+    ...tournamentLogs.map((log) => log.wallet),
+  ]
+    .filter(Boolean)
+    .map((wallet) => wallet.toLowerCase());
+
+  return [...new Set(wallets)];
+}
+
+async function tvl(api) {
+  const owners = await getShowdownEmbeddedWallets(api);
+  return api.sumTokens({
+    owners,
+    tokens: [USDM],
+  });
+}
+
+module.exports = {
+  methodology:
+    "Sums USDm balances held in Showdown app-specific embedded wallets on MegaETH. Wallets are included only if they have auditable on-chain activity via MatchFunded and Registered events on official Showdown contracts. These contracts are owner-restricted and invoked by the Showdown backend exclusively for Showdown gameplay, so the resulting TVL represents USDm held in historically active Showdown in-game wallets.",
+  start: "2026-02-04",
+  megaeth: {
+    tvl,
+  },
+};


### PR DESCRIPTION
## Summary

This PR adds a TVL adapter for Showdown, a competitive Web3 card game on MegaETH.

Showdown is already listed on DefiLlama with an approved Dex Volume adapter (dexs/showdown/index.ts). This PR only adds TVL tracking for the existing listing.

## Why this is valid TVL

Showdown has a non-standard architecture for gameplay balances. Instead of holding player funds in a single custodial smart contract, Showdown uses app-specific embedded wallets, one per player, created through Privy, an embedded wallet infrastructure provider.

These wallets represent the player's in-game USDm balance. They are used exclusively for Showdown gameplay and are not external wallets connected by users.

This adapter treats USDm balances in historically active Showdown embedded wallets as TVL because:

1. **App-specific wallets only**  
   The wallets included by this adapter are app-specific embedded wallets created and used exclusively for Showdown gameplay.

2. **Single-purpose game balances**  
   These wallets are used for Showdown gameplay, and the USDm balances held in them represent funds available inside the Showdown game economy.

3. **Official contract activity identifies active wallets**  
   The wallet set is derived only from on-chain activity with official Showdown contracts. Specifically, the adapter reads MatchFunded events from the Money Games contract and Registered events from the Tournaments contract. This provides an auditable on-chain registry of wallets created by the Showdown game, funded by players, and actively used in Showdown gameplay.

4. **Owner-restricted game contracts**  
   The Money Games and Tournaments contracts are owner-restricted and invoked by the Showdown backend. This prevents arbitrary users from creating misleading contract activity through direct external calls.

5. **Gameplay settlement approvals**  
   Showdown embedded wallets grant standing EIP-2612 approvals to the official game contracts, enabling on-chain settlement of gameplay actions directly from player balances. This is consistent with treating these balances as active in-game funds settling through official Showdown contracts.

6. **Conservative methodology**  
   The adapter excludes created wallets that have not appeared in official Showdown contract event logs, so the reported TVL represents funds available inside the active Showdown game economy.

## Technical implementation

The adapter does not use a backend API or database.

The adapter sources data exclusively from on-chain activity:

- MatchFunded events from the Money Games contract are scanned to identify money game participants
- Registered events from the Tournaments contract are scanned to identify tournament participants
- The resulting wallet list is deduplicated
- sumTokens is used to sum USDm balances across these wallets

Because the historical scan block range can be large, logs are read in 100k-block chunks to comply with MegaETH RPC limits. Each chunk uses a chunk-specific cache key, so previously scanned chunks do not need to be fetched again on later runs.

## Contracts

### Money Games

Address: 0x7B8DF4195eda5b193304eeCB5107DE18b6557D24  
Chain: MegaETH

### Tournaments

Address: 0x130A8Da14C998C0fC23c5F5aDa64a318dFD6A805  
Chain: MegaETH

### USDm

Address: 0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7  
Chain: MegaETH

## Checklist

- Adapter sources data exclusively from on-chain events (no backend API or database dependency).
- Methodology explains the non-standard TVL model.
- Adapter intentionally uses a conservative wallet set based only on verified on-chain gameplay activity.
- Tested locally against MegaETH RPC.
- Showdown is already listed on DefiLlama: https://defillama.com/protocol/showdown


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Total Value Locked (TVL) tracking for Showdown embedded wallets, enabling real-time monitoring of USDm token holdings and platform liquidity metrics and exposing the new TVL metric in the MegaETH data feed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19389?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->