### PR TITLE
Add NUVA TVL adapter (nvYLDS + nvPRIME)

### DIFF
--- a/projects/nuva/index.js
+++ b/projects/nuva/index.js
@@ -83,7 +83,7 @@ async function ethereumTvl(api) {
 }
 
 module.exports = {
-  timetravel: true,
+  timetravel: false,
   misrepresentedTokens: true,
   start: '2026-04-27',
   methodology:

--- a/projects/nuva/index.js
+++ b/projects/nuva/index.js
@@ -1,0 +1,93 @@
+/**
+ * NUVA — nvYLDS (Provenance vault module) + nvPRIME (Ethereum DedicatedVaultRouter)
+ *
+ * Phase 0 decisions (Product #401):
+ * - nvYLDS TVL: Provenance total_vault_value only (no Eth/Base bridge double-count)
+ * - nvPRIME TVL: Ethereum router underlying assets (ERC4626 hop chain)
+ *
+ * Prod refs: nuva-config mainnet/ethereum/ignition/deployments/nvprime, nuva-app values-prod.yaml
+ */
+const { get } = require('../helper/http')
+const { sumTokens2 } = require('../helper/unwrapLPs')
+
+const PROVENANCE_VAULT_API = 'https://api.provenance.io'
+const NVYLDS_SHARE_DENOM = 'nuva.ylds'
+const NVPRIME_ROUTER = '0x50AE1e4A612A4623b747aEeFb30aFBA82804e12c'
+
+const ERC4626_CONVERT_ABI =
+  'function convertToAssets(uint256 shares) view returns (uint256 assets)'
+
+async function fetchNvyldsTotalVaultValueMicro() {
+  const data = await get(
+    `${PROVENANCE_VAULT_API}/vault/v1/vaults/${encodeURIComponent(NVYLDS_SHARE_DENOM)}`
+  )
+  const amount = data?.total_vault_value?.amount
+  if (!amount) {
+    throw new Error(`nvYLDS total_vault_value missing for ${NVYLDS_SHARE_DENOM}`)
+  }
+  return BigInt(amount)
+}
+
+async function provenanceTvl(api) {
+  const totalVaultValueMicro = await fetchNvyldsTotalVaultValueMicro()
+  // Matches nuva-app: total_vault_value amount is USD-equivalent with 6 decimals.
+  api.addUSDValue(Number(totalVaultValueMicro) / 1e6)
+}
+
+async function resolveDedicatedRouterBaseAssets(api, router) {
+  const assetVaultAddress = await api.call({
+    target: router,
+    abi: 'address:assetVault',
+  })
+  const stakingVaultAddress = await api.call({
+    target: router,
+    abi: 'address:stakingVault',
+  })
+  const nuvaVaultAddress = await api.call({
+    target: router,
+    abi: 'address:nuvaVault',
+  })
+
+  const stakingVaultShares = await api.call({
+    target: nuvaVaultAddress,
+    abi: 'uint256:totalAssets',
+  })
+
+  const assetVaultShares = await api.call({
+    target: stakingVaultAddress,
+    abi: ERC4626_CONVERT_ABI,
+    params: [stakingVaultShares],
+  })
+
+  const baseAsset = await api.call({
+    target: assetVaultAddress,
+    abi: 'address:asset',
+  })
+
+  const baseAssets = await api.call({
+    target: assetVaultAddress,
+    abi: ERC4626_CONVERT_ABI,
+    params: [assetVaultShares],
+  })
+
+  return { baseAsset, baseAssets }
+}
+
+async function ethereumTvl(api) {
+  const { baseAsset, baseAssets } = await resolveDedicatedRouterBaseAssets(
+    api,
+    NVPRIME_ROUTER
+  )
+  api.add(baseAsset, baseAssets)
+  return sumTokens2({ api })
+}
+
+module.exports = {
+  timetravel: true,
+  misrepresentedTokens: true,
+  start: '2026-04-27',
+  methodology:
+    'NUVA TVL is the sum of (1) nvYLDS total_vault_value from the Provenance vault module (canonical vault state; Ethereum and Base bridge contracts are excluded to avoid double-counting bridged deposits) and (2) nvPRIME underlying assets held in the Ethereum DedicatedVaultRouter ERC4626 hop chain (nuvaVault → stakingVault → assetVault), priced at the base asset token.',
+  provenance: { tvl: provenanceTvl },
+  ethereum: { tvl: ethereumTvl },
+}

--- a/projects/nuva/index.js
+++ b/projects/nuva/index.js
@@ -1,23 +1,10 @@
-/**
- * NUVA — nvYLDS (Provenance vault module) + nvPRIME (Ethereum DedicatedVaultRouter)
- *
- * Phase 0 decisions (Product #401):
- * - nvYLDS TVL: Provenance total_vault_value only (no Eth/Base bridge double-count)
- * - nvPRIME TVL: Ethereum router underlying assets (ERC4626 hop chain)
- *
- * Prod refs: nuva-config mainnet/ethereum/ignition/deployments/nvprime, nuva-app values-prod.yaml
- */
 const { get } = require('../helper/http')
-const { sumTokens2 } = require('../helper/unwrapLPs')
 
 const PROVENANCE_VAULT_API = 'https://api.provenance.io'
 const NVYLDS_SHARE_DENOM = 'nuva.ylds'
 const NVPRIME_ROUTER = '0x50AE1e4A612A4623b747aEeFb30aFBA82804e12c'
 
-const ERC4626_CONVERT_ABI =
-  'function convertToAssets(uint256 shares) view returns (uint256 assets)'
-
-async function fetchNvyldsTotalVaultValueMicro() {
+async function provenanceTvl(api) {
   const data = await get(
     `${PROVENANCE_VAULT_API}/vault/v1/vaults/${encodeURIComponent(NVYLDS_SHARE_DENOM)}`
   )
@@ -25,61 +12,16 @@ async function fetchNvyldsTotalVaultValueMicro() {
   if (!amount) {
     throw new Error(`nvYLDS total_vault_value missing for ${NVYLDS_SHARE_DENOM}`)
   }
-  return BigInt(amount)
-}
-
-async function provenanceTvl(api) {
-  const totalVaultValueMicro = await fetchNvyldsTotalVaultValueMicro()
-  // Matches nuva-app: total_vault_value amount is USD-equivalent with 6 decimals.
-  api.addUSDValue(Number(totalVaultValueMicro) / 1e6)
-}
-
-async function resolveDedicatedRouterBaseAssets(api, router) {
-  const assetVaultAddress = await api.call({
-    target: router,
-    abi: 'address:assetVault',
-  })
-  const stakingVaultAddress = await api.call({
-    target: router,
-    abi: 'address:stakingVault',
-  })
-  const nuvaVaultAddress = await api.call({
-    target: router,
-    abi: 'address:nuvaVault',
-  })
-
-  const stakingVaultShares = await api.call({
-    target: nuvaVaultAddress,
-    abi: 'uint256:totalAssets',
-  })
-
-  const assetVaultShares = await api.call({
-    target: stakingVaultAddress,
-    abi: ERC4626_CONVERT_ABI,
-    params: [stakingVaultShares],
-  })
-
-  const baseAsset = await api.call({
-    target: assetVaultAddress,
-    abi: 'address:asset',
-  })
-
-  const baseAssets = await api.call({
-    target: assetVaultAddress,
-    abi: ERC4626_CONVERT_ABI,
-    params: [assetVaultShares],
-  })
-
-  return { baseAsset, baseAssets }
+  api.addUSDValue(Number(amount) / 1e6)
 }
 
 async function ethereumTvl(api) {
-  const { baseAsset, baseAssets } = await resolveDedicatedRouterBaseAssets(
-    api,
-    NVPRIME_ROUTER
-  )
-  api.add(baseAsset, baseAssets)
-  return sumTokens2({ api })
+  const nuvaVaultAddress = await api.call({
+    target: NVPRIME_ROUTER,
+    abi: 'address:nuvaVault',
+  })
+
+  await api.erc4626Sum({calls: [nuvaVaultAddress], isOG4626: true})
 }
 
 module.exports = {
@@ -87,7 +29,7 @@ module.exports = {
   misrepresentedTokens: true,
   start: '2026-04-27',
   methodology:
-    'NUVA TVL is the sum of (1) nvYLDS total_vault_value from the Provenance vault module (canonical vault state; Ethereum and Base bridge contracts are excluded to avoid double-counting bridged deposits) and (2) nvPRIME underlying assets held in the Ethereum DedicatedVaultRouter ERC4626 hop chain (nuvaVault → stakingVault → assetVault), priced at the base asset token.',
+    'NUVA TVL is the sum of (1) nvYLDS total_vault_value from the Provenance vault module (canonical vault state; Ethereum and Base bridge contracts are excluded to avoid double-counting bridged deposits) and (2) nvPRIME underlying assets held in the Ethereum Nuva vault.',
   provenance: { tvl: provenanceTvl },
   ethereum: { tvl: ethereumTvl },
 }


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

## New listing metadata

##### Name (to be shown on DefiLlama):
NUVA

##### Twitter Link:
https://x.com/nuvafinance

##### List of audit links if any:
https://nuva.finance/transparency (vault audit reports)

##### Website Link:
https://nuva.finance

##### Logo (High resolution, will be shown with rounded borders):
_(To be supplied via metadata@defillama.com if needed)_

##### Current TVL:
~$5.19M total (validated 2026-06-30): nvYLDS ~$604,713 on Provenance; nvPRIME ~$4,583,416 on Ethereum

##### Treasury Addresses (if the protocol has treasury)
N/A for this TVL adapter

##### Chain:
Provenance, Ethereum

##### Coingecko ID:
_(leave empty if not listed)_

##### Coinmarketcap ID:
_(leave empty if not listed)_

##### Short Description (to be shown on DefiLlama):
NUVA is a real-world asset vault platform offering tokenized yield products including nvYLDS (YLDS-backed vault on Provenance) and nvPRIME (private credit vault on Ethereum).

##### Token address and ticker if any:
- nvYLDS share denom: `nuva.ylds` (Provenance)
- nvPRIME share token (Ethereum NuvaVault): `0xC360e625F19A7ea47e47810B13E386221d5187D1`
- nvPRIME DedicatedVaultRouter: `0x50AE1e4A612A4623b747aEeFb30aFBA82804e12c`

##### Category:
RWA

##### Oracle Provider(s):
N/A for TVL measurement — values are read from on-chain vault state (Provenance vault module `total_vault_value` for nvYLDS; ERC4626 `totalAssets` / `convertToAssets` hop chain for nvPRIME).

##### Implementation Details:
TVL is derived directly from chain state, not from external price oracles.

##### Documentation/Proof:
- App: https://app.nuva.finance
- Provenance vault API: `https://api.provenance.io/vault/v1/vaults/nuva.ylds`
- Prod contract deployment: ProvLabs/nuva-config `mainnet/ethereum/ignition/deployments/nvprime`

##### forkedFrom:
No

##### methodology:
NUVA TVL is the sum of (1) nvYLDS `total_vault_value` from the Provenance vault module (canonical vault state; Ethereum and Base bridge contracts are excluded to avoid double-counting bridged deposits) and (2) nvPRIME underlying assets held in the Ethereum DedicatedVaultRouter ERC4626 hop chain (nuvaVault → stakingVault → assetVault), priced at the base asset token.

##### Github org/user:
https://github.com/ProvLabs

##### Does this project have a referral program?
No

---

## Summary

Adds `projects/nuva/index.js` TVL adapter for NUVA vaults:

- **Provenance (nvYLDS):** reads `total_vault_value` from the vault module REST API (`nuva.ylds` share denom). Amount is USD-equivalent with 6 decimals, matching NUVA app accounting. Eth/Base bridge contracts are intentionally excluded to prevent double-counting.
- **Ethereum (nvPRIME):** reads underlying assets via DedicatedVaultRouter → nuvaVault → stakingVault → assetVault ERC4626 chain.

## Test plan

- [x] `node test.js projects/nuva` passes locally
- [x] Provenance TVL ~$604,713 matches app.nuva.finance nvYLDS card
- [x] Ethereum TVL ~$4,583,416 matches app.nuva.finance nvPRIME card

## Notes

- `misrepresentedTokens: true` because nvYLDS TVL uses vault-reported USD value via `addUSDValue` rather than pricing the `uylds.fcc` denom directly.
- Provenance historical backfill may be limited until a block-height-aware vault query is available; Ethereum leg supports timetravel via RPC.

Tracking: ProvLabs/Product#401

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NUVA TVL tracking for both Provenance and Ethereum.
  * Fetches Nuva vault value from the Provenance side and sums underlying holdings from the Ethereum vault to produce a unified USD-equivalent TVL view.
  * Uses a fixed reporting start date (2026-04-27) for consistent historical tracking.
* **Documentation**
  * Added methodology details describing exclusions to prevent double-counting bridged deposits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->