### PR TITLE
  credit: split TVL into available liquidity and borrowed

### DIFF
--- a/projects/credit/index.js
+++ b/projects/credit/index.js
@@ -1,26 +1,27 @@
 const methodologies = require('../helper/methodologies');
 
+const VAULT = '0xcE4602C16f6e83eEa77BFb3CCe6f6BCE9EcBb92E';
+
 async function tvl(api) {
-    const vault = '0xcE4602C16f6e83eEa77BFb3CCe6f6BCE9EcBb92E'
-
-    const token = await api.call({
-        abi: 'address:asset',
-        target: vault,
-        params: [],
-    });
-
-    const balance = await api.call({
-        abi: 'uint256:totalAssets',
-        target: vault,
-        params: [],
-    });
-
-    api.add(token, balance)
+    const asset = await api.call({ abi: 'address:asset', target: VAULT });
+    const cash = await api.call({ abi: 'erc20:balanceOf', target: asset, params: [VAULT] });
+    api.add(asset, cash);
 }
-  
+
+async function borrowed(api) {
+    const asset = await api.call({ abi: 'address:asset', target: VAULT });
+    const [totalAssets, cash] = await Promise.all([
+        api.call({ abi: 'uint256:totalAssets', target: VAULT }),
+        api.call({ abi: 'erc20:balanceOf', target: asset, params: [VAULT] }),
+    ]);
+    const lent = BigInt(totalAssets) - BigInt(cash);
+    if (lent > 0n) api.add(asset, lent.toString());
+}
+
 module.exports = {
     methodology: methodologies.lendingMarket,
     wc: {
-        tvl
-    }
-}
+        tvl,
+        borrowed,
+    },
+};


### PR DESCRIPTION
This PR refines how the Credit protocol is reported so that DefiLlama can show two distinct indicators side by side, the same way Aave, Compound, and Morpho are displayed today:

- **TVL** — the underlying asset currently held by the vault (available liquidity).
- **Borrowed** — the portion of `totalAssets()` that has been deployed to borrowers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved credit vault TVL calculation to accurately reflect underlying asset balances.

* **New Features**
  * Added borrowed amount tracking to vault adapter metrics for enhanced visibility into lending activity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19418?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->