### PR TITLE
fix: remove duplicate SatLayer SLAY vault

### DIFF
--- a/projects/satlayer/index.js
+++ b/projects/satlayer/index.js
@@ -65,10 +65,6 @@ const vaults = {
     {
       tokenAddress: "0x51477A3002ee04B7542aDfe63ccdb50c00Ee5147", // SLAY
       vaultAddresses: ["0xf80361e9f6b5f75b3e9be82bd1b3c87938e773b0"], // 60d SLAY vault
-    },
-    {
-      tokenAddress: "0x51477A3002ee04B7542aDfe63ccdb50c00Ee5147", // SLAY
-      vaultAddresses: ["0xf80361e9f6b5f75b3e9be82bd1b3c87938e773b0"], // 30d SLAY vault
     }
   ],
 };


### PR DESCRIPTION
### Problem

The SatLayer adapter double-counts the same Ethereum SLAY balance.

`projects/satlayer/index.js` listed the same token and holder twice:

- token: `0x51477A3002ee04B7542aDfe63ccdb50c00Ee5147` (`SLAY`)
- holder: `0xf80361e9f6b5f75b3e9be82bd1b3c87938e773b0`

Both entries call `balanceOf(SLAY, holder)`, so the adapter adds the same on-chain balance twice.

### Fix

Remove the duplicate SLAY vault entry. All BTC vault discovery and other SatLayer chains are unchanged.

### Verification

On-chain balance check on Ethereum mainnet:

```text
symbol: SLAY
token: 0x51477A3002ee04B7542aDfe63ccdb50c00Ee5147
holder: 0xf80361e9f6b5f75b3e9be82bd1b3c87938e773b0
raw balance: 2273102688461
decimals: 6
human balance: 2,273,102.688461 SLAY
```

Local adapter output:

Before:

```text
--- ethereum ---
SLAY                      4.23 k
Total: 111.14 k

--- tvl ---
SLAY                      4.23 k
Total: 194.44 k
```

After:

```text
--- ethereum ---
SLAY                      2.11 k
Total: 109.03 k

--- tvl ---
SLAY                      2.11 k
Total: 192.33 k
```

Test:

```bash
node test.js projects/satlayer/index.js ethereum
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the vault label for a SatLayer Ethereum configuration to accurately reflect vault duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->