### PR TITLE
Add consolidated Ramses TVL adapters

### DIFF
--- a/projects/ramses-cl/index.js
+++ b/projects/ramses-cl/index.js
@@ -1,0 +1,35 @@
+const BigNumber = require('bignumber.js')
+const { uniV3Export } = require('../helper/uniswapV3')
+
+function mergeBalances(target, source = {}) {
+  Object.entries(source).forEach(([token, amount]) => {
+    target[token] = new BigNumber(target[token] || 0).plus(amount).toFixed(0)
+  })
+  return target
+}
+
+function sumTvls(...tvls) {
+  return async (api) => {
+    const balances = {}
+    for (const tvl of tvls) mergeBalances(balances, await tvl(api))
+    return balances
+  }
+}
+
+const arbitrumLegacyCl = uniV3Export({
+  arbitrum: { factory: '0xaa2cd7477c451e703f3b9ba5663334914763edf8', fromBlock: 90593047 },
+}).arbitrum.tvl
+
+const arbitrumRamsesXCl = uniV3Export({
+  arbitrum: { factory: '0xd0019e86edB35E1fedaaB03aED5c3c60f115d28b', fromBlock: 420275312 },
+}).arbitrum.tvl
+
+module.exports = {
+  arbitrum: {
+    tvl: sumTvls(arbitrumLegacyCl, arbitrumRamsesXCl),
+  },
+  ...uniV3Export({
+    hyperliquid: { factory: '0x07E60782535752be279929e2DFfDd136Db2e6b45', fromBlock: 18149975 },
+    polygon: { factory: '0x2Bef16A0081565E72100D73CBe19B1Bd2d802380', fromBlock: 82177771 },
+  }),
+}

--- a/projects/ramses-cl/index.js
+++ b/projects/ramses-cl/index.js
@@ -1,5 +1,9 @@
-const sdk = require('@defillama/sdk')
 const { uniV3Export } = require('../helper/uniswapV3')
