### PR TITLE
beraborrow: fix no-op blacklist

### DIFF
--- a/projects/beraborrow/index.js
+++ b/projects/beraborrow/index.js
@@ -50,8 +50,8 @@ async function tvl(api) {
   const bbInfraWrappers = infraAssets.filter((a, i) => names[i] && names[i].startsWith('Beraborrow: '))
   const bbInfraWrapperUnderlyings = await api.multiCall({ abi: 'address:underlying', calls: bbInfraWrappers })
   bbInfraWrapperUnderlyings.forEach((u, i) => tokensAndOwners.push([u, bbInfraWrappers[i]]))
-  const beraTokens = bbInfraWrappers.push(beraBorrowWberaToken)
-  return api.sumTokens({ tokensAndOwners, blacklistedTokens: beraTokens })
+  const blacklistedTokens = [...bbInfraWrappers, beraBorrowWberaToken]
+  return api.sumTokens({ tokensAndOwners, blacklistedTokens })
 }
 
 module.exports = {


### PR DESCRIPTION
Fixes blacklist creation in `projects/beraborrow/index.js`.

Previously:

```js
const beraTokens = bbInfraWrappers.push(beraBorrowWberaToken)
return api.sumTokens({ tokensAndOwners, blacklistedTokens: beraTokens })
```


### Fix

```js
const blacklistedTokens = [...bbInfraWrappers, beraBorrowWberaToken]
return api.sumTokens({ tokensAndOwners, blacklistedTokens })
```

This correctly passes the intended blacklist and avoids mutating `bbInfraWrappers`.

### Impact

No TVL change observed ($317.56k before/after).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed token blacklisting logic in TVL calculations to ensure the correct set of blacklisted tokens are properly excluded from the total value locked computation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->