### PR TITLE
fix mezo earn: separate MEZO governance token into staking export

### DIFF
--- a/projects/mezo-earn/index.js
+++ b/projects/mezo-earn/index.js
@@ -5,8 +5,9 @@ const VEBTC_CONTRACT  = "0x3D4b1b884A7a1E59fE8589a3296EC8f8cBB6f279";
 const VEMEZO_CONTRACT = "0xb90fdAd3DFD180458D62Cc6acedc983D78E20122";
 
 module.exports = {
-    methodology: 'Sum of BTC and MEZO locked by users in Mezo Earn vote-escrow contracts (veBTC, veMEZO) for governance voting power.',
-    mezo: {
-        tvl: sumTokensExport({ tokensAndOwners: [[ADDRESSES.mezo.MEZO, VEMEZO_CONTRACT], [ADDRESSES.mezo.BTC, VEBTC_CONTRACT]]})
-    }
+  methodology: 'TVL counts BTC locked by users in the veBTC vote-escrow contract. MEZO locked in veMEZO is the protocol own governance token and is reported separately under staking.',
+  mezo: {
+    tvl: sumTokensExport({ tokensAndOwners: [[ADDRESSES.mezo.BTC, VEBTC_CONTRACT]] }),
+    staking: sumTokensExport({ tokensAndOwners: [[ADDRESSES.mezo.MEZO, VEMEZO_CONTRACT]] }),
+  }
 }


### PR DESCRIPTION
## What's wrong
mezo earn counts veMEZO (locked MEZO governance token) as TVL, inflating the headline number by ~$7.74M.

## Fix
- veBTC (locked BTC) = legitimate external TVL → stays in `tvl`
- veMEZO (locked MEZO) = protocol's own governance token → moved to `staking`

This follows standard DefiLlama convention for own-token vote escrow systems.

## Test output
mezo tvl:     $40.49M (BTC only)
mezo staking: $7.74M  (MEZO)

## Reference
DefiLlama maintainer comment on PR #17375:
"please use tvl: () => ({}) and export this function as staking as it is your own token"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated staking metric for separate MEZO tracking

* **Documentation**
  * Updated reporting methodology to clarify TVL calculations for BTC and staking metrics for MEZO

<!-- end of auto-generated comment: release notes by coderabbit.ai -->