### PR TITLE
Add Zinc TVL adapter

### DIFF
--- a/projects/zinc/index.js
+++ b/projects/zinc/index.js
@@ -1,0 +1,31 @@
+const { sumTokens2 } = require("../helper/solana");
+
+const STAKED_ZINC_TOKEN_ACCOUNT = "4Ym9uvwrwdpiTKq874T8wSqzaFkh8AVazf255FKLt9MR";
+const STOCKPILE_SOL_VAULT = "8RxMJD7BtdzxuZkmDqcxhR6gWvegLJ1GNf9NFrPkCmwf";
+const BONANZA_SOL_VAULT = "DNJGqahXJfu8Fsg4HRS7bKWFLnSzU5fvt85fkake7JFY";
+
+async function tvl() {
+  return sumTokens2({
+    solOwners: [
+      STOCKPILE_SOL_VAULT,
+      BONANZA_SOL_VAULT,
+    ],
+  });
+}
+
+async function staking() {
+  return sumTokens2({
+    tokenAccounts: [STAKED_ZINC_TOKEN_ACCOUNT],
+  });
+}
+
+module.exports = {
+  timetravel: false,
+  start: "2026-05-26",
+  methodology:
+    "TVL counts SOL held in Zinc stockpile and bonanza prize vaults. Staking counts ZINC deposited in the staking vault. Treasury and buyback vault balances are excluded.",
+  solana: {
+    tvl,
+    staking,
+  },
+};

--- a/projects/zinc/index.js
+++ b/projects/zinc/index.js
@@ -1,23 +1,8 @@
-const { sumTokens2 } = require("../helper/solana");
+const { sumTokensExport } = require("../helper/solana");
 
 const STAKED_ZINC_TOKEN_ACCOUNT = "4Ym9uvwrwdpiTKq874T8wSqzaFkh8AVazf255FKLt9MR";
 const STOCKPILE_SOL_VAULT = "8RxMJD7BtdzxuZkmDqcxhR6gWvegLJ1GNf9NFrPkCmwf";
 const BONANZA_SOL_VAULT = "DNJGqahXJfu8Fsg4HRS7bKWFLnSzU5fvt85fkake7JFY";
-
-async function tvl() {
-  return sumTokens2({
-    solOwners: [
-      STOCKPILE_SOL_VAULT,
-      BONANZA_SOL_VAULT,
-    ],
-  });
-}
-
-async function staking() {
-  return sumTokens2({
-    tokenAccounts: [STAKED_ZINC_TOKEN_ACCOUNT],
-  });
-}
 
 module.exports = {
   timetravel: false,
@@ -25,7 +10,7 @@ module.exports = {
   methodology:
     "TVL counts SOL held in Zinc stockpile and bonanza prize vaults. Staking counts ZINC deposited in the staking vault. Treasury and buyback vault balances are excluded.",
   solana: {
-    tvl,
-    staking,
+    tvl: sumTokensExport({solOwners: [STOCKPILE_SOL_VAULT, BONANZA_SOL_VAULT]}),
+    staking: sumTokensExport({tokenAccounts: [STAKED_ZINC_TOKEN_ACCOUNT]}),
   },
 };


### PR DESCRIPTION
Adds a TVL adapter for Zinc on Solana.

What is counted:
- SOL held in the stockpile prize vault
- SOL held in the bonanza prize vault
- ZINC deposited in the staking vault, reported under staking

What is intentionally excluded:
- Treasury SOL
- Buyback SOL vault

The adapter is marked timetravel: false because it relies on current Solana RPC balances rather than a historical balance backfill.

Tests run:
```
node test.js projects/zinc/index.js
node test.js projects/zinc/index.js 2026-05-27
pnpm exec eslint projects/zinc/index.js
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Zinc protocol integration for Solana, enabling tracking of Total Value Locked (TVL) across vault accounts and staking metrics for ZINC tokens.
  * Historical data collection for this integration begins on 2026-05-26; timetravel/querying prior snapshots is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->