### PR TITLE
Skip DeBank for TVL calculations

### DIFF
--- a/projects/kpk/index.js
+++ b/projects/kpk/index.js
@@ -196,7 +196,7 @@ for (const chain of allChains) {
       // Zodiac-managed Safe TVL via DeBank
       if (ZODIAC_CHAINS.includes(chain)) owners.push(...ZODIAC_MANAGED_SAFES)
         // await getDebankTvl(api, ZODIAC_MANAGED_SAFES)
-      return sumTokens2({ api, owners, fetchCoValentTokens: true, permitFailure: true, tokenConfig: {
+      return sumTokens2({ api, owners, fetchCoValentTokens: true, blacklistedTokens: getCuratedVaults(api.chain), permitFailure: true, tokenConfig: {
         onlyWhitelisted: false,
       }, resolveUniV3: chain !== 'xdai', resolveLP: true, })
     }

--- a/projects/kpk/index.js
+++ b/projects/kpk/index.js
@@ -1,5 +1,6 @@
 const { getCuratorExport } = require("../helper/curators")
 const { sumTokensDebank } = require("../helper/debank")
+const { sumTokens2 } = require("../helper/unwrapLPs")
 
 // ---- Minimal ABIs / constants from Gearbox v3.1 adapter ----
 const DEFILLAMA_COMPRESSOR_V310 = "0x81cb9eA2d59414Ab13ec0567EFB09767Ddbe897a"
@@ -186,12 +187,18 @@ for (const chain of allChains) {
       const hasAleph = chainCfg?.alephVaults
       if (hasGearbox) await getGearboxV31Collateral(api, hasGearbox)
       if (hasAleph) await getAlephVaultTvl(api, hasAleph)
+        const owners = []
 
       // kpk Fund (OIV) TVL via DeBank
-      if (OIV_CHAINS.includes(chain)) await getDebankTvl(api, OIV_SAFES)
+      if (OIV_CHAINS.includes(chain)) owners.push(...OIV_SAFES)
+        // await getDebankTvl(api, OIV_SAFES)
 
       // Zodiac-managed Safe TVL via DeBank
-      if (ZODIAC_CHAINS.includes(chain)) await getDebankTvl(api, ZODIAC_MANAGED_SAFES)
+      if (ZODIAC_CHAINS.includes(chain)) owners.push(...ZODIAC_MANAGED_SAFES)
+        // await getDebankTvl(api, ZODIAC_MANAGED_SAFES)
+      return sumTokens2({ api, owners, fetchCoValentTokens: true, permitFailure: true, tokenConfig: {
+        onlyWhitelisted: false,
+      }, resolveUniV3: chain !== 'xdai', resolveLP: true, })
     }
   }
 }


### PR DESCRIPTION
Remove the DeBank TVL calculation for both KPK Fund and Zodiac-managed Safe, replacing it with a new method that aggregates owners and computes TVL using a different approach.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TVL calculation for safe/custody wallets by switching to a safer token aggregation flow, improving reliability of counted balances across supported chains.
  * Enhanced support for liquidity positions (including Uniswap V3/LP resolution), with more resilient handling of partial data or lookup failures so results remain accurate when some sources are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->