### PR TITLE
Update MineBTC mainnet adapters

### DIFF
--- a/projects/minebtc/index.js
+++ b/projects/minebtc/index.js
@@ -2,21 +2,24 @@ const { PublicKey } = require("@solana/web3.js");
 const { getConnection, sumTokens2, getTokenAccountBalances } = require("../helper/solana");
 const ADDRESSES = require("../helper/coreAssets.json");
 
-// MineBTC Program: Hw9uxvtmQdS57N6aNwJA5iqjSqzhRDdopCHgm8EPwkqx
-const DOGEBTC_MINT = "BwMCF5LSHPvrR8pLVvcsa4k1AMg4VWVnMWUiNEXMtLkE";
+// MineBTC Program: 1eotiTH2UxCpPMmtzUDGqf1b8dwM7AMKb8a2Tio51an
+const DBTC_MINT = "CtAu3kc8cQ1jcDMmRTBsDHoPuE3sswCagQ3BuqFDC6dt";
 
-// --- Raydium CP-Swap Pool (DogeBTC/SOL) ---
-const RAYDIUM_POOL_STATE = "HmPwHy2z9aQa2Ce2kMhwvjaiqCBiE7kdHppkUP6jZ7nf";
-const POOL_TOKEN0_VAULT = "4YGosu8THGYPVToa8YttLe8kefNNhsc66wWScT9ZaDxc"; // SOL vault (9 decimals)
-const POOL_TOKEN1_VAULT = "AnPauy18Yi2YCPiKcgg69mzrhSH6wVxvCNtvfe8gaxp";  // DogeBTC vault (6 decimals)
+// --- Raydium CP-Swap Pool (dBTC/SOL) ---
+const RAYDIUM_POOL_STATE = "F87M4sT6Wtfk4enVVbtM4ZnWsqCE9TXzL12Apwj3Cjtj";
+const POOL_TOKEN0_VAULT = "EMDuS9XZesBDo8urJzwgrKC7qJrLQ6hHXVvSLNE6s3ui"; // SOL vault (9 decimals)
+const POOL_TOKEN1_VAULT = "79nGAzP7D7GvHe4bPPs4DBHHGXspqE16Kn3w5e9QHEQw"; // dBTC vault (6 decimals)
 const LP_SUPPLY_OFFSET = 333; // u64 LE offset for lp_supply in Raydium CP-Swap PoolState
 
 // --- Token Vaults ---
-const STAKED_DOGEBTC_CUSTODIAN = "523EuRZDDyvCaVJGsqgcAuifcLiVvgAYynmjVWd1RXDR";
-const STAKED_LP_CUSTODIAN = "Eyzfok5go6ddaKHEddVza5QTKzo4tcYF282cM1nU8GqV";
+const STAKED_DBTC_CUSTODIAN = "HXVe2xLchtKV332QKyh2kRJ6dQf3XxbhsnLGQu4bfLM9";
+const STAKED_LP_CUSTODIAN = "EJ7ZomjToiB68rNFRa83wrBD11rvmDEa29PbJ4ct8ciW";
 
 // --- SOL Vaults ---
