### PR TITLE
Add INRISwap TVL adapter on INRI CHAIN

### DIFF
--- a/projects/helper/chains.json
+++ b/projects/helper/chains.json
@@ -217,6 +217,7 @@
   "imx",
   "inertia",
   "inevm",
+  "inri",
   "initia",
   "injective",
   "ink",

--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -44,7 +44,7 @@ const fixBalancesTokens = {
   inri: {
     '0x116b2ff23e062a52e2c0ea12df7e2638b62fa0fc': {
       coingeckoId: 'tether',
-      decimals: 18,
+      decimals: 6,
     },
   },
   ozone: {

--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -41,6 +41,12 @@ const ibcMappings = {
 }
 
 const fixBalancesTokens = {
+  inri: {
+    '0x116b2ff23e062a52e2c0ea12df7e2638b62fa0fc': {
+      coingeckoId: 'tether',
+      decimals: 18,
+    },
+  },
   ozone: {
     // '0x83048f0bf34feed8ced419455a4320a735a92e9d': { coingeckoId: "ozonechain", decimals: 18 }, // was mapped to wrong chain
   },

--- a/projects/inriswap/index.js
+++ b/projects/inriswap/index.js
@@ -1,0 +1,22 @@
+const { sumTokens2 } = require('../helper/unwrapLPs')
+
+const PAIR_IUSD_WINRI = '0xcaFFACD05499d005d8441337811bAd227Fa24643'
+
+const IUSD = '0x116b2fF23e062A52E2c0ea12dF7e2638b62Fa0FC'
+const WINRI = '0x8731F1709745173470821eAeEd9BC600EEC9A3D1'
+
+async function tvl(api) {
+  return sumTokens2({
+    api,
+    owner: PAIR_IUSD_WINRI,
+    tokens: [IUSD, WINRI],
+  })
+}
+
+module.exports = {
+  methodology:
+    'TVL counts the iUSD and WINRI reserves held in the official INRISwap iUSD/WINRI liquidity pair on INRI CHAIN. Initial liquidity is small and should not be used as an official INRI price source.',
+  inri: {
+    tvl,
+  },
+}

--- a/projects/inriswap/index.js
+++ b/projects/inriswap/index.js
@@ -20,6 +20,7 @@ async function tvl(api) {
 }
 
 module.exports = {
+  misrepresentedTokens: true,
   methodology:
     'TVL counts assets held in the official INRISwap iUSD/WINRI pair and the official Liquidity Seeder contract used during the liquidity formation phase. The Seeder holds iUSD and native INRI outside the live pair until the liquidity target is reached.',
   inri: {

--- a/projects/inriswap/index.js
+++ b/projects/inriswap/index.js
@@ -1,6 +1,8 @@
 const { sumTokens2 } = require('../helper/unwrapLPs')
+const { nullAddress } = require('../helper/tokenMapping')
 
 const PAIR_IUSD_WINRI = '0xcaFFACD05499d005d8441337811bAd227Fa24643'
+const LIQUIDITY_SEEDER = '0x34583A7080d47Af38d76Bae78c51Ecd0C64442cF'
 
 const IUSD = '0x116b2fF23e062A52E2c0ea12dF7e2638b62Fa0FC'
 const WINRI = '0x8731F1709745173470821eAeEd9BC600EEC9A3D1'
@@ -8,14 +10,18 @@ const WINRI = '0x8731F1709745173470821eAeEd9BC600EEC9A3D1'
 async function tvl(api) {
   return sumTokens2({
     api,
-    owner: PAIR_IUSD_WINRI,
-    tokens: [IUSD, WINRI],
+    tokensAndOwners: [
+      [IUSD, PAIR_IUSD_WINRI],
+      [WINRI, PAIR_IUSD_WINRI],
+      [IUSD, LIQUIDITY_SEEDER],
+      [nullAddress, LIQUIDITY_SEEDER],
+    ],
   })
 }
 
 module.exports = {
   methodology:
-    'TVL counts the iUSD and WINRI reserves held in the official INRISwap iUSD/WINRI liquidity pair on INRI CHAIN. Initial liquidity is small and should not be used as an official INRI price source.',
+    'TVL counts assets held in the official INRISwap iUSD/WINRI pair and the official Liquidity Seeder contract used during the liquidity formation phase. The Seeder holds iUSD and native INRI outside the live pair until the liquidity target is reached.',
   inri: {
     tvl,
   },


### PR DESCRIPTION
Adds INRISwap TVL tracking on INRI CHAIN.

This adapter tracks the official iUSD/WINRI liquidity pair only:

- Pair: 0xcaFFACD05499d005d8441337811bAd227Fa24643
- iUSD: 0x116b2fF23e062A52E2c0ea12dF7e2638b62Fa0FC
- WINRI: 0x8731F1709745173470821eAeEd9BC600EEC9A3D1

Methodology:
TVL counts the iUSD and WINRI reserves held in the official INRISwap iUSD/WINRI pair on INRI CHAIN.

Network:
- Name: INRI CHAIN
- Chain ID: 3777
- Short name: inri
- RPC: https://rpc-chain.inri.life/
- Explorer: https://explorer.inri.life/
- Website: https://inri.life
- Platform: https://platform.inri.life/

Notes:
- Initial liquidity is small.
- This adapter does not use the pool as an official INRI price source.
- iUSD is mapped to USDT for pricing because it is the bridged stable asset used in the INRI ecosystem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the INRI chain.
  * Added INRISwap TVL adapter to track IUSD and WINRI reserves, including assets held by the Liquidity Seeder and native-asset holdings.

* **Bug Fixes**
  * Added a token mapping for INRI to correctly represent a stablecoin with 6 decimals.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19428?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->