### PR TITLE
Panther Protocol: count shielded-pool ZKP in TVL, not staking

### DIFF
--- a/projects/panther-protocol/index.js
+++ b/projects/panther-protocol/index.js
@@ -4,8 +4,10 @@ const ADDRESSES = require('../helper/coreAssets.json')
 
 // Panther Protocol v1 vault holds all shielded pool deposits
 const vault = "0xDD1fD1a7b4482Dce1287aFFE6Ca8EA128C7a9046";
+const ZKP = "0x9A06Db14D639796B25A6ceC6A1bf614fd98815EC";
 const zAssets = [
   ADDRESSES.null, // POL
+  ZKP,
   ADDRESSES.polygon.QUICK,
   ADDRESSES.polygon.WETH_1,
   ADDRESSES.polygon.WBTC,
@@ -18,11 +20,10 @@ const zAssets = [
 
 const contracts = {
   polygon: {
-    core: "0x9A06Db14D639796B25A6ceC6A1bf614fd98815EC",
+    core: ZKP,
     staking: [
       "0x4cec451f63dbe47d9da2debe2b734e4cb4000eac",
       "0x5e7fda6d9f5024c4ad1c780839987ab8c76486c9",
-      vault
     ],
   },
   ethereum: {
@@ -32,7 +33,7 @@ const contracts = {
 };
 
 module.exports = {
-  methodology: "TVL is the value of assets deposited into the Panther Protocol shielded pool, held by the protocol Vault contract. Staking counts ZKP tokens in the vault and staking contracts.",
+  methodology: "TVL is the value of assets deposited into the Panther Protocol shielded pool, held by the protocol Vault contract. Staking counts ZKP tokens in the v0 staking contracts.",
   polygon: { tvl: sumTokensExport({ owner: vault, tokens: zAssets })},
   ethereum: { tvl: () => ({}) }
 };


### PR DESCRIPTION
## Update to existing listing (panther-protocol)

Follow-up to the recent Panther Protocol adapter changes. In the current adapter, ZKP is excluded from the shielded-pool TVL token list and instead counted under **staking** (with the Vault added as a staking owner). Because ZKP is the dominant asset in the pool, this makes the headline TVL show ~$740 while ~$94k of real deposits sit under "staking."

### Why this is a misclassification
ZKP deposited into the Panther v1 shielded pool is custodied by the **Vault** (`0xDD1fD1a7b4482Dce1287aFFE6Ca8EA128C7a9046`) as an ordinary user deposit — exactly like every other zAsset (POL, USDC, WETH, WBTC, LINK, UNI, AAVE, GRT, QUICK). It is *not* staked; users deposit it for privacy/shielding. So the Vault's ZKP belongs in **TVL**, not staking.

Staking should reflect only the protocol's actual staking program — the two **v0 staking contracts** (`0x4cec451f…`, `0x5e7fda6d…`), which still hold residual ZKP while users withdraw.

### Changes
- Add ZKP to the Vault's TVL token list (`zAssets`)
- Remove the Vault from the `staking` owners list (avoids double-counting the Vault's ZKP across TVL + staking)
- Keep the two v0 staking contracts under staking
- Update the methodology string accordingly

### Test output
```
--- polygon ---
$ZKP                      96.53 k
USDC                      634.70
POL                       104.50
WETH                      0.99
WBTC                      0.98
AAVE / LINK / GRT / UNI / QUICK   ~0.8 combined
Total: 97.27 k

--- staking ---
$ZKP                      113.61 k   (v0 staking contracts: polygon 66.17k + ethereum 47.44k)

------ TVL ------
polygon                   97.27 k
total                     97.27 k
```

ZKP is now counted exactly once (in TVL), and staking reflects only the v0 staking contracts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated staking methodology description to reflect how ZKP tokens are counted in v0 staking contracts.

* **Chores**
  * Refined Polygon staking configuration and optimized core address references for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->