### PR TITLE
centrifuge: track JAAA on Solana, subtract from Ethereum to avoid dou…

### DIFF
--- a/projects/centrifuge/index.js
+++ b/projects/centrifuge/index.js
@@ -1,4 +1,5 @@
 const { getLogs2 } = require('../helper/cache/getLogs');
+const { getTokenSupplies } = require('../helper/solana');
 const ADDRESSES = require('../helper/coreAssets.json')
 
 const nullAddress = ADDRESSES.null
@@ -153,7 +154,37 @@ const tvl = async (api) => {
   await api.erc4626Sum({ calls: uniqueVaults, tokenAbi: 'address:asset', balanceAbi: 'uint256:totalAssets', permitFailure: true })
 }
 
-module.exports.methodology = `TVL corresponds to the total USD value of tokens minted on Centrifuge across Ethereum, Base, and Arbitrum.`
+// The JAAA share class is also issued as an SPL token on Solana. The mint is
+// not independently priced, so its total supply is valued at the EVM JAAA share
+// price (same NAV per share; both tokens are 6 decimals). The assets backing
+// these Solana-issued shares already sit in the EVM vault and are therefore
+// counted in the Ethereum TVL above, so we subtract the same value from
+// Ethereum to attribute it to Solana without double counting.
+const JAAA_SOLANA_MINT = 'AAAJXeGjpKu7W3X4QTSU4pm1Wbj4G2LPcdg7A6xJLLyG'
+const JAAA_EVM = '0x5a0F93D040De44e78F251b03c43be9CF317Dcf64' // ethereum, 6 decimals
+
+const getJaaaSolanaSupply = async () => {
+  const supplies = await getTokenSupplies([JAAA_SOLANA_MINT])
+  return supplies[JAAA_SOLANA_MINT]
+}
+
+const solanaTvl = async (api) => {
+  const supply = await getJaaaSolanaSupply()
+  if (supply) api.add(`ethereum:${JAAA_EVM}`, supply, { skipChain: true })
+}
+
+// Ethereum wraps the shared EVM tvl and removes the Solana-issued JAAA value,
+// whose backing is already reflected in the vault assets measured above.
+const ethereumTvl = async (api) => {
+  await tvl(api)
+  const supply = await getJaaaSolanaSupply()
+  if (supply) api.add(JAAA_EVM, (-BigInt(supply)).toString())
+}
+
+module.exports.methodology = `TVL corresponds to the total USD value of tokens minted on Centrifuge. On EVM chains it is measured from the assets backing each share class vault. The JAAA share class is also issued on Solana; its SPL supply is valued at the EVM JAAA share price and shown on Solana, with the equivalent value subtracted from Ethereum to avoid double counting (its backing already sits in the EVM vault).`
 Object.keys(CONFIG).forEach((chain) => {
   module.exports[chain] = { tvl }
 })
+
+module.exports.ethereum = { tvl: ethereumTvl }
+module.exports.solana = { tvl: solanaTvl }

--- a/projects/centrifuge/index.js
+++ b/projects/centrifuge/index.js
@@ -168,7 +168,20 @@ const getJaaaSolanaSupply = async () => {
   return supplies[JAAA_SOLANA_MINT]
 }
 
+// getTokenSupplies reads the mint's live supply from the Solana RPC and is not
+// block/timestamp aware, unlike the EVM vault reads. To avoid subtracting today's
+// JAAA supply from historical Ethereum balances during backfill, the Solana
+// adjustment is applied only to live runs (the current UTC day). Historical points
+// keep all JAAA backing on Ethereum, where it was before the Solana mint launched
+// and where it remains unmeasurable historically.
+const startOfTodayUTC = () => {
+  const now = new Date()
+  return Math.floor(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()) / 1000)
+}
+const isHistorical = (api) => api.timestamp && api.timestamp < startOfTodayUTC()
+
 const solanaTvl = async (api) => {
+  if (isHistorical(api)) return
   const supply = await getJaaaSolanaSupply()
   if (supply) api.add(`ethereum:${JAAA_EVM}`, supply, { skipChain: true })
 }
@@ -177,6 +190,7 @@ const solanaTvl = async (api) => {
 // whose backing is already reflected in the vault assets measured above.
 const ethereumTvl = async (api) => {
   await tvl(api)
+  if (isHistorical(api)) return
   const supply = await getJaaaSolanaSupply()
   if (supply) api.add(JAAA_EVM, (-BigInt(supply)).toString())
 }


### PR DESCRIPTION
…ble counting

Credit the JAAA SPL token's total supply to the Solana chain, valued at the EVM JAAA share price. Since the assets backing these Solana-issued shares already sit in the EVM vault and are counted in the Ethereum TVL, subtract the same value from Ethereum instead of using the blanket doublecounted flag.

**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).

2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** It is a different repo, you can find your listing in [this file](https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts), you can edit it there and put up a PR
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes

---
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):

##### Twitter Link:

##### List of audit links if any:

##### Website Link:

##### Logo (High resolution, will be shown with rounded borders):

##### Current TVL:

##### Treasury Addresses (if the protocol has treasury)

##### Chain:

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama):

##### Token address and ticker if any:

##### Category (full list at https://defillama.com/categories) \*Please choose only one:

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

##### forkedFrom (Does your project originate from another project):

##### methodology (what is being counted as tvl, how is tvl being calculated):

##### Github org/user (Optional, if your code is open source, we can track activity):

##### Does this project have a referral program?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Solana TVL reporting for the JAAA share class, valuing Solana supply using EVM-derived price.

* **Bug Fixes**
  * Prevented cross-chain double-counting by subtracting the Solana-valued JAAA amount from Ethereum TVL in current (non-historical) runs.

* **Documentation**
  * Expanded TVL methodology to describe Solana valuation and the Ethereum subtraction approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->