### PR TITLE
hubra: restore raSOL stake pool, add validator + Max vault; drop sola…

### DIFF
--- a/projects/hubra/index.js
+++ b/projects/hubra/index.js
@@ -1,19 +1,63 @@
-const { getSolBalanceFromStakePool, getConnection } = require('../helper/solana')
+const ADDRESSES = require('../helper/coreAssets.json')
+const { getConnection } = require('../helper/solana')
+const { decodeAccount } = require('../helper/utils/solana/layout')
 const { PublicKey } = require('@solana/web3.js')
 
-// Voltr vault account layout:
-// offset 104: asset mint (pubkey, 32 bytes)
-// offset 168: totalValue (u64, 8 bytes)
+const RASOL_STAKE_POOL = 'ECRqn7gaNASuvTyC5xfCUjehWZCSowMXstZiM5DNweyB'
+const HUBRA_VOTE_ACCOUNT = '7K8DVxtNJGnMtUY1CQJT5jcs8sFGSZTDiG7kowvFpECh'
+
+// SPL stake pool ValidatorList: 1-byte account_type + 4-byte max_validators + 4-byte vec_len + entries
+// ValidatorStakeInfo entry (73 bytes): active(u64) | transient(u64) | last_update_epoch(u64)
+//   | transient_seed_suffix(u64) | unused(u32) | validator_seed_suffix(u32) | status(u8) | vote_pubkey(32)
+const VL_HEADER = 9
+const VL_ENTRY = 73
+
+// Voltr vault account layout: asset mint at offset 104 (32 bytes), totalValue (u64 LE) at offset 168
 const EARN_VAULTS = [
   '3maCuTJVPteZ2dFA8dADxz2EbpJHfoAG5txYhXDs6gNQ', // USDC
   '663azFYEnHDTLGf4CEk8KpNTje8XxZVLnQwo9LjbSejy', // USD1
   '3kzb6rcDJxSdkWCwXXP9PULSqBy6rVDNWanzw5dBCYCj', // USDT
   '5mv1cURMSaPU3q3wFVoN4mKMWNFVvUtH3UZrG4Z2Mgfz', // USDS
   '7VZ1XKK7Zns6UzRc1Wz54u6cypN7zaduasVXXr7NysxH', // USDG
+  'Gj8kURFs8fK3GhiX5Yc6H1HQKSpEvLHeDRZsP6Y2D1je', // raSOL (raSOL Max vault)
 ]
 
 async function tvl(api) {
   const connection = getConnection()
+
+  // raSOL liquid staking: SPL stake pool totalLamports = SOL backing the LST
+  const poolInfo = await connection.getAccountInfo(new PublicKey(RASOL_STAKE_POOL))
+  const pool = decodeAccount('stakePool', poolInfo)
+  api.add(ADDRESSES.solana.SOL, +pool.totalLamports)
+
+  // Hubra validator: SOL delegated to the vote account, minus the portion already provided
+  // by the raSOL stake pool (otherwise raSOL's delegation would be counted twice).
+  const [vlInfo, voteAccounts] = await Promise.all([
+    connection.getAccountInfo(pool.validatorList),
+    connection.getVoteAccounts(),
+  ])
+
+  let poolStakeToValidator = 0n
+  if (vlInfo) {
+    const buf = vlInfo.data
+    const count = buf.readUInt32LE(5)
+    for (let i = 0; i < count; i++) {
+      const off = VL_HEADER + i * VL_ENTRY
+      const vote = new PublicKey(buf.slice(off + 41, off + 73)).toBase58()
+      if (vote !== HUBRA_VOTE_ACCOUNT) continue
+      poolStakeToValidator += buf.readBigUInt64LE(off)      // active
+      poolStakeToValidator += buf.readBigUInt64LE(off + 8)  // transient
+    }
+  }
+
+  const validator = voteAccounts.current.find(v => v.votePubkey === HUBRA_VOTE_ACCOUNT)
+    || voteAccounts.delinquent.find(v => v.votePubkey === HUBRA_VOTE_ACCOUNT)
+  if (validator) {
+    const direct = BigInt(validator.activatedStake) - poolStakeToValidator
+    if (direct > 0n) api.add(ADDRESSES.solana.SOL, direct.toString())
+  }
+
+  // Hubra Earn (Voltr) vaults — read asset mint + totalValue from on-chain account data
   const accounts = await connection.getMultipleAccountsInfo(EARN_VAULTS.map(v => new PublicKey(v)))
   for (const account of accounts) {
     if (!account || account.data.length < 176) continue
@@ -24,6 +68,6 @@ async function tvl(api) {
 }
 
 module.exports = {
-  methodology: 'TVL is the underlying stablecoins held in Hubra Earn vaults (Voltr), read directly from on-chain vault account data.',
+  methodology: 'TVL aggregates: (1) SOL backing raSOL — the SPL stake pool\'s totalLamports; (2) SOL delegated directly to Hubra\'s validator vote account, with the raSOL stake pool\'s own delegation subtracted to avoid double-counting; (3) underlying assets held in Hubra Earn vaults (Voltr) — stablecoin vaults (USDC, USD1, USDT, USDS, USDG) and the raSOL Max vault — read directly from on-chain account data.',
   solana: { tvl },
 }

--- a/registries/solanaStakePool.js
+++ b/registries/solanaStakePool.js
@@ -83,11 +83,6 @@ const configs = {
     methodology: "TVL represents the total amount of SOL staked in Adrastea's liquid staking pool",
     solana: '2XhsHdwf4ZDpp2JhpTqPovoVy3L2Atfp1XkLqFMwGP4Y',
   },
-  'solanahub-sol': {
-    doublecounted: true,
-    methodology: "SolanaHub Staked SOL (hubSOL) is a tokenized representation on your staked SOL + stake rewards",
-    solana: 'ECRqn7gaNASuvTyC5xfCUjehWZCSowMXstZiM5DNweyB',
-  },
   'pico-sol': {
     doublecounted: true,
     methodology: "Pico Staked SOL (picoSOL) is a tokenized representation on your staked SOL + stake rewards",


### PR DESCRIPTION
…nahub-sol

Context
-------
SolanaHub rebranded to Hubra. Same team, same on-chain accounts - just a new brand. 
The on-chain evidence is verifiable by anyone:

  Stake pool:  ECRqn7gaNASuvTyC5xfCUjehWZCSowMXstZiM5DNweyB
  LST mint:    HUBsveNpjo5pWqNkH57QzxjQASdTVXcSK7bVKTSZtcSX
  Mint name:   "Hubra staked SOL"
  Mint symbol: "raSOL"  (was "hubSOL")
  Metadata URI: https://raw.githubusercontent.com/Hubra-labs/docs/refs/heads/main/brandkit/meta/raSOL.json

Anyone can run `solana account` on the mint's Metaplex metadata PDA to confirm.

Earlier, the raSOL stake pool line was removed from projects/hubra/index.js in 89813ae35 ("rm solanahub addr") because the same stake pool address was still counted under the legacy `solanahub-sol` registry entry - so keeping both would have double-counted the LST. 
The cleaner fix is to drop the now-stale `solanahub-sol` entry and let the hubra adapter own the LST, validator, and vault surfaces in one place.

Changes
-------
projects/hubra/index.js:
  - Restore raSOL stake pool TVL (totalLamports from the SPL stake pool struct).
  - Add Hubra validator (vote account 7K8DVxtNJGnMtUY1CQJT5jcs8sFGSZTDiG7kowvFpECh) via connection.getVoteAccounts(). The stake pool delegates to this validator, so the adapter parses the pool's ValidatorList account and subtracts the pool-originated portion from the validator's activatedStake to avoid double-counting. Result matches the ~50k SOL the project reports.
  - Add the raSOL Max vault (Voltr) to EARN_VAULTS - same on-chain layout as the stablecoin vaults; the asset comes out as raSOL (priced by DefiLlama).

registries/solanaStakePool.js:
  - Remove the legacy `solanahub-sol` entry. It pointed at the same stake pool address that projects/hubra/ now reads directly; keeping it would double-count.

Methodology is updated to spell out all three components and the dedup.

**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).

2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** It is a different repo, you can find your listing in [this file](https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts), you can edit it there and put up a PR
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes

---
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
Hubra
##### Twitter Link:
HubraApp
##### List of audit links if any:

##### Website Link:
www.hubra.app
##### Logo (High resolution, will be shown with rounded borders):

##### Current TVL:

##### Treasury Addresses (if the protocol has treasury)

##### Chain:

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama):

##### Token address and ticker if any:

##### Category (full list at https://defillama.com/categories) \*Please choose only one:

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

##### forkedFrom (Does your project originate from another project):

##### methodology (what is being counted as tvl, how is tvl being calculated):

##### Github org/user (Optional, if your code is open source, we can track activity):

##### Does this project have a referral program?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TVL calculation now aggregates raSOL stake pool assets and validator delegation amounts alongside existing vault holdings.
  * Hubra Earn vault tracking expanded to include raSOL Max vault with improved asset coverage.

* **Chores**
  * Streamlined Solana stake pool adapter configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19419?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->