### PR TITLE
Add Auxite (tokenized precious metals RWA on Base)

### DIFF
--- a/projects/auxite/index.js
+++ b/projects/auxite/index.js
@@ -17,55 +17,37 @@ const AUXITE_TOKENS = {
 };
 
 const ORACLE_ADDRESS = "0xDB36fFD8a762226928d62a2Fe6F19bB329b5EbbE";
-const STAKING_CONTRACT = "0x1656DcCC8277bC7D6aF93F71464D64ebBC15574d";
 
 const ORACLE_ABI = {
   getAllPrices: "function getAllPrices() view returns (uint256 gold, uint256 silver, uint256 platinum, uint256 palladium, uint256 eth)",
 };
 
 async function getPrices(api) {
-  const allPrices = await api.call({ target: ORACLE_ADDRESS, abi: ORACLE_ABI.getAllPrices });
+  const p = await api.call({ target: ORACLE_ADDRESS, abi: ORACLE_ABI.getAllPrices });
   return {
-    AUXG: allPrices.gold || allPrices[0],
-    AUXS: allPrices.silver || allPrices[1],
-    AUXPT: allPrices.platinum || allPrices[2],
-    AUXPD: allPrices.palladium || allPrices[3],
+    AUXG: p.gold ?? p[0],
+    AUXS: p.silver ?? p[1],
+    AUXPT: p.platinum ?? p[2],
+    AUXPD: p.palladium ?? p[3],
   };
 }
 
-async function calculateTvl(api, balances, prices) {
-  const USDC_BASE = ADDRESSES.base?.USDC || "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
-  let totalUsdcUnits = 0n;
-  Object.keys(AUXITE_TOKENS).forEach((symbol, i) => {
-    const balance = BigInt(balances[i] || 0);
-    const pricePerKgE6 = BigInt(prices[symbol] || 0);
-    totalUsdcUnits += (balance * pricePerKgE6) / 1000000n;
-  });
-  api.add(USDC_BASE, totalUsdcUnits.toString());
-}
-
 module.exports = {
-  methodology: "TVL is the total supply of AUXG, AUXS, AUXPT, AUXPD on Base multiplied by metal prices from the Auxite on-chain oracle. Each token = 1 gram of allocated, physically-backed precious metal.",
+  methodology: "TVL is the total supply of AUXG, AUXS, AUXPT, AUXPD on Base multiplied by per-metal USD prices from the Auxite on-chain oracle. Each token = 1 gram of allocated, physically-backed precious metal; totalSupply equals the full allocated physical metal (AUM).",
   base: {
     tvl: async (api) => {
+      const USDC = ADDRESSES.base?.USDC || "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
       const [supplies, prices] = await Promise.all([
         api.multiCall({ abi: 'erc20:totalSupply', calls: Object.values(AUXITE_TOKENS) }),
         getPrices(api),
       ]);
-      await calculateTvl(api, supplies, prices);
-    },
-    staking: async (api) => {
-      const [stakedBalances, prices] = await Promise.all([
-        api.multiCall({
-          abi: 'erc20:balanceOf',
-          calls: Object.values(AUXITE_TOKENS).map(token => ({ target: token, params: [STAKING_CONTRACT] })),
-        }),
-        getPrices(api),
-      ]);
-      await calculateTvl(api, stakedBalances, prices);
+      let total = 0n;
+      Object.keys(AUXITE_TOKENS).forEach((sym, i) => {
+        total += (BigInt(supplies[i] ?? 0) * BigInt(prices[sym] ?? 0)) / 1000000n;
+      });
+      api.add(USDC, total.toString());
     },
   },
-  doublecounted: true,
   misrepresentedTokens: true,
 };
 

