### PR TITLE
Add SSS DeFi TVL adapter

### DIFF
--- a/projects/sss-defi/README.md
+++ b/projects/sss-defi/README.md
@@ -1,0 +1,53 @@
+# SSS DeFi TVL Adapter
+
+SSS DeFi is a fully on-chain, canister-based DEX on the Internet Computer.
+
+## TVL methodology
+
+TVL is calculated from live raw reserves of enabled public non-legacy canonical SSS pools.
+
+Included assets:
+
+```text
+ICP
+ETH
+USDC
+USDT
+```
+
+Included public pools:
+
+```text
+9  ICP/USDT  10 bps
+10 ICP/USDC  10 bps
+11 ETH/USDT  10 bps
+12 ETH/USDC  10 bps
+13 USDC/USDT 10 bps
+14 USDC/USDT 1 bps
+```
+
+Excluded from TVL:
+
+* user available balances;
+* pending deposits;
+* pending withdrawals;
+* route reserves;
+* treasury reserves;
+* protocol fee vaults;
+* referral liabilities;
+* hidden pools;
+* disabled pools;
+* legacy pools;
+* settlement-route assets.
+
+## Data source
+
+```text
+https://dlhkk-raaaa-aaaak-qyl5a-cai.raw.icp0.io/api/external/v1/live/tvl_inputs.json
+```
+
+Pool ids are SSS synthetic ids, not EVM pair contract addresses:
+
+```text
+sss:<core_canister>:pool:<pool_id>
+```

--- a/projects/sss-defi/index.js
+++ b/projects/sss-defi/index.js
@@ -1,0 +1,121 @@
+// SSS DeFi TVL adapter draft for DefiLlama-Adapters.
+//
+// Target path in a DefiLlama-Adapters fork:
+//   projects/sss-defi/index.js
+//
+// Data source:
+//   https://dlhkk-raaaa-aaaak-qyl5a-cai.raw.icp0.io/api/external/v1/live/tvl_inputs.json
+//
+// This adapter intentionally uses live raw reserves exported by the SSS core
+// canister and leaves USD pricing to DefiLlama's canonical token pricing layer.
+
+const TVL_INPUTS_URL = "https://dlhkk-raaaa-aaaak-qyl5a-cai.raw.icp0.io/api/external/v1/live/tvl_inputs.json";
+const CORE_CANISTER_ID = "dlhkk-raaaa-aaaak-qyl5a-cai";
+const EXPECTED_POOL_IDS = new Set([9, 10, 11, 12, 13, 14]);
+const EXPECTED_SYMBOLS = new Set(["ICP", "ETH", "USDC", "USDT"]);
+
+const COINGECKO_BY_SYMBOL = {
+  ICP: "internet-computer",
+  ETH: "ethereum",
+  USDC: "usd-coin",
+  USDT: "tether",
+};
+
+const METHODOLOGY = `TVL includes only enabled public non-legacy SSS canonical pool reserves on the Internet Computer. Canonical assets are ICP, ETH, USDC, and USDT. User balances, pending deposits, pending withdrawals, route reserves, treasury reserves, protocol fee vaults, referral liabilities, hidden pools, disabled pools, legacy pools, and settlement-route assets are excluded.`;
+
+function decodeNat(value) {
+  if (typeof value === "number") return BigInt(value);
+  if (typeof value === "string") return BigInt(value);
+  if (typeof value === "bigint") return value;
+  if (Array.isArray(value)) {
+    // Candid Nat / num-bigint may be serialized as little-endian base-2^32 limbs.
+    return value.reduce((acc, limb, idx) => acc + (BigInt(limb) << BigInt(32 * idx)), 0n);
+  }
+  throw new Error(`Unsupported integer value: ${JSON.stringify(value)}`);
+}
+
+function atomicToDecimalString(rawAtomic, decimals) {
+  // DefiLlama CG-token helpers may expect decimal amounts depending on the SDK
+  // version. Keep this conversion isolated so it is easy to adapt during PR
+  // review if the target helper expects raw atomic amounts instead.
+  const base = 10n ** BigInt(decimals);
+  const whole = rawAtomic / base;
+  const frac = rawAtomic % base;
+  if (frac === 0n) return whole.toString();
+  return `${whole}.${frac.toString().padStart(decimals, "0").replace(/0+$/, "")}`;
+}
+
+async function fetchJson(url) {
+  const res = await fetch(url, { headers: { accept: "application/json" } });
+  if (!res.ok) throw new Error(`GET ${url} failed: ${res.status}`);
+  return res.json();
+}
+
+function addCanonicalBalance(api, symbol, rawAtomic, decimals) {
+  const coingeckoId = COINGECKO_BY_SYMBOL[symbol];
+  if (!coingeckoId) throw new Error(`Missing CoinGecko id for ${symbol}`);
+  const amount = Number(atomicToDecimalString(rawAtomic, decimals));
+  if (!Number.isFinite(amount)) {
+    throw new Error(`Invalid normalized amount for ${symbol}: ${amount}`);
+  }
+  if (Math.abs(amount) > Number.MAX_SAFE_INTEGER) {
+    throw new Error(`Normalized amount for ${symbol} exceeds Number.MAX_SAFE_INTEGER: ${amount}`);
+  }
+
+  // DefiLlama SDK versions differ across adapters. The common review path is:
+  // 1) prefer api.addCGToken when available;
+  // 2) otherwise store in api.add with a synthetic key agreed during PR review.
+  if (typeof api.addCGToken === "function") {
+    api.addCGToken(coingeckoId, amount);
+    return;
+  }
+  if (typeof api.add === "function") {
+    api.add(`coingecko:${coingeckoId}`, amount);
+    return;
+  }
+  throw new Error("No supported balance add helper found on DefiLlama api object");
+}
+
+async function tvl(api) {
+  const data = await fetchJson(TVL_INPUTS_URL);
+  if (String(data.core_canister_id) !== CORE_CANISTER_ID) {
+    throw new Error(`Unexpected core canister id: ${data.core_canister_id}`);
+  }
+
+  for (const token of data.tokens || []) {
+    const symbol = String(token.symbol || "").toUpperCase();
+    if (!EXPECTED_SYMBOLS.has(symbol)) {
+      throw new Error(`Unexpected exported token: ${symbol}`);
+    }
+  }
+
+  const seen = new Set();
+  for (const pool of data.pools || []) {
+    const poolId = Number(decodeNat(pool.pool_id));
+    seen.add(poolId);
+    if (!EXPECTED_POOL_IDS.has(poolId)) continue;
+    if (pool.enabled !== true || pool.public_visible !== true || pool.legacy !== false) continue;
+
+    for (const side of ["0", "1"]) {
+      const symbol = String(pool[`token${side}_symbol`] || "").toUpperCase();
+      if (!EXPECTED_SYMBOLS.has(symbol)) {
+        throw new Error(`Unexpected token in pool ${poolId}: ${symbol}`);
+      }
+      const decimals = Number(decodeNat(pool[`token${side}_decimals`]));
+      const rawAtomic = decodeNat(pool[`reserve${side}_atomic`]);
+      addCanonicalBalance(api, symbol, rawAtomic, decimals);
+    }
+  }
+
+  for (const expected of EXPECTED_POOL_IDS) {
+    if (!seen.has(expected)) throw new Error(`Missing expected SSS pool id: ${expected}`);
+  }
+}
+
+module.exports = {
+  timetravel: false,
+  methodology: METHODOLOGY,
+  icp: {
+    tvl,
+  },
+};


