### PR TITLE
Add Bulk Trade adapter

### DIFF
--- a/projects/bulk-trade/index.js
+++ b/projects/bulk-trade/index.js
@@ -1,0 +1,13 @@
+const { sumTokensExport } = require('../helper/solana')
+
+module.exports = {
+  timetravel: false,
+  solana: {
+    tvl: sumTokensExport({
+      tokenAccounts: [
+        'HwdwwKH1tMXo7ggTKcA5cdQrpcgqSoVib2eQh3BiyEQL',
+      ]
+    })
+  },
+  methodology: 'Counts USDC deposited into the Bulk Trade Season 1 pre-deposits.',
+}


### PR DESCRIPTION
## New adapter: Bulk Trade

Adds TVL tracking for [Bulk Trade](https://bulk.trade), a Solana-based pre-deposit vault for Season 1.

**Methodology:** Counts USDC deposited into the Bulk Trade Season 1 pre-deposits.

**How TVL is calculated:** Uses `sumTokensExport` from the Solana helper with the single USDC SPL token account (`HwdwwKH1tMXo7ggTKcA5cdQrpcgqSoVib2eQh3BiyEQL`) owned by the pre-deposit vault owner `7Wpp33Dn5KKUFjaij4zKYy1XZ9kdBtHjUatAT6NcjjGt`.

**Test output:**
```
--- solana ---
usdc                      24.58 M
Total: 24.58 M

------ TVL ------
solana                    24.58 M
total                    24.58 M
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added Bulk Trade TVL tracking on Solana, calculating the total value of USDC deposited in Bulk Trade Season 1 pre-deposits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->