### PR TITLE
lagoon: dedupe vaults present in both static list and factory logs

### DIFF
--- a/projects/lagoon/index.js
+++ b/projects/lagoon/index.js
@@ -215,9 +215,12 @@ Object.keys(config).forEach((chain) => {
         beaconFactoryVaults = beaconFactoryVaults.filter((v) => keepVault(v, vaultsBlacklist));
         optinProxyFactoryVaults = optinProxyFactoryVaults.filter((v) => keepVault(v, vaultsBlacklist));
   
-        return await api.erc4626Sum2({
-          calls: [...vaults, ...beaconFactoryVaults, ...optinProxyFactoryVaults],
-        })
+        // A vault can appear both in the static `vaults` list and in the factory
+        // deploy logs (when it was deployed at/after the factory fromBlock). erc4626Sum2
+        // does not de-duplicate its calls, so such a vault would be counted twice;
+        // de-duplicate the merged list before summing.
+        const calls = [...new Set([...vaults, ...beaconFactoryVaults, ...optinProxyFactoryVaults].map((v) => v.toLowerCase()))]
+        return await api.erc4626Sum2({ calls })
       }
     }
   }}


### PR DESCRIPTION
The lagoon TVL adapter merges a static `vaults` list with vaults discovered from the beacon/optin proxy factory deploy logs:

```js
calls: [...vaults, ...beaconFactoryVaults, ...optinProxyFactoryVaults]
```

`erc4626Sum2` does not de-duplicate its `calls`, so a vault that appears in both the static list and the factory logs has its `totalAssets` summed twice. This happens when a statically-listed vault was deployed at/after the factory `fromBlock`, so the deploy-log scan rediscovers it.

On Ethereum two statically-listed vaults are emitted by the beaconFactory at a block at/after its `fromBlock` (22218451) and so are counted twice:

- `0x7895a046b26cc07272b022a0c9bafc046e6f6396` (Noon tacUSN), deployed in block 22253107
- `0xaf87b90e8a3035905697e07bb813d2d59d2b0951` (Usual Invested USD0++ in TAC), deployed in block 22352344

Both of these vaults are empty at the moment, so the current TVL impact is $0, but the duplication would inflate TVL as soon as they hold assets. The other statically-listed vaults (the rest on Ethereum, and all of those on Base and Arbitrum) were either deployed before their factory `fromBlock` or are not emitted by the tracked factories, so they are correctly counted once and are unaffected.

Fix: de-duplicate the merged vault list (case-insensitively, matching the existing `keepVault` comparison) before passing it to `erc4626Sum2`.

Verification: for each static vault I located its on-chain creation block and checked whether the factory emitted its deploy event at/after `fromBlock`; only the two vaults above qualify. `node test.js projects/lagoon/index.js` runs all chains and the totals are unchanged within rounding.