+
+const sumApiTvls = (tvls) => async (api) => {
+  for (const tvl of tvls) await tvl(api)
+  return api.getBalances()
+}
 
 const arbitrumLegacyCl = uniV3Export({
   arbitrum: { factory: '0xaa2cd7477c451e703f3b9ba5663334914763edf8', fromBlock: 90593047 },
@@ -11,7 +15,7 @@ const arbitrumRamsesXCl = uniV3Export({
 
 module.exports = {
   arbitrum: {
-    tvl: sdk.util.sumChainTvls([arbitrumLegacyCl, arbitrumRamsesXCl]),
+    tvl: sumApiTvls([arbitrumLegacyCl, arbitrumRamsesXCl]),
   },
   ...uniV3Export({
     hyperliquid: { factory: '0x07E60782535752be279929e2DFfDd136Db2e6b45', fromBlock: 18149975 },

--- a/projects/ramses-cl/index.js
+++ b/projects/ramses-cl/index.js
@@ -1,20 +1,5 @@
-const BigNumber = require('bignumber.js')
+const sdk = require('@defillama/sdk')
 const { uniV3Export } = require('../helper/uniswapV3')
-
-function mergeBalances(target, source = {}) {
-  Object.entries(source).forEach(([token, amount]) => {
-    target[token] = new BigNumber(target[token] || 0).plus(amount).toFixed(0)
-  })
-  return target
-}
-
-function sumTvls(...tvls) {
-  return async (api) => {
-    const balances = {}
-    for (const tvl of tvls) mergeBalances(balances, await tvl(api))
-    return balances
-  }
-}
 
 const arbitrumLegacyCl = uniV3Export({
   arbitrum: { factory: '0xaa2cd7477c451e703f3b9ba5663334914763edf8', fromBlock: 90593047 },
@@ -26,7 +11,7 @@ const arbitrumRamsesXCl = uniV3Export({
 
 module.exports = {
   arbitrum: {
-    tvl: sumTvls(arbitrumLegacyCl, arbitrumRamsesXCl),
+    tvl: sdk.util.sumChainTvls([arbitrumLegacyCl, arbitrumRamsesXCl]),
   },
   ...uniV3Export({
     hyperliquid: { factory: '0x07E60782535752be279929e2DFfDd136Db2e6b45', fromBlock: 18149975 },

--- a/projects/ramses/index.js
+++ b/projects/ramses/index.js
@@ -1,0 +1,40 @@
+const BigNumber = require('bignumber.js')
+const { getUniTVL } = require('../helper/unknownTokens')
+const { staking } = require('../helper/staking')
+
+const RAM = '0x555570a286F15EbDFE42B66eDE2f724Aa1AB5555'
+const XRAM = '0xAE6D5FcE541216BDA471D311425B5412D9f1DEb9'
+
+function mergeBalances(target, source = {}) {
+  Object.entries(source).forEach(([token, amount]) => {
+    target[token] = new BigNumber(target[token] || 0).plus(amount).toFixed(0)
+  })
+  return target
+}
+
+function sumTvls(...tvls) {
+  return async (api) => {
+    const balances = {}
+    for (const tvl of tvls) mergeBalances(balances, await tvl(api))
+    return balances
+  }
+}
+
+const legacyOptions = { useDefaultCoreAssets: true, hasStablePools: true }
+
+module.exports = {
+  misrepresentedTokens: true,
+  arbitrum: {
+    tvl: sumTvls(
+      getUniTVL({ ...legacyOptions, factory: '0xAAA20D08e59F6561f242b08513D36266C5A29415', stablePoolSymbol: 'crAMM' }),
+      getUniTVL({ ...legacyOptions, factory: '0xADd32480630A16dfAcEe6eeFcB3ab2181449Dc3B', stablePoolSymbol: 'cAMM' }),
+    ),
+  },
+  hyperliquid: {
+    tvl: getUniTVL({ ...legacyOptions, factory: '0xd0a07E160511c40ccD5340e94660E9C9c01b0D27', stablePoolSymbol: 'cAMM' }),
+    staking: staking(XRAM, RAM),
+  },
+  polygon: {
+    tvl: getUniTVL({ ...legacyOptions, factory: '0xA87c8308722237F6442Ef4762B7287afB84fB191', stablePoolSymbol: 'cAMM' }),
+  },
+}

--- a/projects/ramses/index.js
+++ b/projects/ramses/index.js
@@ -1,9 +1,5 @@
 const sdk = require('@defillama/sdk')
 const { getUniTVL } = require('../helper/unknownTokens')
-const { staking } = require('../helper/staking')
-
-const RAM = '0x555570a286F15EbDFE42B66eDE2f724Aa1AB5555'
-const XRAM = '0xAE6D5FcE541216BDA471D311425B5412D9f1DEb9'
 
 const legacyOptions = { useDefaultCoreAssets: true, hasStablePools: true }
 
@@ -17,7 +13,6 @@ module.exports = {
   },
   hyperliquid: {
     tvl: getUniTVL({ ...legacyOptions, factory: '0xd0a07E160511c40ccD5340e94660E9C9c01b0D27', stablePoolSymbol: 'cAMM' }),
-    staking: staking(XRAM, RAM),
   },
   polygon: {
     tvl: getUniTVL({ ...legacyOptions, factory: '0xA87c8308722237F6442Ef4762B7287afB84fB191', stablePoolSymbol: 'cAMM' }),

--- a/projects/ramses/index.js
+++ b/projects/ramses/index.js
@@ -1,34 +1,19 @@
-const BigNumber = require('bignumber.js')
+const sdk = require('@defillama/sdk')
 const { getUniTVL } = require('../helper/unknownTokens')
 const { staking } = require('../helper/staking')
 
 const RAM = '0x555570a286F15EbDFE42B66eDE2f724Aa1AB5555'
 const XRAM = '0xAE6D5FcE541216BDA471D311425B5412D9f1DEb9'
 
-function mergeBalances(target, source = {}) {
-  Object.entries(source).forEach(([token, amount]) => {
-    target[token] = new BigNumber(target[token] || 0).plus(amount).toFixed(0)
-  })
-  return target
-}
-
-function sumTvls(...tvls) {
-  return async (api) => {
-    const balances = {}
-    for (const tvl of tvls) mergeBalances(balances, await tvl(api))
-    return balances
-  }
-}
-
 const legacyOptions = { useDefaultCoreAssets: true, hasStablePools: true }
 
 module.exports = {
   misrepresentedTokens: true,
   arbitrum: {
-    tvl: sumTvls(
+    tvl: sdk.util.sumChainTvls([
       getUniTVL({ ...legacyOptions, factory: '0xAAA20D08e59F6561f242b08513D36266C5A29415', stablePoolSymbol: 'crAMM' }),
       getUniTVL({ ...legacyOptions, factory: '0xADd32480630A16dfAcEe6eeFcB3ab2181449Dc3B', stablePoolSymbol: 'cAMM' }),
-    ),
+    ]),
   },
   hyperliquid: {
     tvl: getUniTVL({ ...legacyOptions, factory: '0xd0a07E160511c40ccD5340e94660E9C9c01b0D27', stablePoolSymbol: 'cAMM' }),


### PR DESCRIPTION
Adds consolidated Ramses Legacy and Ramses CL TVL adapters using on-chain pool/factory helpers. These pair with the server and dimensions PRs that route RamsesX to two active child products.

Goals:
- clean up Ramses TVL into Legacy and CL products
- include current RamsesX liquidity sources
- preserve historical child continuity through the metadata PR

Verification:
- npm run build
- git diff --check
- node test.js projects/ramses/index.js
- node test.js projects/ramses-cl/index.js
- historical Ramses TVL probes

Companion PRs:
- defillama-server: https://github.com/DefiLlama/defillama-server/pull/12189
- dimension-adapters: https://github.com/DefiLlama/dimension-adapters/pull/7483

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for the Ramses protocol on Arbitrum, Hyperliquid, and Polygon.
  * Aggregated Arbitrum liquidity from multiple factory sources to provide a combined TVL view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->