### PR TITLE
Ensuro: adds OpenEden's USDO as asset

### DIFF
--- a/projects/ensuro/index.js
+++ b/projects/ensuro/index.js
@@ -34,6 +34,7 @@ const addressBook = {
   },
   ethereum: {
     usdc: ADDRESSES.ethereum.USDC,
+    usdo: "0x8238884Ec9668Ef77B90C6dfF4D1a9F4F4823BFe", // OpenEden's USDO - Tokenized T-bill
     aave_v3_usdc: "0x98C23E9d8f34FEFb1B7BD6a91B7FF122F4e16F5c", // aEthUSDC
     morpho_vaults: [
       "0xe108fbc04852B5df72f9E44d7C29F47e7A993aDd", // kpk-usdc-prime
@@ -76,8 +77,12 @@ async function tvl(api) {
   const addresses = addressBook[api.chain];
   // Most of the reserves can only have USDC
   const ownerTokens = addresses.reserves.map(i => [[normalize(addresses.usdc)], i.address])
-  // The MSV also has AAVE USDC
-  ownerTokens.push([[normalize(addresses.usdc), normalize(addresses.aave_v3_usdc)], addresses.msv]);
+  // The MSV also has AAVE USDC and OpenEden's USDO
+  if (api.chain === "ethereum" ) {
+    ownerTokens.push([[normalize(addresses.usdc), normalize(addresses.aave_v3_usdc), normalize(addresses.usdo)], addresses.msv]);
+  } else {
+    ownerTokens.push([[normalize(addresses.usdc), normalize(addresses.aave_v3_usdc)], addresses.msv]);
+  }
 
   // Also Morpho vaults
   for (const vault of addresses.morpho_vaults) {


### PR DESCRIPTION
A few days ago, some of the assets were invested in USDO (tokenized T-bill).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for OpenEden's USDO token
  * Updated TVL calculation to include USDO as an additional asset for MSV on Ethereum

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19415?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->