### PR TITLE
Add current MineBTC deployment

### DIFF
--- a/projects/minebtc-fun/index.js
+++ b/projects/minebtc-fun/index.js
@@ -1,0 +1,100 @@
+const { PublicKey } = require("@solana/web3.js");
+const { getConnection, sumTokens2, getTokenAccountBalances } = require("../helper/solana");
+const ADDRESSES = require("../helper/coreAssets.json");
+
+// MineBTC Program: 1eotiTH2UxCpPMmtzUDGqf1b8dwM7AMKb8a2Tio51an
+const DBTC_MINT = "CtAu3kc8cQ1jcDMmRTBsDHoPuE3sswCagQ3BuqFDC6dt";
+
+// Raydium CP-Swap Pool (dBTC/SOL)
+const RAYDIUM_POOL_STATE = "F87M4sT6Wtfk4enVVbtM4ZnWsqCE9TXzL12Apwj3Cjtj";
+const POOL_TOKEN0_VAULT = "EMDuS9XZesBDo8urJzwgrKC7qJrLQ6hHXVvSLNE6s3ui";
+const POOL_TOKEN1_VAULT = "79nGAzP7D7GvHe4bPPs4DBHHGXspqE16Kn3w5e9QHEQw";
+const LP_SUPPLY_OFFSET = 333;
+
+// Staking custodians
+const STAKED_DBTC_CUSTODIAN = "HXVe2xLchtKV332QKyh2kRJ6dQf3XxbhsnLGQu4bfLM9";
+const STAKED_LP_CUSTODIAN = "EJ7ZomjToiB68rNFRa83wrBD11rvmDEa29PbJ4ct8ciW";
+
+// Gameplay reward vaults
+const SOL_PRIZE_POT = "AMuDuGgeWtmT3b7QPCAqQTducxV1Z2s6GjDY2gwGE91C";
+const COUNTRY_RACE_SOL_VAULT = "DRnKgn51Mm7t1UneFD6Je5B6XLWmFt9gBdJN5xPcXfMB";
+const STAKER_SOL_REWARD_VAULT = "FYnbbqMPUetvN22CDeDxAJb4SSXmqZcGEbrwVvoJREvK";
+const FACTION_TREASURY_VAULT = "1gYoc7ojYQdkABsAVFnFQhmYphe532EDnxheRZBDuqr";
+
+/**
+ * Adds the underlying SOL and dBTC value for MineBTC LP tokens staked in the
+ * protocol custodian, using Raydium CP-Swap pool reserves and tracked LP supply.
+ *
+ * @param {object} api DefiLlama chain API accumulator.
+ */
+async function getStakedLpUnderlyingValue(api) {
+  const connection = getConnection();
+
+  const [stakedLpInfo, poolVaultBalances, poolStateAccount] = await Promise.all([
+    getTokenAccountBalances([STAKED_LP_CUSTODIAN], { individual: true, allowError: true }),
+    getTokenAccountBalances([POOL_TOKEN0_VAULT, POOL_TOKEN1_VAULT], { individual: true, allowError: true }),
+    connection.getAccountInfo(new PublicKey(RAYDIUM_POOL_STATE)),
+  ]);
+
+  const stakedLp = stakedLpInfo.length > 0 ? BigInt(stakedLpInfo[0].amount) : 0n;
+  if (stakedLp === 0n) return;
+
+  if (!poolStateAccount || !poolStateAccount.data) return;
+  const lpTotalSupply = poolStateAccount.data.readBigUInt64LE(LP_SUPPLY_OFFSET);
+  if (lpTotalSupply === 0n) return;
+
+  const solInPool = poolVaultBalances.length >= 1 ? BigInt(poolVaultBalances[0].amount) : 0n;
+  const dbtcInPool = poolVaultBalances.length >= 2 ? BigInt(poolVaultBalances[1].amount) : 0n;
+
+  const underlyingSol = (solInPool * stakedLp) / lpTotalSupply;
+  const underlyingDbtc = (dbtcInPool * stakedLp) / lpTotalSupply;
+
+  if (underlyingSol > 0n) api.add(ADDRESSES.solana.SOL, underlyingSol.toString());
+  if (underlyingDbtc > 0n) api.add(DBTC_MINT, underlyingDbtc.toString());
+}
+
+/**
+ * Tracks MineBTC gameplay reward inventory held in protocol-controlled vaults.
+ *
+ * @param {object} api DefiLlama chain API accumulator.
+ */
+async function tvl(api) {
+  await sumTokens2({
+    api,
+    solOwners: [SOL_PRIZE_POT, COUNTRY_RACE_SOL_VAULT, STAKER_SOL_REWARD_VAULT],
+    tokenAccounts: [FACTION_TREASURY_VAULT],
+  });
+}
+
+/**
+ * Tracks user-staked dBTC held by the global staking custodian.
+ *
+ * @param {object} api DefiLlama chain API accumulator.
+ */
+async function staking(api) {
+  await sumTokens2({
+    api,
+    tokenAccounts: [STAKED_DBTC_CUSTODIAN],
+  });
+}
+
+/**
+ * Tracks user-staked dBTC/SOL LP exposure by adding the LP custodian's
+ * pro-rata underlying pool reserves.
+ *
+ * @param {object} api DefiLlama chain API accumulator.
+ */
+async function pool2(api) {
+  await getStakedLpUnderlyingValue(api);
+}
+
+module.exports = {
+  timetravel: false,
+  methodology:
+    "TVL includes SOL in the Casino prize pot, Country Race reward vault, staking reward vault, and dBTC in the faction-tax reward vault. Staking tracks user-staked dBTC. Pool2 tracks staked dBTC/SOL LP tokens valued by their pro-rata share of underlying assets in the Raydium pool.",
+  solana: {
+    tvl,
+    staking,
+    pool2,
+  },
+};

