### PR TITLE
Fix/Stop getHypercoreStakedHype from double counting pending withdrawals

### DIFF
--- a/projects/helper/chain/hyperliquid.js
+++ b/projects/helper/chain/hyperliquid.js
@@ -12,7 +12,7 @@ async function getUserStakingSummary(user) {
 
 async function getHypercoreStakedHype(user) {
   const { delegated, undelegated, totalPendingWithdrawal } = await getUserStakingSummary(user)
-  return BigInt(Math.round((delegated + undelegated - totalPendingWithdrawal) * 1e18))
+  return BigInt(Math.round((delegated + undelegated + totalPendingWithdrawal) * 1e18))
 }
 
 module.exports = { getUserStakingSummary, getHypercoreStakedHype }

--- a/projects/kinetiq/index.js
+++ b/projects/kinetiq/index.js
@@ -2,13 +2,6 @@ const ADDRESSES = require('../helper/coreAssets.json')
 const { staking } = require('../helper/staking')
 const { getHypercoreStakedHype } = require('../helper/chain/hyperliquid')
 
-const accountant = '0x9209648Ec9D448EF57116B73A2f081835643dc7A'
-
-const abis = {
-  kHYPEToHYPE: "function kHYPEToHYPE(uint256 kHYPEAmount) view returns (uint256)",
-  totalQueuedWithdrawals: "function totalQueuedWithdrawals() view returns (uint256)",
-}
-
 const managers = [
   '0x393D0B87Ed38fc779FD9611144aE649BA6082109', // kHype
   '0xaD492f9CADcccE9c3c213edd8aE55c152cD3A3ad', // hiHype
@@ -19,10 +12,6 @@ const managers = [
 
 const tvl = async (api) => {
   await api.sumTokens({ owners: managers, tokens: [ADDRESSES.null] })
-
-  const buffBalance = await api.call({ target: "0x393D0B87Ed38fc779FD9611144aE649BA6082109", abi: abis.totalQueuedWithdrawals })
-  const hypeBalance = await api.call({ target: accountant, params: [buffBalance], abi: abis.kHYPEToHYPE })
-  api.addGasToken(hypeBalance)
 
   const stakedBalances = await Promise.all(managers.map(m => getHypercoreStakedHype(m)))
   for (const bal of stakedBalances) {


### PR DESCRIPTION
The main fix is in the shared helper helper/chain/hyperliquid.js. 
`getHypercoreStakedHype` was subtracting `totalPendingWithdrawal` from the HyperCore staking balance when it should be adding it. 
The projects/kinetiq change only removes a partial workaround that is now redundant.

## The bug (shared helper)
In a HyperCore delegatorSummary, delegated, undelegated, and totalPendingWithdrawal are three disjoint buckets. Per the [HyperLiquid staking docs](https://hyperliquid.gitbook.io/hyperliquid-docs/hypercore/staking), withdrawing moves HYPE out of undelegated into a separate 7-day unstaking queue (totalPendingWithdrawal). That HYPE is still controlled by the staking account, so it's still TVL and must be added.

The helper instead subtracted it:

- delegated + undelegated - totalPendingWithdrawal
+ delegated + undelegated + totalPendingWithdrawal

Subtracting a value that should be added makes the result 2× the pending amount too low — it effectively removes the pending withdrawals twice: once by not counting the bucket, and once by subtracting that amount from the active stake.

## kinetiq cleanup
The kinetiq adapter previously masked half of this with a kHYPE-only buffer add-back (totalQueuedWithdrawals → kHYPEToHYPE), which added one pending amount back so the net error was ~1× pending instead of 2×. With the helper fixed, that workaround is redundant — removed it and the now-unused accountant/abis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected pending withdrawal handling in HYPE staking balance calculations.

* **Refactor**
  * Streamlined TVL calculation for Kinetiq protocol by removing intermediate accounting steps and computing values more directly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19481?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->