### PR TITLE
Track Spark Anchorage TVL

### DIFF
--- a/projects/spark-liquidity-layer/index.js
+++ b/projects/spark-liquidity-layer/index.js
@@ -1,5 +1,6 @@
 const ADDRESSES = require('../helper/coreAssets.json')
 const morphoAbi = require("../helper/abis/morpho.json");
+const { getExports } = require('../helper/heroku-api');
 
 const almProxy = {
   ethereum: '0x1601843c5E9bC251A3272907010AFa41Fa18347E',
@@ -111,6 +112,13 @@ async function tvl(api) {
 
   const allTokens = Object.values(tokenRecords).flat()
   api.add(allTokens, balances)
+
+  if (api.chain === 'ethereum') {
+    // track anchorage allocation
+    const tvl  = getExports('spark-anchorage', ['ethereum']).ethereum.tvl
+    const anchorageBalance = await tvl(api)
+    api.addBalances(anchorageBalance)
+  }
 }
 
 Object.keys(CONFIG).forEach((chain) => {


### PR DESCRIPTION
Implement functionality to track the Total Value Locked (TVL) for Spark Anchorage on the Ethereum chain. This change integrates the necessary API call to fetch and add the anchorage balance to the overall TVL calculation.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ethereum TVL now includes additional balances from Spark Anchorage, improving the accuracy of reported liquidity totals.
  * Existing chain-specific balance calculations continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->