### PR TITLE
durianfun: add V4.6.7 launchpad factory to TVL (Bitkub Chain)

### DIFF
--- a/projects/durianfun/index.js
+++ b/projects/durianfun/index.js
@@ -1,85 +1,141 @@
 /**
- * Durianfun - meme-token launchpad on KUB Chain (chainId 96).
+ * Durianfun — meme-token launchpad on KUB Chain (chainId 96).
  *
  * Tracks native KUB locked across FOUR generations of the launchpad:
  *   - V4.2 (legacy main, frozen)
- *   - V4.5 (sacred main, frozen - no new tokens, residual liquidity)
+ *   - V4.5 (current sacred main, frozen — no new tokens, residual liquidity)
  *   - V4.6.6 Deluxe (deployed 2026-05-03)
- *   - V4.6.7 (current production, deployed 2026-05-31 - dual graduation:
- *     in-contract Durian AMM OR external KUBLERX V3 pool)
+ *   - V4.6.7 (current production, deployed 2026-05-31 — dual graduation:
+ *     in-contract DurianAMM (native KUB) OR external KUBLERX V3 pool (KKUB))
  *
- * TVL formula:
- *   sum(native KUB held by every BondingCurveMarket NOT yet graduated)
- * + sum(native KUB held by every graduated DurianAMM pool)
- * + sum(KKUB held by every V4.6.7 KUBLERX-graduated V3 pool)
+ * ── TVL formula ────────────────────────────────────────────────────
  *
- * Each launchpad token gets a BondingCurveMarket (BCM) holding native KUB
- * during the curve phase. On graduation the KUB is seeded into a pool:
- *   - DURIAN target  -> in-contract DurianAMM, holds NATIVE KUB.
- *   - KUBLERX target (V4.6.7 only) -> external KUBLERX V3 pool, holds the KUB
- *     WRAPPED as KKUB. We sum KKUB alongside native KUB; each owner holds one
- *     or the other, so there is no double-count.
+ *   TVL = Σ(native KUB held by every BondingCurveMarket that has
+ *           NOT yet graduated, across all four factories)
+ *       + Σ(native KUB held by every DurianAMM pool produced by
+ *           graduations from those factories)
+ *       + Σ(KKUB held by every V4.6.7 KUBLERX-graduated V3 pool)
  *
- * The split between (ungraduated BCM) and (graduated pool) prevents double-
- * counting: a graduated BCM has already moved its KUB into the pool.
+ * Each launchpad token gets:
+ *   1. A `BondingCurveMarket` (BCM) that holds native KUB during the
+ *      curve phase (every buy adds KUB, every sell drains it).
+ *   2. An optional `DurianAMM` Uniswap-V2-style pool that gets seeded
+ *      with the BCM's full KUB balance once the migration cap is hit
+ *      (4400 KUB on V4.6.6). Post-graduation, all liquidity lives in
+ *      the AMM.
  *
- * Excluded: token-side AMM reserves (circular pricing - the meme token's only
- * price discovery IS its own pool, and the token half is protocol-minted not
- * user-deposited); and the Factory-D test environment (dKUB, project-mintable).
+ * The split between (ungraduated BCM) ∪ (graduated AMM) prevents
+ * double-counting: a graduated BCM has already moved its KUB into the
+ * AMM, so counting both would inflate via residual dust.
  *
- * Discovery: each factory emits a TokenCreated event whose indexed `market`
- * (topic[2]) is the BCM. V4.2 / V4.5 / V4.6.6 share the 7-arg signature; V4.6.7
- * appends `uint8 graduationTarget`, changing the event hash - so it uses its
- * own ABI. We scan from each deploy block, multiCall ammPool() to detect
- * graduation, then sumTokens({ owners, tokens: [nullAddress, KKUB] }).
+ * ── What's excluded and why ────────────────────────────────────────
+ *
+ * - Token-side AMM reserves: meme-token's only price discovery IS the
+ *   pool itself. Counting both sides would be circular tautology.
+ *   The token half was protocol-minted (not user-deposited), so it's
+ *   not "external" liquidity.
+ * - Factory-D test environment (V2.5 + V2.4.2): denominated in dKUB,
+ *   which is mintable by the project — not real protocol TVL.
+ *
+ * ── Discovery strategy ─────────────────────────────────────────────
+ *
+ * Each factory emits the identical-signature `TokenCreated` event on
+ * every `createToken()` call. `topics[2]` is the indexed BCM market
+ * address. We scan from each factory's deploy block and feed all BCMs
+ * into a single `multiCall` of `ammPool()` to detect graduation. Then
+ * we `sumTokens({ owners, tokens: [nullAddress, KKUB] })` to fetch
+ * native KUB + (for KUBLERX-graduated V4.6.7 pools) KKUB balances in
+ * one batched RPC pass. Each owner holds native KUB or KKUB, never
+ * both, so summing both sentinels never double-counts.
+ *
+ * ── Note on Bond Pool TVL methodology divergence ───────────────────
+ *
+ * For TVL (this adapter + projects/durianfun-bond), Bond Pool reports
+ * `totalLocked × external-oracle-price`. Unpriced memes contribute
+ * $0 — that's DefiLlama policy (conservative, no fake TVL).
+ *
+ * For APY (yield-server/durianfun-bond), we use the on-chain BCM
+ * `currentPricePerToken()` instead — APY calculations are economic-
+ * truth signals for depositors, and the BCM price is canonical for
+ * bond-pool economics whether or not an external oracle exists.
  */
 
 const { getLogs } = require("../helper/cache/getLogs");
 const { nullAddress } = require("../helper/unwrapLPs");
 
