### PR TITLE
wtao: add adapter for TAO bridged to Ethereum (~$24M)

### DIFF
--- a/projects/wtao/index.js
+++ b/projects/wtao/index.js
@@ -1,12 +1,3 @@
-// wTAO: native TAO bridged from Bittensor and minted 1:1 as an ERC-20 on
-// Ethereum. Per maintainer guidance, TVL is the collateral LOCKED ON THE
-// SOURCE CHAIN (Bittensor), not the wrapped supply. The bridge's Bittensor
-// custody coldkey holds the backing and stakes ~all of it through a validator
-// (dlnews.com/articles/defi/wrapped-tao-on-ethereum-...), so the locked amount
-// is the coldkey's free balance PLUS its staked TAO. Read keyless from public
-// substrate RPC: free from System.Account, stake by summing the coldkey's
-// dTAO positions (share pools, both the V2 store and the legacy V1 store),
-// converting alpha -> TAO at each subnet's pool price (root/netuid 0 is 1:1).
 const blake = require('blakejs');
 const { post } = require('../helper/http');
 
@@ -23,8 +14,6 @@ const ITEM = {
   TotalHotkeyShares: '3dbb78074d07a16f4942c7df159ed5e5',
   TotalHotkeySharesV2: 'e47c637aa82c21537eb9caa511e543c5',
   TotalHotkeyAlpha: 'ee25c3b5b1886863480497907f1829e6',
-  SubnetTAO: '7a57dce016211512d1700561066b85a3',
-  SubnetAlphaIn: '2ce12f7007574647d692ac7edf8b7a53',
 };
 const SYS_ACCOUNT = '26aa394eea5630e07c48ae0c9558cef7b99d880ec681799c0cf30e8886371da9';
 
@@ -72,7 +61,7 @@ async function netuidsUnder(pfx, at) {
     start = keys[keys.length - 1];
   }
   return out;
