### PR TITLE
Chutes fix

### DIFF
--- a/projects/chutes/index.js
+++ b/projects/chutes/index.js
@@ -35,6 +35,7 @@ async function readU64(storageKey, at) {
   return Number(buf.readBigUInt64LE())
 }
 
+/** Only track TAO side of subnet AMM: https://docs.learnbittensor.org/subnets/understanding-subnets#liquidity-pools */
 async function tvl(api) {
   const at = await rpc('chain_getFinalizedHead', [])
   const taoIn = await readU64(SUBNET_TAO + u16le(CHUTES_NETUID), at)

--- a/projects/chutes/index.js
+++ b/projects/chutes/index.js
@@ -35,22 +35,16 @@ async function readU64(storageKey, at) {
   return Number(buf.readBigUInt64LE())
 }
 
-/**
- * Prices the TAO and alpha legs of the Chutes pool. Both reads are pinned to
- * one finalized block so the two legs are a consistent snapshot.
- */
 async function tvl(api) {
   const at = await rpc('chain_getFinalizedHead', [])
   const taoIn = await readU64(SUBNET_TAO + u16le(CHUTES_NETUID), at)
-  const alphaIn = await readU64(SUBNET_ALPHA_IN + u16le(CHUTES_NETUID), at)
   api.addCGToken('bittensor', taoIn / 1e9)
-  api.addCGToken('chutes', alphaIn / 1e9)
 }
 
 module.exports = {
   timetravel: false,
   methodology:
-    'Counts the TAO and alpha reserves of the Chutes (netuid 64) dTAO liquidity pool, read from SubtensorModule.SubnetTAO and SubtensorModule.SubnetAlphaIn on public chain RPC.',
+    'Counts the TAO reserves of the Chutes (netuid 64) dTAO liquidity pool, read from SubtensorModule.SubnetTAO and SubtensorModule.SubnetAlphaIn on public chain RPC.',
   bittensor: {
     tvl,
   },

--- a/projects/chutes/index.js
+++ b/projects/chutes/index.js
@@ -44,9 +44,6 @@ async function tvl(api) {
 
 module.exports = {
   timetravel: false,
-  methodology:
-    'Counts the TAO reserves of the Chutes (netuid 64) dTAO liquidity pool, read from SubtensorModule.SubnetTAO and SubtensorModule.SubnetAlphaIn on public chain RPC.',
-  bittensor: {
-    tvl,
-  },
+  methodology: 'Counts the TAO reserves of the Chutes (netuid 64) dTAO liquidity pool, read from SubtensorModule.SubnetTAO on public chain RPC.',
+  bittensor: { tvl },
 }


### PR DESCRIPTION
Each subnet has an AMM liquidity pool with TAO/Alpha pairing, where Alpha is the subnet token. E.g. [chutes](https://www.coingecko.com/en/coins/chutes):  https://taostats.io/subnets/64

[Docs](https://docs.learnbittensor.org/subnets/understanding-subnets#liquidity-pools) describe the AMM TAO and Alpha as:

>  The alpha token is purchased by staking TAO into the subnet's reserve... 
> - Tao reserves: the amount of tao (τ) that has been staked into the subnet
> - Alpha reserves: the amount of alpha (α) available for purchase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Chutes TVL calculation to reflect TAO reserves only, removing previous multi-reserve tracking for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->