### PR TITLE
Add Lightspeed TVL adapter

### DIFF
--- a/projects/lightspeed/index.js
+++ b/projects/lightspeed/index.js
@@ -1,0 +1,35 @@
+const { get } = require('../helper/http')
+
+const FEATURED_APP_LOCKING_URL = 'https://lighthouse.cantonloop.com/api/featured-app-locking'
+const TEMPLE_APP_NAMES = new Set(['Temple Trading', 'Temple Trading Expansion'])
+
+async function tvl(api) {
+  const { apps } = await get(FEATURED_APP_LOCKING_URL)
+  const templeApps = apps.filter(({ app_name, institution }) =>
+    institution === 'Temple' && TEMPLE_APP_NAMES.has(app_name)
+  )
+
+  if (!templeApps.length) throw new Error('No Temple featured-app locking rows found')
+
+  const balancesByWallet = {}
+  for (const app of templeApps) {
+    for (const wallet of app.locking_wallets || []) {
+      if (!wallet.indexed) continue
+      balancesByWallet[wallet.address] = wallet.total_balance
+    }
+  }
+
+  const balances = Object.values(balancesByWallet)
+  if (!balances.length) throw new Error('No indexed Temple locking wallets found')
+
+  for (const balance of balances) {
+    api.addGasToken(Number(balance) * 1e18)
+  }
+}
+
+module.exports = {
+  timetravel: false,
+  canton: { tvl },
+  methodology:
+    "TVL is the deduplicated CC balance in Temple's indexed CIP-0116 featured-app locking wallet for Temple Trading/Lightspeed, sourced from Lighthouse's public Canton explorer API.",
+}

--- a/projects/lightspeed/index.js
+++ b/projects/lightspeed/index.js
@@ -2,6 +2,10 @@ const { get } = require('../helper/http')
 
 const EXCHANGE_API = 'https://api.templedigitalgroup.com/api/exchange'
 const ORDERBOOK_DEPTH = 10000
