### PR TITLE
Add Crovia

### DIFF
--- a/projects/crovia/index.js
+++ b/projects/crovia/index.js
@@ -11,8 +11,8 @@
  * prefers Crovia be listed fees-only, this file can be dropped — the fees adapter
  * still creates the protocol page.
  */
-const ADDRESSES = require('../helpers/coreAssets.json')
-const { sumTokens2 } = require('../helpers/unwrapLPs')
+const ADDRESSES = require('../helper/coreAssets.json')
+const { sumTokens2 } = require('../helper/unwrapLPs')
 
 // CroviaStakingPool — rewardToken is native CRO (0x000..0); deployed 2026-05-14.
 const STAKING_POOL = '0xb396e08ceca0f1bea3c120b21dc2c9ed6e25d7d4'

--- a/projects/crovia/index.js
+++ b/projects/crovia/index.js
@@ -1,0 +1,33 @@
+/**
+ * Crovia — TVL adapter (Cronos).
+ *
+ * Drop-in for github.com/DefiLlama/DefiLlama-Adapters at `projects/crovia/index.js`.
+ *
+ * NOTE: Crovia is an NFT marketplace + aggregator, so it has little fungible TVL.
+ * Its primary DefiLlama listing is the fees/aggregator dimension adapters
+ * (real on-chain trading fees). This TVL adapter is OPTIONAL: it reports the
+ * native CRO reward reserve held by the NFT staking pool, which backs staking
+ * rewards. The staked assets themselves are NFTs (not priced here). If a reviewer
+ * prefers Crovia be listed fees-only, this file can be dropped — the fees adapter
+ * still creates the protocol page.
+ */
+const ADDRESSES = require('../helpers/coreAssets.json')
+const { sumTokens2 } = require('../helpers/unwrapLPs')
+
+// CroviaStakingPool — rewardToken is native CRO (0x000..0); deployed 2026-05-14.
+const STAKING_POOL = '0xb396e08ceca0f1bea3c120b21dc2c9ed6e25d7d4'
+
+async function staking(api) {
+  // Native CRO held by the staking pool (the reward reserve).
+  return sumTokens2({ api, owner: STAKING_POOL, tokens: [ADDRESSES.null] })
+}
+
+module.exports = {
+  methodology:
+    'Native CRO reward reserve held by the CroviaStakingPool that backs NFT-staking rewards. Staked assets are NFTs and are not priced.',
+  start: '2026-05-14',
+  cronos: {
+    tvl: () => ({}),
+    staking,
+  },
+}


### PR DESCRIPTION
Adds Crovia (NFT marketplace + aggregator on Cronos), `projects/crovia/index.js`.

TVL = native CRO reward reserve held by the CroviaStakingPool (`0xb396e08ceca0f1bea3c120b21dc2c9ed6e25d7d4`), reported under `staking`. Crovia is an NFT marketplace, so fungible TVL is small; the substantive listing is the fees/aggregator dimension adapters (separate PR to `DefiLlama/dimension-adapters`). **Happy to drop this PR and list Crovia fees-only if preferred.**

Validation: pure on-chain read (no external API or keys). Please let CI run the standard adapter test — happy to iterate on anything that flags.

Project: https://crovia.app · Security/contracts: https://crovia.app/audit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tracking Crovia on Cronos, including staking balances in TVL reporting.
  * Introduced a new adapter so Crovia data is now available in the dashboard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->