--- a/projects/minebtc-fun/index.js
+++ b/projects/minebtc-fun/index.js
@@ -5,7 +5,7 @@ const ADDRESSES = require("../helper/coreAssets.json");
 // MineBTC Program: 1eotiTH2UxCpPMmtzUDGqf1b8dwM7AMKb8a2Tio51an
 const DBTC_MINT = "CtAu3kc8cQ1jcDMmRTBsDHoPuE3sswCagQ3BuqFDC6dt";
 
-// Raydium CP-Swap pool reserves used for dBTC valuation.
+// Raydium CP-Swap pool reserves used to unwrap staked LP tokens.
 // On-chain token0 vault is wrapped SOL; token1 vault is dBTC.
 const RAYDIUM_POOL_STATE = "F87M4sT6Wtfk4enVVbtM4ZnWsqCE9TXzL12Apwj3Cjtj";
 const POOL_SOL_VAULT = "EMDuS9XZesBDo8urJzwgrKC7qJrLQ6hHXVvSLNE6s3ui";
@@ -24,14 +24,14 @@ const STAKER_SOL_REWARD_VAULT = "FYnbbqMPUetvN22CDeDxAJb4SSXmqZcGEbrwVvoJREvK";
 const FACTION_TREASURY_VAULT = "1gYoc7ojYQdkABsAVFnFQhmYphe532EDnxheRZBDuqr";
 
 /**
- * Reads the live Raydium pool reserves used for dBTC valuation.
+ * Reads the live Raydium pool reserves used to unwrap staked LP tokens.
  *
  * @returns {Promise<{ solInPool: bigint, dbtcInPool: bigint }>} Pool reserves in raw token units.
  */
 async function getPoolReserves() {
   const poolVaultBalances = await getTokenAccountBalances(
     [POOL_SOL_VAULT, POOL_DBTC_VAULT],
-    { individual: true, allowError: true },
+    { individual: true },
   );
 
   return {
@@ -41,34 +41,7 @@ async function getPoolReserves() {
 }
 
 /**
- * Converts a raw dBTC amount to raw SOL value using the live Raydium reserve ratio.
- *
- * @param {bigint} dbtcAmount dBTC amount in raw token units.
- * @param {{ solInPool: bigint, dbtcInPool: bigint }} poolReserves Raydium pool reserves.
- * @returns {bigint} SOL value in lamports.
- */
-function getDbtcValueAsSol(dbtcAmount, { solInPool, dbtcInPool }) {
-  if (dbtcAmount <= 0n || solInPool <= 0n || dbtcInPool <= 0n) return 0n;
-  return (dbtcAmount * solInPool) / dbtcInPool;
-}
-
-/**
- * Reads the raw token amount held by one SPL token account.
- *
- * @param {string} tokenAccount SPL token account address.
- * @returns {Promise<bigint>} Raw token amount.
- */
-async function getTokenAccountAmount(tokenAccount) {
-  const tokenAccountInfo = await getTokenAccountBalances(
-    [tokenAccount],
-    { individual: true, allowError: true },
-  );
-
-  return tokenAccountInfo.length > 0 ? BigInt(tokenAccountInfo[0].amount) : 0n;
-}
-
-/**
- * Adds the underlying SOL and dBTC value for MineBTC LP tokens staked in the
+ * Adds the underlying SOL and dBTC for MineBTC LP tokens staked in the
  * protocol custodian, using Raydium CP-Swap pool reserves and tracked LP supply.
  *
  * @param {object} api DefiLlama chain API accumulator.
@@ -77,7 +50,7 @@ async function getStakedLpUnderlyingValue(api) {
   const connection = getConnection();
 
   const [stakedLpInfo, poolReserves, poolStateAccount] = await Promise.all([
-    getTokenAccountBalances([STAKED_LP_CUSTODIAN], { individual: true, allowError: true }),
+    getTokenAccountBalances([STAKED_LP_CUSTODIAN], { individual: true }),
     getPoolReserves(),
     connection.getAccountInfo(new PublicKey(RAYDIUM_POOL_STATE)),
   ]);
@@ -92,10 +65,9 @@ async function getStakedLpUnderlyingValue(api) {
   const { solInPool, dbtcInPool } = poolReserves;
   const underlyingSol = (solInPool * stakedLp) / lpTotalSupply;
   const underlyingDbtc = (dbtcInPool * stakedLp) / lpTotalSupply;
-  const dbtcValueAsSol = getDbtcValueAsSol(underlyingDbtc, poolReserves);
-  const lpValueAsSol = underlyingSol + dbtcValueAsSol;
 
-  if (lpValueAsSol > 0n) api.add(ADDRESSES.solana.SOL, lpValueAsSol.toString());
+  if (underlyingSol > 0n) api.add(ADDRESSES.solana.SOL, underlyingSol.toString());
+  if (underlyingDbtc > 0n) api.add(DBTC_MINT, underlyingDbtc.toString());
 }
 
 /**
@@ -104,17 +76,10 @@ async function getStakedLpUnderlyingValue(api) {
  * @param {object} api DefiLlama chain API accumulator.
  */
 async function tvl(api) {
-  const [factionTreasuryDbtc, poolReserves] = await Promise.all([
-    getTokenAccountAmount(FACTION_TREASURY_VAULT),
-    getPoolReserves(),
-    sumTokens2({
-      api,
-      solOwners: [SOL_PRIZE_POT, COUNTRY_RACE_SOL_VAULT, STAKER_SOL_REWARD_VAULT],
-    }),
-  ]);
-
-  const factionTreasuryValueAsSol = getDbtcValueAsSol(factionTreasuryDbtc, poolReserves);
-  if (factionTreasuryValueAsSol > 0n) api.add(ADDRESSES.solana.SOL, factionTreasuryValueAsSol.toString());
+  await sumTokens2({
+    api,
+    solOwners: [SOL_PRIZE_POT, COUNTRY_RACE_SOL_VAULT, STAKER_SOL_REWARD_VAULT],
+  });
 }
 
 /**
@@ -123,13 +88,10 @@ async function tvl(api) {
  * @param {object} api DefiLlama chain API accumulator.
  */
 async function staking(api) {
-  const [stakedDbtc, poolReserves] = await Promise.all([
-    getTokenAccountAmount(STAKED_DBTC_CUSTODIAN),
-    getPoolReserves(),
-  ]);
-
-  const stakedDbtcValueAsSol = getDbtcValueAsSol(stakedDbtc, poolReserves);
-  if (stakedDbtcValueAsSol > 0n) api.add(ADDRESSES.solana.SOL, stakedDbtcValueAsSol.toString());
+  await sumTokens2({
+    api,
+    tokenAccounts: [STAKED_DBTC_CUSTODIAN],
+  });
 }
 
 /**
@@ -146,7 +108,7 @@ module.exports = {
   timetravel: false,
   misrepresentedTokens: true,
   methodology:
-    "TVL includes SOL in the Casino prize pot, Country Race reward vault, staking reward vault, and dBTC in the faction-tax reward vault. Staking tracks user-staked dBTC. Pool2 tracks staked dBTC/SOL LP tokens valued by their pro-rata share of underlying assets in the Raydium pool. dBTC is valued from the on-chain Raydium dBTC/SOL pool because it does not yet have a standalone DefiLlama price feed.",
+    "TVL includes SOL in the Casino prize pot, Country Race reward vault, staking reward vault, and dBTC in the faction-tax reward vault. Staking tracks user-staked dBTC. Pool2 tracks staked dBTC/SOL LP tokens by unwrapping them into their pro-rata share of underlying assets in the Raydium pool.",
   solana: {
     tvl,
     staking,

--- a/projects/minebtc-fun/index.js
+++ b/projects/minebtc-fun/index.js
@@ -10,6 +10,7 @@ const RAYDIUM_POOL_STATE = "F87M4sT6Wtfk4enVVbtM4ZnWsqCE9TXzL12Apwj3Cjtj";
 const POOL_TOKEN0_VAULT = "EMDuS9XZesBDo8urJzwgrKC7qJrLQ6hHXVvSLNE6s3ui";
 const POOL_TOKEN1_VAULT = "79nGAzP7D7GvHe4bPPs4DBHHGXspqE16Kn3w5e9QHEQw";
 const LP_SUPPLY_OFFSET = 333;
+const LP_SUPPLY_SIZE = 8;
 
 // Staking custodians
 const STAKED_DBTC_CUSTODIAN = "HXVe2xLchtKV332QKyh2kRJ6dQf3XxbhsnLGQu4bfLM9";
@@ -22,6 +23,50 @@ const STAKER_SOL_REWARD_VAULT = "FYnbbqMPUetvN22CDeDxAJb4SSXmqZcGEbrwVvoJREvK";
 const FACTION_TREASURY_VAULT = "1gYoc7ojYQdkABsAVFnFQhmYphe532EDnxheRZBDuqr";
 
 /**
+ * Reads the live Raydium dBTC/SOL pool reserves used for dBTC valuation.
+ *
+ * @returns {Promise<{ solInPool: bigint, dbtcInPool: bigint }>} Pool reserves in raw token units.
+ */
+async function getPoolReserves() {
+  const poolVaultBalances = await getTokenAccountBalances(
+    [POOL_TOKEN0_VAULT, POOL_TOKEN1_VAULT],
+    { individual: true, allowError: true },
+  );
+
+  return {
+    solInPool: poolVaultBalances.length >= 1 ? BigInt(poolVaultBalances[0].amount) : 0n,
+    dbtcInPool: poolVaultBalances.length >= 2 ? BigInt(poolVaultBalances[1].amount) : 0n,
+  };
+}
+
+/**
+ * Converts a raw dBTC amount to raw SOL value using the live Raydium reserve ratio.
+ *
+ * @param {bigint} dbtcAmount dBTC amount in raw token units.
+ * @param {{ solInPool: bigint, dbtcInPool: bigint }} poolReserves Raydium pool reserves.
+ * @returns {bigint} SOL value in lamports.
+ */
+function getDbtcValueAsSol(dbtcAmount, { solInPool, dbtcInPool }) {
+  if (dbtcAmount <= 0n || solInPool <= 0n || dbtcInPool <= 0n) return 0n;
+  return (dbtcAmount * solInPool) / dbtcInPool;
+}
+
+/**
+ * Reads the raw token amount held by one SPL token account.
+ *
+ * @param {string} tokenAccount SPL token account address.
+ * @returns {Promise<bigint>} Raw token amount.
+ */
+async function getTokenAccountAmount(tokenAccount) {
+  const tokenAccountInfo = await getTokenAccountBalances(
+    [tokenAccount],
+    { individual: true, allowError: true },
+  );
+
+  return tokenAccountInfo.length > 0 ? BigInt(tokenAccountInfo[0].amount) : 0n;
+}
+
+/**
  * Adds the underlying SOL and dBTC value for MineBTC LP tokens staked in the
  * protocol custodian, using Raydium CP-Swap pool reserves and tracked LP supply.
  *
@@ -30,27 +75,26 @@ const FACTION_TREASURY_VAULT = "1gYoc7ojYQdkABsAVFnFQhmYphe532EDnxheRZBDuqr";
 async function getStakedLpUnderlyingValue(api) {
   const connection = getConnection();
 
-  const [stakedLpInfo, poolVaultBalances, poolStateAccount] = await Promise.all([
+  const [stakedLpInfo, poolReserves, poolStateAccount] = await Promise.all([
     getTokenAccountBalances([STAKED_LP_CUSTODIAN], { individual: true, allowError: true }),
-    getTokenAccountBalances([POOL_TOKEN0_VAULT, POOL_TOKEN1_VAULT], { individual: true, allowError: true }),
+    getPoolReserves(),
     connection.getAccountInfo(new PublicKey(RAYDIUM_POOL_STATE)),
   ]);
 
   const stakedLp = stakedLpInfo.length > 0 ? BigInt(stakedLpInfo[0].amount) : 0n;
   if (stakedLp === 0n) return;
 
-  if (!poolStateAccount || !poolStateAccount.data) return;
+  if (!poolStateAccount?.data || poolStateAccount.data.length < LP_SUPPLY_OFFSET + LP_SUPPLY_SIZE) return;
   const lpTotalSupply = poolStateAccount.data.readBigUInt64LE(LP_SUPPLY_OFFSET);
   if (lpTotalSupply === 0n) return;
 
-  const solInPool = poolVaultBalances.length >= 1 ? BigInt(poolVaultBalances[0].amount) : 0n;
-  const dbtcInPool = poolVaultBalances.length >= 2 ? BigInt(poolVaultBalances[1].amount) : 0n;
-
+  const { solInPool, dbtcInPool } = poolReserves;
   const underlyingSol = (solInPool * stakedLp) / lpTotalSupply;
   const underlyingDbtc = (dbtcInPool * stakedLp) / lpTotalSupply;
+  const dbtcValueAsSol = getDbtcValueAsSol(underlyingDbtc, poolReserves);
+  const lpValueAsSol = underlyingSol + dbtcValueAsSol;
 
-  if (underlyingSol > 0n) api.add(ADDRESSES.solana.SOL, underlyingSol.toString());
-  if (underlyingDbtc > 0n) api.add(DBTC_MINT, underlyingDbtc.toString());
+  if (lpValueAsSol > 0n) api.add(ADDRESSES.solana.SOL, lpValueAsSol.toString());
 }
 
 /**
@@ -59,11 +103,17 @@ async function getStakedLpUnderlyingValue(api) {
  * @param {object} api DefiLlama chain API accumulator.
  */
 async function tvl(api) {
-  await sumTokens2({
-    api,
-    solOwners: [SOL_PRIZE_POT, COUNTRY_RACE_SOL_VAULT, STAKER_SOL_REWARD_VAULT],
-    tokenAccounts: [FACTION_TREASURY_VAULT],
-  });
+  const [factionTreasuryDbtc, poolReserves] = await Promise.all([
+    getTokenAccountAmount(FACTION_TREASURY_VAULT),
+    getPoolReserves(),
+    sumTokens2({
+      api,
+      solOwners: [SOL_PRIZE_POT, COUNTRY_RACE_SOL_VAULT, STAKER_SOL_REWARD_VAULT],
+    }),
+  ]);
+
+  const factionTreasuryValueAsSol = getDbtcValueAsSol(factionTreasuryDbtc, poolReserves);
+  if (factionTreasuryValueAsSol > 0n) api.add(ADDRESSES.solana.SOL, factionTreasuryValueAsSol.toString());
 }
 
 /**
@@ -72,10 +122,13 @@ async function tvl(api) {
  * @param {object} api DefiLlama chain API accumulator.
  */
 async function staking(api) {
-  await sumTokens2({
-    api,
-    tokenAccounts: [STAKED_DBTC_CUSTODIAN],
-  });
+  const [stakedDbtc, poolReserves] = await Promise.all([
+    getTokenAccountAmount(STAKED_DBTC_CUSTODIAN),
+    getPoolReserves(),
+  ]);
+
+  const stakedDbtcValueAsSol = getDbtcValueAsSol(stakedDbtc, poolReserves);
+  if (stakedDbtcValueAsSol > 0n) api.add(ADDRESSES.solana.SOL, stakedDbtcValueAsSol.toString());
 }
 
 /**
@@ -90,8 +143,9 @@ async function pool2(api) {
 
 module.exports = {
   timetravel: false,
+  misrepresentedTokens: true,
   methodology:
-    "TVL includes SOL in the Casino prize pot, Country Race reward vault, staking reward vault, and dBTC in the faction-tax reward vault. Staking tracks user-staked dBTC. Pool2 tracks staked dBTC/SOL LP tokens valued by their pro-rata share of underlying assets in the Raydium pool.",
+    "TVL includes SOL in the Casino prize pot, Country Race reward vault, staking reward vault, and dBTC in the faction-tax reward vault. Staking tracks user-staked dBTC. Pool2 tracks staked dBTC/SOL LP tokens valued by their pro-rata share of underlying assets in the Raydium pool. dBTC is valued from the on-chain Raydium dBTC/SOL pool because it does not yet have a standalone DefiLlama price feed.",
   solana: {
     tvl,
     staking,

--- a/projects/minebtc-fun/index.js
+++ b/projects/minebtc-fun/index.js
@@ -5,10 +5,11 @@ const ADDRESSES = require("../helper/coreAssets.json");
 // MineBTC Program: 1eotiTH2UxCpPMmtzUDGqf1b8dwM7AMKb8a2Tio51an
 const DBTC_MINT = "CtAu3kc8cQ1jcDMmRTBsDHoPuE3sswCagQ3BuqFDC6dt";
 
-// Raydium CP-Swap Pool (dBTC/SOL)
+// Raydium CP-Swap pool reserves used for dBTC valuation.
+// On-chain token0 vault is wrapped SOL; token1 vault is dBTC.
 const RAYDIUM_POOL_STATE = "F87M4sT6Wtfk4enVVbtM4ZnWsqCE9TXzL12Apwj3Cjtj";
-const POOL_TOKEN0_VAULT = "EMDuS9XZesBDo8urJzwgrKC7qJrLQ6hHXVvSLNE6s3ui";
-const POOL_TOKEN1_VAULT = "79nGAzP7D7GvHe4bPPs4DBHHGXspqE16Kn3w5e9QHEQw";
+const POOL_SOL_VAULT = "EMDuS9XZesBDo8urJzwgrKC7qJrLQ6hHXVvSLNE6s3ui";
+const POOL_DBTC_VAULT = "79nGAzP7D7GvHe4bPPs4DBHHGXspqE16Kn3w5e9QHEQw";
 const LP_SUPPLY_OFFSET = 333;
 const LP_SUPPLY_SIZE = 8;
 
@@ -23,13 +24,13 @@ const STAKER_SOL_REWARD_VAULT = "FYnbbqMPUetvN22CDeDxAJb4SSXmqZcGEbrwVvoJREvK";
 const FACTION_TREASURY_VAULT = "1gYoc7ojYQdkABsAVFnFQhmYphe532EDnxheRZBDuqr";
 
 /**
- * Reads the live Raydium dBTC/SOL pool reserves used for dBTC valuation.
+ * Reads the live Raydium pool reserves used for dBTC valuation.
  *
  * @returns {Promise<{ solInPool: bigint, dbtcInPool: bigint }>} Pool reserves in raw token units.
  */
 async function getPoolReserves() {
   const poolVaultBalances = await getTokenAccountBalances(
-    [POOL_TOKEN0_VAULT, POOL_TOKEN1_VAULT],
+    [POOL_SOL_VAULT, POOL_DBTC_VAULT],
     { individual: true, allowError: true },
   );
 

--- a/projects/minebtc/index.js
+++ b/projects/minebtc/index.js
@@ -72,6 +72,7 @@ async function pool2(api) {
 }
 
 module.exports = {
+  deadFrom: "2026-05-19",
   timetravel: false,
   methodology:
     "TVL includes SOL in the betting prize pot. Staking tracks user-staked DogeBTC. Pool2 tracks staked DogeBTC/SOL LP tokens valued by their pro-rata share of underlying assets in the Raydium pool.",

--- a/projects/treasury/minebtc-fun.js
+++ b/projects/treasury/minebtc-fun.js
@@ -1,0 +1,25 @@
+const { sumTokens2 } = require("../helper/solana");
+
+// Protocol-owned SOL vaults
+const SOL_TREASURY = "2TU3jP7vnhPD1ksVmSMQhuAauuFCuj9magtMWDW65jEx";
+const BUYBACKS_SOL_VAULT = "DdatmQD4g2vQdgAw7RvdZFYSouTEB4ebjXWAqH1T86rs";
+const NFT_SWEEP_SOL_VAULT = "4XDwhMaA98MaiVXpiqbevr9Kwmp9xGV2nGzQVeF7hbRq";
+
+/**
+ * Tracks protocol-owned SOL balances held by MineBTC treasury, buyback, and
+ * NFT sweep vaults.
+ *
+ * @param {object} api DefiLlama chain API accumulator.
+ */
+async function tvl(api) {
+  await sumTokens2({
+    api,
+    solOwners: [SOL_TREASURY, BUYBACKS_SOL_VAULT, NFT_SWEEP_SOL_VAULT],
+  });
+}
+
+module.exports = {
+  solana: {
+    tvl,
+  },
+};

--- a/projects/treasury/minebtc.js
+++ b/projects/treasury/minebtc.js
@@ -10,6 +10,7 @@ const NFT_FLOOR_SWEEP_VAULT = "DRvR4WpLj85Lfvwk3im7Ucrz1s9FPLPUtrTihUiqaPve";
 const STAKER_SOL_REWARD_VAULT = "HiGNRiXWrqtFbwEH1YKQVHommFU15auksXbe7Qv7Nrrb";
 
 module.exports = {
+  deadFrom: "2026-05-19",
   solana: {
     tvl: async (api) => {
       await sumTokens2({


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

Enabled. `maintainerCanModify` is true for this PR.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).

2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** It is a different repo, you can find your listing in [this file](https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts), you can edit it there and put up a PR
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes

---
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
MineBTC

##### Twitter Link:
https://x.com/minebtcdotfun

##### List of audit links if any:
None

##### Website Link:
https://minebtc.fun

##### Logo (High resolution, will be shown with rounded borders):
https://assets.minebtc.fun/brand/defillama/minebtc-logo-2026-06-04.png

##### Current TVL:
Latest local adapter output after dBTC pool valuation:
- Base TVL: approx. $65.47
- Staking: approx. $1.19k
- Pool2: approx. $5.54

DefiLlama displays staking and pool2 as separate buckets from base TVL. Treasury adapter output is approx. $19.02.

##### Treasury Addresses (if the protocol has treasury)
- SOL treasury: https://solscan.io/account/2TU3jP7vnhPD1ksVmSMQhuAauuFCuj9magtMWDW65jEx
- Buybacks SOL vault: https://solscan.io/account/DdatmQD4g2vQdgAw7RvdZFYSouTEB4ebjXWAqH1T86rs
- NFT sweep SOL vault: https://solscan.io/account/4XDwhMaA98MaiVXpiqbevr9Kwmp9xGV2nGzQVeF7hbRq

##### Chain:
Solana

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description (to be shown on DefiLlama):
MineBTC is a Solana casino-mining game where players run SOL autominers, call country-race outcomes, and earn dBTC through Casino rolls, Country Race payouts, staking rewards, buybacks, and burned LP. HashBeast NFTs add boosts, identity, and game events.

##### Token address and ticker if any:
dBTC: https://solscan.io/token/CtAu3kc8cQ1jcDMmRTBsDHoPuE3sswCagQ3BuqFDC6dt

##### Category (full list at https://defillama.com/categories) \*Please choose only one:
Gamified Mining

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
None. This adapter reads on-chain Solana accounts and Raydium CP-Swap pool state directly.

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
No external oracle is integrated for TVL calculation. The adapter reads Solana vault balances, staking custodian token accounts, and the Raydium CP-Swap pool state / vault reserves on-chain.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
- Website: https://minebtc.fun
- Program: https://solscan.io/account/1eotiTH2UxCpPMmtzUDGqf1b8dwM7AMKb8a2Tio51an
- dBTC mint: https://solscan.io/token/CtAu3kc8cQ1jcDMmRTBsDHoPuE3sswCagQ3BuqFDC6dt
- Raydium CP-Swap pool state: https://solscan.io/account/F87M4sT6Wtfk4enVVbtM4ZnWsqCE9TXzL12Apwj3Cjtj
- Open-source contracts: https://github.com/LifeOrDream/MineBtc-fi
- Frontend: https://github.com/LifeOrDream/mdogeWifBtcFE

##### forkedFrom (Does your project originate from another project):
No

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL includes SOL in the Casino prize pot, Country Race reward vault, staking reward vault, and dBTC in the faction-tax reward vault. Staking tracks user-staked dBTC. Pool2 tracks staked dBTC/SOL LP tokens valued by their pro-rata share of underlying assets in the Raydium CP-Swap pool. Because dBTC does not yet have a standalone DefiLlama price feed, dBTC amounts are valued from the on-chain Raydium dBTC/SOL reserve ratio. Treasury tracks protocol-owned SOL vaults only.

Relevant accounts:
- Casino SOL prize pot: https://solscan.io/account/AMuDuGgeWtmT3b7QPCAqQTducxV1Z2s6GjDY2gwGE91C
- Country Race SOL vault: https://solscan.io/account/DRnKgn51Mm7t1UneFD6Je5B6XLWmFt9gBdJN5xPcXfMB
- Staking SOL reward vault: https://solscan.io/account/FYnbbqMPUetvN22CDeDxAJb4SSXmqZcGEbrwVvoJREvK
- Faction-tax dBTC reward vault: https://solscan.io/account/1gYoc7ojYQdkABsAVFnFQhmYphe532EDnxheRZBDuqr
- Staked dBTC custodian: https://solscan.io/account/HXVe2xLchtKV332QKyh2kRJ6dQf3XxbhsnLGQu4bfLM9
- Staked LP custodian: https://solscan.io/account/EJ7ZomjToiB68rNFRa83wrBD11rvmDEa29PbJ4ct8ciW
- Raydium pool state: https://solscan.io/account/F87M4sT6Wtfk4enVVbtM4ZnWsqCE9TXzL12Apwj3Cjtj

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/LifeOrDream

##### Does this project have a referral program?
Yes. MineBTC supports referral rewards in-game; referral payouts are separate from the TVL methodology above.

---

## Validation
- `node test.js projects/minebtc-fun/index.js`
- `node test.js projects/treasury/minebtc-fun.js`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MineBTC TVL tracking on Solana: includes staking, LP positions (pool2), and on-chain vault/reserve valuation that credits SOL and dBTC separately (no dBTC→SOL conversion).
  * Separate treasury TVL adapter aggregating protocol-owned SOL vaults.
  * Added deprecation metadata (deadFrom) for MineBTC deployments.

* **Chores**
  * Solana adapters exported with timetravel disabled and misrepresentedTokens flagged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

