### PR TITLE
fix: pulsex-v2 adapter to use onchain data

### DIFF
--- a/projects/pulsex-v2/index.js
+++ b/projects/pulsex-v2/index.js
@@ -1,19 +1,14 @@
-const { graphQuery } = require('../helper/http')
+const { getUniTVL } = require('../helper/unknownTokens');
 
-const SUBGRAPH = 'https://graph.pulsechain.com/subgraphs/name/pulsechain/pulsexv2'
-
-async function tvl(api) {
-  const { pulseXFactories } = await graphQuery(SUBGRAPH, `{
-    pulseXFactories {
-      totalLiquidityUSD
-    }
-  }`)
-  api.addUSDValue(+pulseXFactories[0].totalLiquidityUSD)
-}
+// PulseX V2 is a standard Uniswap V2 fork on PulseChain.
+// Factory exposes allPairsLength()/allPairs(uint) and pairs expose getReserves()/token0()/token1().
+// https://otter.pulsechain.com/address/0x29eA7545DEf87022BAdc76323F373EA1e707C523
+const factory = '0x29eA7545DEf87022BAdc76323F373EA1e707C523';
 
 module.exports = {
-  misrepresentedTokens: true,
+  methodology: 'Enumerates all PulseX V2 pairs on-chain via the factory and sums the reserves of known (core) assets held in the liquidity pools.',
+  isHeavyProtocol: true,
   pulse: {
-    tvl,
+    tvl: getUniTVL({ factory, useDefaultCoreAssets: true }),
   },
 };


### PR DESCRIPTION
This PR fixes the PulseX V2 TVL calculation by replacing a stale subgraph value with on-chain liquidity data. This restores accurate historical TVL (timetravel) support.

## What was wrong?

The adapter was reading a single subgraph field (`totalLiquidityUSD`), which always returned the latest TVL regardless of the requested timestamp.

This caused:
- TVL to remain around **$15M** across all dates
- Historical queries to return current values
- TVL to be derived from subgraph data instead of on-chain reserves

## Results

| Date | Pair Count | TVL |
|--------|----------:|--------:|
| Current | 181,356 | **$19.19M** |
| 2024-06-23 | 77,372 | **$26.92M** |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated PulseX V2 TVL tracking to use on-chain pool enumeration, improving the accuracy and reliability of displayed liquidity data.
  * Core asset reserves are now counted directly in the valuation, helping keep TVL totals aligned with live protocol state.

* **Documentation**
  * Added clearer methodology information for how PulseX V2 TVL is calculated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->