### PR TITLE
test.js: add NaN and negative balance health warnings

### DIFF
--- a/test.js
+++ b/test.js
@@ -31,7 +31,7 @@ function checkBalanceHealth(balances, storedKey) {
   for (const [token, amount] of Object.entries(balances)) {
     const value = Number(amount)
     if (Number.isNaN(value)) {
-      nanTokens.push(token)
+      nanTokens.push(`${token} = ${amount}`)
     } else if (value < 0) {
       negativeTokens.push(`${token} = ${amount}`)
     }

--- a/test.js
+++ b/test.js
@@ -24,6 +24,33 @@ const { normalizeAddress } = require('./projects/helper/tokenMapping')
 const { PromisePool } = require('@supercharge/promise-pool')
 const { allProtocols } = require('./registries')
 
+function checkBalanceHealth(balances, storedKey) {
+  const nanTokens = []
+  const negativeTokens = []
+
+  for (const [token, amount] of Object.entries(balances)) {
+    const value = Number(amount)
+    if (Number.isNaN(value)) {
+      nanTokens.push(token)
+    } else if (value < 0) {
+      negativeTokens.push(`${token} = ${amount}`)
+    }
+  }
+
+  if (nanTokens.length > 0 || negativeTokens.length > 0) {
+    console.warn(`\n⚠  Balance health warning [${storedKey}]:`)
+    if (nanTokens.length > 0) {
+      console.warn(`   NaN balances (${nanTokens.length}):`)
+      nanTokens.forEach(t => console.warn(`     - ${t}`))
+    }
+    if (negativeTokens.length > 0) {
+      console.warn(`   Negative balances (${negativeTokens.length}):`)
+      negativeTokens.forEach(t => console.warn(`     - ${t}`))
+    }
+    console.warn()
+  }
+}
+
 const currentCacheVersion = sdk.cache.currentVersion // load env for cache
 // console.log(`Using cache version ${currentCacheVersion}`)
 
@@ -58,6 +85,7 @@ async function getTvl(
 
   let tvlBalances = await tvlFunction(api, ethBlock, chainBlocks, api);
   if (tvlBalances === undefined) tvlBalances = api.getBalances()
+  checkBalanceHealth(tvlBalances, storedKey)
   const tvlResults = await computeTVL(tvlBalances, unixTimestamp);
   await diplayUnknownTable({ tvlResults, storedKey, tvlBalances, })
   usdTvls[storedKey] = tvlResults.usdTvl;


### PR DESCRIPTION
Implements #19601

Adds `checkBalanceHealth()` to the test harness. Called in `getTvl()` after raw balances are resolved, before `computeTVL()`. Warns via `console.warn` when any token balance is NaN or negative, so developers catch broken adapters during local testing instead of silently submitting bad data.

- Non-breaking: test run continues normally, no exceptions thrown
- Only `test.js` modified
- No new dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added balance health checks during TVL calculations to flag invalid numeric values and negative token amounts.
  * Improved warning output with token-level details when balance issues are detected.
  * Balance checks now run immediately after balances are retrieved, before further TVL computation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->