### PR TITLE
Add USDi TVL adapter

### DIFF
--- a/projects/usdi/index.js
+++ b/projects/usdi/index.js
@@ -1,0 +1,16 @@
+const USDI = '0xAf1157149ff040DAd186a0142a796d901bEF1cf1'
+
+async function tvl(api) {
+  const supply = await api.call({ target: USDI, abi: 'erc20:totalSupply', })
+  const decimals = await api.call({ target: USDI, abi: 'erc20:decimals', })
+  const exchangeRate = await api.call({ target: USDI, abi: 'uint256:getExchangeRate', })
+  api.addUSDValue((supply / 10 ** decimals) * (exchangeRate / 1e18))
+}
+
+module.exports = {
+  misrepresentedTokens: true,
+  methodology: 'USDi is a CPI-tracking unit of account fully backed by the USDi Coin Fund (US Treasuries, inflation-linked bonds, FX, commodities and cash). TVL is the USD value of those reserves, computed on-chain as the USDi totalSupply multiplied by the CPI-linked exchange rate from getExchangeRate on the token contract (also published via the Chainlink USDi/USD feed at 0x79F7ADfd5c3E736c6737B3936aF13b5f05f067FE).',
+  ethereum: {
+    tvl,
+  },
+}


### PR DESCRIPTION
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
USDi

##### Twitter Link:
N/A

##### List of audit links if any:
https://diligence.security/audits/2025/04/usdi/

##### Website Link:
https://www.usdicoin.com

##### Logo (High resolution, will be shown with rounded borders):
https://www.usdicoin.com/img/logo.png

##### Current TVL:
~$250,530

##### Treasury Addresses (if the protocol has treasury)
N/A

##### Chain:
Ethereum

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):

##### Short Description (to be shown on DefiLlama):
USDi is a digitally native unit of account designed to track U.S. CPI and preserve purchasing power over time. Unlike traditional digital dollars that remain nominally stable, USDi adjusts alongside inflation.

##### Token address and ticker if any:
0xAf1157149ff040DAd186a0142a796d901bEF1cf1 (USDi)

##### Category (full list at https://defillama.com/categories) \*Please choose only one:
RWA

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
Chainlink (USDi / USD Exchange Rate feed: 0x79F7ADfd5c3E736c6737B3936aF13b5f05f067FE)

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
The CPI-linked exchange rate is exposed on-chain via `getExchangeRate()` on the USDi token contract and is also published through the Chainlink USDi/USD Exchange Rate feed. Reserve NAV is calculated at each mint/burn by an independent administrator (Trident Fund Services Inc), reported monthly, and the USDi Coin Fund is audited annually.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
https://www.usdicoin.com/api/price
Chainlink feed: 0x79F7ADfd5c3E736c6737B3936aF13b5f05f067FE

##### forkedFrom (Does your project originate from another project):
No

##### methodology (what is being counted as tvl, how is tvl being calculated):
USDi is fully backed by the USDi Coin Fund (US Treasuries, inflation-linked bonds, FX, commodities and cash). TVL is the USD value of those reserves, computed on-chain as USDi totalSupply multiplied by the CPI-linked exchange rate from `getExchangeRate()` on the token contract.

##### Github org/user (Optional, if your code is open source, we can track activity):
N/A

##### Does this project have a referral program?
No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes / Improvements**
  * Updated how the USDi adapter calculates and reports USDi’s USD value on Ethereum, now attributing value based on USDC held in the USDi contract.
  * Added/clarified the adapter’s methodology note and token-handling configuration for this calculation.
* **Refactor**
  * Simplified the adapter to use a more declarative TVL wiring approach instead of manual on-chain math.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->