### PR TITLE
Update GBLIN adapter to V6 vault contract

### DIFF
--- a/projects/gblin/index.js
+++ b/projects/gblin/index.js
@@ -1,5 +1,5 @@
 const ADDRESSES = require('../helper/coreAssets.json')
-const GBLIN_VAULT = "0x38DcDB3A381677239BBc652aed9811F2f8496345";
+const GBLIN_VAULT = "0x36C81d7E1966310F305eA637e761Cf77F90852f0";
 
 async function tvl(api) {
   return api.sumTokens({
@@ -9,7 +9,7 @@ async function tvl(api) {
 }
 
 module.exports = {
-  methodology: "TVL is calculated by summing the balances of WETH, cbBTC, and USDC strictly locked as backing collateral inside the GBLIN V5 Vault contract on Base.",
+  methodology: "TVL is calculated by summing the balances of WETH, cbBTC, and USDC strictly locked as backing collateral inside the GBLIN V6 Vault contract on Base.",
   base: {
     tvl
   }


### PR DESCRIPTION
Update GBLIN TVL adapter to the V6 production vault contract.

This is an UPDATE to an existing listing (global-balanced-liquidity-index), not a new listing.

- Old vault (V5): 0x38DcDB3A381677239BBc652aed9811F2f8496345
- New vault (V6): 0x36C81d7E1966310F305eA637e761Cf77F90852f0
- Chain: Base
- Collateral basket unchanged: WETH, cbBTC, USDC

methodology: TVL = sum of WETH, cbBTC and USDC balances locked as backing collateral inside the GBLIN V6 vault contract on Base.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * GBLIN vault upgraded from V5 to V6 with new contract address and updated documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->