### PR TITLE
minor dead fixes

### DIFF
--- a/projects/accumulated-finance/index.js
+++ b/projects/accumulated-finance/index.js
@@ -71,13 +71,13 @@ const config = {
       }
     }
   ],
-  "artela": [
-    {
-      "artela": {
-        "LST": "0xcba2aeec821b0b119857a9ab39e09b034249681a"
-      },
-    }
-  ],
+  // "artela": [
+  //   {
+  //     "artela": {
+  //       "LST": "0xcba2aeec821b0b119857a9ab39e09b034249681a"
+  //     },
+  //   }
+  // ],
   "bitkub": [{
     "bitkub": {
       "LST": "0xcba2aeec821b0b119857a9ab39e09b034249681a"
@@ -140,3 +140,5 @@ Object.entries(transformedConfig).forEach(([chain, configs]) => {
     },
   }
 })
+
+module.exports.artela = { tvl: () => ({}) };

--- a/projects/helper/deadChains.js
+++ b/projects/helper/deadChains.js
@@ -19,4 +19,10 @@ module.exports =  [
   'tenet', // stopped producing blocks 2026-04-22: https://tenetscan.io/block/27263599
   'enuls', // shutdown 2026-03-25 and merged with NerveNetwork: https://x.com/Nuls/status/2029433112254443679 
   'pryzm', // shutdown 2026-02-09: https://x.com/Pryzm_Zone/status/2000705996969091570
+  'tara', // shutdown 2026-03-09: https://x.com/taraxa_project/status/2031039710278058142
+  'artela', // dead: https://artela.network/
+  'grove', 
+  'crab', // shutdown 2026-01-01: https://x.com/DarwiniaNetwork/status/1998942590927036611
+  'ham', // block explorer and rpcs are dead: https://explorer.ham.fun/
+  'onus', // block explorer and rpcs are dead (rug?): https://explorer.onuschain.io
 ]

--- a/projects/meridian/index.js
+++ b/projects/meridian/index.js
@@ -24,11 +24,6 @@ module.exports = {
     tvl: getLiquityTvl("0xCD413fC3347cE295fc5DB3099839a203d8c2E6D9"),
     staking: staking(FUSE_STAKING_ADDRESS, FUSE_MST_ADDRESS)
    },
-  tara: { tvl: getLiquityTvl("0xd2ff761A55b17a4Ff811B262403C796668Ff610D") },
-  artela: { tvl: getLiquityTvl("0xd2ff761A55b17a4Ff811B262403C796668Ff610D") },
+  tara: { tvl: () => ({})},
+  artela: { tvl: () => ({})}
 };
-
-//const { getLiquityTvl } = require("../helper/liquity.js");
-
-
-

--- a/projects/quicksilver/index.js
+++ b/projects/quicksilver/index.js
@@ -17,6 +17,7 @@ const coinGeckoIds = {
   ppica: "picasso",
   uflix: "omniflix-network",
   inj: "injective",
+  uluna: "terra-luna-2",
 };
 
 async function tvl() {

--- a/projects/snowswap-xyz/index.js
+++ b/projects/snowswap-xyz/index.js
@@ -6,13 +6,14 @@ const baseTvl = getUniTVL({
 })
 
 const tvl = async (api) => {
-  const newRpcUrl = 'https://darwinia.rpc.subquery.network/public';
+  const newRpcUrl = 'https://rpc.darwinia.network';
   api.provider.rpcs = [{ url: newRpcUrl }];
   return baseTvl(api)
 }
 
 module.exports = {
   misrepresentedTokens: true,
-  crab: { tvl: getUniTVL({ useDefaultCoreAssets: true, factory: '0x36ABF1A7851fBF9ae9D79dc3E39C1227068158B3' }), },
+  // crab: { tvl: getUniTVL({ useDefaultCoreAssets: true, factory: '0x36ABF1A7851fBF9ae9D79dc3E39C1227068158B3' }), },
+  crab: { tvl: () => ({}) },
   darwinia: { tvl },
 }


### PR DESCRIPTION
1. accumulated-finance - fixed by removing artela
2. quicksilver - fixed by adding a mapping for terra-luna-2
3. snowswap-xyz - fixed by removing crab
4. meridian - fixed by removing artela and tara

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
- Disabled TVL (Total Value Locked) tracking for select blockchain deployments
- Updated RPC endpoint configurations and infrastructure settings
- Added support for additional asset denominations in network tracking
- Marked multiple blockchain networks as inactive in the system

<!-- end of auto-generated comment: release notes by coderabbit.ai -->