### PR TITLE
fix(k3): remove double-counted Euler owner on monad

### DIFF
--- a/projects/k3/index.js
+++ b/projects/k3/index.js
@@ -77,7 +77,6 @@ const configs = {
       eulerVaultOwners: ["0xAeE4e2E8024C1B58f4686d1CB1646a6d5755F05C"],
     },
     monad: {
-      eulerVaultOwners: ["0x5D42F8aCd567810D57D60f90bB9C6d194207a6e1"],
       erc4626: [
         "0x1E4D67c666c2Ccf27A0aF980fE6c8e0f05aC8949",
         "0x502e4a0B61dEBA3015Eb9E51116B832003B22c2C",


### PR DESCRIPTION
## Problem
k3 double-counts the monad Euler vault owner `0x5D42F8aCd567810D57D60f90bB9C6d194207a6e1`. It is summed in **both** the main `configs` (no `start`) **and** `eulerSunsetConfigs` (`start: "2026-05-06"`), which are combined with `mergeExports` - and `mergeExports` is additive (`addToExports` pushes each tvl fn into an array and sums them). So:

- post-sunset (now) the owner is counted **twice**, inflating k3 TVL by **~$62.74M**; and
- pre-sunset it is wrongly attributed to K3 instead of euler-dao.

Verified on-chain (`node test.js`, current timestamp):
- owner via a plain config: **$62.74M**
- owner via the sunset config (`start: "2026-05-06"`): **$62.74M** (so `start` still counts it now)
- `mergeExports([both])`: **$125.48M = exactly 2x** -> the double-count

## Fix
Remove the duplicated `eulerVaultOwners` line from `configs.blockchains.monad` (keep its `erc4626` vaults). `eulerSunsetConfigs` already attributes this owner correctly from the 2026-05-06 sunset, so current TVL is preserved (counted once).

Closes #19894.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an outdated owner entry from one configuration, keeping the setup aligned with the current state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->