### PR TITLE
mark eralend insolvent

### DIFF
--- a/projects/nexon/index.js
+++ b/projects/nexon/index.js
@@ -3,9 +3,9 @@ const { compoundExports, compoundExports2 } = require('../helper/compound');
 
 const comptroller = "0x0171cA5b372eb510245F5FA214F5582911934b3D"
 
-const lendingMarket = compoundExports(comptroller,  '0x1BbD33384869b30A323e15868Ce46013C82B86FB')
+const lendingMarket = compoundExports(comptroller,  '0x1BbD33384869b30A323e15868Ce46013C82B86FB', undefined, {isInsolvent: true})
 
-const lendingMarket2 = compoundExports2({ comptroller: '0xc955d5fa053d88e7338317cc6589635cd5b2cf09',  cether: '0x22d8b71599e14f20a49a397b88c1c878c86f5579', blacklistedTokens: [
+const lendingMarket2 = compoundExports2({ comptroller: '0xc955d5fa053d88e7338317cc6589635cd5b2cf09',  cether: '0x22d8b71599e14f20a49a397b88c1c878c86f5579', isInsolvent: true, blacklistedTokens: [
   '0x247b1891c1d04d5972658824dcfbab71b0e9ca1d',
   '0x23a7c9bf087f3c52829429458d0dec26567a3ea6',
 ]})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Marked two Compound lending markets as insolvent, preventing further transactions on these markets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->