### PR TITLE
Kerne Protocol: count mint-side PSM v3 USDC in TVL

### DIFF
--- a/projects/kerne-protocol/index.js
+++ b/projects/kerne-protocol/index.js
@@ -1,46 +1,16 @@
-// Kerne Protocol — DefiLlama TVL Adapter (Base, chainId 8453)
-// ----------------------------------------------------------------
-// TVL = the USDC reserves held by Kerne's Peg Stability Module (PSM) contracts
-// on Base, which back circulating kUSD 1:1. kUSD is minted 1:1 from USDC through
-// the PSM and redeemed 1:1 back to USDC, so the USDC sitting in the PSM contracts
-// is the protocol's on-chain, verifiable backing. This matches the published
-// headline TVL at kerne.fi/api/stats and the reserve breakdown at kerne.fi/api/por.
-//
-// After the 2026-06-16 module upgrade, USDC backing is held across two PSM
-// contracts, both of which are summed:
-//   PSM v3 (mint)   0x07eBb486e11BD217e6085eb5ab663e4517595993
-//                   current minting module (USDC into kUSD); holds the USDC
-//                   received for newly minted kUSD.
-//   PSM (redeem)    0xFf3025ec18e301855aB0f36Ec6ECa115a29A5Fbc
-//                   retained as the kUSD into USDC redeem reserve for kUSD
-//                   minted before the upgrade.
-// The kUSD supply itself is not added, since the PSM USDC already backs it 1:1
-// (counting both would double count).
-//
+const ADDRESSES = require('../helper/coreAssets.json')
+
 // The v1 KerneVault (0x8005bc7A86AD904C20fd62788ABED7546c1cF2AC) is intentionally
 // NOT counted: it is in a known degraded accounting state (share supply does not
 // reconcile with its WETH backing), deposits are disabled pending a v2 redeploy,
 // and KerneVault.totalAssets() additionally includes off-chain CEX / Hyperliquid
 // hedge balances that are not on-chain TVL.
-//
-// Contracts (verified on Basescan):
-//   PSM v3 (mint):   0x07eBb486e11BD217e6085eb5ab663e4517595993
-//   PSM (redeem):    0xFf3025ec18e301855aB0f36Ec6ECa115a29A5Fbc
-//   kUSD:            0x5C2EfdF0D8D286959b42308966bc2B97f5680AA3
 
