### PR TITLE
Add Teddy Cash TVL adapter

### DIFF
--- a/projects/teddy-cash/index.js
+++ b/projects/teddy-cash/index.js
@@ -1,0 +1,15 @@
+const { getLiquityTvl } = require("../helper/liquity");
+
+// Teddy Cash is a Liquity fork on Avalanche that mints the TSD stablecoin against
+// native AVAX collateral. The TroveManager exposes activePool()/defaultPool(), which
+// custody the AVAX deposited in Troves, so the standard Liquity helper applies directly.
+const TROVE_MANAGER = "0xd22b04395705144Fd12AfFD854248427A2776194";
+
+module.exports = {
+  methodology:
+    "TVL is the AVAX collateral deposited in Teddy Cash Troves, held by the ActivePool and DefaultPool and read via the TroveManager, following the standard Liquity model. The Stability Pool holds the protocol's own TSD stablecoin and is excluded to avoid counting debt as TVL.",
+  start: "2021-08-26",
+  avax: {
+    tvl: getLiquityTvl(TROVE_MANAGER),
+  },
+};


### PR DESCRIPTION
## Summary

Adds a TVL adapter for **Teddy Cash** (issue #13885), a Liquity fork on Avalanche that mints the **TSD** stablecoin against native **AVAX** collateral.

- Uses the repo's existing Liquity helper (`getLiquityTvl`) against the **TroveManager** `0xd22b04395705144Fd12AfFD854248427A2776194`.
- TVL = AVAX collateral custodied by the **ActivePool + DefaultPool** (read via the TroveManager), the standard Liquity model.
- The **Stability Pool** holds the protocol's own TSD stablecoin (a liability), so it is **excluded** to avoid counting debt as TVL.
- `start: 2021-08-26` = TroveManager deployment date (verified via contract-creation tx).

Closes #13885

## Testing

Tested with `node test.js projects/teddy-cash/index.js` against Avalanche RPC:

| Date | TVL | Note |
|------|-----|------|
| latest | ~1,567 AVAX (≈ $10.6k) | ActivePool 1567.48 + DefaultPool ~0, matches on-chain `eth_getBalance` exactly |
| 2022-01-15 | $5.58M | historical backfill path (protocol's peak era) |

Contract addresses cross-verified against the official docs (docs.teddy.cash/contracts), the GitHub deployment JSON, and live on-chain calls (`TroveManager.activePool()`/`defaultPool()` match the documented pools). TVL is modest today because the protocol has shrunk over time, but the contracts are live and the reads are accurate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking support for Teddy Cash on Avalanche.
  * Included a fixed start date and methodology details for clearer reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->