### PR TITLE
Add XORA — XRP Ledger neobank

### DIFF
--- a/projects/xora/index.js
+++ b/projects/xora/index.js
@@ -1,0 +1,23 @@
+const { sumTokensExport } = require('../helper/sumTokens');
+
+// XORA — XRP Ledger neobank
+// Treasury TVL is the XRP balance of the canonical custodial treasury account.
+// User deposits route via destination tags into this single shared account;
+// per-user accounting is internal to XORA. The on-chain balance is the
+// canonical TVL number.
+const TREASURY_ADDRESSES = [
+  "rhbErkS2d4H82tRbdGyFkhhc4LNtjKaC3o",
+];
+
+module.exports = {
+  methodology:
+    "Sums the XRP balance held in the XORA treasury account " +
+    "rhbErkS2d4H82tRbdGyFkhhc4LNtjKaC3o on the XRP Ledger. The treasury is " +
+    "a single shared custody wallet; user deposits route to it via " +
+    "destination tags. Per-user accounting is internal to XORA; the on-chain " +
+    "balance is the canonical TVL.",
+  start: 1741305600, // 2026-03-07 (treasury first deposit)
+  ripple: {
+    tvl: sumTokensExport({ owners: TREASURY_ADDRESSES }),
+  },
+};

--- a/projects/xora/index.js
+++ b/projects/xora/index.js
@@ -16,7 +16,7 @@ module.exports = {
     "a single shared custody wallet; user deposits route to it via " +
     "destination tags. Per-user accounting is internal to XORA; the on-chain " +
     "balance is the canonical TVL.",
-  start: 1741305600, // 2026-03-07 (treasury first deposit)
+  start: 1772841600, // 2026-03-07 (treasury first deposit)
   ripple: {
     tvl: sumTokensExport({ owners: TREASURY_ADDRESSES }),
   },


### PR DESCRIPTION
# Add XORA — XRP Ledger neobank

**Protocol**: XORA
**Website**: https://xora.finance
**Chain**: XRPL (XRP Ledger)
**Category**: Yield Aggregator / Liquid Staking
**Twitter**: [@xora_finance](https://twitter.com/xora_finance)

## What is XORA?

XORA is a custodial savings product on the XRP Ledger. Users deposit XRP, earn
daily yield from a single treasury wallet, no lock-up, no token swaps required.

## TVL methodology

TVL = XRP balance held in the canonical treasury account
[`rhbErkS2d4H82tRbdGyFkhhc4LNtjKaC3o`](https://livenet.xrpl.org/accounts/rhbErkS2d4H82tRbdGyFkhhc4LNtjKaC3o)
on the XRP Ledger.

The treasury is a single shared custody wallet — user deposits route to it via
destination tags, and per-user accounting is internal. The on-chain balance is
the canonical TVL number.

The adapter calls XRPL's `account_info` RPC against the validated ledger and
returns the balance in drops, priced as `ripple` (XRP) on the `ripple` chain.

## Files added

- `projects/xora/index.js` — TVL adapter

## Verification

You can manually verify the treasury balance:

```bash
curl -s https://xrplcluster.com/ -H "Content-Type: application/json" -d '{
  "method": "account_info",
  "params": [{"account":"rhbErkS2d4H82tRbdGyFkhhc4LNtjKaC3o","ledger_index":"validated","strict":true}]
}' | jq '.result.account_data.Balance'
```

Balance is returned in drops (1 XRP = 1,000,000 drops).

## Contact

For follow-up questions, please reach out via DefiLlama's standard review
channel or email `team@xora.finance`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added XORA total value locked (TVL) tracking for XRP Ledger treasury holdings.
  * Includes published methodology and a fixed start date for the TVL calculation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19453?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->