-const ADDRESSES = require('../helper/coreAssets.json')
-
-// USDC-holding PSM contracts (both back circulating kUSD 1:1).
 const KUSD_PSM_MINT = '0x07eBb486e11BD217e6085eb5ab663e4517595993';
 const KUSD_PSM_REDEEM = '0xFf3025ec18e301855aB0f36Ec6ECa115a29A5Fbc';
 
 async function tvl(api) {
-  await api.sumTokens({
-    tokensAndOwners: [
-      [ADDRESSES.base.USDC, KUSD_PSM_MINT],
-      [ADDRESSES.base.USDC, KUSD_PSM_REDEEM],
-    ],
-  })
+  await api.sumTokens({ tokens: [ADDRESSES.base.USDC], owners: [KUSD_PSM_MINT, KUSD_PSM_REDEEM] })
 }
 
 module.exports = {

--- a/projects/kerne-protocol/index.js
+++ b/projects/kerne-protocol/index.js
@@ -1,31 +1,50 @@
 // Kerne Protocol — DefiLlama TVL Adapter (Base, chainId 8453)
 // ----------------------------------------------------------------
-// TVL = USDC reserves held by the live KUSDPSM, which back circulating kUSD 1:1.
-// This is Kerne's live, user-facing deposit surface and matches the protocol's
-// published headline TVL at kerne.fi/api/stats and the reserve breakdown at
-// kerne.fi/api/por (policy: docs/SEED_TVL_POLICY.md).
+// TVL = the USDC reserves held by Kerne's Peg Stability Module (PSM) contracts
+// on Base, which back circulating kUSD 1:1. kUSD is minted 1:1 from USDC through
+// the PSM and redeemed 1:1 back to USDC, so the USDC sitting in the PSM contracts
+// is the protocol's on-chain, verifiable backing. This matches the published
+// headline TVL at kerne.fi/api/stats and the reserve breakdown at kerne.fi/api/por.
+//
+// After the 2026-06-16 module upgrade, USDC backing is held across two PSM
+// contracts, both of which are summed:
+//   PSM v3 (mint)   0x07eBb486e11BD217e6085eb5ab663e4517595993
+//                   current minting module (USDC into kUSD); holds the USDC
+//                   received for newly minted kUSD.
+//   PSM (redeem)    0xFf3025ec18e301855aB0f36Ec6ECa115a29A5Fbc
+//                   retained as the kUSD into USDC redeem reserve for kUSD
+//                   minted before the upgrade.
+// The kUSD supply itself is not added, since the PSM USDC already backs it 1:1
+// (counting both would double count).
 //
 // The v1 KerneVault (0x8005bc7A86AD904C20fd62788ABED7546c1cF2AC) is intentionally
 // NOT counted: it is in a known degraded accounting state (share supply does not
 // reconcile with its WETH backing), deposits are disabled pending a v2 redeploy,
 // and KerneVault.totalAssets() additionally includes off-chain CEX / Hyperliquid
-// hedge balances that are not on-chain TVL. The vault leg will be re-added once
-// KerneVault v2 redeploys in a healthy, on-chain-reconciled state.
+// hedge balances that are not on-chain TVL.
 //
 // Contracts (verified on Basescan):
-//   KUSDPSM: 0xFf3025ec18e301855aB0f36Ec6ECa115a29A5Fbc
-//   kUSD:    0x5C2EfdF0D8D286959b42308966bc2B97f5680AA3
+//   PSM v3 (mint):   0x07eBb486e11BD217e6085eb5ab663e4517595993
+//   PSM (redeem):    0xFf3025ec18e301855aB0f36Ec6ECa115a29A5Fbc
+//   kUSD:            0x5C2EfdF0D8D286959b42308966bc2B97f5680AA3
 
 const ADDRESSES = require('../helper/coreAssets.json')
 
-const KUSD_PSM = '0xFf3025ec18e301855aB0f36Ec6ECa115a29A5Fbc';
+// USDC-holding PSM contracts (both back circulating kUSD 1:1).
+const KUSD_PSM_MINT = '0x07eBb486e11BD217e6085eb5ab663e4517595993';
+const KUSD_PSM_REDEEM = '0xFf3025ec18e301855aB0f36Ec6ECa115a29A5Fbc';
 
 async function tvl(api) {
-  await api.sumTokens({ tokensAndOwners: [[ADDRESSES.base.USDC, KUSD_PSM]]})
+  await api.sumTokens({
+    tokensAndOwners: [
+      [ADDRESSES.base.USDC, KUSD_PSM_MINT],
+      [ADDRESSES.base.USDC, KUSD_PSM_REDEEM],
+    ],
+  })
 }
 
 module.exports = {
   methodology:
-    'TVL is the USDC reserve held by the Kerne KUSDPSM contract on Base, which backs all circulating kUSD 1:1. This is the protocol\'s live, user-facing deposit surface and matches the published headline TVL at kerne.fi/api/stats.',
+    'TVL is the USDC reserve held by Kerne\'s Peg Stability Module (PSM) contracts on Base, which back all circulating kUSD 1:1. kUSD is minted 1:1 from USDC through the mint PSM (0x07eBb486) and redeemed 1:1 back to USDC through the redeem PSM (0xFf3025ec); both hold USDC backing and are summed. The kUSD supply itself is not added (counting both would double count). This matches the published headline TVL at kerne.fi/api/stats. The v1 KerneVault is intentionally excluded: it is in a known degraded accounting state, deposits are disabled pending a v2 redeploy, and its totalAssets() includes off-chain hedge balances that are not on-chain TVL.',
   base: { tvl },
 };


### PR DESCRIPTION
After Kerne's 2026-06-16 module upgrade, the USDC backing for kUSD is held across two PSM contracts. The TVL adapter previously counted only the redeem-side reserve (0xFf3025ec, ~118 USDC) and missed the mint-side PSM v3 (0x07eBb486), which now holds ~998 USDC from live mints. This PR sums both PSM contracts.

Effect: reported Base TVL goes from ~$118 to ~$1,116, matching circulating kUSD supply (~1,114.7). kUSD is minted 1:1 from USDC through the PSM, so the USDC held across both PSM contracts is the protocol's on-chain backing. The kUSD supply itself is still not added (that would double count).

Verification (Base, chainId 8453; both contracts source-verified on Basescan as KUSDPSM):
- Mint PSM v3 `0x07eBb486e11BD217e6085eb5ab663e4517595993`: USDC balance ~998.00
- Redeem PSM `0xFf3025ec18e301855aB0f36Ec6ECa115a29A5Fbc`: USDC balance ~117.85
- Sum ~1,115.85, which matches circulating kUSD 1,114.74 (difference is the 10 bps mint fee)
- `node test.js projects/kerne-protocol/index.js` returns ~$1.12k

The v1 KerneVault stays excluded (degraded accounting plus off-chain hedge balances). No new npm dependencies; pnpm-lock.yaml untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated TVL calculations on Base to include USDC held across both PSM contracts (mint and redeem), improving accuracy of reported balances.
  * Refined the methodology description to clarify the 1:1 USDC backing approach and prevent double counting.
  * Continued excluding the older v1 KerneVault from calculations to maintain reliable on-chain reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->