### PR TITLE
Add minimal balances health-check to test.js

### DIFF
--- a/test.js
+++ b/test.js
@@ -40,6 +40,23 @@ if (process.env.LLAMA_SANITIZE)
   })
 process.env.SKIP_RPC_CHECK = 'true'
 
+function analyzeBalances(balances) {
+  let hasNaN = false;
+  let hasNegative = false;
+
+  function visit(val) {
+    if (val == null) return;
+    if (typeof val === "number") {
+      if (Number.isNaN(val)) hasNaN = true;
+      if (val < 0) hasNegative = true;
+    } else if (typeof val === "object") {
+      for (const v of Object.values(val)) visit(v);
+    }
+  }
+
+  visit(balances);
+  return { hasNaN, hasNegative };
+}
 
 async function getTvl(
   unixTimestamp,
@@ -58,6 +75,13 @@ async function getTvl(
 
   let tvlBalances = await tvlFunction(api, ethBlock, chainBlocks, api);
   if (tvlBalances === undefined) tvlBalances = api.getBalances()
+
+    const { hasNaN, hasNegative } = analyzeBalances(tvlBalances);
+    if (hasNaN || hasNegative) {
+      console.warn(
+        `Health check warning for ${storedKey}: hasNaN=${hasNaN}, hasNegative=${hasNegative}`
+      );
+    }
   const tvlResults = await computeTVL(tvlBalances, unixTimestamp);
   await diplayUnknownTable({ tvlResults, storedKey, tvlBalances, })
   usdTvls[storedKey] = tvlResults.usdTvl;


### PR DESCRIPTION
Fixes:  #19601

### Description
This PR adds warning-only sanity checks to the existing adapter test flow in test.js. It inspects adapter balances for NaN and negative values, helping surface obviously broken output earlier without adding a new script or changing current behavior for valid adapters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced TVL balance monitoring with automated validation checks that detect anomalies and emit diagnostic warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->