### PR TITLE
jupiter-usd: add Coinbase reserve wallet

### DIFF
--- a/projects/jupiter-usd/index.js
+++ b/projects/jupiter-usd/index.js
@@ -10,6 +10,6 @@ const { sumTokens2 } = require('../helper/solana')
 module.exports = {
   methodology: `Tokens backing the minted JupUSD`,
   solana: {
-    tvl: api => sumTokens2({ api, owners: ['CkzLnD9r4d4ZZofsgNVo2VNunxDmte5YJ4vfAgMfBZNA', 'B3q4P4XSmycvoHLaiEjchsGDafFPhKokvHvNRuW29N1y', '7i6ELgCKhZewDPg4P91w9FYpWKrSx7ptiNrUCrBarHff'] }),
+    tvl: api => sumTokens2({ api, owners: ['CkzLnD9r4d4ZZofsgNVo2VNunxDmte5YJ4vfAgMfBZNA', 'B3q4P4XSmycvoHLaiEjchsGDafFPhKokvHvNRuW29N1y', '7i6ELgCKhZewDPg4P91w9FYpWKrSx7ptiNrUCrBarHff', '4APzEJ8NmeTAq1geJP4dtsZD8hSDqsLiiY914twATk77'] }),
   },
 }


### PR DESCRIPTION
Adds the Coinbase wallet (`4APzEJ8NmeTAq1geJP4dtsZD8hSDqsLiiY914twATk77`)
to the jupiter-usd adapter. It holds a portion of the USDC backing JupUSD.

### Verification (on-chain via Solana RPC)

| Wallet | USDC | USDtb | Subtotal |
|---|---|---|---|
| CkzLnD9r..ZNA (reserve program) | 1.84M | 0 | $1.84M |
| B3q4P4XS..N1y (custodian) | 0.07M | 45.92M | $46.00M |
| 7i6ELgCK..Hff (reserve) | 1.07M | 0 | $1.07M |
| **4APzEJ8N..k77 (Coinbase, added)** | **2.10M** | **0** | **$2.10M** |

- Adapter before: $48.90M
- Adapter after:  $50.99M
- JupUSD circulating supply: $50.99M
- collateral / supply with 4 wallets: 1.0003

`node test.js projects/jupiter-usd/index.js` passes.

No new dependencies. No lockfile changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated JupUSD total value locked (TVL) calculation on Solana to include an additional custodian account, ensuring more comprehensive TVL reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->