### PR TITLE
add uniswap megaeth 

### DIFF
--- a/projects/uniswap-v4/index.js
+++ b/projects/uniswap-v4/index.js
@@ -44,6 +44,7 @@ const config = {
   unichain: { factory: "0x1F98400000000000000000000000000000000004", fromBlock: 1 },
   monad: { factory: "0x188d586ddcf52439676ca21a244753fa19f9ea8e", fromBlock: 29255895 },
   tempo: { factory: "0x33620f62c5b9b2086dd6b62f4a297a9f30347029", fromBlock: 6475880 },
+  megaeth: { factory: "0xacb7e78fa05d562e0a5d3089ec896d57d057d38e", fromBlock: 7009653 },
 }
 const subgraphs = {
   xlayer: {endpoint: '2fc6nFafrPs4xybzHMnmD48qgUYoHTizhDk1mCJJUDjD', factory: '0x360E68faCcca8cA495c1B759Fd9EEe466db9FB32' }

--- a/projects/uniswap/index.js
+++ b/projects/uniswap/index.js
@@ -80,6 +80,7 @@ const uniV3Config = {
   monad: { factory: "0x204faca1764b154221e35c0d20abb3c525710498", fromBlock: 29255827, blacklistedTokens: ['0x760afe86e5de5fa0ee542fc7b7b713e1c5425701'] },
   tempo: { factory: '0x24a3d4757e330890a8b8978028c9e58e04611fd6', fromBlock: 6455886, },
   '0g': { factory: '0xcb2436774C3e191c85056d248EF4260ce5f27A9D', fromBlock: 6673868 },
+  megaeth: { factory: '0x3a5f0cd7d62452b7f899b2a5758bfa57be0de478', fromBlock: 7009646 },
 }
 
 Object.keys(uniV3Config).forEach(chain => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the MegaETH network in Uniswap v3 and v4 tracking.
  * MegaETH data will now be included in the existing Uniswap export outputs alongside other supported chains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->