### PR TITLE
add pionex cex btc addresses

### DIFF
--- a/projects/helper/bitcoin-book/index.js
+++ b/projects/helper/bitcoin-book/index.js
@@ -909,6 +909,11 @@ module.exports = {
     "bc1qcwk60napcfcljv6phg69gfyfmp3emsgdj9cn5v",
     "bc1q4rtnrtnu829eet3m27huh6ld7x0xczjxd5dg5r",
     "bc1q7vfv3h99vxwu300qej6x2qdfsn58kq6nc9hec6",
+    "bc1qaxrcxhhukne3mnk7jt60d7hgn9a2dqt0gmwh67",
+    "bc1qgu9sf2888glnm6xzfz0q503gpdn64u2swlj2qh",
+    "bc1qh24tm2d8ve8nvjx6uugm2mf28m2z5ytdjvk06v",
+    "bc1ql3fe2x2tpyl75hwn7xe0g42dsenaxvr6qvccdy",
+    "bc1qn54dfx4r8tf7ychn6fvas8tczkcq302gjfsrh4",
   ],
   probit: [
     "19EgVpboqNjortWyhJSDAGRvHDtduqiSfr",


### PR DESCRIPTION
Add 5 new BTC wallet addresses for Pionex CEX proof of reserves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Bitcoin wallet addresses to exchange reference data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->