### PR TITLE
Add PredictStreet adapter

### DIFF
--- a/projects/helper/chains.json
+++ b/projects/helper/chains.json
@@ -3,6 +3,7 @@
   "abstract",
   "acala",
   "ace",
+  "adi",
   "arc",
   "aelf",
   "aeternity",

--- a/projects/helper/coreAssets.json
+++ b/projects/helper/coreAssets.json
@@ -2089,7 +2089,10 @@
     "WETN": "0x138dafbda0ccb3d8e39c19edb0510fc31b7c1c77"
   },
   "bitkub": {
-    "KKUB": "0x67ebd850304c70d983b2d1b93ea79c7cd6c3f6b5"
+    "KKUB": "0x67ebd850304c70d983b2d1b93ea79c7cd6c3f6b5",
+    "KUSDT": "0x7d984c24d2499d840eb3b7016077164e15e5faa6",
+    "USDT": "0x21cdc3706b8c7b1836df0e533dd884069521350b",
+    "USDC_E": "0x31929a0fd776f971c5dd14bf03e1f9ff69d9c91c"
   },
   "shape": {
     "WETH": "0x4200000000000000000000000000000000000006",

--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -54,6 +54,9 @@ const fixBalancesTokens = {
     'pm.pool.asset.3hjz8rcr3pejdc3msntlvy': { coingeckoId: 'usd-coin', decimals: 0 },
     'pm.pool.asset.1y3flutqcyuf8duew1vj2g': { coingeckoId: 'usd-coin', decimals: 0 },
   },
+  adi: {
+    '0x9cb8142aebbcdc60af7c97af897a67a8f3ca71c2': { coingeckoId: 'usd-coin', decimals: 6 },
+  },
 }
 
 ibcChains.forEach(chain => fixBalancesTokens[chain] = { ...ibcMappings, ...(fixBalancesTokens[chain] || {}) })

--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -54,9 +54,6 @@ const fixBalancesTokens = {
     'pm.pool.asset.3hjz8rcr3pejdc3msntlvy': { coingeckoId: 'usd-coin', decimals: 0 },
     'pm.pool.asset.1y3flutqcyuf8duew1vj2g': { coingeckoId: 'usd-coin', decimals: 0 },
   },
-  adi: {
-    '0x9cb8142aebbcdc60af7c97af897a67a8f3ca71c2': { coingeckoId: 'usd-coin', decimals: 6 },
-  },
 }
 
 ibcChains.forEach(chain => fixBalancesTokens[chain] = { ...ibcMappings, ...(fixBalancesTokens[chain] || {}) })

--- a/projects/predictstreet/index.js
+++ b/projects/predictstreet/index.js
@@ -1,7 +1,6 @@
 const { getLogs2 } = require('../helper/cache/getLogs')
 const ADDRESSES = require('../helper/coreAssets.json')
 
-const USDC_E = ADDRESSES.adi.USDC_e
 const VAULT_FACTORY = '0xc16B8b190064451c2FeEb2e77c4B2aC4c7009552'
 const CONDITIONAL_TOKENS = '0xD28B8295Cd57F205e4d080Ff4c6d23C06a9EEe3a' // locks collateral backing open positions
 const NEG_RISK_ADAPTER = '0x29e58C3916d1fD235f3d1e7fCF640fd1fA8BDb1e'
