### PR TITLE
add circle xreserve

### DIFF
--- a/registries/sumTokens.js
+++ b/registries/sumTokens.js
@@ -7081,6 +7081,12 @@ const configs = {
       "token": "0x5dF82810CB4B8f3e0Da3c031cCc9208ee9cF9500"
     },
   },
+  "circle-xreserve": {
+    "ethereum": {
+      "owner": "0x77777777Dcc4d5A8B6E418Fd04D8997ef11000eE",
+      "token": ADDRESSES.ethereum.USDC
+    }
+  },
   "citadao": {
     "ethereum": {
       "tvl": {


### PR DESCRIPTION
per-chain breakdowns can be seen by calling `balanceOfNativeCollateral(usdc,domain)` on the [xReserve contract](https://etherscan.io/address/0x8888888199b2Df864bf678259607d6D5EBb4e3Ce#readProxyContract). 

For example:
- Cardano (10004) returns ~28,581,638.008373 matching [USDCx supply](https://cardanoscan.io/token/1f3aec8bfe7ea4fe14c5f121e2a92e301afe414147860d557cac7e345553444378)

resolves #19605

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an additional token aggregation source, expanding available token coverage for Ethereum-based data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->