### PR TITLE
Add Basalt Vault TVL adapter (Arbitrum)

### DIFF
--- a/projects/basalt-vault/index.js
+++ b/projects/basalt-vault/index.js
@@ -1,0 +1,96 @@
+// Basalt Vault — delta-neutral GMX v2 BTC/USD yield on Arbitrum.
+// Each user owns an NFT-bound vault (VaultCore clone). The vault holds GMX v2 GM
+// (BTC/USD) as collateral inside a Dolomite isolation account and borrows WBTC to
+// run the delta-neutral hedge. TVL is the net equity of every vault:
+//   sum over vaults of ( GM collateral value - WBTC debt value )
+// priced by the Dolomite oracle. Borrowed WBTC (leverage) is excluded, and the GM
+// already lives inside GMX, so this is flagged as misrepresented/double-counted.
+
+const FACTORY = "0x08e466fb09617d16ed27da9ea43ba601665f3b89"; // VaultCoreNftFactory
+const DOLOMITE = "0x6Bd780E7fDf01D77e4d475c821f1e7AE05409072"; // DolomiteMargin
+
+const GM_MARKET = 32;
+const WBTC_MARKET = 4;
+const ISO_ACCOUNT = 100; // Dolomite isolation sub-account used by every vault
+
+const ZERO = "0x0000000000000000000000000000000000000000";
+
+const abi = {
+  nextTokenId: "uint256:nextTokenId",
+  vaultByTokenId: "function vaultByTokenId(uint256) view returns (address)",
+  basaltState: "function basaltState() view returns (address)",
+  dolomiteIsolationVault: "function dolomiteIsolationVault() view returns (address)",
+  getAccountWei:
+    "function getAccountWei((address owner, uint256 number) account, uint256 market) view returns ((bool sign, uint256 value))",
+  getMarketPrice: "function getMarketPrice(uint256 market) view returns ((uint256 value))",
+};
+
+async function tvl(api) {
+  const n = Number(await api.call({ target: FACTORY, abi: abi.nextTokenId }));
+  if (!n) return api.addUSDValue(0);
+
+  const ids = Array.from({ length: n }, (_, i) => i + 1);
+  const notZero = (a) => a && a.toLowerCase() !== ZERO;
+
+  // Every vault is enumerated on-chain; drop never-minted / burned ids at each hop
+  // so a zero address can never make a downstream call revert.
+  const vaults = (
+    await api.multiCall({
+      target: FACTORY,
+      abi: abi.vaultByTokenId,
+      calls: ids.map((id) => ({ params: [id] })),
+    })
+  ).filter(notZero);
+  if (!vaults.length) return api.addUSDValue(0);
+
+  const states = (
+    await api.multiCall({ abi: abi.basaltState, calls: vaults.map((target) => ({ target })) })
+  ).filter(notZero);
+
+  // Only vaults whose Dolomite isolation vault has been created hold a position.
+  const active = (
+    await api.multiCall({ abi: abi.dolomiteIsolationVault, calls: states.map((target) => ({ target })) })
+  ).filter(notZero);
+  if (!active.length) return api.addUSDValue(0);
+
+  const [gmWei, wbtcWei, gmPrice, wbtcPrice] = await Promise.all([
+    api.multiCall({
+      target: DOLOMITE,
+      abi: abi.getAccountWei,
+      calls: active.map((owner) => ({ params: [{ owner, number: ISO_ACCOUNT }, GM_MARKET] })),
+    }),
+    api.multiCall({
+      target: DOLOMITE,
+      abi: abi.getAccountWei,
+      calls: active.map((owner) => ({ params: [{ owner, number: ISO_ACCOUNT }, WBTC_MARKET] })),
+    }),
+    api.call({ target: DOLOMITE, abi: abi.getMarketPrice, params: [GM_MARKET] }),
+    api.call({ target: DOLOMITE, abi: abi.getMarketPrice, params: [WBTC_MARKET] }),
+  ]);
+
+  // Dolomite price precision = 36 - tokenDecimals (GM: E18, WBTC: E28). Multiplying a
+  // raw wei balance by the market price yields a 36-decimal USD value.
+  const gmP = BigInt(gmPrice.value);
+  const wbtcP = BigInt(wbtcPrice.value);
+
+  let nav36 = 0n;
+  for (let i = 0; i < active.length; i++) {
+    const gm = gmWei[i];
+    const wb = wbtcWei[i];
+    const gmCollateral = gm.sign ? BigInt(gm.value) : 0n; // positive = collateral
+    const wbtcDebt = !wb.sign ? BigInt(wb.value) : 0n; // negative = borrowed
+    const wbtcSurplus = wb.sign ? BigInt(wb.value) : 0n; // positive = leftover WBTC
+    nav36 += gmCollateral * gmP + wbtcSurplus * wbtcP - wbtcDebt * wbtcP;
+  }
+
+  const usd = Number(nav36) / 1e36;
+  api.addUSDValue(usd > 0 ? usd : 0);
+}
+
+module.exports = {
+  misrepresentedTokens: true,
+  methodology:
+    "TVL is the net equity summed over every Basalt vault: (GM collateral value + any WBTC surplus - WBTC debt value), priced by the Dolomite oracle and floored at zero. Each NFT-bound vault holds GMX v2 GM (BTC/USD) collateral in a Dolomite isolation account and borrows WBTC for a delta-neutral hedge. Borrowed WBTC (leverage) is excluded and the underlying GM is already counted under GMX, so misrepresentedTokens is set to avoid double-counting into the chain total.",
+  start: 1778198400, // 2026-05-08 — Deployment 6 on Arbitrum One
+  arbitrum: { tvl },
+};

