### PR TITLE
fix: add 2 missing vaults to felix-vanilla subtraction to prevent double-count

### DIFF
--- a/projects/felix-vanilla/index.js
+++ b/projects/felix-vanilla/index.js
@@ -10,6 +10,8 @@ const tvl = async (api) => {
     "0x2900ABd73631b2f60747e687095537B673c06A76",
     "0x9896a8605763106e57A51aa0a97Fe8099E806bb3",
     "0x66c71204B70aE27BE6dC3eb41F9aF5868E68fDb6",
+    "0x8A862fD6c12f9ad34C9c2ff45AB2b6712e8CEa27",
+    "0x207ccaE51Ad2E1C240C4Ab4c94b670D438d2201C",
   ];
 
   const assets = await api.multiCall({


### PR DESCRIPTION
`felix-vaults` tracks 8 vaults but `felix-vanilla` only subtracts 6 from the Morpho Blue total.

The 2 missing vaults:
- `0x8A862fD6c12f9ad34C9c2ff45AB2b6712e8CEa27` — ~$10.5M (6 decimals)
- `0x207ccaE51Ad2E1C240C4Ab4c94b670D438d2201C` — ~$203K (6 decimals)

These are counted in `felix-vaults` but not subtracted in `felix-vanilla`, causing ~$10.7M double-count against Morpho Blue HyperEVM TVL.

Verified on-chain via `totalAssets()` on both vaults.

Closes #19689

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Hyperliquid TVL calculations to use the correct Felix vault addresses, improving reported balances and deductions for affected vaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->