### PR TITLE
Update atomiq.exchange adapter to Solana v2 contract & add STRKBTC asset

### DIFF
--- a/projects/atomiq-exchange/index.js
+++ b/projects/atomiq-exchange/index.js
@@ -16,6 +16,9 @@ const config = {
     citrea: {
         vaults: ["0x5bb0C725939cB825d1322A99a3FeB570097628c3", "0xc98Ef084d3911C8447DBbE4dDa18bC2c9bB0584e"],
     },
+    solana: {
+        tokens: [ADDRESSES.solana.SOL, ADDRESSES.solana.USDC, ADDRESSES.solana.USDT]
+    }
 }
 
 async function tvl(api) {
@@ -23,12 +26,14 @@ async function tvl(api) {
 }
 
 async function tvlSolana(api) {
-    // get the authority PDA from program ID using seed "authority"
-    const [authorityPda] = PublicKey.findProgramAddressSync(
-        [Buffer.from("vault")],
-        new PublicKey(ATOMIQ_PROGRAM_ID)
-    );
-    return sumTokens2({ api, owners: [authorityPda.toString()] });
+    // map to token accounts for all the relevant Solana tokens
+    const tokenAccounts = config.solana.tokens.map(token => {
+        return PublicKey.findProgramAddressSync(
+            [Buffer.from("vault"), new PublicKey(token).toBuffer()],
+            new PublicKey(ATOMIQ_PROGRAM_ID)
+        )[0].toString();
+    });
+    return sumTokens2({ api, tokenAccounts });
 }
 
 module.exports = {

--- a/projects/atomiq-exchange/index.js
+++ b/projects/atomiq-exchange/index.js
@@ -17,7 +17,7 @@ const config = {
         vaults: ["0x5bb0C725939cB825d1322A99a3FeB570097628c3", "0xc98Ef084d3911C8447DBbE4dDa18bC2c9bB0584e"],
     },
     solana: {
-        tokens: [ADDRESSES.solana.SOL, ADDRESSES.solana.USDC, ADDRESSES.solana.USDT]
+        tokens: [ADDRESSES.solana.SOL, ADDRESSES.solana.USDC]
     }
 }
 

--- a/projects/atomiq-exchange/index.js
+++ b/projects/atomiq-exchange/index.js
@@ -3,7 +3,7 @@ const { sumTokens } = require("../helper/sumTokens");
 const { sumTokens2 } = require("../helper/solana");
 const { PublicKey } = require("@solana/web3.js");
 
-const ATOMIQ_PROGRAM_ID = "4hfUykhqmD7ZRvNh1HuzVKEY7ToENixtdUKZspNDCrEM";
+const ATOMIQ_PROGRAM_ID = "atq2FYuvww5EF6qeB28gj9tkao6Ld9mEGUzF4M93cCC";
 
 const config = {
     btnx: {
@@ -11,7 +11,7 @@ const config = {
     },
     starknet: {
         vaults: ["0x01932042992647771f3d0aa6ee526e65359c891fe05a285faaf4d3ffa373e132", "0x04f278e1f19e495c3b1dd35ef307c4f7510768ed95481958fbae588bd173f79a"],
-        tokens: [ADDRESSES.starknet.WBTC, ADDRESSES.starknet.STRK, ADDRESSES.starknet.ETH]
+        tokens: [ADDRESSES.starknet.WBTC, ADDRESSES.starknet.STRK, ADDRESSES.starknet.ETH, ADDRESSES.starknet.STRKBTC]
     },
     citrea: {
         vaults: ["0x5bb0C725939cB825d1322A99a3FeB570097628c3", "0xc98Ef084d3911C8447DBbE4dDa18bC2c9bB0584e"],
@@ -25,7 +25,7 @@ async function tvl(api) {
 async function tvlSolana(api) {
     // get the authority PDA from program ID using seed "authority"
     const [authorityPda] = PublicKey.findProgramAddressSync(
-        [Buffer.from("authority")],
+        [Buffer.from("vault")],
         new PublicKey(ATOMIQ_PROGRAM_ID)
     );
     return sumTokens2({ api, owners: [authorityPda.toString()] });
@@ -37,5 +37,5 @@ module.exports = {
     citrea: { tvl },
     starknet: { tvl },
     solana: { tvl: tvlSolana },
-    methodology: `TVL counts the total assets held in the Atomiq Exchange spv vaults and escrow managers on each chain.`
+    methodology: `TVL counts the total assets held in the Atomiq Exchange spv vaults and escrow managers on each chain (excluding Bitcoin and Lightning).`
 }


### PR DESCRIPTION
- Updates the atomiq program ID on Solana (we've switched to a v2 deployment), with the vault authority now being the vault itself (hence the `"vault"` PDA derivation).
- Adds STRKBTC to the list of assets tracked on Starknet
- Clarifies that Bitcoin on-chain and Lightning balances are excluded in the methodology in the methodology description.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded TVL coverage by adding Starknet token **STRKBTC** and additional Solana tokens (**SOL**, **USDC**) in the Atomiq Exchange view.
  * Refined the published TVL methodology to clarify that reported TVL excludes **Bitcoin** and **Lightning** assets.
* **Bug Fixes**
  * Improved Solana TVL calculations by deriving and summing balances across token-specific vault accounts for the configured tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->