### PR TITLE
Add AFX TVL adapter

### DIFF
--- a/projects/afx/index.js
+++ b/projects/afx/index.js
@@ -1,21 +1,7 @@
 const ADDRESSES = require('../helper/coreAssets.json')
-
-const AFX_BRIDGE = '0xCb3B9A3E5668AFE84DC7A864B36b845dCE062e67'
-
-async function tvl(api) {
-  const usdc = ADDRESSES.arbitrum.USDC_CIRCLE
-  const balance = await api.call({
-    abi: 'erc20:balanceOf',
-    target: usdc,
-    params: [AFX_BRIDGE],
-  })
-
-  api.add(usdc, balance)
-}
+const { sumTokensExport } = require('../helper/unwrapLPs')
 
 module.exports = {
   methodology: 'Counts USDC deposited through Arbitrum and locked in the AFX bridge contract.',
-  arbitrum: {
-    tvl,
-  },
+  arbitrum: { tvl: sumTokensExport({owner: '0xCb3B9A3E5668AFE84DC7A864B36b845dCE062e67', tokens: [ADDRESSES.arbitrum.USDC_CIRCLE]}) },
 }

--- a/projects/afx/index.js
+++ b/projects/afx/index.js
@@ -1,0 +1,21 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+
+const AFX_BRIDGE = '0xCb3B9A3E5668AFE84DC7A864B36b845dCE062e67'
+
+async function tvl(api) {
+  const usdc = ADDRESSES.arbitrum.USDC_CIRCLE
+  const balance = await api.call({
+    abi: 'erc20:balanceOf',
+    target: usdc,
+    params: [AFX_BRIDGE],
+  })
+
+  api.add(usdc, balance)
+}
+
+module.exports = {
+  methodology: 'Counts USDC deposited through Arbitrum and locked in the AFX bridge contract.',
+  arbitrum: {
+    tvl,
+  },
+}


### PR DESCRIPTION

##### Name (to be shown on DefiLlama):
AFX

##### Twitter Link:
https://x.com/AFX_XYZ

##### List of audit links if any:
https://afx-docs.gitbook.io/afx/audits

##### Website Link:
https://app.afx.xyz/trade

##### Logo (High resolution, will be shown with rounded borders):
https://afx-docs.gitbook.io/afx/~gitbook/image?url=https%3A%2F%2F3176913495-files.gitbook.io%2F%7E%2Ffiles%2Fv0%2Fb%2Fgitbook-x-prod.appspot.com%2Fo%2Forganizations%252F5Ay5YCVn2JZD2yaJtSsc%252Fsites%252Fsite_xi5bs%252Ficon%252FHRtvly7s0vGVEgVOZQyJ%252F1.png%3Falt%3Dmedia%26token%3Df7def86c-7a1f-4ed5-813a-0aae3c6f8a8e&width=180&height=180&sign=d6df9f15&sv=2

##### Current TVL:
~$12.64M

##### Treasury Addresses (if the protocol has treasury)
N/A

##### Chain:
AFX

##### Coingecko ID:
N/A

##### Coinmarketcap ID:
N/A

##### Short Description:
AFX is a high-performance sovereign L1 purpose-built for decentralized derivatives. By synthesizing the rapid execution of a centralized exchange with the immutable sovereignty of the blockchain, AFX delivers a professional-grade Perp DEX environment characterized by sub-100ms finality, institutional liquidity, and unmatched capital efficiency.

##### Token address and ticker if any:
N/A, AFX has not issued a token yet.

##### Category:
Derivatives

##### Oracle Provider(s):
Binance, Bybit, OKX, and on-chain order book data.

##### Implementation Details:
AFX mark price is derived from the median of multiple price components, combining on-chain order book data with multi-exchange oracle feeds.

##### Documentation/Proof:
https://afx-docs.gitbook.io/afx

##### forkedFrom:
N/A

##### methodology:
TVL counts USDC deposited through Arbitrum and locked in the AFX bridge contract. The adapter reads the Circle USDC balance of the bridge contract.

##### Github org/user:
https://github.com/afx-dex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Total Value Locked (TVL) tracking for the Arbitrum AFX bridge. Users can now monitor USDC held by the bridge and view real-time liquidity metrics for the protocol on Arbitrum, with an explanatory methodology describing how deposited/locked USDC is accounted for.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->