### PR TITLE
Add Kal Mydas TVL adapter

### DIFF
--- a/projects/kalmydas/index.js
+++ b/projects/kalmydas/index.js
@@ -1,4 +1,4 @@
-const USDC = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+const ADDRESSES = require('../helper/coreAssets.json')
 
 // Kal Mydas strategy vault pools deployed on Base mainnet (2026-05-01).
 // Each KalPool holds USDC and allocates a fraction to an off-chain operator
@@ -15,6 +15,6 @@ module.exports = {
     methodology:
           'TVL is the sum of USDC held by the five KalPool strategy vault contracts (HORIZON, VALKYRIE, REVOLUTION, TREASURY, ORION) on Base mainnet.',
     base: {
-          tvl: (api) => api.sumTokens({ owners: POOLS, tokens: [USDC] }),
+          tvl: (api) => api.sumTokens({ owners: POOLS, tokens: [ADDRESSES.base.USDC] }),
     },
 };

--- a/projects/kalmydas/index.js
+++ b/projects/kalmydas/index.js
@@ -1,0 +1,20 @@
+const USDC = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+
+// Kal Mydas strategy vault pools deployed on Base mainnet (2026-05-01).
+// Each KalPool holds USDC and allocates a fraction to an off-chain operator
+// that routes positions through gTrade (Gains Network) on the XAU/USD pair.
+const POOLS = [
+    '0xe1Cd26c4017cbb66A1Ad6BAc95C3CDE67C24FBE3', // HORIZON
+    '0x375CBbABC481Fb7bEb842D201E57A522e0FcF35B', // VALKYRIE
+    '0x77Cd662165434C0Ab60ded459221f818EF31B58c', // REVOLUTION
+    '0xd29Ef132b730802931FfBC7fAF0d5c0Ab12813c4', // TREASURY
+    '0x4ec08709EB7F2251C4C8bf4867C2C7B9CdFC12Fb', // ORION
+  ];
+
+module.exports = {
+    methodology:
+          'TVL is the sum of USDC held by the five KalPool strategy vault contracts (HORIZON, VALKYRIE, REVOLUTION, TREASURY, ORION) on Base mainnet.',
+    base: {
+          tvl: (api) => api.sumTokens({ owners: POOLS, tokens: [USDC] }),
+    },
+};


### PR DESCRIPTION
This PR adds a TVL adapter for Kal Mydas, a decentralized protocol on Base mainnet built around gold and bitcoin. USDC is deposited into one of five strategy vault pools (HORIZON, VALKYRIE, REVOLUTION, TREASURY, ORION). Each pool routes capital to an off-chain operator that opens positions on gTrade (Gains Network) on the XAU/USD pair.

**Allow edits by maintainers** is enabled.

---

##### Name (to be shown on DefiLlama):
Kal Mydas

##### Twitter Link:
https://x.com/kalmydas

##### List of audit links if any:
Omniscient (three passes, no residual finding) and Codex Security Lab (eight findings remediated). Audit summaries are referenced from https://docs.kalmydas.com.

##### Website Link:
https://kalmydas.com

##### Logo (High resolution, will be shown with rounded borders):
Available from https://kalmydas.com; a high-resolution PNG can be provided separately if needed.

##### Current TVL:
Computed on-chain by the adapter. The protocol opened on Base mainnet on 2026-05-01 and is in early Alpha, so TVL is currently small.

##### Treasury Addresses (if the protocol has treasury)
TreasuryRWAV2 on Base mainnet: `0x4f1F316e76d8E8637006eF246E9dD6dc3b4680C1`

##### Chain:
Base

##### Coingecko ID:
(not listed yet)

##### Coinmarketcap ID:
(not listed yet)

##### Short Description (to be shown on DefiLlama):
Kal Mydas is a decentralized protocol on Base mainnet built around gold and bitcoin. USDC deposited into one of five strategy vault pools (HORIZON, VALKYRIE, REVOLUTION, TREASURY, ORION) is allocated to an off-chain operator that opens positions on gTrade (Gains Network) on the XAU/USD pair.

##### Token address and ticker if any:
KAL: `0xe99556D5594faf533fcB346A8a9B11259D29afA8` on Base

##### Category:
Asset Management

##### Oracle Provider(s):
Chainlink XAU/USD on Base: `0x5213eBB69743b85644dbB6E25cdF994aFBb8cF31`

##### Implementation Details:
Chainlink XAU/USD is read by the KalPool contracts for share-price accounting (`reportLoss` / `reportGains`). Trade execution prices come from gTrade Diamond on Base. The TVL adapter itself does not depend on any oracle: it sums USDC `balanceOf` over the five KalPool contracts.

##### Documentation/Proof:
https://docs.kalmydas.com

##### forkedFrom:
Not a fork.

##### methodology:
TVL is the sum of USDC held by the five KalPool strategy vault contracts (HORIZON, VALKYRIE, REVOLUTION, TREASURY, ORION) on Base mainnet. The adapter calls USDC `balanceOf` on each pool address and sums the result. No off-chain data is used.

KalPool addresses on Base mainnet:

```
HORIZON    0xe1Cd26c4017cbb66A1Ad6BAc95C3CDE67C24FBE3
VALKYRIE   0x375CBbABC481Fb7bEb842D201E57A522e0FcF35B
REVOLUTION 0x77Cd662165434C0Ab60ded459221f818EF31B58c
TREASURY   0xd29Ef132b730802931FfBC7fAF0d5c0Ab12813c4
ORION      0x4ec08709EB7F2251C4C8bf4867C2C7B9CdFC12Fb
```

USDC token (native Base): `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`

##### Github org/user:
KalMydasSHARE

##### Does this project have a referral program?
Yes, on-chain via the KalReferral contract at `0xadEd1b00159fABCefd111bA97E64875B8c82a21A` on Base.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for Kal Mydas strategy vaults on Base mainnet, enabling users to monitor the total value of locked USDC across five vault contracts.
  * Included an explanatory methodology describing how TVL is calculated (USDC balances aggregated across the vaults) for transparency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19460?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->