### PR TITLE
Update Kerne Protocol TVL: count only live PSM USDC, exclude degraded…

### DIFF
--- a/projects/kerne-protocol/index.js
+++ b/projects/kerne-protocol/index.js
@@ -1,16 +1,31 @@
+// Kerne Protocol — DefiLlama TVL Adapter (Base, chainId 8453)
+// ----------------------------------------------------------------
+// TVL = USDC reserves held by the live KUSDPSM, which back circulating kUSD 1:1.
+// This is Kerne's live, user-facing deposit surface and matches the protocol's
+// published headline TVL at kerne.fi/api/stats and the reserve breakdown at
+// kerne.fi/api/por (policy: docs/SEED_TVL_POLICY.md).
+//
+// The v1 KerneVault (0x8005bc7A86AD904C20fd62788ABED7546c1cF2AC) is intentionally
+// NOT counted: it is in a known degraded accounting state (share supply does not
+// reconcile with its WETH backing), deposits are disabled pending a v2 redeploy,
+// and KerneVault.totalAssets() additionally includes off-chain CEX / Hyperliquid
+// hedge balances that are not on-chain TVL. The vault leg will be re-added once
+// KerneVault v2 redeploys in a healthy, on-chain-reconciled state.
+//
+// Contracts (verified on Basescan):
+//   KUSDPSM: 0xFf3025ec18e301855aB0f36Ec6ECa115a29A5Fbc
+//   kUSD:    0x5C2EfdF0D8D286959b42308966bc2B97f5680AA3
+
 const ADDRESSES = require('../helper/coreAssets.json')
 
-const KERNE_VAULT = '0x8005bc7A86AD904C20fd62788ABED7546c1cF2AC';
 const KUSD_PSM = '0xFf3025ec18e301855aB0f36Ec6ECa115a29A5Fbc';
-const USDC_BASE = ADDRESSES.base.USDC;
 
 async function tvl(api) {
   await api.sumTokens({ tokensAndOwners: [[ADDRESSES.base.USDC, KUSD_PSM]]})
-  await api.erc4626Sum2({ calls: [KERNE_VAULT]})
 }
 
 module.exports = {
   methodology:
-    'TVL is the sum of two on-chain surfaces on Base: (1) KerneVault.totalAssets() in its underlying asset (WETH), and (2) USDC reserves held by the KUSDPSM contract backing outstanding kUSD 1:1. The vault WETH backs kLP shares; the PSM USDC backs kUSD. Both are protocol-controlled deposit surfaces. The kUSD supply itself is NOT added, because counting it would double-count the PSM USDC reserves that already back it.',
+    'TVL is the USDC reserve held by the Kerne KUSDPSM contract on Base, which backs all circulating kUSD 1:1. This is the protocol\'s live, user-facing deposit surface and matches the published headline TVL at kerne.fi/api/stats. The v1 KerneVault is intentionally excluded: it is in a known degraded accounting state (share supply does not reconcile with backing), deposits are disabled pending a v2 redeploy, and its totalAssets() includes off-chain CEX and Hyperliquid hedge balances that are not on-chain TVL. The vault leg will be re-added when KerneVault v2 redeploys healthy. The kUSD supply itself is not added, since the PSM USDC already backs it 1:1 (counting both would double-count).',
   base: { tvl },
 };

--- a/projects/kerne-protocol/index.js
+++ b/projects/kerne-protocol/index.js
@@ -26,6 +26,6 @@ async function tvl(api) {
 
 module.exports = {
   methodology:
-    'TVL is the USDC reserve held by the Kerne KUSDPSM contract on Base, which backs all circulating kUSD 1:1. This is the protocol\'s live, user-facing deposit surface and matches the published headline TVL at kerne.fi/api/stats. The v1 KerneVault is intentionally excluded: it is in a known degraded accounting state (share supply does not reconcile with backing), deposits are disabled pending a v2 redeploy, and its totalAssets() includes off-chain CEX and Hyperliquid hedge balances that are not on-chain TVL. The vault leg will be re-added when KerneVault v2 redeploys healthy. The kUSD supply itself is not added, since the PSM USDC already backs it 1:1 (counting both would double-count).',
+    'TVL is the USDC reserve held by the Kerne KUSDPSM contract on Base, which backs all circulating kUSD 1:1. This is the protocol\'s live, user-facing deposit surface and matches the published headline TVL at kerne.fi/api/stats.',
   base: { tvl },
 };


### PR DESCRIPTION
## What this changes

Updates the Kerne Protocol TVL adapter to count only the live KUSDPSM USDC reserve (which backs circulating kUSD 1:1) and to exclude the v1 KerneVault.

## Why

- The v1 KerneVault (`0x8005bc7A86AD904C20fd62788ABED7546c1cF2AC`) is in a known degraded accounting state: its share supply does not reconcile with its WETH backing, and deposits are disabled pending a v2 redeploy.
- `KerneVault.totalAssets()` additionally includes off-chain CEX and Hyperliquid hedge balances (`offChainAssets + l1Assets + hedgingReserve`), which are not on-chain TVL.
- Counting only the on-chain PSM USDC matches Kerne's own published headline TVL at https://kerne.fi/api/stats and the reserve policy in `docs/SEED_TVL_POLICY.md`.
- TVL is computed from on-chain data via `api.sumTokens` (not a fetch adapter).

The vault leg will be re-added in a follow-up once KerneVault v2 redeploys in a healthy, on-chain-reconciled state.

Local `node test.js projects/kerne-protocol` output: `Total: 6.85` (Base USDC), matching kerne.fi/api/stats.

Allow edits by maintainers: enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * TVL now exclusively counts USDC reserves held in the PSM contract on Base; vault-held assets are no longer included to prevent double-counting.
* **Documentation**
  * Methodology updated to clarify the single on-chain reserve leg, explicitly exclude the v1 KerneVault, and confirm kUSD supply is not added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->