### PR TITLE
realtoken-rmm-v3: price collateral via market oracle (fixes $0 TVL)

### DIFF
--- a/projects/realtoken-rmm-v3/index.js
+++ b/projects/realtoken-rmm-v3/index.js
@@ -27,9 +27,12 @@ async function getMarket(api) {
 }
 
 function addUsd(api, amounts, decimals, prices, baseUnit) {
+  const SCALE = 10n ** 18n; // keep fractional precision through integer math
+  const base = BigInt(baseUnit);
   amounts.forEach((amount, i) => {
-    const usd = (Number(amount) / 10 ** Number(decimals[i])) * (Number(prices[i]) / Number(baseUnit));
-    api.addUSDValue(usd);
+    const denom = 10n ** BigInt(decimals[i]) * base;
+    const usdScaled = (BigInt(amount) * BigInt(prices[i]) * SCALE) / denom;
+    api.addUSDValue(Number(usdScaled) / 1e18);
   });
 }
 
@@ -43,7 +46,7 @@ async function borrowed(api) {
   const { reserveTokens, prices, baseUnit, decimals } = await getMarket(api);
   const variableDebt = await api.multiCall({ abi: "erc20:totalSupply", calls: reserveTokens.map((r) => r.variableDebtTokenAddress) });
   const stableDebt = await api.multiCall({ abi: "erc20:totalSupply", calls: reserveTokens.map((r) => r.stableDebtTokenAddress) });
-  const debt = variableDebt.map((v, i) => Number(v) + Number(stableDebt[i]));
+  const debt = variableDebt.map((v, i) => (BigInt(v) + BigInt(stableDebt[i])).toString());
   addUsd(api, debt, decimals, prices, baseUnit);
 }
 

--- a/projects/realtoken-rmm-v3/index.js
+++ b/projects/realtoken-rmm-v3/index.js
@@ -1,0 +1,55 @@
+const methodologies = require("../helper/methodologies");
+
+// RealT RMM v3 is an Aave-fork money market on Gnosis. Its collateral is RealT
+// "Wrapped USD" tokens (e.g. RTW-USD-01) that have no external market price, so
+// the market exposes its own Aave price oracle to value every reserve. We price
+// supply and borrows through that oracle (base unit = 1e8, USD).
+const DATA_PROVIDER = "0x11B45acC19656c6C52f93d8034912083AC7Dd756";
+const ORACLE = "0xb4AE809Ad7CEB7e5B579dEdD0De7c213aD5AB516";
+
+const abi = {
+  getAllATokens: "function getAllATokens() view returns (tuple(string symbol, address tokenAddress)[])",
+  getReserveTokensAddresses: "function getReserveTokensAddresses(address asset) view returns (address aTokenAddress, address stableDebtTokenAddress, address variableDebtTokenAddress)",
+  getAssetsPrices: "function getAssetsPrices(address[] assets) view returns (uint256[])",
+  BASE_CURRENCY_UNIT: "uint256:BASE_CURRENCY_UNIT",
+};
+
+async function getMarket(api) {
+  const aTokens = (await api.call({ target: DATA_PROVIDER, abi: abi.getAllATokens })).map((i) => i.tokenAddress);
+  const underlyings = await api.multiCall({ abi: "address:UNDERLYING_ASSET_ADDRESS", calls: aTokens });
+  const [reserveTokens, prices, baseUnit, decimals] = await Promise.all([
+    api.multiCall({ target: DATA_PROVIDER, abi: abi.getReserveTokensAddresses, calls: underlyings }),
+    api.call({ target: ORACLE, abi: abi.getAssetsPrices, params: [underlyings] }),
+    api.call({ target: ORACLE, abi: abi.BASE_CURRENCY_UNIT }),
+    api.multiCall({ abi: "uint8:decimals", calls: underlyings }),
+  ]);
+  return { aTokens, underlyings, reserveTokens, prices, baseUnit, decimals };
+}
+
+function addUsd(api, amounts, decimals, prices, baseUnit) {
+  amounts.forEach((amount, i) => {
+    const usd = (Number(amount) / 10 ** Number(decimals[i])) * (Number(prices[i]) / Number(baseUnit));
+    api.addUSDValue(usd);
+  });
+}
+
+async function tvl(api) {
+  const { aTokens, underlyings, prices, baseUnit, decimals } = await getMarket(api);
+  const supplied = await api.multiCall({ abi: "erc20:balanceOf", calls: aTokens.map((aToken, i) => ({ target: underlyings[i], params: aToken })) });
+  addUsd(api, supplied, decimals, prices, baseUnit);
+}
+
+async function borrowed(api) {
+  const { reserveTokens, prices, baseUnit, decimals } = await getMarket(api);
+  const variableDebt = await api.multiCall({ abi: "erc20:totalSupply", calls: reserveTokens.map((r) => r.variableDebtTokenAddress) });
+  const stableDebt = await api.multiCall({ abi: "erc20:totalSupply", calls: reserveTokens.map((r) => r.stableDebtTokenAddress) });
+  const debt = variableDebt.map((v, i) => Number(v) + Number(stableDebt[i]));
+  addUsd(api, debt, decimals, prices, baseUnit);
+}
+
+module.exports = {
+  // supply/borrow values are reported in USD (priced via the market oracle), not the underlying tokens
+  misrepresentedTokens: true,
+  methodology: methodologies.lendingMarket,
+  xdai: { tvl, borrowed },
+};

