### PR TITLE
Track kpk USDC Prime Core, ETH Yield Term, and USD Alpha Fund

### DIFF
--- a/projects/kpk/index.js
+++ b/projects/kpk/index.js
@@ -3,7 +3,8 @@ const { sumTokensDebank } = require("../helper/debank")
 
 // ---- Minimal ABIs / constants from Gearbox v3.1 adapter ----
 const DEFILLAMA_COMPRESSOR_V310 = "0x81cb9eA2d59414Ab13ec0567EFB09767Ddbe897a"
-const PORTFOLIO_SAFE="0x99b9F5F24205Cb88E33b1CC72008f644Fc23768b"
+const ETH_ALPHA_SAFE = "0x99b9F5F24205Cb88E33b1CC72008f644Fc23768b" // ETH Alpha Fund Portfolio Safe
+const USD_ALPHA_SAFE = "0x38F6a1B46144fAEe6a6D9F79D8dE264C18e23848" // USD Alpha Fund Portfolio Safe
 
 const GearboxCompressorABI = {
   // returns credit managers associated with the given legacy (market) configurators
@@ -36,6 +37,7 @@ const configs = {
         "0x0c6aec603d48eBf1cECc7b247a2c3DA08b398DC1", //Morpho v1 EURC Yield
         "0xd564F765F9aD3E7d2d6cA782100795a885e8e7C8", //Morpho v1 ETH Prime
         "0x4Ef53d2cAa51C447fdFEEedee8F07FD1962C9ee6", //Morpho v2 USDC Prime
+        "0x1a1985F50352b58090eb36425AfdFacbaC7806F4", //Morpho v2 USDC Prime Core
         "0xa877D5bb0274dcCbA8556154A30E1Ca4021a275f", //Morpho v2 EURC Yield
         "0xbb50a5341368751024ddf33385ba8cf61fe65ff9", //Morpho v2 ETH Prime
         "0x5dbf760b4fd0cDdDe0366b33aEb338b2A6d77725", //Morpho v2 ETH Yield
@@ -48,7 +50,8 @@ const configs = {
 
       // Other ERC-4626 vaults (non-Morpho)
       erc4626: [
-        "0x2B47c128b35DDDcB66Ce2FA5B33c95314a7de245", //kpk RWA Euler USDC Earn
+        "0x2B47c128b35DDDcB66Ce2FA5B33c95314a7de245", //kpk USDC Prime RWA (Euler Earn)
+        "0xB6D6D89ad4b4D61C15a293e28b74f77F6817fF48", //kpk ETH Yield Term (Euler Earn)
         "0x9396dcbf78fc526bb003665337c5e73b699571ef", //Gearbox ETH
         "0xA9d17f6D3285208280a1Fd9B94479c62e0AABa64", //Gearbox wstETH
       ],
@@ -138,7 +141,7 @@ async function getAlephVaultTvl(api, vaults) {
 }
 
 // ---- kpk Fund (OIV) TVL via DeBank ----
-const OIV_SAFES = [PORTFOLIO_SAFE]
+const OIV_SAFES = [ETH_ALPHA_SAFE, USD_ALPHA_SAFE]
 const OIV_CHAINS = ['ethereum', 'arbitrum', 'base', 'xdai', 'optimism']
 
 // ---- Zodiac-managed Safes (Institutional vertical) TVL via DeBank ----


### PR DESCRIPTION
Adds three kpk-curated vaults/funds that were missing, and corrects one label. All addresses verified against kpk's published docs (docs.kpk.io).

### Changes
- **Morpho v2 USDC Prime Core** `0x1a1985F50352b58090eb36425AfdFacbaC7806F4` added to the Ethereum `morpho` array. ([docs](https://docs.kpk.io/vaults/vaults/morpho))
- **Euler ETH Yield Term** Earn vault `0xB6D6D89ad4b4D61C15a293e28b74f77F6817fF48` added to the Ethereum `erc4626` array (standard ERC-4626, same path as the existing Euler entry). ([docs](https://docs.kpk.io/vaults/vaults/euler/ethereum/eth-yield-term))
- **USD Alpha Fund** Portfolio Safe `0x38F6a1B46144fAEe6a6D9F79D8dE264C18e23848` added to `OIV_SAFES`, alongside the existing ETH Alpha Fund safe. Replaced the single `PORTFOLIO_SAFE` const with named `ETH_ALPHA_SAFE` / `USD_ALPHA_SAFE`. ([docs](https://docs.kpk.io/funds/funds/usd-alpha/policies-and-addresses))
- **Label fix:** the RWA Euler entry (`0x2B47...de245`) is now branded **USDC Prime RWA** in kpk's docs; comment updated accordingly. No address change.

### Verification
Ran `node test.js projects/kpk/index.js` locally. Total TVL ~$57.7M, all token balances resolve as expected (USDC Prime Core's USDC and ETH Yield Term's WETH now included; savETH from the Gearbox credit-account crawler unaffected).

> **Note:** this local figure does not capture everything. The Zodiac-managed Safes and OIV Fund safes are valued via the DeBank API, which under-reports some positions actively managed through the Roles Modifier. The real total is higher (>$154M).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TVL source configuration to improve tracking accuracy.
  * Added support for two new vaults: Morpho v2 USDC Prime Core and kpk ETH Yield Term (Euler Earn).
  * Refreshed safe address references to use updated DeBank constants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->