### PR TITLE
feat: include voltr tvl into neutral trade

### DIFF
--- a/projects/neutral-trade/constants.js
+++ b/projects/neutral-trade/constants.js
@@ -72,13 +72,7 @@ const HYPERLIQUID_VAULTS = [
 
 const NT_VAULT_PROGRAM_ID = "BUNDDh4P5XviMm1f3gCvnq2qKx6TGosAGnoUK12e7cXU";
 
-const VOLTR_VAULTS_URL = "https://api.voltr.xyz/vaults";
-const VOLTR_ASSET_MINTS = {
-  USDC: ADDRESSES.solana.USDC,
-  USDT: ADDRESSES.solana.USDT,
-  USDG: "2u1tszSeqZ3qBWF3uNGPFc8TzMk2tdiwknnRMWGWjGWH",
-  USDS: "USDSwr9ApdHk5bvJKMjzff41FfuX8bSxdKcR81vTwcA",
-};
+const VOLTR_VAULT_PROGRAM_ID = "vVoLTRjQmtFpiYoegx285Ze4gsLJ8ZxgFKVcuvmG1a8";
 
 module.exports = {
   START_TIMESTAMP,
@@ -89,6 +83,5 @@ module.exports = {
   KAMINO_VAULTS,
   HYPERLIQUID_VAULTS,
   NT_VAULT_PROGRAM_ID,
-  VOLTR_VAULTS_URL,
-  VOLTR_ASSET_MINTS,
+  VOLTR_VAULT_PROGRAM_ID,
 };

--- a/projects/neutral-trade/constants.js
+++ b/projects/neutral-trade/constants.js
@@ -72,12 +72,6 @@ const HYPERLIQUID_VAULTS = [
 
 const NT_VAULT_PROGRAM_ID = "BUNDDh4P5XviMm1f3gCvnq2qKx6TGosAGnoUK12e7cXU";
 
-// Voltr (acquired by Neutral Trade). TVL is sourced from Voltr's public API,
-// the same endpoint the Voltr frontend uses. Each vault's `tvl` field is the
-// raw token amount; we add it under the deposit token's mint and let DefiLlama
-// price it. The list endpoint only exposes the asset name, so this acts as an
-// allowlist mapping supported asset names to their Solana mints. Assets not
-// listed here are skipped (e.g. raSOL, which DefiLlama has no price feed for).
 const VOLTR_VAULTS_URL = "https://api.voltr.xyz/vaults";
 const VOLTR_ASSET_MINTS = {
   USDC: ADDRESSES.solana.USDC,

--- a/projects/neutral-trade/constants.js
+++ b/projects/neutral-trade/constants.js
@@ -72,6 +72,20 @@ const HYPERLIQUID_VAULTS = [
 
 const NT_VAULT_PROGRAM_ID = "BUNDDh4P5XviMm1f3gCvnq2qKx6TGosAGnoUK12e7cXU";
 
+// Voltr (acquired by Neutral Trade). TVL is sourced from Voltr's public API,
+// the same endpoint the Voltr frontend uses. Each vault's `tvl` field is the
+// raw token amount; we add it under the deposit token's mint and let DefiLlama
+// price it. The list endpoint only exposes the asset name, so this acts as an
+// allowlist mapping supported asset names to their Solana mints. Assets not
+// listed here are skipped (e.g. raSOL, which DefiLlama has no price feed for).
+const VOLTR_VAULTS_URL = "https://api.voltr.xyz/vaults";
+const VOLTR_ASSET_MINTS = {
+  USDC: ADDRESSES.solana.USDC,
+  USDT: ADDRESSES.solana.USDT,
+  USDG: "2u1tszSeqZ3qBWF3uNGPFc8TzMk2tdiwknnRMWGWjGWH",
+  USDS: "USDSwr9ApdHk5bvJKMjzff41FfuX8bSxdKcR81vTwcA",
+};
+
 module.exports = {
   START_TIMESTAMP,
   DRIFT_PROGRAM_ID,
@@ -81,4 +95,6 @@ module.exports = {
   KAMINO_VAULTS,
   HYPERLIQUID_VAULTS,
   NT_VAULT_PROGRAM_ID,
+  VOLTR_VAULTS_URL,
+  VOLTR_ASSET_MINTS,
 };

--- a/projects/neutral-trade/index.js
+++ b/projects/neutral-trade/index.js
@@ -12,6 +12,7 @@ const { getTvl: getDriftVaultTvl } = require("./utils/drift");
 const { getTvl: getKaminoVaultTvl } = require("./utils/kamino");
 const { getTvl: getHyperliquidVaultTvl } = require("./utils/hyperliquid");
 const { getTvl: getNtVaultTvl } = require("./utils/ntVaults");
+const { addTvl: addVoltrTvl } = require("./utils/voltr");
 
 async function getDriftAndBundleVaults() {
   const vaults = await getConfig("neutral-trade/vaults", VAULTS_REGISTRY_URL);
@@ -65,11 +66,16 @@ async function nt_vaults_tvl(api) {
   }
 }
 
+async function voltr_vaults_tvl(api) {
+  await addVoltrTvl(api);
+}
+
 async function tvl(api) {
   // await drift_vaults_tvl(api);
   await kamino_vaults_tvl(api);
   await hyperliquid_vaults_tvl(api);
   await nt_vaults_tvl(api);
+  await voltr_vaults_tvl(api);
 }
 
 

--- a/projects/neutral-trade/utils/voltr.js
+++ b/projects/neutral-trade/utils/voltr.js
@@ -20,6 +20,11 @@ async function addTvl(api) {
   });
 
   for (const { account } of vaultAccounts) {
+    if (account.data.length < VOLTR_VAULT_DATA_SLICE_LENGTH) {
+      console.log(`Voltr: skipping short vault account (${account.data.length} bytes)`);
+      continue;
+    }
+
     const mint = new PublicKey(
       account.data.slice(VOLTR_VAULT_ASSET_MINT_OFFSET, VOLTR_VAULT_ASSET_MINT_OFFSET + PUBLIC_KEY_SIZE)
     ).toBase58();

--- a/projects/neutral-trade/utils/voltr.js
+++ b/projects/neutral-trade/utils/voltr.js
@@ -1,27 +1,30 @@
-const { get } = require("../../helper/http");
-const { VOLTR_VAULTS_URL, VOLTR_ASSET_MINTS } = require("../constants");
+const { createHash } = require("crypto");
+const { PublicKey } = require("@solana/web3.js");
+const { getConnection } = require("../../helper/solana");
+const { VOLTR_VAULT_PROGRAM_ID } = require("../constants");
+
+const VOLTR_VAULT_DISCRIMINATOR_B64 = createHash("sha256").update("account:Vault").digest().subarray(0, 8).toString("base64");
+const VOLTR_VAULT_ASSET_MINT_OFFSET = 104;
+const VOLTR_VAULT_ASSET_TOTAL_VALUE_OFFSET = 168;
+const PUBLIC_KEY_SIZE = 32;
+const U64_SIZE = 8;
+const VOLTR_VAULT_DATA_SLICE_LENGTH = VOLTR_VAULT_ASSET_TOTAL_VALUE_OFFSET + U64_SIZE;
 
 async function addTvl(api) {
-  let vaults;
-  try {
-    ({ vaults } = await get(VOLTR_VAULTS_URL));
-  } catch (e) {
-    console.log(`Voltr: failed to fetch vaults from ${VOLTR_VAULTS_URL}: ${e.message}`);
-    return;
-  }
-  if (!Array.isArray(vaults)) {
-    console.log(`Voltr: unexpected response from ${VOLTR_VAULTS_URL}, expected vaults array but got ${typeof vaults}`);
-    return;
-  }
-  for (const vault of vaults) {
-    const mint = VOLTR_ASSET_MINTS[vault.asset?.name];
-    if (!mint) {
-      // Only count assets in the allowlist (i.e. ones DefiLlama can price).
-      console.log(`Voltr: skipping unsupported asset ${vault.asset?.name} for vault ${vault.pubkey}`);
-      continue;
-    }
-    // `tvl` is the raw token amount; DefiLlama prices it by mint.
-    api.add(mint, vault.tvl);
+  const connection = getConnection();
+  const vaultAccounts = await connection.getProgramAccounts(new PublicKey(VOLTR_VAULT_PROGRAM_ID), {
+    filters: [
+      { memcmp: { offset: 0, bytes: VOLTR_VAULT_DISCRIMINATOR_B64, encoding: "base64" } },
+    ],
+    dataSlice: { offset: 0, length: VOLTR_VAULT_DATA_SLICE_LENGTH },
+  });
+
+  for (const { account } of vaultAccounts) {
+    const mint = new PublicKey(
+      account.data.slice(VOLTR_VAULT_ASSET_MINT_OFFSET, VOLTR_VAULT_ASSET_MINT_OFFSET + PUBLIC_KEY_SIZE)
+    ).toBase58();
+    const totalValue = account.data.readBigUInt64LE(VOLTR_VAULT_ASSET_TOTAL_VALUE_OFFSET);
+    if (totalValue > 0n) api.add(mint, totalValue.toString());
   }
 }
 

--- a/projects/neutral-trade/utils/voltr.js
+++ b/projects/neutral-trade/utils/voltr.js
@@ -2,8 +2,17 @@ const { get } = require("../../helper/http");
 const { VOLTR_VAULTS_URL, VOLTR_ASSET_MINTS } = require("../constants");
 
 async function addTvl(api) {
-  const { vaults } = await get(VOLTR_VAULTS_URL);
-  if (!Array.isArray(vaults)) return;
+  let vaults;
+  try {
+    ({ vaults } = await get(VOLTR_VAULTS_URL));
+  } catch (e) {
+    console.log(`Voltr: failed to fetch vaults from ${VOLTR_VAULTS_URL}: ${e.message}`);
+    return;
+  }
+  if (!Array.isArray(vaults)) {
+    console.log(`Voltr: unexpected response from ${VOLTR_VAULTS_URL}, expected vaults array but got ${typeof vaults}`);
+    return;
+  }
   for (const vault of vaults) {
     const mint = VOLTR_ASSET_MINTS[vault.asset?.name];
     if (!mint) {

--- a/projects/neutral-trade/utils/voltr.js
+++ b/projects/neutral-trade/utils/voltr.js
@@ -1,0 +1,21 @@
+const { get } = require("../../helper/http");
+const { VOLTR_VAULTS_URL, VOLTR_ASSET_MINTS } = require("../constants");
+
+async function addTvl(api) {
+  const { vaults } = await get(VOLTR_VAULTS_URL);
+  if (!Array.isArray(vaults)) return;
+  for (const vault of vaults) {
+    const mint = VOLTR_ASSET_MINTS[vault.asset?.name];
+    if (!mint) {
+      // Only count assets in the allowlist (i.e. ones DefiLlama can price).
+      console.log(`Voltr: skipping unsupported asset ${vault.asset?.name} for vault ${vault.pubkey}`);
+      continue;
+    }
+    // `tvl` is the raw token amount; DefiLlama prices it by mint.
+    api.add(mint, vault.tvl);
+  }
+}
+
+module.exports = {
+  addTvl,
+};


### PR DESCRIPTION
## Summary

With the acquisition of Voltr by Neutral Trade, this PR combines Voltr's vault TVL into the existing `neutral-trade` adapter. TVL is sourced from Voltr's public API the same endpoint the Voltr frontend uses. Each vault's `tvl` field is the raw token amount, which we add under the deposit token's mint and let DefiLlama price.

## Changes

- **`projects/neutral-trade/utils/voltr.js`** (new) — fetches the Voltr vault list and adds each vault's raw `tvl` under its deposit token mint via `api.add(mint, tvl)`.
- **`projects/neutral-trade/constants.js`** — added `VOLTR_VAULTS_URL` and `VOLTR_ASSET_MINTS`, an allowlist mapping supported asset names → Solana mints (USDC, USDT, USDG, USDS). USDG/USDS aren't in `coreAssets`, so their mints are hardcoded.
- **`projects/neutral-trade/index.js`** — added `voltr_vaults_tvl(api)` to the `tvl` flow and noted Voltr in the methodology string.

## Validation

- Confirmed DefiLlama has price feeds for all allowlisted mints (USDC/USDT/USDG/USDS) via `coins.llama.fi`.
- `node --check` passes on all three files.

## Notes

- `VOLTR_ASSET_MINTS` is an allowlist: any future Voltr asset not listed is skipped (and logged) until added. This trades auto-discovery for not silently adding unpriceable tokens.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Expanded the Solana TVL calculation to include Voltr vault holdings, so the total TVL now reflects supported assets held in Voltr vault contracts.
- Added dedicated Voltr vault TVL support, including a new Voltr vault program identifier and logic to discover vault accounts and include balances where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->