### PR TITLE
Fusion (by IPOR) add option to properly calculate historical TVL

### DIFF
--- a/projects/ipor-fusion/index.js
+++ b/projects/ipor-fusion/index.js
@@ -39,10 +39,28 @@ async function tvl(api) {
     return {};
   }
   
-  debugLog(`[Fusion (by IPOR)] Processing ${chainConfig.vaults.length} vaults on ${chain}:`);
-  
-  const calls = chainConfig.vaults.map((vault, index) => {
-    debugLog(`  Vault ${index + 1}/${chainConfig.vaults.length}: ${vault.PlasmaVault} (${vault.name || 'Unknown'})`);
+  // Deduplicate by PlasmaVault address (case-insensitive) so the same vault is only counted once per chain
+  const vaultsByAddress = new Map();
+  const duplicateAddresses = [];
+  for (const vault of chainConfig.vaults) {
+    const key = vault.PlasmaVault.toLowerCase();
+    if (vaultsByAddress.has(key)) {
+      duplicateAddresses.push(vault.PlasmaVault);
+      continue;
+    }
+    vaultsByAddress.set(key, vault);
+  }
+  const uniqueVaults = [...vaultsByAddress.values()];
+
+  if (duplicateAddresses.length > 0) {
+    debugLog(`[Fusion (by IPOR)] Found ${duplicateAddresses.length} duplicate vault(s) by PlasmaVault address on ${chain}; counting each unique address once:`);
+    duplicateAddresses.forEach(address => debugLog(`  Duplicate PlasmaVault: ${address}`));
+  }
+
+  debugLog(`[Fusion (by IPOR)] Processing ${uniqueVaults.length} vaults on ${chain}:`);
+
+  const calls = uniqueVaults.map((vault, index) => {
+    debugLog(`  Vault ${index + 1}/${uniqueVaults.length}: ${vault.PlasmaVault} (${vault.name || 'Unknown'})`);
     return vault.PlasmaVault;
   });
 
@@ -52,7 +70,7 @@ async function tvl(api) {
   debugLog(`[Fusion (by IPOR)] GRAND TOTAL vaults processed across all chains so far: ${totalVaultsProcessed}`);
 
   if (DEBUG_LOGGING) {
-    await logVaultUsdValues(api, chain, chainConfig.vaults, calls)
+    await logVaultUsdValues(api, chain, uniqueVaults, calls)
   }
 
   // permitFailure so vaults not yet deployed at a historical block are skipped instead of throwing

--- a/projects/ipor-fusion/index.js
+++ b/projects/ipor-fusion/index.js
@@ -1,3 +1,4 @@
+const sdk = require('@defillama/sdk')
 const { getConfig } = require('../helper/cache')
 
 const IPOR_GITHUB_ADDRESSES_URL = "https://raw.githubusercontent.com/IPOR-Labs/ipor-abi/refs/heads/main/mainnet/addresses.json";
@@ -6,6 +7,26 @@ const DEBUG_LOGGING = false; // Set to true to enable debug logs
 const debugLog = (...args) => DEBUG_LOGGING && console.log(...args);
 
 let totalVaultsProcessed = 0;
+
+// Logs the USD value each vault contributes. Enabled by setting DEBUG_LOGGING = true.
+async function logVaultUsdValues(api, chain, vaults, calls) {
+  const assets = await api.multiCall({ calls, abi: 'address:asset', permitFailure: true })
+  const totalAssets = await api.multiCall({ calls, abi: 'uint256:totalAssets', permitFailure: true })
+
+  const rows = await Promise.all(calls.map(async (vaultAddress, i) => {
+    let usd = 0
+    if (assets[i] && totalAssets[i])
+      usd = Number(await sdk.Balances.getUSDValue({ [`${chain}:${assets[i]}`]: totalAssets[i] }, api.timestamp)) || 0
+    return { name: vaults[i].name || 'Unknown', vault: vaultAddress, usd }
+  }))
+
+  rows.sort((a, b) => b.usd - a.usd)
+  console.log(`\n[Fusion (by IPOR)] Per-vault USD value on ${chain}:`)
+  rows.forEach(({ name, vault, usd }) => {
+    console.log(`  ${Math.round(usd).toLocaleString().padStart(15)} USD  ${vault}  ${name}`)
+  })
+  console.log(`  ${Math.round(rows.reduce((s, r) => s + r.usd, 0)).toLocaleString().padStart(15)} USD  TOTAL (${rows.length} vaults)\n`)
+}
 
 async function tvl(api) {
   const config  = await getConfig('ipor/assets', IPOR_GITHUB_ADDRESSES_URL);
@@ -26,11 +47,16 @@ async function tvl(api) {
   });
 
   totalVaultsProcessed += calls.length;
-  
+
   debugLog(`[Fusion (by IPOR)] Total vaults processed on ${chain}: ${calls.length}`);
   debugLog(`[Fusion (by IPOR)] GRAND TOTAL vaults processed across all chains so far: ${totalVaultsProcessed}`);
-  
-  return api.erc4626Sum2({ calls })
+
+  if (DEBUG_LOGGING) {
+    await logVaultUsdValues(api, chain, chainConfig.vaults, calls)
+  }
+
+  // permitFailure so vaults not yet deployed at a historical block are skipped instead of throwing
+  return api.erc4626Sum2({ calls, permitFailure: true })
 }
 
 module.exports = {


### PR DESCRIPTION
**_EXTRA REQUEST:_** Please recalculate Fusion (by IPOR) TVL value from 9th May 2026 till current date to fix TVL value.

There was an issue with vault list in `ipor-abi` repo which is the source for the vault list on DefiLlama.
Some vaults were duplicated. It was merged on 9th May 2026 and from this date TVL value was not counted correctly. We fixed this in repo and in process that is creating vault list. We have also added a uniqueness check for the vault address to avoid making this mistake in the future.

What was changed:
- Add `permitFailure: true` to properly calculate historical TVL. Some vaults will be not present in the past so to not throw an exception they will be skipped.
- Add some optional debug, turned off by default.
- Add deduplicate by PlasmaVault address

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * TVL calculation at historical blocks now skips missing or non-deployed vaults and avoids throwing errors.
  * Vaults are deduplicated by address (case-insensitive) to prevent double-counting.

* **Improvements**
  * Optional debug logging now reports per-vault and total USD contributions for clearer monitoring and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->