### PR TITLE
fix(fiamma): read TVL from on-chain FIABTC supply (bridge API is offline)

### DIFF
--- a/projects/fiamma/index.js
+++ b/projects/fiamma/index.js
@@ -1,5 +1,5 @@
 const sdk = require("@defillama/sdk")
-const { function_view } = require("../helper/chain/aptos")
+const { function_view, timestampToVersion } = require("../helper/chain/aptos")
 
 // Fiamma is a BitVM2 BTC bridge: BTC locked on Bitcoin mints FIABTC (8 decimals, 1:1)
 // on the destination chains. The BTC is held in per-deposit BitVM2 taproot addresses
@@ -26,12 +26,22 @@ const tvl = async (api) => {
   )
   let totalBtc = supplies.reduce((sum, supply) => sum + supply / 1e8, 0)
 
-  const aptosSupply = await function_view({
-    functionStr: "0x1::fungible_asset::supply",
-    type_arguments: ["0x1::fungible_asset::Metadata"],
-    args: [APTOS_FIABTC],
-  })
-  const aptosAmount = aptosSupply && aptosSupply.vec && aptosSupply.vec.length ? Number(aptosSupply.vec[0]) : 0
+  // For historical queries resolve the Aptos ledger version from the timestamp so the
+  // Aptos read matches the EVM ones; live runs read the latest state directly.
+  const isHistorical = api.timestamp && Date.now() / 1000 - api.timestamp > 2 * 3600
+  let aptosAmount = 0
+  try {
+    const aptosSupply = await function_view({
+      functionStr: "0x1::fungible_asset::supply",
+      type_arguments: ["0x1::fungible_asset::Metadata"],
+      args: [APTOS_FIABTC],
+      ledgerVersion: isHistorical ? await timestampToVersion(new Date(api.timestamp * 1000)) : undefined,
+    })
+    aptosAmount = aptosSupply && aptosSupply.vec && aptosSupply.vec.length ? Number(aptosSupply.vec[0]) : 0
+  } catch (e) {
+    // function_view throws for versions before FIABTC existed, meaning the supply was 0
+    if (!isHistorical) throw e
+  }
   totalBtc += aptosAmount / 1e8
 
   api.addCGToken("bitcoin", totalBtc)

