### PR TITLE
fix marinade select

### DIFF
--- a/projects/marinade-select/index.js
+++ b/projects/marinade-select/index.js
@@ -8,12 +8,13 @@ const STAKER_OFFSET = 12
 const DEACTIVATION_OFFSET = 172
 const U64_MAX = 0xffffffffffffffffn
 
-// Solana RPC occasionally returns stale/buggy gPA snapshots that inflate
-// the active-stake sum by ~2.5x. Each fetch is compared to the last good value
-// in cache; anything >50% above baseline is retried after RETRY_DELAY_MS.
+// RPC occasionally returns extra SA that increases sum by ~2.5x. Each fetch is compared 
+// to the last value in cache; anything >50% above baseline is retried after RETRY_DELAY_MS.
 const SPIKE_THRESHOLD_BPS = 5000n
 const RETRY_ATTEMPTS = 3
 const RETRY_DELAY_MS = 1000
+// todo: remove once cache is set
+const BASELINE = 1148868506938795n  // 1.1M SOL, 2026-06
 
 async function fetchWithRetries(connection, cached) {
   const spikeCap = cached + (cached * SPIKE_THRESHOLD_BPS) / 10000n
@@ -41,8 +42,11 @@ async function fetchWithRetries(connection, cached) {
 
 async function tvl(api) {
   const cache = await getCache('marinade-select', 'solana')
-  const cached = cache?.activeLamports ? BigInt(cache.activeLamports) : null
-  if (!cached) throw new Error('marinade-select: missing reference cache')
+  const cached = (cache?.activeLamports ? BigInt(cache.activeLamports) : null) ?? BASELINE
+
+  // todo: use instead once initial cache is set
+  // const cached = cache?.activeLamports ? BigInt(cache.activeLamports) : null
+  // if (!cached) throw new Error('marinade-select: missing reference cache')
 
   const balance = await fetchWithRetries(getConnection(), cached)
   if (balance === null) throw new Error(`marinade-select: ${RETRY_ATTEMPTS} attempts spiked or errored`)
@@ -54,6 +58,5 @@ async function tvl(api) {
 module.exports = {
   timetravel: false,
   solana: { tvl },
-  methodology:
-    'Counts SOL in stake accounts where Marinade Select (STNi1NHDUi6Hvibvonawgze8fM83PFLeJhuGMEXyGps) is the staker authority. Only active stake (deactivation_epoch = u64::MAX) is counted; accounts in cooldown are excluded. The result is cached across runs; any sample more than 50% above the cached baseline is rejected as a known gPA inconsistency and retried via a fallback RPC. If both attempts spike or error, the adapter throws.',
+  methodology: 'We sum the amount of SOL staked by account STNi1NHDUi6Hvibvonawgze8fM83PFLeJhuGMEXyGps.',
 }

--- a/projects/marinade-select/index.js
+++ b/projects/marinade-select/index.js
@@ -1,0 +1,59 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+const { StakeProgram } = require('@solana/web3.js')
+const { getConnection } = require('../helper/solana')
+const { getCache, setCache } = require('../helper/cache')
+
+const MARINADE_SELECT_STAKER = 'STNi1NHDUi6Hvibvonawgze8fM83PFLeJhuGMEXyGps'
+const STAKER_OFFSET = 12
+const DEACTIVATION_OFFSET = 172
+const U64_MAX = 0xffffffffffffffffn
+
+// Solana RPC occasionally returns stale/buggy gPA snapshots that inflate
+// the active-stake sum by ~2.5x. Each fetch is compared to the last good value
+// in cache; anything >50% above baseline is retried after RETRY_DELAY_MS.
+const SPIKE_THRESHOLD_BPS = 5000n
+const RETRY_ATTEMPTS = 3
+const RETRY_DELAY_MS = 1000
+
+async function fetchWithRetries(connection, cached) {
+  const spikeCap = cached + (cached * SPIKE_THRESHOLD_BPS) / 10000n
+  for (let attempt = 0; attempt < RETRY_ATTEMPTS; attempt++) {
+    if (attempt > 0) await new Promise((r) => setTimeout(r, RETRY_DELAY_MS))
+    try {
+      const accts = await connection.getProgramAccounts(StakeProgram.programId, {
+        filters: [{ memcmp: { bytes: MARINADE_SELECT_STAKER, offset: STAKER_OFFSET } }],
+      })
+      const seen = new Set()
+      let active = 0n
+      for (const { pubkey, account } of accts) {
+        const key = pubkey.toBase58()
+        if (seen.has(key)) continue
+        seen.add(key)
+        if (account.data.readBigUInt64LE(DEACTIVATION_OFFSET) === U64_MAX) {
+          active += BigInt(account.lamports)
+        }
+      }
+      if (active <= spikeCap) return active
+    } catch (e) {}
+  }
+  return null
+}
+
+async function tvl(api) {
+  const cache = await getCache('marinade-select', 'solana')
+  const cached = cache?.activeLamports ? BigInt(cache.activeLamports) : null
+  if (!cached) throw new Error('marinade-select: missing reference cache')
+
+  const balance = await fetchWithRetries(getConnection(), cached)
+  if (balance === null) throw new Error(`marinade-select: ${RETRY_ATTEMPTS} attempts spiked or errored`)
+
+  await setCache('marinade-select', 'solana', { activeLamports: balance.toString() })
+  api.add(ADDRESSES.solana.SOL, balance.toString())
+}
+
+module.exports = {
+  timetravel: false,
+  solana: { tvl },
+  methodology:
+    'Counts SOL in stake accounts where Marinade Select (STNi1NHDUi6Hvibvonawgze8fM83PFLeJhuGMEXyGps) is the staker authority. Only active stake (deactivation_epoch = u64::MAX) is counted; accounts in cooldown are excluded. The result is cached across runs; any sample more than 50% above the cached baseline is rejected as a known gPA inconsistency and retried via a fallback RPC. If both attempts spike or error, the adapter throws.',
+}

--- a/registries/solanaStakePool.js
+++ b/registries/solanaStakePool.js
@@ -95,10 +95,6 @@ const configs = {
     ],
   },
   // getStakedSol adapters
-  'marinade-select': {
-    methodology: 'We sum the amount of SOL staked by account STNi1NHDUi6Hvibvonawgze8fM83PFLeJhuGMEXyGps',
-    solana: { type: 'staked', address: 'STNi1NHDUi6Hvibvonawgze8fM83PFLeJhuGMEXyGps' },
-  },
   'thevault': {
     solana: { type: 'staked', address: 'GdNXJobf8fbTR5JSE7adxa6niaygjx4EEbnnRaDCHMMW' },
   },


### PR DESCRIPTION
`STNi1NHDUi6Hvibvonawgze8fM83PFLeJhuGMEXyGps` typically returns ~4k SA but occasionally spikes to >7k. 

Fix: compare previous cached lamports to newly fetched value, if it increased by more than 50% then sleep and retry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for the Marinade Select Solana staking strategy, including automated spike detection and retry logic to keep TVL accurate during transient network inconsistencies.
* **Chores**
  * Removed the Marinade Select entry from the Solana stake-pool registry so it will no longer be included in the generated stake-pool exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->