### PR TITLE
fix pondo tvl: include delegated stake

### DIFF
--- a/projects/helper/chain/aleo.js
+++ b/projects/helper/chain/aleo.js
@@ -3,49 +3,22 @@ const axios = require('axios')
 const endpoint = 'https://api.provable.com/v1/mainnet'
 
 async function aQuery(path) {
-  const { data } = await axios.get(`${endpoint}${path}`, { timeout: 3000 })
+  const { data } = await axios.get(`${endpoint}${path}`, { timeout: 10000 })
   return data
 }
 
 /**
  * Fetch a value from a mapping within an Aleo program.
- * e.g., getProgramMappingValue('credits.aleo', 'account', 'aleo1...')
+ * Program ids are auto-resolved to their addresses by the API, so either a
+ * program id (e.g. 'delegator1.aleo') or an aleo1... address works as the key.
+ * Returns the raw value (a string such as "1000000u64", or a struct string for
+ * composite values like `bonded`), or null when there is no entry for the key.
+ * e.g. getProgramMappingValue('credits.aleo', 'account', 'aleo1...')
  */
 async function getProgramMappingValue(programId, mappingName, key) {
-  let url = `/program/${programId}/mapping/${mappingName}/${key}`
-  return aQuery(url)
-}
-
-async function sumTokens({ owners = [], api }) {
-  // Aleo's native token is mapped in credits.aleo -> account
-  for (const owner of owners) {
-    try {
-      // The API returns the value as a string, e.g. "1000000u64"
-      const res = await getProgramMappingValue('credits.aleo', 'account', owner)
-      if (res) {
-        // Strip the "u64" or other type suffixes
-        const amountStr = res.replace(/u64$/, '')
-        const amount = Number(amountStr) / 1e6 // Convert microcredits to Aleo
-
-        if (!Number.isFinite(amount)) {
-          throw new Error(`Failed to parse valid numeric balance from Aleo mapping for ${owner}. Received: ${res}`)
-        }
-        
-        api.addCGToken('aleo', amount)
-      }
-    } catch (e) {
-      // Only swallow 404/not found errors (which means empty balance/account not initialized). Fail on other RPC issues.
-      if (e.response && e.response.status === 404) {
-        // mapping not found
-        continue
-      }
-      throw e
-    }
-  }
-  return api.getBalances()
+  return aQuery(`/program/${programId}/mapping/${mappingName}/${key}`)
 }
 
 module.exports = {
   getProgramMappingValue,
-  sumTokens,
 }