-const SOL_PRIZE_POT = "GqMyratKThjEKzqZQStUy2LNB3dogZ3ETDBMQ33fmUw5";
+const SOL_PRIZE_POT = "AMuDuGgeWtmT3b7QPCAqQTducxV1Z2s6GjDY2gwGE91C";
+const COUNTRY_RACE_SOL_VAULT = "DRnKgn51Mm7t1UneFD6Je5B6XLWmFt9gBdJN5xPcXfMB";
+const STAKER_SOL_REWARD_VAULT = "FYnbbqMPUetvN22CDeDxAJb4SSXmqZcGEbrwVvoJREvK";
+const FACTION_TREASURY_VAULT = "1gYoc7ojYQdkABsAVFnFQhmYphe532EDnxheRZBDuqr";
 
 async function getStakedLpUnderlyingValue(api) {
   const connection = getConnection();
@@ -47,34 +50,35 @@ async function getStakedLpUnderlyingValue(api) {
   const underlyingDbtc = Math.floor(dbtcInPool * share);
 
   if (underlyingSol > 0) api.add(ADDRESSES.solana.SOL, underlyingSol);
-  if (underlyingDbtc > 0) api.add(DOGEBTC_MINT, underlyingDbtc);
+  if (underlyingDbtc > 0) api.add(DBTC_MINT, underlyingDbtc);
 }
 
 async function tvl(api) {
-  // SOL in betting prize pot (funded by user bets, paid out to winners)
+  // User reward pools funded by gameplay and tax cranks.
   await sumTokens2({
     api,
-    solOwners: [SOL_PRIZE_POT],
+    solOwners: [SOL_PRIZE_POT, COUNTRY_RACE_SOL_VAULT, STAKER_SOL_REWARD_VAULT],
+    tokenAccounts: [FACTION_TREASURY_VAULT],
   });
 }
 
 async function staking(api) {
-  // Staked DogeBTC (protocol's own token)
+  // Staked dBTC (protocol's own token)
   await sumTokens2({
     api,
-    tokenAccounts: [STAKED_DOGEBTC_CUSTODIAN],
+    tokenAccounts: [STAKED_DBTC_CUSTODIAN],
   });
 }
 
 async function pool2(api) {
-  // Staked LP (DogeBTC/SOL) -> pro-rata underlying value
+  // Staked LP (dBTC/SOL) -> pro-rata underlying value
   await getStakedLpUnderlyingValue(api);
 }
 
 module.exports = {
   timetravel: false,
   methodology:
-    "TVL includes SOL in the betting prize pot. Staking tracks user-staked DogeBTC. Pool2 tracks staked DogeBTC/SOL LP tokens valued by their pro-rata share of underlying assets in the Raydium pool.",
+    "TVL includes SOL in the Casino prize pot, Country Race reward vault, staking reward vault, and dBTC in the faction-tax reward vault. Staking tracks user-staked dBTC. Pool2 tracks staked dBTC/SOL LP tokens valued by their pro-rata share of underlying assets in the Raydium pool.",
   solana: {
     tvl,
     staking,

--- a/projects/minebtc/index.js
+++ b/projects/minebtc/index.js
@@ -31,26 +31,25 @@ async function getStakedLpUnderlyingValue(api) {
     connection.getAccountInfo(new PublicKey(RAYDIUM_POOL_STATE)),
   ]);
 
-  const stakedLp = stakedLpInfo.length > 0 ? Number(stakedLpInfo[0].amount) : 0;
-  if (stakedLp === 0) return;
+  const stakedLp = stakedLpInfo.length > 0 ? BigInt(stakedLpInfo[0].amount) : 0n;
+  if (stakedLp === 0n) return;
 
   // Read lp_supply from pool state account (total LP ever minted, includes burned)
   // LP tokens are burned for permanent liquidity — mint supply shows 0 but pool tracks total
   if (!poolStateAccount || !poolStateAccount.data) return;
-  const lpTotalSupply = Number(poolStateAccount.data.readBigUInt64LE(LP_SUPPLY_OFFSET));
-  if (lpTotalSupply === 0) return;
+  const lpTotalSupply = poolStateAccount.data.readBigUInt64LE(LP_SUPPLY_OFFSET);
+  if (lpTotalSupply === 0n) return;
 
   // Get pool vault reserves (raw amounts)
-  const solInPool = poolVaultBalances.length >= 1 ? Number(poolVaultBalances[0].amount) : 0;
-  const dbtcInPool = poolVaultBalances.length >= 2 ? Number(poolVaultBalances[1].amount) : 0;
+  const solInPool = poolVaultBalances.length >= 1 ? BigInt(poolVaultBalances[0].amount) : 0n;
+  const dbtcInPool = poolVaultBalances.length >= 2 ? BigInt(poolVaultBalances[1].amount) : 0n;
 
   // Calculate pro-rata share of underlying tokens for staked LP
-  const share = stakedLp / lpTotalSupply;
-  const underlyingSol = Math.floor(solInPool * share);
-  const underlyingDbtc = Math.floor(dbtcInPool * share);
+  const underlyingSol = (solInPool * stakedLp) / lpTotalSupply;
+  const underlyingDbtc = (dbtcInPool * stakedLp) / lpTotalSupply;
 
-  if (underlyingSol > 0) api.add(ADDRESSES.solana.SOL, underlyingSol);
-  if (underlyingDbtc > 0) api.add(DBTC_MINT, underlyingDbtc);
+  if (underlyingSol > 0n) api.add(ADDRESSES.solana.SOL, underlyingSol.toString());
+  if (underlyingDbtc > 0n) api.add(DBTC_MINT, underlyingDbtc.toString());
 }
 
 async function tvl(api) {

--- a/projects/minebtc/index.js
+++ b/projects/minebtc/index.js
@@ -21,6 +21,12 @@ const COUNTRY_RACE_SOL_VAULT = "DRnKgn51Mm7t1UneFD6Je5B6XLWmFt9gBdJN5xPcXfMB";
 const STAKER_SOL_REWARD_VAULT = "FYnbbqMPUetvN22CDeDxAJb4SSXmqZcGEbrwVvoJREvK";
 const FACTION_TREASURY_VAULT = "1gYoc7ojYQdkABsAVFnFQhmYphe532EDnxheRZBDuqr";
 
+/**
+ * Adds the underlying SOL and dBTC value for MineBTC LP tokens staked in the
+ * protocol custodian, using Raydium CP-Swap pool reserves and tracked LP supply.
+ *
+ * @param {object} api DefiLlama chain API accumulator.
+ */
 async function getStakedLpUnderlyingValue(api) {
   const connection = getConnection();
 
@@ -52,6 +58,11 @@ async function getStakedLpUnderlyingValue(api) {
   if (underlyingDbtc > 0n) api.add(DBTC_MINT, underlyingDbtc.toString());
 }
 
+/**
+ * Tracks MineBTC gameplay reward inventory held in protocol-controlled vaults.
+ *
+ * @param {object} api DefiLlama chain API accumulator.
+ */
 async function tvl(api) {
   // User reward pools funded by gameplay and tax cranks.
   await sumTokens2({
@@ -61,6 +72,11 @@ async function tvl(api) {
   });
 }
 
+/**
+ * Tracks user-staked dBTC held by the global staking custodian.
+ *
+ * @param {object} api DefiLlama chain API accumulator.
+ */
 async function staking(api) {
   // Staked dBTC (protocol's own token)
   await sumTokens2({
@@ -69,6 +85,12 @@ async function staking(api) {
   });
 }
 
+/**
+ * Tracks user-staked dBTC/SOL LP exposure by adding the LP custodian's
+ * pro-rata underlying pool reserves.
+ *
+ * @param {object} api DefiLlama chain API accumulator.
+ */
 async function pool2(api) {
   // Staked LP (dBTC/SOL) -> pro-rata underlying value
   await getStakedLpUnderlyingValue(api);

--- a/projects/treasury/minebtc.js
+++ b/projects/treasury/minebtc.js
@@ -5,13 +5,21 @@ const SOL_TREASURY = "2TU3jP7vnhPD1ksVmSMQhuAauuFCuj9magtMWDW65jEx";
 const BUYBACKS_SOL_VAULT = "DdatmQD4g2vQdgAw7RvdZFYSouTEB4ebjXWAqH1T86rs";
 const NFT_SWEEP_SOL_VAULT = "4XDwhMaA98MaiVXpiqbevr9Kwmp9xGV2nGzQVeF7hbRq";
 
+/**
+ * Tracks protocol-owned SOL balances held by MineBTC treasury, buyback, and
+ * NFT sweep vaults.
+ *
+ * @param {object} api DefiLlama chain API accumulator.
+ */
+async function tvl(api) {
+  await sumTokens2({
+    api,
+    solOwners: [SOL_TREASURY, BUYBACKS_SOL_VAULT, NFT_SWEEP_SOL_VAULT],
+  });
+}
+
 module.exports = {
   solana: {
-    tvl: async (api) => {
-      await sumTokens2({
-        api,
-        solOwners: [SOL_TREASURY, BUYBACKS_SOL_VAULT, NFT_SWEEP_SOL_VAULT],
-      });
-    },
+    tvl,
   },
 };

--- a/projects/treasury/minebtc.js
+++ b/projects/treasury/minebtc.js
@@ -1,26 +1,16 @@
 const { sumTokens2 } = require("../helper/solana");
 
-const DOGEBTC_MINT = "BwMCF5LSHPvrR8pLVvcsa4k1AMg4VWVnMWUiNEXMtLkE";
-
-// Protocol-owned DogeBTC vaults (funded by 1% transfer tax)
-const FACTION_TREASURY_VAULT = "GUrrK4c1RmTDqYbEbWSjq6mfUcujpgTtasU4JXVzEKMA";
-const NFT_FLOOR_SWEEP_VAULT = "DRvR4WpLj85Lfvwk3im7Ucrz1s9FPLPUtrTihUiqaPve";
-
-// Protocol-owned SOL vault (staker reward fees from bets)
-const STAKER_SOL_REWARD_VAULT = "HiGNRiXWrqtFbwEH1YKQVHommFU15auksXbe7Qv7Nrrb";
+// Protocol-owned SOL vaults
+const SOL_TREASURY = "2TU3jP7vnhPD1ksVmSMQhuAauuFCuj9magtMWDW65jEx";
+const BUYBACKS_SOL_VAULT = "DdatmQD4g2vQdgAw7RvdZFYSouTEB4ebjXWAqH1T86rs";
+const NFT_SWEEP_SOL_VAULT = "4XDwhMaA98MaiVXpiqbevr9Kwmp9xGV2nGzQVeF7hbRq";
 
 module.exports = {
   solana: {
     tvl: async (api) => {
       await sumTokens2({
         api,
-        solOwners: [STAKER_SOL_REWARD_VAULT],
-      });
-    },
-    ownTokens: async (api) => {
-      await sumTokens2({
-        api,
-        tokenAccounts: [FACTION_TREASURY_VAULT, NFT_FLOOR_SWEEP_VAULT],
+        solOwners: [SOL_TREASURY, BUYBACKS_SOL_VAULT, NFT_SWEEP_SOL_VAULT],
       });
     },
   },


### PR DESCRIPTION
Updates MineBTC's Solana TVL and treasury adapters to the current mainnet deployment.\n\nChanges:\n- Replaces stale dBTC, Raydium pool, staking custodian, and reward vault addresses.\n- Counts current user reward pools in TVL: Casino prize pot, Country Race SOL vault, staking SOL reward vault, and faction-tax dBTC reward vault.\n- Values staked dBTC/SOL LP through the current Raydium CP-Swap pool state.\n- Keeps treasury adapter focused on protocol-owned SOL vaults only: treasury, buyback SOL vault, and NFT sweep SOL vault.\n\nAudit notes:\n- dBTC and LP staking custody is global; per-country staking lives in FactionState reward indexes/hashpower, not separate token vaults.\n- The faction treasury dBTC vault is a Country Race / staking reward flow, so it belongs in protocol TVL/reward inventory, not protocol treasury.\n- POL / LP burn mechanics are untouched.\n\nValidation:\n- node test.js projects/minebtc/index.js\n- node test.js projects/treasury/minebtc.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * TVL calculations now include additional SOL vault sources for more accurate reporting.

* **Chores**
  * Protocol integration updated to use dBTC instead of DogeBTC.
  * Staking and LP attribution adjusted to correctly report staked dBTC and SOL balances.
  * Treasury aggregation simplified to report TVL from multiple protocol-owned SOL vaults.

* **Documentation**
  * Methodology text updated to reflect the new token and expanded vault accounting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/DefiLlama-Adapters/pull/19483?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->