### PR TITLE
Panther Protocol: track v1 shielded pool vault, remove completed v0 staking

### DIFF
--- a/projects/panther-protocol/index.js
+++ b/projects/panther-protocol/index.js
@@ -1,24 +1,42 @@
-const { sumTokensExport, nullAddress } = require("../helper/unwrapLPs");
+const { stakings } = require("../helper/staking");
+const { sumTokensExport } = require("../helper/unwrapLPs");
+const ADDRESSES = require('../helper/coreAssets.json')
 
 // Panther Protocol v1 vault holds all shielded pool deposits
 const vault = "0xDD1fD1a7b4482Dce1287aFFE6Ca8EA128C7a9046";
 const zAssets = [
-  nullAddress, // POL
-  "0x9A06Db14D639796B25A6ceC6A1bf614fd98815EC", // ZKP
+  ADDRESSES.null, // POL
+  ADDRESSES.polygon.QUICK,
+  ADDRESSES.polygon.WETH_1,
+  ADDRESSES.polygon.WBTC,
+  ADDRESSES.polygon.USDC_CIRCLE,
   "0x53E0bca35eC356BD5ddDFebbD1Fc0fD03FaBad39", // LINK
   "0xb33EaAd8d922B1083446DC23f610c2567fB5180f", // UNI
   "0xD6DF932A45C0f255f85145f286eA0b292B21C90B", // AAVE
-  "0x5fe2B58c013d7601147DcdD68C143A77499f5531", // GRT
-  "0xB5C064F955D8e7F38fE0460C556a72987494eE17", // QUICK
-  "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619", // WETH
-  "0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6", // WBTC
-  "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359", // USDC
+  "0x5fe2B58c013d7601147DcdD68C143A77499f5531" // GRT
 ];
 
-module.exports = {
-  methodology:
-    "TVL is the value of assets deposited into the Panther Protocol shielded pool, held by the protocol Vault contract.",
+const contracts = {
   polygon: {
-    tvl: sumTokensExport({ owner: vault, tokens: zAssets }),
+    core: "0x9A06Db14D639796B25A6ceC6A1bf614fd98815EC",
+    staking: [
+      "0x4cec451f63dbe47d9da2debe2b734e4cb4000eac",
+      "0x5e7fda6d9f5024c4ad1c780839987ab8c76486c9",
+      vault
+    ],
+  },
+  ethereum: {
+    core: "0x909E34d3f6124C324ac83DccA84b74398a6fa173",
+    staking: ["0xf4d06d72dacdd8393fa4ea72fdcc10049711f899"],
   },
 };
+
+module.exports = {
+  methodology: "TVL is the value of assets deposited into the Panther Protocol shielded pool, held by the protocol Vault contract. Staking counts ZKP tokens in the vault and staking contracts.",
+  polygon: { tvl: sumTokensExport({ owner: vault, tokens: zAssets })},
+  ethereum: { tvl: () => ({}) }
+};
+
+for (const [chain, { staking, core }] of Object.entries(contracts)) {
+  module.exports[chain].staking = stakings(staking, core)
+}

--- a/projects/panther-protocol/index.js
+++ b/projects/panther-protocol/index.js
@@ -1,22 +1,24 @@
-const { stakings } = require("../helper/staking");
+const { sumTokensExport, nullAddress } = require("../helper/unwrapLPs");
 
-const contracts = {
+// Panther Protocol v1 vault holds all shielded pool deposits
+const vault = "0xDD1fD1a7b4482Dce1287aFFE6Ca8EA128C7a9046";
+const zAssets = [
+  nullAddress, // POL
+  "0x9A06Db14D639796B25A6ceC6A1bf614fd98815EC", // ZKP
+  "0x53E0bca35eC356BD5ddDFebbD1Fc0fD03FaBad39", // LINK
+  "0xb33EaAd8d922B1083446DC23f610c2567fB5180f", // UNI
+  "0xD6DF932A45C0f255f85145f286eA0b292B21C90B", // AAVE
+  "0x5fe2B58c013d7601147DcdD68C143A77499f5531", // GRT
+  "0xB5C064F955D8e7F38fE0460C556a72987494eE17", // QUICK
+  "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619", // WETH
+  "0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6", // WBTC
+  "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359", // USDC
+];
+
+module.exports = {
+  methodology:
+    "TVL is the value of assets deposited into the Panther Protocol shielded pool, held by the protocol Vault contract.",
   polygon: {
-    core: "0x9A06Db14D639796B25A6ceC6A1bf614fd98815EC",
-    staking: [
-      "0x4cec451f63dbe47d9da2debe2b734e4cb4000eac",
-      "0x5e7fda6d9f5024c4ad1c780839987ab8c76486c9",
-    ],
-  },
-  ethereum: {
-    core: "0x909E34d3f6124C324ac83DccA84b74398a6fa173",
-    staking: ["0xf4d06d72dacdd8393fa4ea72fdcc10049711f899"],
+    tvl: sumTokensExport({ owner: vault, tokens: zAssets }),
   },
 };
-
-Object.keys(contracts).forEach((chain) => {
-  module.exports[chain] = {
-    tvl: () => ({}),
-    staking: stakings(contracts[chain].staking, contracts[chain].core),
-  };
-});


### PR DESCRIPTION
## Update to existing listing (panther-protocol)

Panther Protocol has launched v1 (shielded pool) on Polygon, and the old v0 staking programs on both Polygon and Ethereum have concluded — users have already withdrawn their staked funds (or are in the process of doing so).

This PR:
- Removes the deprecated v0 staking/core contracts (Polygon + Ethereum)
- Tracks TVL as the assets deposited into the Panther Protocol v1 shielded pool, held by the protocol Vault contract on Polygon (`0xDD1fD1a7b4482Dce1287aFFE6Ca8EA128C7a9046`)

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL is the value of assets deposited into the Panther Protocol shielded pool, held by the protocol Vault contract on Polygon. Counted assets are the registered zAssets: POL, ZKP, LINK, UNI, AAVE, GRT, QUICK, WETH, WBTC, USDC.

Test output:
```
--- polygon ---
$ZKP                      93.71 k
USDC                      634.76
POL                       103.77
WETH                      0.98
WBTC                      0.97
AAVE                      0.23
LINK                      0.19
GRT                       0.19
UNI                       0.11
quick                     0.10
Total: 94.46 k

------ TVL ------
polygon                   94.46 k
total                     94.46 k
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated Panther protocol exports to a static per-chain layout and streamlined staking assignment.
* **New Features**
  * Polygon TVL now reports assets derived from shielded-pool vault deposits.
* **Behavior**
  * Ethereum TVL remains empty; polygon staking now includes the vault address for staking calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->