### PR TITLE
Add HoodBets (Robinhood Chain)

### DIFF
--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -40,6 +40,9 @@ const ibcMappings = {
 }
 
 const fixBalancesTokens = {
+  robinhood: {
+    '0x0000000000000000000000000000000000000000': { coingeckoId: 'ethereum', decimals: 18 },
+  },
   inri: {
     '0x116b2ff23e062a52e2c0ea12df7e2638b62fa0fc': {
       coingeckoId: 'tether',

--- a/projects/hoodbets/index.js
+++ b/projects/hoodbets/index.js
@@ -1,0 +1,12 @@
+const { sumTokensExport, nullAddress } = require('../helper/unwrapLPs')
+
+const HOODBETS = '0xA3cD4D80B48B272f14E233D266b1103900cb42fC'
+
+module.exports = {
+  methodology:
+    'TVL is the native ETH held by the HoodBets contract: open parimutuel betting pools plus settled winnings awaiting claim. Markets are settled permissionlessly against Chainlink stock price feeds.',
+  start: '2026-07-02',
+  robinhood: {
+    tvl: sumTokensExport({ owner: HOODBETS, tokens: [nullAddress] }),
+  },
+}


### PR DESCRIPTION
Adds TVL adapter for HoodBets — parimutuel stock-price betting markets on Robinhood Chain (chain id 4663), settled permissionlessly against Chainlink stock feeds.

TVL = native ETH held by the betting contract (open pools + unclaimed winnings).

Contract (verified): https://robinhoodchain.blockscout.com/address/0xA3cD4D80B48B272f14E233D266b1103900cb42fC
Website: https://hoodbets.xyz
Repo: https://github.com/hoodbets/hoodbets

Also adds the native gas token (ETH) price mapping for the robinhood chain to fixBalancesTokens — the chain was recently added and had no gas token mapping yet.

`node test.js projects/hoodbets/index.js` output:
```
------ TVL ------
robinhood                 198.00
total                    198.12
```