### PR TITLE
Remove ZINC TVL reporting

### DIFF
--- a/registries/sumTokens.js
+++ b/registries/sumTokens.js
@@ -41184,20 +41184,10 @@ const configs = {
     },
   },
   "zinc": {
-    "timetravel": false,
-    "start": "2026-05-26",
-    "methodology": "TVL counts SOL held in Zinc stockpile and bonanza prize vaults. Staking counts ZINC deposited in the staking vault. Treasury and buyback vault balances are excluded.",
+    "methodology": "ZINC does not report TVL.",
     "solana": {
       "tvl": {
-        "solOwners": [
-          "8RxMJD7BtdzxuZkmDqcxhR6gWvegLJ1GNf9NFrPkCmwf",
-          "DNJGqahXJfu8Fsg4HRS7bKWFLnSzU5fvt85fkake7JFY"
-        ]
-      },
-      "staking": {
-        "tokenAccounts": [
-          "4Ym9uvwrwdpiTKq874T8wSqzaFkh8AVazf255FKLt9MR"
-        ]
+        "__empty": true
       }
     },
   },


### PR DESCRIPTION
Removes ZINC TVL/staking reporting.

The intended UI outcome is that ZINC remains a fees/revenue-only listing and does not show a TVL surface to users. This should not be interpreted as a request to display ZINC with `$0 TVL`; if cached/current TVL still appears after merge, please clear cached TVL for ZINC or apply the metadata-side `dummy.js` mapping.

The previously counted balances are protocol-controlled/operational accounts and should not be represented as user-supplied TVL.

ZINC should remain listed for fees/revenue via its dimensions adapter, but should not report TVL.

If needed, please clear cached historical TVL for ZINC after merge.
