### PR TITLE
fix islandstake: read pool_ton_balance from correct index

### DIFF
--- a/projects/islandstake/index.js
+++ b/projects/islandstake/index.js
@@ -6,7 +6,7 @@ module.exports = {
   ton: {
     tvl: async (api) => {
       const result = await call({ target: 'EQD4l0TnN13SmF_wSIL6ho1sBmqc4H_KN1kFqPjLJgIpkBOZ', abi: 'get_pool_data' });
-      api.addGasToken(result[3]);
+      api.addGasToken(result[0]);
     },
   },
 };


### PR DESCRIPTION
## Bug
`get_pool_data` on the IslandStake master contract returns:
[pool_ton_balance, staked_total, rate, fee]
  idx0              idx1          idx2  idx3

Adapter was reading `result[3]` (fee, ~0.5 TON) instead of
`result[0]` (actual pool balance, ~19 TON).

## Impact
~38× undercount. Protocol showed ~$1 TVL instead of ~$40.

## Fix
`result[3]` → `result[0]`

## Verified on-chain
Queried contract directly: index 0 = 19.09 TON, index 3 = 0.50 TON
node test.js after fix: ~40 TON ✓

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the data source used for calculating gas token liquidity in TVL computations, ensuring more accurate total value locked metrics are reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->