### PR TITLE
Add Igra Network Attestation staking adapter

### DIFF
--- a/registries/stakingOnly.js
+++ b/registries/stakingOnly.js
@@ -69,6 +69,13 @@ const configs = {
     }
   },
 
+  'igra-attestation': {
+    methodology: 'IGRA tokens locked by attesters in the Attestation Diamond contract, securing Igra network state validation with a 6-month lockup.',
+    igra: {
+      staking: { owners: ['0xc24Df70E408739aeF6bF594fd41db4632dF49188'], tokens: ['0x093d77d397F8acCbaee0820345E9E700B1233cD1'] },
+    },
+  },
+
   // ============================================================
   // Tomb forks (tombTvl, tokensOnCoingecko=true) - array staking + array pool2
   // ============================================================


### PR DESCRIPTION
**Protocol**: Igra Attestation
**Website**: https://igralabs.com
**Chain**: Igra (chain ID 38833)
**Current TVL**: ~$558K staking (pending CoinGecko IGRA price sync)
**CoinGecko ID**: igra
**Category**: Staking
**Methodology**: IGRA tokens locked by attesters in the Attestation Diamond contract, securing Igra network state validation.

**Contracts**:
- Diamond (staking contract): `0xc24Df70E408739aeF6bF594fd41db4632dF49188`
- IGRA token: `0x093d77d397F8acCbaee0820345E9E700B1233cD1`