### PR TITLE
Add JackCo adapter (no-loss lottery on Base)

### DIFF
--- a/projects/jackco/index.js
+++ b/projects/jackco/index.js
@@ -1,25 +1,62 @@
 const ADDRESSES = require('../helper/coreAssets.json')
 
-// JackCo: No-loss lottery on Base — deposits earn yield across Aave, Morpho, Pendle;
+// JackCo: No-loss lottery — deposits earn yield across Aave, Morpho, Pendle;
 // weekly prize pool funded entirely by yield (principal always 100% safe).
 //
-// TVL = USDC managed by JackCoVault, including assets deployed to yield adapters.
-// totalAssets() is the ERC-4626 standard view function tracking _totalManagedAssets,
-// which is incremented on deposit, decremented on withdrawal, and synced to
-// strategyManager.totalValue() + vaultBalance via syncTotalAssets() (keeper-called weekly).
+// TVL = USDC managed by each chain's JackCoVault (ERC-4626).
+// totalAssets() tracks _totalManagedAssets (incremented on deposit, decremented
+// on withdrawal, synced weekly to strategyManager.totalValue() + vaultBalance).
 
-const VAULT   = '0xB751a4831A893a2feaC6D9642E6680f13D8dbDD2'
-const USDC    = ADDRESSES.base.USDC  // 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913
+const config = {
+  // Base (8453) — primary chain
+  base: {
+    vault: '0xB751a4831A893a2feaC6D9642E6680f13D8dbDD2',
+    usdc:  ADDRESSES.base.USDC,  // 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913
+  },
+  // Ethereum mainnet (1)
+  ethereum: {
+    vault: '0x0e710E542033f3D4292A6E0B0A69923e0B6b43CF',
+    usdc:  ADDRESSES.ethereum.USDC,  // 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48
+  },
+  // Arbitrum (42161)
+  arbitrum: {
+    vault: '0xbA30Fcfb482c8897D9fBDD55cf1606f4442A6a43',
+    usdc:  ADDRESSES.arbitrum.USDC,
+  },
+  // Optimism (10)
+  optimism: {
+    vault: '0x498f98E70968Be25D770a812F2a1a458f1Ee79Be',
+    usdc:  ADDRESSES.optimism.USDC,
+  },
+  // Polygon (137)
+  polygon: {
+    vault: '0x498f98E70968Be25D770a812F2a1a458f1Ee79Be',
+    usdc:  ADDRESSES.polygon.USDC,
+  },
+  // BSC (56)
+  bsc: {
+    vault: '0x498f98E70968Be25D770a812F2a1a458f1Ee79Be',
+    usdc:  ADDRESSES.bsc.USDC,
+  },
+  // Avalanche (43114)
+  avax: {
+    vault: '0x498f98E70968Be25D770a812F2a1a458f1Ee79Be',
+    usdc:  ADDRESSES.avax.USDC,
+  },
+}
 
 async function tvl(api) {
+  const { vault, usdc } = config[api.chain]
   const total = await api.call({
-    target: VAULT,
+    target: vault,
     abi:    'uint256:totalAssets',
   })
-  api.add(USDC, total)
+  api.add(usdc, total)
 }
 
 module.exports = {
-  methodology: 'Counts USDC deposited in the JackCo no-loss lottery vault on Base (ERC-4626). TVL includes funds deployed across Aave, Morpho, and Pendle yield adapters, as tracked by the vault\'s totalAssets() which is synced with the StrategyManager weekly.',
-  base: { tvl },
+  methodology: 'Counts USDC deposited in JackCo no-loss lottery vaults (ERC-4626) across all deployed chains. TVL includes funds deployed across Aave, Morpho, and Pendle yield adapters, as tracked by each vault\'s totalAssets(), synced weekly with the StrategyManager.',
+  ...Object.fromEntries(
+    Object.keys(config).map(chain => [chain, { tvl }])
+  ),
 }

--- a/projects/jackco/index.js
+++ b/projects/jackco/index.js
@@ -1,0 +1,25 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+
+// JackCo: No-loss lottery on Base — deposits earn yield across Aave, Morpho, Pendle;
+// weekly prize pool funded entirely by yield (principal always 100% safe).
+//
+// TVL = USDC managed by JackCoVault, including assets deployed to yield adapters.
+// totalAssets() is the ERC-4626 standard view function tracking _totalManagedAssets,
+// which is incremented on deposit, decremented on withdrawal, and synced to
+// strategyManager.totalValue() + vaultBalance via syncTotalAssets() (keeper-called weekly).
+
+const VAULT   = '0xB751a4831A893a2feaC6D9642E6680f13D8dbDD2'
+const USDC    = ADDRESSES.base.USDC  // 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913
+
+async function tvl(api) {
+  const total = await api.call({
+    target: VAULT,
+    abi:    'uint256:totalAssets',
+  })
+  api.add(USDC, total)
+}
+
+module.exports = {
+  methodology: 'Counts USDC deposited in the JackCo no-loss lottery vault on Base (ERC-4626). TVL includes funds deployed across Aave, Morpho, and Pendle yield adapters, as tracked by the vault\'s totalAssets() which is synced with the StrategyManager weekly.',
+  base: { tvl },
+}


### PR DESCRIPTION
## JackCo — No-Loss Lottery on Base

**Website:** https://jackco.net  
**Chain:** Base (chainId 8453)  
**Category:** Yield / Prize Savings

### What is JackCo?

JackCo is a no-loss prize savings protocol on Base. Users deposit USDC which is deployed across Aave, Morpho, and Pendle to generate yield. The yield funds a weekly prize draw (using Chainlink VRF) while 100% of principal is always withdrawable.

### TVL Definition

**TVL = USDC managed by JackCoVault**, including assets deployed to yield adapters.

- Contract: [JackCoVault](https://basescan.org/address/0xB751a4831A893a2feaC6D9642E6680f13D8dbDD2) (ERC-4626)
- Underlying: USDC (`0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`)
- Strategy: ~65% deployed across Aave (30%), Morpho (25%), Pendle (10%); ~35% idle in vault

### Methodology

`totalAssets()` is called on the ERC-4626 vault. This returns `_totalManagedAssets`, an internal tracking variable that is:
- incremented on every deposit
- decremented on every withdrawal
- synced weekly to `strategyManager.totalValue() + vaultBalance` by the keeper bot via `syncTotalAssets()`

This ensures TVL includes both idle USDC in the vault and USDC deployed across yield adapters.

### Verification

```bash
# On-chain check (Base mainnet)
cast call 0xB751a4831A893a2feaC6D9642E6680f13D8dbDD2 "totalAssets()(uint256)" \
  --rpc-url https://mainnet.base.org
```

### Test Output

```
--- base ---
Total: 0.00   ← protocol is live but accumulating first deposits

--- tvl ---
Total: 0.00
```

> Note: TVL is currently near zero (protocol freshly deployed, accumulating initial deposits). The adapter is submitted early to establish the listing ahead of TVL growth.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Total Value Locked (TVL) monitoring for JackCo, enabling users to track USDC-denominated vault assets in real time across multiple chains: Base, Ethereum, Arbitrum, Optimism, Polygon, BSC, and Avalanche.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->