### PR TITLE
Add chain: Mars Credit (mars, 110110)

### DIFF
--- a/projects/helper/chains.json
+++ b/projects/helper/chains.json
@@ -177,6 +177,7 @@
   "manta",
   "manta_atlantic",
   "mantle",
+  "mars",
   "map",
   "mayachain",
   "meer",


### PR DESCRIPTION
## Chain registration: Mars Credit (mars)

Adds the slug `mars` to `projects/helper/chains.json` so future Mars Credit protocol adapters can target the chain.

### Background

Mars Credit (MARS) is an **Ethash proof-of-work, EVM-compatible Layer-1**, already supported in `@defillama/sdk` providers.json (Chain ID 110110, auto-pulled from chainlist.org):

```
{
  "rpc": [
    "https://rpc.marscredit.xyz",
    "https://rpc.marscredit.xyz:443"
  ],
  "chainId": 110110
}
```

Source: https://unpkg.com/@defillama/sdk@latest/build/providers.json

### Independent verification

| | |
|---|---|
| Website | https://marscredit.xyz |
| RPC | https://rpc.marscredit.xyz (`eth_chainId` → `0x1ae9e` = 110110) |
| Explorer | https://blockscan.marscredit.xyz (Blockscout, EIP-3091) |
| Source | https://github.com/marscredit |
| Chain registry | https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-110110.json |
| Chainlist | https://chainlist.org/chain/110110 |
| Block height (today) | ~4.79M (~18 months continuous block production) |
| Stack | go-ethereum v1.10.18 fork, London hard fork from genesis |
| Decimals | 18 |
| Launch | December 2024 mainnet |

### Notes

- No protocol adapter is included in this PR — registering the chain slug first so future protocols can target it without a circular dependency.
- Happy to add coreAssets / token mapping entries in a follow-up PR if requested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for an additional chain name: **Mars**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->