### PR TITLE
fix: count ACRED Solana supply in TVL

### DIFF
--- a/projects/acred/index.js
+++ b/projects/acred/index.js
@@ -34,10 +34,11 @@ async function tvl(api) {
   if (!chainAddresses) return api.getBalances();
 
   // Solana:
-  // Supply may be zero if the mint is not indexed or has no discoverable supply.
-  // This is expected behavior and values should not be inferred from other chains.
+  // getTokenSupplies adds the supply to the balances (keyed solana:<mint>);
+  // return the api balances so the value is priced, consistent with the other chains.
   if (chain === 'solana') {
-    return getTokenSupplies([chainAddresses.token], { api });
+    await getTokenSupplies([chainAddresses.token], { api });
+    return api.getBalances();
   }
 
   // Aptos:


### PR DESCRIPTION
### Problem

The ACRED adapter reports **\$0 on Solana** while there is ~\$24.7M of ACRED actually minted and priced on Solana.

The Solana branch returns the raw `getTokenSupplies` response (an object keyed by the bare mint address) instead of the api balances:

```js
if (chain === 'solana') {
  return getTokenSupplies([chainAddresses.token], { api });
}
```

`getTokenSupplies(..., { api })` already adds the supply to the api (keyed `solana:<mint>`), but the function then returns the helper's plain `{ mint: supply }` object. That bare, unprefixed key is not priced by the TVL pipeline, so the Solana value is dropped — whereas every other chain branch returns `api.getBalances()`.

### Fix

Await the supply call and return `api.getBalances()`, matching the EVM and Aptos branches.

### Verification

- Solana ACRED mint `FubtUcvhSCr3VPXEcxouoQjKQ7NWTCzXyECe76B7L3f8`: total supply 22,510.19 ACRED, priced ~\$1,098.95 (continuous price history since March 2025).
- The token is natively issued on Solana (Securitize controller mint authority, not a bridge wrapper), so it is counted independently of the other chains and is not double-counted.
- Local test before: Solana \$0, protocol total \$89.96M. After: Solana \$24.74M, protocol total \$114.69M.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Solana token supply calculation accuracy for total value locked (TVL) metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->