### PR TITLE
  morpho-blue: add 0G chain

### DIFF
--- a/projects/morpho-blue/index.js
+++ b/projects/morpho-blue/index.js
@@ -207,6 +207,10 @@ const config = {
     morphoBlue: "0x34CD04070dD72b14E241112F6d83812Df5Af7fCD",
     fromBlock: 1,
   },
+  "0g": {
+    morphoBlue: "0x9CDD13a2212D94C4f12190cA30783B743E83C89e",
+    fromBlock: 7526486,
+  },
 }
 
 const eventAbis = {


### PR DESCRIPTION
 Adds the 0G chain to the existing Morpho Blue (`projects/morpho-blue/`) adapter.

  This is the standard Morpho singleton — no fork, no new dependencies — so it slots
  straight into the existing config.

  ### Deployment
  - **morpho (singleton):** `0x9CDD13a2212D94C4f12190cA30783B743E83C89e`
  - **fromBlock:** `7526486`
  - **chain key:** `0g`

  ### On-chain verification
  - Singleton emits the standard Morpho Blue events (`CreateMarket`, `Supply`, `AccrueInterest`)
    and exposes the Morpho Blue interface (`idToMarketParams`, `market`, `owner`, `feeRecipient`).
  - Official Morpho stack, all wired back to this singleton:
    - `metaMorphoFactory.MORPHO()` → `0x9CDD…C89e` ✓
    - `publicAllocator.MORPHO()` → `0x9CDD…C89e` ✓
    - markets use the official `adaptiveCurveIrm` (`0xf52e20C42FEc624819D4184226C4777D7cbd767e`) ✓
  - Live markets on 0G assets: **W0G / USDC.e / mEDGE**.

  ### Methodology
  Unchanged from the existing morpho-blue adapter — discovers markets via `CreateMarket`
  events, then sums collateral + loan tokens held by the morpho singleton for TVL, and
  `totalBorrowAssets` per loan token for borrowed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `0g` blockchain with total value locked and borrowed metrics tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->