### PR TITLE
feat: add boardwalk tvl tracking

### DIFF
--- a/projects/boardwalk/index.js
+++ b/projects/boardwalk/index.js
@@ -1,0 +1,31 @@
+const { getUniTVL } = require('../helper/unknownTokens')
+const { staking } = require('../helper/staking')
+
+// Legacy BMX staking (Morphex/GMX-style), Base only.
+// Migrated here from the 'bmx' entry in registries/gmx.js.
+const stakedBmxTracker = '0x3085F25Cbb5F34531229077BAAC20B9ef2AE85CB'
+const BMX = '0x548f93779fBC992010C07467cBaf329DD5F059B7'
+
+// Boardwalk DEX (UniswapV2 fork) factory per chain
+const config = {
+  base:     { factory: '0x5ab5575262c823CcB6F43aEd44e071eDb6Ef9e3c' },
+  ethereum: { factory: '0x8b59270dc8cF89EBF00F0e8558409e5B6321F13a' },
+  ink:      { factory: '0x8e28edBFb74F5ef7De12E5091CACDcE45EE0BEaC' },
+  katana:   { factory: '0x177dbEDd02cEe010b80a0A3F284c9FD9F67D8a9e' },
+  fraxtal:  { factory: '0x31e5Ff91e8471346dDEb41cb3E974950F1c256d4' },
+}
+
+module.exports = {
+  misrepresentedTokens: true,
+  start: '2026-05-29',
+  methodology: 'Counts the liquidity in all Boardwalk DEX pairs, plus BMX staked on Base.',
+}
+
+Object.keys(config).forEach((chain) => {
+  module.exports[chain] = {
+    tvl: getUniTVL({ factory: config[chain].factory, useDefaultCoreAssets: true }),
+  }
+})
+
+// Base-only BMX staking (migrated from registries/gmx.js)
+module.exports.base.staking = staking(stakedBmxTracker, BMX)

--- a/registries/gmx.js
+++ b/registries/gmx.js
@@ -175,7 +175,6 @@ const configs = {
     methodology: 'BMX Classic liquidity is calculated by the value of tokens in the BLT/MLT pool. TVL also includes BMX staked.',
     base: {
       vault: '0xec8d8D4b215727f3476FF0ab41c406FA99b4272C',
-      staking: ['0x3085F25Cbb5F34531229077BAAC20B9ef2AE85CB', '0x548f93779fBC992010C07467cBaf329DD5F059B7'],
     },
     sonic: '0x9cC4E8e60a2c9a67Ac7D20f54607f98EfBA38AcF',
     mode: {


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).

2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** It is a different repo, you can find your listing in [this file](https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts), you can edit it there and put up a PR
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes

---
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama): Boardwalk

##### Twitter Link: https://x.com/useboardwalk

##### List of audit links if any: https://github.com/useboardwalk/boardwalk-contracts/tree/main/audits

##### Website Link: https://www.useboardwalk.com/

##### Logo (High resolution, will be shown with rounded borders): https://www.useboardwalk.com/images/power/logo.svg

##### Current TVL: $1.06M (from BMX staking, DEX tvl is currently 0)

##### Treasury Addresses (if the protocol has treasury)

##### Chain: Base, Ethereum, Katana, Ink, Fraxtal

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): bmx (https://www.coingecko.com/en/coins/boardwalk)
(https://api.coingecko.com/api/v3/coins/list)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama): Boardwalk is a permissionless, community-centered fee-protection protocol for launching, discovering, and participating in token economies. Issuers create a launch, define its rules up front, and auction a new token under visible mechanics. If the auction reaches its graduation threshold, the raised asset pairs with the token supply to seed permanently locked liquidity, and the token moves into a live economy. If the threshold isn't met, contributors can claim a full refund.

##### Token address and ticker if any: $BMX 0x548f93779fbc992010c07467cbaf329dd5f059b7 (Base)

##### Category (full list at https://defillama.com/categories) \*Please choose only one: Launchpad

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.): none

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

##### forkedFrom (Does your project originate from another project): DEX contracts are forked from Uni v2

##### methodology (what is being counted as tvl, how is tvl being calculated): Counts the liquidity in all Boardwalk DEX pairs, plus BMX staked on Base.

##### Github org/user (Optional, if your code is open source, we can track activity): useboardwalk

##### Does this project have a referral program?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Boardwalk DEX TVL tracking with per-chain support and staked BMX accounting for Base network.

* **Chores**
  * Updated Base network configuration for BMX protocol.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->