### PR TITLE
Add templ.fun adapter

### DIFF
--- a/projects/templ-fun/index.js
+++ b/projects/templ-fun/index.js
@@ -1,0 +1,33 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+const { cachedGraphQuery } = require('../helper/cache')
+const { sumTokens2 } = require('../helper/unwrapLPs')
+
+const SUBGRAPH = 'https://subgraph.templ.fun'
+const ETH = ADDRESSES.null
+
+const TEMPLS_QUERY = `{
+  Templ(where: { chainId: { _eq: 8453 } }) {
+    token
+    treasury
+    memberPool
+  }
+}`
+
+async function tvl(api) {
+  const data = await cachedGraphQuery('templ-fun/templs', SUBGRAPH, TEMPLS_QUERY)
+  const templs = data.Templ
+
+  const tokensAndOwners = templs.flatMap(({ token, treasury, memberPool }) => [
+    [token, treasury],
+    [token, memberPool],
+    [ETH, treasury],
+  ])
+
+  return sumTokens2({ api, tokensAndOwners })
+}
+
+module.exports = {
+  methodology:
+    "TVL sums each Templ's entry token held by its Treasury and MemberPool, plus any native ETH held by its Treasury. The Templ list and per-templ entry token are fetched live from the project subgraph at subgraph.templ.fun, so new templs and any entry-token changes are picked up automatically. Pricing comes from coins.llama.fi; entry tokens without a CoinGecko listing or sufficient on-chain DEX liquidity contribute zero until liquidity exists.",
+  base: { tvl },
+}


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
templ.fun

##### Twitter Link:
https://twitter.com/templfun

##### List of audit links if any:
(none public at this time)

##### Website Link:
https://templ.fun

##### Logo (High resolution, will be shown with rounded borders):
https://templ.fun/icon.png

##### Current TVL:
~$1,050 (verified locally via `node test.js projects/templ-fun/index.js`)

##### Treasury Addresses (if the protocol has treasury)
Each templ deploys its own Treasury and MemberPool contracts. The full live set is enumerated by the adapter from the project subgraph at https://subgraph.templ.fun. The protocol's own fee-recipient address is intentionally excluded from TVL (it is protocol revenue, not community-locked value).

##### Chain:
Base

##### Coingecko ID:
(none — protocol has no token)

##### Coinmarketcap ID:
(none — protocol has no token)

##### Short Description (to be shown on DefiLlama):
templ.fun lets communities launch on-chain groups (\"templs\") with a shared treasury, member pool, chat room, and configurable governance. Each templ has its own token, fee splits, and referral program; the protocol is permissionless and admin-free at the templ level.

##### Token address and ticker if any:
None — templ.fun has no protocol-level token at this time. (The \"TEMPL\" token at 0x012923e48cc62474f1cFe15fe360dBD0E615aB07 is a third-party squatter, unaffiliated with the project.)

##### Category (full list at https://defillama.com/categories) *Please choose only one:
SoFi

##### Oracle Provider(s):
None. Pricing for TVL is delegated to DefiLlama's own coins.llama.fi service against the addresses returned by the subgraph; the protocol itself does not consume any on-chain oracle.

##### Implementation Details:
N/A — no oracle integration in the protocol.

##### Documentation/Proof:
N/A — see above.

##### forkedFrom (Does your project originate from another project):
None — original design.

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL sums, for every Templ deployed by the factory on Base:

1. The templ's entry token held by its Treasury contract
2. The templ's entry token held by its MemberPool contract
3. Any native ETH held by its Treasury contract

The Templ list and per-templ entry token are fetched live from the project subgraph at https://subgraph.templ.fun, so new templs and entry-token changes are picked up automatically without an adapter redeploy. Pricing is delegated to coins.llama.fi; entry tokens without a CoinGecko listing or sufficient on-chain DEX liquidity contribute zero until liquidity exists, by design.

Protocol-side fee accumulation (the protocol's \`protocolBps\` slice, paid to the \`protocolFeeRecipient\` configured on the Factory) is intentionally not counted — that is protocol revenue and belongs in the dimension-adapters repo, not in TVL.

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/templ-fun

##### Does this project have a referral program?
Yes. Each templ has a configurable \`referralShareBps\` carved from the entry-fee member-pool slice. When someone joins via a referral, the referrer is paid directly by the contract and a \`ReferralRewardPaid(templ, referrer, member, amount)\` event is emitted. The referral system is fully on-chain and permissionless.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added TVL tracking support for Templ protocol on the Base network, aggregating token data from treasury and member pool sources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19424?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->