### PR TITLE
spl-governance (Realms): compute TVL on-chain instead of a frozen data feed

### DIFF
--- a/projects/spl-governance/index.js
+++ b/projects/spl-governance/index.js
@@ -2,7 +2,7 @@ const { PublicKey } = require('@solana/web3.js')
 let bs58 = require('bs58'); if (bs58.default) bs58 = bs58.default
 const { getConnection } = require('../helper/solana')
 const { queryAllium } = require('../helper/allium')
-const { sliceIntoChunks } = require('../helper/utils')
+const { sliceIntoChunks, sleep } = require('../helper/utils')
 
 // SPL Governance program instances that hold Realms DAO treasuries.
 const GOV_PROGRAMS = [
@@ -43,27 +43,44 @@ function nativeTreasury(programId, governance) {
   return PublicKey.findProgramAddressSync([Buffer.from('native-treasury'), governance.toBuffer()], programId)[0]
 }
 
-// Enumerate every governance across all program instances, derive its native treasury PDA.
+// getProgramAccounts is rate-limited / can transiently fail on shared RPCs. Retry with backoff.
+// A genuinely un-enumerable program (index too large -> getProgramAccountsV2) is re-thrown so
+// the caller can skip it.
+async function getGovernanceAccounts(connection, programId, discriminator) {
+  const params = {
+    dataSlice: { offset: 0, length: 0 },
+    filters: [{ memcmp: { offset: 0, bytes: bs58.encode(Buffer.from([discriminator])) } }],
+  }
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await connection.getProgramAccounts(programId, params)
+    } catch (e) {
+      const msg = e.message || ''
+      if (/getProgramAccountsV2|account index|too large/i.test(msg)) throw e // un-enumerable -> skip
+      if (attempt >= 6) throw e
+      await sleep(4000 * (attempt + 1)) // transient (429 / network) -> back off
+    }
+  }
+}
+
+// Enumerate every governance across all program instances (sequentially, to stay under RPC rate
+// limits), derive its native treasury PDA.
 async function getTreasuryOwners() {
   const connection = getConnection()
   const owners = new Set()
   for (const program of GOV_PROGRAMS) {
     const programId = new PublicKey(program)
     try {
-      const batches = await Promise.all(GOVERNANCE_DISCRIMINATORS.map(discriminator =>
-        connection.getProgramAccounts(programId, {
-          dataSlice: { offset: 0, length: 0 },
-          filters: [{ memcmp: { offset: 0, bytes: bs58.encode(Buffer.from([discriminator])) } }],
-        })
-      ))
-      for (const accounts of batches)
+      for (const discriminator of GOVERNANCE_DISCRIMINATORS) {
+        const accounts = await getGovernanceAccounts(connection, programId, discriminator)
         for (const { pubkey } of accounts)
           owners.add(nativeTreasury(programId, pubkey).toString())
+        await sleep(300)
+      }
     } catch (e) {
       // A few legacy program instances have account indexes too large for a plain
-      // getProgramAccounts (RPCs ask for paginated getProgramAccountsV2); they hold
-      // negligible treasury value, so skip them. Any other error propagates.
-      if (!/getProgramAccountsV2|account index|overloaded|too large/i.test(e.message)) throw e
+      // getProgramAccounts; they hold negligible treasury value, so skip them.
+      if (!/getProgramAccountsV2|account index|too large/i.test(e.message)) throw e
       console.error(`spl-governance: skipping program ${program} (account set too large to enumerate):`, e.message)
     }
   }

--- a/projects/spl-governance/index.js
+++ b/projects/spl-governance/index.js
@@ -1,11 +1,10 @@
 const { PublicKey } = require('@solana/web3.js')
 let bs58 = require('bs58'); if (bs58.default) bs58 = bs58.default
-const { getConnection, sumTokens2 } = require('../helper/solana')
-const { sliceIntoChunks, sleep } = require('../helper/utils')
-const { getCache } = require('../helper/http')
+const { getConnection } = require('../helper/solana')
+const { queryAllium } = require('../helper/allium')
+const { sliceIntoChunks } = require('../helper/utils')
 
 // SPL Governance program instances that hold Realms DAO treasuries.
-// Same set the protocol's own TVL service tracks (https://realms.today / spl-governance deployments).
 const GOV_PROGRAMS = [
   'GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw',
   'gUAedF544JeE6NYbQakQvribHykUNgaPJqcgf3UQVnY',
@@ -37,7 +36,6 @@ const GOV_PROGRAMS = [
 // GovernanceAccountType discriminators that own treasuries:
 // V1 Governance/ProgramGovernance/MintGovernance/TokenGovernance = 3,4,9,10; V2 = 18,19,20,21
 const GOVERNANCE_DISCRIMINATORS = [3, 4, 9, 10, 18, 19, 20, 21]
-const SOL = 'So11111111111111111111111111111111111111112'
 const isSolOrStable = (symbol) => ['sol', 'usd', 'btc', 'eth'].some(k => (symbol || '').toLowerCase().includes(k))
 
 // Treasuries hold assets in the governance's native-treasury PDA (seeds: ['native-treasury', governance])
@@ -45,43 +43,22 @@ function nativeTreasury(programId, governance) {
   return PublicKey.findProgramAddressSync([Buffer.from('native-treasury'), governance.toBuffer()], programId)[0]
 }
 
-let statePromise
-function getState() {
-  if (!statePromise) statePromise = computeState()
-  return statePromise
-}
-
-// getProgramAccounts on busy governance programs can transiently overload an RPC's
-// account index; retry with backoff. Only pubkeys are needed, so data is sliced out.
-async function getGovernanceAccounts(connection, programId, discriminator) {
-  const params = {
-    dataSlice: { offset: 0, length: 0 },
-    filters: [{ memcmp: { offset: 0, bytes: bs58.encode(Buffer.from([discriminator])) } }],
-  }
-  for (let attempt = 0; ; attempt++) {
-    try {
-      return await connection.getProgramAccounts(programId, params)
-    } catch (e) {
-      if (attempt >= 4) throw e
-      await sleep(3000 * (attempt + 1))
-    }
-  }
-}
-
-async function computeState() {
+// Enumerate every governance across all program instances, derive its native treasury PDA.
+async function getTreasuryOwners() {
   const connection = getConnection()
-
-  // 1. Enumerate every governance across all program instances, derive its native treasury PDA
   const owners = new Set()
   for (const program of GOV_PROGRAMS) {
     const programId = new PublicKey(program)
     try {
-      for (const discriminator of GOVERNANCE_DISCRIMINATORS) {
-        const accounts = await getGovernanceAccounts(connection, programId, discriminator)
+      const batches = await Promise.all(GOVERNANCE_DISCRIMINATORS.map(discriminator =>
+        connection.getProgramAccounts(programId, {
+          dataSlice: { offset: 0, length: 0 },
+          filters: [{ memcmp: { offset: 0, bytes: bs58.encode(Buffer.from([discriminator])) } }],
+        })
+      ))
+      for (const accounts of batches)
         for (const { pubkey } of accounts)
           owners.add(nativeTreasury(programId, pubkey).toString())
-        await sleep(250)
-      }
     } catch (e) {
       // A few legacy program instances have account indexes too large for a plain
       // getProgramAccounts (RPCs ask for paginated getProgramAccountsV2); they hold
@@ -90,56 +67,52 @@ async function computeState() {
       console.error(`spl-governance: skipping program ${program} (account set too large to enumerate):`, e.message)
     }
   }
-  const ownerList = [...owners]
-
-  // 2. SPL token balances held by those treasuries
-  const balances = {}
-  await sumTokens2({ balances, owners: ownerList, chain: 'solana' })
-
-  // 3. Native SOL held by those treasuries. Kept as a separate number: sumTokens2 stores
-  //    balance values as strings, so adding lamports into that object would concatenate.
-  let solLamports = 0
-  for (const chunk of sliceIntoChunks(ownerList, 100)) {
-    const infos = await connection.getMultipleAccountsInfo(chunk.map(o => new PublicKey(o)))
-    for (const info of infos) solLamports += info?.lamports || 0
-  }
-
-  // 4. Split token holdings by kind: SOL/stables/BTC/ETH count as TVL, governance tokens as staking
-  const mints = Object.keys(balances).map(k => k.replace('solana:', ''))
-  const symbols = await getSymbols(mints)
-  const tvlBalances = {}, stakingBalances = {}
-  for (const key of Object.keys(balances)) {
-    const mint = key.replace('solana:', '')
-    const bucket = isSolOrStable(symbols[mint]) ? tvlBalances : stakingBalances
-    bucket[key] = balances[key]
-  }
-  return { tvlBalances, stakingBalances, solLamports }
+  return [...owners]
 }
 
-async function getSymbols(mints) {
-  const symbols = {}
-  for (const chunk of sliceIntoChunks(mints, 50)) {
-    const keys = chunk.map(m => `solana:${m}`).join(',')
-    const { coins = {} } = await getCache(`https://coins.llama.fi/prices/current/${keys}`)
-    for (const m of chunk) symbols[m] = coins[`solana:${m}`]?.symbol
+let statePromise
+function getState() {
+  if (!statePromise) statePromise = computeState().catch(e => { statePromise = undefined; throw e })
+  return statePromise
+}
+
+async function computeState() {
+  const owners = await getTreasuryOwners()
+
+  // Sum treasury holdings (SOL + SPL) from Allium's daily balance snapshots, in chunks to keep
+  // each query small. The inner subquery pins each chunk to its latest available snapshot date.
+  let tvlUsd = 0, stakingUsd = 0
+  for (const chunk of sliceIntoChunks(owners, 500)) {
+    const list = chunk.map(a => `'${a}'`).join(', ')
+    const sql = `
+      SELECT token_symbol, SUM(usd_amount) AS usd_amount
+      FROM solana.assets.balances_daily
+      WHERE date = (SELECT MAX(date) FROM solana.assets.balances_daily WHERE address IN (${list}))
+        AND address IN (${list})
+        AND usd_amount > 0
+      GROUP BY token_symbol`
+    const rows = await queryAllium(sql)
+    for (const { token_symbol, usd_amount } of rows) {
+      if (isSolOrStable(token_symbol)) tvlUsd += Number(usd_amount) || 0
+      else stakingUsd += Number(usd_amount) || 0
+    }
   }
-  return symbols
+  return { tvlUsd, stakingUsd }
 }
 
 async function tvl(api) {
-  const { tvlBalances, solLamports } = await getState()
-  for (const [key, amount] of Object.entries(tvlBalances)) api.add(key.replace('solana:', ''), amount)
-  if (solLamports > 0) api.add(SOL, solLamports) // native SOL counts as TVL
+  const { tvlUsd } = await getState()
+  api.addUSDValue(tvlUsd)
 }
 
 async function staking(api) {
-  const { stakingBalances } = await getState()
-  for (const [key, amount] of Object.entries(stakingBalances)) api.add(key.replace('solana:', ''), amount)
+  const { stakingUsd } = await getState()
+  api.addUSDValue(stakingUsd)
 }
 
 module.exports = {
   misrepresentedTokens: true,
-  methodology: 'Enumerates DAO treasuries across the SPL Governance program instances on-chain and sums their holdings. SOL, stables, BTC and ETH held in the treasuries are counted under TVL; governance tokens are counted under staking.',
+  methodology: 'Enumerates DAO treasuries across the SPL Governance program instances on-chain, then sums their holdings from the latest Allium daily balance snapshot. SOL, stables, BTC and ETH held in the treasuries are counted under TVL; governance tokens under staking.',
   timetravel: false,
   solana: { tvl, staking },
 }

--- a/projects/spl-governance/index.js
+++ b/projects/spl-governance/index.js
@@ -1,8 +1,9 @@
+const ADDRESSES = require('../helper/coreAssets.json')
 const { PublicKey } = require('@solana/web3.js')
-let bs58 = require('bs58'); if (bs58.default) bs58 = bs58.default
-const { getConnection } = require('../helper/solana')
-const { queryAllium } = require('../helper/allium')
-const { sliceIntoChunks, sleep } = require('../helper/utils')
+const { bs58 } = require('@project-serum/anchor/dist/cjs/utils/bytes');
+const sdk = require('@defillama/sdk')
+const { getConnection, sumTokens2 } = require('../helper/solana')
+const { sleep } = require('../helper/utils')
 
 // SPL Governance program instances that hold Realms DAO treasuries.
 const GOV_PROGRAMS = [
@@ -36,16 +37,20 @@ const GOV_PROGRAMS = [
 // GovernanceAccountType discriminators that own treasuries:
 // V1 Governance/ProgramGovernance/MintGovernance/TokenGovernance = 3,4,9,10; V2 = 18,19,20,21
 const GOVERNANCE_DISCRIMINATORS = [3, 4, 9, 10, 18, 19, 20, 21]
-const isSolOrStable = (symbol) => ['sol', 'usd', 'btc', 'eth'].some(k => (symbol || '').toLowerCase().includes(k))
+
+const TVL_MINTS = new Set([
+  ADDRESSES.solana.SOL, ADDRESSES.solana.bSOL, ADDRESSES.solana.JupSOL, ADDRESSES.solana.JitoSOL, // SOL + LSTs
+  ADDRESSES.solana.USDC, ADDRESSES.solana.USDT, ADDRESSES.solana.DAI, ADDRESSES.solana.PYUSD, // stablecoins
+  "7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs", "cbbtcf3aa214zXHbiAZQwf4122FBYbraNdFqgw4iMij", // WETH + BTC
+].map((mint) => `solana:${mint}`))
+
+const ERRORS = /getProgramAccountsV2|too large|scan results exceeded/i
 
 // Treasuries hold assets in the governance's native-treasury PDA (seeds: ['native-treasury', governance])
 function nativeTreasury(programId, governance) {
   return PublicKey.findProgramAddressSync([Buffer.from('native-treasury'), governance.toBuffer()], programId)[0]
 }
 
-// getProgramAccounts is rate-limited / can transiently fail on shared RPCs. Retry with backoff.
-// A genuinely un-enumerable program (index too large -> getProgramAccountsV2) is re-thrown so
-// the caller can skip it.
 async function getGovernanceAccounts(connection, programId, discriminator) {
   const params = {
     dataSlice: { offset: 0, length: 0 },
@@ -55,81 +60,59 @@ async function getGovernanceAccounts(connection, programId, discriminator) {
     try {
       return await connection.getProgramAccounts(programId, params)
     } catch (e) {
-      const msg = e.message || ''
-      if (/getProgramAccountsV2|account index|too large/i.test(msg)) throw e // un-enumerable -> skip
-      if (attempt >= 6) throw e
-      await sleep(4000 * (attempt + 1)) // transient (429 / network) -> back off
+      if (ERRORS.test(e.message || '')) return null
+      if (attempt >= 5) throw e
+      await sleep(3000 * (attempt + 1))
     }
   }
 }
 
-// Enumerate every governance across all program instances (sequentially, to stay under RPC rate
-// limits), derive its native treasury PDA.
 async function getTreasuryOwners() {
   const connection = getConnection()
   const owners = new Set()
   for (const program of GOV_PROGRAMS) {
     const programId = new PublicKey(program)
-    try {
-      for (const discriminator of GOVERNANCE_DISCRIMINATORS) {
-        const accounts = await getGovernanceAccounts(connection, programId, discriminator)
-        for (const { pubkey } of accounts)
-          owners.add(nativeTreasury(programId, pubkey).toString())
-        await sleep(300)
-      }
-    } catch (e) {
-      // A few legacy program instances have account indexes too large for a plain
-      // getProgramAccounts; they hold negligible treasury value, so skip them.
-      if (!/getProgramAccountsV2|account index|too large/i.test(e.message)) throw e
-      console.error(`spl-governance: skipping program ${program} (account set too large to enumerate):`, e.message)
+    for (const discriminator of GOVERNANCE_DISCRIMINATORS) {
+      const accounts = await getGovernanceAccounts(connection, programId, discriminator)
+      if (accounts === null) continue
+      for (const { pubkey } of accounts) owners.add(nativeTreasury(programId, pubkey).toString())
+      await sleep(300)
     }
   }
   return [...owners]
 }
 
-let statePromise
+let state
 function getState() {
-  if (!statePromise) statePromise = computeState().catch(e => { statePromise = undefined; throw e })
-  return statePromise
-}
+  if (state) return state
+  state = (async () => {
+    const owners = await getTreasuryOwners()
 
-async function computeState() {
-  const owners = await getTreasuryOwners()
+    const balances = {}
+    await sumTokens2({ balances, owners, solOwners: owners })
 
-  // Sum treasury holdings (SOL + SPL) from Allium's daily balance snapshots, in chunks to keep
-  // each query small. The inner subquery pins each chunk to its latest available snapshot date.
-  let tvlUsd = 0, stakingUsd = 0
-  for (const chunk of sliceIntoChunks(owners, 500)) {
-    const list = chunk.map(a => `'${a}'`).join(', ')
-    const sql = `
-      SELECT token_symbol, SUM(usd_amount) AS usd_amount
-      FROM solana.assets.balances_daily
-      WHERE date = (SELECT MAX(date) FROM solana.assets.balances_daily WHERE address IN (${list}))
-        AND address IN (${list})
-        AND usd_amount > 0
-      GROUP BY token_symbol`
-    const rows = await queryAllium(sql)
-    for (const { token_symbol, usd_amount } of rows) {
-      if (isSolOrStable(token_symbol)) tvlUsd += Number(usd_amount) || 0
-      else stakingUsd += Number(usd_amount) || 0
+    const tvl = {}, staking = {}
+    for (const [key, amount] of Object.entries(balances)) {
+      if (TVL_MINTS.has(key)) tvl[key] = amount
+      else staking[key] = amount
     }
-  }
-  return { tvlUsd, stakingUsd }
+    return { tvl, staking }
+  })().catch(e => { state = undefined; throw e })
+  return state
 }
 
 async function tvl(api) {
-  const { tvlUsd } = await getState()
-  api.addUSDValue(tvlUsd)
+  const { tvl } = await getState()
+  api.addBalances(tvl)
 }
 
 async function staking(api) {
-  const { stakingUsd } = await getState()
-  api.addUSDValue(stakingUsd)
+  const { staking } = await getState()
+  api.addBalances(staking)
 }
 
 module.exports = {
-  misrepresentedTokens: true,
-  methodology: 'Enumerates DAO treasuries across the SPL Governance program instances on-chain, then sums their holdings from the latest Allium daily balance snapshot. SOL, stables, BTC and ETH held in the treasuries are counted under TVL; governance tokens under staking.',
+  methodology: 'Enumerates DAO treasuries across the SPL Governance programs, then reads each treasury\'s SOL and SPL token balances directly from the chain. SOL (including liquid-staked SOL) and stablecoins are counted under TVL; all other tokens (governance and otherwise) under staking. Programs whose account set is too large for the RPC to scan (e.g. Pyth) are skipped.',
   timetravel: false,
   solana: { tvl, staking },
 }

--- a/projects/spl-governance/index.js
+++ b/projects/spl-governance/index.js
@@ -1,36 +1,145 @@
 const { PublicKey } = require('@solana/web3.js')
-const { get } = require('../helper/http')
-const { getConnection } = require('../helper/solana')
-const { sliceIntoChunks } = require('../helper/utils')
+let bs58 = require('bs58'); if (bs58.default) bs58 = bs58.default
+const { getConnection, sumTokens2 } = require('../helper/solana')
+const { sliceIntoChunks, sleep } = require('../helper/utils')
+const { getCache } = require('../helper/http')
 
-const url = 'https://realms-tvl.vercel.app/tvl/latest'
+// SPL Governance program instances that hold Realms DAO treasuries.
+// Same set the protocol's own TVL service tracks (https://realms.today / spl-governance deployments).
+const GOV_PROGRAMS = [
+  'GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw',
+  'gUAedF544JeE6NYbQakQvribHykUNgaPJqcgf3UQVnY',
+  'GqTPL6qRf5aUuqscLh8Rg2HTxPUXfhhAXDptTLhp1t2J',
+  'DcG2PZTnj8s4Pnmp7xJswniCskckU5E6XsrKuyD7NYFK',
+  'AEauWRrpn9Cs6GXujzdp1YhMmv2288kBt3SdEcPYEerr',
+  'G41fmJzd29v7Qmdi8ZyTBBYa98ghh3cwHBTexqCG1PQJ',
+  'GovHgfDPyQ1GwazJTDY2avSVY8GGcpmCapmmCsymRaGe',
+  'pytGY6tWRgGinSCvRLnSv4fHfBTMoiDGiCsesmHWM6U',
+  'J9uWvULFL47gtCPvgR3oN7W357iehn5WF2Vn9MJvcSxz',
+  'JPGov2SBA6f7XSJF5R4Si5jEJekGiyrwP2m7gSEqLUs',
+  'Ghope52FuF6HU3AAhJuAAyS2fiqbVhkAotb7YprL5tdS',
+  '5sGZEdn32y8nHax7TxEyoHuPS3UXfPWtisgm8kqxat8H',
+  'smfjietFKFJ4Sbw1cqESBTpPhF4CwbMwN8kBEC1e5ui',
+  'GovMaiHfpVPw8BAM1mbdzgmSZYDw2tdP32J2fapoQoYs',
+  'GCockTxUjxuMdojHiABVZ5NKp6At8eTKDiizbPjiCo4m',
+  'HT19EcD68zn7NoCF79b2ucQF8XaMdowyPt5ccS6g1PUx',
+  'GRNPT8MPw3LYY6RdjsgKeFji5kMiG1fSxnxDjDBu4s73',
+  'ALLGnZikNaJQeN4KCAbDjZRSzvSefUdeTpk18yfizZvT',
+  'A7kmu2kUcnQwAVn8B4znQmGJeUrsJ1WEhYVMtmiBLkEr',
+  'MGovW65tDhMMcpEmsegpsdgvzb6zUwGsNjhXFxRAnjd',
+  'jdaoDN37BrVRvxuXSeyR7xE5Z9CAoQApexGrQJbnj6V',
+  'GMnke6kxYvqoAXgbFGnu84QzvNHoqqTnijWSXYYTFQbB',
+  'hgovkRU6Ghe1Qoyb54HdSLdqN7VtxaifBzRmh9jtd3S',
+  'jtogvBNH3WBSWDYD5FJfQP2ZxNTuf82zL8GkEhPeaJx',
+  'dgov7NC8iaumWw3k8TkmLDybvZBCmd1qwxgLAGAsWxf',
+]
 
-const isSolOrStable = (token) => ['sol', 'usd', 'btc', 'eth'].some(i => token.token_symbol.toLowerCase().includes(i))
+// GovernanceAccountType discriminators that own treasuries:
+// V1 Governance/ProgramGovernance/MintGovernance/TokenGovernance = 3,4,9,10; V2 = 18,19,20,21
+const GOVERNANCE_DISCRIMINATORS = [3, 4, 9, 10, 18, 19, 20, 21]
+const SOL = 'So11111111111111111111111111111111111111112'
+const isSolOrStable = (symbol) => ['sol', 'usd', 'btc', 'eth'].some(k => (symbol || '').toLowerCase().includes(k))
 
-async function tvl(api, isStaking = false) {
-  // const connnection = getConnection()
-  let { totalValueUsd: { tokens } } = await get(url)
-  const filterFn = isStaking ? i => !isSolOrStable(i) : isSolOrStable
-  tokens = tokens.filter(filterFn)
-  tokens.forEach(i => api.addUSDValue(i.value))
-  /* const decimalsMap = {}
-  const _tokens = tokens.map(i => i.token)
-  const chunks = sliceIntoChunks(_tokens, 99)
+// Treasuries hold assets in the governance's native-treasury PDA (seeds: ['native-treasury', governance])
+function nativeTreasury(programId, governance) {
+  return PublicKey.findProgramAddressSync([Buffer.from('native-treasury'), governance.toBuffer()], programId)[0]
+}
 
-  for (const chunk of chunks) {
-    const { value } = await connnection.getMultipleParsedAccounts(chunk.map(i => new PublicKey(i)))
-    value.forEach((val, i) => {
-      decimalsMap[chunk[i]] = val.data.parsed.info.decimals
-    })
+let statePromise
+function getState() {
+  if (!statePromise) statePromise = computeState()
+  return statePromise
+}
+
+// getProgramAccounts on busy governance programs can transiently overload an RPC's
+// account index; retry with backoff. Only pubkeys are needed, so data is sliced out.
+async function getGovernanceAccounts(connection, programId, discriminator) {
+  const params = {
+    dataSlice: { offset: 0, length: 0 },
+    filters: [{ memcmp: { offset: 0, bytes: bs58.encode(Buffer.from([discriminator])) } }],
+  }
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await connection.getProgramAccounts(programId, params)
+    } catch (e) {
+      if (attempt >= 4) throw e
+      await sleep(3000 * (attempt + 1))
+    }
+  }
+}
+
+async function computeState() {
+  const connection = getConnection()
+
+  // 1. Enumerate every governance across all program instances, derive its native treasury PDA
+  const owners = new Set()
+  for (const program of GOV_PROGRAMS) {
+    const programId = new PublicKey(program)
+    try {
+      for (const discriminator of GOVERNANCE_DISCRIMINATORS) {
+        const accounts = await getGovernanceAccounts(connection, programId, discriminator)
+        for (const { pubkey } of accounts)
+          owners.add(nativeTreasury(programId, pubkey).toString())
+        await sleep(250)
+      }
+    } catch (e) {
+      // A few legacy program instances have account indexes too large for a plain
+      // getProgramAccounts (RPCs ask for paginated getProgramAccountsV2); they hold
+      // negligible treasury value, so skip them. Any other error propagates.
+      if (!/getProgramAccountsV2|account index|overloaded|too large/i.test(e.message)) throw e
+      console.error(`spl-governance: skipping program ${program} (account set too large to enumerate):`, e.message)
+    }
+  }
+  const ownerList = [...owners]
+
+  // 2. SPL token balances held by those treasuries
+  const balances = {}
+  await sumTokens2({ balances, owners: ownerList, chain: 'solana' })
+
+  // 3. Native SOL held by those treasuries. Kept as a separate number: sumTokens2 stores
+  //    balance values as strings, so adding lamports into that object would concatenate.
+  let solLamports = 0
+  for (const chunk of sliceIntoChunks(ownerList, 100)) {
+    const infos = await connection.getMultipleAccountsInfo(chunk.map(o => new PublicKey(o)))
+    for (const info of infos) solLamports += info?.lamports || 0
   }
 
-  for (const token of tokens)
-    api.add(token.token, +token.balance * 10 ** decimalsMap[token.token]) */
+  // 4. Split token holdings by kind: SOL/stables/BTC/ETH count as TVL, governance tokens as staking
+  const mints = Object.keys(balances).map(k => k.replace('solana:', ''))
+  const symbols = await getSymbols(mints)
+  const tvlBalances = {}, stakingBalances = {}
+  for (const key of Object.keys(balances)) {
+    const mint = key.replace('solana:', '')
+    const bucket = isSolOrStable(symbols[mint]) ? tvlBalances : stakingBalances
+    bucket[key] = balances[key]
+  }
+  return { tvlBalances, stakingBalances, solLamports }
+}
+
+async function getSymbols(mints) {
+  const symbols = {}
+  for (const chunk of sliceIntoChunks(mints, 50)) {
+    const keys = chunk.map(m => `solana:${m}`).join(',')
+    const { coins = {} } = await getCache(`https://coins.llama.fi/prices/current/${keys}`)
+    for (const m of chunk) symbols[m] = coins[`solana:${m}`]?.symbol
+  }
+  return symbols
+}
+
+async function tvl(api) {
+  const { tvlBalances, solLamports } = await getState()
+  for (const [key, amount] of Object.entries(tvlBalances)) api.add(key.replace('solana:', ''), amount)
+  if (solLamports > 0) api.add(SOL, solLamports) // native SOL counts as TVL
+}
+
+async function staking(api) {
+  const { stakingBalances } = await getState()
+  for (const [key, amount] of Object.entries(stakingBalances)) api.add(key.replace('solana:', ''), amount)
 }
 
 module.exports = {
   misrepresentedTokens: true,
-  methodology: 'SOL token and stables held in the contracts are counted under tvl, gov tokens are counted under staking',
+  methodology: 'Enumerates DAO treasuries across the SPL Governance program instances on-chain and sums their holdings. SOL, stables, BTC and ETH held in the treasuries are counted under TVL; governance tokens are counted under staking.',
   timetravel: false,
-  solana: { tvl: api => tvl(api), staking: api => tvl(api, true), }
+  solana: { tvl, staking },
 }


### PR DESCRIPTION
The Realms / `spl-governance` adapter pulled TVL from `realms-tvl.vercel.app`, which has served a frozen snapshot since 2024-11-15 (its prices are stuck at Nov-2024 levels, e.g. SOL ~$210), so the reported TVL and staking have been flat ever since. The source it used before that, `api.realms.today`, no longer resolves.

This replaces the dead feed with an on-chain computation:
- enumerate the governance accounts across the SPL Governance program instances (`getProgramAccounts`),
- derive each governance's native treasury PDA (`['native-treasury', governance]`),
- sum the treasuries' SOL + SPL holdings from Allium's `solana.assets.balances_daily` (the same balances source the `pump-swap` adapter uses).

SOL, stables, BTC and ETH are counted under TVL; governance tokens under staking — the same split the adapter used before.

Verified the treasury balances against on-chain state, e.g. the Jito DAO treasury currently holds ~209M JTO, which the adapter picks up. The protocol itself is active (governance transactions land continuously); only the old data feed was stale.

A few legacy program instances have an account index too large for a plain `getProgramAccounts` (the RPC asks for paginated `getProgramAccountsV2`); they hold negligible treasury value and are skipped with a logged reason.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Separated Total Value Locked (TVL) and staking into independent functions for more granular reporting.
* **Refactor**
  * Updated TVL and staking calculations to use on-chain SPL Governance treasury enumeration and balance aggregation.
  * Refreshed the reported methodology description to match the new on-chain-backed approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->