### PR TITLE
thorchain: capture native BNB/ETH pools and add SOL

### DIFF
--- a/projects/thorchain/index.js
+++ b/projects/thorchain/index.js
@@ -25,6 +25,26 @@ const chainMapping = {
   XRP: 'ripple',
   TRON: 'tron',
   THOR: 'thorchain',
+  SOL: 'solana',
+}
+
+// native gas asset symbol per THORChain chain code (the chain prefix often differs
+// from the native asset, e.g. BSC.BNB / BASE.ETH / GAIA.ATOM / TRON.TRX)
+const nativeAsset = {
+  ETH: 'ETH',
+  BTC: 'BTC',
+  AVAX: 'AVAX',
+  BNB: 'BNB',
+  LTC: 'LTC',
+  BCH: 'BCH',
+  DOGE: 'DOGE',
+  GAIA: 'ATOM',
+  BASE: 'ETH',
+  BSC: 'BNB',
+  XRP: 'XRP',
+  TRON: 'TRX',
+  THOR: 'RUNE',
+  SOL: 'SOL',
 }
 
 const defillamaChainMapping = {
@@ -77,7 +97,7 @@ async function tvl(api) {
       if (address && address.length > 8) {
         address = address.toLowerCase()
         sdk.util.sumSingleBalance(balances, address, totalDepth, chain)
-      } else if (chainStr === baseToken) {
+      } else if (baseToken === nativeAsset[chainStr]) {
         sdk.util.sumSingleBalance(balances, nullAddress, totalDepth, chain)
       } else if (tokenGeckoMapping[pool]) {
         sdk.util.sumSingleBalance(balances, tokenGeckoMapping[pool], totalDepth / 1e8)
@@ -85,7 +105,7 @@ async function tvl(api) {
         sdk.log('skipped', pool, Number(totalDepth).toFixed(2))
       }
     } else {
-      if (chainStr === baseToken) {
+      if (baseToken === nativeAsset[chainStr]) {
         if (chain === 'bitcoincash') chain = 'bitcoin-cash'
         sdk.util.sumSingleBalance(balances, chain, totalDepth / 1e8)
       } else if (tokenGeckoMapping[pool]) {


### PR DESCRIPTION
Native-coin detection used `chainStr === baseToken`, which silently dropped the asset leg of pools whose chain code differs from the native symbol — **BSC.BNB** (~$1.5M) and **BASE.ETH**. Switched to a per-chain native-asset map, and added **SOL.SOL** support.

Verified with `node test.js projects/thorchain/index.js`: 0 skipped pools (was 3), BNB now $1.40M under bsc, new `solana` chain entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Solana support to THORChain chain mappings.

* **Bug Fixes**
  * Fixed native asset balance attribution logic for Ethereum, BSC, Avalanche, and Base networks to accurately handle cases when native assets are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->