--- a/projects/pondo/index.js
+++ b/projects/pondo/index.js
@@ -1,12 +1,72 @@
-const { sumTokens } = require('../helper/chain/aleo');
+const { getProgramMappingValue } = require('../helper/chain/aleo')
+
+// Pondo is an ALEO liquid-staking protocol. The core program holds a small
+// liquid buffer, but the bulk of the ALEO is delegated to validators through
+// five delegator programs. TVL must include that delegated stake, otherwise we
+// only count the idle buffer (~2.7% of the real total).
+const CORE_PROTOCOL = 'pondo_protocol.aleo'
+const DELEGATORS = [
+  'delegator1.aleo',
+  'delegator2.aleo',
+  'delegator3.aleo',
+  'delegator4.aleo',
+  'delegator5.aleo',
+]
+
+// Plain Aleo integers come back like "12345u64" — strip the type suffix.
+const toMicrocredits = (v) => (v ? BigInt(String(v).replace(/u\d+$/, '')) : 0n)
+
+// `bonded` / `unbonding` come back as a struct string:
+//   "{ validator: aleo1..., microcredits: 12345u64 }"
+const bondStateMicrocredits = (v) => {
+  if (!v) return 0n
+  const m = String(v).match(/microcredits:\s*(\d+)u64/)
+  return m ? BigInt(m[1]) : 0n
+}
+
+// Small retry wrapper — the public Aleo RPC occasionally rate-limits.
+async function getMapping(programId, mappingName, key, retries = 5) {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await getProgramMappingValue(programId, mappingName, key)
+    } catch (e) {
+      if (attempt >= retries - 1) throw e
+      await new Promise((r) => setTimeout(r, 300 * 2 ** attempt))
+    }
+  }
+}
+
+async function tvl(api) {
+  // 1) Liquid ALEO held by the core protocol account.
+  let total = toMicrocredits(await getMapping('credits.aleo', 'account', CORE_PROTOCOL))
+
+  // 2) ALEO delegated through each delegator: liquid account + bonded + unbonding.
+  const delegatorTotals = await Promise.all(
+    DELEGATORS.map(async (delegator) => {
+      const account = await getMapping('credits.aleo', 'account', delegator)
+      const bonded = await getMapping('credits.aleo', 'bonded', delegator)
+      const unbonding = await getMapping('credits.aleo', 'unbonding', delegator)
+      return (
+        toMicrocredits(account) +
+        bondStateMicrocredits(bonded) +
+        bondStateMicrocredits(unbonding)
+      )
+    })
+  )
+  for (const t of delegatorTotals) total += t
+
+  // 3) Exclude ALEO reserved for / owed to pending withdrawals — it no longer backs pALEO.
+  const bondedWithdrawals = toMicrocredits(await getMapping(CORE_PROTOCOL, 'balances', '1u8'))
+  const reservedForWithdrawals = toMicrocredits(await getMapping(CORE_PROTOCOL, 'balances', '2u8'))
+  total = total - bondedWithdrawals - reservedForWithdrawals
+
+  api.addCGToken('aleo', Number(total) / 1e6)
+  return api.getBalances()
+}
 
 module.exports = {
   timetravel: false,
-  methodology: "TVL is the sum of all Aleo credits staked in the Pondo staking pool",
-  aleo: {
-    tvl: (api) => sumTokens({
-      api,
-      owners: ['pondo_protocol.aleo']
-    })
-  }
+  methodology:
+    'TVL is the total ALEO backing pALEO: liquid credits held by pondo_protocol.aleo plus all credits bonded and unbonding through its five delegators (delegator1-5.aleo), minus ALEO reserved for pending withdrawals.',
+  aleo: { tvl },
 }


### PR DESCRIPTION
Pondo's TVL on DefiLlama looked way off — we were showing around 648k ALEO when the protocol actually has roughly 24M staked. The adapter was only reading the liquid balance sitting in `pondo_protocol.aleo`, which is just the small buffer the protocol keeps on hand. But Pondo is a liquid-staking protocol, so almost all of the ALEO is delegated out to validators through five delegator programs (`delegator1-5.aleo`), and the adapter never looked there. So we were reporting maybe 3% of the real number.

I reworked the TVL calc to mirror how Pondo itself computes it — the same accounting behind the number on pondo.xyz. It starts with the liquid balance in the core program, adds each delegator's account + bonded + unbonding credits, and then subtracts the amounts set aside for pending withdrawals, since those are on their way out and no longer back pALEO.

While I was in there I also dropped the old `sumTokens` helper. It only ever read the `account` mapping, which is exactly what caused the undercount, and nothing else in the repo used it. I bumped the Aleo RPC timeout from 3s to 10s as well, since the adapter makes a handful more calls now.

Ran `node test.js projects/pondo/index.js` and it now comes out to about $743k (~24.34M ALEO), which matches pondo.xyz.

---

This is a fix to an already-listed protocol, not a new listing, so I've left the new-listing form out and just filled in the parts that apply:

##### methodology (what is being counted as tvl, how is tvl being calculated):
Total ALEO backing pALEO: the liquid credits held by `pondo_protocol.aleo`, plus the account + bonded + unbonding credits of each of its five delegators (`delegator1-5.aleo`), minus the ALEO reserved for pending withdrawals. Read live from the Aleo RPC, so it's live-only (no timetravel).

No new npm dependencies, and `pnpm-lock.yaml` is untouched. "Allow edits by maintainers" is enabled.

