### PR TITLE
Add Nad.fun V2 TVL

### DIFF
--- a/projects/nadfun/index.js
+++ b/projects/nadfun/index.js
@@ -1,9 +1,23 @@
 const ADDRESSES = require('../helper/coreAssets.json')
 const { sumTokensExport } = require('../helper/unwrapLPs')
 
+const WMON = ADDRESSES.monad.WMON
+const LVMON = '0x91b81bfbe3A747230F0529Aa28d8b2Bc898E6D56'
+
+const V1_BONDING_CURVE = '0xA7283d07812a02AFB7C09B60f8896bCEA3F90aCE'
+const V2_BONDING_CURVE = '0x9f3832732923252A21044F21eE6bd87F09514ae4'
+
+const tokensAndOwners = [
+  [WMON, V1_BONDING_CURVE],
+  [WMON, V2_BONDING_CURVE],
+  [LVMON, V2_BONDING_CURVE],
+]
+
 module.exports = {
-  methodology: 'Value of monad tokens in the bonding curve',
+  methodology: 'Value of WMON and LVMON held in the Nad.fun bonding curve contracts',
   monad: {
-    tvl: sumTokensExport({ owner: '0xA7283d07812a02AFB7C09B60f8896bCEA3F90aCE', tokens: [ADDRESSES.monad.WMON]}),
+    tvl: sumTokensExport({
+      tokensAndOwners,
+    }),
   },
 }


### PR DESCRIPTION
Updates the Nad.fun TVL adapter to include V2 bonding curve balances.\n\nTVL now counts:\n- V1 BondingCurve WMON\n- V2 BondingCurve WMON\n- V2 BondingCurve LVMON\n\nTested with:\n\n```bash\nnode test.js projects/nadfun/index.js\n```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced TVL calculation for Nad.fun to accurately track both WMON and LVMON token values across bonding curve contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->