### PR TITLE
Revert "Monetrix: derive TVL from USDM supply for historical backfill"

### DIFF
--- a/projects/monetrix/index.js
+++ b/projects/monetrix/index.js
@@ -1,7 +1,7 @@
 const ADDRESSES = require('../helper/coreAssets.json')
 
 const MONETRIX_GENESIS_VAULT = '0xc50A1dd2866A822c81bd0aA00B638c4BdDc9cd63'
-const USDM = '0xE2d2959f89B6389DeB624bF076Fe7D9E5401f377'
+const MONETRIX_ACCOUNTANT = '0x8950A5136f3994f82b998e37e1183b8A37c12705'
 
 const USDC = ADDRESSES.hyperliquid.USDC
 
@@ -9,24 +9,24 @@ async function tvl(api) {
   // Pre-launch Genesis Vault USDC; migrates into the main MonetrixVault when users mint USDM
   await api.sumTokens({ owners: [MONETRIX_GENESIS_VAULT], tokens: [USDC] })
 
-  // USDM is minted 1:1 against USDC collateral, so its total supply equals the USDC
-  // backing the live token (the Genesis USDC above migrates into this supply as users
-  // mint). Read from plain ERC20 storage so historical TVL backfills correctly — unlike
-  // the MonetrixAccountant's mark-to-market backing, which is read via Hyperliquid
-  // precompiles that only expose live state and cannot be queried at historical blocks.
-  const usdmSupply = await api.call({ target: USDM, abi: 'erc20:totalSupply' }).catch(() => 0)
-  if (usdmSupply) api.add(USDC, usdmSupply)
+  // USDC collateral backing USDM, read from the MonetrixAccountant:
+  // EVM USDC in the MonetrixVault and RedeemEscrow, plus the protocol's
+  // Hyperliquid Core account equity (perp margin, spot hedges, HLP and
+  // borrow-lend balances) valued via Hyperliquid precompiles
+  const totalBackingSigned = await api.call({ target: MONETRIX_ACCOUNTANT, abi: 'function totalBackingSigned() view returns (int256)' })
+  // negative backing (mark-to-market drawdown) clamps to zero
+  if (BigInt(totalBackingSigned) > 0n) api.add(USDC, totalBackingSigned)
 }
 
 module.exports = {
   misrepresentedTokens: true,
-  start: '2026-06-10',
   methodology:
-    'TVL is the USDC collateral backing USDM. USDM is minted 1:1 against USDC, so the ' +
-    'circulating USDM supply equals the USDC collateral held by the protocol (in the ' +
-    'MonetrixVault, RedeemEscrow and the Hyperliquid Core account that runs the ' +
-    'delta-neutral basis-trading strategy). USDC still in the pre-launch Genesis Vault ' +
-    'is also counted and migrates into the supply as users mint USDM. Staked USDM ' +
+    'TVL is the USDC collateral backing USDM: USDC held by the MonetrixVault and ' +
+    'RedeemEscrow on HyperEVM plus the protocol\'s Hyperliquid Core account equity ' +
+    '(delta-neutral spot + short-perp positions, HLP and borrow-lend balances), read ' +
+    'on-chain from the MonetrixAccountant (totalBacking), which marks Core positions ' +
+    'to market via Hyperliquid precompiles. USDC still in the pre-launch Genesis Vault ' +
+    'is also counted and migrates into the main vault as users mint USDM. Staked USDM ' +
     '(sUSDM), the insurance fund (funded from skimmed yield) and undistributed yield ' +
     'are excluded.',
   hyperliquid: {


### PR DESCRIPTION
Reverts DefiLlama/DefiLlama-Adapters#19695

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Monetrix total value locked calculation on Hyperliquid to accurately reflect current protocol backing, providing more precise TVL reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->