### PR TITLE
Update Cookie Chain TVL to price both sides of liquidity pools

### DIFF
--- a/projects/cookiechain/index.js
+++ b/projects/cookiechain/index.js
@@ -1,66 +1,12 @@
-const { PublicKey } = require('@solana/web3.js')
-const { getConnection, getTokenAccountBalances } = require('../helper/solana')
-
-const TOKEN_PROGRAMS = [
-  new PublicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'),
-  new PublicKey('TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb'),
-]
-
-// CookieBox DAMM (Meteora Dynamic AMM v2 / cp_amm fork) and CookieBox DBC (Meteora
-// Dynamic Bonding Curve fork) both hold every pool's token vaults under a single
-// `pool_authority` PDA, so we enumerate the vault token accounts owned by that PDA.
-async function sumPoolAuthorityVaults(connection, api) {
-  const programs = [
-    'DAMMjDCEFTDkt7ywazZS8GoaLtjb3HaJo3pLbf64xrPY', // CookieBox DAMM
-    'DBCg4ugDEztk6MbqHEJvx5a5YGJTj45Jb5NvtQ48Rvsf', // CookieBox DBC
-  ]
-  for (const programId of programs) {
-    const [auth] = PublicKey.findProgramAddressSync(
-      [Buffer.from('pool_authority')],
-      new PublicKey(programId),
-    )
-    for (const tokenProgram of TOKEN_PROGRAMS) {
-      const { value } = await connection.getParsedTokenAccountsByOwner(auth, { programId: tokenProgram })
-      for (const { account } of value) {
-        const info = account.data.parsed?.info
-        const amount = info?.tokenAmount?.amount
-        if (!amount || amount === '0') continue
-        api.add(info.mint, amount)
-      }
-    }
-  }
-}
-
-// CookieBox CLMM (Orca Whirlpool fork): Whirlpool account dataSize=653,
-// discriminator 3f95d10ce1806309, tokenVaultA at offset 133, tokenVaultB at offset 213.
-async function getClmmVaults(connection) {
-  const accounts = await connection.getProgramAccounts(
-    new PublicKey('CLMMmWqTtyNSomqXP3kETJy2SGKPdr31USsm4GfbLyKs'),
-    { filters: [{ dataSize: 653 }] },
-  )
-  const vaults = []
-  for (const { account } of accounts) {
-    if (account.data.subarray(0, 8).toString('hex') !== '3f95d10ce1806309') continue
-    vaults.push(new PublicKey(account.data.slice(133, 165)).toBase58())
-    vaults.push(new PublicKey(account.data.slice(213, 245)).toBase58())
-  }
-  return vaults
-}
+const { addCookiePoolTvl } = require('../helper/cookiechain')
 
 async function tvl(api) {
-  const connection = getConnection(api.chain)
-
-  await sumPoolAuthorityVaults(connection, api)
-
-  const vaults = await getClmmVaults(connection)
-  if (vaults.length) {
-    const balances = await getTokenAccountBalances(vaults, { chain: api.chain, allowError: true })
-    for (const [mint, amount] of Object.entries(balances)) api.add(mint, amount)
-  }
+  await addCookiePoolTvl(api, 'cookiebox')
 }
 
 module.exports = {
   timetravel: false,
-  methodology: 'TVL is calculated by summing token balances held in liquidity pool vault accounts across CookieBox DAMM, CookieBox DBC, and CookieBox CLMM on Cookie Chain.',
+  misrepresentedTokens: true,
+  methodology: 'Counts the value of all tokens held in CookieBox liquidity pools on Cookie Chain. For token launches (bonding curves), only the COOK raised is counted, not the unsold token supply. Tokens that are not listed elsewhere are priced from their COOK liquidity pool.',
   cookiechain: { tvl },
 }

