### PR TITLE
fix gaib legacy tvl

### DIFF
--- a/projects/gaib/index.js
+++ b/projects/gaib/index.js
@@ -3,6 +3,13 @@ const ADDRESSES = require('../helper/coreAssets.json');
 // AID.v0 token address (same on all chains: Ethereum, BNB Chain, Base, Arbitrum)
 const AID_TOKEN = '0x18F52B3fb465118731d9e0d276d4Eb3599D57596';
 
+const MIGRATION_CONTRACTS = {
+    ethereum: '0x410c19f3f80b64c7486ae34890ee9251d0696433',
+    arbitrum: '0x77b69A6bAE1360A176452B00F61A0Fc21C7EF333',
+    base: '0xE2b908aa7C5DECBFC4260E52e138fc8d08272D03',
+    bsc: '0x77b69A6bAE1360A176452B00F61A0Fc21C7EF333'
+};
+
 // Legacy AIDa (Alpha) pool contracts
 const aidaContracts = {
     ethereum: [
@@ -75,17 +82,30 @@ const balanceOfABI = "function balanceOf(address) external view returns (uint256
 async function aidaTvl(api) {
     const chain = api.chain;
     const pools = aidaContracts[chain];
+    if (!pools?.length) return api.getBalances();
 
-    if (pools && pools.length > 0) {
-        const totalAssetsAmounts = await api.multiCall({
-            abi: totalAssetsABI,
-            calls: pools.map(p => p.poolToken),
-        });
+    const poolAddrs = pools.map(p => p.poolToken);
+    const migration = MIGRATION_CONTRACTS[chain];
 
-        totalAssetsAmounts.forEach((amount, index) => {
-            api.add(pools[index].token, amount);
-        });
+    if (!migration) {
+        const totalAssetsAmounts = await api.multiCall({ abi: totalAssetsABI, calls: poolAddrs });
+        totalAssetsAmounts.forEach((amount, i) => api.add(pools[i].token, amount));
+        return api.getBalances();
     }
+
+    const [totalAssets, totalSupplies, migrationBals] = await Promise.all([
+        api.multiCall({ abi: totalAssetsABI, calls: poolAddrs }),
+        api.multiCall({ abi: totalSupplyABI, calls: poolAddrs }),
+        api.multiCall({ abi: balanceOfABI, calls: poolAddrs.map(p => ({ target: p, params: migration })) }),
+    ]);
+
+    totalAssets.forEach((assets, i) => {
+        const supply = BigInt(totalSupplies[i]);
+        if (supply === 0n) return;
+        const claimableShares = supply - BigInt(migrationBals[i]);
+        const claimable = (BigInt(assets) * claimableShares) / supply;
+        api.add(pools[i].token, claimable.toString());
+    });
 
     return api.getBalances();
 }


### PR DESCRIPTION
remove migrated shares from tvl as they are no longer held by users (moved to migration contract). Users can call `migrate()` to receive AID at 1:1 ratio for their legacy shares, then they can swap AID into USDC, USDT, etc. Examples:

- [base migration](https://basescan.org/token/0x18f52b3fb465118731d9e0d276d4eb3599d57596?a=0x1d8c4d80464270afb50576cab66f08a29903747f#transactions)
- [ethereum migration](https://etherscan.io/token/0x18f52b3fb465118731d9e0d276d4eb3599d57596?a=0xb1eb4ec5ef5272a6c4909922c62b13668de3672b#transactions)
- [bsc migration](https://bscscan.com/token/0x18f52b3fb465118731d9e0d276d4eb3599d57596?a=0x9c0d93856c6c1dc8034340d137db70e04460a698#transactions)
- [arbitrum migration](https://arbiscan.io/token/0x18f52b3fb465118731d9e0d276d4eb3599d57596?a=0x5675869fb879620db7cc106a704bdd41bb0f3064#transactions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced AIDa pool TVL calculations across Ethereum, Arbitrum, Base, and BSC to properly account for migration contracts.
  * Improved accuracy of asset claimability computations using pro-rata share methodology.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19402?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->