### PR TITLE
Add Liquidium ETH pool to TVL adapter

### DIFF
--- a/projects/liquidium/index.js
+++ b/projects/liquidium/index.js
@@ -5,16 +5,19 @@ const BTC_POOL_CANISTER_ID = 'hkmli-faaaa-aaaar-qb4ba-cai'
 const USDT_POOL_CANISTER_ID = 'hnnn4-iyaaa-aaaar-qb4bq-cai'
 const USDC_POOL_CANISTER_ID = '6sna2-oiaaa-aaaar-qb66q-cai'
 const ICP_POOL_CANISTER_ID = 'r2pk3-4yaaa-aaaar-qb7zq-cai'
+const ETH_POOL_CANISTER_ID = 'qcg7y-syaaa-aaaar-qb75q-cai'
 const ALLOWED_POOL_CANISTERS = new Set([
   BTC_POOL_CANISTER_ID,
   USDT_POOL_CANISTER_ID,
   USDC_POOL_CANISTER_ID,
   ICP_POOL_CANISTER_ID,
+  ETH_POOL_CANISTER_ID,
 ])
 const MAX_SAFE_BIGINT = BigInt(Number.MAX_SAFE_INTEGER)
 
 const ASSET_META = {
   BTC: { decimals: 8, coingeckoId: 'bitcoin' },
+  ETH: { decimals: 18, coingeckoId: 'ethereum' },
   SOL: { decimals: 9, coingeckoId: 'solana' },
   USDC: { decimals: 6, coingeckoId: 'usd-coin' },
   USDT: { decimals: 6, coingeckoId: 'tether' },


### PR DESCRIPTION
Adds the live Liquidium ETH pool to the existing Liquidium TVL adapter. This follows the same pattern as the previous Liquidium USDC and ICP pool additions.

## Pool

ETH pool canister from the live lending canister `list_pools` response:

- `qcg7y-syaaa-aaaar-qb75q-cai`

## Validation

```bash
node test.js projects/liquidium
```

Result includes ETH in TVL:

```text
ETH                       1.21 k
```

Borrowed remains unchanged for ETH because the pool currently has zero outstanding ETH debt.
