### PR TITLE
Feat Extended-spot-orderbook

### DIFF
--- a/projects/extended-spot-orderbook/index.js
+++ b/projects/extended-spot-orderbook/index.js
@@ -1,0 +1,39 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+const { get } = require('../helper/http')
+const { multiCall } = require('../helper/chain/starknet')
+
+const API_URL = 'https://api.starknet.extended.exchange/api/v1'
+const USDC = ADDRESSES.starknet.USDC_CIRCLE
+
+const decimalsAbi = {
+  name: 'decimals',
+  type: 'function',
+  inputs: [],
+  outputs: [{ name: 'decimals', type: 'felt' }],
+  stateMutability: 'view',
+}
+
+async function tvl(api) {
+  const { data: markets } = await get(`${API_URL}/info/markets`)
+  const spotMarkets = markets.filter(m => m.type === 'SPOT' && m.active && m.status === 'ACTIVE')
+
+  const tokens = spotMarkets.map(m => m.l2Config.syntheticId)
+  const decimals = await multiCall({ abi: decimalsAbi, calls: tokens.map(t => ({ target: t })) })
+
+  await Promise.all(spotMarkets.map(async (mkt, i) => {
+    const { data: ob } = await get(`${API_URL}/info/markets/${mkt.name}/orderbook`)
+    const tokenDecimals = Number(decimals[i])
+    const collateralResolution = Number(mkt.l2Config.collateralResolution)
+
+    const bidsUSDC = (ob.bid || []).reduce((s, b) => s + Number(b.qty) * Number(b.price), 0)
+    api.add(USDC, Math.round(bidsUSDC * collateralResolution))
+
+    const asksTokens = (ob.ask || []).reduce((s, a) => s + Number(a.qty), 0)
+    api.add(mkt.l2Config.syntheticId, Math.round(asksTokens * 10 ** tokenDecimals))
+  }))
+}
+
+module.exports = {
+  methodology: 'TVL represents assets locked in limit orders on the Extended spot order book.',
+  starknet: { tvl },
+}

--- a/projects/extended-spot-orderbook/index.js
+++ b/projects/extended-spot-orderbook/index.js
@@ -34,6 +34,7 @@ async function tvl(api) {
 }
 
 module.exports = {
+  timetravel: false,
   methodology: 'TVL represents assets locked in limit orders on the Extended spot order book.',
   starknet: { tvl },
 }

--- a/projects/extended-spot-orderbook/index.js
+++ b/projects/extended-spot-orderbook/index.js
@@ -18,7 +18,7 @@ async function tvl(api) {
   const spotMarkets = markets.filter(m => m.type === 'SPOT' && m.active && m.status === 'ACTIVE')
 
   const tokens = spotMarkets.map(m => m.l2Config.syntheticId)
-  const decimals = await multiCall({ abi: decimalsAbi, calls: tokens.map(t => ({ target: t })) })
+  const decimals = await multiCall({ abi: decimalsAbi, calls: tokens })
 
   await Promise.all(spotMarkets.map(async (mkt, i) => {
     const { data: ob } = await get(`${API_URL}/info/markets/${mkt.name}/orderbook`)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tracking Total Value Locked (TVL) for the Extended Spot order book on Starknet.
  * Reports TVL across both USDC and each active SPOT market’s synthetic asset.
  * Includes a methodology description detailing how bid value and ask quantity are calculated and scaled for reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->