### PR TITLE
fix(predmart): remove inactive Base entry (Polygon-only)

### DIFF
--- a/projects/predmart/index.js
+++ b/projects/predmart/index.js
@@ -6,9 +6,6 @@ const USDC = ADDRESSES.polygon.USDC;
 
 module.exports = {
   methodology: "TVL represents liquid USDC currently available in the PredMart lending pool (total deposits minus outstanding borrows). Borrowed reflects total USDC actively lent out to borrowers who posted Polymarket prediction market shares as collateral. Total lender deposits = TVL + Borrowed.",
-  base: {
-    tvl: () => ({}),
-  },
   polygon: {
     tvl: async (api) => {
       // Liquid USDC sitting in the lending pool contract


### PR DESCRIPTION
PredMart operates only on Polygon. The `base` export returns no TVL (`tvl: () => ({})`) and only causes Base to appear as a supported chain on the protocol page. This removes it; the Polygon `tvl` and `borrowed` logic is unchanged.

- TVL: liquid USDC in the lending pool (Polygon)
- Borrowed: `totalBorrowAssets()` on the pool

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved PredMart TVL reporting by removing an empty chain entry and keeping only the supported network data.
  - Liquid USDC balances and borrowed USDC are now reflected more accurately for the lending pool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->