### PR TITLE
Added Vessel Finance adapter for Scroll

### DIFF
--- a/projects/vessel-finance/index.js
+++ b/projects/vessel-finance/index.js
@@ -1,0 +1,15 @@
+module.exports = {
+  scroll: {
+    tvl: async (api) => {
+      const owner = '0x6126E927627b8d9eb9aDb9faadC47B76F94B6bA2'; // Vessel VaultProxy
+      const tokens = [
+        '0xf55BEC9cafDbE8730f096Aa55dad6D22d44099Df', // USDT (Scroll bridged)
+        '0x06eFdBFf2a14a7c8E15944D1F4A48F9F95F663A4', // USDC (Scroll bridged)
+        '0x3C1BCa5a656e69edCD0D4E36BEbb3FcDAcA60Cf1', // WBTC (Scroll bridged)
+        '0x0000000000000000000000000000000000000000', // native ETH
+      ];
+      return api.sumTokens({ owner, tokens });
+    },
+  },
+  methodology: 'TVL is the sum of ETH, USDT, USDC and WBTC balances held in the Vessel Finance VaultProxy contract on Scroll.',
+};


### PR DESCRIPTION
Name: Vessel Finance
Twitter Link: https://twitter.com/VesselFinance
List of audit links if any: No public audit found
Website Link: https://www.vessel.finance/
Logo: Attached
Current TVL: ~$250,000
Treasury Addresses : N/A
Chain: Scroll
Coingecko ID: 
Coinmarketcap ID: 
Short Description: Vessel is a zero-knowledge-powered decentralized exchange combining a limit order book with an AMM (VAELOB), built by the founders of Scroll.
Token address and ticker if any: 
Category: Dexs
Oracle Provider(s): None, pricing is determined internally via Vessel's own AMM-embedded order book (VAELOB), not an external oracle
Implementation Details: N/A (no external oracle used)
Documentation/Proof: https://vesselfinance.gitbook.io/vessel
Forked From: N/A
Methodology: TVL is the sum of ETH, USDT, USDC and WBTC balances held in the Vessel Finance VaultProxy contract on Scroll.
Github org/user: No public repo found
Does this project have a referral program?: Yes, a mileage-based referral/boost program (see docs)


<img width="400" height="400" alt="vessel_finance" src="https://github.com/user-attachments/assets/989da33a-3a39-4243-876a-430ce4327539" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking Vessel Finance TVL on Scroll.
  * TVL now includes balances of ETH, USDT, USDC, and WBTC held by the relevant contract.
  * Added a clear methodology description for how TVL is calculated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->