### PR TITLE
Add Turbo (HyperEVM DEX)

### DIFF
--- a/registries/uniswapV3.js
+++ b/registries/uniswapV3.js
@@ -1729,6 +1729,10 @@ const uniV3Configs = {
       topics: ['0xab0d57f0df537bb25e80245ef7748fa62353808c54d6e528a9dd20887aed9ac2']
     }
   },
+  'turbo': {
+    methodology: "Counts the tokens locked in Turbo's Uniswap V3 liquidity pools on HyperEVM, enumerated on-chain from the factory's PoolCreated events.",
+    hyperliquid: { factory: '0xc72d2695A203696243Aa3EdD6CC98E43262E007E', fromBlock: 36463669 },
+  },
   'kublerx-v3': {
     methodology: 'TVL is calculated by summing the reserves of all Kublerx V3 pools on KUB. Pools are discovered from PoolCreated events emitted by the V3 factory.',
     bitkub: { factory: '0xD679d310008A2595B8d3DeB83bb93EB23F9b0942', fromBlock: 31936260 }


### PR DESCRIPTION
Adds **Turbo**, a Uniswap V3 DEX on HyperEVM (chain 999). TVL uses the standard `uniV3Export` helper (pools enumerated from the factory's `PoolCreated` events). `node test.js projects/turbo/index.js` passes: ~$22k across 3 pools, all priced.

##### Name (to be shown on DefiLlama): Turbo

##### Twitter Link: https://x.com/Turbo_HL

##### Website Link: https://turbotrade.app

##### Logo: Posted in the comments below.

##### Current TVL: ~$24k

##### Treasury Addresses (if the protocol has treasury): none

##### Chain: Hyperliquid

##### Coingecko ID: none (no protocol token)

##### Coinmarketcap ID: none

##### Short Description: Turbo is a Uniswap V3-style DEX on HyperEVM (Hyperliquid's EVM chain).

##### Token address and ticker if any: none

##### Category: Dexes

##### Oracle Provider(s): N/A (AMM; TVL derived from pool reserves, no external oracle)

##### forkedFrom: Uniswap V3

##### methodology: Counts the tokens locked in Turbo's Uniswap V3 liquidity pools on HyperEVM, enumerated on-chain from the factory's PoolCreated events.

##### Github org/user: n/a (closed source)

##### Does this project have a referral program? Yes (invite codes + points-based referrals)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tracking Turbo's on-chain liquidity pools on the hyperliquid network through the Uniswap V3 registry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->