### PR TITLE
fix: count Oro Finance Solana GOLD supply in TVL

### DIFF
--- a/projects/oro-finance/index.js
+++ b/projects/oro-finance/index.js
@@ -4,5 +4,12 @@ const GOLD = "GoLDppdjB1vDTPSGxyMJFqdnj134yH6Prg9eqsGDiw6A"
 
 module.exports = {
   methodology: 'The TVL corresponds to the amount of Gold tokens minted',
-  solana: { tvl: async (api) => getTokenSupplies([GOLD], { api }) }
+  solana: {
+    tvl: async (api) => {
+      // getTokenSupplies adds the supply to the balances (keyed solana:<mint>);
+      // return the api balances so the value is priced instead of the helper's raw response.
+      await getTokenSupplies([GOLD], { api })
+      return api.getBalances()
+    }
+  }
 }


### PR DESCRIPTION
### Problem

Oro Finance reports **\$0 TVL** (its only chain is Solana), but there is ~\$2.6M of GOLD minted on Solana.

The Solana tvl function returns the raw `getTokenSupplies` response (an object keyed by the bare mint address) directly:

```js
solana: { tvl: async (api) => getTokenSupplies([GOLD], { api }) }
```

`getTokenSupplies(..., { api })` already adds the supply to the api (keyed `solana:<mint>`), but because the function returns the helper's plain `{ mint: supply }` object — whose bare, unprefixed key is not priced — that returned value is used as the balances and the position is dropped, so TVL is \$0.

### Fix

Await the supply call and return `api.getBalances()` so the priced balance is used.

### Verification

- GOLD mint `GoLDppdjB1vDTPSGxyMJFqdnj134yH6Prg9eqsGDiw6A`: total supply 608.43 GOLD, priced ~\$4,263 (gold spot, continuous price feed).
- Local test before: \$0. After: \$2.59M.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Solana TVL calculation to ensure accurate balance retrieval and pricing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->