### PR TITLE
fix allbridge classic

### DIFF
--- a/projects/allbridge/index.js
+++ b/projects/allbridge/index.js
@@ -208,8 +208,8 @@ function getStakingFunction(chain) {
     return staking(stakingData.contractAddress, stakingData.abrAddress, chain, "allbridge", stakingData.decimals);
 }
 
-async function solanaTvl() {
-    return solana.sumTokens2({ tokenAccounts: solanaData.tokens.map(i => i.tokenAccount)})
+async function solanaTvl() {    
+    return solana.sumTokens2({ tokenAccounts: solanaData.tokens.map(i => i.tokenAccount), allowError: true}) // Skip closed TAs
 }
 
 async function solanaStaking() {


### PR DESCRIPTION
Allbridge classic is actively being deprecated: https://docs.allbridge.io/

As the team closes their Solana token accounts, they will throw inside sumTokens2. E.g.: `Invalid account: HHC3niNsTB3hNN1kZH9BHMLiwLvCSegKBLu82tAT2iG8`

Closed tx: https://solscan.io/tx/m4b7wiFt6yiWVJJ2nPrU34DUrnAuymzXuNRh96zneQ2FEKn2L3pbxSdWwvT4KBkcFfxG4WA2NsiGhEXj5BoF1SF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for Solana token account calculations to gracefully skip closed accounts and improve data retrieval reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->