### PR TITLE
feat(reservoir-protocol): sync adapter with latest reserve asset registry

### DIFF
--- a/projects/reservoir-protocol/index.js
+++ b/projects/reservoir-protocol/index.js
@@ -1,6 +1,5 @@
-const { sumTokensExport, sumTokens2 } = require('../helper/unwrapLPs')
 const ADDRESSES = require('../helper/coreAssets.json')
-const { sumTokens2: solanaSumTokens } = require('../helper/solana')
+const { sumTokensExport } = require('../helper/solana')
 
 const config = {
   ethereum: {
@@ -234,7 +233,7 @@ Object.keys(config).forEach(chain => {
 })
 
 module.exports.solana = {
-  tvl: async () => solanaSumTokens({
+  tvl: sumTokensExport({
     allowError: true,
     tokensAndOwners: [
       ['3b8X44fLF9ooXaUm3hhSgjpmVs6rZZ3pPoGnGahc3Uu7', 'FWKPQGz7RtFa5yY4moKJS4x6bhBeAFpqjuNRxLJJ8Fon'], // PRIME (Hastra)

--- a/projects/reservoir-protocol/index.js
+++ b/projects/reservoir-protocol/index.js
@@ -235,6 +235,7 @@ Object.keys(config).forEach(chain => {
 
 module.exports.solana = {
   tvl: async () => solanaSumTokens({
+    allowError: true,
     tokensAndOwners: [
       ['3b8X44fLF9ooXaUm3hhSgjpmVs6rZZ3pPoGnGahc3Uu7', 'FWKPQGz7RtFa5yY4moKJS4x6bhBeAFpqjuNRxLJJ8Fon'], // PRIME (Hastra)
       ['2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo', 'FWKPQGz7RtFa5yY4moKJS4x6bhBeAFpqjuNRxLJJ8Fon'], // kV-PYUSD (Kamino - Sentora)

--- a/projects/reservoir-protocol/index.js
+++ b/projects/reservoir-protocol/index.js
@@ -1,5 +1,6 @@
 const { sumTokensExport, sumTokens2 } = require('../helper/unwrapLPs')
 const ADDRESSES = require('../helper/coreAssets.json')
+const { sumTokens2: solanaSumTokens } = require('../helper/solana')
 
 const config = {
   ethereum: {
@@ -11,7 +12,6 @@ const config = {
       '0xC5deA68CCe26c014BEC516CDA70c107c534a73C4', // bbqUSDC - Steakhouse High Yield Instant
       '0x65078cfef8f7c07441661393eab6cb93b31db0dd', // steakUSDC Prime Instant V2
       // '0x31Eae643b679A84b37E3d0B4Bd4f5dA90fB04a61', - excluded RUSD because it is project's own token
-      '0x86Ac8e29Be5ad83c611fE054Df20970d3b4f9BE0', // gtUSDC - Gauntlet USDC Prime old 2
     ],
     blacklistedTokens: [
       '0x003ca23fd5f0ca87d01f6ec6cd14a8ae60c2b97d', // USD1 Dolomite (would double-count USD1)
@@ -37,6 +37,7 @@ const config = {
       ['0x0C0d01AbF3e6aDfcA0989eBbA9d6e85dD58EaB1E', '0x3063C5907FAa10c01B242181Aa689bEb23D2BD65'], // aEthPYUSD
       ['0x7c0477d085ECb607CF8429f3eC91Ae5E1e460F4F', '0x3063C5907FAa10c01B242181Aa689bEb23D2BD65'], // aEthUSDG
       ['0xE3190143Eb552456F88464662f0c0C4aC67A77eB', '0x3063C5907FAa10c01B242181Aa689bEb23D2BD65'], // aHorRwaRLUSD (Aave Horizon)
+      ['0xE1753F2e00940cC31213dd92013cF019DFE4ca1d', '0x3063C5907FAa10c01B242181Aa689bEb23D2BD65'], // sGHO
       ['0x1a88df1cfe15af22b3c4c783d4e6f7f9e0c1885d', '0x3063C5907FAa10c01B242181Aa689bEb23D2BD65'], // stkGHO
       // --- Cap ---
       ['0x88887bE419578051FF9F4eb6C858A951921D8888', '0x289C204B35859bFb924B9C0759A4FE80f610671c'], // stcUSD
@@ -66,6 +67,7 @@ const config = {
       ['0xb576765fB15505433aF24FEe2c0325895C559FB2', '0x289C204B35859bFb924B9C0759A4FE80f610671c'], // senPYUSDV2
       ['0x6dc58a0fdfc8d694e571dc59b9a52eeea780e6bf', '0x289C204B35859bFb924B9C0759A4FE80f610671c'], // senRLUSDv2
       ['0xd8A6511979D9C5D387c819E9F8ED9F3a5C6c5379', '0x289C204B35859bFb924B9C0759A4FE80f610671c'], // bbqPYUSD
+      ['0xC21b08C16458202593D4D9B26b9984Ee67b38BbD', '0x289C204B35859bFb924B9C0759A4FE80f610671c'], // senPYUSDPRIMEv2
       ['0x23f5E9c35820f4baB695Ac1F19c203cC3f8e1e11', '0x289C204B35859bFb924B9C0759A4FE80f610671c'], // skymoneyusdtsavings
       // Note: Morpho Blue market 0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb is a non-ERC20 singleton and cannot be queried via balanceOf
       // --- Pendle ---
@@ -77,6 +79,8 @@ const config = {
       ['0x545A490f9ab534AdF409A2E682bc4098f49952e3', '0x8Cc5a546408C6cE3C9eeB99788F9EC3b8FA6b9F3'], // PT-cUSD-29JAN2026
       ['0xC3c7E5E277d31CD24a3Ac4cC9af3B6770F30eA33', '0x8Cc5a546408C6cE3C9eeB99788F9EC3b8FA6b9F3'], // PT Staked cap USD 29JAN2026
       ['0x5510B080449d5E3Bf345b6635eD40A35B36b081f', '0x8Cc5a546408C6cE3C9eeB99788F9EC3b8FA6b9F3'], // PT-siUSD-8JAN2026
+      ['0x1D69402390657308C91179aa184bF992908c1e08', '0x8Cc5a546408C6cE3C9eeB99788F9EC3b8FA6b9F3'], // PT-USDat-27AUG2026
+      ['0x23238f20b894f29041f48D88eE91131C395Aaa71', '0x8Cc5a546408C6cE3C9eeB99788F9EC3b8FA6b9F3'], // USDat
       ['0x1fb3c5c35d95f48e48ffc8e36bcce5cb5f29f57c', '0x5563CDA70F7aA8b6C00C52CB3B9f0f45831a22b1'], // PT-srUSDe-15JAN2026
       ['0x3b3fB9C57858EF816833dC91565EFcd85D96f634', '0x5563CDA70F7aA8b6C00C52CB3B9f0f45831a22b1'], // PT-sUSDE-31JUL2025
       ['0x9F56094C450763769BA0EA9Fe2876070c0fD5F77', '0x5563CDA70F7aA8b6C00C52CB3B9f0f45831a22b1'], // PT-sUSDE-25SEP2025
@@ -89,6 +93,8 @@ const config = {
       ['0x62C6E813b9589C3631Ba0Cdb013acdB8544038B7', '0x8d3A354f187065e0D4cEcE0C3a5886ac4eBc4903'], // PT-USDe-27NOV2025
       [ADDRESSES.ethereum.USDe, '0x8d3A354f187065e0D4cEcE0C3a5886ac4eBc4903'], // USDe
       ['0xA01227A26A7710bc75071286539E47AdB6DEa417', '0x8d3A354f187065e0D4cEcE0C3a5886ac4eBc4903'], // tUSDe
+      // --- Real world assets ---
+      ['0x19ebb35279A16207Ec4ba82799CC64715065F7F6', '0x289C204B35859bFb924B9C0759A4FE80f610671c'], // PRIME (Hastra)
       // --- Hyperithm ---
       ['0x777791C4d6DC2CE140D00D2828a7C93503c67777', '0x2adf038b67a8a29cda82f0eceb1ff0dba704b98d'], // hyperUSDC
       // --- IPOR ---
@@ -111,7 +117,7 @@ const config = {
       [ADDRESSES.arbitrum.USDe, '0x9A319b57B80c50f8B19DB35D3224655F3aDd8E4f'], // USDe
       ['0xe818ad0D20D504C55601b9d5e0E137314414dec4', '0x9A319b57B80c50f8B19DB35D3224655F3aDd8E4f'], // k3USDT
       ['0xd8f824d4252caE7d5E49B95d47B0EfAfe6f2d570', '0x9A319b57B80c50f8B19DB35D3224655F3aDd8E4f'], // fUSDe
-      ['0xb77E872A68C62CfC0dFb02C067Ecc3DA23B4bbf3', '0x289C204B35859bFb924B9C0759A4FE80f610671c'], // GHO (Plasma)
+      ['0xb77E872A68C62CfC0dFb02C067Ecc3DA23B4bbf3', '0x3063C5907FAa10c01B242181Aa689bEb23D2BD65'], // GHO (Plasma)
       ['0xAd571979b4245E163A7E2119EB4dFd94AfDaebC5', '0x3063C5907FAa10c01B242181Aa689bEb23D2BD65'], // aPlaGHO
       ['0x96D7478219bFCc9B5d25F08ccb983815ee9D05e2', '0x289C204B35859bFb924B9C0759A4FE80f610671c'], // fGHO (Plasma)
       ['0x9c46EE1f01d2b551048F5fF99a4659D98d04BED1', '0x9A319b57B80c50f8B19DB35D3224655F3aDd8E4f'], // 246USDT0
@@ -187,6 +193,7 @@ const config = {
     tokensAndOwners: [
       ['0x88e0994E8130EF72bf614CBBcF722839B167c8d1', '0x0db79c0770E1C647b8Bb76D94C22420fAA7Ac181'], // cAUSD (Curvance)
       ['0x32841A8511D5c2c5b253f45668780B99139e476D', '0x289C204B35859bFb924B9C0759A4FE80f610671c'], // grove-bbqAUSD (Morpho Grove x Steakhouse)
+      ['0xbeeffb65df79baac701307c9605b7ab207355fdb', '0x289C204B35859bFb924B9C0759A4FE80f610671c'], // bbqUSD1 (Steakhouse High Yield USD1)
     ]
   },
   hyperliquid: {
@@ -198,6 +205,11 @@ const config = {
   katana: {
     tokensAndOwners: [
       ['0x61D4F9D3797BA4dA152238c53a6f93Fb665C3c1d', '0x289C204B35859bFb924B9C0759A4FE80f610671c'], // steakUSDC
+    ]
+  },
+  tempo: {
+    tokensAndOwners: [
+      ['0xC609656Ed9ef219c98C8e549bF729144F211f06E', '0x289C204B35859bFb924B9C0759A4FE80f610671c'], // pathUSD (Gauntlet)
     ]
   },
 }
@@ -220,6 +232,15 @@ const tvl = async (api) => {
 Object.keys(config).forEach(chain => {
   module.exports[chain] = { tvl }
 })
+
+module.exports.solana = {
+  tvl: async () => solanaSumTokens({
+    tokensAndOwners: [
+      ['3b8X44fLF9ooXaUm3hhSgjpmVs6rZZ3pPoGnGahc3Uu7', 'FWKPQGz7RtFa5yY4moKJS4x6bhBeAFpqjuNRxLJJ8Fon'], // PRIME (Hastra)
+      ['2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo', 'FWKPQGz7RtFa5yY4moKJS4x6bhBeAFpqjuNRxLJJ8Fon'], // kV-PYUSD (Kamino - Sentora)
+    ]
+  })
+}
 
 module.exports.hallmarks = [
   ['2025-11-04', 'Stream finance XUSD depeg'],


### PR DESCRIPTION
## Summary

- **Add 6 new Ethereum positions**: sGHO (Aave Savings GHO), PT-USDat-27AUG2026 (Pendle), USDat, PRIME / senPYUSDPRIMEv2 (Hastra × Sentora Morpho vault)
- **Add 1 new Monad position**: bbqUSD1 (Steakhouse High Yield USD1 on Morpho)
- **Add Tempo Mainnet**: pathUSD (Gauntlet Morpho vault)
- **Add Solana chain**: PRIME token holding (Hastra) + kV-PYUSD vault shares (Kamino – Sentora)
- **Bug fix**: GHO on Plasma had the wrong owner address (`0x289C...` → `0x3063...`)
- **Remove stale fund**: `0x86Ac8e29Be5ad83c611fE054Df20970d3b4f9BE0` (gtUSDC old 2) is no longer in the reserve asset registry

## Test plan

- [x] `LLAMA_DEBUG_MODE=true node test.js projects/reservoir-protocol/index.js` passes on all EVM chains (~$70M measured locally; production will be higher as several vault tokens lack local price feeds)
- [x] New entries confirmed: `senPYUSDPRIMEv2 $18M`, `PRIME $15.5M`, `PT-USDat $8M`, `aPlaGHO $12M` (GHO Plasma fix), `bbqUSD1 $5.2M`
- [x] No regressions on existing chains

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Solana network support with TVL calculations.

* **Updates**
  * Expanded token coverage (Aave sGHO, senPYUSDPRIMEv2, Pendle PT-USDat pair, USDat, PRIME/Hastra) across multiple chains.
  * Added Tempo chain section and added bbqUSD1 to Monad; updated Plasma GHO owner and adjusted fund entries for accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->