### PR TITLE
fix(stakestone-stoneusd): price STONEUSD and add missing BNB Chain

### DIFF
--- a/projects/stakestone-stoneusd/index.js
+++ b/projects/stakestone-stoneusd/index.js
@@ -8,7 +8,7 @@ const tvl = (target) => async (api) => {
     target,
   });
 
-  api.addUSDValue(Number(BigInt(totalSupply) / 10n ** 12n) / 1e6);
+  api.add(target, totalSupply);
 }
 
 module.exports = {

--- a/projects/stakestone-stoneusd/index.js
+++ b/projects/stakestone-stoneusd/index.js
@@ -1,30 +1,25 @@
 const STONEUSD_ETH = '0x6A6E3a4396993A4eC98a6f4A654Cc0819538721e';
+const STONEUSD_BSC = '0x8B4E28607bdcacBf937f81F29E3DAFe7Bc1D7c0b';
 const STONEUSD_MONAD = '0x095957CEB9f317ac1328f0aB3123622401766D71';
 
-const ethTvl = async (api) => {
+const tvl = (target) => async (api) => {
   const totalSupply = await api.call({
     abi: 'erc20:totalSupply',
-    target: STONEUSD_ETH,
+    target,
   });
 
-  api.add(STONEUSD_ETH, totalSupply)
-}
-
-const monadTvl = async (api) => {
-  const totalSupply = await api.call({
-    abi: 'erc20:totalSupply',
-    target: STONEUSD_MONAD,
-  });
-
-  api.add(STONEUSD_MONAD, totalSupply)
+  api.addUSDValue(Number(BigInt(totalSupply) / 10n ** 12n) / 1e6);
 }
 
 module.exports = {
   ethereum: {
-    tvl: ethTvl,
+    tvl: tvl(STONEUSD_ETH),
+  },
+  bsc: {
+    tvl: tvl(STONEUSD_BSC),
   },
   monad: {
-    tvl: monadTvl,
+    tvl: tvl(STONEUSD_MONAD),
   },
   doublecounted: false
 }


### PR DESCRIPTION
This PR fixes the zero TVL issue for StakeStone STONEUSD stablecoin.

- Adds the missing BNB Chain STONEUSD deployment contract address.
- Bypasses the Coins price-feed gap by calculating onchain totalSupply and adding its USD value directly using api.addUSDValue().
- Verified locally via node test.js projects/stakestone-stoneusd/index.js which recovers ~$2.25M TVL.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tracking StoneUSD on BSC.
  * Unified StoneUSD TVL reporting across Ethereum, Monad, and BSC for more consistent totals.

* **Bug Fixes**
  * Updated StoneUSD TVL computation to improve accuracy and consistency across networks.
  * Marked StoneUSD as non-double-counted to prevent it from inflating combined totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->