### PR TITLE
Add CrystalClear TVL adapter

### DIFF
--- a/projects/crystalclear/index.js
+++ b/projects/crystalclear/index.js
@@ -1,0 +1,19 @@
+const { sumERC4626VaultsExport2 } = require("../helper/erc4626");
+
+module.exports = {
+  methodology: "TVL is the sum of totalAssets() across all live CrystalClear ERC-4626 vaults on HyperEVM. Each vault holds USDC and trades perpetuals on Hyperliquid via a delegated agent.",
+  hyperliquid: {
+    tvl: sumERC4626VaultsExport2({
+      vaults: [
+        "0x231f66c336512e897855420a2788B83e164C6Adf", // Onyx
+        "0x1b463561f264114F9D4db6FF9eE2771B33076B13", // Amber
+        "0xb44169e66C898FF70029f9CF2fdB9685d7bC99c6", // Ruby
+        "0x015A70185a80D8C8c034e3d360E25A14c7FB8cF0", // Moonstone
+        "0x1efAE1f600947cA5dc0E87AA18657f36c559A40b", // Emerald
+        "0x2D7ACD39B634B50Cd37883FE374E1f430e27Ea50", // Peridot
+        "0x6B88f2975B784531DB1159D37CFf9f1629e93fa8", // Sapphire
+        "0x89C08a6F468CA5AF65E7D48bC091E5c4025b42C2", // Opal
+      ],
+    }),
+  },
+};


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
CrystalClear

##### Twitter Link:
https://x.com/CrystalClearHL

##### List of audit links if any:
None yet

##### Website Link:
https://crystalclear.finance

##### Logo (High resolution, will be shown with rounded borders):
https://crystalclear.finance/assets/logo-icon.svg

##### Current TVL:
~$566 (USDC) — recently launched

##### Treasury Addresses (if the protocol has treasury)
None

##### Chain:
Hyperliquid L1 (HyperEVM)

##### Coingecko ID (leave empty if not listed):
(empty — no token)

##### Coinmarketcap ID (leave empty if not listed):
(empty — no token)

##### Short Description (to be shown on DefiLlama):
ERC-4626 USDC vaults on HyperEVM. Deposits trade Hyperliquid perpetuals via a delegated agent.

##### Token address and ticker if any:
None

##### Category (choose only one):
Yield

##### Oracle Provider(s):
None for TVL accounting — vault NAV is read directly onchain via totalAssets().

##### Implementation Details:
N/A (no external oracle used for TVL).

##### Documentation/Proof:
https://crystalclear.finance

##### forkedFrom (Does your project originate from another project):
No

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL = totalAssets() of the 8 live ERC-4626 vaults (Onyx, Amber, Ruby, Moonstone, Emerald, Peridot, Sapphire, Opal), denominated in USDC (0xb88339cb7199b77E23DB6E890353E22632Ba630f). Deposits trade Hyperliquid perps via a delegated agent.

##### Github org/user (Optional, if your code is open source, we can track activity):
(closed source)

##### Does this project have a referral program?
No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL (Total Value Locked) calculation support for CrystalClear vaults on the Hyperliquid network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->