### PR TITLE
fix(increment-lending): replace web API with on-chain Cadence reads

### DIFF
--- a/projects/increment-lending/index.js
+++ b/projects/increment-lending/index.js
@@ -1,17 +1,67 @@
-const { fetchURL } = require("../helper/utils");
+const { callCadence } = require("../helper/chain/flow");
 
-// lending info: https://app.increment.fi/markets
-async function borrowed(api) {
-  const { data: tvls } = await fetchURL("https://app.increment.fi/info/tvl");
-  return api.addUSDValue(Math.round(tvls.LendingBorrow))
+// Queries each lending pool's cash + borrows via on-chain Cadence script.
+const script = `
+import LendingInterfaces from 0x2df970b6cdee5735
+import LendingConfig from 0x2df970b6cdee5735
+
+access(all) view fun main(): [UFix64] {
+    let comptrollerRef = getAccount(0xf80cb737bfe7c792)
+        .capabilities.borrow<&{LendingInterfaces.ComptrollerPublic}>(/public/comptrollerModule)
+        ?? panic("Cannot borrow LendingComptroller")
+
+    let oracleRef = getAccount(0x72d3a05910b6ffa3)
+        .capabilities.borrow<&{LendingInterfaces.OraclePublic}>(/public/oracleModule)
+        ?? panic("Cannot borrow LendingOracle")
+
+    var totalCashUSD: UFix64 = 0.0
+    var totalBorrowUSD: UFix64 = 0.0
+
+    for poolAddr in comptrollerRef.getAllMarkets() {
+        if let poolRef = getAccount(poolAddr)
+            .capabilities.borrow<&{LendingInterfaces.PoolPublic}>(/public/incrementLendingPoolPublic) {
+
+            let price = oracleRef.getUnderlyingPrice(pool: poolAddr)
+            if price != 0.0 {
+                let cashScaled = poolRef.getPoolCash()
+                let borrowScaled = poolRef.getPoolTotalBorrowsScaled()
+                totalCashUSD = totalCashUSD + LendingConfig.ScaledUInt256ToUFix64(cashScaled) * price
+                totalBorrowUSD = totalBorrowUSD + LendingConfig.ScaledUInt256ToUFix64(borrowScaled) * price
+            }
+        }
+    }
+
+    return [totalCashUSD, totalBorrowUSD]
+}
+`;
+
+let _cachedData;
+async function fetchMarketData () {
+  if (!_cachedData) {
+    _cachedData = callCadence(script).then((result) => {
+      const vals = result.value;
+      return {
+        cashUSD: parseFloat(vals[0].value),
+        borrowUSD: parseFloat(vals[1].value),
+      };
+    });
+    _cachedData.catch(() => { _cachedData = null; });
+  }
+  return _cachedData;
 }
 
-const tvl = async (api) => {
-  const { data: tvls } = await fetchURL("https://app.increment.fi/info/tvl")
-  return api.addUSDValue(Math.round(tvls.LendingTVL - tvls.LendingBorrow))
+async function tvl (api) {
+  const { cashUSD } = await fetchMarketData();
+  api.addUSDValue(cashUSD);
+}
+
+async function borrowed (api) {
+  const { borrowUSD } = await fetchMarketData();
+  api.addUSDValue(borrowUSD);
 }
 
 module.exports = {
+  timetravel: false,
   misrepresentedTokens: true,
   methodology: "Counting the tokens locked in the contracts to be used as collateral to borrow or to earn yield. Borrowed funds are not counted in the TVL, so only the tokens actually locked in the contracts are counted.",
   flow: { tvl, borrowed },


### PR DESCRIPTION
This PR replaces Increment Lending’s previous API-based data source with an on-chain Flow query.

To remove that dependency, the adapter now reads protocol data directly from Flow using a Cadence script executed through the existing `callCadence` helper.

## Implementation Details

The adapter executes a single Cadence view script that gathers both TVL and borrow data in one request.

The script:

- Borrows the `LendingComptroller` capability at `0xf80cb737bfe7c792`.
- Iterates through every market returned by `getAllMarkets()`.
- For each market, borrows its `PoolPublic` capability and retrieves:
  - `getPoolCash()` — assets currently held in the pool vault.
  - `getPoolTotalBorrowsScaled()` — total outstanding borrows.
- Reads market prices from the `LendingOracle` at `0x72d3a05910b6ffa3`.
- Converts scaled `UInt256` values into `UFix64` using `LendingConfig.ScaledUInt256ToUFix64`.
- Multiplies balances by their corresponding USD prices and accumulates:
  - `totalCashUSD`
  - `totalBorrowUSD`
- Automatically skips markets that do not have an oracle price available (for example, deprecated markets such as USDC).

## Test Output

| Metric | Token | Value |
|----------|----------|----------|
| flow | USDT | 407.31k |
| flow-borrowed | USDT | 46.94k |
| borrowed | USDT | 46.94k |
| total | — | 407.31k |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Switched lending TVL and borrow calculations to use on-chain data, improving accuracy and reducing reliance on external snapshots.
  * Added a shared cache so repeated balance and borrow lookups reuse the same result and recover cleanly if a fetch fails.

* **New Features**
  * Exposed additional USD-based metrics for cash and borrows in the lending dashboard.
  * Marked the project as not supporting timetravel queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->