### PR TITLE
Add flooor.fun TVL adapter (Base)

### DIFF
--- a/projects/flooor-fun/index.js
+++ b/projects/flooor-fun/index.js
@@ -1,0 +1,15 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+const { sumTokensExport } = require('../helper/unwrapLPs')
+
+const FLOOOR_CONTRACT = '0xF6B2C2411a101Db46c8513dDAef10b11184c58fF'
+
+module.exports = {
+  methodology: 'TVL is the native ETH held in the flooor.fun auction contract on Base, comprising the current highest bid locked in escrow (activebidAM) plus accumulated epoch pool rewards (poolAccrued). ETH exits the contract when sellToHighest() is called, distributing 99.5% to the NFT seller and 0.5% fee to the protocol.',
+
+  base: {
+    tvl: sumTokensExport({
+      owners: [FLOOOR_CONTRACT],
+      tokens: [ADDRESSES.null],
+    }),
+  },
+}


### PR DESCRIPTION
## Summary
- Adds TVL adapter for **flooor.fun**, an NFT auction platform on Base chain
- Users bid in native ETH; the contract holds bids in escrow until `sellToHighest()` is called
- Platform takes 0.5% fee on each settled auction
- TVL = ETH locked in contract (active highest bid + accumulated epoch pool)

## Contract
- Chain: **Base**
- Contract: `0xF6B2C2411a101Db46c8513dDAef10b11184c58fF`

## Test
```
node test.js projects/flooor-fun/index.js
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking support for the flooor.fun auction contract on Base.
  * TVL now reflects native ETH held in the contract, including escrowed bids and accumulated rewards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->