### PR TITLE
Add Rubin Trade TVL adapter

### DIFF
--- a/projects/helper/chains.json
+++ b/projects/helper/chains.json
@@ -391,6 +391,7 @@
   "rpg",
   "rsk",
   "rss3_vsl",
+  "rubin",
   "rvn",
   "saakuru",
   "saga",

--- a/projects/rubin/index.js
+++ b/projects/rubin/index.js
@@ -1,0 +1,20 @@
+const { get } = require("../helper/http");
+
+// Rubin — self-custody decentralized perpetual & spot exchange.
+// TVL = USDC collateral deposited on the Rubin chain, measured as the on-chain
+// total supply of the USDC collateral denom (uusdc, 6 decimals), via the
+// Cosmos bank REST. Mirrors the dydx-v4 adapter approach.
+async function tvl() {
+  const data = await get(
+    "https://rest.mainnet.rubin.trade/cosmos/bank/v1beta1/supply/by_denom?denom=uusdc"
+  );
+  return { "usd-coin": Number(data.amount.amount) / 1e6 };
+}
+
+module.exports = {
+  methodology:
+    "Counts USDC collateral deposited on Rubin, measured as the total supply of the chain's USDC (uusdc) collateral denomination.",
+  rubin: {
+    tvl,
+  },
+};

--- a/projects/rubin/index.js
+++ b/projects/rubin/index.js
@@ -3,7 +3,7 @@ const { get } = require("../helper/http");
 // Rubin — self-custody decentralized perpetual & spot exchange.
 // TVL = USDC collateral deposited on the Rubin chain, measured as the on-chain
 // total supply of the USDC collateral denom (uusdc, 6 decimals), via the
-// Cosmos bank REST. Mirrors the dydx-v4 adapter approach.
+// Cosmos bank REST.
 async function tvl() {
   const data = await get(
     "https://rest.mainnet.rubin.trade/cosmos/bank/v1beta1/supply/by_denom?denom=uusdc"

--- a/projects/rubin/index.js
+++ b/projects/rubin/index.js
@@ -12,6 +12,7 @@ async function tvl() {
 }
 
 module.exports = {
+  timetravel: false,
   methodology:
     "Counts USDC collateral deposited on Rubin, measured as the total supply of the chain's USDC (uusdc) collateral denomination.",
   rubin: {


### PR DESCRIPTION
Adds a TVL adapter for **Rubin Trade** — a self-custody decentralized perpetual & spot exchange.

**Methodology:** TVL = USDC collateral deposited on the Rubin chain, measured as the on-chain total supply of the USDC collateral denom (`uusdc`, 6 decimals) via the Cosmos bank REST.

- File: `projects/rubin/index.js`, chain key `rubin`
- Source: https://rest.mainnet.rubin.trade/cosmos/bank/v1beta1/supply/by_denom?denom=uusdc
- Live sanity check (2026-06-29): ~$8.1k

**Protocol metadata for listing:**
- Name: **Rubin Trade**
- Category: Derivatives (perps) + Spot DEX
- Website: https://rubin.trade
- Explorer: https://explorer.rubin.trade
- Volume + OI already merged in dimension-adapters (`dexs/rubin`, #7762).

**New chain:** Rubin runs its own chain (key `rubin`). Could you register/map the `rubin` chain so the protocol's TVL also rolls up on /chains? Happy to provide native-token (`urit`) and explorer details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Rubin network in TVL tracking.
  * TVL now reports Rubin’s `usd-coin` supply as a USD-denominated value.
  * Added Rubin to the supported chain list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->