### PR TITLE
tensorplex: fix $0 TVL (stTAO not priced at its own address)

### DIFF
--- a/projects/tensorplex/index.js
+++ b/projects/tensorplex/index.js
@@ -1,12 +1,16 @@
+// stTAO is Tensorplex's liquid-staked TAO. The previous adapter added the
+// stTAO token by its own address, but the coins API has no price for that
+// contract, so the protocol rendered $0 despite real staked TAO. stTAO is
+// TAO-denominated (9 decimals), so value the supply as native TAO instead.
 const st_tao = "0xB60acD2057067DC9ed8c083f5aa227a244044fD6"
 
 async function tvl(api) {
   const supply = await api.call({ abi: 'erc20:totalSupply', target: st_tao })
-  api.add(st_tao, supply)
+  api.addCGToken('bittensor', supply / 1e9)
 }
 
 module.exports = {
-  methodology: "TVL counts tokens staked by the protocol.",
+  methodology: "Counts TAO staked through Tensorplex, measured as the total supply of stTAO (liquid-staked TAO, 9 decimals) and valued as native TAO.",
   ethereum: {
     tvl,
   },


### PR DESCRIPTION
The Tensorplex listing shows $0 TVL. The adapter reads stTAO's total supply and does `api.add(st_tao, supply)`, but the coins API has no price entry for the stTAO contract (`0xB60acD2057067DC9ed8c083f5aa227a244044fD6`), so it contributes nothing and the protocol renders $0 — despite ~6,276 stTAO (~$1.3M) of real staked TAO on-chain.

stTAO is liquid-staked TAO (9 decimals), so this values the supply as native TAO via `addCGToken('bittensor', ...)`, the same approach used for other TAO-denominated Bittensor adapters.

```
node test.js projects/tensorplex/index.js
```
$0 → ~$1.34M (supply read live from the contract; valued at the TAO price).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Tensorplex liquid-staking TVL adapter that previously displayed $0 due to missing pricing data. Now correctly values stTAO supply in native TAO.

* **Documentation**
  * Updated methodology description to reflect proper stTAO valuation and decimal handling approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->