### PR TITLE
turboflow: add treasury adapter for Fireblocks MPC custody

### DIFF
--- a/projects/treasury/turboflow.js
+++ b/projects/treasury/turboflow.js
@@ -1,0 +1,59 @@
+const ADDRESSES = require("../helper/coreAssets.json");
+const { sumTokens2 } = require("../helper/unwrapLPs");
+const { sumTokens2: solanaSumTokens } = require("../helper/solana");
+
+// Protocol-operated Fireblocks MPC custody wallets that back TurboFlow
+// user deposits and settlement obligations. These EOA/safe-style balances
+// are tracked separately from the bridge-contract TVL exported by
+// `projects/turboflow/index.js`, in line with DefiLlama's policy of not
+// counting EOA/safe holdings toward TVL. All addresses are publicly
+// disclosed by the protocol and verifiable on-chain.
+
+// --- BSC ---
+
+const BSC_FIREBLOCKS_VAULTS = [
+  "0x8757f9E16d775759671e95e50D749CECCDA375AE", // Fireblocks MPC vault (SIG)
+  "0x077Ab3f5D4372cA14c6AA417215Af3d91B55bAFc", // Fireblocks MPC vault (TFUSERS)
+];
+
+const BSC_TOKENS = [ADDRESSES.bsc.USDT, ADDRESSES.bsc.USDC];
+
+async function bscTvl(api) {
+  return sumTokens2({ api, owners: BSC_FIREBLOCKS_VAULTS, tokens: BSC_TOKENS });
+}
+
+// --- Solana ---
+
+const SOLANA_FIREBLOCKS_OWNERS = [
+  "6FaXzEC4CNAh1ECxc8FUnjpcnMYYG4M7DVJ5ZMbTmcWH", // Fireblocks MPC vault (SIG)
+  "4wHLLe6ovPqmGoBjvk6ogxgFbiGMCUUPvnMqmxyprX5C", // Fireblocks MPC vault (TFUSERS)
+];
+
+const SOLANA_FIREBLOCKS_PAIRS = SOLANA_FIREBLOCKS_OWNERS.flatMap((owner) => [
+  [ADDRESSES.solana.USDT, owner],
+  [ADDRESSES.solana.USDC, owner],
+]);
+
+async function solanaTvl(api) {
+  // `computeTokenAccount: true` derives the canonical associated token
+  // account (ATA) for each (mint, owner) pair locally and reads them via
+  // a single `getMultipleAccounts` batched call, avoiding the throttled
+  // `getTokenAccountsByOwner` path on public Solana RPCs from CI egress.
+  //
+  // `allowError: true` tolerates Fireblocks ATAs that have not yet been
+  // initialised on chain (a mint/owner pair with no deposits to date)
+  // by treating a missing account as a zero balance instead of throwing.
+  return solanaSumTokens({
+    api,
+    tokensAndOwners: SOLANA_FIREBLOCKS_PAIRS,
+    computeTokenAccount: true,
+    allowError: true,
+  });
+}
+
+module.exports = {
+  methodology:
+    "Treasury counts USDT and USDC balances held by TurboFlow's protocol-operated Fireblocks MPC custody wallets on BSC and Solana, which back user deposits and settlement obligations. The bridge contracts that receive user deposits are tracked separately as TVL (see projects/turboflow/index.js).",
+  bsc: { tvl: bscTvl },
+  solana: { tvl: solanaTvl },
+};