-// V4.5 (sacred main, frozen) + V4.2 (legacy main, frozen).
+// V4.5 (current sacred main, frozen) + V4.2 (legacy main, frozen).
 const FACTORY_V45 = "0xdf4f3dB298A9aDe853191F58b4b2a322D47EC005";
 const FACTORY_V42 = "0xeadEc9dA89F97Ae6215362EBA4B33F3F1d1775b2";
 
-// V4.6.6 Deluxe - deployed 2026-05-03. Native KUB.
+// V4.6.6 Deluxe — deployed 2026-05-03. Native KUB only.
 const FACTORY_V466 = "0x89b6b73BD18dbEA0e2218c25c1963fd5FBaB3c87";
 
-// V4.6.7 - dual-graduation launchpad deployed 2026-05-31. Native KUB.
+// V4.6.7 — current production launchpad, deployed 2026-05-31. Dual
+// graduation: in-contract DurianAMM (native KUB) OR external KUBLERX
+// V3 pool (KUB wrapped as KKUB). Its TokenCreated appends a trailing
+// `uint8 graduationTarget`, changing the event hash — so it needs its
+// own 8-arg ABI (below); the 7-arg ABI matches zero V4.6.7 events.
 const FACTORY_V467 = "0x0480017E51dC813a0fad8aA73EAb2f8476ac0e8F";
 
-// KKUB (wrapped native KUB) - the V4.6.7 KUBLERX-graduated side (see header).
+// KKUB (wrapped native KUB) — the V4.6.7 KUBLERX-graduated side holds
+// KUB wrapped as KKUB. Summed alongside native KUB (see header).
 const KKUB = "0x67eBD850304c70d983B2d1b93ea79c7CD6c3F6b5";
 
-const FACTORY_V45_BLOCK  = 30_999_992;
-const FACTORY_V42_BLOCK  = 30_990_140;
+const FACTORY_V45_BLOCK = 30_999_992;
+const FACTORY_V42_BLOCK = 30_990_140;
 const FACTORY_V466_BLOCK = 31_393_573;
 const FACTORY_V467_BLOCK = 32_196_516;
 
-// 7-arg signature across V4.2 / V4.5 / V4.6.6.
+// Identical signature across V4.2 / V4.5 / V4.6.6.
 const TOKEN_CREATED_ABI =
   "event TokenCreated(address indexed token, address indexed market, address indexed creator, string name, string symbol, uint256 totalSupply, uint256 timestamp)";
 
