### PR TITLE
fix(felix-vanilla): deduct missing vaults to prevent double counting

### DIFF
--- a/projects/felix-vanilla/index.js
+++ b/projects/felix-vanilla/index.js
@@ -10,6 +10,8 @@ const tvl = async (api) => {
     "0x2900ABd73631b2f60747e687095537B673c06A76",
     "0x9896a8605763106e57A51aa0a97Fe8099E806bb3",
     "0x66c71204B70aE27BE6dC3eb41F9aF5868E68fDb6",
+    "0x8A862fD6c12f9ad34C9c2ff45AB2b6712e8CEa27",
+    "0x207ccaE51Ad2E1C240C4Ab4c94b670D438d2201C",
   ];
 
   const assets = await api.multiCall({


### PR DESCRIPTION
This PR resolves the TVL double-counting issue on the Felix protocol on HyperEVM (Hyperliquid), which was reported in issue #19689.

### The Bug & On-Chain Proof
Felix Combined TVL is calculated as `felix-vaults` TVL plus `felix-vanilla` TVL. Since Felix Vaults deposit into Morpho Blue, their assets are already included in Morpho Blue's overall TVL. To prevent double-counting, the `felix-vanilla` adapter retrieves Morpho Blue's TVL and subtracts the assets held by all Felix Vaults.

However, the hardcoded list of vault addresses in `projects/felix-vanilla/index.js` only tracks 6 vaults, whereas `projects/felix-vaults/index.js` tracks 8 active vaults. The following 2 vaults are missing from the subtraction list:
- `0x8A862fD6c12f9ad34C9c2ff45AB2b6712e8CEa27` (feUSDC)
- `0x207ccaE51Ad2E1C240C4Ab4c94b670D438d2201C` (feUSDH)

These two vaults hold active deposits on-chain (verified via the Hyperliquid EVM node):
- `0x8A862fD6...` has `10,427,215,122,012` atomic units of USDC (~$10.42M USDC).
- `0x207ccaE5...` has `203,783,510,686` atomic units of USDH (~$203.78k USDH).

Because they are not deducted from `felix-vanilla`, their combined ~$10.62M in assets is counted twice—once in vaults and once in vanilla.

### The Fix
This PR adds the two missing vault addresses to the `felixVaultAddresses` array in `projects/felix-vanilla/index.js`. 

Local execution tests confirm that this resolves the double-counting cleanly, lowering `felix-vanilla` TVL from $235.66 M to $225.30 M, bringing the combined TVL into sync.

Closes #19689.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded Felix vault tracking so TVL calculations now include two additional vault addresses.
  * Improved the accuracy of Felix vault balance reporting by covering more vaults in the totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->