### PR TITLE
Add Monetrix TVL adapter

### DIFF
--- a/projects/monetrix/index.js
+++ b/projects/monetrix/index.js
@@ -13,8 +13,9 @@ async function tvl(api) {
   // EVM USDC in the MonetrixVault and RedeemEscrow, plus the protocol's
   // Hyperliquid Core account equity (perp margin, spot hedges, HLP and
   // borrow-lend balances) valued via Hyperliquid precompiles
-  const totalBacking = await api.call({ target: MONETRIX_ACCOUNTANT, abi: 'uint256:totalBacking' })
-  api.add(USDC, totalBacking)
+  const totalBackingSigned = await api.call({ target: MONETRIX_ACCOUNTANT, abi: 'function totalBackingSigned() view returns (int256)' })
+  // negative backing (mark-to-market drawdown) clamps to zero
+  if (BigInt(totalBackingSigned) > 0n) api.add(USDC, totalBackingSigned)
 }
 
 module.exports = {

--- a/projects/monetrix/index.js
+++ b/projects/monetrix/index.js
@@ -1,22 +1,34 @@
 const ADDRESSES = require('../helper/coreAssets.json')
-const { sumTokensExport } = require('../helper/sumTokens')
 
 const MONETRIX_GENESIS_VAULT = '0xc50A1dd2866A822c81bd0aA00B638c4BdDc9cd63'
+const MONETRIX_ACCOUNTANT = '0x8950A5136f3994f82b998e37e1183b8A37c12705'
 
 const USDC = ADDRESSES.hyperliquid.USDC
 
+async function tvl(api) {
+  // Pre-launch Genesis Vault USDC; migrates into the main MonetrixVault when users mint USDM
+  await api.sumTokens({ owners: [MONETRIX_GENESIS_VAULT], tokens: [USDC] })
+
+  // USDC collateral backing USDM, read from the MonetrixAccountant:
+  // EVM USDC in the MonetrixVault and RedeemEscrow, plus the protocol's
+  // Hyperliquid Core account equity (perp margin, spot hedges, HLP and
+  // borrow-lend balances) valued via Hyperliquid precompiles
+  const totalBacking = await api.call({ target: MONETRIX_ACCOUNTANT, abi: 'uint256:totalBacking' })
+  api.add(USDC, totalBacking)
+}
+
 module.exports = {
+  misrepresentedTokens: true,
   methodology:
-    'TVL is the USDC held by the Monetrix Genesis Vault on HyperEVM. ' +
-    'Users deposit USDC into the Genesis Vault during the pre-commit phase and ' +
-    'receive non-transferable mgUSDC receipts. After USDM goes live, users may ' +
-    'either burn mgUSDC for newly minted USDM (USDC migrates to the main MonetrixVault) ' +
-    'or withdraw their original USDC after the per-user delay; both reduce the TVL ' +
-    'counted by this adapter.',
+    'TVL is the USDC collateral backing USDM: USDC held by the MonetrixVault and ' +
+    'RedeemEscrow on HyperEVM plus the protocol\'s Hyperliquid Core account equity ' +
+    '(delta-neutral spot + short-perp positions, HLP and borrow-lend balances), read ' +
+    'on-chain from the MonetrixAccountant (totalBacking), which marks Core positions ' +
+    'to market via Hyperliquid precompiles. USDC still in the pre-launch Genesis Vault ' +
+    'is also counted and migrates into the main vault as users mint USDM. Staked USDM ' +
+    '(sUSDM), the insurance fund (funded from skimmed yield) and undistributed yield ' +
+    'are excluded.',
   hyperliquid: {
-    tvl: sumTokensExport({
-      owners: [MONETRIX_GENESIS_VAULT],
-      tokens: [USDC],
-    }),
+    tvl,
   },
 }

--- a/projects/monetrix/index.js
+++ b/projects/monetrix/index.js
@@ -1,0 +1,22 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+const { sumTokensExport } = require('../helper/sumTokens')
+
+const MONETRIX_GENESIS_VAULT = '0xc50A1dd2866A822c81bd0aA00B638c4BdDc9cd63'
+
+const USDC = ADDRESSES.hyperliquid.USDC
+
+module.exports = {
+  methodology:
+    'TVL is the USDC held by the Monetrix Genesis Vault on HyperEVM. ' +
+    'Users deposit USDC into the Genesis Vault during the pre-commit phase and ' +
+    'receive non-transferable mgUSDC receipts. After USDM goes live, users may ' +
+    'either burn mgUSDC for newly minted USDM (USDC migrates to the main MonetrixVault) ' +
+    'or withdraw their original USDC after the per-user delay; both reduce the TVL ' +
+    'counted by this adapter.',
+  hyperliquid: {
+    tvl: sumTokensExport({
+      owners: [MONETRIX_GENESIS_VAULT],
+      tokens: [USDC],
+    }),
+  },
+}


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).

2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** It is a different repo, you can find your listing in [this file](https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts), you can edit it there and put up a PR
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes

---

## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
Monetrix

##### Twitter Link:
https://x.com/monetrix_xyz

##### List of audit links if any:


##### Website Link:
https://www.monetrix.xyz/

##### Logo (High resolution, will be shown with rounded borders):

<img width="400" height="400" alt="Frame 2147228782" src="https://github.com/user-attachments/assets/bd82437b-9a69-46a0-9a1b-9e8f153f5c85" />


##### Current TVL:
1.16M

##### Treasury Addresses (if the protocol has treasury)

##### Chain:
hyperevm chainId(999)

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):
(https://api.coingecko.com/api/v3/coins/list)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):
(https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama):

Monetrix is the first fully on-chain funding-driven yield-bearing stable token, native to Hyperliquid.

##### Token address and ticker if any:
USDM: 0xE2d2959f89B6389DeB624bF076Fe7D9E5401f377 (HyperEVM)

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Basis Trading

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
Hyperliquid native precompiles (HyperCore state read on-chain)

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
The MonetrixAccountant contract (0x8950A5136f3994f82b998e37e1183b8A37c12705) reads the protocol's Hyperliquid Core account state (perp account value, spot balances, HLP equity, borrow-lend balances) through Hyperliquid's read precompiles and exposes totalBacking() as an on-chain view. The adapter sums this with the Genesis Vault USDC balance.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/hyperevm/interacting-with-hypercore

##### forkedFrom (Does your project originate from another project):

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL is the USDC collateral backing USDM: USDC held by the MonetrixVault and RedeemEscrow on HyperEVM, plus the protocol's Hyperliquid Core account equity (delta-neutral spot + short-perp positions, HLP and borrow-lend balances). The Core leg is read on-chain via MonetrixAccountant.totalBacking(), which marks positions to market through Hyperliquid precompiles. USDC still in the pre-launch Genesis Vault is also counted and migrates into the main vault as users mint USDM. Staked USDM (sUSDM), the insurance fund (funded from skimmed yield) and undistributed yield are excluded to avoid double counting / protocol-owned funds.

##### Github org/user (Optional, if your code is open source, we can track activity):

##### Does this project have a referral program?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Monetrix hyperliquid TVL adapter is now available, reporting pre-launch USDC reserves and additional protocol-backed USDC metrics.

* **Documentation**
  * Added a methodology explaining how TVL is calculated and what reserves/backing are included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->