### PR TITLE
fix(origami): tolerate per-vault read failures so TVL stops freezing

### DIFF
--- a/projects/origami/index.js
+++ b/projects/origami/index.js
@@ -82,13 +82,14 @@ async function processRepricingVaults(api, vaults) {
  */
 async function processErc4626Vaults(api, vaults) {
   const [assets, totalAssets] = await Promise.all([
-    api.multiCall({ abi: 'address:asset', calls: vaults, permitFailure: false }),
-    api.multiCall({ abi: 'uint256:totalAssets', calls: vaults, permitFailure: false })
+    api.multiCall({ abi: 'address:asset', calls: vaults, permitFailure: true }),
+    api.multiCall({ abi: 'uint256:totalAssets', calls: vaults, permitFailure: true })
   ])
 
-  await Promise.all(vaults.map(async (_vault, i) => {
+  vaults.forEach((_vault, i) => {
+    if (!assets[i] || !totalAssets[i]) return
     api.addToken(assets[i], totalAssets[i])
-  }))
+  })
 }
 
 /**
@@ -97,13 +98,14 @@ async function processErc4626Vaults(api, vaults) {
  */
 async function processBalanceSheetVaults(api, vaults) {
   const [tokens, balanceSheet] = await Promise.all([
-    api.multiCall({ abi: 'function tokens() external view returns (address[] memory assetTokens, address[] memory liabilityTokens)', calls: vaults, permitFailure: false }),
-    api.multiCall({ abi: 'function balanceSheet() external view returns (uint256[] memory totalAssets, uint256[] memory totalLiabilities)', calls: vaults, permitFailure: false })
+    api.multiCall({ abi: 'function tokens() external view returns (address[] memory assetTokens, address[] memory liabilityTokens)', calls: vaults, permitFailure: true }),
+    api.multiCall({ abi: 'function balanceSheet() external view returns (uint256[] memory totalAssets, uint256[] memory totalLiabilities)', calls: vaults, permitFailure: true })
   ])
 
   vaults.forEach((_vault, i) => {
     const vaultTokens = tokens[i]
     const vaultBalanceSheet = balanceSheet[i]
+    if (!vaultTokens || !vaultBalanceSheet) return
 
     vaultTokens.assetTokens.forEach((token, j) => {
       const assetAmount = vaultBalanceSheet.totalAssets[j];
@@ -124,11 +126,12 @@ async function processBalanceSheetVaults(api, vaults) {
  */
 async function processAutoStakingVaults(api, vaults) {
   const [stakingToken, totalSupply] = await Promise.all([
-    api.multiCall({ abi: 'function stakingToken() external view returns (address)', calls: vaults, permitFailure: false }),
-    api.multiCall({ abi: 'function totalSupply() external view returns (uint256)', calls: vaults, permitFailure: false })
+    api.multiCall({ abi: 'function stakingToken() external view returns (address)', calls: vaults, permitFailure: true }),
+    api.multiCall({ abi: 'function totalSupply() external view returns (uint256)', calls: vaults, permitFailure: true })
   ])
 
   vaults.forEach((_vault, i) => {
+    if (!stakingToken[i] || !totalSupply[i]) return
     api.addToken(stakingToken[i], totalSupply[i])
   })
 }
@@ -170,13 +173,14 @@ async function borrowedLeveragedVaults(api, leveragedVaults) {
  */
 async function borrowedBalanceSheetVaults(api, vaults) {
   const [tokens, balanceSheet] = await Promise.all([
-    api.multiCall({ abi: 'function tokens() external view returns (address[] memory assetTokens, address[] memory liabilityTokens)', calls: vaults, permitFailure: false }),
-    api.multiCall({ abi: 'function balanceSheet() external view returns (uint256[] memory totalAssets, uint256[] memory totalLiabilities)', calls: vaults, permitFailure: false })
+    api.multiCall({ abi: 'function tokens() external view returns (address[] memory assetTokens, address[] memory liabilityTokens)', calls: vaults, permitFailure: true }),
+    api.multiCall({ abi: 'function balanceSheet() external view returns (uint256[] memory totalAssets, uint256[] memory totalLiabilities)', calls: vaults, permitFailure: true })
   ])
 
   vaults.forEach((_vault, i) => {
     const vaultTokens = tokens[i]
     const vaultBalanceSheet = balanceSheet[i]
+    if (!vaultTokens || !vaultBalanceSheet) return
 
     vaultTokens.liabilityTokens.forEach((token, j) => {
       const liabilityAmount = vaultBalanceSheet.totalLiabilities[j];


### PR DESCRIPTION
## Problem

DefiLlama has shown Origami Finance frozen at **~$49.4M** since **2026-05-27**, while the protocol's actual TVL is **~$33.3M**. There has been no new TVL data point since that date.

`2026-05-27` is when #19316 merged (vault discovery switched from the subgraph to the Origami API). The chart froze that same day.

## Root cause

`getVaults` itself is fine (the API is live). The failure is downstream: the `ERC4626`, `BALANCE_SHEET` and `AUTO_STAKING` readers — plus `borrowedBalanceSheetVaults` — call `api.multiCall({ ..., permitFailure: false })` and then index the results with no null guard. When any one of those multicalls hits a transient RPC failure, it throws and aborts the entire chain's `tvl()` / `borrowed()`, so DefiLlama can't store a new value and the last one (~$49.4M) stays frozen.

Reproduced locally — runs intermittently abort with:

```
Error: Multicall failed! [chain: ethereum] [fail count: 4]
[abi: function balanceSheet() external view returns (uint256[] totalAssets, uint256[] totalLiabilities)]
```

The `LEVERAGE` and `REPRICING` readers in this same file already use `permitFailure: true` + guards and don't have this problem.

## Fix

Set `permitFailure: true` on the four affected readers and skip vaults whose reads came back empty — identical to the existing `LEVERAGE` / `REPRICING` handling. A transient failure on one vault now just omits that vault for that run instead of freezing the whole protocol.

## Verification

- Origami's own API (`/public/external/vault-token-balances`) sums to **$33.3M** net (assets − liabilities) across ethereum/berachain/plasma — confirming the live value, not the frozen $49.4M.
- Before: `node test.js projects/origami/index.js` aborts on roughly 1 in 3 runs.
- After: 6/6 runs complete and return a stable **$33.33M**, matching the API.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience of vault data retrieval by gracefully handling cases where required data points are unavailable, preventing incomplete results from disrupting token accounting and balance calculations across supported vault types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->