### PR TITLE
Sweep n' Flip: add Abstract + Ronin chains

### DIFF
--- a/projects/sweep-n-flip/index.js
+++ b/projects/sweep-n-flip/index.js
@@ -24,6 +24,8 @@ const config = {
   apechain:    { start: '2026-04-28', factories: [{ factory: '0x85039B2e95558aDdCCf4379728b8433C447E37bE', fromBlock: 37153586 }] },
   berachain:   { start: '2026-04-28', factories: [{ factory: '0x85039B2e95558aDdCCf4379728b8433C447E37bE', fromBlock: 20200289 }] },
   monad:       { start: '2026-04-28', factories: [{ factory: '0x85039B2e95558aDdCCf4379728b8433C447E37bE', fromBlock: 71175180 }] },
+  abstract:    { start: '2026-06-15', factories: [{ factory: '0x4a1775B76D9d4260C60f3376eCDA618e316c662D', fromBlock: 70255154 }] },
+  ronin:       { start: '2026-06-15', factories: [{ factory: '0x85039B2e95558aDdCCf4379728b8433C447E37bE', fromBlock: 57049023 }] },
   mode:        { start: '2024-06-01', factories: [{ factory: '0x7962223D940E1b099AbAe8F54caBFB8a3a0887AB', fromBlock: 6989680 }] },
 }
 


### PR DESCRIPTION
Adds **Abstract (2741)** and **Ronin (2020)** to the existing, already-merged Sweep n' Flip TVL adapter. Both chains went live on 2026-06-15. No other changes — same `config` shape, same `tvl` logic approved in #19519.

### What changed
Two entries appended to `config` in `projects/sweep-n-flip/index.js`:

| Chain | DeFiLlama key | Factory | fromBlock |
| --- | --- | --- | --- |
| Abstract | `abstract` | `0x4a1775B76D9d4260C60f3376eCDA618e316c662D` | 70255154 |
| Ronin | `ronin` | `0x85039B2e95558aDdCCf4379728b8433C447E37bE` | 57049023 |

### Local validation (`node test.js projects/sweep-n-flip`)
- `ronin` → WRON **$0.36** (priceable side resolves on DeFiLlama). ✅
- `abstract` → **$0.00** — runs clean (zkSync Era `getLogs` works); no NFT-pool liquidity priced yet, consistent with other low-liquidity chains. ✅
- All previously-listed chains unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded Sweep n' Flip TVL tracking to include Abstract and Ronin blockchains, enabling TVL monitoring across these additional networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->