### PR TITLE
Add ClawPump (Solana)

### DIFF
--- a/projects/clawpump/index.js
+++ b/projects/clawpump/index.js
@@ -1,0 +1,13 @@
+const { fetchURL } = require('../helper/utils')
+const ADDRESSES = require('../helper/coreAssets.json')
+
+async function tvl(api) {
+  const { data } = await fetchURL('https://agents.clawpump.tech/api/platform-stats')
+  api.add(ADDRESSES.solana.SOL, data.agenticFundingSol * 1e9)
+}
+
+module.exports = {
+  methodology: 'TVL is the SOL deposited by users into ClawPump to fund AI agent compute and trading, as reported by the platform stats API.',
+  timetravel: false,
+  solana: { tvl },
+}


### PR DESCRIPTION
## New protocol listing: ClawPump

**Name:** ClawPump
**Category:** Launchpad
**Chain:** Solana
**Website:** https://clawpump.tech (app: https://agents.clawpump.tech)
**Twitter:** https://twitter.com/clawpumptech
**Token:** `739dnZEG4yaBWFsY8L8ZwrfhGG6dhtCSercW8Umspump` (CLAW)

## About
ClawPump is an AI agent token launchpad on Solana. Agents launch tokens gaslessly on pump.fun, earn 65% of trading fees on their tokens, and self-fund their compute. Users deposit SOL to fund agents.

## Methodology
TVL is the SOL deposited by users into ClawPump to fund AI agent compute and trading, as reported by the platform stats API (`https://agents.clawpump.tech/api/platform-stats`, field `agenticFundingSol`). `timetravel: false` as the API only exposes a current snapshot.

## Test output
```
--- tvl ---
SOL    288.16 k
total  288.16 k
```

A companion fees/volume adapter is being submitted to dimension-adapters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ClawPump platform integration to track Solana TVL (Total Value Locked) metrics in real-time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->