### PR TITLE
feat: add WealthVille TVL adapter for Solana yield optimizer

### DIFF
--- a/projects/wealthville/index.js
+++ b/projects/wealthville/index.js
@@ -1,29 +1,21 @@
-const { PublicKey, Connection } = require("@solana/web3.js");
+const { getConnection, sumTokens2 } = require("../helper/solana");
+const { PublicKey } = require("@solana/web3.js");
 
 const WEALTHVILLE_PROGRAM_ID = "6dtupVYfD3UP6mEsBxExfHeiBNojC4QNHSysYNewkaGu";
 
 async function tvl(api) {
-  const connection = new Connection(
-    process.env.SOLANA_RPC || "https://api.mainnet-beta.solana.com"
-  );
+  const connection = getConnection();
   const accounts = await connection.getProgramAccounts(
     new PublicKey(WEALTHVILLE_PROGRAM_ID)
   );
-  await Promise.all(
-    accounts.map(async ({ pubkey }) => {
-      try {
-        const balance = await connection.getTokenAccountBalance(pubkey);
-        if (balance.value && balance.value.uiAmount > 0) {
-          api.add(balance.value.mint, balance.value.uiAmount);
-        }
-      } catch (_) {}
-    })
-  );
+  const owners = accounts.map(({ pubkey }) => pubkey.toBase58());
+  return sumTokens2({ api, owners });
 }
 
 module.exports = {
   methodology:
-    "Sums all token balances held in WealthVille smart vault accounts on Solana, " +
-    "representing user-deposited assets under automated yield management.",
+    "TVL is the sum of all SPL token balances held in token accounts owned by " +
+    "WealthVille smart vault PDAs, representing user-deposited assets under " +
+    "automated yield management.",
   solana: { tvl },
 };

--- a/projects/wealthville/index.js
+++ b/projects/wealthville/index.js
@@ -1,21 +1,32 @@
-const { getConnection, sumTokens2 } = require("../helper/solana");
-const { PublicKey } = require("@solana/web3.js");
+const { get } = require('../helper/http');
 
-const WEALTHVILLE_PROGRAM_ID = "6dtupVYfD3UP6mEsBxExfHeiBNojC4QNHSysYNewkaGu";
+const TVL_ENDPOINT = 'https://wealthville.net/tvl';
 
+// WealthVille is a non-custodial yield optimizer on Solana. Each vault holds a mix of
+// SPL tokens, native SOL, and Orca/Raydium CLMM positions. The /tvl endpoint exposes the
+// full on-chain breakdown per vault (token_accounts[].value_usd, native SOL lamports, and
+// clmm_positions[].value_usd), with per-vault tvl_usd already equal to the sum of those
+// components. We report the aggregate USD value, which is independently verifiable from the
+// on-chain addresses included in the same response.
 async function tvl(api) {
-  const connection = getConnection();
-  const accounts = await connection.getProgramAccounts(
-    new PublicKey(WEALTHVILLE_PROGRAM_ID)
-  );
-  const owners = accounts.map(({ pubkey }) => pubkey.toBase58());
-  return sumTokens2({ api, owners });
+  const vaults = await get(TVL_ENDPOINT);
+  const list = Array.isArray(vaults) ? vaults : (vaults && vaults.data) || [];
+
+  let totalUsd = 0;
+  for (const v of list) {
+    if (!v || v.status !== 'active') continue;
+    totalUsd += Number(v.tvl_usd) || 0;
+  }
+
+  api.addUSDValue(totalUsd);
 }
 
 module.exports = {
+  timetravel: false,
+  misrepresentedTokens: true,
   methodology:
-    "TVL is the sum of all SPL token balances held in token accounts owned by " +
-    "WealthVille smart vault PDAs, representing user-deposited assets under " +
-    "automated yield management.",
+    'Aggregates the USD value of all active WealthVille vaults from the protocol /tvl endpoint. ' +
+    'Each vault total is the sum of its on-chain holdings: SPL token accounts, native SOL, and ' +
+    'Orca/Raydium CLMM positions, all of which are enumerated with addresses in the same response.',
   solana: { tvl },
 };

--- a/projects/wealthville/index.js
+++ b/projects/wealthville/index.js
@@ -1,32 +1,19 @@
-const { get } = require('../helper/http');
+const { getConnection, sumTokens2 } = require("../helper/solana");
+const { PublicKey } = require("@solana/web3.js");
+const { bs58 } = require("@project-serum/anchor/dist/cjs/utils/bytes");
 
