### PR TITLE
claimrush: surface LP-vault holdings under TVL (was pool2)

### DIFF
--- a/projects/claimrush/index.js
+++ b/projects/claimrush/index.js
@@ -7,7 +7,7 @@ const LP_STAKING_VAULT_7D = '0xafdbB422CF75D6f2C557BDD2EF955c518b086271';
 const GENESIS_LP_VAULT_24M = '0x1532F33e53680f89d083a0bf5baedcCCD2E7267a';
 const AERODROME_WETH_CLAIM_POOL = '0x7274599ec9DBf15D474A6FB18aA285aE001d87Aa';
 
-async function pool2(api) {
+async function lpVaultTvl(api) {
   return sumTokens2({
     api,
     tokensAndOwners: [
@@ -20,10 +20,9 @@ async function pool2(api) {
 
 module.exports = {
   methodology:
-    'Pool2 = Aerodrome v2 vAMM WETH/CLAIM LP tokens custodied by LpStakingVault7D (7-day rolling staking position for active stakers) plus GenesisLPVault24M (24-month time-locked genesis seed liquidity). LP tokens are unwrapped into their underlying WETH and CLAIM reserves. Staking bucket = CLAIM principal locked in VeClaimNFT (voting-escrow NFT, max 1-year linear-decay locks) to receive a pro-rata share of ETH royalties from every Mine takeover.',
+    'TVL = Aerodrome v2 vAMM WETH/CLAIM LP tokens custodied by LpStakingVault7D (7-day rolling staking position for active stakers) plus GenesisLPVault24M (24-month time-locked genesis seed liquidity). LP tokens are unwrapped into their underlying WETH and CLAIM reserves. Staking bucket = CLAIM principal locked in VeClaimNFT (voting-escrow NFT, max 1-year linear-decay locks) to receive a pro-rata share of ETH royalties from every Mine takeover.',
   base: {
-    tvl: () => ({}),
-    pool2,
+    tvl: lpVaultTvl,
     staking: staking(VE_CLAIM, CLAIM),
   },
 };


### PR DESCRIPTION
## Summary

Move the LP-vault holdings (Aerodrome WETH/CLAIM LP custodied by `GenesisLPVault24M` + `LpStakingVault7D`) from the `pool2` bucket into the `tvl` bucket so they're actually visible on the protocol page. The locked CLAIM in `VeClaimNFT` stays under `staking` (unchanged).

## The concrete UI problem this PR fixes

The current adapter routes the LP-vault value into `pool2`, which works fine in the API but is **invisible on the protocol page**. The page's `__NEXT_DATA__` blob exposes the following `availableCharts` for `claimrush`:

```json
"availableCharts": ["TVL", "Fees", "Revenue", "Holders Revenue", "Staking", "USD Inflows"]
```

**Pool2 is not in the list.** The "Add Metrics +" button offers no way for a user to display the $187K of LP-vault holdings on `defillama.com/protocol/ClaimRush`. The data is computed, indexed, and returned by the API correctly — it just has no UI surface on the protocol page.

To compound the issue, the page renders the methodology text under a "TVL:" prefix while the headline TVL value reads `$0` — producing the visibly contradictory line `TVL: Pool2 = Aerodrome v2 vAMM WETH/CLAIM LP tokens...`. The page itself describes the TVL bucket as containing the LP, while the TVL number shows zero.

## Why TVL is the correct bucket for this value

Half the LP value is WETH — non-native to ClaimRush. The hack-loss test from the [Staking TVL FAQ](https://docs.llama.fi/faqs/frequently-asked-questions#what-is-staking-tvl) passes on the WETH portion: if the lock contracts were drained, the protocol cannot mint WETH to backfill the loss. The LP itself is custodied in two immutable vaults — `GenesisLPVault24M` (730-day time-lock, can only be extended, immutable recipient) and `LpStakingVault7D` (7-day rolling user staking). Structurally identical to Olympus-style Protocol-Owned Liquidity.

## What changes

```diff
-async function pool2(api) {
+async function lpVaultTvl(api) {
   return sumTokens2({
     api,
     tokensAndOwners: [
       [AERODROME_WETH_CLAIM_POOL, LP_STAKING_VAULT_7D],
       [AERODROME_WETH_CLAIM_POOL, GENESIS_LP_VAULT_24M],
     ],
     resolveLP: true,
   });
 }

 module.exports = {
-  methodology: 'Pool2 = Aerodrome v2 vAMM WETH/CLAIM LP tokens...',
+  methodology: 'TVL = Aerodrome v2 vAMM WETH/CLAIM LP tokens...',
   base: {
-    tvl: () => ({}),
-    pool2,
+    tvl: lpVaultTvl,
     staking: staking(VE_CLAIM, CLAIM),
   },
 };
```

No on-chain or RPC changes. Same `sumTokens2` + `resolveLP: true` unwrap, same two vault addresses, same LP token.

## Smoke test against Base mainnet

```
$ node test.js projects/claimrush/index.js
...
--- base ---
CLAIM                     94.68 k
WETH                      92.56 k
Total: 187.24 k

--- staking ---
CLAIM                     41.76 k
Total: 41.76 k

------ TVL ------
base                      187.24 k
base-staking              41.76 k
staking                   41.76 k

total                    187.24 k
```

Headline TVL: $187.24K. Staking bucket unchanged at $41.76K (locked CLAIM in VeClaimNFT).

## On the 24-month lock

For context on the GenesisLPVault24M lock binding: source at [`src/vault/GenesisLPVault24M.sol`](https://github.com/claimrush/claimrush/blob/main/src/vault/GenesisLPVault24M.sol) — `INITIAL_LOCK_DURATION = 730 days` (immutable), `recipient` is `immutable`, `extendLock()` can only push the unlock time further out (never shorter), no `emergencyWithdraw` / no admin override. The lock currently runs to 2028-05-28. The 7-day vault is user-staking (rolling), where the LP is contractually held for the 7-day cool-down window before unstaking is permitted.

cc @FelixBruguera

Thanks!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized TVL calculation methodology with improved naming conventions for enhanced clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->