### PR TITLE
Add AquaFlux AMM pool TVL

### DIFF
--- a/projects/aquaflux/index.js
+++ b/projects/aquaflux/index.js
@@ -2,6 +2,19 @@ const ADDRESSES = require('../helper/coreAssets.json')
 
 const CORE = '0x0da98a8447b6B4aDD9733011A812922954d3e127'
 const PALPHA = '0xE47E9bA4EA2320A6ed87246d02Fd5C38485Ed7d1'
+const WAD = 10n ** 18n
+
+const AMM_POOLS = [
+  {
+    name: 'pAlpha',
+    poolId: '0x12e8e4f5d37f7fa03a0da9b547cd31c2c1394dce0069371d96e2e6439ee9f673',
+    swapHook: '0x958a6E98203FE71Ae3A30c515D4705cb73C2Aa88',
+    token0: '0x34fD642Fa9fDc6Ce4013d4F3cde575C6dac904f9',
+    token1: '0xe150A72352a189dCe0D671C08F721B458104a2Af',
+    fee: 3000,
+    tickSpacing: 60,
+  },
+]
 
 async function tvl(api) {
   const balance = await api.call({ abi: 'erc20:balanceOf', target: PALPHA, params: [CORE] })
@@ -10,14 +23,48 @@ async function tvl(api) {
     target: PALPHA,
     params: [balance],
   })
+  const coreTVL = BigInt(assets)
+  const ammTVL = await getAmmTVL(api)
+  api.add(ADDRESSES.pharos.USDC, coreTVL + ammTVL)
+}
 
-  api.add(ADDRESSES.pharos.USDC, assets)
+async function getAmmTVL(api) {
+  let total = 0n
+
+  // Each AquaFlux AMM pool is a PT/AQ stable swap market implemented through Uniswap v4 hook.
+  for (const pool of AMM_POOLS) {
+    const poolInfo = await api.call({
+      abi: 'function poolInfo(bytes32 id) view returns (tuple(bool configured,bool isPToken0,uint256 valuationStart,uint256 maturity,uint256 pInitialValue,uint256 pMaturityValue,uint256 underlyingInitialValue,uint256 underlyingMaturityValue,uint256 amplification,uint256 creditLayer,uint256 pTokenScale,uint256 underlyingTokenScale,uint256 swapFeeRate,uint128 reserveP,uint128 reserveUnderlying,uint256 totalShares,address lpToken,bool paused))',
+      target: pool.swapHook,
+      params: [pool.poolId],
+    })
+
+    // PT is a principal tranche token, and value it with the AquaFlux Rate Hook's on-chain principal value for the AMM pool.
+    const pValue = await api.call({
+      abi: 'function pValue((address currency0, address currency1, uint24 fee, int24 tickSpacing, address hooks) key) view returns (uint256)',
+      target: pool.swapHook,
+      params: [[pool.token0, pool.token1, pool.fee, pool.tickSpacing, pool.swapHook]],
+    })
+    const pAssets = BigInt(poolInfo.reserveP) * BigInt(pValue) / WAD
+
+    // AQ Token reserves are underlying wrapped exposure;
+    // e.g. AQ-pAlpha represents pAlpha 1:1 backed wrapped exposure, and value it through pAlpha.convertToAssets.
+    const aqAssets = await api.call({
+      abi: 'function convertToAssets(uint256 shares) view returns (uint256 assets)',
+      target: PALPHA,
+      params: [poolInfo.reserveUnderlying],
+    })
+
+    total += pAssets + BigInt(aqAssets)
+  }
+
+  return total
 }
 
 module.exports = {
   doublecounted: true,
   methodology:
-    'Counts active assets locked in AquaFluxCore contracts.',
+    'Counts vault assets held by AquaFluxCore and value locked in AquaFlux AMM pools.',
   pharos: {
     tvl,
   },


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).

2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** It is a different repo, you can find your listing in [this file](https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts), you can edit it there and put up a PR
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes

---
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):

##### Twitter Link:

##### List of audit links if any:

##### Website Link:

##### Logo (High resolution, will be shown with rounded borders):

##### Current TVL:

##### Treasury Addresses (if the protocol has treasury)

##### Chain:

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama):

##### Token address and ticker if any:

##### Category (full list at https://defillama.com/categories) \*Please choose only one:

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

##### forkedFrom (Does your project originate from another project):

##### methodology (what is being counted as tvl, how is tvl being calculated):
Counts vault assets held by AquaFluxCore and value locked in AquaFlux AMM pools.

##### Github org/user (Optional, if your code is open source, we can track activity):

##### Does this project have a referral program?

## Update
This PR extends the existing AquaFlux TVL adapter to include AquaFlux AMM pool liquidity.

AquaFlux AMM pools are PT/AQ stable swap market implemented through Uniswap v4 hook. 
PT reserves are principal tranche reserves and are valued using the AquaFlux Rate Hook for the corresponding pool.
AQ Token reserves are underlying wrapped exposure, e.g. AQ-pAlpha represents pAlpha 1:1 backed wrapped exposure, and value it through pAlpha.convertToAssets.

This follows the same rule used by Spectra: count deposited principal-token backing and liquidity supplied to protocol markets. `doublecounted: true` is preserved from the existing AquaFlux adapter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended AquaFlux TVL metrics to include AMM pool valuations alongside core valuations, providing a more comprehensive view of total value locked in the platform.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19392?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->