### PR TITLE
term-structure: track additional vault & market factories on base

### DIFF
--- a/projects/term-structure/index.js
+++ b/projects/term-structure/index.js
@@ -271,11 +271,25 @@ const ADDRESSES = {
         address: "0xa6875Af7a45BEf941e484b59C149E5C1772DE643",
         fromBlock: 43289754,
       },
+      // TermMax V2.01 (same MarketCreated event signature)
+      {
+        address: "0x2aFEf28a8Ab57d2F5A5663Ef69351e9d3abf1779",
+        fromBlock: 47709827,
+      },
     ],
     VaultFactoryV2: [
       {
         address: "0xDA4aAF85Bb924B53DCc2DFFa9e1A9C2Ef97aCFDF",
         fromBlock: 43289755,
+      },
+      {
+        address: "0x28e47A7d7E710d796DBAFd8081c052444deEcF10",
+        fromBlock: 44680222,
+      },
+      // TermMax V2.01 (same VaultCreated event signature)
+      {
+        address: "0x34F7b52b0d33959C8351eF95F3523C89b6123C0b",
+        fromBlock: 47709826,
       },
     ],
     TermMax4626Factory: [


### PR DESCRIPTION
Adds three newly deployed TermMax factories on the base chain to the term-structure adapter:

| Address | Type | fromBlock |
|---------|------|-----------|
| `0x2aFEf28a8Ab57d2F5A5663Ef69351e9d3abf1779` | FactoryV2 (V2.01 market factory) | 47709827 |
| `0x28e47A7d7E710d796DBAFd8081c052444deEcF10` | VaultFactoryV2 | 44680222 |
| `0x34F7b52b0d33959C8351eF95F3523C89b6123C0b` | VaultFactoryV2 (V2.01) | 47709826 |

Factory types were confirmed by matching deployed-bytecode function selectors against the existing TermMax V2/V2.01 factories on other chains (exact match). `fromBlock` values are the on-chain deployment blocks. These factories are picked up by the existing `getTermMaxMarketV2Addresses` / `getTermMaxVaultV2Addresses` discovery, so no logic changes are needed.

Tested with `LLAMA_DEBUG_MODE=true node test.js projects/term-structure/index.js` (pinned to a past block to avoid a chain-head race on recently deployed contracts); the adapter runs cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced Base network configuration to support discovery and tracking of TermMax V2.01 contracts, improving accuracy of TVL and borrow metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->