### PR TITLE
fix: mark laraProtocol, defily-dex, onus-usdo as dead (tara/onus chains shutdown)

### DIFF
--- a/projects/defily-dex/index.js
+++ b/projects/defily-dex/index.js
@@ -1,15 +1,4 @@
-const { getUniTVL } = require('../helper/unknownTokens')
-
-const config = {
-  onus: '0xf57578DD26422e80ab4051165Fb64DA1F25E740A',
-}
-
 module.exports = {
-  misrepresentedTokens: true,
-};
-
-Object.keys(config).forEach(chain => {
-  module.exports[chain] = {
-    tvl: getUniTVL({ useDefaultCoreAssets: true, factory: config[chain], })
-  }
-})
+  deadFrom: '2026-01-01',
+  onus: { tvl: () => ({}) }
+}

--- a/projects/laraProtocol/index.js
+++ b/projects/laraProtocol/index.js
@@ -1,18 +1,7 @@
-
-const { staking } = require('../helper/staking')
-
-const LARA_ADDRESS = '0xE6A69cD4FF127ad8E53C21a593F7BaC4c608945e'
-const LARA_STAKING_CONTRACT = '0x9B859bEc39B47C8d9C1459046a32d76B1A6883C1'
-const STTARA_ADDRESS = '0x37Df886BE517F9c75b27Cb70dac0D61432C92FBE'
-
-async function tvl(api) {
-  const stTara = await api.call({ abi: 'erc20:totalSupply', target: STTARA_ADDRESS, })
-  api.addGasToken(stTara);
-}
-
 module.exports = {
+  deadFrom: '2026-03-09',
   tara: {
-    tvl,
-    staking: staking(LARA_STAKING_CONTRACT, LARA_ADDRESS)
+    tvl: () => ({}),
+    staking: () => ({})
   }
 };

--- a/projects/onus-usdo/index.js
+++ b/projects/onus-usdo/index.js
@@ -1,14 +1,4 @@
-const ADDRESSES = require('../helper/coreAssets.json')
-
-const owner = '0x3D513abc13f53A1E18Ae59A7B5B0930E55733C87'
-const onuBUSD = '0xdfB5E8a4AC08E46258A12AbE737bba5D8c452508'
-const BUSD = ADDRESSES.ethereum.BUSD
-
-const tvl = async (api) => {
-  const balance = await api.call({ target: onuBUSD, params: owner, abi: 'erc20:balanceOf' })
-  api.add(BUSD, balance, { skipChain: true })
-}
-
 module.exports = {
-  onus: { tvl }
+  deadFrom: '2026-01-01',
+  onus: { tvl: () => ({}) }
 }


### PR DESCRIPTION
Fixes three adapters that only export dead chains (tara/onus), causing "Protocol doesn't have total tvl" errors.

- laraProtocol — tara chain shutdown 2026-03-09 (https://x.com/taraxa_project/status/2031039710278058142)
- defily-dex — onus chain dead (https://explorer.onuschain.io)
- onus-usdo — onus chain dead

Both tara and onus were added to deadChains.js in #19547. These adapters need the matching deadFrom field and empty tvl exports to stop erroring.

Pattern follows pryzm-protocol (#19527) and meridian (#19547).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Defily-dex and onus-usdo have been marked as inactive effective January 1, 2026.
  * laraProtocol has been marked as inactive effective March 9, 2026.
  * TVL and staking data collection for these projects will be discontinued on their respective deprecation dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->