--- a/projects/basalt-vault/index.js
+++ b/projects/basalt-vault/index.js
@@ -1,19 +1,13 @@
-// Basalt Vault — delta-neutral GMX v2 BTC/USD yield on Arbitrum.
-// Each user owns an NFT-bound vault (VaultCore clone). The vault holds GMX v2 GM
-// (BTC/USD) as collateral inside a Dolomite isolation account and borrows WBTC to
-// run the delta-neutral hedge. TVL is the net equity of every vault:
-//   sum over vaults of ( GM collateral value - WBTC debt value )
-// priced by the Dolomite oracle. Borrowed WBTC (leverage) is excluded, and the GM
-// already lives inside GMX, so this is flagged as misrepresented/double-counted.
+const ADDRESSES = require("../helper/coreAssets.json");
 
 const FACTORY = "0x08e466fb09617d16ed27da9ea43ba601665f3b89"; // VaultCoreNftFactory
 const DOLOMITE = "0x6Bd780E7fDf01D77e4d475c821f1e7AE05409072"; // DolomiteMargin
 
-const GM_MARKET = 32;
 const WBTC_MARKET = 4;
 const ISO_ACCOUNT = 100; // Dolomite isolation sub-account used by every vault
 
-const ZERO = "0x0000000000000000000000000000000000000000";
+const GM_UNDERLYING = "0x47c031236e19d024b42f8AE6780E44A573170703"; // GMX v2 GM BTC/USD
+const WBTC = ADDRESSES.arbitrum.WBTC;
 
 const abi = {
   nextTokenId: "uint256:nextTokenId",
@@ -22,15 +16,14 @@ const abi = {
   dolomiteIsolationVault: "function dolomiteIsolationVault() view returns (address)",
   getAccountWei:
     "function getAccountWei((address owner, uint256 number) account, uint256 market) view returns ((bool sign, uint256 value))",
-  getMarketPrice: "function getMarketPrice(uint256 market) view returns ((uint256 value))",
 };
 
 async function tvl(api) {
   const n = Number(await api.call({ target: FACTORY, abi: abi.nextTokenId }));
-  if (!n) return api.addUSDValue(0);
+  if (!n) throw new Error("Failed to fetch nextTokenId.");
 
   const ids = Array.from({ length: n }, (_, i) => i + 1);
-  const notZero = (a) => a && a.toLowerCase() !== ZERO;
+  const notZero = (a) => a && a.toLowerCase() !== ADDRESSES.null;
 
   // Every vault is enumerated on-chain; drop never-minted / burned ids at each hop
   // so a zero address can never make a downstream call revert.
@@ -41,7 +34,7 @@ async function tvl(api) {
       calls: ids.map((id) => ({ params: [id] })),
     })
   ).filter(notZero);
