### PR TITLE
fix: set address field for Perpl protocol metadata

### DIFF
--- a/projects/perpl/index.js
+++ b/projects/perpl/index.js
@@ -2,7 +2,7 @@ const ADDRESSES = require('../helper/coreAssets.json')
 const { sumTokensExport } = require("../helper/unwrapLPs");
 
 const EXCHANGE = "0x34B6552d57a35a1D042CcAe1951BD1C370112a6F";
-const AUSD = ADDRESSES.mantle.AUSD;
+const AUSD = ADDRESSES.monad.AUSD;
 
 module.exports = {
   address: "monad:0x34B6552d57a35a1D042CcAe1951BD1C370112a6F",

--- a/projects/perpl/index.js
+++ b/projects/perpl/index.js
@@ -5,6 +5,7 @@ const EXCHANGE = "0x34B6552d57a35a1D042CcAe1951BD1C370112a6F";
 const AUSD = ADDRESSES.mantle.AUSD;
 
 module.exports = {
+  address: "monad:0x34B6552d57a35a1D042CcAe1951BD1C370112a6F",
   methodology:
     "TVL is the total AUSD collateral deposited in the Perpl Exchange contract.",
   monad: {


### PR DESCRIPTION
Closes #19504

Sets the address field for Perpl protocol to:
monad:0x34B6552d57a35a1D042CcAe1951BD1C370112a6F

This is the Perpl Exchange (UUPS proxy) on Monad mainnet,
same contract used by TVL adapter merged in #18382.

Verified: https://monadscan.com/address/0x34B6552d57a35a1D042CcAe1951BD1C370112a6F

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Configured Perpl exchange address for the Monad network (uses a monad: address format).
  * Updated AUSD token source to Monad so TVL and token-owner calculations reference the correct network.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->