### PR TITLE
Add HypeMarket TVL adapter

### DIFF
--- a/projects/hypemarket/index.js
+++ b/projects/hypemarket/index.js
@@ -22,8 +22,10 @@ async function tvl(api) {
   for (const t of tokens) {
     const cgId = t.coingeckoId || SYMBOL_TO_CG[String(t.symbol || '').toUpperCase()]
     if (!cgId) continue // unpriceable collateral — skip rather than mis-value
+    const amount = Number(t.amount)
+    if (!Number.isFinite(amount) || amount <= 0) continue // skip missing/NaN/non-positive amounts
     // `amount` is whole tokens (rawAmount / 10**decimals); addCGToken prices by CoinGecko id.
-    api.addCGToken(cgId, Number(t.amount))
+    api.addCGToken(cgId, amount)
   }
 }
 

--- a/projects/hypemarket/index.js
+++ b/projects/hypemarket/index.js
@@ -1,0 +1,41 @@
+const { get } = require('../helper/http')
+
+// Hypemarket public TVL feed. Enumerates every live market (each market is its own
+// on-chain object) and sums each market's on-chain `collateral_amount` — the LS-LMSR
+// collateral backing pool — grouped by collateral token.
+// NOTE: BASE_PATH defaults to /api in the backend. Confirm whether your reverse
+// proxy keeps the /api prefix on api.hypemarket.trade and adjust if it strips it.
+const TVL_URL = 'https://api.hypemarket.trade/api/defillama/tvl'
+
+// Fallback CoinGecko ids if the API ever omits `coingeckoId` for a known symbol.
+const SYMBOL_TO_CG = {
+  USDC: 'usd-coin',
+  USDT: 'tether',
+  SUPRA: 'supra',
+}
+
+async function tvl(api) {
+  const res = await get(TVL_URL)
+  // The API wraps its payload in { data, success }; tolerate both that and a bare body.
+  const payload = res && res.data ? res.data : res
+  const tokens = Array.isArray(payload.tokens) ? payload.tokens : []
+  for (const t of tokens) {
+    const cgId = t.coingeckoId || SYMBOL_TO_CG[String(t.symbol || '').toUpperCase()]
+    if (!cgId) continue // unpriceable collateral — skip rather than mis-value
+    // `amount` is whole tokens (rawAmount / 10**decimals); addCGToken prices by CoinGecko id.
+    api.addCGToken(cgId, Number(t.amount))
+  }
+}
+
+module.exports = {
+  timetravel: false, // API serves current TVL only; no historical backfill
+  methodology:
+    'TVL is the total collateral locked across all live HypeMarket prediction markets — ' +
+    'the LS-LMSR backing pool securing outstanding outcome tokens. Each market is its own ' +
+    'on-chain object; markets are enumerated from the market factory and each market\'s ' +
+    'on-chain collateral_amount is summed, grouped by collateral token (SUPRA). ' +
+    'Collateral that has been redeemed or refunded out of resolved/voided markets is excluded.',
+  supra: {
+    tvl,
+  },
+}


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
HypeMarket

##### Twitter Link:
https://x.com/HypeMarketTrade

##### List of audit links if any:
None at this time

##### Website Link:
https://beta.hypemarket.trade (now)
https://hypemarket.trade (from July 1st)

##### Logo (High resolution, will be shown with rounded borders):
Brand kit: https://hypemarket-protocol.gitbook.io/hypemarket-protocol-docs/partnerships/brand-kit
<img width="513" height="513" alt="Icon" src="https://github.com/user-attachments/assets/5b6d6fc4-1e77-48cd-83ba-1b0bdeb37000" />
<img width="1005" height="262" alt="Logo full" src="https://github.com/user-attachments/assets/f194dff2-d771-4182-a02a-18f489680578" />


##### Current TVL:
~$2,121 (≈6,757,938 SUPRA locked across 15 live markets, as of 2026-06-09)

##### Treasury Addresses (if the protocol has treasury)
N/A

##### Chain:
Supra

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description (to be shown on DefiLlama):
HypeMarket is a community-driven, on-chain prediction market on Supra L1. It uses an LS-LMSR (Liquidity-Sensitive Logarithmic Market Scoring Rule) automated market maker: users trade outcome shares of real-world events against a per-market collateral pool, and anyone can create markets. Markets are denominated in native SUPRA and settled on-chain using Supra's native oracle and automation services.

##### Token address and ticker if any:
None (no protocol token). Markets are collateralized in native SUPRA.

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Prediction Market

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
Supra — the protocol uses Supra's native oracle and on-chain automation services for market resolution/settlement. (TVL itself is independent of any oracle.)

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
Each market has a designated resolver; outcome settlement is performed on-chain using Supra's native oracle/automation. The TVL reported here does not depend on any oracle — it is the on-chain SUPRA collateral_amount held by each market object.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
https://hypemarket-protocol.gitbook.io/hypemarket-protocol-docs

##### forkedFrom (Does your project originate from another project):
No

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL is the total collateral locked across all live HypeMarket markets — the LS-LMSR backing pool that secures outstanding outcome tokens. Each market is its own on-chain object. Markets are enumerated from the market factory and each market's on-chain `collateral_amount` (the authoritative locked balance, read via the `market::get_collateral_amount` view) is summed and grouped by collateral token (native SUPRA), then priced via the SUPRA CoinGecko id. Collateral redeemed or refunded out of resolved/voided markets is excluded. Cumulative trade volume is NOT counted as TVL.

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/HypeMarket-Protocol

##### Does this project have a referral program?
Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hypemarket TVL tracking added for real-time total value locked monitoring.
  * Automatic token valuation with fallback symbol resolution when upstream IDs are missing.
  * Robust data handling: supports varied payload formats, ignores unknown tokens, and validates token amounts for more reliable reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->