### PR TITLE
feat: add Fluxpad adapter

### DIFF
--- a/projects/fluxpad/index.js
+++ b/projects/fluxpad/index.js
@@ -1,0 +1,62 @@
+const { nullAddress } = require('../helper/unwrapLPs');
+
+// Fluxpad Factory Addresses
+const CONTRACTS = {
+  alvey: {
+    factoryV1: '0xCe025C574C6AD0f4F96B85D385Da2E31278E54D2',
+    factoryV2: '0x586af47cb950C6Cb9960aBAb3fC1437df177417C',
+    ausdt: '0x223Cb45fB37e9b927b0c1Fab58d4a1A819C0C4f6', // stable quote on Alvey
+  },
+  bitroot: {
+    factoryV1: '0xF491b7cfb0b31D384b80F1949E0b3D6701D5794A',
+  },
+  robinhood: {
+    // UPDATE THIS: Replace with your mainnet deployment address once live
+    factoryV2: '0x0000000000000000000000000000000000000000',
+  }
+};
+
+async function alvTvl(timestamp, block, chainBlocks, { api }) {
+  return api.sumTokens({
+    owners: [CONTRACTS.alvey.factoryV1, CONTRACTS.alvey.factoryV2],
+    tokens: [nullAddress, CONTRACTS.alvey.ausdt]
+  });
+}
+
+// Bitroot is not yet listed as a supported chain on DefiLlama. 
+// Uncomment this and add "bitroot" to module.exports once the chain is registered.
+/*
+async function bitrootTvl(timestamp, block, chainBlocks, { api }) {
+  return api.sumTokens({
+    owners: [CONTRACTS.bitroot.factoryV1],
+    tokens: [nullAddress]
+  });
+}
+*/
+
+async function robinhoodTvl(timestamp, block, chainBlocks, { api }) {
+  const factory = CONTRACTS.robinhood.factoryV2;
+  if (!factory || factory === '0x0000000000000000000000000000000000000000') {
+    return {};
+  }
+  return api.sumTokens({
+    owners: [factory],
+    tokens: [nullAddress]
+  });
+}
+
+module.exports = {
+  timetravel: true,
+  misrepresentedTokens: false,
+  methodology: "TVL is calculated by summing the native and quote token balances held as reserves inside the active Fluxpad factory contracts.",
+  start: 1714692286, //  Timestamp of the first factory deployment (approx. 2026-05-02)
+  alv: {
+    tvl: alvTvl,
+  },
+  // bitroot: {
+  //   tvl: bitrootTvl,
+  // },
+  robinhood: {
+    tvl: robinhoodTvl,
+  }
+};


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).

2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** Please send a mail to metadata@defillama.com
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes

---
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
Fluxpad

##### Twitter Link:
https://x.com/Ascendia_Labs

##### List of audit links if any:
None

##### Website Link:
https://fluxpad.fun

##### Logo (High resolution, will be shown with rounded borders):

<img width="598" height="598" alt="Ascendia circular" src="https://github.com/user-attachments/assets/f9a2bc28-abc7-49b0-bddf-bd25ff821504" />

##### Current TVL:
~$3,500 USD (Approx. 1,063,174 ALV currently locked in curves)

##### Treasury Addresses (if the protocol has treasury)


##### Chain:
Alvey, Bitroot, Robinhood

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):


##### Short Description (to be shown on DefiLlama):
Multi-chain decentralized launchpad utilizing dynamic bonding curves for instant token deployments and trading.

##### Token address and ticker if any:


##### Category (full list at https://defillama.com/categories) \*Please choose only one:
Launchpad

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
None (on-chain bonding curves)

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
Balances are computed directly from on-chain reserves held inside the factory contracts.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:


##### forkedFrom (Does your project originate from another project):
pump.fun (conceptual model)

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL is calculated by summing the native and quote token balances held as reserves inside the active Fluxpad factory contracts.

##### Github org/user (Optional, if your code is open source, we can track activity): Is not open source


##### Does this project have a referral program?
No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Fluxpad TVL support for supported networks, allowing balances to be tracked across active factory contracts.
  * Included coverage for the Alvey and Robinhood network deployments, with token reserves counted for the relevant assets.
  * Added standard TVL metadata for better integration and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->