### PR TITLE
Add BlackDoor prediction markets adapter (Arbitrum One)

### DIFF
--- a/projects/blackdoor/index.js
+++ b/projects/blackdoor/index.js
@@ -1,43 +1,13 @@
-// BlackDoor — geo-anchored prediction markets on Arbitrum One
-// TVL = actual USDC locked in each market contract (usdc.balanceOf(market))
-// Factory: 0x4FaCa0EA8Dd4fE6E703f001435A99263336a498E
-
-const FACTORY = "0x4FaCa0EA8Dd4fE6E703f001435A99263336a498E";
-const USDC    = "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"; // Arbitrum One native USDC
+const ADDRESSES = require('../helper/coreAssets.json');
+const target = "0x4FaCa0EA8Dd4fE6E703f001435A99263336a498E";
 
 async function tvl(api) {
-  const total = Number(
-    await api.call({ target: FACTORY, abi: "uint256:totalMarkets" })
-  );
-  if (total === 0) return;
+  const markets = await api.fetchList({ lengthAbi: "uint256:totalMarkets", itemAbi: "function markets(uint256) view returns (address)", target, });
 
-  const indices = Array.from({ length: total }, (_, i) => i);
-
-  const markets = await api.multiCall({
-    abi: "function markets(uint256) view returns (address)",
-    calls: indices.map((i) => ({ target: FACTORY, params: [i] })),
-    permitFailure: true,
-  });
-
-  const validMarkets = markets.filter(Boolean);
-
-  // Use actual USDC balance of each contract — not poolYes + poolNo which
-  // double-counts: the FPMM seeds both pools equal to `net` from a single deposit,
-  // so poolYes ≈ poolNo ≈ contract balance, making their sum ≈ 2× the real TVL.
-  const balances = await api.multiCall({
-    abi: "function balanceOf(address) view returns (uint256)",
-    calls: validMarkets.map((m) => ({ target: USDC, params: [m] })),
-    permitFailure: true,
-  });
-
-  balances.forEach((bal) => {
-    if (bal) api.add(USDC, bal);
-  });
+  await api.sumTokens({owners: markets, tokens: [ADDRESSES.arbitrum.USDC_CIRCLE]});
 }
 
 module.exports = {
   arbitrum: { tvl },
-  methodology:
-    "Sum of USDC held in each BlackDoor PredictionMarket contract on Arbitrum One, " +
-    "measured as the actual token balance rather than internal pool accounting variables.",
+  methodology: "Sum of USDC held in each BlackDoor PredictionMarket contract on Arbitrum One.",
 };

--- a/projects/blackdoor/index.js
+++ b/projects/blackdoor/index.js
@@ -1,9 +1,6 @@
 // BlackDoor — geo-anchored prediction markets on Arbitrum One
-// TVL = sum of USDC locked in all market liquidity pools (poolYes + poolNo)
+// TVL = actual USDC locked in each market contract (usdc.balanceOf(market))
 // Factory: 0x4FaCa0EA8Dd4fE6E703f001435A99263336a498E
-// Note: the factory deploys every contract — both binary markets and each
-// individual outcome sub-contract of multi-outcome markets — so iterating
-// factory.markets(i) captures the full TVL without extra recursion.
 
 const FACTORY = "0x4FaCa0EA8Dd4fE6E703f001435A99263336a498E";
 const USDC    = "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"; // Arbitrum One native USDC
