### PR TITLE
Add FWB TVL adapter

### DIFF
--- a/projects/finwb/index.js
+++ b/projects/finwb/index.js
@@ -1,45 +1,26 @@
-const FINWB_ABI = {
-getProtocolTvlTokensAndAmounts:
-'function getProtocolTvlTokensAndAmounts() view returns (address[] tokens, uint256[] amounts)',
-}
+const getProtocolTvlTokensAndAmountsAbi = 'function getProtocolTvlTokensAndAmounts() view returns (address[] tokens, uint256[] amounts)';
 
 const CONTRACTS = {
-ethereum: '0x1Ef96B8fad9aE983E60610C4ba13536606B5c477',
-polygon: '0xd17127796D46c1588550Df783FCfE3D08ef8F6c0',
-arbitrum: '0xF5d84413f2cd33d6d473BA9D0c665a73472d8fC7',
-base: '0x199180dfbACEE5c204Db4E803A92a9D3A9Db4d1F',
-bsc: '0x18A021d1c89Af87AaeD266B2C58dD16855Ad3702',
+    ethereum: '0x1Ef96B8fad9aE983E60610C4ba13536606B5c477',
+    polygon: '0xd17127796D46c1588550Df783FCfE3D08ef8F6c0',
+    arbitrum: '0xF5d84413f2cd33d6d473BA9D0c665a73472d8fC7',
+    base: '0x199180dfbACEE5c204Db4E803A92a9D3A9Db4d1F',
+    bsc: '0x18A021d1c89Af87AaeD266B2C58dD16855Ad3702',
 }
 
 async function tvl(api) {
-const contract = CONTRACTS[api.chain]
+    const [tokens, amounts] = await api.call({
+        target: CONTRACTS[api.chain],
+        abi: getProtocolTvlTokensAndAmountsAbi,
+    })
 
-const [tokens, amounts] = await api.call({
-target: contract,
-abi: FINWB_ABI.getProtocolTvlTokensAndAmounts,
-})
-
-tokens.forEach((token, i) => {
-api.add(token, amounts[i])
-})
+    tokens.forEach((token, i) => {api.add(token, amounts[i])})
 }
 
 module.exports = {
-methodology:
-'FWB TVL is calculated from active user principal tracked on-chain by each deployed FWB contract via getProtocolTvlTokensAndAmounts(). User deposits are transferred to protocol payout wallets for managed fixed-yield operations, while the contracts keep active principal accounting per supported token.',
-ethereum: {
-tvl,
-},
-polygon: {
-tvl,
-},
-arbitrum: {
-tvl,
-},
-base: {
-tvl,
-},
-bsc: {
-tvl,
-},
+    methodology: 'FWB TVL is calculated from active user principal tracked on-chain by each deployed FWB contract via getProtocolTvlTokensAndAmounts(). User deposits are transferred to protocol payout wallets for managed fixed-yield operations, while the contracts keep active principal accounting per supported token.',
 }
+
+Object.keys(CONTRACTS).forEach(chain => {
+    module.exports[chain] = { tvl }
+})

--- a/projects/finwb/index.js
+++ b/projects/finwb/index.js
@@ -1,0 +1,45 @@
+const FINWB_ABI = {
+getProtocolTvlTokensAndAmounts:
+'function getProtocolTvlTokensAndAmounts() view returns (address[] tokens, uint256[] amounts)',
+}
+
+const CONTRACTS = {
+ethereum: '0x1Ef96B8fad9aE983E60610C4ba13536606B5c477',
+polygon: '0xd17127796D46c1588550Df783FCfE3D08ef8F6c0',
+arbitrum: '0xF5d84413f2cd33d6d473BA9D0c665a73472d8fC7',
+base: '0x199180dfbACEE5c204Db4E803A92a9D3A9Db4d1F',
+bsc: '0x18A021d1c89Af87AaeD266B2C58dD16855Ad3702',
+}
+
+async function tvl(api) {
+const contract = CONTRACTS[api.chain]
+
+const [tokens, amounts] = await api.call({
+target: contract,
+abi: FINWB_ABI.getProtocolTvlTokensAndAmounts,
+})
+
+tokens.forEach((token, i) => {
+api.add(token, amounts[i])
+})
+}
+
+module.exports = {
+methodology:
+'FWB TVL is calculated from active user principal tracked on-chain by each deployed FWB contract via getProtocolTvlTokensAndAmounts(). User deposits are transferred to protocol payout wallets for managed fixed-yield operations, while the contracts keep active principal accounting per supported token.',
+ethereum: {
+tvl,
+},
+polygon: {
+tvl,
+},
+arbitrum: {
+tvl,
+},
+base: {
+tvl,
+},
+bsc: {
+tvl,
+},
+}


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

