### PR TITLE
export sky treasury GROVE as ownTokens

### DIFF
--- a/registries/treasury.js
+++ b/registries/treasury.js
@@ -3429,8 +3429,7 @@ const configs = {
   'treasury/maker': {
     ethereum: {
       owners: ['0xBE8E3e3618f7474F8cB1d074A26afFef007E98FB'],
-      ownTokens: ['0xc20059e0317de91738d13af027dfc4a50781b066', '0x56072c95faa701256059aa122697b133aded9279', ADDRESSES.ethereum.MKR],
-      blacklistedTokens: ['0xB30FE1Cf884B48a22a50D22a9282004F2c5E9406']
+      ownTokens: ['0xc20059e0317de91738d13af027dfc4a50781b066', '0x56072c95faa701256059aa122697b133aded9279', ADDRESSES.ethereum.MKR, '0xB30FE1Cf884B48a22a50D22a9282004F2c5E9406']
     },
     arbitrum: {
       owners: ['0x10e6593cdda8c58a1d0f14c5164b376352a55f2f'],

--- a/registries/treasury.js
+++ b/registries/treasury.js
@@ -3429,7 +3429,8 @@ const configs = {
   'treasury/maker': {
     ethereum: {
       owners: ['0xBE8E3e3618f7474F8cB1d074A26afFef007E98FB'],
-      ownTokens: ['0xc20059e0317de91738d13af027dfc4a50781b066', '0x56072c95faa701256059aa122697b133aded9279', ADDRESSES.ethereum.MKR]
+      ownTokens: ['0xc20059e0317de91738d13af027dfc4a50781b066', '0x56072c95faa701256059aa122697b133aded9279', ADDRESSES.ethereum.MKR],
+      blacklistedTokens: ['0xB30FE1Cf884B48a22a50D22a9282004F2c5E9406']
     },
     arbitrum: {
       owners: ['0x10e6593cdda8c58a1d0f14c5164b376352a55f2f'],


### PR DESCRIPTION
Sky was given 7B out of a total 10B GROVE, which "are distributed to USDS users" and "reserved for future token rewards as determined by Sky Governance"

- https://sky-atlas.io/#5b43f4d8-9728-411c-92c7-a7ebaf368ca0
- https://etherscan.io/tx/0x6443c0b430528439a7a45350b36d6bafe203a0a71305c1a17227f28d90e90ee7

This closely follows the SPK pattern: https://etherscan.io/tx/0x88a06d14503443756f5d1e6cd6ff08002c7a8e9780eeb759d3b8b859b14cb4ed