### PR TITLE
Add Pharaoh DLMM TVL adapter

### DIFF
--- a/projects/pharaoh-exchange-dlmm/index.js
+++ b/projects/pharaoh-exchange-dlmm/index.js
@@ -1,0 +1,5 @@
+const { joeV2Export } = require('../helper/traderJoeV2')
+
+module.exports = joeV2Export({
+  avax: '0xEb480050b016f6c6d45203D2346B68bDDDa23D4D',
+})


### PR DESCRIPTION
Adds the TVL adapter for Pharaoh DLMM on Avalanche.

This is the TVL-side piece of the Pharaoh DLMM batch. The adapter uses the Trader Joe v2 helper against the DLMM factory.

Companion PRs in this batch:
- defillama-server: https://github.com/DefiLlama/defillama-server/pull/12232
- dimension-adapters: https://github.com/DefiLlama/dimension-adapters/pull/7626

Tested:
- `node test.js projects/pharaoh-exchange-dlmm`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Pharaoh Exchange's dynamic liquidity market maker on the Avalanche network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->