### PR TITLE
Add TVL calculation for ArcisVault

### DIFF
--- a/projects/arcis-protocol/index.js
+++ b/projects/arcis-protocol/index.js
@@ -4,10 +4,11 @@ const VAULT = "0x00325d9da832b38179ed2f0dabd4062d93e325a7";
 const USDC = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
 
 async function tvl(api) {
-  return sumTokens2({
-    api,
-    tokensAndOwners: [[USDC, VAULT]],
+  const totalAssets = await api.call({
+    target: VAULT,
+    abi: "uint256:totalAssets",
   });
+  api.add(USDC, totalAssets);
 }
 
 module.exports = {

--- a/projects/arcis-protocol/index.js
+++ b/projects/arcis-protocol/index.js
@@ -1,0 +1,19 @@
+const { sumTokens2 } = require("../helper/unwrapLPs");
+
+const VAULT = "0x00325d9da832b38179ed2f0dabd4062d93e325a7";
+const USDC = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+
+async function tvl(api) {
+  return sumTokens2({
+    api,
+    tokensAndOwners: [[USDC, VAULT]],
+  });
+}
+
+module.exports = {
+  methodology:
+    "TVL is calculated as the total USDC held in the ArcisVault contract, including both reserve and deployed capital across yield strategies.",
+  base: {
+    tvl,
+  },
+};


### PR DESCRIPTION
Name (to be shown on DefiLlama):
Arcis Protocol

Twitter Link:
https://x.com/ArcisProtocol

List of audit links if any:

Website Link:
https://arcis.money/

Logo (High resolution, will be shown with rounded borders):
https://arcis.money/arcis-icon.png
Current TVL:

$100
Treasury Addresses (if the protocol has treasury)

Chain:
Base

Coingecko ID:

Coinmarketcap ID:

Short Description (to be shown on DefiLlama):
Financial infrastructure for autonomous AI agents. ERC-4626 yield vaults, identity-aware credit lines, and revenue bonds accessible through the Agent Treasury Interface (ATI).

Token address and ticker if any:

Category:
Yield

Oracle Provider(s):
None (direct on-chain pricing via ERC-4626 exchange rate)

Implementation Details:
ArcisVault uses internal share/asset accounting with virtual offset inflation protection. Exchange rate derived from totalAssets/totalSupply. No external oracle dependency.

Documentation/Proof:
https://github.com/Arcis-Protocol/core

forkedFrom:

methodology:
TVL is the total USDC held in the ArcisVault contract (0x00325d9da832b38179ed2f0dabd4062d93e325a7), including reserve balance and capital deployed to yield strategies (Aave V3).

Github org/user:
Arcis-Protocol

Does this project have a referral program?
No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for Arcis Protocol, reporting the USDC held in the protocol’s vault as part of its on-chain value.
  * Included an updated methodology note clarifying how the TVL number is derived.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->