-const TVL_ENDPOINT = 'https://wealthville.net/tvl';
+const WEALTHVILLE_PROGRAM_ID = new PublicKey("6dtupVYfD3UP6mEsBxExfHeiBNojC4QNHSysYNewkaGu");
+const VAULT_DISCRIMINATOR = bs58.encode(Buffer.from("dae002b6f091b8d7", "hex"));
 
-// WealthVille is a non-custodial yield optimizer on Solana. Each vault holds a mix of
-// SPL tokens, native SOL, and Orca/Raydium CLMM positions. The /tvl endpoint exposes the
-// full on-chain breakdown per vault (token_accounts[].value_usd, native SOL lamports, and
-// clmm_positions[].value_usd), with per-vault tvl_usd already equal to the sum of those
-// components. We report the aggregate USD value, which is independently verifiable from the
-// on-chain addresses included in the same response.
 async function tvl(api) {
-  const vaults = await get(TVL_ENDPOINT);
-  const list = Array.isArray(vaults) ? vaults : (vaults && vaults.data) || [];
-
-  let totalUsd = 0;
-  for (const v of list) {
-    if (!v || v.status !== 'active') continue;
-    totalUsd += Number(v.tvl_usd) || 0;
-  }
-
-  api.addUSDValue(totalUsd);
+  const accounts = await getConnection().getProgramAccounts(WEALTHVILLE_PROGRAM_ID, {
+    filters: [{ memcmp: { offset: 0, bytes: VAULT_DISCRIMINATOR } }],
+  });
+  const owners = accounts.map(({ pubkey }) => pubkey.toBase58());
+  return sumTokens2({ api, owners, solOwners: owners });
 }
 
 module.exports = {
-  timetravel: false,
-  misrepresentedTokens: true,
-  methodology:
-    'Aggregates the USD value of all active WealthVille vaults from the protocol /tvl endpoint. ' +
-    'Each vault total is the sum of its on-chain holdings: SPL token accounts, native SOL, and ' +
-    'Orca/Raydium CLMM positions, all of which are enumerated with addresses in the same response.',
+  methodology: "TVL counts all SPL token balances held in token accounts owned by WealthVille smart vault PDAs, representing user-deposited assets under automated yield management.",
   solana: { tvl },
 };

--- a/projects/wealthville/index.js
+++ b/projects/wealthville/index.js
@@ -1,0 +1,29 @@
+const { PublicKey, Connection } = require("@solana/web3.js");
+
+const WEALTHVILLE_PROGRAM_ID = "6dtupVYfD3UP6mEsBxExfHeiBNojC4QNHSysYNewkaGu";
+
+async function tvl(api) {
+  const connection = new Connection(
+    process.env.SOLANA_RPC || "https://api.mainnet-beta.solana.com"
+  );
+  const accounts = await connection.getProgramAccounts(
+    new PublicKey(WEALTHVILLE_PROGRAM_ID)
+  );
+  await Promise.all(
+    accounts.map(async ({ pubkey }) => {
+      try {
+        const balance = await connection.getTokenAccountBalance(pubkey);
+        if (balance.value && balance.value.uiAmount > 0) {
+          api.add(balance.value.mint, balance.value.uiAmount);
+        }
+      } catch (_) {}
+    })
+  );
+}
+
+module.exports = {
+  methodology:
+    "Sums all token balances held in WealthVille smart vault accounts on Solana, " +
+    "representing user-deposited assets under automated yield management.",
+  solana: { tvl },
+};


### PR DESCRIPTION
WealthVille is a non-custodial automated yield optimizer on Solana. Program ID: 6dtupVYfD3UP6mEsBxExfHeiBNojC4QNHSysYNewkaGu. TVL: ~$14.2M across 24 active vaults using Orca Whirlpools and Raydium.

---
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
WealthVille

##### Twitter Link:
https://twitter.com/wealthville_net

##### List of audit links if any:
N/A (V1.0 - audit in progress)

##### Website Link:
https://wealthville.net

##### Logo (High resolution, will be shown with rounded borders):
https://wealthville.net/icon-only.png

##### Current TVL:
~$14.2M

##### Treasury Addresses (if the protocol has treasury)
N/A

##### Chain:
Solana

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):
(not listed yet)

##### CoinMarketCap ID (so your TVL can appear on CoinMarketCap, leave empty if not listed):
(not listed yet)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Total Value Locked (TVL) tracking for WealthVille on Solana by scanning the program’s on-chain vault accounts and computing totals for displayed TVL.
* **Refactor**
  * Updated the TVL methodology to derive values directly from the retrieved account ownership set, simplifying how the published Solana TVL numbers are calculated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->