### PR TITLE
Add Neverland AUSD/PT-AUSD Isolated Pool

### DIFF
--- a/projects/neverland/index.js
+++ b/projects/neverland/index.js
@@ -1,19 +1,23 @@
 const { aaveV3Export } = require("../helper/aave");
 const { sumTokens2 } = require("../helper/unwrapLPs");
 
-// Neverland Money - Aave V3-based lending protocol on Monad with vote-escrow tokenomics
+// Neverland - Aave V3-based lending protocol on Monad with vote-escrow tokenomics
 // Docs: https://docs.neverland.money
 
 const CONTRACTS = {
   monad: {
-    poolDataProvider: '0xfd0b6b6F736376F7B99ee989c749007c7757fDba',
+    // Aave V3 markets (differ only in listed reserves):
+    poolDataProviders: [
+      '0xfd0b6b6F736376F7B99ee989c749007c7757fDba', // canonical market (multi-reserve)
+      '0xeEb78818C026A3c1b82804627d101e27Ce5E60CB', // isolated market (AUSD + PT-AUSD tokens)
+    ],
     dust: '0xAD96C3dffCD6374294e2573A7fBBA96097CC8d7c',
     dustLock: '0xBB4738D05AD1b3Da57a4881baE62Ce9bb1eEeD6C',
   },
 };
 
 const aaveConfig = {
-  monad: [CONTRACTS.monad.poolDataProvider],
+  monad: CONTRACTS.monad.poolDataProviders,
 };
 
 const aaveExports = aaveV3Export(aaveConfig);


### PR DESCRIPTION
Adds the `AaveProtocolDataProvider` for the new isolated AUSD/PT-AUSD market alongside the canonical (cross) one.
`aaveV3Export` already aggregates multiple providers, so TVL/Borrowed pick it up with no new code.

There is no need of any special handling. The market is isolated in name only; its behavior is identical to any Aave V3 pool, and the isolation derives purely from the operational listing of correlated assets only, here a Pendle strategy with the AUSD and it's PTs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Monad market configuration to use multiple pool data sources, improving the accuracy of reported Aave V3 market data.
  * Adjusted the calculated TVL and borrowed values for Monad to reflect the expanded set of markets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->