### PR TITLE
pumex: track v4 CL pools (vault) alongside v2 pairs

### DIFF
--- a/projects/pumex/index.js
+++ b/projects/pumex/index.js
@@ -40,6 +40,7 @@ async function v4Tvl(api) {
 
 module.exports = {
   methodology: 'TVL is the value of tokens locked in Pumex v2 liquidity pairs plus tokens held in the Pumex v4 concentrated liquidity Vault.',
+  timetravel: false,
   injective: {
     tvl: sdk.util.sumChainTvls([v2Tvl, v4Tvl]),
   },

--- a/projects/pumex/index.js
+++ b/projects/pumex/index.js
@@ -1,0 +1,46 @@
+const sdk = require('@defillama/sdk')
+const { getUniTVL } = require('../helper/unknownTokens')
+const { getLogs2 } = require('../helper/cache/getLogs')
+const { sumTokens2 } = require('../helper/unwrapLPs')
+
+const V4_CL_POOL_MANAGER = '0xd79Cb76F783c332CeE7656243e136F94f43b6913'
+const V4_VAULT = '0x8367cc5B351183f486E007DfEA712B909EdDCC12'
+const V4_FROM_BLOCK = 141334571
+
+// v2 pairs (previously tracked via registries/uniswapV2.js)
+const v2Tvl = getUniTVL({
+  factory: '0x105A0A9c1D9e29e0D68B746538895c94468108d2',
+  useDefaultCoreAssets: true,
+  hasStablePools: true,
+})
+
+// v4 CL pools: pool tokens are enumerated from CLPoolManager Initialize events,
+// all funds are held in the Vault contract
+async function v4Tvl(api) {
+  // the sdk misclassifies injective as a cosmos chain when fetching the latest
+  // block (the LCD endpoint it uses is deprecated), so we set the block
+  // explicitly using the EVM RPC instead
+  if (!api.block) api.block = (await api.provider.getBlockNumber()) - 20
+
+  const logs = await getLogs2({
+    api,
+    target: V4_CL_POOL_MANAGER,
+    fromBlock: V4_FROM_BLOCK,
+    eventAbi: 'event Initialize(bytes32 indexed id, address indexed currency0, address indexed currency1, address hooks, uint24 fee, bytes32 parameters, uint160 sqrtPriceX96, int24 tick)',
+  })
+
+  const tokens = new Set()
+  logs.forEach(log => {
+    tokens.add(String(log.currency0).toLowerCase())
+    tokens.add(String(log.currency1).toLowerCase())
+  })
+
+  return sumTokens2({ api, tokens: Array.from(tokens), owner: V4_VAULT, permitFailure: true })
+}
+
+module.exports = {
+  methodology: 'TVL is the value of tokens locked in Pumex v2 liquidity pairs plus tokens held in the Pumex v4 concentrated liquidity Vault.',
+  injective: {
+    tvl: sdk.util.sumChainTvls([v2Tvl, v4Tvl]),
+  },
+}

--- a/registries/uniswapV2.js
+++ b/registries/uniswapV2.js
@@ -1566,12 +1566,6 @@ const uniV2Configs = {
   'pulsex': {
     pulse: '0x1715a3E4A142d8b698131108995174F37aEBA10D',
   },
-  'pumex': {
-    _options: {
-      hasStablePools: true,
-    },
-    injective: '0x105A0A9c1D9e29e0D68B746538895c94468108d2',
-  },
   'punkswap': {
     op_bnb: '0x5640113EA7F369E6DAFbe54cBb1406E5BF153E90',
     scroll: '0x5640113EA7F369E6DAFbe54cBb1406E5BF153E90',


### PR DESCRIPTION
## What this PR does

**Updates the existing `pumex` listing — not a new listing.**

Pumex (Injective) migrated most of its liquidity to v4-style concentrated
liquidity pools in June 2026 (PancakeSwap-Infinity architecture:
CLPoolManager `0xd79Cb76F783c332CeE7656243e136F94f43b6913`, funds held in
Vault `0x8367cc5B351183f486E007DfEA712B909EdDCC12`). The current
`registries/uniswapV2.js` entry only tracks our old v2 factory
(`0x105A0A9c1D9e29e0D68B746538895c94468108d2`), so the listed TVL dropped
from ~$1.5M to ~$2.5k while actual TVL was unchanged:
https://defillama.com/protocol/pumex

Changes:
- Add `projects/pumex/index.js` covering both v2 pairs (same logic as the
  registry entry) and v4 CL pools (tokens enumerated from CLPoolManager
  `Initialize` events, balances summed on the Vault)
- Remove the `pumex` entry from `registries/uniswapV2.js` to avoid a
  duplicate export key

## Notes for reviewers

- The adapter sets `api.block` from the EVM provider before `getLogs2`:
  the SDK treats `injective` as a cosmos chain for block lookups and the
  LCD endpoint it queries (`sentry.lcd.injective.network/blocks/latest`)
  now returns 501.
- Verified the v4 `Initialize` topic0 on-chain: `0x426cc62f...b99c`
  (pancake-infinity style), 24 pools initialized since block 141334571.
- Could not complete a full local `test.js` run: all public Injective EVM
  RPCs in providers.json were returning 502/530/"no eligible backend" at
  submission time. The v2 portion (11 pairs) runs correctly. No new npm
  dependencies added.

## (Needs to be filled only for new listings)

N/A — existing listing (`pumex`), adapter update only.

##### methodology (what is being counted as tvl, how is tvl being calculated):
Value of tokens locked in Pumex v2 liquidity pairs plus tokens held in the
Pumex v4 concentrated liquidity Vault contract, all priced by the standard
DefiLlama token pricing.
##### forkedFrom (Does your project originate from another project):
v2: Solidly/Uniswap V2 style pairs; v4: PancakeSwap Infinity (CL)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Injective TVL tracking for Pumex, combining standard liquidity (v2) with concentrated-liquidity pool holdings (v4).
  * Included a methodology description for how TVL is calculated.
* **Bug Fixes**
  * Updated Pumex TVL to reflect the correct v2 + v4 sources, ensuring more accurate total calculations. 
* **Chores**
  * Removed the older Pumex registry configuration to prevent duplicate or legacy handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->