### PR TITLE
fix(ada-harvest): update to current vault address + lovelace-only TVL

### DIFF
--- a/projects/ada-harvest/index.js
+++ b/projects/ada-harvest/index.js
@@ -2,10 +2,10 @@ const { sumTokensExport } = require('../helper/chain/cardano');
 
 // ADA Harvest - Cardano PlutusV3 flash loan vault + yield aggregator
 // Vault address (base address, delegates to a stake pool):
-//   addr1zx0es78sfa3cl47pmu9tcwqc7mx9wacu270u76yrk4duk2ggucktr6zta3rtuqlqam4395sry3vl5c7ss08m50qtnj6s4zlejx
+//   addr1z993rpqdxcgnncqxjyy37kjy27f94gyvwcatg7x86wk8xjcgucktr6zta3rtuqlqam4395sry3vl5c7ss08m50qtnj6slx9svv
 // Docs: https://ada-harvest.com
 
-const VAULT_ADDRESS = 'addr1zx0es78sfa3cl47pmu9tcwqc7mx9wacu270u76yrk4duk2ggucktr6zta3rtuqlqam4395sry3vl5c7ss08m50qtnj6s4zlejx';
+const VAULT_ADDRESS = 'addr1z993rpqdxcgnncqxjyy37kjy27f94gyvwcatg7x86wk8xjcgucktr6zta3rtuqlqam4395sry3vl5c7ss08m50qtnj6slx9svv';
 
 module.exports = {
   // Vault funds may later be deployed into Minswap/Liqwid, which have their own

--- a/projects/ada-harvest/index.js
+++ b/projects/ada-harvest/index.js
@@ -2,10 +2,10 @@ const { sumTokensExport } = require('../helper/chain/cardano');
 
 // ADA Harvest - Cardano PlutusV3 flash loan vault + yield aggregator
 // Vault address (base address, delegates to a stake pool):
-//   addr1zyn8hlf0wqkcvsdu89yvnt5kqnf69560xej36vrt4ue6uzcgucktr6zta3rtuqlqam4395sry3vl5c7ss08m50qtnj6sjernpa
+//   addr1zx0es78sfa3cl47pmu9tcwqc7mx9wacu270u76yrk4duk2ggucktr6zta3rtuqlqam4395sry3vl5c7ss08m50qtnj6s4zlejx
 // Docs: https://ada-harvest.com
 
-const VAULT_ADDRESS = 'addr1zyn8hlf0wqkcvsdu89yvnt5kqnf69560xej36vrt4ue6uzcgucktr6zta3rtuqlqam4395sry3vl5c7ss08m50qtnj6sjernpa';
+const VAULT_ADDRESS = 'addr1zx0es78sfa3cl47pmu9tcwqc7mx9wacu270u76yrk4duk2ggucktr6zta3rtuqlqam4395sry3vl5c7ss08m50qtnj6s4zlejx';
 
 module.exports = {
   // Vault funds may later be deployed into Minswap/Liqwid, which have their own

--- a/projects/ada-harvest/index.js
+++ b/projects/ada-harvest/index.js
@@ -2,10 +2,10 @@ const { sumTokensExport } = require('../helper/chain/cardano');
 
 // ADA Harvest - Cardano PlutusV3 flash loan vault + yield aggregator
 // Vault address (base address, delegates to a stake pool):
-//   addr1z993rpqdxcgnncqxjyy37kjy27f94gyvwcatg7x86wk8xjcgucktr6zta3rtuqlqam4395sry3vl5c7ss08m50qtnj6slx9svv
+//   addr1z9mhqtrnwpc76frp2xtgtfyt4lwzzdfwsye0uh335kycu4sgucktr6zta3rtuqlqam4395sry3vl5c7ss08m50qtnj6s5usxpa
 // Docs: https://ada-harvest.com
 
-const VAULT_ADDRESS = 'addr1z993rpqdxcgnncqxjyy37kjy27f94gyvwcatg7x86wk8xjcgucktr6zta3rtuqlqam4395sry3vl5c7ss08m50qtnj6slx9svv';
+const VAULT_ADDRESS = 'addr1z9mhqtrnwpc76frp2xtgtfyt4lwzzdfwsye0uh335kycu4sgucktr6zta3rtuqlqam4395sry3vl5c7ss08m50qtnj6s5usxpa';
 
 module.exports = {
   // Vault funds may later be deployed into Minswap/Liqwid, which have their own

--- a/projects/ada-harvest/index.js
+++ b/projects/ada-harvest/index.js
@@ -1,14 +1,20 @@
 const { sumTokensExport } = require('../helper/chain/cardano');
 
-// ADA Harvest - Cardano DeFi yield aggregator + flash loan vault
-// Vault address: addr1w89u29sdr6aazr6v9zhdk6vh4az75enlzph2372v3tq55usz9ale6
+// ADA Harvest - Cardano PlutusV3 flash loan vault + yield aggregator
+// Vault address (base address, delegates to a stake pool):
+//   addr1zyn8hlf0wqkcvsdu89yvnt5kqnf69560xej36vrt4ue6uzcgucktr6zta3rtuqlqam4395sry3vl5c7ss08m50qtnj6sjernpa
 // Docs: https://ada-harvest.com
 
-const VAULT_ADDRESS = 'addr1w89u29sdr6aazr6v9zhdk6vh4az75enlzph2372v3tq55usz9ale6';
+const VAULT_ADDRESS = 'addr1zyn8hlf0wqkcvsdu89yvnt5kqnf69560xej36vrt4ue6uzcgucktr6zta3rtuqlqam4395sry3vl5c7ss08m50qtnj6sjernpa';
 
 module.exports = {
-  methodology: 'Counts ADA locked in the ADA Harvest PlutusV3 vault contract. The vault earns yield via flash loan fees, AI-council-governed DeFi protocol deployments, and ADA staking rewards.',
+  // Vault funds may later be deployed into Minswap/Liqwid, which have their own
+  // adapters, so flag as double-counted to avoid inflating total Cardano TVL.
+  doublecounted: true,
+  methodology:
+    'Counts only the ADA (lovelace) locked in the ADA Harvest PlutusV3 vault contract. ' +
+    'Non-ADA assets are excluded. The vault earns flash loan fees and ADA staking rewards.',
   cardano: {
-    tvl: sumTokensExport({ scripts: [VAULT_ADDRESS] }),
+    tvl: sumTokensExport({ scripts: [VAULT_ADDRESS], tokens: ['lovelace'] }),
   },
 };


### PR DESCRIPTION
Follow-up to #19538 (merged).

The merged adapter pointed at an earlier ADA Harvest vault address that has since been migrated on mainnet — that old address is now drained (0 ADA), so the adapter reports 0 TVL.

This PR:
- Updates `VAULT_ADDRESS` to the current live base vault: `addr1zyn8hlf0wqkcvsdu89yvnt5kqnf69560xej36vrt4ue6uzcgucktr6zta3rtuqlqam4395sry3vl5c7ss08m50qtnj6sjernpa`
- Applies the CodeRabbit review from #19538: restricts `sumTokensExport` to `tokens: ['lovelace']` (no non-ADA double counting), adds `doublecounted: true`, and an accurate methodology string.

Verify on Cardanoscan: the vault holds ~90 ADA and is delegated to a stake pool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * ADA Harvest now reports TVL using ADA-only (lovelace) balances.
  * Vault updated to the new PlutusV3 deployment address.
  * Vault is marked as double-counted and methodology clarified to exclude non-ADA assets, preventing TVL inflation from downstream deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->