### PR TITLE
Add Tokamak Network (TON seigniorage staking)

### DIFF
--- a/projects/tokamak-network/index.js
+++ b/projects/tokamak-network/index.js
@@ -1,0 +1,24 @@
+// Tokamak Network — TON seigniorage staking (Ethereum L1)
+//
+// Stakers delegate TON to operator (DAO candidate) contracts. The staked principal is
+// custodied as WTON — a 27-decimal "ray" wrapped TON where 1 WTON == 1 TON in value —
+// held by the DepositManager contract. We report the DepositManager's WTON balance as
+// staked TON. TON is Tokamak Network's own token, so this is reported under `staking`.
+const TON = '0x2be5e8c109e2197D077D13A82dAead6a9b3433C5' // ERC-20, 18 decimals
+const WTON = '0xc4A11aaf6ea915Ed7Ac194161d2fC9384F15bff2' // Wrapped TON, 27 decimals (RAY)
+const DEPOSIT_MANAGER = '0x0b58ca72b12f01fc05f8f252e226f3e2089bd00e'
+
+async function staking(api) {
+  const wtonBalance = await api.call({ target: WTON, abi: 'erc20:balanceOf', params: DEPOSIT_MANAGER })
+  // Convert 27-decimal WTON to 18-decimal TON (1 WTON == 1 TON) and price as TON.
+  api.add(TON, (BigInt(wtonBalance) / 10n ** 9n).toString())
+}
+
+module.exports = {
+  methodology:
+    'TON staked through Tokamak Network seigniorage staking on Ethereum L1. Stakers delegate TON to operator (DAO candidate) contracts; the principal is custodied as WTON (27-decimal wrapped TON) in the DepositManager (0x0b58ca72b12f01fc05f8f252e226f3e2089bd00e). Reported staking value is the DepositManager WTON balance expressed as TON (1 WTON = 1 TON).',
+  ethereum: {
+    tvl: () => ({}),
+    staking,
+  },
+}


### PR DESCRIPTION
## Tokamak Network — TON seigniorage staking (Ethereum L1)

Adds a TVL adapter for **Tokamak Network**'s native TON staking.

### Protocol metadata
- **Name:** Tokamak Network
- **Category:** Staking
- **Chain:** Ethereum
- **Token:** TON `0x2be5e8c109e2197D077D13A82dAead6a9b3433C5` — Tokamak Network's ERC-20. ⚠️ Not Toncoin / The Open Network (same ticker, different token).
- **App / website:** https://toki.tokamak.network (toki — the consumer staking app) · https://tokamak.network
- **Docs:** https://docs.tokamak.network
- **Twitter:** https://twitter.com/tokamak_network

### Methodology
Stakers delegate TON to operator (DAO candidate) contracts. The staked principal is custodied as **WTON** (27-decimal "ray" wrapped TON, where `1 WTON == 1 TON` in value) held by the **DepositManager** (`0x0b58ca72b12f01fc05f8f252e226f3e2089bd00e`). The adapter reports `WTON.balanceOf(DepositManager)` expressed as TON, under the `staking` export (TON is the protocol's own token).

Verified on Ethereum mainnet:
- `WTON.balanceOf(DepositManager)` ≈ **31,100,670 WTON** (≈ 31.1M TON locked)
- `WTON.balanceOf(SeigManager)` = 0 (all token custody is in the DepositManager)
- Alternative internal metric `SeigManager.stakeOfTotal()` ≈ 24.8M TON (currently-staked, excludes the withdrawal queue) — happy to switch the adapter to this if preferred.

### Contracts
- DepositManager `0x0b58ca72b12f01fc05f8f252e226f3e2089bd00e`
- SeigManager `0x0b55a0f463b6defb81c6063973763951712d0e5f`
- Layer2Registry `0x7846c2248A7B4dE77E9C2Bae7FBB93bfC286837B`
- TON `0x2be5e8c109e2197D077D13A82dAead6a9b3433C5` · WTON `0xc4A11aaf6ea915Ed7Ac194161d2fC9384F15bff2`

Logo: https://toki.tokamak.network/toki-logo.png (happy to provide the Tokamak Network logo instead if you prefer the protocol mark).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Tokamak Network's TON seigniorage staking module for Ethereum L1, enabling tracking of staking positions and balance monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->