### PR TITLE
[TermMax] track V2.01 factories on BSC

### DIFF
--- a/projects/term-structure/index.js
+++ b/projects/term-structure/index.js
@@ -100,6 +100,17 @@ const ADDRESSES = {
         fromBlock: 67248948,
       },
       // End of TermMax Alpha
+      // TermMax V2.01 (same MarketCreated event signature)
+      {
+        address: "0x4a34b4cAaA6AD23B95d6ec6394472fbB857eB064",
+        fromBlock: 92440281,
+      },
+      // Start of TermMax Alpha
+      {
+        address: "0x22105089AFC8F35D55a9Efb19785fd350ADdd7C3",
+        fromBlock: 92440287,
+      },
+      // End of TermMax Alpha
     ],
     VaultFactory: [
       {
@@ -116,6 +127,17 @@ const ADDRESSES = {
       {
         address: "0xC63858D1eFa377f94392Ba5dEb521233Ec1548eb",
         fromBlock: 67251242,
+      },
+      // End of TermMax Alpha
+      // TermMax V2.01 (same VaultCreated event signature)
+      {
+        address: "0x310ec798C59894c0eC6ce5c18060f63a37592BC7",
+        fromBlock: 92440303,
+      },
+      // Start of TermMax Alpha
+      {
+        address: "0x34bF74BA2534fC80b52e8C8F2C6b2B9FBc01d3B8",
+        fromBlock: 92465857,
       },
       // End of TermMax Alpha
     ],


### PR DESCRIPTION
Add the V2.01-generation market and vault factories on BSC that were missing from the adapter. They reuse the existing MarketCreated / VaultCreated event signatures, so the existing EVENTS.V2.* ABIs decode them without change.

Without them the V2.01 option-style markets (e.g. NVDAon/USDT, SPYon/USDT puts) and their idle USDT/WBNB were excluded, under-counting BSC TVL by ~$0.87M (0.43M → 1.30M, in line with Sentio/Dune).

- Market factory:
  - 0x4a34b4cAaA6AD23B95d6ec6394472fbB857eB064
  - 0x22105089AFC8F35D55a9Efb19785fd350ADdd7C3
- Vault factory:
  - 0x310ec798C59894c0eC6ce5c18060f63a37592BC7
  - 0x34bF74BA2534fC80b52e8C8F2C6b2B9FBc01d3B8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Binance Smart Chain network contract configurations to support the latest market and vault event sources, enhancing data tracking accuracy for TVL and borrowing calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->