### PR TITLE
Add MACKE STRAT TVL adapter

### DIFF
--- a/projects/macke-strat/index.js
+++ b/projects/macke-strat/index.js
@@ -1,0 +1,28 @@
+const { sumTokens2 } = require('../helper/unwrapLPs')
+
+// Public mSTRAT portfolios on Ethereum (Velvet Capital non-custodial vaults)
+// Source: https://github.com/macke.meme frontend config (KNOWN_VAULTS)
+// Excludes BLOCKED_PORTFOLIOS (failed/withheld deploys and hidden MSTRAT4)
+const STRAT_PORTFOLIOS = [
+  '0xec0aca1a5793bd9e46d36158c5f08942e44a6da9', // MSTRAT
+  '0x5f9e99874574c0c55387359aa8a1a86e61fed180', // MSTRAT1
+  '0xb94503152bbeab4dd64fa03b4a101c681b020676', // MSTRAT2
+]
+
+async function tvl(api) {
+  const [tokens, vaults] = await Promise.all([
+    api.multiCall({ abi: 'address[]:getTokens', calls: STRAT_PORTFOLIOS }),
+    api.multiCall({ abi: 'address:vault', calls: STRAT_PORTFOLIOS }),
+  ])
+
+  const ownerTokens = tokens.map((tokens, i) => [tokens, vaults[i]])
+  return sumTokens2({ api, ownerTokens, resolveLP: true })
+}
+
+module.exports = {
+  methodology:
+    'Counts MACKE and other whitelisted assets held in Velvet vault Safe addresses backing public mSTRAT portfolios (MSTRAT, MSTRAT1, MSTRAT2). Withheld or failed deploys are excluded.',
+  start: 1781084831, // MSTRAT portfolio deployment (block 25286245)
+  timetravel: true,
+  ethereum: { tvl },
+}


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).

2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** It is a different repo, you can find your listing in [this file](https://github.com/DefiLlama/defillama-server/blob/master/defi/src/protocols/data2.ts), you can edit it there and put up a PR
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes

---
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
MACKE STRAT

##### Twitter Link:
https://x.com/macke_eth

##### List of audit links if any:
N/A (uses audited Velvet Capital vault infrastructure: https://github.com/Velvet-Capital/audits)

##### Website Link:
https://macke.meme/

##### Logo (High resolution, will be shown with rounded borders):
https://www.macke.meme/macke.png

##### Current TVL:
~$1.6k (123,194 MACKE across 3 public vaults at time of submission)

##### Treasury Addresses (if the protocol has treasury)
- MSTRAT reserve Safe: `0x8906107eb55df9b313fe6b6316c36015b350f4af`
- MSTRAT1 reserve Safe: `0xbf05b33b824b0a93dda6b9a2af2662c877b79d95`
- MSTRAT2 reserve Safe: `0x008b4ef0a4a5c8c1f4ef6d4032897ed5aec11f58`

##### Chain:
Ethereum

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):
mackerel-2

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):


##### Short Description (to be shown on DefiLlama):
MACKE STRAT is an onchain decentralized autonomous treasury (DAT) on Ethereum. Depositors send ETH or MACKE through Velvet Capital vaults and receive mSTRAT share tokens representing a pro-rata claim on vault MACKE reserves.

##### Token address and ticker if any:
MACKE — `0xD69a0A9682F679f50e34dE40105A93BEbB2fF43d`

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Indexes

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
Chainlink (ETH/USD), Uniswap V3 TWAP (MACKE/ETH via MackeTokenPriceFeed)

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
On-chain MackeTokenPriceFeed (`0x0320B4b0547BF0bcA7E04D6Cde9C03A9fA7810C0`) reads Uniswap V3 MACKE/WETH pool TWAP with Chainlink ETH/USD for USD pricing. Used for NAV display on macke.meme.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
- https://macke.meme/learn
- https://dune.com/macke6416/macke-treasury-strat
- Portfolio verification links on site (Etherscan + Velvet)

##### forkedFrom (Does your project originate from another project):
Uses Velvet Capital infrastructure (not a fork)

##### methodology (what is being counted as tvl, how is tvl being calculated):
Counts MACKE and other whitelisted assets held in Velvet vault Safe addresses backing public mSTRAT portfolios (MSTRAT, MSTRAT1, MSTRAT2). Failed/withheld deploys and hidden MSTRAT4 are excluded per project config. mSTRAT share token supply is not counted — only underlying vault assets.

##### Github org/user (Optional, if your code is open source, we can track activity):


##### Does this project have a referral program?
No

---

### Adapter notes

- SDK adapter only — no API fetch, `timetravel: true`
- Tested locally: `node test.js projects/macke-strat/index.js`
- Portfolios deployed via Velvet factory `0xeadd9eef6f21eae3d0f1c6031f0f455522a081c2`
- If Velvet V3 Ethereum TVL is enabled in future, please exclude these 3 portfolio addresses from `velvet-capital-v3` to avoid double counting


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mSTRAT portfolio support on Ethereum with the ability to track token holdings, monitor total value locked across vault addresses, and access historical data through timetravel functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->