### PR TITLE
ens treasury fix

### DIFF
--- a/projects/helper/unwrapLPs.js
+++ b/projects/helper/unwrapLPs.js
@@ -982,7 +982,7 @@ async function sumTokens2({
   sumChunkSleep,
 }) {
 
-  if (fetchCoValentTokens && owners.length > 10) {
+  if (fetchCoValentTokens && owners.length > 11) {
     throw new Error('fetchCoValentTokens option is not recommended for more than 10 owners due to rate limits')
   }
 

--- a/projects/treasury/ens.js
+++ b/projects/treasury/ens.js
@@ -1,11 +1,23 @@
 const ADDRESSES = require('../helper/coreAssets.json')
 const { treasuryExports } = require("../helper/treasury");
 
-const treasury = "0xFe89cc7aBB2C4183683ab71653C4cdc9B02D44b7";
 const vestingAddress = "0xd7a029db2585553978190db5e85ec724aa4df23f"
+
+const treasury = "0xFe89cc7aBB2C4183683ab71653C4cdc9B02D44b7"
 const treasury2 = "0x690f0581ececcf8389c223170778cd9d029606f2"
 
-const ENS= "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72";
+const publicGoods = "0xcD42b4c4D102cc22864e3A1341Bb0529c17fD87d"
+
+const metaGov = "0x91c32893216dE3eA0a55ABb9851f581d4503d39b"
+const metaGov2 = "0xB162Bf7A7fD64eF32b787719335d06B2780e31D1"
+
+const eco = "0x536013c57DAF01D78e8a70cAd1B1abAda9411819"
+const eco2 = "0x9B9c249Be04dd433c7e8FbBF5E61E6741b89966D"
+
+const registrar = "0x283Af0B28c62C092C9727F1Ee09c02CA627EB7F5"
+const registrar2 = "0x253553366Da8546fC250F225fe3d25d0C782303b"
+
+const ENS= "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72"
 
 module.exports = treasuryExports({
   ethereum: {
@@ -17,6 +29,6 @@ module.exports = treasuryExports({
         ADDRESSES.ethereum.LINK
      ],
      ownTokens: [ENS],
-    owners: [treasury, vestingAddress, treasury2],
+    owners: [treasury, vestingAddress, treasury2, publicGoods, metaGov, metaGov2, eco, eco2, registrar, registrar2],
   },
 })

--- a/projects/treasury/ens.js
+++ b/projects/treasury/ens.js
@@ -17,18 +17,21 @@ const eco2 = "0x9B9c249Be04dd433c7e8FbBF5E61E6741b89966D"
 const registrar = "0x283Af0B28c62C092C9727F1Ee09c02CA627EB7F5"
 const registrar2 = "0x253553366Da8546fC250F225fe3d25d0C782303b"
 
-const ENS= "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72"
+const endowment = '0x4F2083f5fBede34C2714aFfb3105539775f7FE64'
+
+const ENS = "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72"
 
 module.exports = treasuryExports({
   ethereum: {
-    tokens: [ 
-        ADDRESSES.null,
-        ADDRESSES.ethereum.WETH,
-        ADDRESSES.ethereum.USDC,
-        ADDRESSES.ethereum.sUSDS,
-        ADDRESSES.ethereum.LINK
-     ],
-     ownTokens: [ENS],
-    owners: [treasury, vestingAddress, treasury2, publicGoods, metaGov, metaGov2, eco, eco2, registrar, registrar2],
+    tokens: [
+      ADDRESSES.null,
+      ADDRESSES.ethereum.WETH,
+      ADDRESSES.ethereum.USDC,
+      ADDRESSES.ethereum.sUSDS,
+      ADDRESSES.ethereum.LINK
+    ],
+    resolveUniV3: true,
+    ownTokens: [ENS],
+    owners: [treasury, vestingAddress, treasury2, publicGoods, metaGov, metaGov2, eco, eco2, registrar, registrar2, endowment,],
   },
 })

--- a/projects/treasury/ens.js
+++ b/projects/treasury/ens.js
@@ -11,6 +11,7 @@ module.exports = treasuryExports({
   ethereum: {
     tokens: [ 
         ADDRESSES.null,
+        ADDRESSES.ethereum.WETH,
         ADDRESSES.ethereum.USDC,
         ADDRESSES.ethereum.sUSDS,
         ADDRESSES.ethereum.LINK

--- a/projects/treasury/ens.js
+++ b/projects/treasury/ens.js
@@ -1,5 +1,5 @@
-const { karpatKeyTvl } = require('../helper/karpatkey');
-const { sumTokensExport } = require('../helper/unknownTokens');
+const ADDRESSES = require('../helper/coreAssets.json')
+const { treasuryExports } = require("../helper/treasury");
 
 const treasury = "0xFe89cc7aBB2C4183683ab71653C4cdc9B02D44b7";
 const vestingAddress = "0xd7a029db2585553978190db5e85ec724aa4df23f"
@@ -7,12 +7,15 @@ const treasury2 = "0x690f0581ececcf8389c223170778cd9d029606f2"
 
 const ENS= "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72";
 
-module.exports={
-  ethereum:{
-    tvl: async (api)=>karpatKeyTvl(api, "ENS DAO", "ENS"),
-    ownTokens: sumTokensExport({
-      tokens: [ENS],
-      owners: [treasury, vestingAddress, treasury2],
-    })
-  }
-}
+module.exports = treasuryExports({
+  ethereum: {
+    tokens: [ 
+        ADDRESSES.null,
+        ADDRESSES.ethereum.USDC,
+        ADDRESSES.ethereum.sUSDS,
+        ADDRESSES.ethereum.LINK
+     ],
+     ownTokens: [ENS],
+    owners: [treasury, vestingAddress, treasury2],
+  },
+})


### PR DESCRIPTION
kpk manages their endowment safe: https://etherscan.io/address/0x4F2083f5fBede34C2714aFfb3105539775f7FE64

which currently holds ~$88M (reports 77M since 11M is in kpk vaults), together with these wallets, we track ~$104M. This leaves a ~30M gap in the last reported ENS treasury tvl

Comparison:

| token | treasury | kpk | total | last reported |
| --- | --- | --- | --- | --- |
| ENS | $362M | 0 | $362M | $373M | 
| ETH/WETH/stETH/rETH/ETHx | $9.41M | $52.19M | $61.6M | $89.1M | 
| USDC/USDS | $6.83M | $24.87M (+$11M) | $42.7M | $44.32M | 

Output:
---
`projects/treasury/ens.js`: 

<img width="262" height="475" alt="image" src="https://github.com/user-attachments/assets/372c9a01-7685-4498-8f62-f9281de5b541" />


`projects/kpk/index.js`: 

<img width="252" height="140" alt="image" src="https://github.com/user-attachments/assets/3ef39f8a-fb71-4717-8b42-279e90ceac1f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated rate-limit validation to support up to 11 owners in token data queries (increased from 10).
  * Refactored ENS treasury configuration to include expanded token support, resolver settings, and enhanced owner address tracking across governance and treasury functions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19446?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->