### PR TITLE
update CCIP tvl

### DIFF
--- a/projects/ccip/index.js
+++ b/projects/ccip/index.js
@@ -4,6 +4,16 @@ const { PublicKey } = require('@solana/web3.js')
 const { getConnection } = require('../helper/solana')
 const { bs58 } = require("@project-serum/anchor/dist/cjs/utils/bytes");
 
+//  Pool types:
+//  1. Holds tokens directly: LockReleaseTokenPool, LockReleaseTokenPoolAndProxy, 
+//   SiloedLockReleaseTokenPool, HybridWithExternalMinterTokenPool
+//  2. Holds tokens at child contract:
+//   USDCTokenPoolProxy - getPools().siloedLockReleasePool -> getAllLockboxConfigs().lockbox OR getLockBox(getSupportedChains())
+//   XERC20LockBoxTokenPool - address:getLockbox
+//  3. Holds tokens directly AND at child:
+//   SiloedWithUnsiloedXERC20GroupTokenPool - address:getLockbox
+//  4. Doesn't hold tokens (untracked): BurnMint, LombardTokenPool
+
 const TOKEN_ADMIN_REGISTRY = {
   ethereum: '0xb22764f98dD05c789929716D677382Df22C05Cb6',
   bsc: '0x736Fd8660c443547a85e4Eaf70A49C1b7Bb008fc',
@@ -23,9 +33,14 @@ const TOKEN_ADMIN_REGISTRY = {
   pharos: '0xB79791184973589c38e114D43Eb8E4588C283A18',
   bob: '0xa57d04119AFf4884F8602213E58d8AaAD18229cb',
   astar: '0xB98eEd70e3cE8E342B0f770589769E3A6bc20A09',
+  bittensor_evm: '0xe72d25aDd538E8ef9CeF85622eA8912a6CB98Be6',
+  hyperliquid: '0xcE44363496ABc3a9e53B3F404a740F992D977bDF',
 }
 
 const PAGE = 500
+
+const LOCKBOX_CFG_ABI = 'function getAllLockBoxConfigs() view returns (tuple(uint64 remoteChainSelector, address lockBox)[])'
+const PROXY_POOLS_ABI = 'function getPools() view returns (tuple(address cctpV1Pool, address cctpV2Pool, address cctpV2PoolWithCCV, address siloedLockReleasePool))'
 
 async function tvl(api) {
   const registry = TOKEN_ADMIN_REGISTRY[api.chain]
@@ -57,10 +72,47 @@ async function tvl(api) {
     permitFailure: true,
   })
 
-  // filter out BurnMint and BurnWithFromMint pools
-  const lockReleasePairs = pairs.filter((_, i) => typeof types[i] === 'string' && types[i].includes('LockRelease'))
+  const entries = pairs
+    .map(([token, pool], i) => ({ token, pool, type: types[i] }))
+    .filter(({ type }) => typeof type === 'string' && !/Burn|Lombard/.test(type))
 
-  return sumTokens2({ api, tokensAndOwners: lockReleasePairs })
+  const poolList = entries.map((e) => e.pool)
+
+  const [lockboxes, boxConfigs] = await Promise.all([
+    api.multiCall({ abi: 'function getLockbox() view returns (address)', calls: poolList, permitFailure: true }),
+    api.multiCall({ abi: LOCKBOX_CFG_ABI, calls: poolList, permitFailure: true }),
+  ])
+
+  const proxyIdx = entries
+    .map((e, i) => (e.type.includes('USDCTokenPoolProxy') ? i : -1))
+    .filter((i) => i >= 0)
+  const proxyStructs = await api.multiCall({ abi: PROXY_POOLS_ABI, calls: proxyIdx.map((i) => entries[i].pool), permitFailure: true })
+  const validProxies = proxyIdx
+    .map((entryIdx, k) => ({ entryIdx, struct: proxyStructs[k] }))
+    .filter((p) => p.struct && p.struct.siloedLockReleasePool && p.struct.siloedLockReleasePool !== ADDRESSES.null)
+  const siloedConfigs = await api.multiCall({ abi: LOCKBOX_CFG_ABI, calls: validProxies.map((p) => p.struct.siloedLockReleasePool), permitFailure: true })
+
+  const seen = new Set()
+  const tokensAndOwners = []
+  const add = (token, owner) => {
+    if (!owner || owner === ADDRESSES.null) return
+    const key = `${token}-${owner}`.toLowerCase()
+    if (seen.has(key)) return
+    seen.add(key)
+    tokensAndOwners.push([token, owner])
+  }
+
+  entries.forEach(({ token, pool }, i) => {
+    add(token, pool)                                             
+    add(token, lockboxes[i]) // XERC20Lockbox / hybrid Siloed child pool                                          
+    if (Array.isArray(boxConfigs[i])) boxConfigs[i].forEach((c) => add(token, c.lockBox)) // siloed-with-lockbox
+  })
+  validProxies.forEach((p, k) => {
+    const { token } = entries[p.entryIdx]
+    if (Array.isArray(siloedConfigs[k])) siloedConfigs[k].forEach((c) => add(token, c.lockBox))
+  })
+
+  return sumTokens2({ api, tokensAndOwners })
 }
 
 async function solanaTvl(api) {


### PR DESCRIPTION
1. adds support for pool types where tokens are held by a child pool/lockbox

2. adds hyperliquid and bittensor_evm - both have 'Lock' pools with non-zero token balances

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved CCIP token pool tracking to comprehensively discover and aggregate pools across multiple configurations and address types for more accurate visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->