--- a/projects/cookiechain/index.js
+++ b/projects/cookiechain/index.js
@@ -7,6 +7,6 @@ async function tvl(api) {
 module.exports = {
   timetravel: false,
   misrepresentedTokens: true,
-  methodology: 'Counts the value of all tokens held in CookieBox liquidity pools on Cookie Chain. For token launches (bonding curves), only the COOK raised is counted, not the unsold token supply. Tokens that are not listed elsewhere are priced from their COOK liquidity pool.',
+  methodology: 'Counts the value of all tokens held in CookieBox liquidity pools on Cookie Chain. For new token launches (bonding curves), only the COOK raised is counted, not the unsold token supply. Tokens without their own market price are valued through their COOK pool, or through another already-priced token they are paired with when no COOK pool exists. Each token can only add value in proportion to the COOK backing it, so low-liquidity pools cannot overstate TVL.',
   cookiechain: { tvl },
 }

--- a/projects/cookieswap/index.js
+++ b/projects/cookieswap/index.js
@@ -1,52 +1,12 @@
-const { PublicKey } = require('@solana/web3.js')
-const { getConnection, getTokenAccountBalances } = require('../helper/solana')
-
-async function getRaydiumPoolVaults(connection) {
-  const pools = [
-    { programId: 'WTzkPUoprVx7PDc1tfKA5sS7k1ynCgU89WtwZhksHX5', vaultA: 137, vaultB: 169 }, // CookieSwap BAMM (Raydium CLMM)
-  ]
-  const vaults = []
-  for (const { programId, vaultA, vaultB } of pools) {
-    const accounts = await connection.getProgramAccounts(new PublicKey(programId))
-    for (const { account } of accounts) {
-      if (account.data.subarray(0, 8).toString('hex') !== 'f7ede3f5d7c3de46') continue
-      if (account.data.length < vaultB + 32) continue
-      vaults.push(new PublicKey(account.data.slice(vaultA, vaultA + 32)).toBase58())
-      vaults.push(new PublicKey(account.data.slice(vaultB, vaultB + 32)).toBase58())
-    }
-  }
-  return vaults
-}
-
-async function getSplTokenSwapVaults(connection) {
-  // CookieSwap CPAMM (Token-Swap)
-  const accounts = await connection.getProgramAccounts(
-    new PublicKey('xYBN2zddsqSy41tg1yD9nJScCmqquZnHUyzXBfLEqC8'),
-  )
-  const vaults = []
-  for (const { account } of accounts) {
-    if (account.data[0] !== 0x01 || account.data[1] !== 0x01) continue
-    if (account.data.length < 99) continue
-    vaults.push(new PublicKey(account.data.slice(35, 67)).toBase58())
-    vaults.push(new PublicKey(account.data.slice(67, 99)).toBase58())
-  }
-  return vaults
-}
+const { addCookiePoolTvl } = require('../helper/cookiechain')
 
 async function tvl(api) {
-  const connection = getConnection(api.chain)
-
-  const raydiumVaults = await getRaydiumPoolVaults(connection)
-  const tokenSwapVaults = await getSplTokenSwapVaults(connection)
-  const vaults = [...raydiumVaults, ...tokenSwapVaults]
-  if (vaults.length) {
-    const balances = await getTokenAccountBalances(vaults, { chain: api.chain, allowError: true })
-    for (const [mint, amount] of Object.entries(balances)) api.add(mint, amount)
-  }
+  await addCookiePoolTvl(api, 'cookieswap')
 }
 
 module.exports = {
   timetravel: false,
-  methodology: 'TVL is calculated by summing token balances held in liquidity pool vault accounts across CookieSwap BAMM and CookieSwap CPAMM on Cookie Chain.',
+  misrepresentedTokens: true,
+  methodology: 'Counts the value of all tokens held in CookieSwap liquidity pools on Cookie Chain. Tokens that are not listed elsewhere are priced from their COOK liquidity pool.',
   cookiechain: { tvl },
 }

--- a/projects/cookieswap/index.js
+++ b/projects/cookieswap/index.js
@@ -7,6 +7,6 @@ async function tvl(api) {
 module.exports = {
   timetravel: false,
   misrepresentedTokens: true,
-  methodology: 'Counts the value of all tokens held in CookieSwap liquidity pools on Cookie Chain. Tokens that are not listed elsewhere are priced from their COOK liquidity pool.',
+  methodology: 'Counts the value of all tokens held in CookieSwap liquidity pools on Cookie Chain. Tokens without their own market price are valued through their COOK pool, or through another already-priced token they are paired with when no COOK pool exists. Each token can only add value in proportion to the COOK backing it, so low-liquidity pools cannot overstate TVL.',
   cookiechain: { tvl },
 }

--- a/projects/helper/cookiechain.js
+++ b/projects/helper/cookiechain.js
@@ -1,14 +1,21 @@
 const { PublicKey } = require('@solana/web3.js')
 const { getConnection } = require('./solana')
 
+// Shared TVL/pricing helper for Cookie Chain protocols.
+//
 // On Cookie Chain only COOK (the wrapped native gas token) has an external price feed
 // (mapped to coingecko `cookie-2`). Every other token that lives on the chain has no
 // price source, so DefiLlama silently drops it from TVL - leaving pools showing only
-// their COOK side. This helper derives a price for those tokens from the on-chain DEX
-// pools and re-expresses each one as its COOK-equivalent, so both sides of every pool
+// their COOK side. This helper derives a price for those tokens from the chain's on-chain
+// DEX pools and re-expresses each one as its COOK-equivalent, so both sides of every pool
 // get counted. Conceptually this is the SVM analog of helper/cache/sumUnknownTokens
 // (price unknown tokens against a core asset from their LP pools); we hand-roll it here
 // because that helper only supports EVM (multiCall / getReserves).
+//
+// New protocols plug in by registering their pool programs in POOL_SOURCES (tagged with a
+// `protocol` id) and calling addCookiePoolTvl(api, '<their id>') from their adapter. The
+// COOK price graph is always built from ALL registered pools chain-wide, so every protocol
+// benefits from the chain's full liquidity when pricing tokens.
 const COOK = 'So11111111111111111111111111111111111111112'
 const Q64 = 2 ** 64
 // An indirect (non-COOK) hop is only trusted if it is backed by at least this much
@@ -20,13 +27,20 @@ const MIN_INDIRECT_COOK_RAW = 1e9
 // in helper/cache/sumUnknownTokens). The real COOK side is never capped.
 const RESTRICT_TOKEN_RATIO = 100
 
-// Pool account layouts, validated byte-for-byte against live accounts on rpc.cookiescan.io.
-// `sqrtPrice` is Meteora/Orca/Raydium style: (sqrtPrice / 2^64)^2 == tokenB_raw per tokenA_raw,
-// where tokenA is the vaultA side and tokenB the vaultB side. `null` => constant-product pool,
-// price is taken from the raw reserve ratio instead.
-// `kind`: 'amm' pools are real two-sided LPs => both sides are TVL. 'curve' pools are bonding
-// curves whose base (vaultA) side is just unsold mint supply, NOT deposited value => only the
-// quote (vaultB) side counts as TVL.
+// Registry of every protocol's pool programs. Add an entry here when onboarding a new
+// Cookie Chain dapp; account offsets must be validated byte-for-byte against live accounts.
+// Fields:
+//   protocol  - id matched by addCookiePoolTvl(api, protocol)
+//   kind      - 'amm': real two-sided LP, both sides count as TVL.
+//               'curve': bonding curve whose base (vaultA) side is unsold mint supply, NOT
+//               deposited value => only the quote (vaultB) side counts as TVL.
+//   dataSize  - account size filter (omit if pools share size with other account types)
+//   disc      - first 8 bytes (hex) to match when dataSize alone is ambiguous (optional)
+//   initFlag  - require data[0]==data[1]==1 to skip uninitialised accounts (optional)
+//   vaultA/B  - byte offset of each token vault pubkey
+//   sqrtPrice - byte offset of the u128 sqrt price; (sqrtPrice / 2^64)^2 == vaultB_raw per
+//               vaultA_raw (Meteora/Orca/Raydium convention). null => constant-product pool,
+//               price is taken from the raw reserve ratio instead.
 const POOL_SOURCES = [
   // CookieBox DAMM (Meteora Dynamic AMM v2 / cp_amm fork)
   { protocol: 'cookiebox', kind: 'amm', program: 'DAMMjDCEFTDkt7ywazZS8GoaLtjb3HaJo3pLbf64xrPY', dataSize: 1112, vaultA: 232, vaultB: 264, sqrtPrice: 456 },
@@ -74,9 +88,9 @@ async function getMultipleAccountInfo(connection, keys) {
   return out
 }
 
-// Scans every CookieBox / CookieSwap pool once, caches on the api object, and returns
-// { pools, cookRawPer } where cookRawPer[mint] is how many COOK base-units equal one
-// base-unit of `mint`. Pricing happens in two phases:
+// Scans every registered pool once, caches on the api object, and returns
+// { pools, cookRawPer, support } where cookRawPer[mint] is how many COOK base-units equal
+// one base-unit of `mint`. Pricing happens in two phases:
 //   A) DIRECT COOK pairs - each token priced from the pool holding the most COOK; these
 //      prices are authoritative and never overridden.
 //   B) INDIRECT tokens (no direct COOK pool) - priced by hopping through an already-priced
@@ -174,12 +188,12 @@ async function getCookieChainData(api) {
   return api._cookieChainData
 }
 
-// One-call TVL for a pool-based Cookie Chain protocol ('cookiebox' or 'cookieswap').
-// AMM pools contribute both sides; bonding-curve pools contribute only their quote side
-// (the base side is unsold mint supply, not deposited value). COOK is summed exactly;
-// every other token is valued through the derived price map and its TOTAL contribution is
-// capped at RESTRICT_TOKEN_RATIO x the COOK liquidity backing its price, so a thin or
-// manipulated pool cannot inflate TVL.
+// One-call TVL for a pool-based Cookie Chain protocol: pass the `protocol` id used in
+// POOL_SOURCES. AMM pools contribute both sides; bonding-curve pools contribute only their
+// quote side (the base side is unsold mint supply, not deposited value). COOK is summed
+// exactly; every other token is valued through the derived price map and its TOTAL
+// contribution is capped at RESTRICT_TOKEN_RATIO x the COOK liquidity backing its price,
+// so a thin or manipulated pool cannot inflate TVL.
 async function addCookiePoolTvl(api, protocol) {
   const { pools, cookRawPer, support } = await getCookieChainData(api)
   let cookRaw = 0n

--- a/projects/helper/cookiechain.js
+++ b/projects/helper/cookiechain.js
@@ -1,0 +1,213 @@
+const { PublicKey } = require('@solana/web3.js')
+const { getConnection } = require('./solana')
+
+// On Cookie Chain only COOK (the wrapped native gas token) has an external price feed
+// (mapped to coingecko `cookie-2`). Every other token that lives on the chain has no
+// price source, so DefiLlama silently drops it from TVL - leaving pools showing only
+// their COOK side. This helper derives a price for those tokens from the on-chain DEX
+// pools and re-expresses each one as its COOK-equivalent, so both sides of every pool
+// get counted. Conceptually this is the SVM analog of helper/cache/sumUnknownTokens
+// (price unknown tokens against a core asset from their LP pools); we hand-roll it here
+// because that helper only supports EVM (multiCall / getReserves).
+const COOK = 'So11111111111111111111111111111111111111112'
+const Q64 = 2 ** 64
+// An indirect (non-COOK) hop is only trusted if it is backed by at least this much
+// already-trusted COOK liquidity (raw, 9 decimals => 1 COOK). Keeps thin/degenerate
+// pools from injecting garbage prices through multi-hop propagation.
+const MIN_INDIRECT_COOK_RAW = 1e9
+// A derived pool side is counted for at most this multiple of its real counter-side
+// liquidity, so a thin or manipulated pool cannot inflate TVL (cf. restrictTokenRatio
+// in helper/cache/sumUnknownTokens). The real COOK side is never capped.
+const RESTRICT_TOKEN_RATIO = 100
+
+// Pool account layouts, validated byte-for-byte against live accounts on rpc.cookiescan.io.
+// `sqrtPrice` is Meteora/Orca/Raydium style: (sqrtPrice / 2^64)^2 == tokenB_raw per tokenA_raw,
+// where tokenA is the vaultA side and tokenB the vaultB side. `null` => constant-product pool,
+// price is taken from the raw reserve ratio instead.
+// `kind`: 'amm' pools are real two-sided LPs => both sides are TVL. 'curve' pools are bonding
+// curves whose base (vaultA) side is just unsold mint supply, NOT deposited value => only the
+// quote (vaultB) side counts as TVL.
+const POOL_SOURCES = [
+  // CookieBox DAMM (Meteora Dynamic AMM v2 / cp_amm fork)
+  { protocol: 'cookiebox', kind: 'amm', program: 'DAMMjDCEFTDkt7ywazZS8GoaLtjb3HaJo3pLbf64xrPY', dataSize: 1112, vaultA: 232, vaultB: 264, sqrtPrice: 456 },
+  // CookieBox CLMM (Orca Whirlpool fork)
+  { protocol: 'cookiebox', kind: 'amm', program: 'CLMMmWqTtyNSomqXP3kETJy2SGKPdr31USsm4GfbLyKs', dataSize: 653, disc: '3f95d10ce1806309', vaultA: 133, vaultB: 213, sqrtPrice: 65 },
+  // CookieBox DBC (Meteora Dynamic Bonding Curve fork); vaultA = base (unsold supply), vaultB = quote
+  { protocol: 'cookiebox', kind: 'curve', program: 'DBCg4ugDEztk6MbqHEJvx5a5YGJTj45Jb5NvtQ48Rvsf', dataSize: 424, disc: 'd5e005d16245775c', vaultA: 168, vaultB: 200, sqrtPrice: 280 },
+  // CookieSwap BAMM (Raydium CLMM fork)
+  { protocol: 'cookieswap', kind: 'amm', program: 'WTzkPUoprVx7PDc1tfKA5sS7k1ynCgU89WtwZhksHX5', dataSize: 1544, disc: 'f7ede3f5d7c3de46', vaultA: 137, vaultB: 169, sqrtPrice: 253 },
+  // CookieSwap CPAMM (SPL Token-Swap fork) - constant product
+  { protocol: 'cookieswap', kind: 'amm', program: 'xYBN2zddsqSy41tg1yD9nJScCmqquZnHUyzXBfLEqC8', dataSize: 324, initFlag: true, vaultA: 35, vaultB: 67, sqrtPrice: null },
+]
+
+function readU128LE(buf, offset) {
+  let x = 0n
+  for (let i = 15; i >= 0; i--) x = (x << 8n) | BigInt(buf[offset + i])
+  return x
+}
+
+function sqrtToPrice(sqrtPrice) {
+  const f = Number(sqrtPrice) / Q64 // tokenB_raw per tokenA_raw == sqrt(price) before squaring
+  return f * f
+}
+
+function decodeTokenAccount(buf) {
+  // SPL token (and Token-2022) base layout: mint @0, owner @32, amount (u64 LE) @64
+  if (!buf || buf.length < 72) return null
+  return {
+    mint: new PublicKey(buf.slice(0, 32)).toBase58(),
+    raw: Number(buf.readBigUInt64LE(64)),
+    rawStr: buf.readBigUInt64LE(64).toString(),
+  }
+}
+
+async function getMultipleAccountInfo(connection, keys) {
+  const out = {}
+  for (let i = 0; i < keys.length; i += 100) {
+    const chunk = keys.slice(i, i + 100).map((k) => new PublicKey(k))
+    // Only mint (@0) and amount (@64) are read, so 72 bytes per token account suffice.
+    const infos = await connection.getMultipleAccountsInfo(chunk, { dataSlice: { offset: 0, length: 72 } })
+    infos.forEach((info, j) => {
+      if (info) out[keys[i + j]] = info.data
+    })
+  }
+  return out
+}
+
+// Scans every CookieBox / CookieSwap pool once, caches on the api object, and returns
+// { pools, cookRawPer } where cookRawPer[mint] is how many COOK base-units equal one
+// base-unit of `mint`. Pricing happens in two phases:
+//   A) DIRECT COOK pairs - each token priced from the pool holding the most COOK; these
+//      prices are authoritative and never overridden.
+//   B) INDIRECT tokens (no direct COOK pool) - priced by hopping through an already-priced
+//      neighbour, but only along the path backed by the deepest trusted COOK liquidity and
+//      only when each hop clears MIN_INDIRECT_COOK_RAW. Unbounded transitive pricing is
+//      avoided on purpose: it both corrupts good direct prices and blows up through thin
+//      pools (verified against live chain data).
+async function getCookieChainData(api) {
+  if (api._cookieChainData) return api._cookieChainData
+
+  const connection = getConnection(api.chain)
+  const pools = []
+  for (const src of POOL_SOURCES) {
+    // Only the discriminator, vault pubkeys and sqrt price are needed, so slice from the
+    // account start (offsets stay valid) instead of downloading the whole pool account.
+    const sliceLen = Math.max(src.vaultA + 32, src.vaultB + 32, src.sqrtPrice != null ? src.sqrtPrice + 16 : 0)
+    const accounts = await connection.getProgramAccounts(new PublicKey(src.program), {
+      filters: src.dataSize ? [{ dataSize: src.dataSize }] : [],
+      dataSlice: { offset: 0, length: sliceLen },
+    })
+    for (const { account } of accounts) {
+      const data = account.data
+      if (src.disc && data.subarray(0, 8).toString('hex') !== src.disc) continue
+      if (src.initFlag && !(data[0] === 1 && data[1] === 1)) continue
+      pools.push({
+        protocol: src.protocol,
+        kind: src.kind,
+        vaultA: new PublicKey(data.slice(src.vaultA, src.vaultA + 32)).toBase58(),
+        vaultB: new PublicKey(data.slice(src.vaultB, src.vaultB + 32)).toBase58(),
+        sqrtPrice: src.sqrtPrice == null ? null : readU128LE(data, src.sqrtPrice),
+      })
+    }
+  }
+
+  const vaultKeys = [...new Set(pools.flatMap((p) => [p.vaultA, p.vaultB]))]
+  const vaultData = await getMultipleAccountInfo(connection, vaultKeys)
+  for (const p of pools) {
+    const a = decodeTokenAccount(vaultData[p.vaultA])
+    const b = decodeTokenAccount(vaultData[p.vaultB])
+    if (a) { p.mintA = a.mint; p.balA = a.raw; p.balAStr = a.rawStr }
+    if (b) { p.mintB = b.mint; p.balB = b.raw; p.balBStr = b.rawStr }
+  }
+  const validPools = pools.filter((p) => p.mintA && p.mintB)
+
+  // Each pool's marginal price as tokenB_raw per tokenA_raw (sqrt price for CL pools,
+  // reserve ratio for constant-product pools).
+  for (const p of validPools) {
+    p.ratioBperA = p.sqrtPrice != null
+      ? sqrtToPrice(p.sqrtPrice)
+      : (p.balA > 0 ? p.balB / p.balA : null)
+  }
+  const usablePools = validPools.filter((p) => p.ratioBperA > 0 && isFinite(p.ratioBperA))
+
+  const cookRawPer = { [COOK]: 1 }
+  const support = { [COOK]: Infinity } // trusted COOK-equiv liquidity backing each price
+  const direct = new Set([COOK])
+
+  // Phase A - authoritative prices from direct COOK pools (deepest COOK reserve wins).
+  const bestCookReserve = {}
+  for (const p of usablePools) {
+    let token, factor, cookReserve
+    if (p.mintA === COOK && p.mintB !== COOK) { token = p.mintB; factor = 1 / p.ratioBperA; cookReserve = p.balA }
+    else if (p.mintB === COOK && p.mintA !== COOK) { token = p.mintA; factor = p.ratioBperA; cookReserve = p.balB }
+    else continue
+    if (cookReserve > (bestCookReserve[token] || 0)) {
+      bestCookReserve[token] = cookReserve
+      cookRawPer[token] = factor
+      support[token] = cookReserve
+      direct.add(token)
+    }
+  }
+
+  // Phase B - extend to tokens with no direct COOK pool, hopping through a priced neighbour.
+  // Only still-unpriced tokens are touched; the deepest-backed path wins; each hop must
+  // clear MIN_INDIRECT_COOK_RAW.
+  for (let round = 0, changed = true; changed && round < 8; round++) {
+    changed = false
+    for (const p of usablePools) {
+      if (cookRawPer[p.mintA] != null && !direct.has(p.mintB)) {
+        const backing = Math.min(support[p.mintA], p.balA * cookRawPer[p.mintA])
+        if (backing >= MIN_INDIRECT_COOK_RAW && backing > (support[p.mintB] || 0)) {
+          support[p.mintB] = backing; cookRawPer[p.mintB] = cookRawPer[p.mintA] / p.ratioBperA; changed = true
+        }
+      }
+      if (cookRawPer[p.mintB] != null && !direct.has(p.mintA)) {
+        const backing = Math.min(support[p.mintB], p.balB * cookRawPer[p.mintB])
+        if (backing >= MIN_INDIRECT_COOK_RAW && backing > (support[p.mintA] || 0)) {
+          support[p.mintA] = backing; cookRawPer[p.mintA] = p.ratioBperA * cookRawPer[p.mintB]; changed = true
+        }
+      }
+    }
+  }
+
+  api._cookieChainData = { pools: validPools, cookRawPer, support }
+  return api._cookieChainData
+}
+
+// One-call TVL for a pool-based Cookie Chain protocol ('cookiebox' or 'cookieswap').
+// AMM pools contribute both sides; bonding-curve pools contribute only their quote side
+// (the base side is unsold mint supply, not deposited value). COOK is summed exactly;
+// every other token is valued through the derived price map and its TOTAL contribution is
+// capped at RESTRICT_TOKEN_RATIO x the COOK liquidity backing its price, so a thin or
+// manipulated pool cannot inflate TVL.
+async function addCookiePoolTvl(api, protocol) {
+  const { pools, cookRawPer, support } = await getCookieChainData(api)
+  let cookRaw = 0n
+  const valueByMint = {} // non-COOK mint -> COOK-equivalent value (raw)
+
+  for (const p of pools) {
+    if (p.protocol !== protocol) continue
+    const sides = p.kind === 'curve'
+      ? [[p.mintB, p.balB, p.balBStr]]                       // quote only
+      : [[p.mintA, p.balA, p.balAStr], [p.mintB, p.balB, p.balBStr]]
+    for (const [mint, raw, rawStr] of sides) {
+      if (!raw) continue
+      if (mint === COOK) { cookRaw += BigInt(rawStr); continue }
+      const factor = cookRawPer[mint]
+      if (factor == null) continue                            // no price path -> skipped
+      valueByMint[mint] = (valueByMint[mint] || 0) + raw * factor
+    }
+  }
+
+  if (cookRaw > 0n) api.add(COOK, cookRaw.toString())
+  for (const [mint, value] of Object.entries(valueByMint)) {
+    const capped = Math.min(value, RESTRICT_TOKEN_RATIO * (support[mint] || 0))
+    if (capped > 0) api.add(COOK, Math.round(capped))
+  }
+}
+
+module.exports = {
+  COOK_MINT: COOK,
+  getCookieChainData,
+  addCookiePoolTvl,
+}


### PR DESCRIPTION
## Problem

On Cookie Chain, only **COOK** (the native gas token, mapped to coingecko `cookie-2`) has a price feed. Every other token on the chain has no price source, so DeFiLlama silently drops it from TVL — leaving each liquidity pool counted at **only its COOK side**.

## Solution

New shared helper `projects/helper/cookiechain.js` that derives prices for the chain's tokens directly from the on-chain DEX pools and re-expresses them as their COOK-equivalent (the SVM analog of the EVM-only `helper/cache/sumUnknownTokens`).

It reads every pool over RPC and:

1. **Phase A — direct COOK pricing (authoritative):** each token is priced from the COOK pool holding the most COOK; these prices are never overridden.
2. **Phase B — indirect pricing:** a token with no direct COOK pool is priced one hop further through an already-priced neighbour, but only along the deepest-backed path and only when the hop clears a minimum COOK-liquidity floor. (Unbounded transitive pricing was tested and rejected — it corrupts good prices and blows up through thin pools.)
3. **Per-token cap:** a token's total contribution is capped at `RESTRICT_TOKEN_RATIO` (100×) the COOK liquidity backing its price, so a thin or manipulated pool cannot inflate TVL.
4. **Bonding curves (DBC):** counted by their **quote (deposited COOK) side only** — the base side is unsold mint supply, not real locked value.

AMM pools (DAMM, CLMM, BAMM, CPAMM) contribute both sides.

## Implementation notes

- Pure on-chain reads via the configured Cookie Chain RPC — `getProgramAccounts` (pool discovery, with `dataSize` filter + `dataSlice`) and `getMultipleAccountsInfo` (vault mint + balance, sliced to 72 bytes). No external/price API is called inside the adapter.
- All pool account layouts (vault offsets, discriminators) and the `sqrt_price → price` direction were validated byte-for-byte against live accounts on `rpc.cookiescan.io`.
- COOK is summed exactly (`BigInt`); derived values are float-rounded (≪0.01% error).
- Both adapters set `misrepresentedTokens: true`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a shared Cookie Chain pool valuation helper and enabled Cookie Chain + CookieSwap TVL tracking through it for consistent, COOK-equivalent pool valuation.
  * Added pricing support that can derive token value via multi-hop routes when direct COOK pricing is unavailable.
* **Bug Fixes**
  * Improved TVL methodology and token handling for launch/bonding-curve style cases, with safeguards to reduce overcounting.
  * Updated Cookie Chain/CookieSwap metadata (including methodology text and token representation rules).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->