### PR TITLE
Add Ethereum TVL calculation for Privacy Cash

### DIFF
--- a/projects/privacy-cash/index.js
+++ b/projects/privacy-cash/index.js
@@ -20,4 +20,13 @@ module.exports = {
       tokens: [ADDRESSES.null, ADDRESSES.base.USDC],
     })
   },
+  ethereum: {
+    tvl: evmSumTokensExport({
+      owners: [
+        '0x77A10AE3E513c2D73D73eb52212c6918C8830dd0',
+        '0xC88F4dF2B6EdDd6B6Bdf95A0177f50C90Fa7527f',
+      ],
+      tokens: [ADDRESSES.null, ADDRESSES.ethereum.USDT],
+    })
+  },
 }


### PR DESCRIPTION
This PR adds TVL calculation for Privacy Cash on Ethereum.

https://etherscan.io/address/0x77A10AE3E513c2D73D73eb52212c6918C8830dd0
https://etherscan.io/address/0xC88F4dF2B6EdDd6B6Bdf95A0177f50C90Fa7527f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ethereum network support for TVL tracking in the Privacy Cash project, enabling users to monitor total value locked metrics across the Ethereum blockchain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->