### PR TITLE
mugen-fi: count real treasury holdings instead of frozen reserveBalance

### DIFF
--- a/projects/mugen-fi/index.js
+++ b/projects/mugen-fi/index.js
@@ -1,17 +1,27 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+const { sumTokensExport } = require('../helper/unwrapLPs')
 const { staking } = require('../helper/staking')
 
-async function tvl(api) {
-  const reserveBalance = await api.call({  abi: 'uint256:reserveBalance', target:  '0xf7be8476ae27d27ebc236e33020150b23a86f3dd'}) 
-  return {
-    tether: reserveBalance / 1e18
-  }
-}
+// Deposits were forwarded by the Treasury contract to the team treasury wallet
+// (treasury()). reserveBalance() is only a deposit counter - it has been frozen
+// at ~3.35M since 2023-11-15 while the treasury was emptied on 2023-11-28, so we
+// count the actual token balances instead.
+const TREASURY_CONTRACT = '0xf7be8476ae27d27ebc236e33020150b23a86f3dd'
+const TREASURY_WALLET = '0x00236173844ac7f7091d69d6cbf7e0430222296e'
 
 module.exports = {
-  misrepresentedTokens: true,
   doublecounted: true,
   arbitrum: {
-    tvl,
+    tvl: sumTokensExport({
+      owners: [TREASURY_CONTRACT, TREASURY_WALLET],
+      tokens: [
+        ADDRESSES.arbitrum.USDC,
+        ADDRESSES.arbitrum.USDC_CIRCLE,
+        ADDRESSES.arbitrum.USDT,
+        ADDRESSES.arbitrum.WETH,
+        ADDRESSES.arbitrum.DAI,
+      ],
+    }),
     staking: staking('0x25b9f82d1f1549f97b86bd0873738e30f23d15ea', '0xfc77b86f3ade71793e1eec1e7944db074922856e')
   }
 }

--- a/projects/mugen-fi/index.js
+++ b/projects/mugen-fi/index.js
@@ -1,27 +1,21 @@
-const ADDRESSES = require('../helper/coreAssets.json')
-const { sumTokensExport } = require('../helper/unwrapLPs')
 const { staking } = require('../helper/staking')
 
-// Deposits were forwarded by the Treasury contract to the team treasury wallet
-// (treasury()). reserveBalance() is only a deposit counter - it has been frozen
-// at ~3.35M since 2023-11-15 while the treasury was emptied on 2023-11-28, so we
-// count the actual token balances instead.
-const TREASURY_CONTRACT = '0xf7be8476ae27d27ebc236e33020150b23a86f3dd'
-const TREASURY_WALLET = '0x00236173844ac7f7091d69d6cbf7e0430222296e'
+// Deposits were forwarded by the Treasury contract (0xf7be8476ae27d27ebc236e33020150b23a86f3dd) 
+// to the team treasury wallet (treasury() - 0x00236173844ac7f7091d69d6cbf7e0430222296e). 
+// reserveBalance() has returned stale ~3.35M since 2023-11-15 and the treasury wallet was emptied 2023-11-28.
+// async function tvl(api) {
+//   const reserveBalance = await api.call({  abi: 'uint256:reserveBalance', target:  '0xf7be8476ae27d27ebc236e33020150b23a86f3dd'}) 
+//   return {
+//     tether: reserveBalance / 1e18
+//   }
+// }
 
 module.exports = {
+  misrepresentedTokens: true,
   doublecounted: true,
+  deadFrom: '2023-11-28',
   arbitrum: {
-    tvl: sumTokensExport({
-      owners: [TREASURY_CONTRACT, TREASURY_WALLET],
-      tokens: [
-        ADDRESSES.arbitrum.USDC,
-        ADDRESSES.arbitrum.USDC_CIRCLE,
-        ADDRESSES.arbitrum.USDT,
-        ADDRESSES.arbitrum.WETH,
-        ADDRESSES.arbitrum.DAI,
-      ],
-    }),
+    tvl: () => ({}),
     staking: staking('0x25b9f82d1f1549f97b86bd0873738e30f23d15ea', '0xfc77b86f3ade71793e1eec1e7944db074922856e')
   }
 }


### PR DESCRIPTION
### Problem
MugenFinance has reported **\$3,354,846 TVL, byte-identical since 2023-11-15** (~2.5 years). The adapter reads `reserveBalance()` from the Treasury contract (`0xf7be8476…`) and reports it 1:1 as USD — but that's a deposit counter, not actual holdings.

What's actually on-chain (Arbitrum):
- The Treasury contract forwards every deposit to the team treasury wallet (`treasury()` = `0x00236173…`): `IERC20(_token).safeTransferFrom(msg.sender, treasury, _amount)`.
- That wallet was emptied on **2023-11-28** (final 74,315 USDC.e swept out) and now holds only unsolicited airdrop tokens and 0 ETH.
- The Treasury contract itself holds **112 USDC.e** — the protocol's entire real holdings.

So ~\$3.35M of the reported TVL is a frozen accounting value with no backing; real TVL is ~\$112.

### Fix
Sum the actual token balances (USDC.e/USDC/USDT/WETH/DAI) held by the Treasury contract and the treasury wallet, instead of trusting `reserveBalance()`. Dropped `misrepresentedTokens` since the adapter now reports the real tokens.

### Verification
- `reserveBalance()` = 3,354,846.66 (frozen; identical on every daily TVL point since 2023-11-15)
- Full token scan of both addresses: 112 USDC.e total, 0 ETH
- `node test.js projects/mugen-fi`: **\$112.18** (was \$3.35M)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled Arbitrum TVL reporting for this project (no TVL returned).
* **Chores**
  * Marked the project as inactive from 2023-11-28.
  * Kept existing token representation flags and staking configuration intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->