### PR DESCRIPTION
Name (to be shown on DefiLlama):
SSS DeFi

Twitter Link:
https://x.com/SSSDefi

List of audit links if any:
N/A for the current public beta listing.

Website Link:
https://sssdefi.ai

Logo (High resolution, will be shown with rounded borders):
https://github.com/SSS-DeFi/sss-brand-assets

Current TVL:
~10.0k USD based on the adapter test output.

Treasury Addresses (if the protocol has treasury):
N/A for TVL calculation. Treasury and protocol fee reserves are explicitly excluded from TVL.

Chain:
ICP

Coingecko ID:
N/A

Coinmarketcap ID:
N/A

Short Description:
SSS DeFi is a fully on-chain, canister-based DEX on the Internet Computer, designed to provide a CEX-like trading experience with DEX transparency.

Token address and ticker if any:
N/A. SSS does not have a listed governance token for this TVL adapter.

Category:
Dexes

Oracle Provider(s):
N/A for TVL. TVL is calculated from live raw pool reserves and DefiLlama’s canonical pricing layer.

Implementation Details:
The adapter reads live public pool reserves directly from the SSS core canister HTTP endpoint:
https://dlhkk-raaaa-aaaak-qyl5a-cai.raw.icp0.io/api/external/v1/live/tvl_inputs.json

The endpoint exposes canonical public pool state from the on-chain core canister. It is not frontend-computed TVL and not an off-chain database.

Documentation/Proof:
https://docs.sssdefi.ai/external-data/sss_external_data_api_v1.md
https://docs.sssdefi.ai/external-data/defillama/pr_package_tvl_v1/README.md

forkedFrom:
No

methodology:
TVL includes only enabled, public, non-legacy SSS canonical pool reserves on ICP.

Included pools:
- ICP/USDT
- ICP/USDC
- ETH/USDT
- ETH/USDC
- USDC/USDT 0.10%
- USDC/USDT 0.01%

Included assets:
- ICP
- ETH
- USDC
- USDT

Excluded from TVL:
- user balances
- pending deposits / withdrawals
- route reserves
- treasury reserves
- protocol fee vaults
- referral liabilities
- hidden / disabled / legacy pools
- settlement-route assets

Github org/user:
https://github.com/SSS-DeFi

Does this project have a referral program?
Yes, but referral liabilities and referral rewards are excluded from TVL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced SSS DeFi TVL adapter for Internet Computer, enabling live total value locked tracking from canonical pools.

* **Documentation**
  * Added detailed TVL methodology documentation outlining computation approach, included asset types, pool selection criteria, and exclusion categories.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19480?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->