### PR TITLE
Add SukukFi (Berachain)

### DIFF
--- a/projects/sukukfi/index.js
+++ b/projects/sukukfi/index.js
@@ -1,0 +1,52 @@
+/**
+ * SukukFi — Berachain
+ *
+ * Two products, one protocol:
+ * - duPRT (investment layer, ERC-7575): Mudarabah profit-share vaults financing telecom invoice
+ *   receivables. `totalAssets()` on these vaults deliberately excludes pending deposits,
+ *   claimable redemptions, cancellations, AND already-invested capital — it is not a TVL figure,
+ *   it's an "available for investment" helper (see ERC7575VaultUpgradeable.sol NatSpec on
+ *   totalAssets()). The complete on-chain balance held by a duPRT vault, regardless of state, is
+ *   just its raw ERC20 balance — the same value the contract's own getVaultMetrics() calls
+ *   `grossAssetBalance`.
+ * - trUST (settlement layer, WERC7575): a 1:1 permissioned settlement token for CommTrade telecom
+ *   invoice settlement. No yield, by design.
+ *
+ * Once a duPRT vault invests idle assets (investAssets()), the capital physically moves into the
+ * matching trUST vault for the same asset — confirmed on-chain: a duPRT vault's `investmentVault`
+ * field points directly at trUST's vault for that asset. trUST's totalAssets() is a plain
+ * balanceOf(this), so it already captures any duPRT-invested capital once it moves. Summing
+ * duPRT's raw balance (everything still sitting there, any state) + trUST's raw balance (native
+ * settlement capital + anything duPRT has already invested) counts every dollar exactly once.
+ */
+const ADDRESSES = require('../helper/coreAssets.json');
+
+// duPRT (investment layer) vaults — proxy addresses, from the SukukFi frontend-integration handoff.
+const DUPRT_VAULTS = [
+  ['0x549943e04f40284185054145c6E4e9568C1D3241', '0x1B610abd3dFA170fdC579c48da7007217c06149D'], // USDC.e
+  ['0x779Ded0c9e1022225f8E0630b35a9b54bE713736', '0x3d6D8D7e66594f3cFbbF2c65dcE305edCD325f7e'], // USD₮0
+  ['0xFCBD14DC51f0A4d49d5E53C2E0950e0bC26d0Dce', '0xdc9D7e60f3091029FA2479919325385a56F2A2F8'], // HONEY
+];
+
+// trUST (settlement layer / WERC7575) vaults — internal, not for UI calls, but real on-chain TVL.
+const TRUST_VAULTS = [
+  ['0x549943e04f40284185054145c6E4e9568C1D3241', '0x23953876A0f7c367B0Ae5E8b9cFb6b42E503F09b'], // USDC.e
+  ['0x779Ded0c9e1022225f8E0630b35a9b54bE713736', '0x3ddECA146B3179367cC1d782889f938f449c9d21'], // USD₮0
+  ['0xFCBD14DC51f0A4d49d5E53C2E0950e0bC26d0Dce', '0xC441d4c5F060f96bD7CD20d3D13Ecf957Ea308C7'], // HONEY
+];
+
+async function tvl(api) {
+  return api.sumTokens({ tokensAndOwners: [...DUPRT_VAULTS, ...TRUST_VAULTS] });
+}
+
+module.exports = {
+  methodology: 'Sums the raw ERC20 balance held by SukukFi\'s duPRT (investment layer) and trUST '
+    + '(settlement layer) vaults on Berachain. This equals duPRT\'s grossAssetBalance (idle + '
+    + 'pending + claimable + cancelled — everything not yet invested elsewhere) plus trUST\'s '
+    + 'totalAssets (native settlement capital plus any duPRT-invested capital, since investing '
+    + 'moves the underlying asset into the matching trUST vault). No double counting: money is '
+    + 'either still in a duPRT vault or has moved to trUST, never both.',
+  berachain: {
+    tvl,
+  },
+};


### PR DESCRIPTION
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
SukukFi

##### Twitter Link:
https://x.com/sukukfi

##### List of audit links if any:
https://github.com/sukukfi/security-audits (Code4rena audit report + fix report included in repo)

##### Website Link:
https://sukuk.fi

##### Logo (High resolution, will be shown with rounded borders):
https://sukuk.fi/images/insignia.svg

##### Current TVL:
~$54 (early/bootstrap stage — the protocol has processed its first live deposits on Berachain mainnet but has not yet completed a full settlement cycle)

##### Treasury Addresses (if the protocol has treasury)
N/A

##### Chain:
Berachain

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description (to be shown on DefiLlama):
SukukFi is a real-world-asset protocol structured on Islamic finance principles. Its vaults (investment layer) finance telecom invoice receivables under a Mudarabah profit-share structure, and its trUST vaults (settlement layer) provide 1:1 permissioned settlement for telecom carrier trade. SukukFi has not obtained independent Sharia certification; "structured on Islamic finance principles" describes methodology, not a certified compliance claim.

##### Token address and ticker if any:
duPRT (share token): 0xf5Bac52e31317dE901edc773fbef8f75c798f36f (Berachain). Not a freely tradable governance/utility token — an ERC-7575 vault share token representing a claim on deposited assets.

##### Category (full list at https://defillama.com/categories) \*Please choose only one:
RWA

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
None. Vaults are single-stablecoin-denominated (USDC.e, USD₮0, HONEY) with internal share pricing; no external price oracle is used for accounting.

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
N/A, no oracle. TVL for this adapter is the raw ERC20 balance held by each duPRT vault (investment layer) plus each trUST vault (settlement layer), summed with no double counting — investing moves the underlying asset from a duPRT vault into the matching trUST vault, and trUST's totalAssets() already captures it once moved. Full derivation: https://docs.sukuk.fi/transparency/contracts

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
https://docs.sukuk.fi/transparency/contracts
https://dune.com/sukukfi/sukukfi-berachain-vault-metrics-duprt-trust (independent third-party reconstruction of the same TVL formula from raw on-chain event logs)

##### forkedFrom (Does your project originate from another project):
No. Contracts implement the ERC-7575 (multi-asset vault) and ERC-7540 (async deposit/redeem) standards but are not a fork of another protocol's codebase.

##### methodology (what is being counted as tvl, how is tvl being calculated):
Sums the raw ERC20 balance held by SukukFi's duPRT (investment layer) and trUST (settlement layer) vaults on Berachain. This equals duPRT's gross balance (idle + pending + claimable + cancelled, everything not yet invested elsewhere) plus trUST's totalAssets (native settlement capital plus any duPRT-invested capital, since investing moves the underlying asset into the matching trUST vault). No double counting: money is either still in a duPRT vault or has moved to trUST, never both.

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/sukukfi

##### Does this project have a referral program?
Yes, an on-chain, invite-code-based LP introducer commission program (paid in trUST).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL support for Berachain SukukFi.
  * Included balances from both the investment-layer and settlement-layer vaults for a more complete TVL view.
* **Documentation**
  * Added a methodology note explaining how TVL is calculated and how double counting is avoided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
