### PR TITLE
fix(pool-party): consume coingeckoId from CCTools, drop hardcoded token map

### DIFF
--- a/projects/pool-party/index.js
+++ b/projects/pool-party/index.js
@@ -2,11 +2,6 @@ const { get } = require('../helper/http')
 
 const POOLS_URL = 'https://api.cctools.network/api/markets/send/pools'
 
-// const parties = [
-//   'mainnet-pool-party-amulet-cusd-operator::1220724bbd5179d9f5d19de90f31cfa0e99e4bf9cf815e3e5e669a40524725d9e98b',
-//   'mainnet-pool-party-amulet-usdcx-operator::1220647009424eff86ef09493a366aa314e8533c0cd8070aa82a9b014e42daad03c3',
-// ]
-
 // CCTools rejects axios's default User-Agent; identify ourselves explicitly.
 const FETCH_OPTS = { headers: { 'User-Agent': 'DefiLlama-Adapter (pool-party)' } }
 
@@ -15,8 +10,9 @@ async function tvl(api) {
   for (const pool of pools) {
     if (pool.status !== 'live') continue
     for (const side of [pool.baseReserve, pool.quoteReserve]) {
-      const m = side.tokenId == 'Amulet' ? 1e18 : 1e6
-      api.add(side.tokenId, Number(side.amount) * m)
+      if (side.coingeckoId) {
+        api.addCGToken(side.coingeckoId, Number(side.amount))
+      }
     }
   }
 }
@@ -25,7 +21,10 @@ module.exports = {
   timetravel: false,
   canton: { tvl },
   methodology:
-    "Sum of raw token reserves across Pool Party's live pools (CC/USDCx, " +
-    "CC/CUSD, CUSD/USDCx), via the CCTools API — an independent Canton DeFi " +
-    "aggregator that exposes per-pool reserves with canonical token IDs."
+    "Sum of raw token reserves across Pool Party's live pools, via the " +
+    "CCTools API — an independent Canton DeFi aggregator that exposes " +
+    "per-pool reserves with canonical token IDs and CoinGecko slugs. The " +
+    "CoinGecko slug per token comes from the API response " +
+    "(reserve.coingeckoId), so new pools and tokens are picked up " +
+    "automatically without adapter changes.",
 }


### PR DESCRIPTION
CCTools added a `coingeckoId` field to each pool reserve in `/api/markets/send/pools`, so the adapter can now read the CoinGecko slug directly from the API response instead of carrying a hardcoded `TOKEN_TO_CG` map.

Two effects:

1. **New pools/tokens are picked up automatically.** Pool Party recently added CC/USDC.B, CC/FRXUSD.B, FRXUSD.B/USDC.B, and CBTC/* pools — none of which the previous adapter recognized. After this change the adapter just reads `reserve.coingeckoId` and routes via `addCGToken`, so future pool launches don't need adapter PRs.

2. **CBTC pricing is now correct.** The earlier hardcoded map (and the in-flight dimension-adapters interim at DefiLlama/dimension-adapters#7615) had CBTC mapped to `coinbase-wrapped-btc`. Per the protocol team, `CBTC` is actually `bitsafe-bridged-wrapped-bitcoin-canton` (Bitsafe-bridged BTC, not Coinbase's cbBTC). CCTools' API now returns the correct slug per token, so the adapter inherits it.

Methodology updated to reflect that token pricing comes from the API response. No other adapter changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New pools and tokens are now automatically detected and included in reserve calculations without requiring manual adapter updates.

* **Chores**
  * Improved token reserve calculation approach with enhanced data source integration and updated documentation to reflect new methodology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->