### PR TITLE
Add Sentry (Robinhood Chain launchpad) TVL adapter

### DIFF
--- a/projects/sentry-trading/index.js
+++ b/projects/sentry-trading/index.js
@@ -1,0 +1,29 @@
+const { getLogs } = require('../helper/cache/getLogs')
+const { sumTokens2 } = require('../helper/unwrapLPs')
+
+// Sentry Launch Factory on Robinhood Chain: a token launchpad that
+// deploys ERC-20s, seeds a Uniswap V3 pool (token/WETH, 1% tier), and
+// permanently locks the LP NFT inside the factory. TVL is the liquidity
+// in those factory-created pools.
+const FACTORY = '0x9e8f6f8214b01Fd4Cf1d73FB1fb7cf9f811036Cb'
+const WETH = '0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73'
+const FACTORY_DEPLOY_BLOCK = 1431636
+
+async function tvl(api) {
+  const logs = await getLogs({
+    api,
+    target: FACTORY,
+    eventAbi: 'event PoolInitialized(address indexed pool, address indexed token)',
+    onlyArgs: true,
+    fromBlock: FACTORY_DEPLOY_BLOCK,
+  })
+  const ownerTokens = logs.map((log) => [[log.token, WETH], log.pool])
+  return sumTokens2({ api, ownerTokens })
+}
+
+module.exports = {
+  methodology:
+    'TVL is the liquidity held in the Uniswap V3 pools created by the Sentry Launch Factory (pools are enumerated from the factory\'s PoolInitialized events; every pool is a token/WETH pair whose LP position is permanently locked in the factory).',
+  start: '2026-07-02',
+  robinhood: { tvl },
+}

--- a/projects/sentry-trading/index.js
+++ b/projects/sentry-trading/index.js
@@ -1,29 +1,24 @@
-const { getLogs } = require('../helper/cache/getLogs')
+const { getLogs2 } = require('../helper/cache/getLogs')
 const { sumTokens2 } = require('../helper/unwrapLPs')
+const ADDRESSES = require('../helper/coreAssets.json')
 
-// Sentry Launch Factory on Robinhood Chain: a token launchpad that
-// deploys ERC-20s, seeds a Uniswap V3 pool (token/WETH, 1% tier), and
-// permanently locks the LP NFT inside the factory. TVL is the liquidity
-// in those factory-created pools.
 const FACTORY = '0x9e8f6f8214b01Fd4Cf1d73FB1fb7cf9f811036Cb'
-const WETH = '0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73'
+const WETH = ADDRESSES.robinhood.WETH
 const FACTORY_DEPLOY_BLOCK = 1431636
 
 async function tvl(api) {
-  const logs = await getLogs({
+  const logs = await getLogs2({
     api,
     target: FACTORY,
     eventAbi: 'event PoolInitialized(address indexed pool, address indexed token)',
-    onlyArgs: true,
     fromBlock: FACTORY_DEPLOY_BLOCK,
   })
-  const ownerTokens = logs.map((log) => [[log.token, WETH], log.pool])
-  return sumTokens2({ api, ownerTokens })
+  const owners = logs.map((log) => log.pool)
+  return sumTokens2({ api, owners, tokens: [WETH] })
 }
 
 module.exports = {
-  methodology:
-    'TVL is the liquidity held in the Uniswap V3 pools created by the Sentry Launch Factory (pools are enumerated from the factory\'s PoolInitialized events; every pool is a token/WETH pair whose LP position is permanently locked in the factory).',
+  methodology: 'TVL is the WETH held in the Uniswap V3 pools created by the Sentry Launch Factory (pools are enumerated from the factory\'s PoolInitialized events; every pool is a token/WETH pair whose LP position is permanently locked in the factory).',
   start: '2026-07-02',
   robinhood: { tvl },
 }


### PR DESCRIPTION
## Name (to be shown on DefiLlama)
Sentry

## Twitter Link
https://x.com/sentrylauncher

## List of audit links if any
None

## Website Link
https://sentry.trading

## Logo (High resolution, will be shown with rounded borders)
https://sentry.trading/Sentry-512x512.png

## Current TVL
~$20.6K

## Treasury Addresses (if the protocol has treasury)
0x8852BC7Ca269c276264b8Ad7869956C26304a740

## Chain
Robinhood Chain (chainId 4663)

## Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed)
None

## Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed)
None

## Short Description (to be shown on DefiLlama)
Sentry is a token launchpad on Robinhood Chain: one-click ERC-20 launches with a Uniswap V3 pool seeded at launch and the LP position permanently locked in the factory. LP fees split 65/35 between the token creator and the protocol treasury.

## Forked from (if applicable)
None

## Oracle Provider(s) (if applicable)
None

## Implementation Details
TVL is the liquidity in the Uniswap V3 pools created by the Sentry Launch Factory (0x9e8f6f8214b01Fd4Cf1d73FB1fb7cf9f811036Cb). Pools are enumerated on-chain from the factory's PoolInitialized events (from the factory deploy block 1431636) and balances are summed with sumTokens2. Every pool is a token/WETH pair whose LP NFT is locked in the factory, so this liquidity is protocol-owned and non-withdrawable.

## Category
Launchpad


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for the Robinhood deployment.
  * TVL is computed by automatically discovering supported pools from on-chain `PoolInitialized` events emitted by the factory contract.
  * Reports aggregated liquidity focused on WETH and includes TVL methodology and the data start point through a new public adapter entry point.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->