### PR TITLE
fix gate

### DIFF
--- a/projects/gate-io/index.js
+++ b/projects/gate-io/index.js
@@ -1669,15 +1669,22 @@ const config = {
   },
 };
 
+// remove chains w/o historical tvl
 const unsupportedChains = ['aeternity', 'beam', 'binance', 'bitchain', 'bitcoincash', 'bittensor', 'bone', 'callisto', 'chainx', 'clv', 'concordium', 'conflux', 'cmp', 'dash', 'cube', 'defichain', 'edg', 'elastos', 'elys', 'equilibrium', 'evmos', 'filecoin', 'findora', 'flow', 'fusion', 'heiko', 'hydra', 'hyperliquid', 'icon', 'icp', 'interlay', 'kadena', 'karura', 'kava', 'kintsugi', 'kusuma', 'manta_atlantic', 'lisk', 'neo', 'neo3', 'near', 'nibiru', 'nuls', 'ontology', 'oasis', 'parallel', 'pokt', 'polkadex', 'proton', 'reef', 'rvn', 'shiden', 'sora', 'stafi', 'starcoin', 'syscoin', 'stellar', 'telos', 'thorchain', 'velas', 'venom', 'vite', 'waves', 'wax', 'zilliqa', 'secret', 'etn', 'tara', 'zkfair',
   'vinu', 'rollux', 'syscoin', 'aelf', 'ailayer', 'heco', 'archway',
   'ton', // never had any tvl
-  'enuls'
+  'enuls', 'kardia'
 ]
 
 unsupportedChains.forEach(chain => delete config[chain]);
 
+// export 0 to preserve historical tvl
+const deadChains = ['airdao', 'eos_evm', 'kroma']
+const deadChainsExports = {};
+deadChains.forEach(chain => { deadChainsExports[chain] = { tvl: async () => ({}) }; });
+
 module.exports = mergeExports([
   cexExports(config),
+  deadChainsExports,
   { ethereum: { tvl: getStakedEthTVL({ withdrawalAddresses: ['0x287a66c7d9cba7504e90fa638911d74c4dc6a147', '0xbcf03ce48091e6b820a7c33e166e5d0109d8e712', '0x7a3f9b7120386249528c93e5eb373b78e54d5ba9'], sleepTime: 20_000, size: 200, proxy: true }) } },
 ]);

--- a/projects/gate-io/index.js
+++ b/projects/gate-io/index.js
@@ -1676,10 +1676,12 @@ const unsupportedChains = ['aeternity', 'beam', 'binance', 'bitchain', 'bitcoinc
   'enuls', 'kardia'
 ]
 
-unsupportedChains.forEach(chain => delete config[chain]);
-
 // export 0 to preserve historical tvl
 const deadChains = ['airdao', 'eos_evm', 'kroma']
+
+const allChains = [...unsupportedChains, ...deadChains];
+allChains.forEach(chain => delete config[chain]);
+
 const deadChainsExports = {};
 deadChains.forEach(chain => { deadChainsExports[chain] = { tvl: async () => ({}) }; });
 


### PR DESCRIPTION
- removes kardia 
- exports 0 for kroma, eos_evm, and airdao

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chain handling so some networks now remain queryable for historical TVL data even when current TVL is unavailable.
  * Removed fully unsupported chains from active availability to avoid showing data that cannot be provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->