### PR TITLE
Add Furety TVL adapter

### DIFF
--- a/projects/furety/index.js
+++ b/projects/furety/index.js
@@ -1,0 +1,21 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+
+const FURETY_QUICKSWAP_V2_PAIR = '0x752ba5553d3066d76fd2f9ee6699337ef357cb89'
+
+async function tvl(api) {
+  const wpolBalance = await api.call({
+    abi: 'erc20:balanceOf',
+    target: ADDRESSES.polygon.WMATIC_2,
+    params: [FURETY_QUICKSWAP_V2_PAIR],
+  })
+
+  api.add(ADDRESSES.polygon.WMATIC_2, wpolBalance)
+}
+
+module.exports = {
+  methodology:
+    'Furety TVL counts the WPOL side of the public QuickSwap V2 FTY/WPOL pair on Polygon. Treasury-held FTY and internal reserves are not counted as TVL, and the FTY side of the pair is excluded until it has a DefiLlama-supported price source.',
+  polygon: {
+    tvl,
+  },
+}


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).

2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** Please send a mail to metadata@defillama.com
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes

---
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
Furety Halal Coin

##### Twitter Link:
https://x.com/Furetycoin

##### List of audit links if any:
No external audit published yet. Contract source and public proof pages are published at https://furety.com/coin/contracts and https://furety.com/coin/listings.json

##### Website Link:
https://furety.com

##### Logo (High resolution, will be shown with rounded borders):
https://res.cloudinary.com/duja2smra/image/upload/c_pad,w_512,h_512,b_transparent,f_png/Symbol_logo-FTY-Furety-Halal-Coin-G-_qicjqv.png

##### Current TVL:
Conservative adapter TVL counts the WPOL balance in the QuickSwap V2 FTY/WPOL pair. At local test time it reported about $0.15 from 2.1 WPOL. Public reserve evidence: https://furety.com/coin/defillama-metrics.json

##### Treasury Addresses (if the protocol has treasury):
Polygon Safe treasury: 0x7bf885BD36A55D8231268346A06758573c1557De

##### Chain:
Polygon

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)
Pending CoinGecko review. Submission recorded at https://furety.com/coin/listings.json

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
Pending CoinMarketCap review. Submission recorded at https://furety.com/coin/listings.json

##### Short Description (to be shown on DefiLlama):
Furety Halal Coin is a Polygon mainnet utility token for ethical digital payment infrastructure, service payments, merchant checkout, and developer payment APIs.

##### Token address and ticker if any:
FTY: 0xD1f0Cd986Da6E05619Ef81559BCA5e82609A66E5

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Payments

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
The TVL adapter does not use an oracle. It reads the WPOL ERC-20 balance held by the QuickSwap V2 pair directly on Polygon.

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
No oracle is used by this adapter. It calls `balanceOf(pair)` on Polygon WPOL and adds that balance. Treasury-held FTY and internal reserves are not counted as TVL. The FTY side of the pair is intentionally excluded until it has a DefiLlama-supported price source.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
Adapter evidence feed: https://furety.com/coin/defillama-metrics.json
DEX proof: https://furety.com/coin/dex-listing-proof.json
Pair: https://www.geckoterminal.com/polygon_pos/pools/0x752ba5553d3066d76fd2f9ee6699337ef357cb89

##### forkedFrom (Does your project originate from another project):
No.

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL counts only the WPOL side of the public QuickSwap V2 FTY/WPOL pair on Polygon by reading the WPOL ERC-20 balance held by the pair contract. Treasury-held FTY, founder/team allocation, development reserve, and internal reserves are not counted as TVL. The FTY side of the pair is excluded until it has a DefiLlama-supported price source.

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/Gusgraph

##### Does this project have a referral program?
No.

Validation run locally:
`node test.js projects/furety/index.js`

Result:
- polygon TVL returned successfully
- total TVL returned successfully
- no package or lockfile changes included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Polygon TVL support for the Furety project.
  * TVL is now calculated from the token balance held in the relevant QuickSwap V2 pair.
  * Included a clear methodology note describing what is counted in TVL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->