### PR TITLE
Fix Eigenpod

### DIFF
--- a/projects/eigenlayer/index.js
+++ b/projects/eigenlayer/index.js
@@ -33,6 +33,11 @@ async function getEigenPods(timestamp) {
     .split("T")[0] + "T23:59:59"
 
   const query = `
+    WITH latest_slot AS (
+      SELECT MAX(slot_timestamp) AS ts
+      FROM beacon.validator.balances
+      WHERE slot_timestamp <= '${targetDate}'
+    )
     SELECT SUM(balance) AS sum
     FROM (
       SELECT params
@@ -49,7 +54,7 @@ async function getEigenPods(timestamp) {
         'pending_initialized',
         'withdrawal_possible'
       )
-        AND slot_timestamp = '${targetDate}'
+        AND slot_timestamp = (SELECT ts FROM latest_slot)
     ) beacon
     WHERE pods.params['eigenPod'] = beacon.WITHDRAWAL_ADDRESS
   `


### PR DESCRIPTION
```
------ TVL ------
ethereum                  5.67 B
ethereum-staking          63.52 M
staking                   63.52 M

total                    5.67 B 
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data retrieval for EigenLayer pods to use the latest available timestamp instead of requiring exact date matches, ensuring data is consistently available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->