### PR TITLE
Parallelize pool processing in muuu adapter

### DIFF
--- a/projects/muuu/tvl.js
+++ b/projects/muuu/tvl.js
@@ -16,8 +16,7 @@ async function tvl(api) {
   api.add(ADDRESSES.astar.LAY, veLAY)
   const pools = await api.fetchList({ lengthAbi: ABI.poolLength, itemAbi: ABI.poolInfo, target: BOOSTER_ADDRESS })
   const supply = await api.multiCall({ abi: 'erc20:totalSupply', calls: pools.map(i => i.token) })
-  let i = 0
-  for (const pool of pools) await addTokensInPool(api, pool.lptoken, supply[i++])
+  await Promise.all(pools.map((pool, i) => addTokensInPool(api, pool.lptoken, supply[i])))
 }
 
 module.exports = {
@@ -52,10 +51,10 @@ async function addTokensInPool(api, lpToken, tokenBal) {
     bals = await api.call({  abi: ABI.get_balances, target: REGISTRY_ADDRESS, params: pool })
   }
   const ratio = tokenBal / supply
-  for (const t of tokens) {
-    if (t === ZERO_ADDRESS) continue;
-    const name = await api.call({  abi: 'string:name', target: t })
-    if (name.includes('Kagla.fi')) await addTokensInPool(api, t, bals[tokens.indexOf(t)] * ratio)
-    else api.add(t, bals[tokens.indexOf(t)] * ratio)
-  }
+  const validTokens = tokens.map((t, i) => ({ t, bal: bals[i] })).filter(({ t }) => t !== ZERO_ADDRESS)
+  const names = await Promise.all(validTokens.map(({ t }) => api.call({ abi: 'string:name', target: t })))
+  await Promise.all(validTokens.map(({ t, bal }, i) => {
+    if (names[i].includes('Kagla.fi')) return addTokensInPool(api, t, bal * ratio)
+    else api.add(t, bal * ratio)
+  }))
 }


### PR DESCRIPTION
The tvl function iterated over pools with await inside a for loop, processing each pool sequentially. Within addTokensInPool, token name lookups were also fetched one at a time.

Changed the outer pool loop to Promise.all so all pools are processed concurrently. Batched the string:name calls for valid tokens into a single parallel fetch before processing results.

No logic changes, only the scheduling of async calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized TVL aggregation to process pool tokens concurrently instead of sequentially.
  * Enhanced token handling with parallel name fetching and balance allocation for improved calculation performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19470?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->