### PR TITLE
mark umee insolvent

### DIFF
--- a/projects/umee/index.js
+++ b/projects/umee/index.js
@@ -1,6 +1,5 @@
 const { aaveV2Export } = require("../helper/aave");
-const { queryV1Beta1 } = require("../helper/chain/cosmos");
-const { sumTokens } = require('../helper/chain/cosmos')
+const { queryV1Beta1, sumTokens } = require("../helper/chain/cosmos");
 
 const LEVERAGE_MODULE = 'umee185vjuy55vukn8fdz8fax4rs5xnhl3ufmsul2ks'
 
@@ -29,7 +28,7 @@ async function tvl(api) {
   //   api.add(i.base_denom, i.supplied - i.borrowed)
   // );
 
-  await sumTokens({api, owners: [LEVERAGE_MODULE], chain: 'umee'})
+  await sumTokens({api, owners: [LEVERAGE_MODULE]})
 
 }
 

--- a/projects/umee/index.js
+++ b/projects/umee/index.js
@@ -1,5 +1,8 @@
 const { aaveV2Export } = require("../helper/aave");
 const { queryV1Beta1 } = require("../helper/chain/cosmos");
+const { sumTokens } = require('../helper/chain/cosmos')
+
+const LEVERAGE_MODULE = 'umee185vjuy55vukn8fdz8fax4rs5xnhl3ufmsul2ks'
 
 let data;
 
@@ -21,10 +24,13 @@ async function getData() {
 }
 
 async function tvl(api) {
-  const data = await getData();
-  data.forEach((i) =>
-    api.add(i.base_denom, i.supplied - i.borrowed)
-  );
+  // const data = await getData();
+  // data.forEach((i) =>
+  //   api.add(i.base_denom, i.supplied - i.borrowed)
+  // );
+
+  await sumTokens({api, owners: [LEVERAGE_MODULE], chain: 'umee'})
+
 }
 
 async function borrowed(api) {
@@ -34,12 +40,16 @@ async function borrowed(api) {
   );
 }
 
+// bad debt from exploit:
+// - https://common.xyz/ux/discussion/1312478-UX%20Wind%20Down%20and%20Preparation%20Plan
+// - https://x.com/ux_xyz/status/2039031451111330264
 module.exports = {
   timetravel: false,
+  hallmarks: [['2026-05-15', 'protocol shutdown']],
   methodology: "Total supplied assets - total borrowed assets",
   umee: {
     tvl,
-    borrowed,
+    borrowed: () => ({}), 
   },
-  ethereum: aaveV2Export('0xe296db0a0e9a225202717e9812bf29ca4f333ba6', { fromBlock: 14216544, }),
+  ethereum: aaveV2Export('0xe296db0a0e9a225202717e9812bf29ca4f333ba6', { fromBlock: 14216544, isInsolvent: true}),
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added protocol shutdown date marker for Umee (May 15, 2026).

* **Bug Fixes**
  * Switched Umee TVL calculation to use direct token balance aggregation.
  * Disabled Umee borrowed-amount reporting.
  * Marked Ethereum Aave V2 as insolvent in configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->