### PR TITLE
Add Moono TVL adapter

### DIFF
--- a/projects/moono/index.js
+++ b/projects/moono/index.js
@@ -17,12 +17,24 @@ const QUOTE_VAULTS = [
 const DISCRIMINATOR_SIZE = 8
 const PUBKEY_SIZE = 32
 const U64_SIZE = 8
+const QUOTE_VAULT_DISCRIMINATOR = Buffer.from([41, 177, 89, 127, 84, 216, 60, 124])
 
 const BALANCE_OFFSET = DISCRIMINATOR_SIZE + (PUBKEY_SIZE * 3)
 const BORROWED_OFFSET = BALANCE_OFFSET + U64_SIZE
+const MIN_QUOTE_VAULT_SIZE = BORROWED_OFFSET + U64_SIZE
 
 function readU64LE(data, offset) {
   return data.readBigUInt64LE(offset)
+}
+
+function assertQuoteVaultLayout(data, quoteVault) {
+  if (data.length < MIN_QUOTE_VAULT_SIZE) {
+    throw new Error(`Unexpected Moono quote vault layout: ${quoteVault}`)
+  }
+
+  if (!data.subarray(0, DISCRIMINATOR_SIZE).equals(QUOTE_VAULT_DISCRIMINATOR)) {
+    throw new Error(`Unexpected Moono quote vault discriminator: ${quoteVault}`)
+  }
 }
 
 function addVaultAmounts(api, accounts, selector) {
@@ -30,6 +42,8 @@ function addVaultAmounts(api, accounts, selector) {
     if (!account) throw new Error(`Missing Moono quote vault account: ${QUOTE_VAULTS[index].quoteVault}`)
 
     const data = Buffer.from(account.data)
+    assertQuoteVaultLayout(data, QUOTE_VAULTS[index].quoteVault)
+
     const balance = readU64LE(data, BALANCE_OFFSET)
     const borrowed = readU64LE(data, BORROWED_OFFSET)
 

--- a/projects/moono/index.js
+++ b/projects/moono/index.js
@@ -1,0 +1,60 @@
+const { getMultipleAccounts } = require('../helper/solana')
+
+const WSOL_MINT = 'So11111111111111111111111111111111111111112'
+const USDC_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
+
+const QUOTE_VAULTS = [
+  {
+    mint: WSOL_MINT,
+    quoteVault: 'Dor7sETLfp4uxjkETvBRdJd4pYuiNAp8ZVrPzL9CD2Uo',
+  },
+  {
+    mint: USDC_MINT,
+    quoteVault: '6Mgt39gtfEMM5c21GAy6kaEHUgce12iUGYChiYfftgZF',
+  },
+]
+
+const DISCRIMINATOR_SIZE = 8
+const PUBKEY_SIZE = 32
+const U64_SIZE = 8
+
+const BALANCE_OFFSET = DISCRIMINATOR_SIZE + (PUBKEY_SIZE * 3)
+const BORROWED_OFFSET = BALANCE_OFFSET + U64_SIZE
+
+function readU64LE(data, offset) {
+  return data.readBigUInt64LE(offset)
+}
+
+function addVaultAmounts(api, accounts, selector) {
+  accounts.forEach((account, index) => {
+    if (!account) throw new Error(`Missing Moono quote vault account: ${QUOTE_VAULTS[index].quoteVault}`)
+
+    const data = Buffer.from(account.data)
+    const balance = readU64LE(data, BALANCE_OFFSET)
+    const borrowed = readU64LE(data, BORROWED_OFFSET)
+
+    api.add(QUOTE_VAULTS[index].mint, selector({ balance, borrowed }).toString())
+  })
+}
+
+async function tvl(api) {
+  const accounts = await getMultipleAccounts(QUOTE_VAULTS.map((vault) => vault.quoteVault), { api })
+
+  addVaultAmounts(api, accounts, ({ balance, borrowed }) => balance + borrowed)
+}
+
+async function borrowed(api) {
+  const accounts = await getMultipleAccounts(QUOTE_VAULTS.map((vault) => vault.quoteVault), { api })
+
+  addVaultAmounts(api, accounts, ({ borrowed }) => borrowed)
+}
+
+module.exports = {
+  timetravel: false,
+  methodology:
+    'TVL counts gross LP-supplied quote liquidity tracked by Moono quote vaults: idle vault balance plus outstanding borrowed principal. Borrowed reports the outstanding principal separately.',
+  solana: {
+    tvl,
+    borrowed,
+  },
+}


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
Moono Protocol

##### Twitter Link:
https://x.com/MoonoProtocol

##### List of audit links if any:
N/A

##### Website Link:
https://moono.ch

##### Logo (High resolution, will be shown with rounded borders):
https://moono.ch/ms-icon-310x310.png

##### Current TVL:
Approximately $41k at the time of submission.
Adapter-reported underlying balances at submission time:
- WSOL supplied liquidity: 273.629737958 WSOL
- USDC supplied liquidity: 19,564.642332 USDC

##### Treasury Addresses (if the protocol has treasury)
N/A

##### Chain:
Solana

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description (to be shown on DefiLlama):
Moono Protocol is a decentralized lending protocol on Solana for token launches. Borrowers can borrow launch liquidity, launch tokens through supported Solana launchpads, and repay from profits, while LPs supply
liquidity and earn interest and fees.

##### Token address and ticker if any:
N/A

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Lending

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
N/A

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
Moono does not rely on an external oracle for the TVL reported by this adapter. The adapter reads Moono quote vault accounting directly from Solana on-chain accounts.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
N/A

##### forkedFrom (Does your project originate from another project):
N/A

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL counts gross LP-supplied quote liquidity tracked by Moono quote vault accounts on Solana.

For each supported quote vault:

TVL = quote_vault.balance + quote_vault.borrowed

- quote_vault.balance is idle quote liquidity still held by the vault.
- quote_vault.borrowed is outstanding principal currently issued into active loans.
- The adapter also reports borrowed separately as quote_vault.borrowed.

Currently included vaults:
- WSOL quote vault
- USDC quote vault

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/MoonoProtocol

##### Does this project have a referral program?
Yes

Sources used: Moono site says it is Solana/mainnet, decentralized, borrow SOL for launches, LPs earn on loans, loan range/duration/tier model, and links Twitter/GitHub/docs from the footer.
https://moono.ch
https://docs.moono.ch/getting-started/introduction/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tracking Moono on Solana.
  * Users can now view total tracked quote liquidity (idle plus borrowed) and borrowed balances for the protocol.
  * Included clear methodology details for how values are computed, with timetravel disabled for this adapter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->