### PR TITLE
update bluefin x alphalend attribution

### DIFF
--- a/projects/bluefin-alphalend/core.js
+++ b/projects/bluefin-alphalend/core.js
@@ -1,0 +1,33 @@
+const { getDynamicFieldObjects } = require('../helper/chain/sui');
+
+const MARKETS_CONTAINER = '0x2326d387ba8bb7d24aa4cfa31f9a1e58bf9234b097574afb06c5dfb267df4c2e';
+const SWITCH_TS = 1778976000;
+
+async function fetchMarkets() {
+  return getDynamicFieldObjects({
+    parent: MARKETS_CONTAINER,
+    idFilter: (i) => i.objectType.includes('::market::Market'),
+  });
+}
+
+async function tvl(api) {
+  const marketData = await fetchMarkets();
+  for (const market of marketData) {
+    const { fields } = market;
+    if (!fields) continue;
+    const coinType = "0x" + fields.value.fields.coin_type.fields.name;
+    api.add(coinType, Number(fields.value.fields.balance_holding));
+  }
+}
+
+async function borrowed(api) {
+  const marketData = await fetchMarkets();
+  for (const market of marketData) {
+    const { fields } = market;
+    if (!fields) continue;
+    const coinType = "0x" + fields.value.fields.coin_type.fields.name;
+    api.add(coinType, Number(fields.value.fields.borrowed_amount));
+  }
+}
+
+module.exports = { tvl, borrowed, SWITCH_TS};

--- a/projects/bluefin-alphalend/index.js
+++ b/projects/bluefin-alphalend/index.js
@@ -1,45 +1,15 @@
-const { getDynamicFieldObjects, getObjects } = require('../helper/chain/sui');
+const { tvl, borrowed, SWITCH_TS } = require('./core');
 
-const MARKETS_CONTAINER = '0x2326d387ba8bb7d24aa4cfa31f9a1e58bf9234b097574afb06c5dfb267df4c2e';
-
-async function tvl(api) {
-  const marketData = await getDynamicFieldObjects({
-    parent: MARKETS_CONTAINER,
-    idFilter: (i) => i.objectType.includes('::market::Market'),
-  });
-
-  for (const market of marketData) {
-    const { fields } = market;
-    if (!fields) continue;
-
-    const coinType = "0x" + fields.value.fields.coin_type.fields.name;
-    const balance = Number(fields.value.fields.balance_holding);
-    api.add(coinType, balance);
-  }
-}
-async function borrowed(api) {
-  const marketData = await getDynamicFieldObjects({
-    parent: MARKETS_CONTAINER,
-    idFilter: (i) => i.objectType.includes('::market::Market'),
-  });
-
-  for (const market of marketData) {
-    const { fields } = market;
-    if (!fields) continue;
-
-    const coinType = "0x" + fields.value.fields.coin_type.fields.name;
-    const borrowed = Number(fields.value.fields.borrowed_amount);
-
-    api.add(coinType, borrowed);
-  }
-}
+// TVL attributed to bluefin until partnership ended 2026-05-17
+const gate = (fn) => async (api) => api.timestamp >= SWITCH_TS ? {} : fn(api);
 
 module.exports = {
   sui: {
-    tvl: tvl,
-    borrowed: borrowed,
+    tvl: gate(tvl),
+    borrowed: gate(borrowed),
   },
   hallmarks: [
     ['2025-05-07', 'AlphaLend Launched'],
+    ['2026-05-17', 'AlphaFi Partnership Ended'],
   ],
 };

--- a/projects/lending-by-alphafi/index.js
+++ b/projects/lending-by-alphafi/index.js
@@ -1,0 +1,11 @@
+const { tvl, borrowed, SWITCH_TS } = require('../bluefin-alphalend/core');
+
+// TVL attributed to bluefin until partnership ended 2026-05-17
+const gate = (fn) => async (api) => api.timestamp < SWITCH_TS ? {} : fn(api);
+
+module.exports = {
+  sui: {
+      tvl: gate(tvl),
+      borrowed: gate(borrowed),
+  },
+};


### PR DESCRIPTION
AlphaFi's alphalend tvl was attributed to bluefin throughout their parternship, now that it has ended we attribute it to AlphaFi


resolves #19534
resolves #19542

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added adapter support for Bluefin AlphaLend protocol to track TVL and borrowed amounts.
  * Added support for tracking lending protocol metrics with timestamp-based data collection.
  * Added historical milestone marker for partnership event.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->