### PR TITLE
tao-wormhole: add adapter for TAO bridged to Solana (~$1.1M)

### DIFF
--- a/projects/tao-wormhole/index.js
+++ b/projects/tao-wormhole/index.js
@@ -1,0 +1,22 @@
+// Canonical TAO on Solana: native TAO bridged from Bittensor via Wormhole's
+// Native Token Transfer (NTT) and minted as an SPL token on Solana. The minted
+// supply is backed 1:1 by TAO locked on the bridge, so TAO locked = SPL total
+// supply. Read the mint supply (9 decimals) and value it as native TAO.
+const { getTokenSupplies } = require('../helper/solana');
+
+const TAO_MINT = 'taoC6xyv2v8tDLcev4uaGUgV4vdQsWJrGft2kcBRrBY';
+
+async function tvl(api) {
+  const supplies = await getTokenSupplies([TAO_MINT]);
+  const raw = Number(supplies[TAO_MINT] || 0);
+  api.addCGToken('bittensor', raw / 1e9);
+}
+
+module.exports = {
+  timetravel: false,
+  methodology:
+    'TAO bridged to Solana, measured as the total supply of the canonical TAO SPL token (taoC6xyv2v8tDLcev4uaGUgV4vdQsWJrGft2kcBRrBY) minted 1:1 via Wormhole NTT against native TAO locked on the bridge, and priced as TAO.',
+  solana: {
+    tvl,
+  },
+};


### PR DESCRIPTION
Adds a TVL adapter for canonical TAO on Solana — native TAO bridged from Bittensor via Wormhole Native Token Transfer (NTT) and minted as an SPL token (`taoC6xyv2v8tDLcev4uaGUgV4vdQsWJrGft2kcBRrBY`, 9 decimals) — currently untracked on DefiLlama.

Backed 1:1 by TAO locked on the bridge, so locked TAO = SPL total supply. The adapter reads the mint supply via the solana helper and prices it as native TAO. No new dependencies.

```
node test.js projects/tao-wormhole/index.js
```
~$1.12M (5,114 TAO).

## (Needs to be filled only for new listings)

- Name (to be shown on DefiLlama): TAO (Wormhole, Solana)
- Twitter Link: https://twitter.com/opentensor
- List of audit links if any: Wormhole NTT audited (framework-level)
- Website Link: https://wormhole.com
- Logo: https://assets.coingecko.com/coins/images/28452/large/ARUsPeNQ_400x400.jpeg
- Current TVL: ~$1.12M
- Treasury Addresses: none
- Chain: Solana
- Coingecko ID: bittensor
- Coinmarketcap ID: bittensor
- Short Description: Canonical TAO on Solana, bridged from Bittensor via Wormhole NTT and minted 1:1 as an SPL token.
- Token address and ticker if any: solana:taoC6xyv2v8tDLcev4uaGUgV4vdQsWJrGft2kcBRrBY (TAO)
- Category: Bridge
- Oracle Provider(s): none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking support for canonical bridged TAO tokens on the Solana blockchain. Users can now monitor real-time token supply data and review documentation detailing the 1:1 backing mechanism for full asset transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->