### PR TITLE
Add Aurevaz — token & LP locker on Polygon, BSC, Arbitrum

### DIFF
--- a/projects/aurevaz/index.js
+++ b/projects/aurevaz/index.js
@@ -1,0 +1,34 @@
+const { sumTokens2 } = require("../helper/unwrapLPs");
+
+const lockerAddresses = {
+  polygon: "0xBEdDcf2c709B3cEd29560E32322E09AEaC79316E",
+  bsc: "0x0504C1048E3E8f49B435638496202337881c7F89",
+  arbitrum: "0xBEdDcf2c709B3cEd29560E32322E09AEaC79316E",
+};
+
+async function tvl(api) {
+  const target = lockerAddresses[api.chain];
+  const locks = await api.fetchList({ target, itemAbi: "function locks(uint256) view returns (address token, address owner, uint256 amount, uint256 claimed, uint256 lockDate, uint256 unlockDate, uint256 vestingStart, uint256 vestingDuration, bool isLP)", lengthAbi: "uint256:lockCount" });
+
+  const tokens = [];
+  for (const lock of locks) {
+    const remaining = BigInt(lock.amount) - BigInt(lock.claimed);
+    if (remaining > 0n) {
+      api.add(lock.token, remaining.toString());
+    }
+  }
+
+  return sumTokens2({ api });
+}
+
+const chains = ["polygon", "bsc", "arbitrum"];
+const config = {
+  methodology: "Counts the remaining locked token balances (amount - claimed) across all active locks in the TokenLocker contract on each chain.",
+  start: 1717200000,
+};
+
+chains.forEach((chain) => {
+  config[chain] = { tvl };
+});
+
+module.exports = config;

--- a/projects/aurevaz/index.js
+++ b/projects/aurevaz/index.js
@@ -1,4 +1,4 @@
-const { sumTokens2 } = require("../helper/unwrapLPs");
+const { unwrapLPsAuto } = require("../helper/unwrapLPs");
 
 const lockerAddresses = {
   polygon: "0xBEdDcf2c709B3cEd29560E32322E09AEaC79316E",
@@ -6,28 +6,41 @@ const lockerAddresses = {
   arbitrum: "0xBEdDcf2c709B3cEd29560E32322E09AEaC79316E",
 };
 
-async function tvl(api) {
-  const target = lockerAddresses[api.chain];
-  const locks = await api.fetchList({ target, itemAbi: "function locks(uint256) view returns (address token, address owner, uint256 amount, uint256 claimed, uint256 lockDate, uint256 unlockDate, uint256 vestingStart, uint256 vestingDuration, bool isLP)", lengthAbi: "uint256:lockCount" });
+const AVZ = "0x26A352A55F9F278Cf939cc57AB10cfe7c6e636b8";
+const LOCK_ABI = "function locks(uint256) view returns (address token, address owner, uint256 amount, uint256 claimed, uint256 lockDate, uint256 unlockDate, uint256 vestingStart, uint256 vestingDuration, bool isLP)";
 
+const isVesting = (lock) => lock.vestingStart != 0;
+const isAVZ = (lock) => lock.token.toLowerCase() === AVZ.toLowerCase();
+
+async function addLocks(api, filter) {
+  const locks = await api.fetchList({ target: lockerAddresses[api.chain], lengthAbi: "uint256:lockCount", itemAbi: LOCK_ABI });
   for (const lock of locks) {
+    if (!filter(lock)) continue;
     const remaining = BigInt(lock.amount) - BigInt(lock.claimed);
-    if (remaining > 0n) {
-      api.add(lock.token, remaining.toString());
-    }
+    if (remaining > 0n) api.add(lock.token, remaining.toString());
   }
+}
 
-  return sumTokens2({ api, resolveLP: true });
+async function tvl(api) {
+  await addLocks(api, (l) => !isVesting(l) && !isAVZ(l));
+  await unwrapLPsAuto({ api });
+}
+
+async function staking(api) {
+  await addLocks(api, (l) => !isVesting(l) && isAVZ(l));
+}
+
+async function vesting(api) {
+  await addLocks(api, (l) => isVesting(l));
+  await unwrapLPsAuto({ api });
 }
 
 const chains = ["polygon", "bsc", "arbitrum"];
-const config = {
-  methodology: "Counts the remaining locked token balances (amount - claimed) across all active locks in the TokenLocker contract on each chain.",
-  start: 1717200000,
+module.exports = {
+  methodology: "TVL is the remaining locked balance (amount - claimed) of every non-AVZ, non-vesting lock in the TokenLocker on each chain. Staking is locked AVZ (the protocol token). Vesting is the remaining balance of locks with a vesting schedule.",
+  start: '2026-06-20',
 };
 
 chains.forEach((chain) => {
-  config[chain] = { tvl };
+  module.exports[chain] = { tvl, staking, vesting };
 });
-
-module.exports = config;

--- a/projects/aurevaz/index.js
+++ b/projects/aurevaz/index.js
@@ -10,7 +10,6 @@ async function tvl(api) {
   const target = lockerAddresses[api.chain];
   const locks = await api.fetchList({ target, itemAbi: "function locks(uint256) view returns (address token, address owner, uint256 amount, uint256 claimed, uint256 lockDate, uint256 unlockDate, uint256 vestingStart, uint256 vestingDuration, bool isLP)", lengthAbi: "uint256:lockCount" });
 
-  const tokens = [];
   for (const lock of locks) {
     const remaining = BigInt(lock.amount) - BigInt(lock.claimed);
     if (remaining > 0n) {
@@ -18,7 +17,7 @@ async function tvl(api) {
     }
   }
 
-  return sumTokens2({ api });
+  return sumTokens2({ api, resolveLP: true });
 }
 
 const chains = ["polygon", "bsc", "arbitrum"];

--- a/projects/aurevaz/index.js
+++ b/projects/aurevaz/index.js
@@ -42,5 +42,7 @@ module.exports = {
 };
 
 chains.forEach((chain) => {
-  module.exports[chain] = { tvl, staking, vesting };
+  module.exports[chain] = { tvl, vesting };
 });
+
+module.exports.polygon.staking = staking;


### PR DESCRIPTION
## Aurevaz — DeFi Token Locker

**Website:** https://aurevaz.com
**Category:** Services — Token Locker

### Contracts (verified on all explorers):
- Polygon: `0xBEdDcf2c709B3cEd29560E32322E09AEaC79316E`
- BSC: `0x0504C1048E3E8f49B435638496202337881c7F89`
- Arbitrum: `0xBEdDcf2c709B3cEd29560E32322E09AEaC79316E`

### TVL Methodology:
Counts remaining locked token balances (amount - claimed) across all active locks.

### Active locks:
- 500,000 AVZ locked on Polygon until Jan 2027

Note: Previous PR #19737 was closed due to zero TVL. Tokens are now locked with non-zero TVL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded locked-asset balance reporting to Polygon, BSC, and Arbitrum with separate TVL and Vesting views.
  * Added Staking tracking for Polygon alongside the existing lock breakdown.
* **Bug Fixes**
  * Improved accuracy by counting only unclaimed portions of locked assets toward TVL and Vesting.
  * Ensured TVL excludes vesting-related and specific AVZ locks, while Vesting includes only actively vesting balances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->