### PR TITLE
fix: wrap Scallop exchange rate in try/catch to prevent $0 TVL for all nemo markets

### DIFF
--- a/projects/nemo/index.js
+++ b/projects/nemo/index.js
@@ -77,6 +77,7 @@ async function getTvl(type, fields, api) {
   if (!watchCoinType.includes(coinConfig.coinType)) return null;
 
   const txBlockBytes = await getExchangeRate(coinConfig);
+  if (!txBlockBytes || txBlockBytes.length === 0) return null;
 
   const inspectionResult = await sui.call(
     'sui_devInspectTransactionBlock',

--- a/projects/nemo/price.js
+++ b/projects/nemo/price.js
@@ -46,7 +46,14 @@ function parseSuiAddress(str) {
 
 async function getExchangeRate(coinConfig) {
   if (coinConfig.provider === 'Scallop') {
-    return await getScallopTokenExchangeRate(coinConfig);
+    try {
+      return await getScallopTokenExchangeRate(coinConfig);
+    } catch (e) {
+      // Scallop package version mismatch after upgrade - return empty to avoid $0 TVL for all markets
+      // TODO: update package address 0x14c26838... and providerVersion object IDs when Nemo team republishes
+      console.error(`Scallop exchange rate failed for ${coinConfig.coinType}: ${e.message}`);
+      return [];
+    }
   } else if (coinConfig.provider === 'Nemo') {
     return await getNemoTokenExchangeRate(coinConfig);
   } else if (coinConfig.coinType === '0xf325ce1300e8dac124071d3152c5c5ee6174914f8bc2161e88329cf579246efc::afsui::AFSUI') {


### PR DESCRIPTION
## Summary
Closes #19531

## Problem
Scallop upgraded their on-chain package causing version mismatch:
`MoveAbort version::assert_current_version (error 513)`

This caused the entire nemo adapter to silently return $0 TVL 
instead of only the Scallop markets failing.

## Fix
Wrap `getScallopTokenExchangeRate()` in try/catch so non-Scallop 
providers continue reporting TVL:
- SpringSui (6 markets)
- Winter (2 markets)  
- Nemo (2 markets)
- Haedal, Cetus, Volo, Strater

## Remaining Issue
Scallop markets (~9) will show $0 until Nemo team updates:
1. Package address `0x14c26838...`
2. `providerVersion` object IDs in `coinConfig.js`

These require the Nemo team to republish the rate helper compiled 
against current Scallop deps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when external exchange-rate providers fail: errors are now logged and the system falls back safely instead of crashing.
  * Prevented downstream failures in TVL calculations by detecting missing exchange-rate data early and skipping invalid transaction calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->