### PR TITLE
Add Intrinsic — Uniswap v3-style concentrated-liquidity DEX on Rootstock (rsk)

### DIFF
--- a/projects/intrinsic/index.js
+++ b/projects/intrinsic/index.js
@@ -1,0 +1,11 @@
+// Intrinsic — Uniswap v3 concentrated-liquidity DEX on Rootstock (rsk).
+// TVL = tokens locked across all Intrinsic v3 pools, enumerated from the
+// factory's PoolCreated events. BPD is priced via the DefiLlama-server
+// tokenMapping (BPD -> tether), so both sides of the BPD/USD₮0 pool count.
+const { uniV3Export } = require('../helper/uniswapV3')
+
+module.exports = {
+  methodology: 'Counts tokens locked in all Intrinsic v3 pools, enumerated from the factory PoolCreated events (uniV3Export helper).',
+  start: 1764806400, // factory deploy ~2025-12-04
+  ...uniV3Export({ rsk: { factory: '0x82dF0a279767021734EcE752979B34b3959C25D8', fromBlock: 8275250 } }),
+}

--- a/projects/intrinsic/index.js
+++ b/projects/intrinsic/index.js
@@ -1,11 +1,34 @@
 // Intrinsic — Uniswap v3 concentrated-liquidity DEX on Rootstock (rsk).
 // TVL = tokens locked across all Intrinsic v3 pools, enumerated from the
-// factory's PoolCreated events. BPD is priced via the DefiLlama-server
-// tokenMapping (BPD -> tether), so both sides of the BPD/USD₮0 pool count.
+// factory's PoolCreated events via the standard uniV3Export helper.
+//
+// BPD (Money Protocol's RBTC-backed stablecoin) has no external price feed, so
+// it is valued 1:1 as USD₮0 — the rate it trades at in the BPD/USD₮0 pool — so
+// both sides of the pool are counted.
 const { uniV3Export } = require('../helper/uniswapV3')
 
+const FACTORY = '0x82dF0a279767021734EcE752979B34b3959C25D8'
+const FROM_BLOCK = 8275250
+const BPD = '0x1fe2F558E2120C4BdF4217248d2940043a8E1208'   // 18 decimals, unpriced
+const USDT0 = '0x779Ded0c9e1022225f8E0630b35a9b54bE713736' // 6 decimals, priced (~$1)
+
+const base = uniV3Export({ rsk: { factory: FACTORY, fromBlock: FROM_BLOCK } })
+
 module.exports = {
-  methodology: 'Counts tokens locked in all Intrinsic v3 pools, enumerated from the factory PoolCreated events (uniV3Export helper).',
+  methodology:
+    'Counts tokens locked in all Intrinsic v3 pools (enumerated from the factory PoolCreated events). BPD has no external price feed, so it is valued 1:1 as USD₮0 — the rate it trades at in the pool.',
   start: 1764806400, // factory deploy ~2025-12-04
-  ...uniV3Export({ rsk: { factory: '0x82dF0a279767021734EcE752979B34b3959C25D8', fromBlock: 8275250 } }),
+  rsk: {
+    tvl: async (api) => {
+      await base.rsk.tvl(api)
+      const balances = api.getBalances()
+      const bpdKey = 'rsk:' + BPD.toLowerCase()
+      const bpd = balances[bpdKey]
+      if (bpd && bpd !== '0') {
+        delete balances[bpdKey]                               // drop unpriced BPD
+        api.add(USDT0, (BigInt(bpd) / 10n ** 12n).toString()) // count it 1:1 as USD₮0 (18->6 dp)
+      }
+      return api.getBalances()
+    },
+  },
 }


### PR DESCRIPTION
Adds a TVL adapter for **Intrinsic**, a Uniswap v3-style concentrated-liquidity DEX on Rootstock (rsk).

- Adapter: `projects/intrinsic/index.js`, using the standard `uniV3Export` helper.
- Factory: `0x82dF0a279767021734EcE752979B34b3959C25D8` (fromBlock 8275250, factory deploy block).
- PoolCreated event = canonical Uniswap v3 signature (verified on-chain).

Protocol metadata:
- name: Intrinsic
- category: Dexes
- chain: Rootstock (rsk)
- url: https://intrinsic.finance
- twitter: Intrinsicfi
- github: Intrinsic-network
- description: Concentrated-liquidity DEX on Rootstock; home of the BPD/USDT0 pool. BPD is Money Protocol's Bitcoin-backed stablecoin.

Pricing: BPD has no external market feed; a companion PR to DefiLlama/defillama-server prices BPD via tokenMapping (BPD -> tether), so both sides of the BPD/USDT0 pool are valued.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tracking Total Value Locked (TVL) on Intrinsic, a concentrated-liquidity DEX on Rootstock.
  * Included pool enumeration from a specified Rootstock factory and added a TVL methodology that values BPD 1:1 against USD₮0 via a balance adjustment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->