### PR TITLE
Add Suigar (SweetHouse) TVL adapter

### DIFF
--- a/projects/suigar/index.js
+++ b/projects/suigar/index.js
@@ -43,6 +43,7 @@ async function tvl(api) {
 
 module.exports = {
   timetravel: false,
+  doublecounted: true,
   methodology:
     "TVL is the SweetHouse bankroll on Sui that backs Suigar's provably-fair casino payouts. For each supported coin (SUI, USDC) it sums, across the private, public, rakeback and whitelist liquidity pools of that coin's House, the on-hand balance plus the liquidity routed into yield venues (pipe debt).",
   sui: { tvl },

--- a/projects/suigar/index.js
+++ b/projects/suigar/index.js
@@ -1,0 +1,49 @@
+const sui = require("../helper/chain/sui");
+
+// SweetHouse vault (shared object) on Sui mainnet. It stores one House<CoinType>
+// per supported asset as a dynamic object field (keyed by sweethouse::HouseKey).
+const VAULT =
+  "0xa1549d73230118716bc08865b8d62454f360ddaf40eee2158e458e52125d4ef1";
+
+async function tvl(api) {
+  // Resolve only the per-coin House objects out of the vault's dynamic fields.
+  const houses = await sui.getDynamicFieldObjects({
+    parent: VAULT,
+    idFilter: (i) => i.objectType && i.objectType.includes("::house::House<"),
+  });
+
+  for (const house of houses) {
+    if (!house || !house.fields) continue;
+    // House<COIN_TYPE> — the phantom coin type backs every pool below.
+    const match = (house.type || "").match(/::house::House<(.+)>$/);
+    if (!match) continue;
+    const coinType = match[1];
+
+    const pools = [
+      house.fields.private_pool,
+      house.fields.public_pool,
+      house.fields.rakeback_pool,
+      ...(house.fields.whitelist_pools || []),
+    ];
+
+    for (const pool of pools) {
+      if (!pool || !pool.fields) continue;
+      // On-hand liquidity (Balance<T>, serialized as a u64 string) plus liquidity
+      // routed into yield venues (pipe_debt is a Supply<PoolDebt<T>>, value nested
+      // under .fields.value) — both are bankroll that backs casino payouts.
+      const balance = pool.fields.balance;
+      const pipeDebt = pool.fields.pipe_debt && pool.fields.pipe_debt.fields
+        ? pool.fields.pipe_debt.fields.value
+        : undefined;
+      if (balance) api.add(coinType, balance);
+      if (pipeDebt) api.add(coinType, pipeDebt);
+    }
+  }
+}
+
+module.exports = {
+  timetravel: false,
+  methodology:
+    "TVL is the SweetHouse bankroll on Sui that backs Suigar's provably-fair casino payouts. For each supported coin (SUI, USDC) it sums, across the private, public, rakeback and whitelist liquidity pools of that coin's House, the on-hand balance plus the liquidity routed into yield venues (pipe debt).",
+  sui: { tvl },
+};


### PR DESCRIPTION
## Suigar / SweetHouse — TVL adapter (Sui)

Adds a TVL adapter for **Suigar**, a provably-fair on-chain casino on Sui mainnet, and its bankroll protocol **SweetHouse**.

### What is counted
TVL = the SweetHouse bankroll that backs casino payouts. The vault (a shared object) holds one `House<CoinType>` per supported asset as a dynamic object field. Each House splits liquidity across `private`, `public`, `rakeback` and `whitelist` pools. For every pool the adapter sums:
- `balance` — liquidity on hand (`Balance<T>`), and
- `pipe_debt.value` — liquidity routed into yield venues (Suilend) via the protocol's "pipes".

Both represent bankroll the protocol controls and can recall to cover payouts. The coin set (currently SUI + USDC) is discovered dynamically from the vault's dynamic fields, so new assets are picked up automatically.

> Transparency note: a portion of the bankroll is deposited into Suilend to earn yield (the `pipe_debt` part). It is included because it is protocol-owned bankroll; happy to adjust if you'd prefer to exclude routed liquidity to avoid cross-protocol double counting.

### On-chain references (Sui mainnet)
- SweetHouse vault: `0xa1549d73230118716bc08865b8d62454f360ddaf40eee2158e458e52125d4ef1`
- Package: `0xcbb0929f21450013ebe5e86e7139f2409da2e3ed212c51126a7e6448b795a43f`
- Coins: `0x2::sui::SUI`, `0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC`

### Test
`node test.js projects/suigar/index.js`
```
--- tvl ---
SUI    40.63 k
USDC   30.53 k
Total: 71.16 k
```

### Listing metadata
- Name: Suigar
- Category: Gambling
- Chain: Sui
- URL: https://suigar.com
- Twitter: @Suigar_com
- Audit: https://movebit.xyz/reports/Suigar-Audit-Report-2025-11-10.pdf
- Logo: https://suigar.com/logo/suigar.png
- No governance/tradeable token.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for a new Sui-based protocol, including multiple pool types (private, public, rakeback, and whitelist) and routed liquidity.
  * Introduced a methodology note for reporting and disabled historical backfilling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->