-// V4.6.7 appends `uint8 graduationTarget` -> distinct event hash + ABI.
+// V4.6.7 appends a trailing `uint8 graduationTarget` → distinct event hash.
 const TOKEN_CREATED_ABI_V467 =
   "event TokenCreated(address indexed token, address indexed market, address indexed creator, string name, string symbol, uint256 totalSupply, uint256 timestamp, uint8 graduationTarget)";
 
 async function tvl(api) {
-  // 1. Pull every TokenCreated event from all factories in parallel.
+  // 1. Pull every TokenCreated event from all four factories in parallel.
   const [logsV45, logsV42, logsV466, logsV467] = await Promise.all([
-    getLogs({ api, target: FACTORY_V45,  eventAbi: TOKEN_CREATED_ABI,      fromBlock: FACTORY_V45_BLOCK,  onlyArgs: true }),
-    getLogs({ api, target: FACTORY_V42,  eventAbi: TOKEN_CREATED_ABI,      fromBlock: FACTORY_V42_BLOCK,  onlyArgs: true }),
-    getLogs({ api, target: FACTORY_V466, eventAbi: TOKEN_CREATED_ABI,      fromBlock: FACTORY_V466_BLOCK, onlyArgs: true }),
-    getLogs({ api, target: FACTORY_V467, eventAbi: TOKEN_CREATED_ABI_V467, fromBlock: FACTORY_V467_BLOCK, onlyArgs: true }),
+    getLogs({
+      api,
+      target: FACTORY_V45,
+      eventAbi: TOKEN_CREATED_ABI,
+      fromBlock: FACTORY_V45_BLOCK,
+      onlyArgs: true,
+    }),
+    getLogs({
+      api,
+      target: FACTORY_V42,
+      eventAbi: TOKEN_CREATED_ABI,
+      fromBlock: FACTORY_V42_BLOCK,
+      onlyArgs: true,
+    }),
+    getLogs({
+      api,
+      target: FACTORY_V466,
+      eventAbi: TOKEN_CREATED_ABI,
+      fromBlock: FACTORY_V466_BLOCK,
+      onlyArgs: true,
+    }),
+    getLogs({
+      api,
+      target: FACTORY_V467,
+      eventAbi: TOKEN_CREATED_ABI_V467,
+      fromBlock: FACTORY_V467_BLOCK,
+      onlyArgs: true,
+    }),
   ]);
 
   // 2. Each `market` is a bonding-curve contract that holds KUB until graduation.
   const markets = [...logsV45, ...logsV42, ...logsV466, ...logsV467].map((l) => l.market);
   if (markets.length === 0) return {};
 
-  // 3. After graduation `market.ammPool()` returns the pool address (DurianAMM
-  //    or KUBLERX V3); pre-graduation it returns the zero address. Split so the
-  //    curve side counts ONLY ungraduated markets - graduated markets moved
-  //    their KUB into the pool, so counting both would double-count.
+  // 3. After graduation `market.ammPool()` returns the DurianAMM pool address;
+  //    pre-graduation it returns the zero address. We split markets into two
+  //    sets so the curve side counts ONLY ungraduated markets (matches the
+  //    methodology) — graduated markets have transferred their KUB to the
+  //    AMM pool, so counting both would double-count any residual dust.
   const ammPools = await api.multiCall({
     abi: "function ammPool() view returns (address)",
     calls: markets,
@@ -92,10 +148,10 @@ async function tvl(api) {
   const ungraduatedMarkets = markets.filter((_, i) => !isGraduated(ammPools[i]));
   const liveAmmPools = ammPools.filter(isGraduated);
 
-  // 4. Sum native KUB + KKUB held across (a) ungraduated markets and (b)
-  //    graduated pools. Native KUB covers curves + DurianAMM; KKUB covers
-  //    KUBLERX-graduated V4.6.7 pools. Each owner holds one or the other, so
-  //    summing both sentinels never double-counts. Dedup owners defensively.
+  // 4. Sum native KUB held across (a) ungraduated markets + (b) graduated AMM
+  //    pools. Dedup owners as a defensive measure against any duplicate event
+  //    log echoes. `permitFailure` on multiCall above already protects against
+  //    individual contract reverts.
   const owners = Array.from(new Set([...ungraduatedMarkets, ...liveAmmPools]));
   return api.sumTokens({ owners, tokens: [nullAddress, KKUB] });
 }

--- a/projects/durianfun/index.js
+++ b/projects/durianfun/index.js
@@ -1,116 +1,85 @@
 /**
- * Durianfun — meme-token launchpad on KUB Chain (chainId 96).
+ * Durianfun - meme-token launchpad on KUB Chain (chainId 96).
  *
- * Tracks native KUB locked across THREE generations of the launchpad:
+ * Tracks native KUB locked across FOUR generations of the launchpad:
  *   - V4.2 (legacy main, frozen)
- *   - V4.5 (current sacred main, frozen — no new tokens, residual liquidity)
- *   - V4.6.6 Deluxe (production, deployed 2026-05-03)
+ *   - V4.5 (sacred main, frozen - no new tokens, residual liquidity)
+ *   - V4.6.6 Deluxe (deployed 2026-05-03)
+ *   - V4.6.7 (current production, deployed 2026-05-31 - dual graduation:
+ *     in-contract Durian AMM OR external KUBLERX V3 pool)
  *
- * ── TVL formula ────────────────────────────────────────────────────
+ * TVL formula:
+ *   sum(native KUB held by every BondingCurveMarket NOT yet graduated)
+ * + sum(native KUB held by every graduated DurianAMM pool)
+ * + sum(KKUB held by every V4.6.7 KUBLERX-graduated V3 pool)
  *
- *   TVL = Σ(native KUB held by every BondingCurveMarket that has
- *           NOT yet graduated, across all three factories)
- *       + Σ(native KUB held by every DurianAMM pool produced by
- *           graduations from those factories)
+ * Each launchpad token gets a BondingCurveMarket (BCM) holding native KUB
+ * during the curve phase. On graduation the KUB is seeded into a pool:
+ *   - DURIAN target  -> in-contract DurianAMM, holds NATIVE KUB.
+ *   - KUBLERX target (V4.6.7 only) -> external KUBLERX V3 pool, holds the KUB
+ *     WRAPPED as KKUB. We sum KKUB alongside native KUB; each owner holds one
+ *     or the other, so there is no double-count.
  *
- * Each launchpad token gets:
- *   1. A `BondingCurveMarket` (BCM) that holds native KUB during the
- *      curve phase (every buy adds KUB, every sell drains it).
- *   2. An optional `DurianAMM` Uniswap-V2-style pool that gets seeded
- *      with the BCM's full KUB balance once the migration cap is hit
- *      (4400 KUB on V4.6.6). Post-graduation, all liquidity lives in
- *      the AMM.
+ * The split between (ungraduated BCM) and (graduated pool) prevents double-
+ * counting: a graduated BCM has already moved its KUB into the pool.
  *
- * The split between (ungraduated BCM) ∪ (graduated AMM) prevents
- * double-counting: a graduated BCM has already moved its KUB into the
- * AMM, so counting both would inflate via residual dust.
+ * Excluded: token-side AMM reserves (circular pricing - the meme token's only
+ * price discovery IS its own pool, and the token half is protocol-minted not
+ * user-deposited); and the Factory-D test environment (dKUB, project-mintable).
  *
- * ── What's excluded and why ────────────────────────────────────────
- *
- * - Token-side AMM reserves: meme-token's only price discovery IS the
- *   pool itself. Counting both sides would be circular tautology.
- *   The token half was protocol-minted (not user-deposited), so it's
- *   not "external" liquidity.
- * - Factory-D test environment (V2.5 + V2.4.2): denominated in dKUB,
- *   which is mintable by the project — not real protocol TVL.
- *
- * ── Discovery strategy ─────────────────────────────────────────────
- *
- * Each factory emits the identical-signature `TokenCreated` event on
- * every `createToken()` call. `topics[2]` is the indexed BCM market
- * address. We scan from each factory's deploy block and feed all BCMs
- * into a single `multiCall` of `ammPool()` to detect graduation. Then
- * we `sumTokens({ owners, tokens: [nullAddress] })` to fetch native
- * KUB balances in one batched RPC pass.
- *
- * ── Note on Bond Pool TVL methodology divergence ───────────────────
- *
- * For TVL (this adapter + projects/durianfun-bond), Bond Pool reports
- * `totalLocked × external-oracle-price`. Unpriced memes contribute
- * $0 — that's DefiLlama policy (conservative, no fake TVL).
- *
- * For APY (yield-server/durianfun-bond), we use the on-chain BCM
- * `currentPricePerToken()` instead — APY calculations are economic-
- * truth signals for depositors, and the BCM price is canonical for
- * bond-pool economics whether or not an external oracle exists.
+ * Discovery: each factory emits a TokenCreated event whose indexed `market`
+ * (topic[2]) is the BCM. V4.2 / V4.5 / V4.6.6 share the 7-arg signature; V4.6.7
+ * appends `uint8 graduationTarget`, changing the event hash - so it uses its
+ * own ABI. We scan from each deploy block, multiCall ammPool() to detect
+ * graduation, then sumTokens({ owners, tokens: [nullAddress, KKUB] }).
  */
 
 const { getLogs } = require("../helper/cache/getLogs");
 const { nullAddress } = require("../helper/unwrapLPs");
 
-// V4.5 (current sacred main, frozen) + V4.2 (legacy main, frozen).
+// V4.5 (sacred main, frozen) + V4.2 (legacy main, frozen).
 const FACTORY_V45 = "0xdf4f3dB298A9aDe853191F58b4b2a322D47EC005";
 const FACTORY_V42 = "0xeadEc9dA89F97Ae6215362EBA4B33F3F1d1775b2";
 
-// V4.6.6 Deluxe — production launchpad deployed 2026-05-03.
-// Native KUB only (createToken is payable, not dKUB-minted).
-// If a V4.6.7 ships, add a NEW factory entry — the adapter still
-// aggregates without code changes elsewhere.
+// V4.6.6 Deluxe - deployed 2026-05-03. Native KUB.
 const FACTORY_V466 = "0x89b6b73BD18dbEA0e2218c25c1963fd5FBaB3c87";
 
-const FACTORY_V45_BLOCK = 30_999_992;
-const FACTORY_V42_BLOCK = 30_990_140;
-const FACTORY_V466_BLOCK = 31_393_573;
+// V4.6.7 - dual-graduation launchpad deployed 2026-05-31. Native KUB.
+const FACTORY_V467 = "0x0480017E51dC813a0fad8aA73EAb2f8476ac0e8F";
 
-// Identical signature across V4.2 / V4.5 / V4.6.6.
+// KKUB (wrapped native KUB) - the V4.6.7 KUBLERX-graduated side (see header).
+const KKUB = "0x67eBD850304c70d983B2d1b93ea79c7CD6c3F6b5";
+
+const FACTORY_V45_BLOCK  = 30_999_992;
+const FACTORY_V42_BLOCK  = 30_990_140;
+const FACTORY_V466_BLOCK = 31_393_573;
+const FACTORY_V467_BLOCK = 32_196_516;
+
+// 7-arg signature across V4.2 / V4.5 / V4.6.6.
 const TOKEN_CREATED_ABI =
   "event TokenCreated(address indexed token, address indexed market, address indexed creator, string name, string symbol, uint256 totalSupply, uint256 timestamp)";
 
+// V4.6.7 appends `uint8 graduationTarget` -> distinct event hash + ABI.
+const TOKEN_CREATED_ABI_V467 =
+  "event TokenCreated(address indexed token, address indexed market, address indexed creator, string name, string symbol, uint256 totalSupply, uint256 timestamp, uint8 graduationTarget)";
+
 async function tvl(api) {
-  // 1. Pull every TokenCreated event from all three factories in parallel.
-  const [logsV45, logsV42, logsV466] = await Promise.all([
-    getLogs({
-      api,
-      target: FACTORY_V45,
-      eventAbi: TOKEN_CREATED_ABI,
-      fromBlock: FACTORY_V45_BLOCK,
-      onlyArgs: true,
-    }),
-    getLogs({
-      api,
-      target: FACTORY_V42,
-      eventAbi: TOKEN_CREATED_ABI,
-      fromBlock: FACTORY_V42_BLOCK,
-      onlyArgs: true,
-    }),
-    getLogs({
-      api,
-      target: FACTORY_V466,
-      eventAbi: TOKEN_CREATED_ABI,
-      fromBlock: FACTORY_V466_BLOCK,
-      onlyArgs: true,
-    }),
+  // 1. Pull every TokenCreated event from all factories in parallel.
+  const [logsV45, logsV42, logsV466, logsV467] = await Promise.all([
+    getLogs({ api, target: FACTORY_V45,  eventAbi: TOKEN_CREATED_ABI,      fromBlock: FACTORY_V45_BLOCK,  onlyArgs: true }),
+    getLogs({ api, target: FACTORY_V42,  eventAbi: TOKEN_CREATED_ABI,      fromBlock: FACTORY_V42_BLOCK,  onlyArgs: true }),
+    getLogs({ api, target: FACTORY_V466, eventAbi: TOKEN_CREATED_ABI,      fromBlock: FACTORY_V466_BLOCK, onlyArgs: true }),
+    getLogs({ api, target: FACTORY_V467, eventAbi: TOKEN_CREATED_ABI_V467, fromBlock: FACTORY_V467_BLOCK, onlyArgs: true }),
   ]);
 
   // 2. Each `market` is a bonding-curve contract that holds KUB until graduation.
-  const markets = [...logsV45, ...logsV42, ...logsV466].map((l) => l.market);
+  const markets = [...logsV45, ...logsV42, ...logsV466, ...logsV467].map((l) => l.market);
   if (markets.length === 0) return {};
 
-  // 3. After graduation `market.ammPool()` returns the DurianAMM pool address;
-  //    pre-graduation it returns the zero address. We split markets into two
-  //    sets so the curve side counts ONLY ungraduated markets (matches the
-  //    methodology) — graduated markets have transferred their KUB to the
-  //    AMM pool, so counting both would double-count any residual dust.
+  // 3. After graduation `market.ammPool()` returns the pool address (DurianAMM
+  //    or KUBLERX V3); pre-graduation it returns the zero address. Split so the
+  //    curve side counts ONLY ungraduated markets - graduated markets moved
+  //    their KUB into the pool, so counting both would double-count.
   const ammPools = await api.multiCall({
     abi: "function ammPool() view returns (address)",
     calls: markets,
@@ -123,17 +92,17 @@ async function tvl(api) {
   const ungraduatedMarkets = markets.filter((_, i) => !isGraduated(ammPools[i]));
   const liveAmmPools = ammPools.filter(isGraduated);
 
-  // 4. Sum native KUB held across (a) ungraduated markets + (b) graduated AMM
-  //    pools. Dedup owners as a defensive measure against any duplicate event
-  //    log echoes. `permitFailure` on multiCall above already protects against
-  //    individual contract reverts.
+  // 4. Sum native KUB + KKUB held across (a) ungraduated markets and (b)
+  //    graduated pools. Native KUB covers curves + DurianAMM; KKUB covers
+  //    KUBLERX-graduated V4.6.7 pools. Each owner holds one or the other, so
+  //    summing both sentinels never double-counts. Dedup owners defensively.
   const owners = Array.from(new Set([...ungraduatedMarkets, ...liveAmmPools]));
-  return api.sumTokens({ owners, tokens: [nullAddress] });
+  return api.sumTokens({ owners, tokens: [nullAddress, KKUB] });
 }
 
 module.exports = {
   methodology:
-    "TVL counts native KUB locked in (a) Durianfun bonding-curve markets that have not yet graduated (V4.2 + V4.5 + V4.6.6 Deluxe), and (b) DurianAMM liquidity pools that hold post-graduation liquidity. Meme-token reserves are intentionally excluded to avoid circular pricing, and the separately-deployed Factory-D test environment is excluded.",
+    "TVL counts native KUB locked in (a) Durianfun bonding-curve markets that have not yet graduated (V4.2 + V4.5 + V4.6.6 Deluxe + V4.6.7), and (b) post-graduation liquidity pools. V4.6.7 tokens that graduate to a KUBLERX V3 pool hold wrapped KKUB, which is summed alongside native KUB. Meme-token reserves are intentionally excluded to avoid circular pricing, and the separately-deployed Factory-D test environment is excluded.",
   start: FACTORY_V42_BLOCK,
   bitkub: { tvl },
 };


### PR DESCRIPTION
## Update: Durianfun launchpad — add V4.6.7 factory

`projects/durianfun/index.js` aggregates the V4.2 + V4.5 + V4.6.6 launchpad factories on Bitkub Chain (chainId 96). This adds the **V4.6.7** factory (current production launchpad, deployed 2026-05-31) that the adapter was missing.

### Changes
- Add factory `0x0480017E51dC813a0fad8aA73EAb2f8476ac0e8F` (deploy block 32196516).
- V4.6.7's `TokenCreated` appends a trailing `uint8 graduationTarget`, changing the event hash — decoded with its own ABI (the 7-arg ABI matches zero V4.6.7 events).
- V4.6.7 has dual graduation: in-contract DurianAMM (native KUB) or an external KUBLERX V3 pool (wrapped KKUB). `sumTokens` now also sums KKUB; each owner holds native KUB or KKUB, never both, so there is no double-count.

### Verification
Direct KUB-RPC read of the V4.6.7 factory: 4 live markets (THB, ICEMAN, MOOPING, SAYWALLH), all pre-graduation, holding 0.847 KUB total. KKUB side = 0 (no KUBLERX graduation yet; the path is in place for when it happens).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Durianfun TVL calculations to include V4.6.7 launchpad generation and its associated markets.

* **Improvements**
  * Enhanced value accounting by incorporating both native KUB and wrapped KKUB in TVL totals.
  * Improved graduation/liquidity handling to ensure pools are categorized correctly and avoid double-counting.
  * Updated the methodology description to reflect the expanded asset and pool counting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->