### PR TITLE
add change morpho

### DIFF
--- a/projects/morpho-blue/index.js
+++ b/projects/morpho-blue/index.js
@@ -202,11 +202,12 @@ const config = {
   klaytn: {
     morphoBlue: "0xa8beebdca34d83c697c302a0594f3c41f3994cd2",
     fromBlock: 208021118,
-  },
+  },/* still in private mainnet
   arc: {
     morphoBlue: "0x34CD04070dD72b14E241112F6d83812Df5Af7fCD",
     fromBlock: 1,
   },
+  */
   "0g": {
     morphoBlue: "0x9CDD13a2212D94C4f12190cA30783B743E83C89e",
     fromBlock: 7526486,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated chain availability so the `arc` network is no longer included in the adapter’s public exports.
  * This prevents TVL and borrowed data from running for `arc` in the current release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->