--- a/registries/aave.js
+++ b/registries/aave.js
@@ -366,13 +366,6 @@ const aaveConfigs = {
       v3: true,
     },
   },
-  'realtoken-rmm-v3': {
-    methodology,
-    xdai: {
-      addressesProviderRegistry: '0xC6c4b123e731819AC5f7F9E0fe3A118e9b1227Cd',
-      dataHelpers: ['0x11B45acC19656c6C52f93d8034912083AC7Dd756'],
-    },
-  },
   'realtmarkets': {
     misrepresentedTokens: true,
     methodology,


### PR DESCRIPTION
### Problem
`realtoken-rmm-v3` (RealT RMM v3, Gnosis) reports **\$0 TVL** while the market is active with **~\$14.7M borrowed** — which is impossible for a healthy lending market.

The reserves are WXDAI, USDC and RealT "Wrapped USD" collateral tokens (RTW-USD-01, REUSD). WXDAI/USDC are ~100% utilized, so the aTokens hold ~0 underlying; the value actually locked is the RTW-USD-01 collateral (~31.2M, supplied by 2,238 addresses). DefiLlama has no market price for these RealT tokens (no DEX, not in the coins API), so they were valued at \$0 — and once WXDAI/USDC utilization reached ~100%, total TVL collapsed to \$0.

### Fix
The market exposes its own Aave price oracle (`0xb4AE809…`) that prices every reserve (RTW-USD-01 at \$1.00). This standalone adapter reads supply (aToken-held underlying) and debt (variable + stable debt-token supply) from the data provider and values both through that oracle. The sibling RealT market (`realtmarkets`) already uses the same oracle-based approach.

Moved out of the shared aave-fork registry into its own adapter because the registry path priced reserves through DefiLlama's token pricing (which can't price the RealT collateral), and its borrowed reader assumed a data-provider return layout this market does not use.

### Verification (Gnosis mainnet)
- Reserves — RTW-USD-01: supplied 31.19M / borrowed 0; USDC: supplied 8.84M / borrowed 8.84M; WXDAI: supplied 5.84M / borrowed 5.84M.
- Oracle `getAssetPrice`: RTW-USD-01 = \$1.00; WXDAI/USDC ≈ \$1.00.
- RTW-USD-01 is supplied by 2,238 distinct addresses and is not in the RealT community token API, so this does not double-count with the `realt-tokens` adapter.
- `node test.js projects/realtoken-rmm-v3`: TVL = \$31.25M, borrowed = \$14.67M.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for RealT RMM v3 lending market on Gnosis, enabling TVL and borrowed-asset reporting in USD.

* **Chores**
  * Updated protocol registry by removing an outdated configuration entry related to the Aave integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->