### PR TITLE
fix: price Dinari USD+ supply

### DIFF
--- a/projects/dinari/index.js
+++ b/projects/dinari/index.js
@@ -28,10 +28,14 @@ const config = {
 }
 
 const abi = "function getDShares() external view returns (address[] memory, address[] memory)"
+const USD_PLUS_DECIMALS = 1e6
 
 const tvl = async (api) => {
   const { factory, usdplus } = config[api.chain]
-  if (usdplus) api.add(usdplus, await api.call({ target: usdplus, abi: 'erc20:totalSupply'}))
+  if (usdplus) {
+    const supply = await api.call({ target: usdplus, abi: 'erc20:totalSupply'})
+    api.addCGToken('usd-coin', supply / USD_PLUS_DECIMALS)
+  }
   if (!factory) return
   const [tokens] = (await api.call({ target: factory, abi, permitFailure: true})) ?? []
   if (!tokens) return;


### PR DESCRIPTION
### Problem

The Dinari adapter reports **$0 TVL** even though Dinari USD+ has live on-chain supply.

The adapter was adding each configured `USD+` contract address directly:

```js
api.add(usdplus, await api.call({ target: usdplus, abi: 'erc20:totalSupply'}))
```

Those Dinari USD+ token addresses are currently not priced by the DefiLlama coins API, so the nonzero balances are dropped to $0 in the TVL pipeline.

### Fix

Map Dinari `USD+` supply to `usd-coin` after dividing by the token's 6 decimals.

This is scoped only to USD+. I did not change dShare discovery/pricing.

### Verification

Dinari / DefiLlama both treat USD+ as a $1 stable asset:
- Dinari docs: USD+ is 100% backed by short-term US Treasuries and USD.
- Dinari USD+ page: each USD+ maintains a value of $1 USD with $1 redemption value.
- DefiLlama RWA page for Dinari USD+ shows `USD+ Price $1` and onchain market cap ~$10.83M.

On-chain supply checked at current blocks:
- Ethereum `0x98C6616F1CC0D3E938A16200830DD55663dd7DD3`: `7,718,972.736256` USD+
- Arbitrum `0xfc90518D5136585ba45e34ED5E1D108BD3950CFa`: `3,113,158.466093` USD+
- Base `0x98C6616F1CC0D3E938A16200830DD55663dd7DD3`: `146.622889` USD+

Local tests:

```bash
LLAMA_RUN_LOCAL=1 node test.js projects/dinari
```

Before: `0.00`
After: `10.83M`

```bash
LLAMA_RUN_LOCAL=1 node test.js projects/dinari 2026-06-22
```

After: `10.83M`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated USD+ token supply calculation in the Dinari project integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->