### PR TITLE
fix: set address field for Perpl protocol metadata

### DIFF
--- a/projects/perpl/index.js
+++ b/projects/perpl/index.js
@@ -5,6 +5,7 @@ const EXCHANGE = "0x34B6552d57a35a1D042CcAe1951BD1C370112a6F";
 const AUSD = ADDRESSES.monad.AUSD;
 
 module.exports = {
+  address: "monad:0x34B6552d57a35a1D042CcAe1951BD1C370112a6F",
   methodology:
     "TVL is the total AUSD collateral deposited in the Perpl Exchange contract.",
   monad: {


### PR DESCRIPTION
Closes #19504

Sets the `address` field for the Perpl protocol to:
`monad:0x34B6552d57a35a1D042CcAe1951BD1C370112a6F`

This is the Perpl Exchange (UUPS proxy) on Monad mainnet —
the same contract used by the TVL adapter merged in #18382.

Verified on MonadScan:
https://monadscan.com/address/0x34B6552d57a35a1D042CcAe1951BD1C370112a6F

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration to include address information for Perpl Exchange integration on the Monad blockchain, enabling improved asset tracking and monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->