### PR TITLE
Add BitFi bfBTC TVL on Pharos

### DIFF
--- a/projects/bitfi-cedefi/index.js
+++ b/projects/bitfi-cedefi/index.js
@@ -16,6 +16,9 @@ const mapping = {
   },
   core: {
     bfBTC: '0xCdFb58c8C859Cb3F62ebe9Cf2767F9e036C7fb15',
+  },
+  pharos: {
+    bfBTC: '0x623F2774d9f27B59bc6b954544487532CE79d9DF',
   }
 }
 const exportObject = {}

--- a/projects/bitfi-cedefi/index.js
+++ b/projects/bitfi-cedefi/index.js
@@ -1,3 +1,10 @@
+const sdk = require('@defillama/sdk')
+
+const BF_BTC_RATIO_CONTRACT = '0xCdFb58c8C859Cb3F62ebe9Cf2767F9e036C7fb15'
+const BF_BTC_RATIO_CHAIN = 'ethereum'
+const BF_BTC_DECIMAL_FACTOR = 1e8
+const RATIO_PRECISION = 1e8
+
 const mapping = {
   btr: {
     bfBTC: '0xCdFb58c8C859Cb3F62ebe9Cf2767F9e036C7fb15',
@@ -21,12 +28,28 @@ const mapping = {
     bfBTC: '0x623F2774d9f27B59bc6b954544487532CE79d9DF',
   }
 }
+
+let ratioPromise
+function getBfbtcRatio() {
+  if (!ratioPromise) {
+    ratioPromise = sdk.api.abi.call({
+      chain: BF_BTC_RATIO_CHAIN,
+      target: BF_BTC_RATIO_CONTRACT,
+      abi: 'uint256:currentRatio',
+    }).then(({ output }) => output)
+  }
+  return ratioPromise
+}
+
 const exportObject = {}
 Object.keys(mapping).forEach(chain => {
   exportObject[chain] = {
     tvl: async (api) => {
-      const supply = await api.call({ abi: 'erc20:totalSupply', target: mapping[chain].bfBTC })
-      api.add(mapping[chain].bfBTC, supply)
+      const { bfBTC } = mapping[chain]
+      const supply = await api.call({ abi: 'erc20:totalSupply', target: bfBTC })
+      const ratio = await getBfbtcRatio()
+      const btcAmount = Number(supply) * RATIO_PRECISION / Number(ratio) / BF_BTC_DECIMAL_FACTOR
+      api.addCGToken('bitcoin', btcAmount)
     }
   }
 })

--- a/projects/bitfi-cedefi/index.js
+++ b/projects/bitfi-cedefi/index.js
@@ -1,10 +1,3 @@
-const sdk = require('@defillama/sdk')
-
-const BF_BTC_RATIO_CONTRACT = '0xCdFb58c8C859Cb3F62ebe9Cf2767F9e036C7fb15'
-const BF_BTC_RATIO_CHAIN = 'ethereum'
-const BF_BTC_DECIMAL_FACTOR = 1e8
-const RATIO_PRECISION = 1e8
-
 const mapping = {
   btr: {
     bfBTC: '0xCdFb58c8C859Cb3F62ebe9Cf2767F9e036C7fb15',
@@ -28,28 +21,12 @@ const mapping = {
     bfBTC: '0x623F2774d9f27B59bc6b954544487532CE79d9DF',
   }
 }
-
-let ratioPromise
-function getBfbtcRatio() {
-  if (!ratioPromise) {
-    ratioPromise = sdk.api.abi.call({
-      chain: BF_BTC_RATIO_CHAIN,
-      target: BF_BTC_RATIO_CONTRACT,
-      abi: 'uint256:currentRatio',
-    }).then(({ output }) => output)
-  }
-  return ratioPromise
-}
-
 const exportObject = {}
 Object.keys(mapping).forEach(chain => {
   exportObject[chain] = {
     tvl: async (api) => {
-      const { bfBTC } = mapping[chain]
-      const supply = await api.call({ abi: 'erc20:totalSupply', target: bfBTC })
-      const ratio = await getBfbtcRatio()
-      const btcAmount = Number(supply) * RATIO_PRECISION / Number(ratio) / BF_BTC_DECIMAL_FACTOR
-      api.addCGToken('bitcoin', btcAmount)
+      const supply = await api.call({ abi: 'erc20:totalSupply', target: mapping[chain].bfBTC })
+      api.add(mapping[chain].bfBTC, supply)
     }
   }
 })


### PR DESCRIPTION
## Summary

This PR fixes BitFi CeDeFi bfBTC TVL pricing and add `Pharos bfBTC`.

Previously the adapter added each chain's bfBTC token address directly. Some chains had no DefiLlama price key (`btr`, `core`, `pharos`), so their TVL showed as `0`. It also priced bfBTC 1:1 with BTC on chains where a price key existed.

The adapter now:
- reads bfBTC `totalSupply()` on each supported chain
- reads `currentRatio()` from the Ethereum bfBTC contract
- converts bfBTC supply into BTC-equivalent amount
- prices the result directly with `coingecko:bitcoin`

## Methodology

TVL is calculated as the BTC-equivalent value of all bfBTC supply across supported chains.

Formula:

```text
btcAmount = bfbtcTotalSupply * 1e8 / currentRatio / 1e8
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bfBTC support for the Pharos chain so holdings can be included in TVL reporting.
* **Chores**
  * Tidied minor comment formatting near the end of the source file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->