@@ -23,8 +22,9 @@ async function tvl(api) {
   const wcols = await api.multiCall({ abi: 'function wcolOf(bytes32) view returns (address)', calls: marketLogs.map(l => ({ target: NEG_RISK_ADAPTER, params: [l.marketId] })) })
   const clones = wcols.filter(a => a && a !== ADDRESSES.null)
 
+  const owners = [CONDITIONAL_TOKENS].concat(vaults, clones)
   // sum idle USDC.e in all vaults, ConditionalTokens, and neg-risk WrappedCollateral clones
-  await api.sumTokens({ owners: [CONDITIONAL_TOKENS, ...vaults, ...clones], tokens: [USDC_E] })
+  await api.sumTokens({ owners, tokens: ['0x9cb8142aEBBcdc60AF7c97Af897A67A8f3CA71C2'] }) // USDC.e
 }
 
 module.exports = {

--- a/projects/predictstreet/index.js
+++ b/projects/predictstreet/index.js
@@ -1,0 +1,79 @@
+const { getLogs2 } = require('../helper/cache/getLogs')
+const { getFixBalances } = require('../helper/portedTokens')
+
+// Bridged USDC (USDC.e), 6 decimals — the collateral that backs every position.
+const USDC_E = '0x9cb8142aebbcdc60af7c97af897a67a8f3ca71c2'
+
+const VAULT_FACTORY = '0xc16B8b190064451c2FeEb2e77c4B2aC4c7009552'
+const CONDITIONAL_TOKENS = '0xD28B8295Cd57F205e4d080Ff4c6d23C06a9EEe3a' // locks collateral backing open positions
+const NEG_RISK_ADAPTER = '0x29e58C3916d1fD235f3d1e7fCF640fd1fA8BDb1e'
+const FROM_BLOCK = 32200            // VaultFactory deploy
+const NEG_RISK_FROM_BLOCK = 32196   // NegRiskAdapter deploy
+
+// Neg-risk markets wrap USDC.e into a per-market WrappedCollateral clone — the raw
+// USDC.e sits in that clone, not in the adapter or ConditionalTokens. Enumerate
+// markets via MarketPrepared, resolve each clone via wcolOf, and sum its balance.
+const MARKET_PREPARED = 'event MarketPrepared(uint64 seq, bytes32 indexed marketId, uint8 questionCount)'
+
+// Every VaultFactory event that mutates a vault's USDC.e ledger carries the absolute
+// post-op balance and a monotonic `seq`, so the latest event per vault gives its
+// current balance — no per-vault balanceOf needed.
+const LEDGER_EVENTS = [
+  // events carrying an explicit `token` → keep only USDC.e
+  { abi: 'event DepositedERC20(uint64 seq, address indexed vault, address indexed from, address indexed token, uint256 amount, uint256 ledgerAfter)', bal: 'ledgerAfter', token: 'token' },
+  { abi: 'event WithdrawnERC20(uint64 seq, address indexed vault, address indexed to, address indexed token, uint256 amount, uint256 ledgerAfter)', bal: 'ledgerAfter', token: 'token' },
+  { abi: 'event EmergencyExecuted(uint64 seq, address indexed vault, address indexed token, uint256 amount, uint256 ledgerAfter)', bal: 'ledgerAfter', token: 'token' },
+  { abi: 'event VaultERC20BalanceChanged(uint64 seq, address indexed vault, address indexed token, uint256 balanceAfter, bytes4 reason)', bal: 'balanceAfter', token: 'token' },
+  // collateral-only events (no token field) → always USDC.e
+  { abi: 'event PositionSplit(uint64 seq, address indexed vault, bytes32 indexed conditionId, uint256 amount, uint256 ledgerAfter)', bal: 'ledgerAfter' },
+  { abi: 'event PositionsMerged(uint64 seq, address indexed vault, bytes32 indexed conditionId, uint256 amount, uint256 ledgerAfter)', bal: 'ledgerAfter' },
+  { abi: 'event PositionRedeemed(uint64 seq, address indexed vault, bytes32 indexed conditionId, uint256 payout, uint256 ledgerAfter)', bal: 'ledgerAfter' },
+]
+
+async function tvl(api) {
+  const latest = {} // vault => { seq, bal } — newest USDC.e ledger value per vault
+
+  for (const ev of LEDGER_EVENTS) {
+    // distinct extraKey per event: getLogs caches by chain/target only, so without it
+    // the events would share one cache file and cross-contaminate.
+    const name = ev.abi.slice(6, ev.abi.indexOf('('))
+    const logs = await getLogs2({ api, target: VAULT_FACTORY, eventAbi: ev.abi, fromBlock: FROM_BLOCK, extraKey: name })
+    for (const log of logs) {
+      if (ev.token && log[ev.token].toLowerCase() !== USDC_E) continue
+      const seq = Number(log.seq)
+      if (!latest[log.vault] || seq > latest[log.vault].seq)
+        latest[log.vault] = { seq, bal: log[ev.bal] }
+    }
+  }
+
+  // idle USDC.e across all vaults
+  for (const { bal } of Object.values(latest)) api.add(USDC_E, bal)
+
+  // + collateral locked in ConditionalTokens (single read, no multicall)
+  const ct = await api.call({ abi: 'erc20:balanceOf', target: USDC_E, params: [CONDITIONAL_TOKENS] })
+  api.add(USDC_E, ct)
+
+  // neg-risk collateral: sum USDC.e across every market's WrappedCollateral clone
+  // (single calls — ADI has no Multicall3 with tryAggregate)
+  const marketLogs = await getLogs2({ api, target: NEG_RISK_ADAPTER, eventAbi: MARKET_PREPARED, fromBlock: NEG_RISK_FROM_BLOCK, extraKey: 'MarketPrepared' })
+  const wcols = await Promise.all(marketLogs.map(l =>
+    api.call({ abi: 'function wcolOf(bytes32) view returns (address)', target: NEG_RISK_ADAPTER, params: [l.marketId] })))
+  const clones = wcols.filter(a => a && BigInt(a) !== 0n)
+  const wcolBalances = await Promise.all(clones.map(c =>
+    api.call({ abi: 'erc20:balanceOf', target: USDC_E, params: [c] })))
+  for (const bal of wcolBalances) api.add(USDC_E, bal)
+
+  // USDC.e is a brand-new-chain token DefiLlama can't auto-price; the adi entry in
+  // tokenMapping.js maps it to usd-coin. Apply that transform to the balances.
+  return getFixBalances('adi')(api.getBalances())
+}
+
+module.exports = {
+  methodology:
+    'TVL is the USDC.e (bridged USDC) collateral held by PredictStreet: per-vault balances ' +
+    'reconstructed from VaultFactory events (each emits the absolute post-op ledger balance with a ' +
+    'monotonic seq; the latest event per vault is its current balance), plus collateral locked in ' +
+    'the ConditionalTokens contract, plus the USDC.e backing each neg-risk market (held in that ' +
+    "market's WrappedCollateral clone).",
+  adi: { tvl },
+}

--- a/projects/predictstreet/index.js
+++ b/projects/predictstreet/index.js
@@ -1,16 +1,10 @@
 const { getLogs2 } = require('../helper/cache/getLogs')
-const { getFixBalances } = require('../helper/portedTokens')
+const ADDRESSES = require('../helper/coreAssets.json')
 
-// Bridged USDC (USDC.e), 6 decimals — the collateral that backs every position.
-const USDC_E = '0x9cb8142aebbcdc60af7c97af897a67a8f3ca71c2'
-
+const USDC_E = ADDRESSES.adi.USDC_e
 const VAULT_FACTORY = '0xc16B8b190064451c2FeEb2e77c4B2aC4c7009552'
 const CONDITIONAL_TOKENS = '0xD28B8295Cd57F205e4d080Ff4c6d23C06a9EEe3a' // locks collateral backing open positions
 const NEG_RISK_ADAPTER = '0x29e58C3916d1fD235f3d1e7fCF640fd1fA8BDb1e'
-// ADI's multicall implements only aggregate3 (no tryAggregate), so the SDK's
-// automatic multiCall/sumTokens routing can't use it — we call aggregate3
-// directly as a plain contract call instead.
-const MULTICALL = '0x73df6E8F0D112D22bD672952323b43d6893AB6D2'
 const FROM_BLOCK = 32200            // VaultFactory deploy
 const NEG_RISK_FROM_BLOCK = 32196   // NegRiskAdapter deploy
 
@@ -21,62 +15,22 @@ const VAULT_CREATED = 'event VaultCreated(uint64 seq, address indexed owner, add
 // USDC.e sits in that clone, not in the adapter or ConditionalTokens.
 const MARKET_PREPARED = 'event MarketPrepared(uint64 seq, bytes32 indexed marketId, uint8 questionCount)'
 
-const AGGREGATE3_ABI = 'function aggregate3((address target, bool allowFailure, bytes callData)[] calls) payable returns ((bool success, bytes returnData)[] returnData)'
-const SELECTORS = {
-  ledgerERC20: '0xd3cc7c57', // ledgerERC20(address)
-  balanceOf: '0x70a08231',   // balanceOf(address)
-  wcolOf: '0x40ece17a',      // wcolOf(bytes32)
-}
-
-// Batched read-only calls; throws on any failed/empty read — for TVL accounting
-// a bad call must fail the adapter, not silently count as a zero balance.
-async function aggregate3(api, calls, batchSize = 500) {
-  const out = []
-  for (let i = 0; i < calls.length; i += batchSize) {
-    const batch = calls.slice(i, i + batchSize)
-    const res = await api.call({ abi: AGGREGATE3_ABI, target: MULTICALL, params: [batch] })
-    for (let j = 0; j < res.length; j++) {
-      const r = res[j]
-      if (!r.success || r.returnData === '0x') throw new Error(`aggregate3 call failed at index ${i + j}`)
-      out.push(r.returnData)
-    }
-  }
-  return out
-}
-
-const encodeArg = (hex) => hex.replace(/^0x/, '').padStart(64, '0').toLowerCase()
-
 async function tvl(api) {
-  // (1) idle USDC.e across all user vaults: enumerate vaults via VaultCreated,
-  // then read each vault's live internal USDC.e ledger. ledgerERC20 (not
-  // balanceOf) so stray direct transfers that no user deposited are excluded.
   const created = await getLogs2({ api, target: VAULT_FACTORY, eventAbi: VAULT_CREATED, fromBlock: FROM_BLOCK, extraKey: 'VaultCreated' })
   const vaults = [...new Set(created.map(l => l.vault))]
-  const ledgerData = SELECTORS.ledgerERC20 + encodeArg(USDC_E)
-  const ledgers = await aggregate3(api, vaults.map(v => [v, false, ledgerData]))
-  for (const bal of ledgers) if (bal) api.add(USDC_E, BigInt(bal).toString())
 
-  // (2) collateral locked in ConditionalTokens (binary markets)
-  const ct = await api.call({ abi: 'erc20:balanceOf', target: USDC_E, params: [CONDITIONAL_TOKENS] })
-  api.add(USDC_E, ct)
-
-  // (3) neg-risk collateral: USDC.e held by every market's WrappedCollateral clone
   const marketLogs = await getLogs2({ api, target: NEG_RISK_ADAPTER, eventAbi: MARKET_PREPARED, fromBlock: NEG_RISK_FROM_BLOCK, extraKey: 'MarketPrepared' })
-  const wcols = await aggregate3(api, marketLogs.map(l => [NEG_RISK_ADAPTER, false, SELECTORS.wcolOf + encodeArg(l.marketId)]))
-  const clones = wcols.filter(a => a && BigInt(a) !== 0n).map(a => '0x' + a.slice(26))
-  const wcolBalances = await aggregate3(api, clones.map(c => [USDC_E, false, SELECTORS.balanceOf + encodeArg(c)]))
-  for (const bal of wcolBalances) if (bal) api.add(USDC_E, BigInt(bal).toString())
+  const wcols = await api.multiCall({ abi: 'function wcolOf(bytes32) view returns (address)', calls: marketLogs.map(l => ({ target: NEG_RISK_ADAPTER, params: [l.marketId] })) })
+  const clones = wcols.filter(a => a && a !== ADDRESSES.null)
 
-  // USDC.e is a brand-new-chain token DefiLlama can't auto-price; the adi entry in
-  // tokenMapping.js maps it to usd-coin. Apply that transform to the balances.
-  return getFixBalances('adi')(api.getBalances())
+  // sum idle USDC.e in all vaults, ConditionalTokens, and neg-risk WrappedCollateral clones
+  await api.sumTokens({ owners: [CONDITIONAL_TOKENS, ...vaults, ...clones], tokens: [USDC_E] })
 }
 
 module.exports = {
   methodology:
-    'TVL is the USDC.e (bridged USDC) collateral held by PredictStreet: the live internal ' +
-    'USDC.e ledger of every user vault (vaults enumerated via VaultCreated events, balances ' +
-    'read on-chain in batches), plus collateral locked in the ConditionalTokens contract, plus ' +
-    "the USDC.e backing each neg-risk market (held in that market's WrappedCollateral clone).",
+    'TVL is the USDC.e (bridged USDC) collateral held by PredictStreet: the idle balance of every ' +
+    'user vault (vaults enumerated via VaultCreated events), plus collateral locked in the ConditionalTokens ' +
+    "contract, plus the backing each neg-risk market (held in that market's WrappedCollateral clone).",
   adi: { tvl },
 }

--- a/projects/predictstreet/index.js
+++ b/projects/predictstreet/index.js
@@ -28,12 +28,18 @@ const SELECTORS = {
   wcolOf: '0x40ece17a',      // wcolOf(bytes32)
 }
 
-// Batched read-only calls; returns one returnData hex (or null) per call, in order.
+// Batched read-only calls; throws on any failed/empty read — for TVL accounting
+// a bad call must fail the adapter, not silently count as a zero balance.
 async function aggregate3(api, calls, batchSize = 500) {
   const out = []
   for (let i = 0; i < calls.length; i += batchSize) {
-    const res = await api.call({ abi: AGGREGATE3_ABI, target: MULTICALL, params: [calls.slice(i, i + batchSize)] })
-    for (const r of res) out.push(r.success && r.returnData !== '0x' ? r.returnData : null)
+    const batch = calls.slice(i, i + batchSize)
+    const res = await api.call({ abi: AGGREGATE3_ABI, target: MULTICALL, params: [batch] })
+    for (let j = 0; j < res.length; j++) {
+      const r = res[j]
+      if (!r.success || r.returnData === '0x') throw new Error(`aggregate3 call failed at index ${i + j}`)
+      out.push(r.returnData)
+    }
   }
   return out
 }
@@ -47,7 +53,7 @@ async function tvl(api) {
   const created = await getLogs2({ api, target: VAULT_FACTORY, eventAbi: VAULT_CREATED, fromBlock: FROM_BLOCK, extraKey: 'VaultCreated' })
   const vaults = [...new Set(created.map(l => l.vault))]
   const ledgerData = SELECTORS.ledgerERC20 + encodeArg(USDC_E)
-  const ledgers = await aggregate3(api, vaults.map(v => [v, true, ledgerData]))
+  const ledgers = await aggregate3(api, vaults.map(v => [v, false, ledgerData]))
   for (const bal of ledgers) if (bal) api.add(USDC_E, BigInt(bal).toString())
 
   // (2) collateral locked in ConditionalTokens (binary markets)
@@ -56,9 +62,9 @@ async function tvl(api) {
 
   // (3) neg-risk collateral: USDC.e held by every market's WrappedCollateral clone
   const marketLogs = await getLogs2({ api, target: NEG_RISK_ADAPTER, eventAbi: MARKET_PREPARED, fromBlock: NEG_RISK_FROM_BLOCK, extraKey: 'MarketPrepared' })
-  const wcols = await aggregate3(api, marketLogs.map(l => [NEG_RISK_ADAPTER, true, SELECTORS.wcolOf + encodeArg(l.marketId)]))
+  const wcols = await aggregate3(api, marketLogs.map(l => [NEG_RISK_ADAPTER, false, SELECTORS.wcolOf + encodeArg(l.marketId)]))
   const clones = wcols.filter(a => a && BigInt(a) !== 0n).map(a => '0x' + a.slice(26))
-  const wcolBalances = await aggregate3(api, clones.map(c => [USDC_E, true, SELECTORS.balanceOf + encodeArg(c)]))
+  const wcolBalances = await aggregate3(api, clones.map(c => [USDC_E, false, SELECTORS.balanceOf + encodeArg(c)]))
   for (const bal of wcolBalances) if (bal) api.add(USDC_E, BigInt(bal).toString())
 
   // USDC.e is a brand-new-chain token DefiLlama can't auto-price; the adi entry in

--- a/projects/predictstreet/index.js
+++ b/projects/predictstreet/index.js
@@ -7,61 +7,59 @@ const USDC_E = '0x9cb8142aebbcdc60af7c97af897a67a8f3ca71c2'
 const VAULT_FACTORY = '0xc16B8b190064451c2FeEb2e77c4B2aC4c7009552'
 const CONDITIONAL_TOKENS = '0xD28B8295Cd57F205e4d080Ff4c6d23C06a9EEe3a' // locks collateral backing open positions
 const NEG_RISK_ADAPTER = '0x29e58C3916d1fD235f3d1e7fCF640fd1fA8BDb1e'
+// ADI's multicall implements only aggregate3 (no tryAggregate), so the SDK's
+// automatic multiCall/sumTokens routing can't use it — we call aggregate3
+// directly as a plain contract call instead.
+const MULTICALL = '0x73df6E8F0D112D22bD672952323b43d6893AB6D2'
 const FROM_BLOCK = 32200            // VaultFactory deploy
 const NEG_RISK_FROM_BLOCK = 32196   // NegRiskAdapter deploy
 
+// One event per vault, used only to enumerate vaults — balances are read live
+// (this RPC caps getLogs responses, so dense event scans are unreliable).
+const VAULT_CREATED = 'event VaultCreated(uint64 seq, address indexed owner, address indexed vault)'
 // Neg-risk markets wrap USDC.e into a per-market WrappedCollateral clone — the raw
-// USDC.e sits in that clone, not in the adapter or ConditionalTokens. Enumerate
-// markets via MarketPrepared, resolve each clone via wcolOf, and sum its balance.
+// USDC.e sits in that clone, not in the adapter or ConditionalTokens.
 const MARKET_PREPARED = 'event MarketPrepared(uint64 seq, bytes32 indexed marketId, uint8 questionCount)'
 
-// Every VaultFactory event that mutates a vault's USDC.e ledger carries the absolute
-// post-op balance and a monotonic `seq`, so the latest event per vault gives its
-// current balance — no per-vault balanceOf needed.
-const LEDGER_EVENTS = [
-  // events carrying an explicit `token` → keep only USDC.e
-  { abi: 'event DepositedERC20(uint64 seq, address indexed vault, address indexed from, address indexed token, uint256 amount, uint256 ledgerAfter)', bal: 'ledgerAfter', token: 'token' },
-  { abi: 'event WithdrawnERC20(uint64 seq, address indexed vault, address indexed to, address indexed token, uint256 amount, uint256 ledgerAfter)', bal: 'ledgerAfter', token: 'token' },
-  { abi: 'event EmergencyExecuted(uint64 seq, address indexed vault, address indexed token, uint256 amount, uint256 ledgerAfter)', bal: 'ledgerAfter', token: 'token' },
-  { abi: 'event VaultERC20BalanceChanged(uint64 seq, address indexed vault, address indexed token, uint256 balanceAfter, bytes4 reason)', bal: 'balanceAfter', token: 'token' },
-  // collateral-only events (no token field) → always USDC.e
-  { abi: 'event PositionSplit(uint64 seq, address indexed vault, bytes32 indexed conditionId, uint256 amount, uint256 ledgerAfter)', bal: 'ledgerAfter' },
-  { abi: 'event PositionsMerged(uint64 seq, address indexed vault, bytes32 indexed conditionId, uint256 amount, uint256 ledgerAfter)', bal: 'ledgerAfter' },
-  { abi: 'event PositionRedeemed(uint64 seq, address indexed vault, bytes32 indexed conditionId, uint256 payout, uint256 ledgerAfter)', bal: 'ledgerAfter' },
-]
+const AGGREGATE3_ABI = 'function aggregate3((address target, bool allowFailure, bytes callData)[] calls) payable returns ((bool success, bytes returnData)[] returnData)'
+const SELECTORS = {
+  ledgerERC20: '0xd3cc7c57', // ledgerERC20(address)
+  balanceOf: '0x70a08231',   // balanceOf(address)
+  wcolOf: '0x40ece17a',      // wcolOf(bytes32)
+}
+
+// Batched read-only calls; returns one returnData hex (or null) per call, in order.
+async function aggregate3(api, calls, batchSize = 500) {
+  const out = []
+  for (let i = 0; i < calls.length; i += batchSize) {
+    const res = await api.call({ abi: AGGREGATE3_ABI, target: MULTICALL, params: [calls.slice(i, i + batchSize)] })
+    for (const r of res) out.push(r.success && r.returnData !== '0x' ? r.returnData : null)
+  }
+  return out
+}
+
+const encodeArg = (hex) => hex.replace(/^0x/, '').padStart(64, '0').toLowerCase()
 
 async function tvl(api) {
-  const latest = {} // vault => { seq, bal } — newest USDC.e ledger value per vault
+  // (1) idle USDC.e across all user vaults: enumerate vaults via VaultCreated,
+  // then read each vault's live internal USDC.e ledger. ledgerERC20 (not
+  // balanceOf) so stray direct transfers that no user deposited are excluded.
+  const created = await getLogs2({ api, target: VAULT_FACTORY, eventAbi: VAULT_CREATED, fromBlock: FROM_BLOCK, extraKey: 'VaultCreated' })
+  const vaults = [...new Set(created.map(l => l.vault))]
+  const ledgerData = SELECTORS.ledgerERC20 + encodeArg(USDC_E)
+  const ledgers = await aggregate3(api, vaults.map(v => [v, true, ledgerData]))
+  for (const bal of ledgers) if (bal) api.add(USDC_E, BigInt(bal).toString())
 
-  for (const ev of LEDGER_EVENTS) {
-    // distinct extraKey per event: getLogs caches by chain/target only, so without it
-    // the events would share one cache file and cross-contaminate.
-    const name = ev.abi.slice(6, ev.abi.indexOf('('))
-    const logs = await getLogs2({ api, target: VAULT_FACTORY, eventAbi: ev.abi, fromBlock: FROM_BLOCK, extraKey: name })
-    for (const log of logs) {
-      if (ev.token && log[ev.token].toLowerCase() !== USDC_E) continue
-      const seq = Number(log.seq)
-      if (!latest[log.vault] || seq > latest[log.vault].seq)
-        latest[log.vault] = { seq, bal: log[ev.bal] }
-    }
-  }
-
-  // idle USDC.e across all vaults
-  for (const { bal } of Object.values(latest)) api.add(USDC_E, bal)
-
-  // + collateral locked in ConditionalTokens (single read, no multicall)
+  // (2) collateral locked in ConditionalTokens (binary markets)
   const ct = await api.call({ abi: 'erc20:balanceOf', target: USDC_E, params: [CONDITIONAL_TOKENS] })
   api.add(USDC_E, ct)
 
-  // neg-risk collateral: sum USDC.e across every market's WrappedCollateral clone
-  // (single calls — ADI has no Multicall3 with tryAggregate)
+  // (3) neg-risk collateral: USDC.e held by every market's WrappedCollateral clone
   const marketLogs = await getLogs2({ api, target: NEG_RISK_ADAPTER, eventAbi: MARKET_PREPARED, fromBlock: NEG_RISK_FROM_BLOCK, extraKey: 'MarketPrepared' })
-  const wcols = await Promise.all(marketLogs.map(l =>
-    api.call({ abi: 'function wcolOf(bytes32) view returns (address)', target: NEG_RISK_ADAPTER, params: [l.marketId] })))
-  const clones = wcols.filter(a => a && BigInt(a) !== 0n)
-  const wcolBalances = await Promise.all(clones.map(c =>
-    api.call({ abi: 'erc20:balanceOf', target: USDC_E, params: [c] })))
-  for (const bal of wcolBalances) api.add(USDC_E, bal)
+  const wcols = await aggregate3(api, marketLogs.map(l => [NEG_RISK_ADAPTER, true, SELECTORS.wcolOf + encodeArg(l.marketId)]))
+  const clones = wcols.filter(a => a && BigInt(a) !== 0n).map(a => '0x' + a.slice(26))
+  const wcolBalances = await aggregate3(api, clones.map(c => [USDC_E, true, SELECTORS.balanceOf + encodeArg(c)]))
+  for (const bal of wcolBalances) if (bal) api.add(USDC_E, BigInt(bal).toString())
 
   // USDC.e is a brand-new-chain token DefiLlama can't auto-price; the adi entry in
   // tokenMapping.js maps it to usd-coin. Apply that transform to the balances.
@@ -70,10 +68,9 @@ async function tvl(api) {
 
 module.exports = {
   methodology:
-    'TVL is the USDC.e (bridged USDC) collateral held by PredictStreet: per-vault balances ' +
-    'reconstructed from VaultFactory events (each emits the absolute post-op ledger balance with a ' +
-    'monotonic seq; the latest event per vault is its current balance), plus collateral locked in ' +
-    'the ConditionalTokens contract, plus the USDC.e backing each neg-risk market (held in that ' +
-    "market's WrappedCollateral clone).",
+    'TVL is the USDC.e (bridged USDC) collateral held by PredictStreet: the live internal ' +
+    'USDC.e ledger of every user vault (vaults enumerated via VaultCreated events, balances ' +
+    'read on-chain in batches), plus collateral locked in the ConditionalTokens contract, plus ' +
+    "the USDC.e backing each neg-risk market (held in that market's WrappedCollateral clone).",
   adi: { tvl },
 }


### PR DESCRIPTION
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
PredictStreet

##### Twitter Link:
https://x.com/Predictstreet

##### List of audit links if any:
https://hackenproof.com/audit-portfolio?page=2
https://hackenproof.com/audit-programs/adi-predictstreet-sc-dualdefense-audit

##### Website Link:
https://adipredictstreet.com/

##### Logo (High resolution, will be shown with rounded borders):
https://adipredictstreet.com/images/logo.png
https://adipredictstreet.com/images/logo.svg

##### Current TVL:
~$4.7M

##### Treasury Addresses (if the protocol has treasury)

##### Chain:
ADI Chain

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama):
PredictStreet is a prediction-market exchange where users trade binary (YES/NO) outcome shares on real-world events — sports and beyond — and earn a return when their forecast is right. Every position is fully collateralized by USDC.e and settled on-chain on ADI Chain.

##### Token address and ticker if any:

##### Category (full list at https://defillama.com/categories) \*Please choose only one:
Prediction Market

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
Custom (in-house optimistic resolution oracle: PredictStreet Oracle + NegRiskOracle)

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
Market resolution is two-phase optimistic: a whitelisted proposer posts the market outcome on-chain to the oracle contract; during a configurable challenge window (default ~2 hours) anyone can dispute the outcome by posting a bond; once the window passes the outcome finalizes and the oracle reports payouts to the ConditionalTokens contract (via NegRiskAdapter for multi-outcome markets), which unlocks USDC.e redemption for winning outcome shares.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
https://docs.adipredictstreet.com/concepts/settlement/overview

##### forkedFrom (Does your project originate from another project):
Polymarket

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL is the USDC.e (bridged USDC) collateral held by PredictStreet: the live internal USDC.e ledger of every user vault (vaults enumerated via VaultCreated events, balances read on-chain in batches), plus collateral locked in the ConditionalTokens contract backing open binary-market positions, plus the USDC.e backing each neg-risk (multi-outcome) market held in that market's WrappedCollateral contract.

##### Github org/user (Optional, if your code is open source, we can track activity):

##### Does this project have a referral program?
No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `adi` support with enhanced total value locked (TVL) tracking.
  * TVL calculations now incorporate newly included chains/assets and aggregate balances across vaults, markets, wrapped collateral, and Conditional Tokens.
* **Bug Fixes**
  * Improved TVL coverage by automatically discovering relevant on-chain vaults and collateral contracts.
* **Chores**
  * Updated supported chain identifiers and expanded the `bitkub` asset map to include additional stablecoin entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->