### PR TITLE
claimrush: surface locked CLAIM as tvl (was staking)

### DIFF
--- a/projects/claimrush/index.js
+++ b/projects/claimrush/index.js
@@ -1,11 +1,17 @@
 const { sumTokens2 } = require('../helper/unwrapLPs');
-const { staking } = require('../helper/staking');
 
 const CLAIM = '0x059D278233fEC14CB6D1A74E6FB482BC3f91ADbf';
 const VE_CLAIM = '0x876Da22a5bBEe4f8963b791631D2cAC5199389eE';
 const LP_STAKING_VAULT_7D = '0xafdbB422CF75D6f2C557BDD2EF955c518b086271';
 const GENESIS_LP_VAULT_24M = '0x1532F33e53680f89d083a0bf5baedcCCD2E7267a';
 const AERODROME_WETH_CLAIM_POOL = '0x7274599ec9DBf15D474A6FB18aA285aE001d87Aa';
+
+async function tvl(api) {
+  return sumTokens2({
+    api,
+    tokensAndOwners: [[CLAIM, VE_CLAIM]],
+  });
+}
 
 async function pool2(api) {
   return sumTokens2({
@@ -20,10 +26,9 @@ async function pool2(api) {
 
 module.exports = {
   methodology:
-    'Pool2 = Aerodrome v2 vAMM WETH/CLAIM LP tokens custodied by LpStakingVault7D (7-day rolling staking position for active stakers) plus GenesisLPVault24M (24-month time-locked genesis seed liquidity). LP tokens are unwrapped into their underlying WETH and CLAIM reserves. Staking bucket = CLAIM principal locked in VeClaimNFT (voting-escrow NFT, max 1-year linear-decay locks) to receive a pro-rata share of ETH royalties from every Mine takeover.',
+    'TVL = CLAIM principal locked in VeClaimNFT (voting-escrow ERC-721, max 1-year linear-decay locks). veCLAIM holders receive a pro-rata share of ETH royalties from every Mine takeover (25% of each takeover ETH flows to lockers, weighted by veCLAIM share). This is the productive long-term-locked, ETH-yield-bearing position and the correct denominator for the protocol\'s ETH-royalty APR. Pool2 = Aerodrome v2 vAMM WETH/CLAIM LP tokens custodied by LpStakingVault7D (7-day rolling stake for active LP stakers) and GenesisLPVault24M (24-month time-locked genesis seed liquidity). LP positions earn CLAIM emissions (token issuance) rather than ETH royalties, so they are reported under pool2 (protocol-native LP) per DefiLlama convention. LP tokens are unwrapped into their underlying WETH and CLAIM reserves.',
   base: {
-    tvl: () => ({}),
+    tvl,
     pool2,
-    staking: staking(VE_CLAIM, CLAIM),
   },
 };


### PR DESCRIPTION
Small follow-up to #19495 (the ClaimRush adapter, merged earlier today as `8401761`) — refines the bucket shape so the headline TVL number matches the productive ETH-yield-bearing position.

## Why

Current state on `main` after #19495 was merged:

| Bucket | Content | Live value |
|---|---|---|
| `tvl` | `() => ({})` (empty) | $0 |
| `pool2` | Aerodrome WETH/CLAIM LP positions | ~$218k |
| `staking` | locked CLAIM in `VeClaimNFT` | ~$19k |

This makes the headline TVL on `defillama.com/protocol/claimrush` read **$0**, with both productive buckets shown as side metrics. The locked CLAIM (`staking`) is actually the only ETH-yield-bearing position in the protocol — every Mine takeover routes 25% of its ETH to veCLAIM lockers pro-rata to ve-share — so it's a more accurate denominator for ETH-royalty APR display than either the empty `tvl` bucket or the `pool2` bucket would be.

ClaimRush has three positions with very different economic semantics:

| Position | Capital type | Yield earned | Right DefiLlama bucket |
|---|---|---|---|
| `VeClaimNFT` (locked CLAIM) | User capital, ≤1-year linear-decay lock | **ETH royalties** (25% of every Mine takeover) | `tvl` (productive ETH-yield position) |
| `LpStakingVault7D` (user LP) | User capital, 7-day rolling stake | CLAIM emissions (token issuance) | `pool2` (protocol-native LP) |
| `GenesisLPVault24M` (protocol seed) | Protocol-owned, 24-month time-lock | CLAIM emissions | `pool2` (protocol-native LP) |

Same pattern Convex / Olympus / Pendle / various LSDs use for protocols where the lock IS the yield-bearing position (as opposed to vanilla governance staking, which the `staking` bucket was designed for).

## What changed

```diff
- async function tvl(api) { ... }   // was renamed to pool2 at merge time
+ async function tvl(api) {
+   return sumTokens2({
+     api,
+     tokensAndOwners: [[CLAIM, VE_CLAIM]],
+   });
+ }
  ...
  module.exports = {
    methodology: '... (updated to cover both buckets) ...',
    base: {
-     tvl: () => ({}),
+     tvl,
      pool2,
-     staking: staking(VE_CLAIM, CLAIM),
    },
  };
```

- `tvl` now reads the CLAIM ERC-20 balance held by `VeClaimNFT` directly (raw token balance, no LP-detection trigger). This is the same value the `staking` helper was reading.
- `pool2` is unchanged (LP positions stay where they belong).
- `staking` export dropped (the value moved into `tvl`).
- `methodology` string rewritten to document the bucket distinction explicitly.

## Smoke output (local, 2026-06-01 ~00:48 UTC)

```
$ node test.js projects/claimrush/index.js

--- tvl ---
CLAIM                     19.17 k
Total: 19.17 k

--- pool2 ---
WETH                      111.40 k
CLAIM                     107.55 k
Total: 218.95 k

------ TVL ------
base                      19.18 k
base-pool2                218.95 k
total                    19.17 k
```

Live behavior cross-check:

- `cast call CLAIM "balanceOf(address)" VE_CLAIM` → `7172182607308538278169631 wei` = `7,172,182.61 CLAIM` (matches `tvl` bucket at ~$0.0027/CLAIM ≈ $19.17k)
- Pool reserves: `40,967,635.05 CLAIM + 54.36 WETH` (matches `pool2` underlying unwrap)

I have "Allow edits by maintainers" enabled on this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed TVL calculation to accurately report total value locked instead of displaying zero.

* **Documentation**
  * Updated methodology description to clarify ETH-royalty denomination and LP position reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->