### PR TITLE
add getEnv import to cetus

### DIFF
--- a/projects/cetus/index.js
+++ b/projects/cetus/index.js
@@ -4,6 +4,7 @@ const sui = require('../helper/chain/sui')
 const { transformDexBalances } = require('../helper/portedTokens')
 const { PromisePool } = require('@supercharge/promise-pool')
 const sdk = require('@defillama/sdk')
+const { getEnv } = require('../helper/env')
 
 async function tvl() {
   let data = await getResources('0xa7f01413d33ba919441888637ca1607ca0ddcbfa3c0a9ddea64743aaa560e498')


### PR DESCRIPTION
resolves `getEnv is not defined` error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Fixed a critical runtime error that was preventing the application from properly performing required environment configuration validation and system checks. The issue occurred during custom job operations and has now been completely resolved by restoring a missing required system dependency that was essential for ensuring proper execution and operation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19455?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->