### PR TITLE
Add Sylision Ofiliun adapter

### DIFF
--- a/projects/sylision-ofiliun/index.js
+++ b/projects/sylision-ofiliun/index.js
@@ -1,0 +1,21 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+const { sumTokensExport } = require('../helper/sumTokens')
+
+// Sylision Ofiliun — P2P secondary marketplace for locked staking positions
+// Sellers exit early for USDC; buyers acquire positions at a discount (10-40% APY)
+// https://app.sylision.com | Arbitrum One
+
+const POSITION_ESCROW = '0xfB5A9eDbCf439529B523791d9cD77C2f066c6e8a'
+
+module.exports = {
+  arbitrum: {
+    tvl: sumTokensExport({
+      owner: POSITION_ESCROW,
+      tokens: [
+        ADDRESSES.arbitrum.USDC_CIRCLE, // native USDC (Circle)
+        ADDRESSES.arbitrum.USDC,        // bridged USDC.e
+      ],
+    }),
+  },
+  methodology: 'TVL is measured as the total USDC held in the PositionEscrow contract on Arbitrum One, representing locked buyer capital committed to staking exit positions.',
+}


### PR DESCRIPTION
## Summary

Adds TVL adapter for **Sylision Ofiliun** — the first P2P secondary marketplace for locked staking positions on Arbitrum One.

**Protocol**: https://app.sylision.com  
**Chain**: Arbitrum One  
**Category**: Marketplace / Yield

## What it tracks

TVL = total USDC held in the `PositionEscrow` contract (`0xfB5A9eDbCf439529B523791d9cD77C2f066c6e8a`), representing buyer capital committed to staking exit positions.

## How the protocol works

- **Sellers** (stakers): Exit locked positions early (ETH, ATOM, SOL, DOT, ADA, 41+ assets) and receive USDC immediately, at a small discount
- **Buyers** (yield hunters): Pay USDC now, receive staked tokens at unlock date → 10–40% APY
- **Protocol fee**: 15% of buyer's yield
- Non-custodial, Arbitrum One (fees <$0.01)

## Checklist
- [x] Adapter reads from on-chain contract (PositionEscrow)
- [x] Tracks USDC_CIRCLE and bridged USDC.e
- [x] Methodology string included
- [x] No external API calls (fully on-chain)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Sylision Ofiliun to the platform with Total Value Locked (TVL) tracking on Arbitrum One, aggregating USDC balances across native and bridged token variants to provide comprehensive TVL metrics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19462?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->