### PR TITLE
fix Ethena dedup calculation for Jupiter Lend

### DIFF
--- a/projects/jupiter-lend/index.js
+++ b/projects/jupiter-lend/index.js
@@ -1,6 +1,7 @@
 const { getConfig } = require('../helper/cache')
 const { getProvider, sumTokens2, getTokenAccountBalances } = require('../helper/solana')
 const { Program } = require("@coral-xyz/anchor");
+const { PublicKey } = require('@solana/web3.js');
 
 const LIQUIDITY_IDL_URL = "https://raw.githubusercontent.com/jup-ag/jupiter-lend/refs/heads/main/target/idl/liquidity.json";
 const LIQUIDITY_PROGRAM_IDS = [
@@ -35,12 +36,18 @@ async function tvl(api) {
   tokenReserves.forEach(r => { reserveByMint[r.mint.toBase58()] = r })
   const accounts = Object.keys(ETHENA_ATOKEN_ACCOUNTS)
   const balances = await getTokenAccountBalances(accounts, { individual: true, allowError: true })
-  balances.forEach((b, i) => {
+  const connection = getProvider().connection
+  for (let i = 0; i < balances.length; i++) {
+    const b = balances[i]
     const underlyingMint = ETHENA_ATOKEN_ACCOUNTS[accounts[i]]
     const reserve = reserveByMint[underlyingMint]
-    const underlying = +b.amount * (+reserve.supplyExchangePrice.toString()) / EXCHANGE_PRICE_PRECISION
-    api.add(underlyingMint, -underlying)
-  })
+    if (!reserve) continue
+    const totalReceiptSupply = +(await connection.getTokenSupply(new PublicKey(b.mint))).value.amount
+    if (!totalReceiptSupply) continue
+    const vaultFree = +(await getTokenAccountBalances([reserve.vault.toBase58()], { individual: true }))[0].amount
+    const ethenaShare = +b.amount / totalReceiptSupply
+    api.add(underlyingMint, -ethenaShare * vaultFree)
+  }
 }
 async function borrowed(api) {
   const tokenReserves = await getData()


### PR DESCRIPTION
Follow-up to #19366.

The Ethena dedup computes Ethena's USDG amount as `jleUSDG balance × supplyExchangePrice` and subtracts it from the USDG TVL line. For Ethena's current jleUSDG balance:

    250,930,298 × 1.001826 = $251.4M

This is Ethena's full deposit principal in the isolated Ethena market.

The USDG TVL line only contains the free vault balances that `sumTokens2` adds:

    $0.72M (main market) + $12.09M (isolated market) = $12.81M

The remaining $239M of Ethena's principal is currently lent out to borrowers.

Subtracting $251.4M of principal from a $12.81M TVL line leaves -$238.6M.

### Fix

Subtract Ethena's pro-rata share of the free vault balance:

    ethena_share = jleUSDG_balance / jleUSDG_total_supply
    subtract     = ethena_share × free_USDG_in_vault

### Result

|                          | Before     | After     |
|--------------------------|------------|-----------|
| USDG TVL line            | -$238.66M  | +$721k    |
| jupiter-lend total TVL   | $844.77M   | $1.08B    |
| Borrowed                 | $792M      | $792M     |

`node test.js projects/jupiter-lend/index.js` passes.

No new dependencies. No lockfile changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of Total Value Locked (TVL) calculations for Ethena-related deposits by refining how ownership percentages and underlying asset values are computed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->