### PR TITLE
Add USDCx Aleo stablecoin

### DIFF
--- a/projects/usdcx/index.js
+++ b/projects/usdcx/index.js
@@ -1,0 +1,16 @@
+const axios = require('axios')
+
+module.exports = {
+  timetravel: false,
+  methodology: "Tracks the circulating supply of USDCx on Aleo using Circle's xReserve API, which reports the USDC balance reserved for Aleo (chain ID 10002). USDCx is backed 1:1 by USDC.",
+  aleo: {
+    tvl: async (api) => {
+      const { data } = await axios.get('https://xreserve-api.circle.com/v1/balances/10002', { timeout: 5000 })
+      if (!Array.isArray(data?.balances)) throw new Error('Unexpected response from Circle xReserve API')
+      const usdcEntry = data.balances.find(b => b.token === 'USDC')
+      if (!usdcEntry) throw new Error('USDC balance not found in Circle xReserve API response')
+      api.addCGToken('usd-coin', Number(usdcEntry.balance))
+      return api.getBalances()
+    }
+  }
+}


### PR DESCRIPTION
Adds USDCx TVL adapter for Aleo. Supply is pulled from Circle's xReserve API (chain ID 10002) — same source Circle uses to prove the USDC reserves backing USDCx.

> USAD was dropped from this PR per reviewer feedback — it can't be independently validated via Circle API.

---

## USDCx

##### Name: USDCx
##### Website: https://aleo.org/usdcx/
##### Chain: Aleo
##### Current TVL: ~$203,600
##### Category: Stablecoins
##### Short Description: USDCx is a private, programmable stablecoin on Aleo built with Circle, backed 1:1 by USDC held in Circle xReserve.
##### Token: `usdcx_stablecoin.aleo`, USDCx
##### Methodology: Circulating supply from Circle's xReserve API (`/v1/balances/10002`), priced as USDC (1:1 backed).
##### Oracle: N/A — priced via underlying USDC
##### Documentation: https://aleo.org/usdcx/ — contract: https://explorer.provable.com/program/usdcx_stablecoin.aleo
##### Referral program: No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Aleo blockchain support with real-time USDCx TVL tracking powered by Circle reserve data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->