+const CONCURRENCY_LIMIT = 10
+const DECIMALS = 12
+const SCALE = 10n ** 12n
+const GAS_TOKEN_SCALE = 10n ** 18n
 
 const CG_TOKENS = {
   CBTC: 'bitcoin',
@@ -9,31 +13,76 @@ const CG_TOKENS = {
   USDCx: 'usd-coin',
 }
 
+function parseFixed(value) {
+  const normalized = String(value)
+  const sign = normalized.startsWith('-') ? -1n : 1n
+  const [whole, fraction = ''] = normalized.replace(/^-/, '').split('.')
+  const wholeValue = BigInt(whole || 0)
+  const fractionValue = BigInt(fraction.padEnd(DECIMALS, '0').slice(0, DECIMALS) || 0)
+
+  return sign * (wholeValue * SCALE + fractionValue)
+}
+
+function multiplyFixed(a, b) {
+  return (a * b) / SCALE
+}
+
+function toNumber(amount) {
+  return Number(amount) / Number(SCALE)
+}
+
+function toGasTokenAmount(amount) {
+  return ((amount * GAS_TOKEN_SCALE) / SCALE).toString()
+}
+
 function addAsset(api, asset, amount) {
-  if (!amount) return
-  if (asset === 'CC') return api.addGasToken(amount * 1e18)
-  if (!CG_TOKENS[asset]) throw new Error(`Missing pricing mapping for ${asset}`)
-  api.addCGToken(CG_TOKENS[asset], amount)
+  if (amount <= 0n) return
+  if (asset === 'CC') return api.addGasToken(toGasTokenAmount(amount))
+
+  const cgToken = CG_TOKENS[asset]
+  if (!cgToken) {
+    api.log?.(`Skipping unmapped Lightspeed asset ${asset}`)
+    return
+  }
+
+  api.addCGToken(cgToken, toNumber(amount))
 }
 
 function addAmount(amounts, asset, amount) {
-  if (!Number.isFinite(amount) || amount <= 0) return
-  amounts[asset] = (amounts[asset] || 0) + amount
+  if (amount <= 0n) return
+  amounts[asset] = (amounts[asset] || 0n) + amount
+}
+
+async function fetchOrderbooks(tickers) {
+  const orderbooks = []
+
+  for (let index = 0; index < tickers.length; index += CONCURRENCY_LIMIT) {
+    const chunk = tickers.slice(index, index + CONCURRENCY_LIMIT)
+    const chunkOrderbooks = await Promise.all(
+      chunk.map(async (ticker) => ({
+        ticker,
+        orderbook: await get(`${EXCHANGE_API}/orderbook?ticker_id=${encodeURIComponent(ticker.ticker_id)}&depth=${ORDERBOOK_DEPTH}`),
+      }))
+    )
+
+    orderbooks.push(...chunkOrderbooks)
+  }
+
+  return orderbooks
 }
 
 async function tvl(api) {
   const tickers = await get(`${EXCHANGE_API}/tickers`)
   const amounts = {}
+  const orderbooks = await fetchOrderbooks(tickers)
 
-  for (const ticker of tickers) {
-    const orderbook = await get(`${EXCHANGE_API}/orderbook?ticker_id=${ticker.ticker_id}&depth=${ORDERBOOK_DEPTH}`)
-
+  for (const { ticker, orderbook } of orderbooks) {
     for (const [price, quantity] of orderbook.bids || []) {
-      addAmount(amounts, ticker.target_currency, Number(price) * Number(quantity))
+      addAmount(amounts, ticker.target_currency, multiplyFixed(parseFixed(price), parseFixed(quantity)))
     }
 
     for (const [, quantity] of orderbook.asks || []) {
-      addAmount(amounts, ticker.base_currency, Number(quantity))
+      addAmount(amounts, ticker.base_currency, parseFixed(quantity))
     }
   }
 

--- a/projects/lightspeed/index.js
+++ b/projects/lightspeed/index.js
@@ -1,35 +1,48 @@
 const { get } = require('../helper/http')
 
-const FEATURED_APP_LOCKING_URL = 'https://lighthouse.cantonloop.com/api/featured-app-locking'
-const TEMPLE_APP_NAMES = new Set(['Temple Trading', 'Temple Trading Expansion'])
+const EXCHANGE_API = 'https://api.templedigitalgroup.com/api/exchange'
+const ORDERBOOK_DEPTH = 10000
+
+const CG_TOKENS = {
+  CBTC: 'bitcoin',
+  USDA: 'usd-coin',
+  USDCx: 'usd-coin',
+}
+
+function addAsset(api, asset, amount) {
+  if (!amount) return
+  if (asset === 'CC') return api.addGasToken(amount * 1e18)
+  if (!CG_TOKENS[asset]) throw new Error(`Missing pricing mapping for ${asset}`)
+  api.addCGToken(CG_TOKENS[asset], amount)
+}
+
+function addAmount(amounts, asset, amount) {
+  if (!Number.isFinite(amount) || amount <= 0) return
+  amounts[asset] = (amounts[asset] || 0) + amount
+}
 
 async function tvl(api) {
-  const { apps } = await get(FEATURED_APP_LOCKING_URL)
-  const templeApps = apps.filter(({ app_name, institution }) =>
-    institution === 'Temple' && TEMPLE_APP_NAMES.has(app_name)
-  )
+  const tickers = await get(`${EXCHANGE_API}/tickers`)
+  const amounts = {}
 
-  if (!templeApps.length) throw new Error('No Temple featured-app locking rows found')
+  for (const ticker of tickers) {
+    const orderbook = await get(`${EXCHANGE_API}/orderbook?ticker_id=${ticker.ticker_id}&depth=${ORDERBOOK_DEPTH}`)
 
-  const balancesByWallet = {}
-  for (const app of templeApps) {
-    for (const wallet of app.locking_wallets || []) {
-      if (!wallet.indexed) continue
-      balancesByWallet[wallet.address] = wallet.total_balance
+    for (const [price, quantity] of orderbook.bids || []) {
+      addAmount(amounts, ticker.target_currency, Number(price) * Number(quantity))
+    }
+
+    for (const [, quantity] of orderbook.asks || []) {
+      addAmount(amounts, ticker.base_currency, Number(quantity))
     }
   }
 
-  const balances = Object.values(balancesByWallet)
-  if (!balances.length) throw new Error('No indexed Temple locking wallets found')
-
-  for (const balance of balances) {
-    api.addGasToken(Number(balance) * 1e18)
-  }
+  Object.entries(amounts).forEach(([asset, amount]) => addAsset(api, asset, amount))
 }
 
 module.exports = {
   timetravel: false,
   canton: { tvl },
   methodology:
-    "TVL is the deduplicated CC balance in Temple's indexed CIP-0116 featured-app locking wallet for Temple Trading/Lightspeed, sourced from Lighthouse's public Canton explorer API.",
+    "TVL is the current resting liquidity on Lightspeed's public spot orderbooks. Bid-side liquidity is counted as quote assets, ask-side liquidity is counted as base assets, and all listed Lightspeed markets are fetched from Temple's public exchange-listing API.",
 }


### PR DESCRIPTION
## Summary

Adds a DeFiLlama TVL adapter for Lightspeed, Temple's spot orderbook on Canton.

## New listing details

##### Name (to be shown on DefiLlama):

Lightspeed

##### Twitter Link:

https://x.com/temple_ny

##### List of audit links if any:

N/A

##### Website Link:

https://templedigitalgroup.com/

##### Logo (High resolution, will be shown with rounded borders):

https://templedigitalgroup.com/

##### Current TVL:

~2.87M USD at latest local test run

##### Treasury Addresses (if the protocol has treasury)

N/A

##### Chain:

Canton

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):


##### Short Description (to be shown on DefiLlama):

Lightspeed is Temple's private, compliant spot orderbook for institutional markets on the Canton Network.

##### Token address and ticker if any:

No protocol token. Current listed orderbook assets include CC, CBTC, USDCx, and USDA.

##### Category (full list at https://defillama.com/categories) *Please choose only one:

Dexes

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

The adapter does not use a protocol oracle. It reports token quantities from Temple's public exchange-listing API and relies on DeFiLlama pricing for supported assets.

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

N/A for protocol oracle integration. The adapter maps CBTC to BTC pricing, USDA/USDCx to USD Coin pricing, and CC to Canton native gas-token pricing in DeFiLlama accounting.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

- https://templedigitalgroup.com/news/temple-lightspeed-trading-canton
- https://api.templedigitalgroup.com/api/exchange/tickers
- https://api.templedigitalgroup.com/api/exchange/orderbook

##### forkedFrom (Does your project originate from another project):

No

##### methodology (what is being counted as tvl, how is tvl being calculated):

TVL is the current resting liquidity on Lightspeed's public spot orderbooks. The adapter fetches every listed Lightspeed market from Temple's public exchange-listing API. Bid-side liquidity is counted as quote assets, ask-side liquidity is counted as base assets, and all mapped assets are summed for Canton TVL. Unknown non-CC assets are skipped rather than failing mapped liquidity, and CC is reported as Canton native gas-token liquidity.

##### Github org/user (Optional, if your code is open source, we can track activity):


##### Does this project have a referral program?

No

## Test

`node test.js projects/lightspeed/index.js`

Output:

```text
--- canton ---
USDC                      2.14 M
CC                        663.70 k
BTC                       62.06 k
Total: 2.87 M

--- tvl ---
USDC                      2.14 M
CC                        663.70 k
BTC                       62.06 k
Total: 2.87 M

------ TVL ------
canton                    2.87 M

total                    2.87 M
```