## New Listing Information

##### Name (to be shown on DefiLlama):

Finances Without Borders

##### Twitter Link:

https://x.com/fwb030101

##### List of audit links if any:

No public audit links available yet.

##### Website Link:

https://finwb.xyz/

##### Logo (High resolution, will be shown with rounded borders):

Not provided yet.

##### Current TVL:

Approximately $200 based on local adapter test. The final TVL is calculated live from on-chain data.

##### Treasury Addresses (if the protocol has treasury)

Protocol payout wallet used by deployed contracts:

`0x33e29fac281B8A8BC6965A30c5619D132FfaC86E`

##### Chain:

Ethereum, Polygon, Arbitrum, Base, BNB Smart Chain

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):

##### Short Description (to be shown on DefiLlama):

Finances Without Borders is a multi-chain fixed-yield deposit protocol. Users deposit supported assets for fixed terms, while FWB contracts track active user principal on-chain.

##### Token address and ticker if any:

No governance token is currently issued.

Supported deposit assets include USDT / USDT0, WETH / ETH, WBTC / BTCB / cbBTC depending on the network.

##### Category (full list at https://defillama.com/categories) *Please choose only one:

Yield

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

Chainlink price feeds.

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

FWB contracts use token price feeds for deposit value checks and protocol accounting. The TVL adapter itself does not use oracle prices directly. It reads token addresses and active principal amounts from the deployed contracts through `getProtocolTvlTokensAndAmounts()`.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

Project repository:
https://github.com/fwb030101/fwb

Documentation:
https://finwb.xyz/docs

Verified contracts:

Ethereum:
https://etherscan.io/address/0x1Ef96B8fad9aE983E60610C4ba13536606B5c477

Polygon:
https://polygonscan.com/address/0xd17127796D46c1588550Df783FCfE3D08ef8F6c0

Arbitrum:
https://arbiscan.io/address/0xF5d84413f2cd33d6d473BA9D0c665a73472d8fC7

Base:
https://basescan.org/address/0x199180dfbACEE5c204Db4E803A92a9D3A9Db4d1F

BNB Smart Chain:
https://bscscan.com/address/0x18A021d1c89Af87AaeD266B2C58dD16855Ad3702

##### forkedFrom (Does your project originate from another project):

No.

##### methodology (what is being counted as tvl, how is tvl being calculated):

FWB TVL is calculated from active user principal tracked on-chain by each deployed FWB contract.

The adapter reads `getProtocolTvlTokensAndAmounts()` from each deployed contract. This function returns supported token addresses and active principal amounts for the selected network.

The adapter then adds the returned token amounts to TVL.

Important note: FWB is a managed fixed-yield protocol. User deposits are transferred to protocol payout wallets for managed fixed-yield operations, while the contracts keep active principal accounting per supported token.

##### Github org/user (Optional, if your code is open source, we can track activity):

https://github.com/fwb030101/fwb

##### Does this project have a referral program?

No public referral program listed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL support for the FINWB protocol on Ethereum, Polygon, Arbitrum, Base, and BSC.
  * Reports token balances and associated amounts to improve visibility into FINWB’s on-chain assets.

* **Documentation**
  * Included a methodology note describing how FINWB TVL is calculated for the reported chains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->