-  if (!vaults.length) return api.addUSDValue(0);
+  if (!vaults.length) throw new Error("Failed to fetch vaults from the factory.");
 
   const states = (
     await api.multiCall({ abi: abi.basaltState, calls: vaults.map((target) => ({ target })) })
@@ -51,46 +44,25 @@ async function tvl(api) {
   const active = (
     await api.multiCall({ abi: abi.dolomiteIsolationVault, calls: states.map((target) => ({ target })) })
   ).filter(notZero);
-  if (!active.length) return api.addUSDValue(0);
+  if (!active.length) return;
 
-  const [gmWei, wbtcWei, gmPrice, wbtcPrice] = await Promise.all([
-    api.multiCall({
-      target: DOLOMITE,
-      abi: abi.getAccountWei,
-      calls: active.map((owner) => ({ params: [{ owner, number: ISO_ACCOUNT }, GM_MARKET] })),
-    }),
-    api.multiCall({
+  const wbtcWei = await api.multiCall({
       target: DOLOMITE,
       abi: abi.getAccountWei,
       calls: active.map((owner) => ({ params: [{ owner, number: ISO_ACCOUNT }, WBTC_MARKET] })),
-    }),
-    api.call({ target: DOLOMITE, abi: abi.getMarketPrice, params: [GM_MARKET] }),
-    api.call({ target: DOLOMITE, abi: abi.getMarketPrice, params: [WBTC_MARKET] }),
-  ]);
+    })
 
-  // Dolomite price precision = 36 - tokenDecimals (GM: E18, WBTC: E28). Multiplying a
-  // raw wei balance by the market price yields a 36-decimal USD value.
-  const gmP = BigInt(gmPrice.value);
-  const wbtcP = BigInt(wbtcPrice.value);
-
-  let nav36 = 0n;
-  for (let i = 0; i < active.length; i++) {
-    const gm = gmWei[i];
+  active.forEach((_, i) => { 
     const wb = wbtcWei[i];
-    const gmCollateral = gm.sign ? BigInt(gm.value) : 0n; // positive = collateral
-    const wbtcDebt = !wb.sign ? BigInt(wb.value) : 0n; // negative = borrowed
-    const wbtcSurplus = wb.sign ? BigInt(wb.value) : 0n; // positive = leftover WBTC
-    nav36 += gmCollateral * gmP + wbtcSurplus * wbtcP - wbtcDebt * wbtcP;
-  }
-
-  const usd = Number(nav36) / 1e36;
-  api.addUSDValue(usd > 0 ? usd : 0);
+    api.add(WBTC, wb.sign ? wb.value : `-${wb.value}`);
+  });
+  await api.sumTokens({ owners: active, tokens: [GM_UNDERLYING] });
 }
 
 module.exports = {
-  misrepresentedTokens: true,
+  doublecounted: true,
   methodology:
-    "TVL is the net equity summed over every Basalt vault: (GM collateral value + any WBTC surplus - WBTC debt value), priced by the Dolomite oracle and floored at zero. Each NFT-bound vault holds GMX v2 GM (BTC/USD) collateral in a Dolomite isolation account and borrows WBTC for a delta-neutral hedge. Borrowed WBTC (leverage) is excluded and the underlying GM is already counted under GMX, so misrepresentedTokens is set to avoid double-counting into the chain total.",
-  start: 1778198400, // 2026-05-08 — Deployment 6 on Arbitrum One
+    "TVL is the net equity summed over every Basalt vault: GM collateral + any WBTC surplus - WBTC debt. Each NFT-bound vault holds GMX v2 GM (BTC/USD) collateral in a Dolomite isolation account and borrows WBTC for a delta-neutral hedge.",
+  start: '2026-05-08',
   arbitrum: { tvl },
 };


### PR DESCRIPTION
## Basalt Vault — TVL adapter (Arbitrum)

**Basalt Vault** is an immutable delta-neutral GMX v2 BTC/USD yield protocol on Arbitrum One. Each user owns an NFT-bound vault (a `VaultCore` clone minted from a factory) that holds GMX v2 GM (BTC/USD) as collateral inside a **Dolomite isolation account** and borrows WBTC to run a delta-neutral hedge (~50% LTV).

Adapter: `projects/basalt-vault/index.js` · chain: Arbitrum One · `start: 1778198400` (2026-05-08).

### Protocol info (for the listing)
| Field | Value |
|---|---|
| Name | Basalt Vault |
| Website | https://btva.io |
| Description | Delta-neutral yield on Arbitrum — GM/BTC via Dolomite & GMX |
| Category | Yield |
| Chain | Arbitrum One |
| Logo | https://raw.githubusercontent.com/andrepurr/basalt-vault/main/resources/logo-cube.png |
| Twitter | https://x.com/basalt_vault |
| GitHub | https://github.com/basalt-vault/basalt-vault |
| Docs | https://btva.io/docs/architecture · https://btva.io/docs/user-guide |
| Token | none (immutable protocol, no governance token) |

### TVL methodology
Positions are per-user and isolated, so TVL is the **net equity summed over every vault**:

```
TVL = Σ_vaults ( GM collateral value − WBTC debt value )
```

priced by the Dolomite oracle. The adapter:
1. enumerates vaults via `VaultCoreNftFactory.nextTokenId()` → `vaultByTokenId(id)`;
2. resolves each vault's Dolomite isolation account (`basaltState()` → `dolomiteIsolationVault()`);
3. reads GM collateral and WBTC debt from `DolomiteMargin.getAccountWei` and prices them with `getMarketPrice`.

`misrepresentedTokens: true` — the underlying GM is already counted under GMX and borrowed WBTC (leverage) is excluded, so this net-equity figure is not double-counted into the chain total.

### Key contracts (Arbitrum One)
- VaultCoreNftFactory: `0x08e466fb09617d16ed27da9ea43ba601665f3b89`
- DolomiteMargin: `0x6Bd780E7fDf01D77e4d475c821f1e7AE05409072`

### Test
```
node test.js projects/basalt-vault/index.js
→ arbitrum  ~20.07k
```
matches the on-chain net equity summed across all isolation accounts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for Basalt Vault on Arbitrum.
  * Calculates vault net equity using GM collateral and WBTC surplus/debt positions, then aggregates NAV for reporting.
  * Includes coverage metadata and documented methodology for the new integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->