### PR TITLE
fix(k3): stop double-counting monad Euler vault owner

### DIFF
--- a/projects/k3/index.js
+++ b/projects/k3/index.js
@@ -77,7 +77,9 @@ const configs = {
       eulerVaultOwners: ["0xAeE4e2E8024C1B58f4686d1CB1646a6d5755F05C"],
     },
     monad: {
-      eulerVaultOwners: ["0x5D42F8aCd567810D57D60f90bB9C6d194207a6e1"],
+      // The Euler vault owner 0x5D42...a6e1 was handed to K3 in the EulerDAO sunset
+      // and is counted from that date via eulerSunsetConfigs below; listing it here as
+      // well summed the same owner twice, double-counting monad TVL. Keep it only there.
       erc4626: [
         "0x1E4D67c666c2Ccf27A0aF980fE6c8e0f05aC8949",
         "0x502e4a0B61dEBA3015Eb9E51116B832003B22c2C",


### PR DESCRIPTION
Fixes #19894.

The monad Euler vault owner `0x5D42...a6e1` was listed in both the always-on `configs.blockchains.monad` and `eulerSunsetConfigs` (which counts it from the 2026-05-06 EulerDAO sunset). `mergeExports` sums both, so from the sunset date on that owner's TVL was counted twice.

The sunset config is the right place for it, it models the euler-dao → K3 handover with the correct start date, so I dropped the duplicate `eulerVaultOwners` entry from the always-on monad config and left the `erc4626` vaults there untouched.

Monad goes from 203.86M → 139.13M (total 353.30M → 288.57M); every other chain is unchanged. The ~64.7M removed is the double-counted owner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Monad TVL reporting to avoid double-counting a vault owner that is tracked separately.
  * Improved curation data handling so totals are more accurate and consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->