### PR TITLE
Add Aurevaz — token & LP locker on Polygon, BSC, Arbitrum

### DIFF
--- a/projects/aurevaz/index.js
+++ b/projects/aurevaz/index.js
@@ -1,4 +1,4 @@
-const { unwrapLPsAuto } = require("../helper/unwrapLPs");
+const { sumTokens2 } = require("../helper/unwrapLPs");
 
 const lockerAddresses = {
   polygon: "0xBEdDcf2c709B3cEd29560E32322E09AEaC79316E",
@@ -9,37 +9,26 @@ const lockerAddresses = {
 const lockCountAbi = "uint256:lockCount";
 const locksAbi = "function locks(uint256) view returns (address token, address owner, uint256 amount, uint256 claimed, uint256 lockDate, uint256 unlockDate, uint256 vestingStart, uint256 vestingDuration, bool isLP)";
 
-async function tvl(api) {
+async function tvl(api, vesting = false) {
   const target = lockerAddresses[api.chain];
-  const lockCount = await api.call({ abi: lockCountAbi, target });
-  const count = Number(lockCount);
-  if (count === 0) return;
-
-  const ids = Array.from({ length: count }, (_, i) => i);
-  const locks = await api.multiCall({
-    abi: locksAbi,
-    target,
-    calls: ids,
-  });
+  const locks = await api.fetchList({ lengthAbi: lockCountAbi, itemAbi: locksAbi, target})
 
   for (const lock of locks) {
+    if((!vesting && lock.vestingStart != 0) || (vesting && lock.vestingStart == 0)) continue
     const remaining = BigInt(lock.amount) - BigInt(lock.claimed);
     if (remaining > 0n) {
       api.add(lock.token, remaining.toString());
     }
   }
 
-  return unwrapLPsAuto({ api });
-}
+  return sumTokens2({ api, resolveLP: true })
+} 
 
-const chains = ["polygon", "bsc", "arbitrum"];
-const config = {
+module.exports = {
   methodology: "Counts the remaining locked token balances (amount - claimed) across all active locks in the TokenLocker contract on each chain.",
   start: 1717200000,
 };
 
-chains.forEach((chain) => {
-  config[chain] = { tvl };
+Object.keys(lockerAddresses).forEach((chain) => {
+  module.exports[chain] = { tvl: api => tvl(api), vesting: api => tvl(api, true) };
 });
-
-module.exports = config;

--- a/projects/aurevaz/index.js
+++ b/projects/aurevaz/index.js
@@ -1,0 +1,40 @@
+const lockerAddresses = {
+  polygon: "0xBEdDcf2c709B3cEd29560E32322E09AEaC79316E",
+  bsc: "0x0504C1048E3E8f49B435638496202337881c7F89",
+  arbitrum: "0xBEdDcf2c709B3cEd29560E32322E09AEaC79316E",
+};
+
+const lockCountAbi = "uint256:lockCount";
+const locksAbi = "function locks(uint256) view returns (address token, address owner, uint256 amount, uint256 claimed, uint256 lockDate, uint256 unlockDate, uint256 vestingStart, uint256 vestingDuration, bool isLP, string description)";
+
+async function tvl(api) {
+  const lockCount = await api.call({ abi: lockCountAbi, target: lockerAddresses[api.chain] });
+  const count = Number(lockCount);
+  if (count === 0) return;
+
+  const ids = Array.from({ length: count }, (_, i) => i);
+  const locks = await api.multiCall({
+    abi: locksAbi,
+    target: lockerAddresses[api.chain],
+    calls: ids,
+  });
+
+  for (const lock of locks) {
+    const remaining = BigInt(lock.amount) - BigInt(lock.claimed);
+    if (remaining > 0n) {
+      api.add(lock.token, remaining.toString());
+    }
+  }
+}
+
+const chains = ["polygon", "bsc", "arbitrum"];
+const config = {
+  methodology: "Counts the remaining locked token balances (amount - claimed) across all active locks in the TokenLocker contract on each chain.",
+  start: 1717200000, // June 2024
+};
+
+chains.forEach((chain) => {
+  config[chain] = { tvl };
+});
+
+module.exports = config;

--- a/projects/aurevaz/index.js
+++ b/projects/aurevaz/index.js
@@ -1,3 +1,5 @@
+const { unwrapLPsAuto } = require("../helper/unwrapLPs");
+
 const lockerAddresses = {
   polygon: "0xBEdDcf2c709B3cEd29560E32322E09AEaC79316E",
   bsc: "0x0504C1048E3E8f49B435638496202337881c7F89",
@@ -5,17 +7,18 @@ const lockerAddresses = {
 };
 
 const lockCountAbi = "uint256:lockCount";
-const locksAbi = "function locks(uint256) view returns (address token, address owner, uint256 amount, uint256 claimed, uint256 lockDate, uint256 unlockDate, uint256 vestingStart, uint256 vestingDuration, bool isLP, string description)";
+const locksAbi = "function locks(uint256) view returns (address token, address owner, uint256 amount, uint256 claimed, uint256 lockDate, uint256 unlockDate, uint256 vestingStart, uint256 vestingDuration, bool isLP)";
 
 async function tvl(api) {
-  const lockCount = await api.call({ abi: lockCountAbi, target: lockerAddresses[api.chain] });
+  const target = lockerAddresses[api.chain];
+  const lockCount = await api.call({ abi: lockCountAbi, target });
   const count = Number(lockCount);
   if (count === 0) return;
 
   const ids = Array.from({ length: count }, (_, i) => i);
   const locks = await api.multiCall({
     abi: locksAbi,
-    target: lockerAddresses[api.chain],
+    target,
     calls: ids,
   });
 
@@ -25,12 +28,14 @@ async function tvl(api) {
       api.add(lock.token, remaining.toString());
     }
   }
+
+  return unwrapLPsAuto({ api });
 }
 
 const chains = ["polygon", "bsc", "arbitrum"];
 const config = {
   methodology: "Counts the remaining locked token balances (amount - claimed) across all active locks in the TokenLocker contract on each chain.",
-  start: 1717200000, // June 2024
+  start: 1717200000,
 };
 
 chains.forEach((chain) => {


### PR DESCRIPTION
Aurevaz — Token & LP locker with linear vesting support.

- Chains: Polygon, BSC, Arbitrum
- Contracts verified on all explorers
- Website: https://aurevaz.com

Contract addresses:
- Polygon: 0xBEdDcf2c709B3cEd29560E32322E09AEaC79316E
- BSC: 0x0504C1048E3E8f49B435638496202337881c7F89
- Arbitrum: 0xBEdDcf2c709B3cEd29560E32322E09AEaC79316E

TVL methodology: counts remaining locked balances (amount - claimed) across all active locks in the TokenLocker contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a multi-chain TVL calculator for the TokenLocker contract with live support for Polygon, Binance Smart Chain, and Arbitrum. It aggregates remaining locked token balances per network, accounting for claimed amounts, to provide an accurate consolidated view of total value secured across chains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->