### PR TITLE
Add Panoptic V2 TVL adapter

### DIFF
--- a/projects/panoptic-v2/index.js
+++ b/projects/panoptic-v2/index.js
@@ -1,0 +1,87 @@
+const { getLogs2 } = require('../helper/cache/getLogs')
+
+const NULL_ADDRESS = '0x0000000000000000000000000000000000000000'
+
+const methodology = 'Counts assets managed by Panoptic V2 collateral trackers for all PanopticPool contracts deployed by the PanopticFactoryV3 and PanopticFactoryV4 contracts. CollateralTracker.totalAssets() includes tracked deposits, assets deployed into AMM positions, and unrealized interest, so no separate SFPM chunk/subgraph accounting is needed.'
+
+const abi = {
+  PoolDeployedV3: 'event PoolDeployed(address indexed poolAddress, address indexed uniswapPool, address collateralTracker0, address collateralTracker1, address riskEngine)',
+  PoolDeployedV4: 'event PoolDeployed(address indexed poolAddress, bytes32 indexed idV4, address collateralTracker0, address collateralTracker1, address riskEngine)',
+}
+
+const config = {
+  ethereum: {
+    startBlock: 25276309,
+    factories: [
+      {
+        target: '0x0000000000000aDC9A108591e718F2aee963a2a7',
+        eventAbi: abi.PoolDeployedV3,
+        extraKey: 'pool-deployed-v3',
+      },
+      {
+        target: '0x0000000000000c51d0f8cf4bd9adE7191372a625',
+        eventAbi: abi.PoolDeployedV4,
+        extraKey: 'pool-deployed-v4',
+      },
+    ],
+  },
+}
+
+async function tvl(api) {
+  const { startBlock, factories } = config[api.chain]
+  const logs = (
+    await Promise.all(
+      factories.map(({ target, eventAbi, extraKey }) =>
+        getLogs2({
+          api,
+          target,
+          fromBlock: startBlock,
+          eventAbi,
+          extraKey,
+          onlyArgs: false,
+          transform: (log) => ({
+            blockNumber: log.blockNumber,
+            poolAddress: log.args.poolAddress,
+            collateralTracker0: log.args.collateralTracker0,
+            collateralTracker1: log.args.collateralTracker1,
+          }),
+        })
+      )
+    )
+  ).flat().filter((log) => !api.block || log.blockNumber <= api.block)
+
+  const collateralTrackers = [
+    ...new Set(
+      logs
+        .flatMap(({ collateralTracker0, collateralTracker1 }) => [
+          collateralTracker0,
+          collateralTracker1,
+        ])
+        .map((address) => address.toLowerCase())
+    ),
+  ]
+
+  const tokens = await api.multiCall({
+    abi: 'function asset() external view returns (address)',
+    calls: collateralTrackers,
+  })
+  // V2 tracks AMM-deployed assets inside each CollateralTracker, unlike V1/V1.1
+  // where the adapter reconstructs SFPM liquidity chunks separately.
+  const balances = await api.multiCall({
+    abi: 'function totalAssets() external view returns (uint256)',
+    calls: collateralTrackers,
+  })
+
+  tokens.forEach((token, i) => {
+    if (token.toLowerCase() === NULL_ADDRESS) return api.addGasToken(balances[i])
+    api.add(token, balances[i])
+  })
+}
+
+module.exports = {
+  ethereum: {
+    tvl,
+    methodology,
+    start: 1780965215,
+  },
+}

--- a/projects/panoptic-v2/index.js
+++ b/projects/panoptic-v2/index.js
@@ -38,6 +38,7 @@ async function tvl(api) {
           fromBlock: startBlock,
           eventAbi,
           extraKey,
+          skipCacheRead: true,
           onlyArgs: false,
           transform: (log) => ({
             blockNumber: log.blockNumber,


### PR DESCRIPTION
We are already listed under Panoptic V1 and V1.1 adapters. We are adding Panoptic V2 adapter in this PR.

Panoptic V2 should be related to / grouped under the existing Panoptic project on DefiLlama, alongside Panoptic V1 and Panoptic V1.1.

Unlike the V1/V1.1 adapters, this V2 adapter does not query SFPM chunks separately. Panoptic V2 CollateralTracker.totalAssets() already includes tracked deposits, assets deployed into AMM positions, and unrealized interest, so reading totalAssets() from both collateral trackers per deployed pool accounts for collateral and AMM-deployed TVL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Panoptic V2 TVL tracking for Ethereum, enabling automated calculation and monitoring of total value locked across Panoptic V2 collateral tracker positions.
  * Includes support for resolving underlying assets and aggregating total managed assets per tracker.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->