### PR TITLE
Fix Bumpin Trade TVL: exclude borrowed-out liquidity

### DIFF
--- a/projects/bumpin/index.js
+++ b/projects/bumpin/index.js
@@ -26,13 +26,10 @@ async function tvl(api) {
     });
 
     const uniqueTokenAccounts = [...new Set(tokenAccounts)];
-    if (tokenVault && tokenVault.length > 0) {
-        tokenVault.forEach((data) => {
-            const mint = data.account.mintKey.toString()
-            api.add(mint, data.account.totalBorrowed)
-        })
-    }
 
+    // Only count coins actually held in the protocol's vaults. totalBorrowed is
+    // liquidity that has been borrowed out of the vaults (not held by the
+    // protocol), so it must not be added to TVL.
     return sumTokens2({
         tokenAccounts: uniqueTokenAccounts.filter(i => i !== '11111111111111111111111111111111'),
         blacklistedTokens, 


### PR DESCRIPTION
The Bumpin Trade adapter adds each TokenVault's `totalBorrowed` to TVL:

```js
tokenVault.forEach((data) => {
  const mint = data.account.mintKey.toString()
  api.add(mint, data.account.totalBorrowed)
})
```

`totalBorrowed` is liquidity that has been borrowed out of the vaults, so it is not held by the protocol. On-chain, all three TokenVault token accounts currently hold 0 tokens, while their `totalBorrowed` fields read ~2.74M USDC, ~13.9k SOL and ~301k JTO. Adding these inflates reported TVL to ~$3.85M.

Summing every token account owned by the protocol's vault authority (`dqwtbXM1woknJ79z1KhEw8erbN7W3RzFeZeaCi1KrtG`, which owns all of the pool / tradeToken / tokenVault vaults) gives ~$4.9k of coins actually held (~2,679 USDC + ~17 SOL + ~485 JTO + ~768 USDT). So ~99% of reported TVL corresponds to tokens the protocol does not hold.

This change removes the `totalBorrowed` addition so TVL reflects only coins held in the contracts, consistent with the `tvl = supply - borrowed` convention used by other lending adapters (borrowed liquidity is tracked separately, not as TVL). Local run after the change: TVL ~= $4,869.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated TVL calculation to exclude borrowed liquidity, ensuring only protocol-held assets are reflected in total value locked metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->