-}
+} 
 
 /** TVL = TAO locked on Bittensor backing wTAO: the custody coldkey's free
  * balance plus its total staked TAO. All reads are pinned to one finalized
@@ -116,15 +105,10 @@ async function tvl(api) {
     reads.push(e.v === 2 ? Buffer.concat([aV2(e.hot), u16le(e.net)]) : Buffer.concat([aV1(e.hot), u16le(e.net)]));
     reads.push(Buffer.concat([prefix(e.v === 2 ? 'TotalHotkeySharesV2' : 'TotalHotkeyShares'), b2c(e.hot), u16le(e.net)]));
     reads.push(Buffer.concat([prefix('TotalHotkeyAlpha'), b2c(e.hot), u16le(e.net)]));
-    if (e.net !== 0) {
-      reads.push(Buffer.concat([prefix('SubnetTAO'), u16le(e.net)]));
-      reads.push(Buffer.concat([prefix('SubnetAlphaIn'), u16le(e.net)]));
-    }
   }
   const vals = await getMany(reads, at);
   const V = (buf) => vals.get(keyHex(buf));
 
-  let stakeTao = 0;
   for (const e of entries) {
     let alpha;
     if (e.v === 2) {
@@ -139,24 +123,14 @@ async function tvl(api) {
       alpha = fpV1(hexToBuf(V(Buffer.concat([aV1(e.hot), u16le(e.net)])) || '0x'));
       if (!alpha) continue;
     }
-    let price = 1; // root (netuid 0) is TAO 1:1
-    if (e.net !== 0) {
-      const t = V(Buffer.concat([prefix('SubnetTAO'), u16le(e.net)]));
-      const a = V(Buffer.concat([prefix('SubnetAlphaIn'), u16le(e.net)]));
-      const T = t ? u64LE(hexToBuf(t), 0) : 0n, A = a ? u64LE(hexToBuf(a), 0) : 0n;
-      price = A === 0n ? 0 : Number(T) / Number(A);
-    }
-    stakeTao += (alpha * price) / 1e9;
+    api.add(e.net.toString(), alpha)
   }
 
-  api.addCGToken('bittensor', free + stakeTao);
+  api.addCGToken('bittensor', free);
 }
 
 module.exports = {
   timetravel: false,
-  methodology:
-    'TAO locked on Bittensor backing wTAO on Ethereum. The bridge custody coldkey (5HiveMEoWPmQmBAb8v63bKPcFhgTGCmST1TVZNvPHSTKFLCv) holds the collateral and stakes most of it, so TVL is its free balance plus its total staked TAO, read keyless from public substrate RPC (dTAO share pools, alpha valued at each subnet pool price; root is 1:1).',
-  ethereum: {
-    tvl,
-  },
+  methodology: 'TAO locked on Bittensor backing wTAO on Ethereum. The bridge custody coldkey (5HiveMEoWPmQmBAb8v63bKPcFhgTGCmST1TVZNvPHSTKFLCv) holds the collateral and stakes most of it, so TVL is its free balance plus its total staked TAO, read keyless from public substrate RPC (dTAO share pools, alpha priced using subnet AMM).',
+  bittensor: { tvl }, 
 };

--- a/projects/wtao/index.js
+++ b/projects/wtao/index.js
@@ -1,19 +1,150 @@
 // wTAO: native TAO bridged from Bittensor and minted 1:1 as an ERC-20 on
-// Ethereum. The wrapped supply is fully backed by TAO custodied on Bittensor,
-// so the TAO locked in the bridge equals the token's total supply. Read it
-// straight from the contract and value it as native TAO (9 decimals).
-const WTAO = '0x77e06c9eccf2e797fd462a92b6d7642ef85b0a44';
+// Ethereum. Per maintainer guidance, TVL is the collateral LOCKED ON THE
+// SOURCE CHAIN (Bittensor), not the wrapped supply. The bridge's Bittensor
+// custody coldkey holds the backing and stakes ~all of it through a validator
+// (dlnews.com/articles/defi/wrapped-tao-on-ethereum-...), so the locked amount
+// is the coldkey's free balance PLUS its staked TAO. Read keyless from public
+// substrate RPC: free from System.Account, stake by summing the coldkey's
+// dTAO positions (share pools, both the V2 store and the legacy V1 store),
+// converting alpha -> TAO at each subnet's pool price (root/netuid 0 is 1:1).
+const blake = require('blakejs');
+const { post } = require('../helper/http');
+
+const RPC = 'https://entrypoint-finney.opentensor.ai';
+// Bittensor custody coldkey behind wTAO (32-byte pubkey of 5HiveMEoW...).
+const CUSTODY = 'fa538a1f58eb874d88632a329bc3e6423be5f7da88c1133e4b4d5ed1f3f1ce05';
+
+// twox128("SubtensorModule") ++ twox128(item), precomputed.
+const PALLET = '658faa385070e074c85bf6b568cf0555';
+const ITEM = {
+  StakingHotkeys: 'b7d32a0408ab25b30dac6ec2cb66fe1f',
+  Alpha: '7261f9a8fde18018cccf70368697902f',
+  AlphaV2: '421d8174603a6a6036511a7619b402f0',
+  TotalHotkeyShares: '3dbb78074d07a16f4942c7df159ed5e5',
+  TotalHotkeySharesV2: 'e47c637aa82c21537eb9caa511e543c5',
+  TotalHotkeyAlpha: 'ee25c3b5b1886863480497907f1829e6',
+  SubnetTAO: '7a57dce016211512d1700561066b85a3',
+  SubnetAlphaIn: '2ce12f7007574647d692ac7edf8b7a53',
+};
+const SYS_ACCOUNT = '26aa394eea5630e07c48ae0c9558cef7b99d880ec681799c0cf30e8886371da9';
+
+const hexToBuf = (h) => Buffer.from(h.replace(/^0x/, ''), 'hex');
+const blake128 = (buf) => Buffer.from(blake.blake2b(buf, undefined, 16));
+const b2c = (buf) => Buffer.concat([blake128(buf), buf]); // Blake2_128Concat
+const u16le = (n) => Buffer.from([n & 0xff, (n >> 8) & 0xff]); // Identity(u16 netuid)
+const prefix = (item) => Buffer.concat([hexToBuf(PALLET), hexToBuf(ITEM[item])]);
+const keyHex = (buf) => '0x' + buf.toString('hex');
+
+function u128LE(b, o) { let v = 0n; for (let i = 15; i >= 0; i--) v = (v << 8n) | BigInt(b[o + i]); return v; }
+function u64LE(b, o) { let v = 0n; for (let i = 7; i >= 0; i--) v = (v << 8n) | BigInt(b[o + i]); return v; }
+function i64LE(b, o) { let v = u64LE(b, o); if (v & (1n << 63n)) v -= (1n << 64n); return v; }
+// V2 SafeDecimal {mantissa:u128, exponent:i64}: real = m * 2^e
+const fpV2 = (b) => (!b || b.length < 24) ? 0 : Number(u128LE(b, 0)) * Math.pow(2, Number(i64LE(b, 16)));
+// V1 U64F64 {bits:u128}: real = bits / 2^64
+const fpV1 = (b) => (!b || b.length < 16) ? 0 : Number(u128LE(b, 0)) / Math.pow(2, 64);
+
+async function rpc(method, params) {
+  const res = await post(RPC, { jsonrpc: '2.0', id: 1, method, params }, { timeout: 30000 });
+  if (res.error) throw new Error(`${method}: ${JSON.stringify(res.error)}`);
+  return res.result;
+}
+async function getMany(keyBufs) {
+  if (!keyBufs.length) return new Map();
+  const keys = keyBufs.map(keyHex);
+  const res = await rpc('state_queryStorageAt', [keys]);
+  const out = new Map(keys.map((k) => [k, null]));
+  for (const cs of res) for (const [k, v] of cs.changes) out.set(k, v);
+  return out;
+}
+async function netuidsUnder(pfx) {
+  const out = []; let start = keyHex(pfx);
+  for (;;) {
+    const keys = await rpc('state_getKeysPaged', [keyHex(pfx), 200, start]);
+    if (!keys.length) break;
+    for (const kh of keys) { const t = hexToBuf(kh).subarray(pfx.length); out.push(t[0] | (t[1] << 8)); }
+    if (keys.length < 200) break;
+    start = keys[keys.length - 1];
+  }
+  return out;
+}
 
 async function tvl(api) {
-  const supply = await api.call({ target: WTAO, abi: 'erc20:totalSupply' });
-  api.addCGToken('bittensor', supply / 1e9);
+  const cold = hexToBuf(CUSTODY);
+
+  // Free balance: System.Account, free = u128 LE at byte offset 16.
+  const accKey = keyHex(Buffer.concat([hexToBuf(SYS_ACCOUNT), blake128(cold), cold]));
+  const accRaw = await rpc('state_getStorage', [accKey]);
+  const free = accRaw ? Number(u128LE(hexToBuf(accRaw), 16)) / 1e9 : 0;
+
+  // Hotkeys this coldkey stakes to: StakingHotkeys(cold) -> Vec<AccountId32>.
+  const shKey = keyHex(Buffer.concat([prefix('StakingHotkeys'), b2c(cold)]));
+  const shRaw = await rpc('state_getStorage', [shKey]);
+  const hotkeys = [];
+  if (shRaw) {
+    const b = hexToBuf(shRaw), mode = b[0] & 3;
+    let count, off;
+    if (mode === 0) { count = b[0] >> 2; off = 1; }
+    else if (mode === 1) { count = (b[0] | (b[1] << 8)) >> 2; off = 2; }
+    else throw new Error('unexpected compact vec length');
+    for (let i = 0; i < count; i++) { hotkeys.push(Buffer.from(b.subarray(off, off + 32))); off += 32; }
+  }
+
+  // Discover which (hotkey, netuid) carry stake, in the V2 and legacy V1 stores.
+  const aV2 = (hot) => Buffer.concat([prefix('AlphaV2'), b2c(hot), b2c(cold)]);
+  const aV1 = (hot) => Buffer.concat([prefix('Alpha'), b2c(hot), b2c(cold)]);
+  const entries = [];
+  for (const hot of hotkeys) {
+    for (const n of await netuidsUnder(aV2(hot))) entries.push({ hot, net: n, v: 2 });
+    for (const n of await netuidsUnder(aV1(hot))) entries.push({ hot, net: n, v: 1 });
+  }
+
+  // One batched read of every share/total/pool value needed.
+  const reads = [];
+  for (const e of entries) {
+    reads.push(e.v === 2 ? Buffer.concat([aV2(e.hot), u16le(e.net)]) : Buffer.concat([aV1(e.hot), u16le(e.net)]));
+    reads.push(Buffer.concat([prefix(e.v === 2 ? 'TotalHotkeySharesV2' : 'TotalHotkeyShares'), b2c(e.hot), u16le(e.net)]));
+    reads.push(Buffer.concat([prefix('TotalHotkeyAlpha'), b2c(e.hot), u16le(e.net)]));
+    if (e.net !== 0) {
+      reads.push(Buffer.concat([prefix('SubnetTAO'), u16le(e.net)]));
+      reads.push(Buffer.concat([prefix('SubnetAlphaIn'), u16le(e.net)]));
+    }
+  }
+  const vals = await getMany(reads);
+  const V = (buf) => vals.get(keyHex(buf));
+
+  let stakeTao = 0;
+  for (const e of entries) {
+    let alpha;
+    if (e.v === 2) {
+      const shareB = hexToBuf(V(Buffer.concat([aV2(e.hot), u16le(e.net)])) || '0x');
+      const share = fpV2(shareB);
+      if (!share) continue;
+      const totShares = fpV2(hexToBuf(V(Buffer.concat([prefix('TotalHotkeySharesV2'), b2c(e.hot), u16le(e.net)])) || '0x'));
+      const taRaw = V(Buffer.concat([prefix('TotalHotkeyAlpha'), b2c(e.hot), u16le(e.net)]));
+      const totAlpha = taRaw ? Number(u64LE(hexToBuf(taRaw), 0)) : 0;
+      alpha = totShares > 0 ? (share / totShares) * totAlpha : 0;
+    } else {
+      alpha = fpV1(hexToBuf(V(Buffer.concat([aV1(e.hot), u16le(e.net)])) || '0x'));
+      if (!alpha) continue;
+    }
+    let price = 1; // root (netuid 0) is TAO 1:1
+    if (e.net !== 0) {
+      const t = V(Buffer.concat([prefix('SubnetTAO'), u16le(e.net)]));
+      const a = V(Buffer.concat([prefix('SubnetAlphaIn'), u16le(e.net)]));
+      const T = t ? u64LE(hexToBuf(t), 0) : 0n, A = a ? u64LE(hexToBuf(a), 0) : 0n;
+      price = A === 0n ? 0 : Number(T) / Number(A);
+    }
+    stakeTao += (alpha * price) / 1e9;
+  }
+
+  api.addCGToken('bittensor', free + stakeTao);
 }
 
 module.exports = {
   timetravel: false,
   methodology:
-    'TAO locked in the bridge, measured as the total supply of the wTAO ERC-20 on Ethereum (0x77e06c9eccf2e797fd462a92b6d7642ef85b0a44), which is minted 1:1 against native TAO custodied on Bittensor and priced as TAO.',
-  ethereum: {
+    'TAO locked on Bittensor backing wTAO on Ethereum. The bridge custody coldkey (5HiveMEoWPmQmBAb8v63bKPcFhgTGCmST1TVZNvPHSTKFLCv) holds the collateral and stakes most of it, so TVL is its free balance plus its total staked TAO, read keyless from public substrate RPC (dTAO share pools, alpha valued at each subnet pool price; root is 1:1).',
+  bittensor: {
     tvl,
   },
 };

--- a/projects/wtao/index.js
+++ b/projects/wtao/index.js
@@ -35,31 +35,37 @@ const u16le = (n) => Buffer.from([n & 0xff, (n >> 8) & 0xff]); // Identity(u16 n
 const prefix = (item) => Buffer.concat([hexToBuf(PALLET), hexToBuf(ITEM[item])]);
 const keyHex = (buf) => '0x' + buf.toString('hex');
 
+/** Read a little-endian u128 from buffer b at offset o. */
 function u128LE(b, o) { let v = 0n; for (let i = 15; i >= 0; i--) v = (v << 8n) | BigInt(b[o + i]); return v; }
