### PR TITLE
clearstar: track Euler vaults deployed by 0x6539...A293 on Base

### DIFF
--- a/projects/clearstar/index.js
+++ b/projects/clearstar/index.js
@@ -9,6 +9,7 @@ const configs = {
       ],
       eulerVaultOwners: [
         '0xb3CF59A5f12cA319861376C5e63Eef4790a42B44',
+        '0x6539519E69343535a2aF6583D9BAE3AD74c6A293',
       ],
       erc4626: [
         '0x1166250D1d6B5a1DBb73526257f6bb2Bbe235295', // yoUSD IPOR Fusion


### PR DESCRIPTION
Adds `0x6539519E69343535a2aF6583D9BAE3AD74c6A293` to Clearstar's `eulerVaultOwners` on Base. This deployer was already tracked on Monad and HyperEVM, but its Base-deployed Euler vaults (e.g. [0xa6aD...FCF86](https://basescan.org/address/0xa6ad67c0c6c2275b616fcc81c55ddd76195fcf86), deployed in [this tx](https://basescan.org/tx/0x7794b7d7b4e637b4fd209eadd92bdafde5d1d2a5598ef4b28763a5813a000280)) were not being picked up.

Verified the vault's `creator()` returns this address, and `node test.js projects/clearstar/index.js` runs clean (Base TVL $24.38M, total $114.53M).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated blockchain configuration to include an additional vault owner address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->