### PR TITLE
Monetrix: derive TVL from USDM supply for historical backfill

### DIFF
--- a/projects/monetrix/index.js
+++ b/projects/monetrix/index.js
@@ -1,7 +1,7 @@
 const ADDRESSES = require('../helper/coreAssets.json')
 
 const MONETRIX_GENESIS_VAULT = '0xc50A1dd2866A822c81bd0aA00B638c4BdDc9cd63'
-const MONETRIX_ACCOUNTANT = '0x8950A5136f3994f82b998e37e1183b8A37c12705'
+const USDM = '0xE2d2959f89B6389DeB624bF076Fe7D9E5401f377'
 
 const USDC = ADDRESSES.hyperliquid.USDC
 
@@ -9,24 +9,24 @@ async function tvl(api) {
   // Pre-launch Genesis Vault USDC; migrates into the main MonetrixVault when users mint USDM
   await api.sumTokens({ owners: [MONETRIX_GENESIS_VAULT], tokens: [USDC] })
 
-  // USDC collateral backing USDM, read from the MonetrixAccountant:
-  // EVM USDC in the MonetrixVault and RedeemEscrow, plus the protocol's
-  // Hyperliquid Core account equity (perp margin, spot hedges, HLP and
-  // borrow-lend balances) valued via Hyperliquid precompiles
-  const totalBackingSigned = await api.call({ target: MONETRIX_ACCOUNTANT, abi: 'function totalBackingSigned() view returns (int256)' })
-  // negative backing (mark-to-market drawdown) clamps to zero
-  if (BigInt(totalBackingSigned) > 0n) api.add(USDC, totalBackingSigned)
+  // USDM is minted 1:1 against USDC collateral, so its total supply equals the USDC
+  // backing the live token (the Genesis USDC above migrates into this supply as users
+  // mint). Read from plain ERC20 storage so historical TVL backfills correctly — unlike
+  // the MonetrixAccountant's mark-to-market backing, which is read via Hyperliquid
+  // precompiles that only expose live state and cannot be queried at historical blocks.
+  const usdmSupply = await api.call({ target: USDM, abi: 'erc20:totalSupply' }).catch(() => 0)
+  if (usdmSupply) api.add(USDC, usdmSupply)
 }
 
 module.exports = {
   misrepresentedTokens: true,
+  start: '2026-06-10',
   methodology:
-    'TVL is the USDC collateral backing USDM: USDC held by the MonetrixVault and ' +
-    'RedeemEscrow on HyperEVM plus the protocol\'s Hyperliquid Core account equity ' +
-    '(delta-neutral spot + short-perp positions, HLP and borrow-lend balances), read ' +
-    'on-chain from the MonetrixAccountant (totalBacking), which marks Core positions ' +
-    'to market via Hyperliquid precompiles. USDC still in the pre-launch Genesis Vault ' +
-    'is also counted and migrates into the main vault as users mint USDM. Staked USDM ' +
+    'TVL is the USDC collateral backing USDM. USDM is minted 1:1 against USDC, so the ' +
+    'circulating USDM supply equals the USDC collateral held by the protocol (in the ' +
+    'MonetrixVault, RedeemEscrow and the Hyperliquid Core account that runs the ' +
+    'delta-neutral basis-trading strategy). USDC still in the pre-launch Genesis Vault ' +
+    'is also counted and migrates into the supply as users mint USDM. Staked USDM ' +
     '(sUSDM), the insurance fund (funded from skimmed yield) and undistributed yield ' +
     'are excluded.',
   hyperliquid: {


### PR DESCRIPTION
Updates the already-merged Monetrix TVL adapter so its history backfills correctly.

The previous version read the Core backing via MonetrixAccountant.totalBackingSigned(), which uses Hyperliquid precompiles that only expose live L1 state and cannot be queried at historical blocks — so the TVL chart could only fill forward from the listing date.

USDM is minted/redeemed 1:1 against USDC, so circulating USDM supply equals the USDC collateral backing the token. Reading USDM.totalSupply() (plain ERC20 storage, archival-readable) lets DefiLlama backfill the full TVL history. Added `start: '2026-06-10'` (mainnet launch). The live value is unchanged (~0.06% vs the backing read). Genesis Vault USDC is still counted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **TVL Calculation Updates**
  * Monetrix TVL calculation enhanced to include Genesis Vault USDC contributions, providing comprehensive view of total protocol collateral and liquidity
  * TVL now directly derives from USDM token total supply, enabling transparent on-chain verification of the 1:1 USDC collateral backing model
  * Updated protocol metadata and start date information to June 10, 2026

<!-- end of auto-generated comment: release notes by coderabbit.ai -->