### PR TITLE
chore: add monad vault address for townsquare

### DIFF
--- a/projects/townsquare-vaults/index.js
+++ b/projects/townsquare-vaults/index.js
@@ -7,10 +7,16 @@ module.exports = {
 };
 
 const config = {
-  monad: {
-    vault: "0x6B00868e2D1385b3804127827bBaB461d3E697E7",
-    vaultFromBlock: 85979242,
-  },
+  monad: [
+    {
+      vault: "0x6B00868e2D1385b3804127827bBaB461d3E697E7",
+      vaultFromBlock: 85979242,
+    },
+    {
+      vault: "0xcD1D2D602C3e7394515DaAe96e4FFe16DE71e5B4", //we are adding additional vaults where Native is also the whitelabeler and TownSquare is the protoco
+      vaultFromBlock: 70146973,
+    },
+  ],
 };
 
 async function getMarketTokens(api, vault, vaultFromBlock) {
@@ -33,40 +39,48 @@ async function getMarketTokens(api, vault, vaultFromBlock) {
 }
 
 Object.keys(config).forEach((chain) => {
-  // get vault and start block
-  const { vault, vaultFromBlock } = config[chain];
+  // get all vaults for this chain
+  const vaults = config[chain];
   module.exports[chain] = {
     tvl: async (api) => {
-      const { tokens } = await getMarketTokens(api, vault, vaultFromBlock);
+      for (const { vault, vaultFromBlock } of vaults) {
+        const { tokens } = await getMarketTokens(api, vault, vaultFromBlock);
 
-      // use sumTokens2 to for cash balances in vault
-      return sumTokens2({
-        api,
-        owner: vault,
-        tokens
-      });
+        // use sumTokens2 to for cash balances in vault
+        await sumTokens2({
+          api,
+          owner: vault,
+          tokens
+        });
+      }
+
+      return api.getBalances();
     },
     borrowed: async (api) => {
-      const { lps, tokens } = await getMarketTokens(api, vault, vaultFromBlock);
-
-      // get total supplied
-      let v2Locked = await api.multiCall({ abi: 'uint256:totalUnderlying', calls: lps });
-
-      // get cash balance by reading each token balanceOf from vault
-      let cashBalances = await api.multiCall({ abi: 'erc20:balanceOf', calls: tokens.map(token => ({ target: token, params: [vault] })) });
-
-      // merge tokens and their corresponding locked and cash values
-      const tokenData = tokens.map((token, i) => ({
-        token,
-        locked: BigNumber(v2Locked[i]),
-        cash: BigNumber(cashBalances[i])
-      }));
-
-      // calculate borrowed amounts
       const borrowedBalances = {};
-      tokenData.forEach(({ token, locked, cash }) => {
-        borrowedBalances[token] = locked.gt(cash) ? locked.minus(cash).toFixed(0) : '0';
-      });
+
+      for (const { vault, vaultFromBlock } of vaults) {
+        const { lps, tokens } = await getMarketTokens(api, vault, vaultFromBlock);
+
+        // get total supplied
+        let v2Locked = await api.multiCall({ abi: 'uint256:totalUnderlying', calls: lps });
+
+        // get cash balance by reading each token balanceOf from vault
+        let cashBalances = await api.multiCall({ abi: 'erc20:balanceOf', calls: tokens.map(token => ({ target: token, params: [vault] })) });
+
+        // merge tokens and their corresponding locked and cash values
+        const tokenData = tokens.map((token, i) => ({
+          token,
+          locked: BigNumber(v2Locked[i]),
+          cash: BigNumber(cashBalances[i])
+        }));
+
+        // calculate borrowed amounts, summing across vaults sharing the same token
+        tokenData.forEach(({ token, locked, cash }) => {
+          const borrowed = locked.gt(cash) ? locked.minus(cash) : BigNumber(0);
+          borrowedBalances[token] = BigNumber(borrowedBalances[token] || 0).plus(borrowed).toFixed(0);
+        });
+      }
 
       return borrowedBalances;
     },

--- a/projects/townsquare-vaults/index.js
+++ b/projects/townsquare-vaults/index.js
@@ -1,5 +1,6 @@
 const { getLogs } = require("../helper/cache/getLogs");
 const { sumTokens2 } = require("../helper/unwrapLPs");
+const BigNumber = require("bignumber.js");
 
 module.exports = {
   methodology: "Gets all the assets deposited by LPs in TownSquare Vault for PMMs to facilitate trades.",
@@ -12,51 +13,44 @@ const config = {
   },
 };
 
+async function getMarketTokens(api, vault, vaultFromBlock) {
+  // get all lps
+  const lpListedLogs = await getLogs({
+    api,
+    target: vault,
+    topic: "MarketListed(address)",
+    eventAbi:
+      "event MarketListed(address lpToken)",
+    onlyArgs: true,
+    fromBlock: vaultFromBlock,
+  });
+  const lps = lpListedLogs.map((i) => i.lpToken);
+
+  // get all underlying tokens
+  const tokens = await api.multiCall({ abi: 'address:underlying', calls: lps });
+
+  return { lps, tokens };
+}
+
 Object.keys(config).forEach((chain) => {
   // get vault and start block
   const { vault, vaultFromBlock } = config[chain];
   module.exports[chain] = {
     tvl: async (api) => {
-      // get all lps
-      const lpListedLogs = await getLogs({
-        api,
-        target: vault,
-        topic: "MarketListed(address)",
-        eventAbi:
-          "event MarketListed(address lpToken)",
-        onlyArgs: true,
-        fromBlock: vaultFromBlock,
-      });
-      const lps = lpListedLogs.map((i) => i.lpToken);
-
-      // get all underlying tokens
-      const tokens = await api.multiCall({ abi: 'address:underlying', calls: lps });
+      const { tokens } = await getMarketTokens(api, vault, vaultFromBlock);
 
       // use sumTokens2 to for cash balances in vault
-      return sumTokens2({ 
-        api, 
-        owner: vault, 
-        tokens 
+      return sumTokens2({
+        api,
+        owner: vault,
+        tokens
       });
     },
     borrowed: async (api) => {
-      // get all lps
-      const lpListedLogs = await getLogs({
-        api,
-        target: vault,
-        topic: "MarketListed(address)",
-        eventAbi:
-          "event MarketListed(address lpToken)",
-        onlyArgs: true,
-        fromBlock: vaultFromBlock,
-      });
-      const lps = lpListedLogs.map((i) => i.lpToken);
-
-      // get all underlying tokens
-      const tokens = await api.multiCall({ abi: 'address:underlying', calls: lps });
+      const { lps, tokens } = await getMarketTokens(api, vault, vaultFromBlock);
 
       // get total supplied
-      let v2Locked = await api.multiCall({ abi: 'address:totalUnderlying', calls: lps });
+      let v2Locked = await api.multiCall({ abi: 'uint256:totalUnderlying', calls: lps });
 
       // get cash balance by reading each token balanceOf from vault
       let cashBalances = await api.multiCall({ abi: 'erc20:balanceOf', calls: tokens.map(token => ({ target: token, params: [vault] })) });
@@ -64,18 +58,14 @@ Object.keys(config).forEach((chain) => {
       // merge tokens and their corresponding locked and cash values
       const tokenData = tokens.map((token, i) => ({
         token,
-        locked: parseInt(v2Locked[i]),
-        cash: parseInt(cashBalances[i])
+        locked: BigNumber(v2Locked[i]),
+        cash: BigNumber(cashBalances[i])
       }));
 
       // calculate borrowed amounts
       const borrowedBalances = {};
       tokenData.forEach(({ token, locked, cash }) => {
-        if (locked > cash) {
-          borrowedBalances[token] = locked - cash;
-        } else {
-          borrowedBalances[token] = 0;
-        }
+        borrowedBalances[token] = locked.gt(cash) ? locked.minus(cash).toFixed(0) : '0';
       });
 
       return borrowedBalances;

--- a/projects/townsquare-vaults/index.js
+++ b/projects/townsquare-vaults/index.js
@@ -1,0 +1,84 @@
+const { getLogs } = require("../helper/cache/getLogs");
+const { sumTokens2 } = require("../helper/unwrapLPs");
+
+module.exports = {
+  methodology: "Gets all the assets deposited by LPs in TownSquare Vault for PMMs to facilitate trades.",
+};
+
+const config = {
+  monad: {
+    vault: "0x6B00868e2D1385b3804127827bBaB461d3E697E7",
+    vaultFromBlock: 85979242,
+  },
+};
+
+Object.keys(config).forEach((chain) => {
+  // get vault and start block
+  const { vault, vaultFromBlock } = config[chain];
+  module.exports[chain] = {
+    tvl: async (api) => {
+      // get all lps
+      const lpListedLogs = await getLogs({
+        api,
+        target: vault,
+        topic: "MarketListed(address)",
+        eventAbi:
+          "event MarketListed(address lpToken)",
+        onlyArgs: true,
+        fromBlock: vaultFromBlock,
+      });
+      const lps = lpListedLogs.map((i) => i.lpToken);
+
+      // get all underlying tokens
+      const tokens = await api.multiCall({ abi: 'address:underlying', calls: lps });
+
+      // use sumTokens2 to for cash balances in vault
+      return sumTokens2({ 
+        api, 
+        owner: vault, 
+        tokens 
+      });
+    },
+    borrowed: async (api) => {
+      // get all lps
+      const lpListedLogs = await getLogs({
+        api,
+        target: vault,
+        topic: "MarketListed(address)",
+        eventAbi:
+          "event MarketListed(address lpToken)",
+        onlyArgs: true,
+        fromBlock: vaultFromBlock,
+      });
+      const lps = lpListedLogs.map((i) => i.lpToken);
+
+      // get all underlying tokens
+      const tokens = await api.multiCall({ abi: 'address:underlying', calls: lps });
+
+      // get total supplied
+      let v2Locked = await api.multiCall({ abi: 'address:totalUnderlying', calls: lps });
+
+      // get cash balance by reading each token balanceOf from vault
+      let cashBalances = await api.multiCall({ abi: 'erc20:balanceOf', calls: tokens.map(token => ({ target: token, params: [vault] })) });
+
+      // merge tokens and their corresponding locked and cash values
+      const tokenData = tokens.map((token, i) => ({
+        token,
+        locked: parseInt(v2Locked[i]),
+        cash: parseInt(cashBalances[i])
+      }));
+
+      // calculate borrowed amounts
+      const borrowedBalances = {};
+      tokenData.forEach(({ token, locked, cash }) => {
+        if (locked > cash) {
+          borrowedBalances[token] = locked - cash;
+        } else {
+          borrowedBalances[token] = 0;
+        }
+      });
+
+      return borrowedBalances;
+    },
+  };
+});

--- a/projects/townsquare/index.js
+++ b/projects/townsquare/index.js
@@ -65,7 +65,7 @@ async function borrowed({ api }) {
 
 
 module.exports = {
-    methodology:"Counts the total amount deposited in all pools",
+    methodology:"Counts the total amount deposited in all TownSquare Lending pools",
     monad: {
         tvl,
         borrowed


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).

2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** Please send a mail to metadata@defillama.com
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes

---
New Features
Added support for the Monad blockchain, enabling users to view and track total value locked (TVL) and borrowed balance information for the Monad vault.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TownSquare Vaults metrics for TVL and borrowed amounts across configured chains.
  * Borrowed amounts are calculated per underlying token to reflect outstanding borrowings.
* **Documentation**
  * Updated the TownSquare Lending methodology text to specify it covers total deposits in TownSquare Lending pools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->