### PR TITLE
Add igra attestation staking adapter

### DIFF
--- a/registries/stakingOnly.js
+++ b/registries/stakingOnly.js
@@ -98,6 +98,12 @@ const configs = {
       staking: { owners: ['0x2015F35030A8Ff2C0CA161a865414996F8E80AA4'], tokens: ['0x547AfD93B9c47D552059FEb556909e017f8a9b25']},
     },
   },
+  'igra-attestation': {
+    methodology: 'IGRA tokens locked by attesters in the Attestation Diamond contract, securing Igra network state validation with a 6-month lockup.',
+    igra: {
+      staking: { owners: ['0xc24Df70E408739aeF6bF594fd41db4632dF49188'], tokens: ['0x093d77d397F8acCbaee0820345E9E700B1233cD1'] },
+    },
+  },
 
   // ============================================================
   // Tomb forks (tombTvl, tokensOnCoingecko=true) - array staking + array pool2


### PR DESCRIPTION
**Protocol**: Igra Attestation
**Website**: https://igralabs.com
**Chain**: Igra (chain ID 38833)
**Current TVL**: ~$558K staking (pending CoinGecko IGRA price sync)
**CoinGecko ID**: igra
**Category**: Staking
**Methodology**: IGRA tokens locked by attesters in the Attestation Diamond contract, securing Igra network state validation with a 6-month lockup.

**Contracts**:
  - Diamond (staking contract): `0xc24Df70E408739aeF6bF594fd41db4632dF49188`
  - IGRA token: `0x093d77d397F8acCbaee0820345E9E700B1233cD1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the igra-attestation protocol, enabling staking functionality with configured network mappings and token support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->