### PR TITLE
Update P0 adapter to new API endpoint

### DIFF
--- a/projects/p0/index.js
+++ b/projects/p0/index.js
@@ -1,108 +1,55 @@
 const axios = require('axios');
-const { getEnv } = require('../helper/env');
 
-const BASE_URL = 'https://base-api-public.mrgn.app';
-const API_ENDPOINT = `${BASE_URL}/v1/bank/metrics`;
-const startTime = new Date().toISOString();
-const END_TIME = '9999-12-31T23:59:59.999Z';
-const GROUP_ADDRESS = '4qp6Fx6tnZkY5Wropq9wUYgtFxXKwE6viZxFHg3rdAG8';
+// P0 public API (p0-monitor). Override the host via P0_PUBLIC_API_BASE if needed.
+const BASE_URL = process.env.P0_PUBLIC_API_BASE || 'https://api.0.xyz';
+const METRICS_ENDPOINT = `${BASE_URL}/v0/bankMetrics`;
 
-async function fetchAllBankMetrics() {
-  const apiKey = getEnv('P0_API_KEY')
-  const allData = [];
-  let page = 1;
-  let hasNextPage = true;
-
-  while (hasNextPage) {
-    const { data: response } = await axios.get(API_ENDPOINT, {
-      params: {
-        start_time: startTime,
-        end_time: END_TIME,
-        group_address: GROUP_ADDRESS,
-        page,
-        page_size: 1000,
-      },
-      headers: {
-        ...(apiKey && { 'x-api-key': apiKey }),
-      },
-    });
-
-    if (!response.success || !Array.isArray(response.data)) {
-      break;
-    }
-
-    allData.push(...response.data);
-
-    const pagination = response.metadata?.pagination;
-    hasNextPage = pagination?.has_next_page === true;
-    if (hasNextPage) {
-      page = (pagination?.current_page ?? page) + 1;
-    }
+async function fetchMetrics() {
+  const { data } = await axios.get(METRICS_ENDPOINT, { timeout: 30000 });
+  if (!data || !Array.isArray(data.banks)) {
+    throw new Error('p0 adapter: unexpected /v0/bankMetrics response shape');
   }
-
-  return allData;
+  return data;
 }
 
-function toRawAmount(value, decimals) {
-  if (value == null || value === 0) return 0;
-  const d = decimals ?? 0;
-  return Math.floor(Number(value) * (10 ** d));
+// Standard banks are added per mint so DefiLlama prices them; Kamino/Drift/JupLend
+// integration banks hold receipt mints DefiLlama can't price, so we add the
+// oracle-computed USD the API already returns for them.
+function addSide(api, banks, nativeField, usdField) {
+  let integrationUsd = 0;
+  for (const b of banks) {
+    if (!b.priced) continue;
+    if (b.isIntegrationBank) {
+      const usd = Number(b[usdField]);
+      if (Number.isFinite(usd) && usd > 0) integrationUsd += usd;
+    } else if (b.mint) {
+      // Whole base units only; skip anything that isn't a clean integer string.
+      const baseUnits = String(b[nativeField] ?? '').split('.')[0];
+      if (/^\d+$/.test(baseUnits) && baseUnits !== '0') api.add(b.mint, baseUnits);
+    }
+  }
+  if (integrationUsd > 0) api.addUSDValue(integrationUsd);
 }
 
 async function tvl(api) {
-  const metrics = await fetchAllBankMetrics();
-  const availableLiquidityByMint = {};
-
-  for (const row of metrics) {
-    const mint = row.mint;
-    if (!mint) continue;
-
-    const deposits = toRawAmount(row.total_deposits, row.mint_decimals);
-    const borrows = toRawAmount(row.total_borrows, row.mint_decimals);
-    const availableLiquidity = Math.max(0, deposits - borrows);
-
-    if (availableLiquidity > 0) {
-      availableLiquidityByMint[mint] = (availableLiquidityByMint[mint] ?? 0) + availableLiquidity;
-    }
-  }
-
-  for (const [mint, amount] of Object.entries(availableLiquidityByMint)) {
-    if (amount > 0) {
-      api.add(mint, amount.toString());
-    }
-  }
-
-  return api.getBalances();
+  const { banks } = await fetchMetrics();
+  addSide(api, banks, 'totalDepositsNative', 'totalDepositsUsd');
 }
 
 async function borrowed(api) {
-  const metrics = await fetchAllBankMetrics();
-  const borrowedByMint = {};
-
-  for (const row of metrics) {
-    const mint = row.mint;
-    if (!mint) continue;
-
-    const borrows = toRawAmount(row.total_borrows, row.mint_decimals);
-    if (borrows > 0) {
-      borrowedByMint[mint] = (borrowedByMint[mint] ?? 0) + borrows;
-    }
-  }
-
-  for (const [mint, amount] of Object.entries(borrowedByMint)) {
-    if (amount > 0) {
-      api.add(mint, amount.toString());
-    }
-  }
-
-  return api.getBalances();
+  const { banks } = await fetchMetrics();
+  addSide(api, banks, 'totalBorrowsNative', 'totalBorrowsUsd');
 }
 
 module.exports = {
   doublecounted: true,
+  // /v0/bankMetrics returns current state only (no historical param), so opt out
+  // of DefiLlama's historical backfill instead of stamping today's TVL onto the past.
+  timetravel: false,
+  methodology:
+    'TVL is the sum of all deposited funds across every P0 bank (deposited amount x oracle price). Active Loans is the sum of all outstanding borrows. Standard banks are reported per underlying mint; Kamino/Drift/JupLend integration banks are reported as oracle-computed USD because their receipt-token mints are not independently priced. Data comes from the P0 public API (/v0/bankMetrics).',
   solana: {
     tvl,
-    borrowed
+    borrowed,
   },
-  methodology: "TVL is calculated as available liquidity across all banks in the P0 program."
 };

--- a/projects/p0/index.js
+++ b/projects/p0/index.js
@@ -12,33 +12,23 @@ async function fetchMetrics() {
   return data;
 }
 
-// Standard banks are added per mint so DefiLlama prices them; Kamino/Drift/JupLend
-// integration banks hold receipt mints DefiLlama can't price, so we add the
-// oracle-computed USD the API already returns for them.
-function addSide(api, banks, nativeField, usdField) {
-  let integrationUsd = 0;
+function addSide(api, banks, nativeField) {
   for (const b of banks) {
-    if (!b.priced) continue;
-    if (b.isIntegrationBank) {
-      const usd = Number(b[usdField]);
-      if (Number.isFinite(usd) && usd > 0) integrationUsd += usd;
-    } else if (b.mint) {
-      // Whole base units only; skip anything that isn't a clean integer string.
-      const baseUnits = String(b[nativeField] ?? '').split('.')[0];
-      if (/^\d+$/.test(baseUnits) && baseUnits !== '0') api.add(b.mint, baseUnits);
-    }
+    if (!b.priced || !b.mint) continue;
+    // Whole base units only; skip anything that isn't a clean integer string.
+    const baseUnits = String(b[nativeField] ?? '').split('.')[0];
+    if (/^\d+$/.test(baseUnits) && baseUnits !== '0') api.add(b.mint, baseUnits);
   }
-  if (integrationUsd > 0) api.addUSDValue(integrationUsd);
 }
 
 async function tvl(api) {
   const { banks } = await fetchMetrics();
-  addSide(api, banks, 'totalDepositsNative', 'totalDepositsUsd');
+  addSide(api, banks, 'totalDepositsNative');
 }
 
 async function borrowed(api) {
   const { banks } = await fetchMetrics();
-  addSide(api, banks, 'totalBorrowsNative', 'totalBorrowsUsd');
+  addSide(api, banks, 'totalBorrowsNative');
 }
 
 module.exports = {
@@ -47,7 +37,7 @@ module.exports = {
   // of DefiLlama's historical backfill instead of stamping today's TVL onto the past.
   timetravel: false,
   methodology:
-    'TVL is the sum of all deposited funds across every P0 bank (deposited amount x oracle price). Active Loans is the sum of all outstanding borrows. Standard banks are reported per underlying mint; Kamino/Drift/JupLend integration banks are reported as oracle-computed USD because their receipt-token mints are not independently priced. Data comes from the P0 public API (/v0/bankMetrics).',
+    'TVL is the sum of all deposited funds across every P0 bank. Active Loans is the sum of all outstanding borrows. All banks are reported per underlying mint; data comes from the P0 public API (/v0/bankMetrics).',
   solana: {
     tvl,
     borrowed,


### PR DESCRIPTION
# Update P0 adapter to new API endpoint

**Protocol:** Project 0 (`projects/p0`)
**Base PR target:** `main`

## What changed
Repoints the P0 TVL adapter from the legacy `base-api-public.mrgn.app/v1/bank/metrics`
service to Project 0's `https://api.0.xyz/v0/bankMetrics` endpoint.

## Methodology
- **TVL = sum of all deposited funds** across every P0 bank (deposit amount × oracle price).
  *(Previously the adapter reported available liquidity = deposits − borrows; it now reports
  gross deposits, which is the figure Project 0 wants surfaced as TVL.)*
- **Active Loans (`borrowed`) = sum of all outstanding borrows.**
- Standard banks are added per underlying mint (`api.add`) so DefiLlama prices them and can
  track inflows.
- Kamino / Drift / JupLend **integration banks** hold receipt-token mints that DefiLlama can't
  price independently, so they're reported as the oracle-computed USD the API already returns
  (`api.addUSDValue`).
- `doublecounted: true` retained (borrowed funds originate as deposits, and integration-bank
  underlyings are also counted by the venue they're deposited into).

The host can be overridden with the `P0_PUBLIC_API_BASE` env var if our hostname ever changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated TVL and borrowed calculations to use the latest public **v0** bank metrics feed (current state only).
  * Removed the prior time-range aggregation and deposits-minus-borrows TVL logic in favor of native totals reporting.
* **New Features**
  * Added support for overriding the public API base URL via configuration.
* **Documentation**
  * Refreshed the exported methodology text to describe the new v0 source and “available/active” behavior based on current-state data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->