### PR TITLE
jupiter-perpetual, jupSOL: fix staked-SOL attribution and JLP-loan accounting

### DIFF
--- a/projects/jupSOL/index.js
+++ b/projects/jupSOL/index.js
@@ -1,16 +1,12 @@
-const { getStakedSol, getSolBalanceFromStakePool } = require('../helper/solana')
+const { getSolBalanceFromStakePool } = require('../helper/solana')
 
 async function tvl(api) {
-  // jupSOL
   await getSolBalanceFromStakePool('8VpRhuxa7sUUepdY3kQiTmX9rS5vx4WgaXiAnXq4KCtr', api)
-
-  // Jupiter Labs Perpetuals Vault
-  await getStakedSol('AVzP2GeRmqGphJsMxWoqjpUifPpCret7LqWhD8NWQK49', api)
 }
 
 module.exports = {
   timetravel: false,
-  methodology: 'Total SOL staked in jupSOL and SOL staked from Jupiter Perpetual Exchange',
+  methodology: 'Total SOL staked in the jupSOL stake pool',
   solana: {
     tvl
   }

--- a/projects/jupiter-perpetual.js
+++ b/projects/jupiter-perpetual.js
@@ -1,16 +1,52 @@
-const { sumTokens2 } = require("./helper/solana");
+const { getProvider, sumTokens2 } = require("./helper/solana");
+const { PublicKey } = require("@solana/web3.js");
+const bs58 = require("bs58").default || require("bs58");
+
+const PERP_PROGRAM = new PublicKey("PERPHjGBqRHArX4DySjwM6UJHiR3sWAatqfdBS2qQJu");
+const CUSTODY_DISCRIMINATOR = Buffer.from([1, 184, 48, 81, 93, 131, 63, 145]);
+const OFFSET_MINT          = 8 + 32;
+const OFFSET_TOKEN_ACCOUNT = 8 + 64;
+const OFFSET_DEBT          = 8 + 996;
+const OFFSET_STAKED        = 8 + 1052;
+const DEBT_PRECISION = 10n ** 9n;
+
+async function getCustodies() {
+  const conn = getProvider().connection;
+  const accounts = await conn.getProgramAccounts(PERP_PROGRAM, {
+    filters: [{ memcmp: { offset: 0, bytes: bs58.encode(CUSTODY_DISCRIMINATOR) } }],
+  });
+  return accounts.map(({ account }) => {
+    const data = account.data;
+    const mint = new PublicKey(data.slice(OFFSET_MINT, OFFSET_MINT + 32)).toBase58();
+    const tokenAccount = new PublicKey(data.slice(OFFSET_TOKEN_ACCOUNT, OFFSET_TOKEN_ACCOUNT + 32)).toBase58();
+    const staked = data.readBigUInt64LE(OFFSET_STAKED);
+    const debtLo = data.readBigUInt64LE(OFFSET_DEBT);
+    const debtHi = data.readBigUInt64LE(OFFSET_DEBT + 8);
+    const debt = (debtLo + (debtHi << 64n)) / DEBT_PRECISION;
+    return { mint, tokenAccount, staked, debt };
+  });
+}
+
+async function tvl(api) {
+  const custodies = await getCustodies();
+  await sumTokens2({ api, tokenAccounts: custodies.map(c => c.tokenAccount) });
+  for (const c of custodies) if (c.staked > 0n) api.add(c.mint, c.staked.toString());
+}
+
+async function borrowed(api) {
+  const custodies = await getCustodies();
+  for (const c of custodies) if (c.debt > 0n) api.add(c.mint, c.debt.toString());
+}
 
 module.exports = {
   hallmarks: [
     ['2024-01-29',"launch jup exchange"]
   ],
   timetravel: false,
-  methodology: "Calculate sum across all program token accounts",
+  methodology:
+    "TVL sums each Custody's tokenAccount SPL balance (LP liquidity plus trader collateral held in the same custody token account) plus Custody.totalStakedAmountLamports (the SOL custody's natively-staked portion held in Solana stake accounts). Borrowed is Custody.debt/1e9 per asset — USDC lent out to JLP-loan borrowers, fully collateralized by JLP, reported separately.",
   solana: {
     tvl,
+    borrowed,
   },
 };
-
-async function tvl() {
-  return sumTokens2({ owner: 'AVzP2GeRmqGphJsMxWoqjpUifPpCret7LqWhD8NWQK49' });
-}


### PR DESCRIPTION
Two coupled changes that must land together (see "Coupling" below).

### jupiter-perpetual (rewrite)

The old adapter did `sumTokens2({ owner: 'AVzP2...' })`, summing every SPL token
at the JLP pool address. Three problems:

1. It counted the pool's own JLP token as TVL. Users post JLP as collateral for
   JLP-loans (~6,400 active positions), and that locked JLP sits at the pool
   address. Its dollar value is already counted via the underlying custody
   assets, so summing it counts the same value twice.
2. It missed the pool's natively-staked SOL (~4.48M SOL), which lives in Solana
   stake accounts, not SPL token accounts, so `sumTokens2` never saw it.
3. It had no Borrowed metric for the JLP-loans lending activity.

The new adapter enumerates the perp program's `Custody` accounts and computes:
- TVL = each custody's `tokenAccount` SPL balance (LP liquidity plus trader
  collateral) plus `Custody.totalStakedAmountLamports` (native-staked SOL).
- Borrowed = `Custody.debt / 1e9` per asset (USDC lent to JLP-loan borrowers,
  fully collateralized by JLP).

This excludes the JLP token (already counted via the underlying) and the
pump-token dust the old sum picked up.

### jupSOL (remove perp staked SOL)

The jupSOL adapter was calling `getStakedSol('AVzP2...')`, which pulled the
perpetual pool's SOL into Jupiter Staked SOL (a Liquid Staking protocol). But
that SOL is natively staked by the perp pool (delegated directly to validators,
no jupSOL or any LST token involved). It is perp-pool liquidity, not a
liquid-staking position. Removed it; jupSOL now reports only its own stake pool
(`8VpRhuxa...`). The perp pool's native-staked SOL is now counted under
jupiter-perpetual instead.

### Coupling: must merge together

The ~4.48M staked SOL moves from jupSOL to jupiter-perpetual:
- Merging jupSOL alone would drop it from DefiLlama entirely.
- Merging perp alone would double-count it (counted in both).

| | Before | After |
|---|---|---|
| jupiter-perpetual TVL | ~$659M | ~$781M |
| jupiter-perpetual Borrowed | none | ~$128M |
| jupSOL TVL | ~$812M | ~$438M |
| parent #jupiter TVL | n/a | roughly unchanged (net-zero SOL re-attribution) |

### Verification

- Custody discriminator re-derived; on-chain IDL confirms the struct layout.
- `totalStakedAmountLamports` reconciles exactly with the sum of the pool's 43
  Solana stake accounts (0 lamport difference).
- `Custody.debt` cross-checked against the sum of all individual
  `BorrowPosition.borrowSize`, reconciling within 0.57% (accrued interest).
- jupSOL output equals stake-pool `totalLamports`; mint supply equals poolTokenSupply.
- `node test.js` passes for both adapters.

No new dependencies (bs58 and @solana/web3.js already present). No lockfile changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected jupSOL TVL calculation to reflect only stake pool contributions, removing previously included Perpetuals Vault data.

* **New Features**
  * Added borrowed amount metrics for Jupiter Perpetual.

* **Refactor**
  * Enhanced Jupiter Perpetual TVL calculation to use on-chain custody account data for improved accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19443?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->