--- a/projects/auxite/index.js
+++ b/projects/auxite/index.js
@@ -1,0 +1,75 @@
+/**
+ * Auxite - Tokenized Precious Metals (RWA) on Base
+ *
+ * TVL = totalSupply of each metal token x on-chain oracle price.
+ * Each token = 1 gram of physically-backed, allocated precious metal
+ * (custody: Silver Bullion SG + Istanbul vault; attestation: The Network Firm).
+ */
+
+const ADDRESSES = require('../helper/coreAssets.json');
+
+// Canonical AuxiteMetal contracts (per-investor on-chain ownership).
+const AUXITE_TOKENS = {
+  AUXG: "0xCef9D7593E8Ba796eE05C54B8983B7749bB1218a",
+  AUXS: "0xB0aC63aeD12b5A0Ee710618D99444bf126068c1a",
+  AUXPT: "0x39F314fb20668997A2ADDaB1eA9236e0072D5E2D",
+  AUXPD: "0x6e4837fCf158D15ABFdf90b3954D041D452BE832",
+};
+
+const ORACLE_ADDRESS = "0xDB36fFD8a762226928d62a2Fe6F19bB329b5EbbE";
+const STAKING_CONTRACT = "0x1656DcCC8277bC7D6aF93F71464D64ebBC15574d";
+
+const ORACLE_ABI = {
+  getAllPrices: "function getAllPrices() view returns (uint256 gold, uint256 silver, uint256 platinum, uint256 palladium, uint256 eth)",
+};
+
+async function getPrices(api) {
+  const allPrices = await api.call({ target: ORACLE_ADDRESS, abi: ORACLE_ABI.getAllPrices });
+  return {
+    AUXG: allPrices.gold || allPrices[0],
+    AUXS: allPrices.silver || allPrices[1],
+    AUXPT: allPrices.platinum || allPrices[2],
+    AUXPD: allPrices.palladium || allPrices[3],
+  };
+}
+
+async function calculateTvl(api, balances, prices) {
+  const USDC_BASE = ADDRESSES.base?.USDC || "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+  let totalUsdcUnits = 0n;
+  Object.keys(AUXITE_TOKENS).forEach((symbol, i) => {
+    const balance = BigInt(balances[i] || 0);
+    const pricePerKgE6 = BigInt(prices[symbol] || 0);
+    totalUsdcUnits += (balance * pricePerKgE6) / 1000000n;
+  });
+  api.add(USDC_BASE, totalUsdcUnits.toString());
+}
+
+module.exports = {
+  methodology: "TVL is the total supply of AUXG, AUXS, AUXPT, AUXPD on Base multiplied by metal prices from the Auxite on-chain oracle. Each token = 1 gram of allocated, physically-backed precious metal.",
+  base: {
+    tvl: async (api) => {
+      const [supplies, prices] = await Promise.all([
+        api.multiCall({ abi: 'erc20:totalSupply', calls: Object.values(AUXITE_TOKENS) }),
+        getPrices(api),
+      ]);
+      await calculateTvl(api, supplies, prices);
+    },
+    staking: async (api) => {
+      const [stakedBalances, prices] = await Promise.all([
+        api.multiCall({
+          abi: 'erc20:balanceOf',
+          calls: Object.values(AUXITE_TOKENS).map(token => ({ target: token, params: [STAKING_CONTRACT] })),
+        }),
+        getPrices(api),
+      ]);
+      await calculateTvl(api, stakedBalances, prices);
+    },
+  },
+  doublecounted: true,
+  misrepresentedTokens: true,
+};
+
+module.exports.hallmarks = [
+  ['2026-02-02', "V8 tokens deployed on Base Mainnet"],
+  ['2026-06-09', "Migrated to canonical AuxiteMetal contracts (per-investor on-chain ownership)"],
+];

--- a/projects/auxite/index.js
+++ b/projects/auxite/index.js
@@ -37,13 +37,22 @@ module.exports = {
   base: {
     tvl: async (api) => {
       const USDC = ADDRESSES.base?.USDC || "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
-      const [supplies, prices] = await Promise.all([
-        api.multiCall({ abi: 'erc20:totalSupply', calls: Object.values(AUXITE_TOKENS) }),
+      const calls = Object.values(AUXITE_TOKENS);
+      const [supplies, decimals, prices] = await Promise.all([
+        api.multiCall({ abi: 'erc20:totalSupply', calls }),
+        api.multiCall({ abi: 'erc20:decimals', calls }),
         getPrices(api),
       ]);
+      // Units: oracle getAllPrices() returns USD per KILOGRAM scaled by 1e6
+      // (6 dp); USDC has 6 dp. With grams = supply / 10^tokenDecimals:
+      //   value_usdc = (supply / 10^d) grams
+      //              * (price / 1e6 USD/kg / 1e3 USD/g) USD per gram
+      //              * 1e6 (USDC dp)
+      //              = supply * price / 10^(d + 3)
       let total = 0n;
       Object.keys(AUXITE_TOKENS).forEach((sym, i) => {
-        total += (BigInt(supplies[i] ?? 0) * BigInt(prices[sym] ?? 0)) / 1000000n;
+        const d = Number(decimals[i] ?? 3);
+        total += (BigInt(supplies[i] ?? 0) * BigInt(prices[sym] ?? 0)) / (10n ** BigInt(d + 3));
       });
       api.add(USDC, total.toString());
     },


### PR DESCRIPTION
### Auxite — Tokenized Precious Metals (RWA) on Base

Adds a TVL adapter for **Auxite**, which issues physically-backed, allocated precious-metal tokens on Base:

- **AUXG** (gold), **AUXS** (silver), **AUXPT** (platinum), **AUXPD** (palladium)
- Each token = 1 gram of allocated physical metal (custody: Silver Bullion SG + Istanbul vault; attestation: The Network Firm)
- Canonical contracts verified on BaseScan

**Methodology:** TVL = on-chain `totalSupply()` of each metal token × per-metal USD price from the Auxite on-chain oracle (`getAllPrices()`). `totalSupply` equals the full allocated physical metal (AUM); the unsold portion is held in the project treasury.

- Public reserves/AUM feed: https://vault.auxite.io/api/supply
- Reserves & attestation: https://vault.auxite.io/trust/reserves


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for Auxite’s precious-metal tokens (AUXG, AUXS, AUXPT, AUXPD) on Base, reporting aggregated USDC-denominated values using on-chain price feeds.
  * Added historical deployment and migration hallmarks for the Auxite ecosystem to provide contextual timeline information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->