### PR TITLE
lista-rwa: add slisXAUE (Ethereum) + filter products by chain

### DIFF
--- a/projects/lista-rwa/index.js
+++ b/projects/lista-rwa/index.js
@@ -8,24 +8,26 @@ const abi = {
 }
 
 async function tvl(api) {
-  const { data: { list: products } } = await getConfig('lista/rwa', 'https://api.lista.org/api/rwa/product/list')
+  const { data: { list: allProducts } } = await getConfig('lista/rwa', 'https://api.lista.org/api/rwa/product/list')
 
-  // Separate Centrifuge and Dowsure products
-  const centrifugeProducts = products.filter(p => p.group === 'centrifuge')
-  const dowsureProducts = products.filter(p => p.group === 'dowsure')
+  // Backend returns mixed-chain products in one payload; filter to the chain being indexed.
+  const products = allProducts.filter(p => p.chain === api.chain)
 
-  // Handle Centrifuge products (existing logic)
-  if (centrifugeProducts.length > 0) {
-    const centrifugeContracts = centrifugeProducts.map(p => getAddress(p.contract))
-    const assets = await api.multiCall({ calls: centrifugeContracts, abi: abi.asset })
-    const totalAssets = await api.multiCall({ calls: centrifugeContracts, abi: abi.totalAssets })
+  // Pool-like products share the same accounting shape — Centrifuge's RWAEarnPool
+  // and XAUE's XAUTStaking both expose asset() + totalAssets() in underlying units.
+  const poolProducts = products.filter(p => p.group === 'centrifuge' || p.group === 'xaue')
+  if (poolProducts.length > 0) {
+    const poolContracts = poolProducts.map(p => getAddress(p.contract))
+    const assets = await api.multiCall({ calls: poolContracts, abi: abi.asset })
+    const totalAssets = await api.multiCall({ calls: poolContracts, abi: abi.totalAssets })
 
-    for (let i = 0; i < centrifugeContracts.length; i++) {
+    for (let i = 0; i < poolContracts.length; i++) {
       api.add(assets[i], totalAssets[i])
     }
   }
 
-  // Handle Dowsure products (new logic for getVaultInfo)
+  // Handle Dowsure products (getVaultInfo path)
+  const dowsureProducts = products.filter(p => p.group === 'dowsure')
   if (dowsureProducts.length > 0) {
     const dowsureContracts = dowsureProducts.map(p => getAddress(p.contract))
     const vaultInfos = await api.multiCall({ calls: dowsureContracts, abi: abi.getVaultInfo })
@@ -49,9 +51,11 @@ async function tvl(api) {
 }
 
 module.exports = {
-  methodology: "TVL is calculated by summing the totalAssets of Centrifuge RWA products and totalDeposited from Dowsure vault products. For Dowsure multi-asset vaults, the entire TVL is attributed to the primary asset (first in metadata) since per-asset breakdown is not available on-chain.",
+  methodology: "TVL is calculated by summing totalAssets of pool-like RWA products (Centrifuge on BSC, slisXAUE/XAUTStaking on Ethereum) and totalDeposited from Dowsure vault products on BSC. For Dowsure multi-asset vaults, the entire TVL is attributed to the primary asset (first in metadata) since per-asset breakdown is not available on-chain.",
   bsc: {
     tvl,
   },
+  ethereum: {
+    tvl,
+  },
 }
-


### PR DESCRIPTION
## Summary
- Add Ethereum chain support to `lista-rwa` for slisXAUE, our new XAUt-backed yield-bearing gold product.
- Filter products from the backend by `api.chain` so each chain only counts its own products (`/api/rwa/product/list` returns mixed chains in one payload).
- XAUE's `XAUTStaking` exposes the same `asset()` + `totalAssets()` shape as Centrifuge's `RWAEarnPool`, so they share one pool-style handler.

## Verification

```
$ node test.js projects/lista-rwa/index.js

--- bsc ---
USDT                      4.03 M
Total: 4.03 M

--- ethereum ---
xaut                      10.96 k
Total: 10.96 k

------ TVL ------
bsc                       4.03 M
ethereum                  10.96 k
total                     4.04 M
```

BSC TVL unchanged. Ethereum reads `XAUTStaking.totalAssets()` on mainnet (proxy `0x86c92fF74fa55b08b4fA0d59E41e26b14ed1150b`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ethereum network support for TVL tracking (previously available only on BSC).

* **Improvements**
  * Optimized TVL calculation methodology to improve accuracy for different product types across supported networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->