### PR TITLE
Consolidate Ramses factories in Uniswap registries

### DIFF
--- a/registries/uniswapV2.js
+++ b/registries/uniswapV2.js
@@ -2669,20 +2669,13 @@ const uniV2Configs = {
     ethereum: { factory: '0xe185e5335d68c2a18564b4b43bdf4ed86337ee70', staking: [["0xc7e40abf6a1f6a6f79b64d86ca1960816271caca"], "0x37A2f8701856a78DE92DBe35dF2200c355EAe090"] },
   },
   'ramses': {
-    _options: { hasStablePools: true, stablePoolSymbol: 'crAMM' },
-    arbitrum: { factory: '0xAAA20D08e59F6561f242b08513D36266C5A29415', staking: ["0xAAA343032aA79eE9a6897Dab03bef967c3289a06", "0xaaa6c1e32c55a7bfa8066a6fae9b42650f262418"] },
-  },
-  'ramses-hl-legacy': {
-    _options: { hasStablePools: true, stablePoolSymbol: 'cAMM' },
-    hyperliquid: '0xd0a07E160511c40ccD5340e94660E9C9c01b0D27',
-  },
-  'ramsesx-arb-legacy': {
-    _options: { hasStablePools: true, stablePoolSymbol: 'cAMM' },
-    arbitrum: '0xADd32480630A16dfAcEe6eeFcB3ab2181449Dc3B',
-  },
-  'ramsesx-poly-legacy': {
-    _options: { hasStablePools: true, stablePoolSymbol: 'cAMM' },
-    polygon: '0xA87c8308722237F6442Ef4762B7287afB84fB191',
+    _options: { hasStablePools: true },
+    arbitrum: [
+      { factory: '0xAAA20D08e59F6561f242b08513D36266C5A29415', stablePoolSymbol: 'crAMM' },
+      { factory: '0xADd32480630A16dfAcEe6eeFcB3ab2181449Dc3B', stablePoolSymbol: 'cAMM' },
+    ],
+    hyperliquid: { factory: '0xd0a07E160511c40ccD5340e94660E9C9c01b0D27', stablePoolSymbol: 'cAMM' },
+    polygon: { factory: '0xA87c8308722237F6442Ef4762B7287afB84fB191', stablePoolSymbol: 'cAMM' },
   },
   'sharkyswap': {
     arbitrum: { factory: '0x36800286f652dDC9bDcFfEDc4e71FDd207C1d07C', staking: ["0xD5f406eB9E38E3B3E35072A8A35E0DcC671ea8DB", "0x73eD68B834e44096eB4beA6eDeAD038c945722F1"] },

--- a/registries/uniswapV3.js
+++ b/registries/uniswapV3.js
@@ -1126,24 +1126,20 @@ const uniV3Configs = {
     },
   },
   'ramses-cl': {
-    arbitrum: {
-      factory: '0xaa2cd7477c451e703f3b9ba5663334914763edf8',
-      fromBlock: 90593047,
-    },
-  },
-  'ramses-hl-cl': {
+    arbitrum: [
+      {
+        factory: '0xaa2cd7477c451e703f3b9ba5663334914763edf8',
+        fromBlock: 90593047,
+      },
+      {
+        factory: '0xd0019e86edB35E1fedaaB03aED5c3c60f115d28b',
+        fromBlock: 420275312,
+      },
+    ],
     hyperliquid: {
       factory: '0x07E60782535752be279929e2DFfDd136Db2e6b45',
       fromBlock: 18149975,
     },
-  },
-  'ramsesx-arb-cl': {
-    arbitrum: {
-      factory: '0xd0019e86edB35E1fedaaB03aED5c3c60f115d28b',
-      fromBlock: 420275312,
-    },
-  },
-  'ramsesx-poly-cl': {
     polygon: {
       factory: '0x2Bef16A0081565E72100D73CBe19B1Bd2d802380',
       fromBlock: 82177771,


### PR DESCRIPTION
Follow-up to https://github.com/DefiLlama/DefiLlama-Adapters/pull/19575.

That PR added project-level wrappers for Ramses TVL and was closed because these factories are already tracked in `registries/uniswapV2.js` and `registries/uniswapV3.js`.

This draft moves toward the registry-only shape discussed there:

- consolidate Legacy factories under the existing `ramses` entry in `registries/uniswapV2.js`
- consolidate CL factories under the existing `ramses-cl` entry in `registries/uniswapV3.js`
- remove the duplicate split Ramses entries so each factory address appears once

The main question is the same one from the closed PR thread: for Ramses we need two Arbitrum factories under each active entry. Is the intended registry shape an array of per-factory configs like this?

```js
'ramses': {
  _options: { hasStablePools: true },
  arbitrum: [
    { factory: '0xAAA20D08e59F6561f242b08513D36266C5A29415', stablePoolSymbol: 'crAMM' },
    { factory: '0xADd32480630A16dfAcEe6eeFcB3ab2181449Dc3B', stablePoolSymbol: 'cAMM' },
  ],
  hyperliquid: { factory: '0xd0a07E160511c40ccD5340e94660E9C9c01b0D27', stablePoolSymbol: 'cAMM' },
  polygon: { factory: '0xA87c8308722237F6442Ef4762B7287afB84fB191', stablePoolSymbol: 'cAMM' },
}
```

```js
'ramses-cl': {
  arbitrum: [
    {
      factory: '0xaa2cd7477c451e703f3b9ba5663334914763edf8',
      fromBlock: 90593047,
    },
    {
      factory: '0xd0019e86edB35E1fedaaB03aED5c3c60f115d28b',
      fromBlock: 420275312,
    },
  ],
  hyperliquid: {
    factory: '0x07E60782535752be279929e2DFfDd136Db2e6b45',
    fromBlock: 18149975,
  },
  polygon: {
    factory: '0x2Bef16A0081565E72100D73CBe19B1Bd2d802380',
    fromBlock: 82177771,
  },
}
```

I have not changed `registries/utils.js` or the helper behavior in this draft. This is just the proposed registry consolidation shape, with duplicate Ramses registry entries removed. But from my understanding this may not working?

Checks:

- `git diff --check`
- `npm run build`
- confirmed each Ramses factory address appears once in its registry file

Companion PRs:

- defillama-server: https://github.com/DefiLlama/defillama-server/pull/12189
- dimension-adapters: https://github.com/DefiLlama/dimension-adapters/pull/7483