### PR TITLE
add cosmos helper and fix broken adapters

### DIFF
--- a/projects/GainzSwap/index.js
+++ b/projects/GainzSwap/index.js
@@ -5,6 +5,7 @@ const ROUTER_CONTRACT = '0xd35C85FbA82587c15D2fa255180146A046B67237';
 const WEDU_CONTRACT = ADDRESSES.occ.WEDU;
 const dEDU_CONTRACT = "0x597FFfA69e133Ee9b310bA13734782605C3549b7";
 const CHAIN = 'occ';
+const UPGRADE_BLOCK = 33029078; 
 
 /**
  * Fetch total supply of dEDU token and add to TVL
@@ -28,11 +29,23 @@ async function addDEDUSupplyToTVL(api) {
  * @returns {Promise<Array<[string, string]>>} - List of [token, owner] pairs
  */
 async function getTokenPairsDEDU(api) {
-  const pairs = await api.call({
-    target: ROUTER_CONTRACT,
-    abi: 'function pairs() external view returns (address[] memory)',
-    chain: CHAIN,
-  });
+  let pairs = []
+  const block = await api.getBlock()
+  // Router was upgraded to impl with broken pairs()
+  if(block < UPGRADE_BLOCK) {
+    pairs = await api.call({
+      target: ROUTER_CONTRACT,
+      abi: 'function pairs() external view returns (address[] memory)',
+      chain: CHAIN,
+    });
+  } else {
+    pairs = [
+      '0xE9DDDDAB75354Ab7ea2365e66902CA61930796C4',
+      '0xa7Ac8F0446A07E98604515dD5F3592fd9C609FCd',
+      '0x36e7fA8F3E64Aa5F009eF838E580904486B6C458'
+    ]
+  }
+  
 
   const reserves = await Promise.all(
     pairs.map(async (pair) => {

--- a/projects/GainzSwap/index.js
+++ b/projects/GainzSwap/index.js
@@ -5,7 +5,6 @@ const ROUTER_CONTRACT = '0xd35C85FbA82587c15D2fa255180146A046B67237';
 const WEDU_CONTRACT = ADDRESSES.occ.WEDU;
 const dEDU_CONTRACT = "0x597FFfA69e133Ee9b310bA13734782605C3549b7";
 const CHAIN = 'occ';
-const UPGRADE_BLOCK = 33029078; 
 
 /**
  * Fetch total supply of dEDU token and add to TVL
@@ -29,23 +28,11 @@ async function addDEDUSupplyToTVL(api) {
  * @returns {Promise<Array<[string, string]>>} - List of [token, owner] pairs
  */
 async function getTokenPairsDEDU(api) {
-  let pairs = []
-  const block = await api.getBlock()
-  // Router was upgraded to impl with broken pairs()
-  if(block < UPGRADE_BLOCK) {
-    pairs = await api.call({
-      target: ROUTER_CONTRACT,
-      abi: 'function pairs() external view returns (address[] memory)',
-      chain: CHAIN,
-    });
-  } else {
-    pairs = [
-      '0xE9DDDDAB75354Ab7ea2365e66902CA61930796C4',
-      '0xa7Ac8F0446A07E98604515dD5F3592fd9C609FCd',
-      '0x36e7fA8F3E64Aa5F009eF838E580904486B6C458'
-    ]
-  }
-  
+  const pairs = await api.call({
+    target: ROUTER_CONTRACT,
+    abi: 'function pairs() external view returns (address[] memory)',
+    chain: CHAIN,
+  });
 
   const reserves = await Promise.all(
     pairs.map(async (pair) => {

--- a/projects/embr-bridge/index.js
+++ b/projects/embr-bridge/index.js
@@ -1,21 +1,18 @@
-const { queryV1Beta1 } = require('../helper/chain/cosmos.js');
+const { queryV1Beta1V2 } = require('../helper/chain/cosmos.js')
 
 module.exports = {
-    timetravel: false,
-    embr: {
-        tvl: async () => {
-            const balances = {}
-            const res = await queryV1Beta1({
-                chain: "embr",
-                url: "/bank/v1beta1/supply",
-            });
-
-            res.supply.map(({ denom, amount }) => {
-                if (!denom.startsWith("evm/")) return 
-                balances[`embr:${denom.replace("evm/", "0x")}`] = amount
-            })
-
-            return balances
-        },
+  timetravel: false,
+  embr: {
+    tvl: async () => {
+      const balances = {}
+      let supply = await queryV1Beta1V2({ chain: 'embr', url: 'bank/v1beta1/supply', limit: 50 })
+      
+      for (const { denom, amount } of supply) {
+        if (denom.startsWith('evm/')) {
+          balances[`embr:${denom.replace('evm/', '0x')}`] = amount
+        }
+      }
+      return balances
     },
-};
+  },
+}

--- a/projects/figure-markets/index.js
+++ b/projects/figure-markets/index.js
@@ -1,16 +1,7 @@
 const { sumTokens2 } = require('../helper/unwrapLPs');
-const { queryV1Beta1 } = require('../helper/chain/cosmos.js');
-
-const paginationLimit = 1000;
+const { queryV1Beta1, queryV1Beta1V2 } = require('../helper/chain/cosmos.js');
 
 const figureMarketsExchangeID = '1'
-
-const lockedTokensQuery = (nextKey) =>
-    `exchange/v1/market/${figureMarketsExchangeID}/commitments?pagination.limit=${
-        paginationLimit
-    }${
-        nextKey ? `&pagination.key=${nextKey}` : ""
-    }`;
 
 const collateralizedAssets = [
     'pm.sale.pool.3dxq3fk9llvhrqqwhodiap', // YLDS HELOCs
@@ -18,22 +9,18 @@ const collateralizedAssets = [
     'pm.pool.asset.3hjz8rcr3pejdc3msntlvy' // YLDS HELOC+
 ]
 
-const getLockedTokens = async (key, api) => {
-    const nextTokens = await queryV1Beta1({
+const getLockedTokens = async (api) => {
+    const commitments = await queryV1Beta1V2({
         chain: 'provenance',
-        url: lockedTokensQuery(key)
+        url: `exchange/v1/market/${figureMarketsExchangeID}/commitments`,
+        limit: 1000,
     })
-    nextTokens.commitments.map((c) =>
-        c.amount.map((a) => {
+    for (const c of commitments) {
+        for (const a of c.amount) {
             if (!collateralizedAssets.includes(a.denom)) {
                 api.add(a.denom, a.amount)
             }
-        })
-    );
-    let nextKey = nextTokens.pagination.next_key;
-    if (nextKey) {
-        nextKey = nextKey.replace(/\+/g, "-").replace(/\//g, "_");
-        return getLockedTokens(nextKey, api);
+        }
     }
 };
 
@@ -68,7 +55,7 @@ const getPoolsCollateralValue = async (api) => {
 }
 
 const tvl = async (api) => {
-    await getLockedTokens(null, api)
+    await getLockedTokens(api)
     await getPoolsCollateralValue(api)
     return sumTokens2({ api })
 }

--- a/projects/helper/chain/cosmos.js
+++ b/projects/helper/chain/cosmos.js
@@ -17,7 +17,8 @@ const endPoints = {
   osmosis: "https://rest-osmosis.ecostake.com",
   // cosmos: "https://cosmoshub-lcd.stakely.io",
   cosmos: "https://cosmos-api.polkachu.com",
-  kujira: "https://kujira-rest.publicnode.com",
+  kujira: "https://rest.cosmos.directory/kujira",
+  // kujira: "https://kujira-api.publicnode.com",
   // comdex: "https://rest.comdex.one",
   comdex: "https://rest.cosmos.directory/comdex",
   terra: "https://terra-classic-lcd.publicnode.com",
@@ -115,25 +116,44 @@ async function query(url, block, chain) {
 }
 
 async function queryV1Beta1({ chain, paginationKey, block, url, api } = {}) {
-  if (api) {
-    chain = api.chain
-  }
+  if (api) chain = api.chain
   const subpath = chainSubpaths[chain] || "cosmos";
   let endpoint = `${getEndpoint(chain)}/${subpath}/${url}`;
+  const sep = endpoint.includes('?') ? '&' : '?';
   if (block !== undefined) {
-    endpoint += `?height=${block - (block % 100)}`;
+    endpoint += sep + `height=${block - (block % 100)}`
   }
   if (paginationKey) {
-    const paginationQueryParam = `pagination.key=${paginationKey}`;
-    if (block === undefined) {
-      endpoint += "?";
-    } else {
-      endpoint += "&";
-    }
-    endpoint += paginationQueryParam;
+    endpoint += sep + `pagination.key=${encodeURIComponent(paginationKey)}`
   }
   return get(endpoint)
 }
+
+async function queryV1Beta1V2({ chain, url, limit = 100, block, api, dataKey } = {}) {
+  if (api) chain = api.chain
+
+  const sep = url.includes('?') ? '&' : '?'
+  const pagedUrl = `${url}${sep}pagination.limit=${limit}`
+
+  let res = await queryV1Beta1({ chain, url: pagedUrl, block })
+
+  if (!dataKey) {
+    dataKey = Object.keys(res).find(k => k !== 'pagination' && Array.isArray(res[k]))
+    if (!dataKey) throw new Error(`queryV1Beta1V2: no array field in response. Keys: ${Object.keys(res).join(', ')}`)
+  }
+
+  let items = res[dataKey] || []
+  let paginationKey = res.pagination?.next_key
+  let safety = 0
+  while (paginationKey) {
+    if (++safety > 1000) throw new Error('queryV1Beta1V2: pagination exceeded 1000 pages')
+    res = await queryV1Beta1({ chain, url: pagedUrl, block, paginationKey })
+    items = items.concat(res[dataKey] || [])
+    paginationKey = res.pagination?.next_key
+  }
+  return items
+}
+
 
 async function getTokenBalance({ token, owner, block, chain }) {
   let denom = token.native_token?.denom;
@@ -365,6 +385,7 @@ module.exports = {
   unwrapLp,
   query,
   queryV1Beta1,
+  queryV1Beta1V2,
   queryContractStore,
   queryContract,
   queryManyContracts,

--- a/projects/helper/chain/cosmos.js
+++ b/projects/helper/chain/cosmos.js
@@ -119,12 +119,11 @@ async function queryV1Beta1({ chain, paginationKey, block, url, api } = {}) {
   if (api) chain = api.chain
   const subpath = chainSubpaths[chain] || "cosmos";
   let endpoint = `${getEndpoint(chain)}/${subpath}/${url}`;
-  const sep = endpoint.includes('?') ? '&' : '?';
   if (block !== undefined) {
-    endpoint += sep + `height=${block - (block % 100)}`
+    endpoint += (endpoint.includes('?') ? '&' : '?') + `height=${block - (block % 100)}`
   }
   if (paginationKey) {
-    endpoint += sep + `pagination.key=${encodeURIComponent(paginationKey)}`
+    endpoint += (endpoint.includes('?') ? '&' : '?') + `pagination.key=${encodeURIComponent(paginationKey)}`
   }
   return get(endpoint)
 }

--- a/projects/helper/deadChains.js
+++ b/projects/helper/deadChains.js
@@ -18,4 +18,5 @@ module.exports =  [
   'redstone', // shutdown 2026-05-18: https://x.com/redstonexyz/status/2055181780043579468
   'tenet', // stopped producing blocks 2026-04-22: https://tenetscan.io/block/27263599
   'enuls', // shutdown 2026-03-25 and merged with NerveNetwork: https://x.com/Nuls/status/2029433112254443679 
+  'pryzm', // shutdown 2026-02-09: https://x.com/Pryzm_Zone/status/2000705996969091570
 ]

--- a/projects/noble/index.js
+++ b/projects/noble/index.js
@@ -5,7 +5,10 @@ const IGNORE_DENOMS = ['ufrienzies', 'ustake'];
 
 async function tvl(api) {
   const supply = await queryV1Beta1V2({ api, url: NOBLE_SUPPLY_URL })
-  supply.forEach(i => api.add(i.denom, i.amount))
+  supply.forEach(({ denom, amount }) => {
+    if (IGNORE_DENOMS.includes(denom)) return
+    api.add(denom, amount)
+  })
 }
 
 module.exports = {

--- a/projects/noble/index.js
+++ b/projects/noble/index.js
@@ -1,16 +1,11 @@
-const { queryV1Beta1 } = require('../helper/chain/cosmos');
+const { queryV1Beta1V2 } = require('../helper/chain/cosmos');
 
 const NOBLE_SUPPLY_URL = 'bank/v1beta1/supply';
 const IGNORE_DENOMS = ['ufrienzies', 'ustake'];
 
 async function tvl(api) {
-  let key
-  do {
-    const { supply, pagination } = await queryV1Beta1({ api, url: `${NOBLE_SUPPLY_URL}?pagination.key=${key || ''}` })
-    key = pagination.next_key
-    supply.forEach(i => api.add(i.denom, i.amount))
-  } while (key);
-  IGNORE_DENOMS.forEach(denom => api.removeTokenBalance(denom))
+  const supply = await queryV1Beta1V2({ api, url: NOBLE_SUPPLY_URL })
+  supply.forEach(i => api.add(i.denom, i.amount))
 }
 
 module.exports = {

--- a/projects/pryzm-protocol/index.js
+++ b/projects/pryzm-protocol/index.js
@@ -30,6 +30,7 @@ async function tvl(api) {
 
 module.exports = {
   methodology: "Counts the liquidity on the refractor module and all AMM pools",
+  deadFrom: '2026-02-09', // chain shutdown
   pryzm: {
     tvl
   },

--- a/projects/shadeprotocol-derivatives/index.js
+++ b/projects/shadeprotocol-derivatives/index.js
@@ -1,4 +1,4 @@
-const { queryV1Beta1 } = require("../helper/chain/cosmos")
+const { queryV1Beta1V2 } = require("../helper/chain/cosmos")
 const { queryContract } = require("../helper/chain/secret")
 
 const STKD_SCRT_CONTRACT = 'secret1k6u0cy4feepm6pehnz804zmwakuwdapm69tuc4'
@@ -13,26 +13,10 @@ function sumAmounts(amounts) {
   return amounts.reduce((sum, amount) => sum + toBaseAmount(amount), 0n)
 }
 
-async function queryPaginated(url, listKey) {
-  let values = []
-  let key
-
-  do {
-    const query = `${url}?pagination.limit=1000${key ? `&pagination.key=${encodeURIComponent(key)}` : ''}`
-    const page = await queryV1Beta1({ chain: 'secret', url: query })
-    const pageValues = page[listKey]
-    if (!Array.isArray(pageValues)) throw new Error(`Missing ${listKey} response`)
-    values = values.concat(pageValues)
-    key = page.pagination?.next_key
-  } while (key)
-
-  return values
-}
-
 async function tvl(api) {
   const [{ staking_info: stakingInfo }, unbonding] = await Promise.all([
     queryContract({ contract: STKD_SCRT_CONTRACT, data: { staking_info: { time: Math.floor(Date.now() / 1000) } } }),
-    queryPaginated(`staking/v1beta1/delegators/${STKD_SCRT_CONTRACT}/unbonding_delegations`, 'unbonding_responses'),
+    queryV1Beta1V2({ chain: 'secret', url: `staking/v1beta1/delegators/${STKD_SCRT_CONTRACT}/unbonding_delegations` }),
   ])
 
   if (!stakingInfo) throw new Error('Missing staking_info response')

--- a/projects/treasury/mantadao.js
+++ b/projects/treasury/mantadao.js
@@ -1,5 +1,5 @@
 const { getConfig } = require("../helper/cache");
-const { sumTokens, queryContract, queryV1Beta1, getBalance2 } = require('../helper/chain/cosmos');
+const { sumTokens, queryContract, getBalance2, queryV1Beta1V2 } = require('../helper/chain/cosmos');
 const owners = ["kujira15e682nq9jees29rm9j3h030af86lq2qtlejgphlspzqcvs9whf2q00nua5"]
 
 async function tvl(api) {
@@ -23,21 +23,7 @@ async function calcPOLValue(api) {
   const contracts = await getConfig("mantadao/contracts", "https://raw.githubusercontent.com/Team-Kujira/kujira.js/master/src/resources/contracts.json");
   const bowPools = contracts["kaiyo-1"].bow.map(x => x.address)
 
-  // Get list of total supply of all native denoms
-  let supplyData = await queryV1Beta1({ chain: 'kujira', url: '/bank/v1beta1/supply' });
-
-  let denomSupply = supplyData.supply;
-  let paginationKey = supplyData.pagination.next_key;
-
-  while (paginationKey) {
-    supplyData = await queryV1Beta1({
-      chain: 'kujira',
-      paginationKey: paginationKey,
-      url: '/bank/v1beta1/supply'
-    });
-    denomSupply = denomSupply.concat(supplyData.supply);
-    paginationKey = supplyData.pagination.next_key;
-  }
+  const denomSupply = await queryV1Beta1V2({ chain: 'kujira', url: '/bank/v1beta1/supply'})
 
   // Get all balances of treasury
   const treasuryBalances = await getBalance2({
@@ -102,6 +88,7 @@ async function ownTokens(api) {
 
 module.exports = {
   timetravel: false,
+  deadFrom: '2025-06-25',
   kujira: {
     tvl,
     ownTokens,

--- a/projects/warp-dex/index.js
+++ b/projects/warp-dex/index.js
@@ -1,4 +1,4 @@
-const { queryV1Beta1, getBalance2 } = require('../helper/chain/cosmos')
+const { queryV1Beta1V2, getBalance2 } = require('../helper/chain/cosmos')
 const { transformDexBalances } = require('../helper/portedTokens')
 
 const chain = 'bostrom'
@@ -6,35 +6,25 @@ const poolURI = 'liquidity/v1beta1/pools'
 const blacklistedTokens = ['ibc/4B322204B4F59D770680FE4D7A565DDC3F37BFF035474B717476C66A4F83DD72'] // DSM giving invalid values for some reason, incorrect decimals?
 
 async function tvl(api) {
-  let paginationKey
-  let data = []
+  const pools = await queryV1Beta1V2({ chain, url: poolURI })
+  const data = []
 
-  do {
-    const { pools, pagination } = await queryV1Beta1({ chain, url: poolURI })
-    paginationKey = pagination.next_key
-    for (const pool of pools) {
-      const tokens = pool.reserve_coin_denoms
-      const owner = pool.reserve_account_address
-      const balances = await getBalance2({ tokens, owner, chain, blacklistedTokens })
-    
-      const keys = Object.keys(balances);
-      const values = Object.values(balances);
-  
-      if (keys.length === 2 && values.length === 2) {
-        const [token0, token1] = keys;
-        const [token0Bal, token1Bal] = values;
-  
-        if (token0 && token1 && token0Bal && token1Bal) {
-          data.push({
-            token0,
-            token0Bal,
-            token1,
-            token1Bal,
-          });
-        }
+  for (const pool of pools) {
+    const tokens = pool.reserve_coin_denoms
+    const owner = pool.reserve_account_address
+    const balances = await getBalance2({ tokens, owner, chain, blacklistedTokens })
+
+    const keys = Object.keys(balances)
+    const values = Object.values(balances)
+
+    if (keys.length === 2 && values.length === 2) {
+      const [token0, token1] = keys
+      const [token0Bal, token1Bal] = values
+      if (token0 && token1 && token0Bal && token1Bal) {
+        data.push({ token0, token0Bal, token1, token1Bal })
       }
     }
-  } while (paginationKey)
+  }
 
   return transformDexBalances({ chain, api, data })
 }


### PR DESCRIPTION
Fixes: 
- embr-bridge, pryzm-protocol, treasury/mantadao, and all adapters with kujira exports

Updates: 
- shadeprotocol-derivatives, warp-dex, noble, figure-markets

1. Added new comos helper `queryV1Beta1V2` that supports pagination and uses the v1 function. Consumed by:
      - embr-bridge, shadeprotocol-derivatives, treasury/mantadao, warp-dex, noble, figure-markets
2. marked pryzm as dead and added deadFrom to pryzm-protocol
3. Updated broken kujira endpoint so its consumers can work again

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved paginated data fetching across several Cosmos-based projects (Embr Bridge, Figure Markets, Noble, Shade Protocol, Warp Dex, Warp Dex)
  * Fixed Kujira chain REST endpoint URL

* **Chores**
  * Marked Pryzm (effective 2026-02-09) and Manta DAO (effective 2025-06-25) as inactive
<!-- end of auto-generated comment: release notes by coderabbit.ai -->