### PR TITLE
suidex: add V3 CLMM pools to TVL

### DIFF
--- a/projects/suidex/index.js
+++ b/projects/suidex/index.js
@@ -1,5 +1,6 @@
 const sui = require("../helper/chain/sui");
 
+// V2 AMM Factory
 const FACTORY_ID =
   "0x81c286135713b4bf2e78c548f5643766b5913dcd27a8e76469f146ab811e922d";
 
@@ -11,22 +12,36 @@ const LOCKED_TOKEN_VAULT_ID =
 const VICTORY_TOKEN_TYPE =
   "0xbfac5e1c6bf6ef29b12f7723857695fd2f4da9a11a7d88162c15e9124c243a4a::victory_token::VICTORY_TOKEN";
 
+// V3 CLMM Pool IDs — concentrated liquidity pools
+const V3_POOL_IDS = [
+  "0xdf8ccfcc10f7daf14e31101c8ca6ac05eaa953afad14195fd2db3a41bad4b284", // SUI/SUITRUMP
+  "0x04db19eb0d0b7518005cc63c0530954f494460de42074749e6b702c443ead952", // SUI/USDC
+  "0x02c83820cc8412e103d6520424a380e207e43033cad040e72331a719335f0629", // SUI/VICTORY
+  "0x39d5ba22e01e45bc4129ec28a0bef52e8fee8db5d07d337adf9540e3cb9074cf", // SUI/TREE
+  "0xe27a85b339b41aea7d513c1373ef2f3babc88e468d9b650bb778265bfdc5f3b7", // USDC/USDSUI
+  "0x51370981fc19b08c840ff39cca3f36c03f396d26a85f522f20f741f1cff014af", // SUI/USDC (0.01%)
+];
+
 async function tvl(api) {
-  // Read Factory object to get all pair IDs from the all_pairs array
+  // V2: Read Factory object to get all pair IDs
   const factory = await sui.getObject(FACTORY_ID);
   const pairIds = factory.fields.all_pairs;
-
-  // Batch-fetch all pair objects
   const pools = await sui.getObjects(pairIds);
 
-  // Sum reserves from each pair
-  // Note: Farm staked LP tokens are NOT additive — the actual token reserves
-  // remain in the Pair objects, LP tokens are just receipts staked in the farm.
   pools.forEach(({ type, fields }) => {
-    // Pair type: 0xPKG::pair::Pair<Token0Type, Token1Type>
     const [token0, token1] = type.replace(">", "").split("<")[1].split(", ");
     api.add(token0, fields.reserve0 ?? fields.reserve_0);
     api.add(token1, fields.reserve1 ?? fields.reserve_1);
+  });
+
+  // V3: Read CLMM pool objects directly
+  const v3Pools = await sui.getObjects(V3_POOL_IDS);
+
+  v3Pools.forEach(({ type, fields }) => {
+    // Pool type: 0xPKG::pool::Pool<TokenX, TokenY>
+    const [tokenX, tokenY] = type.replace(">", "").split("<")[1].split(", ");
+    api.add(tokenX, fields.reserve_x);
+    api.add(tokenY, fields.reserve_y);
   });
 }
 
@@ -40,7 +55,7 @@ async function staking(api) {
 module.exports = {
   timetravel: false,
   methodology:
-    "TVL is the sum of token reserves across all SuiDex AMM liquidity pools. Staking includes VICTORY tokens locked in the Token Locker contract.",
+    "TVL is the sum of token reserves across all SuiDex V2 AMM and V3 CLMM liquidity pools. Staking includes VICTORY tokens locked in the Token Locker contract.",
   sui: {
     tvl,
     staking,


### PR DESCRIPTION
## Summary
- Add SuiDex V3 CLMM concentrated liquidity pool reserves to existing TVL calculation
- V2 AMM pools (54 pairs via factory) unchanged
- V3 pools read `reserve_x` / `reserve_y` from on-chain `Pool<X, Y>` objects
- Staking (VICTORY token locker) unchanged

## Details
SuiDex V3 is the concentrated liquidity upgrade to SuiDex, deployed on Sui mainnet. Package: `0xb5f529c1dcda6580a61bf7ee9fbd524b50be62f11044d137c8202c8cbace9e56` ([verified on Suiscan](https://suiscan.xyz/mainnet/object/0xb5f529c1dcda6580a61bf7ee9fbd524b50be62f11044d137c8202c8cbace9e56)).

6 V3 pools added (SUI/SUITRUMP, SUI/USDC x2, SUI/VICTORY, SUI/TREE, USDC/USDSUI).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * TVL calculation has been expanded to include reserves from both V2 AMM and V3 CLMM liquidity pools.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19468?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->