### PR TITLE
Add ClaimRush (Base) TVL adapter

### DIFF
--- a/projects/claimrush/index.js
+++ b/projects/claimrush/index.js
@@ -7,7 +7,7 @@ const LP_STAKING_VAULT_7D = '0xafdbB422CF75D6f2C557BDD2EF955c518b086271';
 const GENESIS_LP_VAULT_24M = '0x1532F33e53680f89d083a0bf5baedcCCD2E7267a';
 const AERODROME_WETH_CLAIM_POOL = '0x7274599ec9DBf15D474A6FB18aA285aE001d87Aa';
 
-async function tvl(api) {
+async function pool2(api) {
   return sumTokens2({
     api,
     tokensAndOwners: [
@@ -20,9 +20,10 @@ async function tvl(api) {
 
 module.exports = {
   methodology:
-    'TVL = Aerodrome v2 vAMM WETH/CLAIM LP tokens custodied by LpStakingVault7D (7-day rolling staking position for active stakers) plus GenesisLPVault24M (24-month time-locked genesis seed liquidity). LP tokens are unwrapped into their underlying WETH and CLAIM reserves. Staking bucket = CLAIM principal locked in VeClaimNFT (voting-escrow NFT, max 1-year linear-decay locks) to receive a pro-rata share of ETH royalties from every Mine takeover.',
+    'Pool2 = Aerodrome v2 vAMM WETH/CLAIM LP tokens custodied by LpStakingVault7D (7-day rolling staking position for active stakers) plus GenesisLPVault24M (24-month time-locked genesis seed liquidity). LP tokens are unwrapped into their underlying WETH and CLAIM reserves. Staking bucket = CLAIM principal locked in VeClaimNFT (voting-escrow NFT, max 1-year linear-decay locks) to receive a pro-rata share of ETH royalties from every Mine takeover.',
   base: {
-    tvl,
+    tvl: () => ({}),
+    pool2,
     staking: staking(VE_CLAIM, CLAIM),
   },
 };

--- a/projects/claimrush/index.js
+++ b/projects/claimrush/index.js
@@ -1,0 +1,28 @@
+const { sumTokens2 } = require('../helper/unwrapLPs');
+const { staking } = require('../helper/staking');
+
+const CLAIM = '0x059D278233fEC14CB6D1A74E6FB482BC3f91ADbf';
+const VE_CLAIM = '0x876Da22a5bBEe4f8963b791631D2cAC5199389eE';
+const LP_STAKING_VAULT_7D = '0xafdbB422CF75D6f2C557BDD2EF955c518b086271';
+const GENESIS_LP_VAULT_24M = '0x1532F33e53680f89d083a0bf5baedcCCD2E7267a';
+const AERODROME_WETH_CLAIM_POOL = '0x7274599ec9DBf15D474A6FB18aA285aE001d87Aa';
+
+async function tvl(api) {
+  return sumTokens2({
+    api,
+    tokensAndOwners: [
+      [AERODROME_WETH_CLAIM_POOL, LP_STAKING_VAULT_7D],
+      [AERODROME_WETH_CLAIM_POOL, GENESIS_LP_VAULT_24M],
+    ],
+    resolveLP: true,
+  });
+}
+
+module.exports = {
+  methodology:
+    'TVL = Aerodrome v2 vAMM WETH/CLAIM LP tokens custodied by LpStakingVault7D (7-day rolling staking position for active stakers) plus GenesisLPVault24M (24-month time-locked genesis seed liquidity). LP tokens are unwrapped into their underlying WETH and CLAIM reserves. Staking bucket = CLAIM principal locked in VeClaimNFT (voting-escrow NFT, max 1-year linear-decay locks) to receive a pro-rata share of ETH royalties from every Mine takeover.',
+  base: {
+    tvl,
+    staking: staking(VE_CLAIM, CLAIM),
+  },
+};


### PR DESCRIPTION
<!--
PR body for the ClaimRush TVL adapter submission to DefiLlama/DefiLlama-Adapters.
Paste this into the PR description on github.com when opening the PR.
Remove this HTML comment block before pasting.
-->

#### Please enable "Allow edits by maintainers" while putting up the PR.

This PR adds a TVL adapter for **ClaimRush** under `projects/claimrush/index.js`. Adapter computes TVL purely from on-chain reads (no fetch / no third-party API), via the canonical `sumTokens2` + `staking` helpers in this repo. The companion listing-metadata PR for `DefiLlama/defillama-server` (`defi/src/protocols/data6.ts`, id `"7960"`) is queued for submission after this adapter PR merges.

---

## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
ClaimRush

##### Twitter Link:
https://x.com/claimrushgame

##### List of audit links if any:
ClaimRush's public-facing security policy + disclosure pointer is at:
https://github.com/claimrush/claimrush/blob/main/SECURITY.md

The v1.0.0 internal security architecture (pre-implementation audit, global invariants, onchain threat map, CI security gates, verification + audit plan, security-test-matrix, third-party trust inventory, etc.) is maintained as an internal documentation set and shared directly with researchers / auditors / reviewers on request during coordinated disclosure — see the "Security documentation" section of SECURITY.md. Reviewer-access copies available on request to `security@claimru.sh`.

External third-party audit is scheduled post-soak (Phase 8 — Freeze-and-Burn). Will update `audits: "2"` and add the external audit URL via a follow-up `data6.ts` PR once it lands.

##### Website Link:
https://claimru.sh

##### Logo (High resolution, will be shown with rounded borders):
https://claimru.sh/brand/claimrush-defillama-512.jpg

512×512 JPG, canonical ClaimRush Ink background (`#0A0D14`) baked in (matches DefiLlama's `${baseIconsUrl}/<slug>.jpg` convention — JPG, no transparency, branded surface). 256×256 variant also available at `/brand/claimrush-defillama-256.jpg`. The canonical transparent-background SVG / PNG variants used by all other surfaces live at `/brand/claimrush-icon-color.svg` and `/brand/claimrush-icon-color-{64,200,256}.png`.

##### Current TVL:
~$208k base.tvl + ~$17k base.staking as of 2026-05-31 ~22:30 UTC. CLAIM is a 2-day-old genesis token (mainnet launched 2026-05-29). LP-bucket composition: 98.18% is the 24-month time-locked seed liquidity in `GenesisLPVault24M`; 1.82% is user-deposited LP in `LpStakingVault7D` (the 7-day rolling staking position, sourced from an external EOA who added Aerodrome liquidity and staked the resulting LP). Expect organic growth as more users stake LP and lock CLAIM in veCLAIM for the ETH royalty stream.

##### Treasury Addresses (if the protocol has treasury):
The protocol has no separate off-chain treasury wallet. All protocol-locked value sits in the on-chain vaults already counted by this adapter:
- `GenesisLPVault24M` (`0x1532F33e53680f89d083a0bf5baedcCCD2E7267a`) — 24-month time-locked LP seed
- `LpStakingVault7D` (`0xafdbB422CF75D6f2C557BDD2EF955c518b086271`) — 7-day rolling LP staking (user deposits)
- `VeClaimNFT` (`0x876Da22a5bBEe4f8963b791631D2cAC5199389eE`) — ve-locked CLAIM (counted under `staking`)

##### Chain:
Base

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):
Not yet listed. Submitted to CoinGecko 2026-06-01; will update `gecko_id` via follow-up `data6.ts` PR once the listing is approved.

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):
Not yet listed. Submitted to CoinMarketCap 2026-06-01; will update `cmcId` via follow-up `data6.ts` PR once approved.

##### Short Description (to be shown on DefiLlama):
Onchain king-of-the-hill game on Base. Pay ETH to take the Mine. Hold the Crown to earn $CLAIM emissions. Lock $CLAIM in veCLAIM to receive ETH royalties from every takeover.

##### Token address and ticker if any:
- $CLAIM ERC-20: `0x059D278233fEC14CB6D1A74E6FB482BC3f91ADbf` (Base)
- VeClaimNFT ERC-721 (ve-locked positions): `0x876Da22a5bBEe4f8963b791631D2cAC5199389eE` (Base)

##### Category (full list at https://defillama.com/categories) \*Please choose only one:
Yield Aggregator

Rationale: the core value flow is yield-shaped — ETH paid on every Mine takeover routes through `ShareholderRoyalties` to ve-CLAIM lockers pro-rata to ve-share. Same category Aerodrome / Velodrome / Curve use for their ve-token royalty mechanics on DefiLlama. The gameplay layer (King-of-the-Hill mechanic) is the source of the yield; the category groups by where the value lives (LP vaults + ve-locked principal), which matches Yield Aggregator's taxonomy.

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
None on-chain. ClaimRush's Solidity contracts do not call any oracle (verified: `rg "chainlink|AggregatorV3|priceFeed|latestRoundData" src/` returns zero matches). The TVL adapter has no oracle dependency.

For completeness: the frontend + indexer consume the Chainlink ETH/USD feed on Base (`0x71041dddad3595F9CEd3DcCFBe3D1F4b0a16Bb70`) off-chain to render USD-denominated displays. This is documented as "UI/indexer only" in the canonical deployment manifest (see Documentation/Proof below).

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
There is no on-chain oracle integration. The Chainlink ETH/USD feed is read off-chain by:
- the frontend (`frontend/src/lib/usd.ts`-style helpers) for displaying USD prices in the UI
- the indexer / analytics layer for historical USD denomination of takeover ETH flows

Neither path affects TVL computation by this adapter, which prices all balances via DefiLlama's existing Aerodrome WETH/CLAIM pool index for CLAIM and the canonical WETH mapping for WETH. No oracle failure mode can mis-state our reported TVL.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
- The canonical deployment manifest at https://github.com/claimrush/claimrush/blob/main/deployments/base_mainnet.md lists the ETH/USD feed under its "Chainlink" section and annotates it as `used for USD-denominated displays (UI/indexer only)` — i.e. the feed is referenced as an off-chain dependency, not an on-chain integration.
- The internal trust-boundary writeups (`security-architecture-and-trust-boundaries-v1.0.0.md` oracle section, `third-party-trust-inventory-live-v1.0.0.md` Chainlink-feed entry) are part of the coordinated-disclosure docset shared via `security@claimru.sh` per [SECURITY.md](https://github.com/claimrush/claimrush/blob/main/SECURITY.md). Happy to forward those to a maintainer if needed for review.

##### forkedFrom (Does your project originate from another project):
No — ClaimRush is greenfield protocol code. The Aerodrome WETH/CLAIM pool used as the primary liquidity venue is Aerodrome v2 (vAMM), which itself forks from Solidly / Velodrome v2, but ClaimRush contracts are not a fork of any existing protocol.

##### methodology (what is being counted as tvl, how is tvl being calculated):

**TVL bucket (`base.tvl`)**: Sum of Aerodrome WETH/CLAIM LP tokens custodied by:
- `LpStakingVault7D` (`0xafdbB422CF75D6f2C557BDD2EF955c518b086271`) — 7-day rolling staking position, user-deposited LP earning CLAIM emissions
- `GenesisLPVault24M` (`0x1532F33e53680f89d083a0bf5baedcCCD2E7267a`) — 24-month genesis seed liquidity, time-locked

LP tokens are unwrapped into their underlying WETH and CLAIM reserves via this repo's `sumTokens2({ resolveLP: true })` helper, then priced via DefiLlama's existing Aerodrome WETH/CLAIM pool indexing.

**Staking bucket (`base.staking`)**: CLAIM principal locked in `VeClaimNFT` (`0x876Da22a5bBEe4f8963b791631D2cAC5199389eE`) — the voting-escrow ERC-721 (max 1-year linear-decay locks). Locked CLAIM entitles holders to a pro-rata share of ETH royalties from every Mine takeover (25% of each takeover ETH flows to lockers, weighted by veCLAIM share). Read via standard `CLAIM.balanceOf(VeClaimNFT)` — confirmed equivalent to the protocol's own `VeClaimNFT.totalLockedClaim()` accounting view (no fee-on-transfer, no rebasing, no donation drift; invariant proven via Echidna properties + concrete tests in the internal security-test-matrix, shared via coordinated disclosure per SECURITY.md).

**Excluded** (not TVL):
- `ShareholderRoyalties` — ETH royalties in transit between takeover and weekly settlement; flow-through, not protocol-locked.
- `MarketRouter` — escrowed buyer ETH for in-flight veCLAIM secondary-market trades; counterparty funds in transit.
- `Furnace` — ETH-to-CLAIM swap engine; transient ETH balance only, no protocol custody.

##### Github org/user (Optional, if your code is open source, we can track activity):
claimrush

(Public repo: https://github.com/claimrush/claimrush)

##### Does this project have a referral program?
No.

---

## Smoke-test output (run locally 2026-05-31 ~22:30 UTC)

```
$ node test.js projects/claimrush/index.js

--- base-staking ---
CLAIM                     17.34 k
Total: 17.34 k

--- base ---
WETH                      109.21 k
CLAIM                     99.03 k
Total: 208.24 k

--- staking ---
CLAIM                     17.34 k
Total: 17.34 k

--- tvl ---
WETH                      109.21 k
CLAIM                     99.03 k
Total: 208.24 k

------ TVL ------
base                      208.24 k
base-staking              17.34 k
staking                   17.34 k

total                    208.24 k
```

Note: the `base.tvl` bucket may render as either a single `vAMM-CLAIM/WETH ~$XXX k` line (when DefiLlama's pricing engine has indexed the Aerodrome LP token directly) or the unwrapped `WETH ~$XXX k + CLAIM ~$YYY k` pair (when the pricing engine falls back to underlying-reserve pricing). Both are valid views of the same underlying state; the variance is expected during the first few days post-genesis and converges as the LP-token price feed stabilises.

Cross-checked against direct RPC reads at submission time:
- Pool reserves: 40,967,635.05 CLAIM (token0) + 54.36 WETH (token1)
- LP total supply: 47,190.66; `LpStakingVault7D` holds 856.55 (1.82%, user-deposited), `GenesisLPVault24M` holds 46,334.11 (98.18%, genesis seed). Remaining 1000 wei is the Aerodrome v2 first-mint MINIMUM_LIQUIDITY burn.
- `VeClaimNFT.totalLockedClaim()` = `CLAIM.balanceOf(VeClaimNFT)` = 7,172,182.61 CLAIM (zero drift between accounting view and ERC-20 balance — confirms the M-class disjoint-buckets invariant from the internal `invariants-v1.0.0.md` §11; available on coordinated-disclosure request).
- LP-bucket pricing comes from DefiLlama's own Aerodrome WETH/CLAIM pool indexing; the adapter passes `resolveLP: true` so the LP is unwrapped into underlying WETH+CLAIM reserves when DefiLlama's pricing engine doesn't yet have a stable direct LP-token price (which is the typical path for a 2-day-old pool — see the variance note attached to the smoke-test output above). The two paths converge as the LP-token price feed stabilises.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking Aerodrome v2 WETH/CLAIM liquidity pool tokens
  * Added staking support for VE_CLAIM tokens
  * Added methodology documentation for TVL calculations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->