### PR TITLE
fix(snowbl-capital): migrate TVL to new vaults

### DIFF
--- a/registries/erc4626.js
+++ b/registries/erc4626.js
@@ -43,7 +43,11 @@ const configs = {
     ethereum: ['0x8DB2350D78aBc13f5673A411D4700BCF87864dDE'],
   },
   'snowbl-capital': {
-    base: ['0xd61bfc9ca1d0d2b03a3dd74e2ab81df8e5f606e8'],
+    base: [
+      '0x0e1a8354e10057092ecb7218b784c0c21710db91', // sUSD
+      '0xffa67bd20e656f1c7873525df81728e9d26c8ee2', // sETH
+      '0xf423393e84ca810e1955a7806d1cd84d18099809', // sBTC
+    ],
   },
   'return-finance': {
     doublecounted: true,


### PR DESCRIPTION
Snowbl Capital migrated its on-chain contracts. The previous single vault `sSnowbl` (`0xd61b…06e8`) is retired.

This updates the `snowbl-capital` entry in `registries/erc4626.js` to track the three new Base ERC-4626 vaults:

| Vault | Address | Underlying |
|-------|---------|------------|
| sUSD  | `0x0e1a8354e10057092ecb7218b784c0c21710db91` | USDC |
| sETH  | `0xffa67bd20e656f1c7873525df81728e9d26c8ee2` | WETH |
| sBTC  | `0xf423393e84ca810e1955a7806d1cd84d18099809` | cbBTC |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated the vault registry configuration to replace the previous single base vault with three supported base vaults: sUSD, sETH, and sBTC—expanding available vault options and improving asset compatibility across the ecosystem.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->