### PR TITLE
accountable: add yield strategy factory to each chain

### DIFF
--- a/projects/accountable/index.js
+++ b/projects/accountable/index.js
@@ -5,16 +5,19 @@ const FACTORIES = {
         '0x8a5Caf00C3EB20aEC11Fc35C153a8601Cd127fEd',
         '0x2f5CAc28cf80D465d7C8D67a49c8e36710a4B83B',
         '0x4927Ce3402035b801A1bEdDC498b7fb2fe9eA181',
+        '0x9f1EB2be7b6a7e611c270bbdb0A3358786769518', // yield factory
     ],
     ethereum: [
         '0x333a12e2B519DA16EBE75012d54574C16ef4463f',
         '0xDAc0e7EffB16B249d1Bb672D25D7827481Be2081',
         '0x2A7F22f81A3d301b8f0EAf4f09a78558c91Fc69a',
         '0xB4082B8126AF8B5345CfB159AC5d4b4F05F54bC5',
+        '0xC0f778b51bF9751BBccBF4e78A107026aDaDbe43', // yield factory
     ],
     citrea: [
         '0x4927Ce3402035b801A1bEdDC498b7fb2fe9eA181',
         '0x2f5CAc28cf80D465d7C8D67a49c8e36710a4B83B',
+        '0x9f1EB2be7b6a7e611c270bbdb0A3358786769518', // yield factory
     ],
 }
 


### PR DESCRIPTION
The adapter scanned only the fixed-term and open-term factories, so vaults created by the YieldStrategyFactory were not counted in TVL/borrowed. This adds the yield factory for ethereum, monad and citrea. It extends the same StrategyFactoryBase, so strategyProxies/strategyVaults discovery is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated configuration to add additional contract addresses for the Monad, Ethereum, and Citrea chains.
  * Expands on-chain coverage so endpoints and listings reflect these chains, improving visibility and availability of related on-chain items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->