### PR TITLE
feat: add Skate AMM v2 Sui pool to TVL adapter

### DIFF
--- a/projects/skate-amm/index.js
+++ b/projects/skate-amm/index.js
@@ -100,7 +100,8 @@ const svm_config = {
 const sui_config = {
   sui: [
     '0xde93f10233e575043ae56f71e6a60605c85b9bfee5bb1c67bac37577c8cbc8be',//SUI/USDC
-    '0x9cc884871f937a3ebde84ea0af052b886af392b8d4e77bf94b447a93721e00d9' // USDT/USDC
+    '0x9cc884871f937a3ebde84ea0af052b886af392b8d4e77bf94b447a93721e00d9', // USDT/USDC
+    '0xc014f7cb0a2604fb887d09165242828e6fe913f30d7ae2bea80199caed5ccbcb' // v2 USDC/USDT
   ]
 }
 


### PR DESCRIPTION
The live v2 USDC/USDT periphery pool on Sui (`0xc014f7cb0a2604fb887d09165242828e6fe913f30d7ae2bea80199caed5ccbcb`) was missing from `sui_config`, so its reserves were undercounted.

It exposes the same `PeripheryPool` object layout (`pool_coin0_liquidity`/`pool_coin1_liquidity`) as the existing v1 Sui pools, so it slots into the current `suiTvl` reader unchanged. Verified with `node test.js projects/skate-amm` (Sui + total resolve, no errors).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded Sui pool coverage to include additional vaults, so TVL calculations now reflect more on-chain liquidity.
* **Bug Fixes**
  * Improved balance aggregation for Sui pools by summing liquidity across the full set of tracked pool addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->