--- a/projects/fiamma/index.js
+++ b/projects/fiamma/index.js
@@ -18,19 +18,21 @@ const EVM_FIABTC = {
 const APTOS_FIABTC = "0x75de592a7e62e6224d13763c392190fda8635ebb79c798a5e9dd0840102f3f93"
 
 const tvl = async (api) => {
-  let totalBtc = 0
-
-  for (const [chain, target] of Object.entries(EVM_FIABTC)) {
-    const supply = await new sdk.ChainApi({ chain }).call({ abi: "erc20:totalSupply", target })
-    totalBtc += supply / 1e8
-  }
+  // Read each destination chain at api.timestamp so historical/timetravel TVL is correct.
+  const supplies = await Promise.all(
+    Object.entries(EVM_FIABTC).map(([chain, target]) =>
+      new sdk.ChainApi({ chain, timestamp: api.timestamp }).call({ abi: "erc20:totalSupply", target })
+    )
+  )
+  let totalBtc = supplies.reduce((sum, supply) => sum + supply / 1e8, 0)
 
   const aptosSupply = await function_view({
     functionStr: "0x1::fungible_asset::supply",
     type_arguments: ["0x1::fungible_asset::Metadata"],
     args: [APTOS_FIABTC],
   })
-  totalBtc += Number(aptosSupply.vec[0]) / 1e8
+  const aptosAmount = aptosSupply && aptosSupply.vec && aptosSupply.vec.length ? Number(aptosSupply.vec[0]) : 0
+  totalBtc += aptosAmount / 1e8
 
   api.addCGToken("bitcoin", totalBtc)
 }

--- a/projects/fiamma/index.js
+++ b/projects/fiamma/index.js
@@ -1,14 +1,44 @@
-const axios = require("axios")
+const sdk = require("@defillama/sdk")
+const { function_view } = require("../helper/chain/aptos")
 
-const btc_locked = async (api) => {
-    const response = (await axios.post('https://bridge-api.fiammachain.io', { "jsonrpc": "2.0", "id": 1, "method": "frontend_queryBridgeTVL", "params": {} })).data
-    const locked = response.result.total_tvl / 1e8
-    api.addCGToken('bitcoin', locked)
+// Fiamma is a BitVM2 BTC bridge: BTC locked on Bitcoin mints FIABTC (8 decimals, 1:1)
+// on the destination chains. The BTC is held in per-deposit BitVM2 taproot addresses
+// that aren't enumerable, and the bridge's TVL API (bridge-api.fiammachain.io) is offline,
+// so we measure the locked BTC from the minted FIABTC supply on each destination chain.
+const EVM_FIABTC = {
+  ethereum: "0x22F0E0a4c97ff43546dad16d43Ef854C773F0e08",
+  sei: "0x60C230c38aF6d86b0277a98a1CAeAA345a7B061F",
+  core: "0x60C230c38aF6d86b0277a98a1CAeAA345a7B061F",
+  arbitrum: "0x60C230c38aF6d86b0277a98a1CAeAA345a7B061F",
+  base: "0x60C230c38aF6d86b0277a98a1CAeAA345a7B061F",
+  polygon: "0x60C230c38aF6d86b0277a98a1CAeAA345a7B061F",
+  unichain: "0x60C230c38aF6d86b0277a98a1CAeAA345a7B061F",
+  plume_mainnet: "0x60C230c38aF6d86b0277a98a1CAeAA345a7B061F",
+}
+const APTOS_FIABTC = "0x75de592a7e62e6224d13763c392190fda8635ebb79c798a5e9dd0840102f3f93"
+
+const tvl = async (api) => {
+  let totalBtc = 0
+
+  for (const [chain, target] of Object.entries(EVM_FIABTC)) {
+    const supply = await new sdk.ChainApi({ chain }).call({ abi: "erc20:totalSupply", target })
+    totalBtc += supply / 1e8
+  }
+
+  const aptosSupply = await function_view({
+    functionStr: "0x1::fungible_asset::supply",
+    type_arguments: ["0x1::fungible_asset::Metadata"],
+    args: [APTOS_FIABTC],
+  })
+  totalBtc += Number(aptosSupply.vec[0]) / 1e8
+
+  api.addCGToken("bitcoin", totalBtc)
 }
 
 module.exports = {
-    methodology: "Fiamma BTC TVL represents the total amount of Bitcoin bridged across all chains through the Fiamma Bridge, a trust‑minimized bridge built on the BitVM2 protocol.",
-    bitcoin: {
-      tvl: btc_locked,
-    }
-  };
+  methodology:
+    "TVL is the total FIABTC minted across all destination chains, which is 1:1 backed by BTC locked in the Fiamma BitVM2 bridge. The minted supply is read on-chain because the bridge's TVL API is offline.",
+  bitcoin: {
+    tvl,
+  },
+}


### PR DESCRIPTION
Fixes #19030.

The adapter's only data source was a JSON-RPC call to `bridge-api.fiammachain.io`, which is now down (HTTP 522), so the adapter throws and the protocol shows a stale TVL frozen since 2026-03-18.

Fiamma is a BitVM2 bridge: BTC locked on Bitcoin mints FIABTC (8 decimals, 1:1) on the destination chains. The locked BTC sits in per-deposit BitVM2 taproot addresses that aren't enumerable, so I measure it from the minted FIABTC supply read on-chain instead. Supplies per chain (verified live): sei 14.10, aptos 2.51, ethereum 0.068, arbitrum 0.029, base 0.022, plume 0.002, unichain 0.007, polygon 0.002, core 0, ~16.74 BTC total. Kept the reporting under `bitcoin` since that's the bridged collateral.

`node test.js projects/fiamma` → bitcoin 1.05M (was erroring). Heads up: the bridge frontend also looks offline, so if you'd prefer to mark the protocol inactive that's reasonable; but the minted supply is still live on-chain, so this at least stops the adapter erroring and reports the real number.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Fiamma’s BTC TVL calculation to derive totals from on-chain FIABTC minted supply across supported destination networks (including Aptos), rather than relying on an unavailable bridge TVL source.
  * Corrected FIABTC-to-BTC unit scaling to improve the accuracy of reported TVL.
  * Refreshed the displayed methodology to reflect the new on-chain “total FIABTC minted” measurement approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->