### PR TITLE
DeFa: add Ethereum PSP/PayFi settlement liquidity (TVL)

### DIFF
--- a/projects/defa/index.js
+++ b/projects/defa/index.js
@@ -1,6 +1,7 @@
 const { callSoroban } = require("../helper/chain/stellar");
 const { queryContract } = require("../helper/chain/cosmos");
 const { call } = require("../helper/chain/starknet");
+const ADDRESSES = require('../helper/coreAssets.json')
 
 // ============================================================
 // Stellar — Soroban TVL Logger (get_active_tvl)
@@ -79,10 +80,9 @@ async function starknetTvl(api) {
 // ============================================================
 
 const DEFA_PAYFI_ADDRESS = "0x182D16434faa044B9216A490CF0955B04AE16904";
-const ETH_USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
 
 async function ethereumTvl(api) {
-  return api.sumTokens({ owner: DEFA_PAYFI_ADDRESS, tokens: [ETH_USDC] });
+  return api.sumTokens({ owner: DEFA_PAYFI_ADDRESS, tokens: [ADDRESSES.ethereum.USDC] });
 }
 
 // ============================================================

--- a/projects/defa/index.js
+++ b/projects/defa/index.js
@@ -74,6 +74,18 @@ async function starknetTvl(api) {
 }
 
 // ============================================================
+// Ethereum — PSP / PayFi settlement liquidity
+// Short-cycle settlement liquidity in the DeFa PayFi layer (USDC).
+// ============================================================
+
+const DEFA_PAYFI_ADDRESS = "0x182D16434faa044B9216A490CF0955B04AE16904";
+const ETH_USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+
+async function ethereumTvl(api) {
+  return api.sumTokens({ owner: DEFA_PAYFI_ADDRESS, tokens: [ETH_USDC] });
+}
+
+// ============================================================
 // Export
 // ============================================================
 
@@ -81,8 +93,9 @@ module.exports = {
   timetravel: false,
   misrepresentedTokens: true,
   methodology:
-    "TVL is the total active liquidity across invoice-backed pools, reported by on-chain Logger contracts on Stellar (Soroban), ZigChain (CosmWasm), and Starknet (Cairo).",
+    "TVL is DeFa's on-chain liquidity: active invoice-backed pool liquidity reported by on-chain Logger contracts on Stellar (Soroban), ZigChain (CosmWasm) and Starknet (Cairo), plus USDC settlement liquidity in the DeFa PSP/PayFi layer on Ethereum.",
   stellar: { tvl: stellarTvl },
   zigchain: { tvl: zigchainTvl },
   starknet: { tvl: starknetTvl },
+  ethereum: { tvl: ethereumTvl },
 };


### PR DESCRIPTION
Adds **Ethereum** to the DeFa TVL adapter — USDC settlement liquidity in DeFa's PSP/PayFi layer. Same protocol as the already-merged DeFa adapter; this adds the Ethereum leg.

**What it is — DeFa PayFi (Settlement Liquidity):** short-cycle liquidity infrastructure that lets Settlement & Cross-Border Payment Operators scale transaction volume without locking capital in prefunding accounts.

**TVL:** the live USDC liquidity in the DeFa PayFi layer on Ethereum (currently ~$3k; scales as settlement liquidity grows).

**Test** (`node test.js projects/defa/index.js`):
```
stellar   4.01 M
zigchain  2.10 M
starknet  1.07 M
ethereum  3.05 k
total     7.19 M
```

---
**Note for the DefiLlama team:** the **GitHub link** on the DeFa protocol page currently returns 404 (our repository is private). Could you please remove/hide it? 🙏

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tracking for additional Ethereum-based PSP/PayFi settlement liquidity by including USDC held at a configured on-chain settlement address.
  * Expanded total TVL reporting to include the new Ethereum component alongside existing supported networks.
* **Documentation**
  * Updated the methodology description to reflect the broader TVL coverage, including the added Ethereum USDC settlement liquidity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->