### PR TITLE
feat: add Skate AMM v2 pools to TVL adapter

### DIFF
--- a/projects/skate-amm/index.js
+++ b/projects/skate-amm/index.js
@@ -37,6 +37,31 @@ const evm_config = {
   tempo: [{ kernelEventEmitter: '0x8f794F042831345DfA6bFD7FB72d25128AD6ee1b', fromBlock: 14656375 }],
 }
 
+// AMM v2 periphery pools. Registered via the v2 manager (not emitted by the v1
+// PoolCreated emitters above), so they are listed statically; they expose the
+// same balancesAvailable() interface. token0/token1 are the chain-local reserves.
+const v2_evm_config = {
+  ethereum: [
+    { pool: '0x1E0C3acCfD4c9A1731d3A0Cdb6b8afBD0f0c219c', token0: '0xa753a7395cae905cd615da0b82a53e0560f250af', token1: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48' }, // QQQx/USDC
+    { pool: '0x00739d7b2ed5eD3B80d9e10ccBc2468ad1b9C2FD', token0: '0xc845b2894dBddd03858fd2D643B4eF725fE0849d', token1: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48' }, // NVDAx/USDC
+  ],
+  arbitrum: [
+    { pool: '0x0433CCB013a590eA4231aAC9ddf05bb753c14127', token0: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831', token1: '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9' }, // USDC/USDT
+    { pool: '0xcE61ABbf872C86e855D266D30251F741c1f24225', token0: '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1', token1: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831' }, // WETH/USDC
+    { pool: '0xfE696c7Cf1FFac9BeDf558C6e610bD978b08619F', token0: '0xa753a7395cae905cd615da0b82a53e0560f250af', token1: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831' }, // QQQx/USDC
+    { pool: '0xe1e76F6E987219802fC6bAA61040DA40eE0Be16E', token0: '0xc845b2894dBddd03858fd2D643B4eF725fE0849d', token1: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831' }, // NVDAx/USDC
+  ],
+  bsc: [
+    { pool: '0xf1418c3B237f44fB6A163f3a6e66D7A284154cCd', token0: '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d', token1: '0x55d398326f99059fF775485246999027B3197955' }, // USDC/USDT (18-dec)
+    { pool: '0x55dc9eDcEFb3D5c918f1E53668096D27F76e30c5', token0: '0xa753a7395cae905cd615da0b82a53e0560f250af', token1: '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d' }, // QQQx/USDC
+    { pool: '0x3493491b92C25c06d2E47EAE82Bd3251d313dD39', token0: '0xc845b2894dBddd03858fd2D643B4eF725fE0849d', token1: '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d' }, // NVDAx/USDC
+  ],
+  base: [
+    { pool: '0x2103EFCB4A3140F30c745e30Fb360816DC0Da415', token0: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913', token1: '0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2' }, // USDC/USDT
+    { pool: '0x8781383f9e35402Afb2a6a301d35EDf77954d3e1', token0: '0x4200000000000000000000000000000000000006', token1: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913' }, // WETH/USDC
+  ],
+}
+
 const svm_config = {
   eclipse: [
     'BvNLQCQKxq5A7AQUsMdUqRhwXwmnYy7bkpVU67QrakJ8', // tETH/WETH (WETH)
@@ -61,6 +86,14 @@ const svm_config = {
 
     'CXJFEq5QPEkCxFCaiVEFEQpAHCUBDV3nQUTKTzw3mq6F', // PLUME/USDC (PLUME)
     'ENJRMTjGZs1ChGSZxtD8n4KDu9pimDfbmtb5peh8cxCg', // PLUME/USDC (USDC)
+
+    // AMM v2 pool vaults (pool-token PDAs)
+    'BihGfVYmaT4KpiHiBLwH2ad9Q2ybYVHS2Bd3hQtzg486', // v2 USDC/USDT (USDC)
+    '3DW4k4ims6dFB2cXBk5m1uAfh1zowuj9CzBbF4jm1FRh', // v2 USDC/USDT (USDT)
+    'AB6BBRPRt8ZNSsAp4jmwd5BD3Z7uqjkbjXvWrBpsuA4L', // v2 QQQx/USDC (QQQx)
+    'zpAgwiY7Rk2GZ3VHyAx3ZuCCDE8PhkyhPELJEPnV3Th', // v2 QQQx/USDC (USDC)
+    'DsdoQzMUBHe2Q2w4zwSbWzcqMWvSms1XcfiepJKkDHUb', // v2 NVDAx/USDC (NVDAx)
+    '7DmHWD8vbYgqSZoF1sVPJ9BtPzZrHtRBSoduC3Sz9XiK', // v2 NVDAx/USDC (USDC)
   ]
 }
 
@@ -86,6 +119,7 @@ module.exports = {
 }
 
 const evmTvl = async (api) => {
+  // v1: pools discovered from the kernel event emitters' PoolCreated logs
   for (const { kernelEventEmitter, fromBlock } of evm_config[api.chain]) {
     const logs = await getLogs2({ api, target: kernelEventEmitter, eventAbi: eventAbis.pool_created, fromBlock, onlyArgs: true })
     const balances = await api.multiCall({ calls: logs.map(([_, pool]) => ({ target: pool })), abi: abis.balances_available })
@@ -93,6 +127,16 @@ const evmTvl = async (api) => {
       const { amount0, amount1 } = balances[i]
       api.add(token0, amount0)
       api.add(token1, amount1)
+    })
+  }
+  // v2: statically-listed periphery pools, same balancesAvailable() interface
+  const v2Pools = v2_evm_config[api.chain] || []
+  if (v2Pools.length) {
+    const balances = await api.multiCall({ calls: v2Pools.map((p) => ({ target: p.pool })), abi: abis.balances_available })
+    v2Pools.forEach((p, i) => {
+      const { amount0, amount1 } = balances[i]
+      api.add(p.token0, amount0)
+      api.add(p.token1, amount1)
     })
   }
 }


### PR DESCRIPTION
- Add Skate AMM v2 periphery pools (USDC/USDT, WETH/USDC, QQQx/USDC, NVDAx/USDC) on Ethereum, Arbitrum, BSC, Base and Solana, alongside the existing v1 config
- v2 pools listed statically (registered via the v2 manager, not the v1 `PoolCreated` emitters → no double-count); same `balancesAvailable()` on EVM, pool-token vaults on Solana