@@ -24,23 +21,23 @@ async function tvl(api) {
 
   const validMarkets = markets.filter(Boolean);
 
-  const [poolsYes, poolsNo] = await Promise.all([
-    api.multiCall({ abi: "uint256:poolYes", calls: validMarkets.map((m) => ({ target: m })), permitFailure: true }),
-    api.multiCall({ abi: "uint256:poolNo",  calls: validMarkets.map((m) => ({ target: m })), permitFailure: true }),
-  ]);
+  // Use actual USDC balance of each contract — not poolYes + poolNo which
+  // double-counts: the FPMM seeds both pools equal to `net` from a single deposit,
+  // so poolYes ≈ poolNo ≈ contract balance, making their sum ≈ 2× the real TVL.
+  const balances = await api.multiCall({
+    abi: "function balanceOf(address) view returns (uint256)",
+    calls: validMarkets.map((m) => ({ target: USDC, params: [m] })),
+    permitFailure: true,
+  });
 
-  poolsYes.forEach((v, i) => {
-    if (v) api.add(USDC, v);
-    if (poolsNo[i]) api.add(USDC, poolsNo[i]);
+  balances.forEach((bal) => {
+    if (bal) api.add(USDC, bal);
   });
 }
 
 module.exports = {
   arbitrum: { tvl },
   methodology:
-    "Sum of USDC (poolYes + poolNo) across all contracts deployed through the " +
-    "BlackDoor factory on Arbitrum One. The factory registers every deployed " +
-    "contract — binary markets and individual outcome sub-contracts of " +
-    "multi-outcome markets alike — so a single factory iteration captures the " +
-    "full protocol TVL.",
+    "Sum of USDC held in each BlackDoor PredictionMarket contract on Arbitrum One, " +
+    "measured as the actual token balance rather than internal pool accounting variables.",
 };

--- a/projects/blackdoor/index.js
+++ b/projects/blackdoor/index.js
@@ -1,6 +1,9 @@
 // BlackDoor — geo-anchored prediction markets on Arbitrum One
 // TVL = sum of USDC locked in all market liquidity pools (poolYes + poolNo)
 // Factory: 0x4FaCa0EA8Dd4fE6E703f001435A99263336a498E
+// Note: the factory deploys every contract — both binary markets and each
+// individual outcome sub-contract of multi-outcome markets — so iterating
+// factory.markets(i) captures the full TVL without extra recursion.
 
 const FACTORY = "0x4FaCa0EA8Dd4fE6E703f001435A99263336a498E";
 const USDC    = "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"; // Arbitrum One native USDC
@@ -16,23 +19,28 @@ async function tvl(api) {
   const markets = await api.multiCall({
     abi: "function markets(uint256) view returns (address)",
     calls: indices.map((i) => ({ target: FACTORY, params: [i] })),
+    permitFailure: true,
   });
 
+  const validMarkets = markets.filter(Boolean);
+
   const [poolsYes, poolsNo] = await Promise.all([
-    api.multiCall({ abi: "uint256:poolYes", calls: markets.map((m) => ({ target: m })) }),
-    api.multiCall({ abi: "uint256:poolNo",  calls: markets.map((m) => ({ target: m })) }),
+    api.multiCall({ abi: "uint256:poolYes", calls: validMarkets.map((m) => ({ target: m })), permitFailure: true }),
+    api.multiCall({ abi: "uint256:poolNo",  calls: validMarkets.map((m) => ({ target: m })), permitFailure: true }),
   ]);
 
   poolsYes.forEach((v, i) => {
-    api.add(USDC, v);
-    api.add(USDC, poolsNo[i]);
+    if (v) api.add(USDC, v);
+    if (poolsNo[i]) api.add(USDC, poolsNo[i]);
   });
 }
 
 module.exports = {
   arbitrum: { tvl },
   methodology:
-    "Sum of USDC locked in all BlackDoor prediction market liquidity pools (poolYes + poolNo) " +
-    "deployed through the factory contract on Arbitrum One. Includes all binary markets and " +
-    "individual outcome sub-contracts for multi-outcome markets.",
+    "Sum of USDC (poolYes + poolNo) across all contracts deployed through the " +
+    "BlackDoor factory on Arbitrum One. The factory registers every deployed " +
+    "contract — binary markets and individual outcome sub-contracts of " +
+    "multi-outcome markets alike — so a single factory iteration captures the " +
+    "full protocol TVL.",
 };

--- a/projects/blackdoor/index.js
+++ b/projects/blackdoor/index.js
@@ -1,0 +1,38 @@
+// BlackDoor — geo-anchored prediction markets on Arbitrum One
+// TVL = sum of USDC locked in all market liquidity pools (poolYes + poolNo)
+// Factory: 0x4FaCa0EA8Dd4fE6E703f001435A99263336a498E
+
+const FACTORY = "0x4FaCa0EA8Dd4fE6E703f001435A99263336a498E";
+const USDC    = "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"; // Arbitrum One native USDC
+
+async function tvl(api) {
+  const total = Number(
+    await api.call({ target: FACTORY, abi: "uint256:totalMarkets" })
+  );
+  if (total === 0) return;
+
+  const indices = Array.from({ length: total }, (_, i) => i);
+
+  const markets = await api.multiCall({
+    abi: "function markets(uint256) view returns (address)",
+    calls: indices.map((i) => ({ target: FACTORY, params: [i] })),
+  });
+
+  const [poolsYes, poolsNo] = await Promise.all([
+    api.multiCall({ abi: "uint256:poolYes", calls: markets.map((m) => ({ target: m })) }),
+    api.multiCall({ abi: "uint256:poolNo",  calls: markets.map((m) => ({ target: m })) }),
+  ]);
+
+  poolsYes.forEach((v, i) => {
+    api.add(USDC, v);
+    api.add(USDC, poolsNo[i]);
+  });
+}
+
+module.exports = {
+  arbitrum: { tvl },
+  methodology:
+    "Sum of USDC locked in all BlackDoor prediction market liquidity pools (poolYes + poolNo) " +
+    "deployed through the factory contract on Arbitrum One. Includes all binary markets and " +
+    "individual outcome sub-contracts for multi-outcome markets.",
+};


### PR DESCRIPTION
Name (to be shown on DefiLlama): BlackDoor

Twitter Link: https://x.com/TheBoatOfLeegs

List of audit links if any: N/A (unaudited — early stage)

Website Link: https://blackdoor.claims

Logo (High resolution, will be shown with rounded borders):
https://blackdoor.claims/icon-512.png

Current TVL: $15.26 (12 live markets, Arbitrum One)

Treasury Addresses (if the protocol has treasury): N/A

Chain: Arbitrum One

Coingecko ID: (not listed)

Coinmarketcap ID: (not listed)

Short Description (to be shown on DefiLlama):
Geo-anchored prediction markets on Arbitrum One. Each market is pinned to a real-world location on an interactive globe. Powered by FPMM, settled in USDC.

Token address and ticker if any: N/A (no native token — uses USDC)

Category: Prediction Markets

Oracle Provider(s): None — prices are determined entirely by the on-chain FPMM mechanism.

Implementation Details: No oracle. Market odds emerge from pool ratios (poolYes / poolNo).

Documentation/Proof: N/A

forkedFrom: None (original)

methodology: Sum of USDC (6 decimals) in poolYes + poolNo across all 12 markets deployed through the factory on Arbitrum One, read live via multicall.

Github org/user: https://github.com/BLACKDOOR2

Does this project have a referral program? Yes — 1% referral fee on every bet, paid from the 2% protocol fee.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tracking BlackDoor prediction markets’ TVL on Arbitrum One.
  * TVL now aggregates the on-chain USDC balances held by all factory-created market contracts.
* **Bug Fixes**
  * Improved TVL correctness by basing calculations on actual token balances per deployed market, rather than derived/internal accounting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->