### PR TITLE
ample: add solana, hyperliquid, and bsc; migrate to standalone adapter

### DIFF
--- a/projects/ample/index.js
+++ b/projects/ample/index.js
@@ -1,0 +1,38 @@
+const { sumERC4626VaultsExport2 } = require('../helper/erc4626')
+const { getConnection, sumTokens2 } = require('../helper/solana')
+const { PublicKey } = require('@solana/web3.js')
+
+// EVM: ERC-4626 vaults (totalAssets of the underlying asset)
+const vaults = {
+  arbitrum: ['0xd1be1f98991cf69355e468ad15b6d0b6429bcfcb'],
+  base: ['0x1688aeb3ec7b23a22e2418fdf5bccc67ecf39c0f'],
+  katana: ['0xe5092ab6b8b0c37b1bec12c606614706063d04e8'],
+  monad: ['0xE89d322b5822D828B8252D3087be8486cC2048Ef'],
+  hyperliquid: ['0x00a7ab758367da6a3909b75bd30ccc68e8755809'],
+  bsc: ['0x86713f2bf1969e41a5e003a97934801acd291de7'],
+}
+
+// Solana: vaults are program-owned PDAs (one per asset, currently USDC & SOL).
+// Deposits are routed into Jupiter Lend, so each vault PDA holds Jupiter Lend
+// receipt tokens (jlUSDC / jlWSOL), which are priced by DefiLlama.
+const SOLANA_PROGRAM_ID = 'BPdfgbFKNQELh96XFqAZGBRfe3CJ6Ly1JJ4fmAVgWcU8'
+const VAULT_ACCOUNT_SIZE = 424 // distinguishes vault accounts from the config account
+
+async function solanaTvl(api) {
+  const connection = getConnection()
+  const accounts = await connection.getProgramAccounts(new PublicKey(SOLANA_PROGRAM_ID), {
+    filters: [{ dataSize: VAULT_ACCOUNT_SIZE }],
+  })
+  const owners = accounts.map(a => a.pubkey.toString())
+  return sumTokens2({ api, owners })
+}
+
+module.exports = {
+  methodology: 'On EVM chains, TVL is the total assets of each Ample ERC-4626 vault. On Solana, TVL is the balance of tokens held by each vault PDA (deposits are deployed into Jupiter Lend). Marked as double counted because underlying deposits are also tracked by the destination protocols.',
+  doublecounted: true,
+  solana: { tvl: solanaTvl },
+}
+
+Object.entries(vaults).forEach(([chain, chainVaults]) => {
+  module.exports[chain] = { tvl: sumERC4626VaultsExport2({ vaults: chainVaults }) }
+})

--- a/projects/ample/index.js
+++ b/projects/ample/index.js
@@ -17,15 +17,22 @@ const vaults = {
 // receipt tokens (jlUSDC / jlWSOL), which are priced by DefiLlama.
 const SOLANA_PROGRAM_ID = 'BPdfgbFKNQELh96XFqAZGBRfe3CJ6Ly1JJ4fmAVgWcU8'
 const VAULT_ACCOUNT_SIZE = 424 // distinguishes vault accounts from the config account
+const TOKEN_PROGRAM = new PublicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA') // SPL Token
 
 async function solanaTvl(api) {
   const connection = getConnection()
-  const accounts = await connection.getProgramAccounts(new PublicKey(SOLANA_PROGRAM_ID), {
+  const vaultAccounts = await connection.getProgramAccounts(new PublicKey(SOLANA_PROGRAM_ID), {
     filters: [{ dataSize: VAULT_ACCOUNT_SIZE }],
     dataSlice: { offset: 0, length: 0 }, // only pubkeys are used, skip fetching account data
   })
-  const owners = accounts.map(a => a.pubkey.toString())
-  return sumTokens2({ api, owners })
+  // Resolve each vault PDA's token accounts and sum them as tokenAccounts. We avoid
+  // sumTokens2({ owners }) because that path batches getTokenAccountsByOwner into a
+  // single JSON-RPC POST, which public RPCs (incl. the CI default) reject.
+  const results = await Promise.all(
+    vaultAccounts.map(vault => connection.getParsedTokenAccountsByOwner(vault.pubkey, { programId: TOKEN_PROGRAM }))
+  )
+  const tokenAccounts = results.flatMap(res => res.value.map(ta => ta.pubkey.toString()))
+  return sumTokens2({ api, tokenAccounts })
 }
 
 module.exports = {

--- a/projects/ample/index.js
+++ b/projects/ample/index.js
@@ -22,6 +22,7 @@ async function solanaTvl(api) {
   const connection = getConnection()
   const accounts = await connection.getProgramAccounts(new PublicKey(SOLANA_PROGRAM_ID), {
     filters: [{ dataSize: VAULT_ACCOUNT_SIZE }],
+    dataSlice: { offset: 0, length: 0 }, // only pubkeys are used, skip fetching account data
   })
   const owners = accounts.map(a => a.pubkey.toString())
   return sumTokens2({ api, owners })

--- a/registries/erc4626.js
+++ b/registries/erc4626.js
@@ -230,13 +230,6 @@ const configs = {
     methodology: "TVL reads total hub vault assets (USDC)",
     base: ['0xa593A9bBBc65be342FF610a01e96da2EB8539FF2']
   },
-  'ample': {
-    doublecounted: true,
-    arbitrum: ['0xd1be1f98991cf69355e468ad15b6d0b6429bcfcb'],
-    base: ['0x1688aeb3ec7b23a22e2418fdf5bccc67ecf39c0f'],
-    katana: ['0xe5092ab6b8b0c37b1bec12c606614706063d04e8'],
-    monad: ['0xE89d322b5822D828B8252D3087be8486cC2048Ef'],
-  },
   'arche-money': {
     'ethereum': [
       '0x33ffc177a7278ff84aab314a036bc7b799b7cc15', // arUSD


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for Ample vaults across supported EVM networks and Solana.
  * Vault balances are now aggregated directly from on-chain underlying assets for broader, more accurate reporting.
* **Refactor**
  * Updated how Ample TVL is exported so Ample vaults’ metrics remain consistently available across the supported chains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->