--- a/projects/turboflow/index.js
+++ b/projects/turboflow/index.js
@@ -48,18 +48,26 @@ const SOLANA_FIREBLOCKS_PAIRS = SOLANA_FIREBLOCKS_OWNERS.flatMap((owner) => [
 ])
 
 async function solanaTvl(api) {
-  // `computeTokenAccount: true` tells the helper to locally derive the
-  // canonical associated token account (ATA) for each (mint, owner) pair
-  // in `tokensAndOwners`, then read those accounts via `getMultipleAccounts`
-  // instead of issuing `getTokenAccountsByOwner` requests (which public
-  // Solana RPCs throttle aggressively from shared CI egress IPs).
-  //
-  // `allowError: true` tolerates Fireblocks ATAs that have not yet been
-  // initialised on chain (i.e. zero deposits to date): the helper treats
-  // a missing account as a zero balance instead of throwing.
-  return solanaSumTokens({
+  // Bridge SPL token accounts are always-initialised production accounts,
+  // so we read them without `allowError` and let any RPC/account error
+  // surface loudly instead of being silently treated as zero balance.
+  await solanaSumTokens({
     api,
     tokenAccounts: SOLANA_BRIDGE_TOKEN_ACCOUNTS,
+  })
+
+  // Fireblocks MPC vaults are owner wallets; the helper derives the
+  // canonical associated token account (ATA) for each (mint, owner) pair
+  // locally and batches the reads via `getMultipleAccounts`, avoiding the
+  // `getTokenAccountsByOwner` path that public Solana RPCs throttle
+  // aggressively from shared CI egress IPs.
+  //
+  // `allowError: true` is scoped to this call only: it tolerates Fireblocks
+  // ATAs that have not yet been initialised on chain (i.e. zero deposits to
+  // date for that mint/owner) by treating a missing account as zero balance
+  // instead of throwing.
+  await solanaSumTokens({
+    api,
     tokensAndOwners: SOLANA_FIREBLOCKS_PAIRS,
     computeTokenAccount: true,
     allowError: true,

--- a/projects/turboflow/index.js
+++ b/projects/turboflow/index.js
@@ -1,27 +1,64 @@
 const ADDRESSES = require('../helper/coreAssets.json')
-const { sumTokensExport } = require("../helper/sumTokens");
-const { sumTokens2: sumTokensSolana } = require("../helper/solana");
+const { sumTokens2 } = require('../helper/unwrapLPs')
+const { sumTokens2: solanaSumTokens } = require('../helper/solana')
 
-const BSC_CONTRACT = "0x145CD0d5C3dD0eF1405dCf1b4D2BCE7c611625dB";
-const BSC_USDT = ADDRESSES.bsc.USDT;
-const BSC_USDC = ADDRESSES.bsc.USDC;
+// TurboFlow TVL = USDT/USDC held in (1) on-chain bridge contracts on BSC and
+// Solana that receive user deposits, plus (2) Fireblocks MPC custody wallets
+// that back user deposits and settlement obligations.
+//
+// All addresses below are on-chain verifiable and listed publicly by the
+// protocol. No off-chain HTTP source is involved in TVL computation.
 
-const SOLANA_CONTRACT = "8iquHJQyXUq8ykTEKZjtS4wSHKnxiw4ghGWUNzPnA9Q4";
-const SOLANA_USDT = ADDRESSES.solana.USDT;
-const SOLANA_USDC = ADDRESSES.solana.USDC;
+// --- BSC ---
 
-async function solanaTvl() {
-  return sumTokensSolana({
-    tokensAndOwners: [
-      [SOLANA_USDT, SOLANA_CONTRACT],
-      [SOLANA_USDC, SOLANA_CONTRACT],
-    ],
-  });
+const BSC_HOLDERS = [
+  '0x145CD0d5C3dD0eF1405dCf1b4D2BCE7c611625dB', // Bridge contract (user deposits)
+  '0x8757f9E16d775759671e95e50D749CECCDA375AE', // Fireblocks MPC vault (SIG)
+  '0x077Ab3f5D4372cA14c6AA417215Af3d91B55bAFc', // Fireblocks MPC vault (TFUSERS)
+]
+
+const BSC_TOKENS = [
+  ADDRESSES.bsc.USDT, // 0x55d398326f99059fF775485246999027B3197955
+  ADDRESSES.bsc.USDC, // 0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d
+]
+
+async function bscTvl(api) {
+  return sumTokens2({ api, owners: BSC_HOLDERS, tokens: BSC_TOKENS })
+}
+
+// --- Solana ---
+
+// Bridge custody — direct SPL token accounts owned by the bridge program
+// (authority PDA: 8iquHJQyXUq8ykTEKZjtS4wSHKnxiw4ghGWUNzPnA9Q4).
+const SOLANA_BRIDGE_TOKEN_ACCOUNTS = [
+  '9ayXbTyhkJ49WtG6DA2PCN6EAKtM8DCneMzhJPTMRWcj', // Bridge USDC SPL account
+  '6hVp2UaWWQwGo2c6yHj39WJWDNenR48GsLGKPzSa7EU2', // Bridge USDT SPL account
+]
+
+// Fireblocks MPC custody — owner wallet pubkeys. The Solana helper derives
+// each owner's associated token accounts for the listed mints automatically.
+const SOLANA_FIREBLOCKS_OWNERS = [
+  '6FaXzEC4CNAh1ECxc8FUnjpcnMYYG4M7DVJ5ZMbTmcWH', // Fireblocks vault (SIG)
+  '4wHLLe6ovPqmGoBjvk6ogxgFbiGMCUUPvnMqmxyprX5C', // Fireblocks vault (TFUSERS)
+]
+
+const SOLANA_FIREBLOCKS_PAIRS = SOLANA_FIREBLOCKS_OWNERS.flatMap((owner) => [
+  [ADDRESSES.solana.USDT, owner],
+  [ADDRESSES.solana.USDC, owner],
+])
+
+async function solanaTvl(api) {
+  return solanaSumTokens({
+    api,
+    tokenAccounts: SOLANA_BRIDGE_TOKEN_ACCOUNTS,
+    tokensAndOwners: SOLANA_FIREBLOCKS_PAIRS,
+  })
 }
 
 module.exports = {
-  bsc: { tvl:sumTokensExport({ chain: 'bsc', owner: BSC_CONTRACT, tokens: [BSC_USDT, BSC_USDC] })},
-  solana: {tvl:solanaTvl},
-  methodology: "Count the total balance across all pools for all trading pairs.",
+  methodology:
+    'TVL counts USDT and USDC balances held by TurboFlow on (i) on-chain bridge contracts on BSC and Solana that receive user deposits, and (ii) protocol-operated MPC custody wallets (Fireblocks) that back user deposits and settlement obligations. All custody addresses are listed in this adapter and verifiable on-chain via balanceOf (BSC) and getTokenAccountBalance / getTokenAccountsByOwner (Solana). Excludes trading volume, leveraged notional exposure, unrealized PnL, treasury, and operating funds not allocated to user deposit backing.',
+  start: '2025-10-19',
+  bsc: { tvl: bscTvl },
+  solana: { tvl: solanaTvl },
 }
-

--- a/projects/turboflow/index.js
+++ b/projects/turboflow/index.js
@@ -2,20 +2,15 @@ const ADDRESSES = require('../helper/coreAssets.json')
 const { sumTokens2 } = require('../helper/unwrapLPs')
 const { sumTokens2: solanaSumTokens } = require('../helper/solana')
 
-// TurboFlow TVL = USDT/USDC held in (1) on-chain bridge contracts on BSC and
-// Solana that receive user deposits, plus (2) Fireblocks MPC custody wallets
-// that back user deposits and settlement obligations.
-//
-// All addresses below are on-chain verifiable and listed publicly by the
-// protocol. No off-chain HTTP source is involved in TVL computation.
+// TurboFlow TVL = USDT/USDC held in the on-chain bridge contracts that
+// receive user deposits on BSC and Solana. Protocol-operated MPC custody
+// wallets (Fireblocks) that back user deposits and settlement obligations
+// are tracked separately as treasury in `projects/treasury/turboflow.js`,
+// per DefiLlama's policy of not counting EOA/safe balances toward TVL.
 
 // --- BSC ---
 
-const BSC_HOLDERS = [
-  '0x145CD0d5C3dD0eF1405dCf1b4D2BCE7c611625dB', // Bridge contract (user deposits)
-  '0x8757f9E16d775759671e95e50D749CECCDA375AE', // Fireblocks MPC vault (SIG)
-  '0x077Ab3f5D4372cA14c6AA417215Af3d91B55bAFc', // Fireblocks MPC vault (TFUSERS)
-]
+const BSC_BRIDGE = '0x145CD0d5C3dD0eF1405dCf1b4D2BCE7c611625dB'
 
 const BSC_TOKENS = [
   ADDRESSES.bsc.USDT, // 0x55d398326f99059fF775485246999027B3197955
@@ -23,7 +18,7 @@ const BSC_TOKENS = [
 ]
 
 async function bscTvl(api) {
-  return sumTokens2({ api, owners: BSC_HOLDERS, tokens: BSC_TOKENS })
+  return sumTokens2({ api, owner: BSC_BRIDGE, tokens: BSC_TOKENS })
 }
 
 // --- Solana ---
@@ -35,48 +30,16 @@ const SOLANA_BRIDGE_TOKEN_ACCOUNTS = [
   '6hVp2UaWWQwGo2c6yHj39WJWDNenR48GsLGKPzSa7EU2', // Bridge USDT SPL account
 ]
 
-// Fireblocks MPC custody — owner wallet pubkeys. The Solana helper derives
-// each owner's associated token accounts for the listed mints automatically.
-const SOLANA_FIREBLOCKS_OWNERS = [
-  '6FaXzEC4CNAh1ECxc8FUnjpcnMYYG4M7DVJ5ZMbTmcWH', // Fireblocks vault (SIG)
-  '4wHLLe6ovPqmGoBjvk6ogxgFbiGMCUUPvnMqmxyprX5C', // Fireblocks vault (TFUSERS)
-]
-
-const SOLANA_FIREBLOCKS_PAIRS = SOLANA_FIREBLOCKS_OWNERS.flatMap((owner) => [
-  [ADDRESSES.solana.USDT, owner],
-  [ADDRESSES.solana.USDC, owner],
-])
-
 async function solanaTvl(api) {
-  // Bridge SPL token accounts are always-initialised production accounts,
-  // so we read them without `allowError` and let any RPC/account error
-  // surface loudly instead of being silently treated as zero balance.
-  await solanaSumTokens({
+  return solanaSumTokens({
     api,
     tokenAccounts: SOLANA_BRIDGE_TOKEN_ACCOUNTS,
-  })
-
-  // Fireblocks MPC vaults are owner wallets; the helper derives the
-  // canonical associated token account (ATA) for each (mint, owner) pair
-  // locally and batches the reads via `getMultipleAccounts`, avoiding the
-  // `getTokenAccountsByOwner` path that public Solana RPCs throttle
-  // aggressively from shared CI egress IPs.
-  //
-  // `allowError: true` is scoped to this call only: it tolerates Fireblocks
-  // ATAs that have not yet been initialised on chain (i.e. zero deposits to
-  // date for that mint/owner) by treating a missing account as zero balance
-  // instead of throwing.
-  await solanaSumTokens({
-    api,
-    tokensAndOwners: SOLANA_FIREBLOCKS_PAIRS,
-    computeTokenAccount: true,
-    allowError: true,
   })
 }
 
 module.exports = {
   methodology:
-    'TVL counts USDT and USDC balances held by TurboFlow on (i) on-chain bridge contracts on BSC and Solana that receive user deposits, and (ii) protocol-operated MPC custody wallets (Fireblocks) that back user deposits and settlement obligations. All custody addresses are listed in this adapter and verifiable on-chain via balanceOf (BSC) and getTokenAccountBalance / getTokenAccountsByOwner (Solana). Excludes trading volume, leveraged notional exposure, unrealized PnL, treasury, and operating funds not allocated to user deposit backing.',
+    'TVL counts USDT and USDC balances held by the TurboFlow bridge contracts on BSC and Solana, which are the on-chain entry points for user deposits. Protocol-operated MPC custody (Fireblocks) backing user deposits is tracked separately as treasury (see projects/treasury/turboflow.js), in line with DefiLlama policy of not counting EOA/safe balances toward TVL. Excludes trading volume, leveraged notional exposure, unrealized PnL, and any non-circulating tokens.',
   start: '2025-10-19',
   bsc: { tvl: bscTvl },
   solana: { tvl: solanaTvl },

--- a/projects/turboflow/index.js
+++ b/projects/turboflow/index.js
@@ -48,10 +48,21 @@ const SOLANA_FIREBLOCKS_PAIRS = SOLANA_FIREBLOCKS_OWNERS.flatMap((owner) => [
 ])
 
 async function solanaTvl(api) {
+  // `computeTokenAccount: true` tells the helper to locally derive the
+  // canonical associated token account (ATA) for each (mint, owner) pair
+  // in `tokensAndOwners`, then read those accounts via `getMultipleAccounts`
+  // instead of issuing `getTokenAccountsByOwner` requests (which public
+  // Solana RPCs throttle aggressively from shared CI egress IPs).
+  //
+  // `allowError: true` tolerates Fireblocks ATAs that have not yet been
+  // initialised on chain (i.e. zero deposits to date): the helper treats
+  // a missing account as a zero balance instead of throwing.
   return solanaSumTokens({
     api,
     tokenAccounts: SOLANA_BRIDGE_TOKEN_ACCOUNTS,
     tokensAndOwners: SOLANA_FIREBLOCKS_PAIRS,
+    computeTokenAccount: true,
+    allowError: true,
   })
 }
 


### PR DESCRIPTION
**Type of change**: update to an existing adapter (`projects/turboflow/index.js`) + new treasury adapter (`projects/treasury/turboflow.js`).

The TurboFlow listing was originally added by the project team in [#16949](https://github.com/DefiLlama/DefiLlama-Adapters/pull/16949) (Nov 2025, before the rebrand from `surf.one` to `TurboFlow`). This PR's goal is to surface the protocol-operated Fireblocks MPC custody wallets — which back user deposits — in DefiLlama. Per [@RohanNero's review](https://github.com/DefiLlama/DefiLlama-Adapters/pull/19411#discussion_r3325811207), those EOA/safe-style holdings are now tracked as **treasury** rather than TVL.

### Summary of the change

This PR makes two related changes that together represent the protocol's full user-deposit custody surface:

1. **TVL adapter (`projects/turboflow/index.js`)** — kept strictly to on-chain bridge contracts (one per chain). The Fireblocks vaults that had been added in earlier commits on this branch have been removed from TVL, so the TVL adapter is functionally equivalent to the original #16949 scope plus an updated `start` date and methodology string.
2. **Treasury adapter (`projects/treasury/turboflow.js`, new)** — adds the four Fireblocks MPC custody wallets (two BSC + two Solana) that back user deposits and settlement obligations.

| File | Chain | Address | Role |
| --- | --- | --- | --- |
| `index.js` (TVL) | BSC | `0x145CD0d5C3dD0eF1405dCf1b4D2BCE7c611625dB` | Bridge contract |
| `index.js` (TVL) | Solana | `9ayXbTyhkJ49WtG6DA2PCN6EAKtM8DCneMzhJPTMRWcj` | Bridge USDC SPL token account (owned by PDA `8iquHJQy…A9Q4`) |
| `index.js` (TVL) | Solana | `6hVp2UaWWQwGo2c6yHj39WJWDNenR48GsLGKPzSa7EU2` | Bridge USDT SPL token account (owned by the same PDA) |
| `treasury/turboflow.js` | BSC | `0x8757f9E16d775759671e95e50D749CECCDA375AE` | Fireblocks MPC vault (SIG) |
| `treasury/turboflow.js` | BSC | `0x077Ab3f5D4372cA14c6AA417215Af3d91B55bAFc` | Fireblocks MPC vault (TFUSERS) |
| `treasury/turboflow.js` | Solana | `6FaXzEC4CNAh1ECxc8FUnjpcnMYYG4M7DVJ5ZMbTmcWH` | Fireblocks MPC vault (SIG) |
| `treasury/turboflow.js` | Solana | `4wHLLe6ovPqmGoBjvk6ogxgFbiGMCUUPvnMqmxyprX5C` | Fireblocks MPC vault (TFUSERS) |

Tokens counted are the canonical USDT and USDC on each chain (BSC: `0x55d3…7955` / `0x8AC7…580d`; Solana: `Es9vM…NYB` / `EPjFW…Dt1v`), pulled from `helper/coreAssets.json`. The Solana paths use `solanaSumTokens` with `computeTokenAccount: true` so balances are read via canonical-ATA derivation + a single `getMultipleAccounts` batch, avoiding the throttled `getTokenAccountsByOwner` path on public Solana RPCs from CI egress.

### Expected effect on the DefiLlama UI

At the time of this PR, the two adapters produce the following snapshot (USDT + USDC, both stablecoins, so the dollar amounts equal the token amounts):

| Bucket | BSC | Solana | Total |
| --- | --- | --- | --- |
| TVL (bridge contracts) | ~$324K | ~$177K | **~$500K** |
| Treasury (Fireblocks MPC vaults) | ~$660K | ~$106K | **~$765K** |
| **Combined** | ~$984K | ~$282K | **~$1.27M** |

The combined number is the same set of protocol-controlled USDT/USDC we had been reporting; the split simply moves the EOA/safe-style portion out of TVL and into the protocol's treasury entry, per the maintainer's request. Bridge ↔ Fireblocks balances move between these buckets as deposits are swept through normal protocol operation.

### Verification

- BSC: `eth_call balanceOf(owner)` for each of `[USDT, USDC]` × `[owner]` on every listed address.
- Solana: `getTokenAccountBalance` for the two bridge SPL token accounts (TVL adapter); `getMultipleAccounts` on the canonical ATAs derived from each `(mint, owner)` pair (treasury adapter).

Locally: both `node test.js projects/turboflow/index.js` and `node test.js projects/treasury/turboflow.js` succeed and reproduce the table above against `api.mainnet-beta.solana.com`.

### Scope

This PR is strictly balance reporting. No volume / fees / users / perps dimensions are touched; those will be submitted separately. The adapter only exports `bsc.tvl` and `solana.tvl` for each of the two files.

**Excludes**: trading volume, leveraged notional exposure, unrealized PnL, native chain balances, and any non-circulating tokens.

### Product scope and category

The protocol is actively operating perpetuals plus an event-contracts product line, with broader prediction-market products on the roadmap. These product lines share a common user-deposit pool with no per-product on-chain attribution, so the protocol is listed under its dominant product category (`Derivatives`) — consistent with how DefiLlama treats other multi-product protocols with shared collateral (GMX V2, Hyperliquid, Drift).

Separately, the protocol entry was previously marked `deprecated: true` at our own request during the `surf.one` → `TurboFlow` rebrand; the flag was flipped back to `false` by @realShaman via the DefiLlama Discord on 2026-05-29 — thanks again. A few minor remaining protocol-metadata items (audits link, description text, project URL) are being handled in parallel in that Discord thread, separate from this adapter change.

### "Allow edits by maintainers"

This box is checked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * TVL methodology updated and protocol start date added.
  * BSC TVL now aggregates multiple custody sources (bridge + two vaults).
  * Solana TVL now includes bridge token accounts and external vault owners, with tolerant handling for missing/uninitialized token accounts.
  * New treasury adapter added to report custody balances for BSC and Solana.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19411?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->