+/** Read a little-endian u64 from buffer b at offset o. */
 function u64LE(b, o) { let v = 0n; for (let i = 7; i >= 0; i--) v = (v << 8n) | BigInt(b[o + i]); return v; }
+/** Read a little-endian signed i64 from buffer b at offset o. */
 function i64LE(b, o) { let v = u64LE(b, o); if (v & (1n << 63n)) v -= (1n << 64n); return v; }
 // V2 SafeDecimal {mantissa:u128, exponent:i64}: real = m * 2^e
 const fpV2 = (b) => (!b || b.length < 24) ? 0 : Number(u128LE(b, 0)) * Math.pow(2, Number(i64LE(b, 16)));
 // V1 U64F64 {bits:u128}: real = bits / 2^64
 const fpV1 = (b) => (!b || b.length < 16) ? 0 : Number(u128LE(b, 0)) / Math.pow(2, 64);
 
+/** One substrate JSON-RPC call; throws on an error body. */
 async function rpc(method, params) {
   const res = await post(RPC, { jsonrpc: '2.0', id: 1, method, params }, { timeout: 30000 });
   if (res.error) throw new Error(`${method}: ${JSON.stringify(res.error)}`);
   return res.result;
 }
-async function getMany(keyBufs) {
+/** Batch-read many storage keys at one block; returns Map<keyHex, valueHex|null>. */
+async function getMany(keyBufs, at) {
   if (!keyBufs.length) return new Map();
   const keys = keyBufs.map(keyHex);
-  const res = await rpc('state_queryStorageAt', [keys]);
+  const res = await rpc('state_queryStorageAt', [keys, at]);
   const out = new Map(keys.map((k) => [k, null]));
   for (const cs of res) for (const [k, v] of cs.changes) out.set(k, v);
   return out;
 }
-async function netuidsUnder(pfx) {
+/** Enumerate the netuids present under a storage prefix at one block. */
+async function netuidsUnder(pfx, at) {
   const out = []; let start = keyHex(pfx);
   for (;;) {
-    const keys = await rpc('state_getKeysPaged', [keyHex(pfx), 200, start]);
+    const keys = await rpc('state_getKeysPaged', [keyHex(pfx), 200, start, at]);
     if (!keys.length) break;
     for (const kh of keys) { const t = hexToBuf(kh).subarray(pfx.length); out.push(t[0] | (t[1] << 8)); }
     if (keys.length < 200) break;
@@ -68,17 +74,22 @@ async function netuidsUnder(pfx) {
   return out;
 }
 
+/** TVL = TAO locked on Bittensor backing wTAO: the custody coldkey's free
+ * balance plus its total staked TAO. All reads are pinned to one finalized
+ * block so the multi-step stake walk is a consistent snapshot. */
 async function tvl(api) {
   const cold = hexToBuf(CUSTODY);
+  // Pin every read to one finalized block (state advances between calls otherwise).
+  const at = await rpc('chain_getFinalizedHead', []);
 
   // Free balance: System.Account, free = u128 LE at byte offset 16.
   const accKey = keyHex(Buffer.concat([hexToBuf(SYS_ACCOUNT), blake128(cold), cold]));
-  const accRaw = await rpc('state_getStorage', [accKey]);
+  const accRaw = await rpc('state_getStorage', [accKey, at]);
   const free = accRaw ? Number(u128LE(hexToBuf(accRaw), 16)) / 1e9 : 0;
 
   // Hotkeys this coldkey stakes to: StakingHotkeys(cold) -> Vec<AccountId32>.
   const shKey = keyHex(Buffer.concat([prefix('StakingHotkeys'), b2c(cold)]));
-  const shRaw = await rpc('state_getStorage', [shKey]);
+  const shRaw = await rpc('state_getStorage', [shKey, at]);
   const hotkeys = [];
   if (shRaw) {
     const b = hexToBuf(shRaw), mode = b[0] & 3;
@@ -94,8 +105,8 @@ async function tvl(api) {
   const aV1 = (hot) => Buffer.concat([prefix('Alpha'), b2c(hot), b2c(cold)]);
   const entries = [];
   for (const hot of hotkeys) {
-    for (const n of await netuidsUnder(aV2(hot))) entries.push({ hot, net: n, v: 2 });
-    for (const n of await netuidsUnder(aV1(hot))) entries.push({ hot, net: n, v: 1 });
+    for (const n of await netuidsUnder(aV2(hot), at)) entries.push({ hot, net: n, v: 2 });
+    for (const n of await netuidsUnder(aV1(hot), at)) entries.push({ hot, net: n, v: 1 });
   }
 
   // One batched read of every share/total/pool value needed.
@@ -109,7 +120,7 @@ async function tvl(api) {
       reads.push(Buffer.concat([prefix('SubnetAlphaIn'), u16le(e.net)]));
     }
   }
-  const vals = await getMany(reads);
+  const vals = await getMany(reads, at);
   const V = (buf) => vals.get(keyHex(buf));
 
   let stakeTao = 0;
@@ -144,7 +155,7 @@ module.exports = {
   timetravel: false,
   methodology:
     'TAO locked on Bittensor backing wTAO on Ethereum. The bridge custody coldkey (5HiveMEoWPmQmBAb8v63bKPcFhgTGCmST1TVZNvPHSTKFLCv) holds the collateral and stakes most of it, so TVL is its free balance plus its total staked TAO, read keyless from public substrate RPC (dTAO share pools, alpha valued at each subnet pool price; root is 1:1).',
-  bittensor: {
+  ethereum: {
     tvl,
   },
 };

--- a/projects/wtao/index.js
+++ b/projects/wtao/index.js
@@ -1,0 +1,19 @@
+// wTAO: native TAO bridged from Bittensor and minted 1:1 as an ERC-20 on
+// Ethereum. The wrapped supply is fully backed by TAO custodied on Bittensor,
+// so the TAO locked in the bridge equals the token's total supply. Read it
+// straight from the contract and value it as native TAO (9 decimals).
+const WTAO = '0x77e06c9eccf2e797fd462a92b6d7642ef85b0a44';
+
+async function tvl(api) {
+  const supply = await api.call({ target: WTAO, abi: 'erc20:totalSupply' });
+  api.addCGToken('bittensor', supply / 1e9);
+}
+
+module.exports = {
+  timetravel: false,
+  methodology:
+    'TAO locked in the bridge, measured as the total supply of the wTAO ERC-20 on Ethereum (0x77e06c9eccf2e797fd462a92b6d7642ef85b0a44), which is minted 1:1 against native TAO custodied on Bittensor and priced as TAO.',
+  ethereum: {
+    tvl,
+  },
+};

--- a/projects/wtao/index.js
+++ b/projects/wtao/index.js
@@ -96,6 +96,7 @@ async function tvl(api) {
     let count, off;
     if (mode === 0) { count = b[0] >> 2; off = 1; }
     else if (mode === 1) { count = (b[0] | (b[1] << 8)) >> 2; off = 2; }
+    else if (mode === 2) { count = (b[0] | (b[1] << 8) | (b[2] << 16) | (b[3] << 24)) >>> 2; off = 4; }
     else throw new Error('unexpected compact vec length');
     for (let i = 0; i < count; i++) { hotkeys.push(Buffer.from(b.subarray(off, off + 32))); off += 32; }
   }


### PR DESCRIPTION
Adds a TVL adapter for wTAO — native TAO bridged from Bittensor and minted 1:1 as an ERC-20 on Ethereum (`0x77e06c9eccf2e797fd462a92b6d7642ef85b0a44`, 9 decimals) — currently untracked on DefiLlama.

The wrapped supply is fully backed by TAO custodied on Bittensor, so the TAO locked in the bridge equals the token's total supply. The adapter does one `erc20:totalSupply` read and prices it as native TAO via `addCGToken('bittensor', ...)`. No new dependencies.

```
node test.js projects/wtao/index.js
```
~$24.4M (111,661 TAO), consistent with the token's CoinGecko market cap.

## (Needs to be filled only for new listings)

- Name (to be shown on DefiLlama): wTAO (Wrapped TAO)
- Twitter Link: https://twitter.com/opentensor
- List of audit links if any: none
- Website Link: https://bittensor.com
- Logo: https://assets.coingecko.com/coins/images/28452/large/ARUsPeNQ_400x400.jpeg
- Current TVL: ~$24.4M
- Treasury Addresses: none
- Chain: Ethereum
- Coingecko ID: bittensor
- Coinmarketcap ID: bittensor
- Short Description: Bridge that locks native TAO on Bittensor and mints an ERC-20 representation (wTAO) on Ethereum 1:1.
- Token address and ticker if any: ethereum:0x77e06c9eccf2e797fd462a92b6d7642ef85b0a44 (wTAO)
- Category: Bridge
- Oracle Provider(s): none

Note: this is a single-operator custody bridge; flagging that openly in case you want it labeled accordingly. TVL is read on-chain from the wrapped supply.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for wTAO on Bittensor that reports consolidated backing (free + staked) across custody and staking positions.
  * Aggregates custody balances, staked hotkeys, and per-subnet pool valuations to produce a single on-chain TVL figure.
  * Reports current-only values (no historical timetravel) and includes a methodology note explaining the on-chain valuation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->