### PR TITLE
fix (tori-finance):  map trUSD to USDC to fix $0 TVL

### DIFF
--- a/projects/tori-finance/index.js
+++ b/projects/tori-finance/index.js
@@ -1,7 +1,20 @@
-const { sumERC4626VaultsExport } = require('../helper/erc4626');
+const ADDRESSES = require('../helper/coreAssets.json');
+
+const VAULT = '0xcd69123b3FBBfC666E1f6a501da27B564C00De54';
+const USDC = ADDRESSES.ethereum.USDC;
+
+// trUSD is Tori Finance's USD-pegged stablecoin (18 decimals), not yet on
+// CoinGecko. getTotalAssets() returns raw 18-decimal units. We map to USDC
+// (6 decimals) so DefiLlama prices it at $1.
+async function tvl(api) {
+  const total = await api.call({ abi: 'uint256:getTotalAssets', target: VAULT });
+  // convert 18-decimal trUSD → 6-decimal USDC
+  const usdc = BigInt(total) / BigInt(1e12);
+  api.add(USDC, usdc.toString());
+}
 
 module.exports = {
-    methodology: 'Counts total value of assets staked into the Upshift Tori ecosystem vault.',
-    doublecounted: true,
-    ethereum: { tvl: sumERC4626VaultsExport({vaults: ['0xcd69123b3FBBfC666E1f6a501da27B564C00De54'], tokenAbi: 'address:asset', balanceAbi: 'uint:getTotalAssets'}) }
-}
+  methodology: 'Total assets in the Upshift Tori ecosystem vault (sMUSD). trUSD mapped to USDC for pricing.',
+  doublecounted: true,
+  ethereum: { tvl },
+};


### PR DESCRIPTION
## Problem
tori-finance adapter returns $0 TVL because trUSD
(0xd0580192E98eA6CEB9c7b6191Ed2E27560911697) is not listed
on CoinGecko. The vault holds ~38M trUSD but shows $0.

Verified on-chain:
- getTotalAssets() = 3.808e25 (raw 18-decimal units)
- asset() = 0xd0580192... (trUSD, symbol confirmed)

## Fix
Map trUSD to USDC for pricing. trUSD is Tori Finance's
USD-pegged stablecoin (18 decimals). Divides by 1e12 to
convert to USDC (6 decimals).

## Result
ethereum: $38.09M ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Total Value Locked (TVL) calculation methodology to enhance asset valuation accuracy for vault contracts.
  * Improved asset unit conversion and reporting mechanisms to ensure precise pricing data and better protocol transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->