### PR TITLE
feat: add NeuroBeat game TVL adapter for Cronos

### DIFF
--- a/projects/neurobeat/index.js
+++ b/projects/neurobeat/index.js
@@ -1,0 +1,23 @@
+// NeuroBeat — on-chain game TVL adapter
+// Chain: Cronos (EVM, chain ID 25)
+// Contract: NeuroBeatIsland.sol — collects CRO entry fees from players,
+//           pools them and distributes weekly prizes on-chain.
+// TVL = native CRO balance held in the contract at any given block.
+
+const NEUROBEAT_CONTRACT = '0xDeb77dAf2A427fee514CE53143e407276BBf1F45';
+
+async function tvl(api) {
+  const balance = await api.provider.getBalance(NEUROBEAT_CONTRACT);
+  api.addCGToken('crypto-com-chain', Number(balance) / 1e18);
+}
+
+module.exports = {
+  methodology:
+    'TVL counts the native CRO held inside the NeuroBeat game contract ' +
+    '(0xDeb77dAf2A427fee514CE53143e407276BBf1F45). ' +
+    'Players pay a CRO entry fee; funds accumulate in the contract and are ' +
+    'distributed as weekly prizes via on-chain setPrizes() calls.',
+  cronos: {
+    tvl,
+  },
+};

--- a/projects/neurobeat/index.js
+++ b/projects/neurobeat/index.js
@@ -12,8 +12,6 @@ async function tvl(api) {
 }
 
 module.exports = {
-  name: 'NeuroBeat',
-  url: 'https://neuroisland.io',
   methodology:
     'TVL counts the native CRO held inside the NeuroBeat game contract ' +
     '(0xDeb77dAf2A427Fee514CE53143e407276BBf1F45). ' +

--- a/projects/neurobeat/index.js
+++ b/projects/neurobeat/index.js
@@ -4,7 +4,7 @@
 //           pools them and distributes weekly prizes on-chain.
 // TVL = native CRO balance held in the contract at any given block.
 
-const NEUROBEAT_CONTRACT = '0xDeb77dAf2A427fee514CE53143e407276BBf1F45';
+const NEUROBEAT_CONTRACT = '0xDeb77dAf2A427Fee514CE53143e407276BBf1F45';
 
 async function tvl(api) {
   const balance = await api.provider.getBalance(NEUROBEAT_CONTRACT);
@@ -12,9 +12,11 @@ async function tvl(api) {
 }
 
 module.exports = {
+  name: 'NeuroBeat',
+  url: 'https://neuroisland.io',
   methodology:
     'TVL counts the native CRO held inside the NeuroBeat game contract ' +
-    '(0xDeb77dAf2A427fee514CE53143e407276BBf1F45). ' +
+    '(0xDeb77dAf2A427Fee514CE53143e407276BBf1F45). ' +
     'Players pay a CRO entry fee; funds accumulate in the contract and are ' +
     'distributed as weekly prizes via on-chain setPrizes() calls.',
   cronos: {


### PR DESCRIPTION
## Description

Adds a TVL adapter for **NeuroBeat** — the on-chain rhythm game by Neuro Island running on Cronos.

- **Protocol**: NeuroBeat (by Neuro Island)
- **Chain**: Cronos (EVM, chain ID 25)
- **Contract**: `0xDeb77dAf2A427fee514CE53143e407276BBf1F45` (NeuroBeatIsland.sol)
- **TVL methodology**: native CRO balance held in the game contract. Players pay a CRO entry fee; funds accumulate and are distributed as weekly on-chain prizes.
- **Tested locally**: yes — returns live TVL from Cronos blockchain

> Note: this is different from `projects/neuroisland` which tracks the NeuroIsland RewardVault staking contract. NeuroBeat is a separate game contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * NeuroBeat TVL tracking is now available on the Cronos network, providing real-time visibility into the protocol's total value locked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->