### PR TITLE
Strike Finance: add new Cardano protocol address

### DIFF
--- a/projects/strike-finance/index.js
+++ b/projects/strike-finance/index.js
@@ -1,0 +1,53 @@
+const ADDRESSES = require("../helper/coreAssets.json");
+const { sumTokens2: sumCardanoTokens2 } = require("../helper/chain/cardano");
+
+const ETHEREUM_TREASURY_ADDRESSES = [
+  "0xbF4cFccd11257e568A936a7867D138f54A43cffa",
+];
+
+const CARDANO_TREASURY_ADDRESSES = [
+  "addr1wxzar75lms9547xdz4slxk7r362rs4g4ccurl22g764akngjhjtzp",
+  "addr1w88zvhrrlqj6kl94mel769v348khd5w3jz3av33ksp8wgvss6msuw",
+];
+
+const CARDANO_PROTOCOL_ADDRESSES = [
+  "addr1w9ygqdx9law3waqgm6eamf2xhxs5x83r0pfka928jmydkuc6ykls3",
+  "addr1wy2gch9ua0700a3dg423wxcwx4p886m4ny5u3aqs66sluqcly9uud",
+  "addr1q9mqsgrgdaq9aahjfcrc6f45sgmcut4gu3c774kqzawkjkhujht5h40l2yrm8e7r2vwr2g3tv64pzjgnxwsztwg0yu5s00jz00",
+  "addr1z9nsxjyw7xgfw5jtfxcw7fxucte0277ununa4evyxcw3evg6409492020k6xml8uvwn34wrexagjh5fsk5xk96jyxk2q4366ry",
+  "addr1zy48lqwffvzkahcyrhj8982p3f7c002g098ly4zxzxefnlg6409492020k6xml8uvwn34wrexagjh5fsk5xk96jyxk2qst04fy",
+];
+
+const CARDANO_USDM =
+  "c48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad0014df105553444d";
+
+async function ethereumTvl(api) {
+  return api.sumTokens({
+    owners: ETHEREUM_TREASURY_ADDRESSES,
+    tokens: [ADDRESSES.ethereum.USDC],
+  });
+}
+
+async function cardanoTvl() {
+  const balances = await sumCardanoTokens2({
+    owners: CARDANO_PROTOCOL_ADDRESSES,
+  });
+
+  return sumCardanoTokens2({
+    balances,
+    owners: CARDANO_TREASURY_ADDRESSES,
+    tokens: [CARDANO_USDM],
+  });
+}
+
+module.exports = {
+  timetravel: false,
+  methodology:
+    "Counts assets held in Strike's Cardano and Ethereum protocol addresses.",
+  ethereum: {
+    tvl: ethereumTvl,
+  },
+  cardano: {
+    tvl: cardanoTvl,
+  },
+};


### PR DESCRIPTION
Adds a new Cardano protocol address for Strike Finance TVL tracking.

New address: `addr1w9ygqdx9law3waqgm6eamf2xhxs5x83r0pfka928jmydkuc6ykls3`

Follow-up to #19164 — protocol funds have moved to this address, which is now included in `CARDANO_PROTOCOL_ADDRESSES`.

## methodology
Counts assets held in Strike's Cardano and Ethereum protocol addresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for Strike Finance on Ethereum and Cardano.
  * Includes treasury and protocol balance coverage across both networks, with support for the relevant stablecoin holdings.
  * Added project metadata to better describe the TVL methodology and reporting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->