### PR TITLE
feat(evedex): migrate adapter from eventum L3 to arbitrum, remove eve…

### DIFF
--- a/projects/helper/chains.json
+++ b/projects/helper/chains.json
@@ -163,7 +163,6 @@
   "etlk",
   "etn",
   "europa",
-  "eventum",
   "everscale",
   "evmos",
   "fantom",

--- a/projects/helper/coreAssets.json
+++ b/projects/helper/coreAssets.json
@@ -2668,9 +2668,6 @@
   "xo": {
     "USDC": "0xCf65732699b4eFc2Bc7b87fB6d75F3aAa6CFC867"
   },
-  "eventum": {
-    "USDT": "0xC9b68d8ab057b52785cF0e8e983A2eaFE6858979"
-  },
   "gatelayer": {
     "WGT": "0x6803b8e93b13941f6b73b82e324b80251b3de338"
   },

--- a/registries/sumTokens.js
+++ b/registries/sumTokens.js
@@ -14226,15 +14226,17 @@ const configs = {
     },
   },
   "evedex": {
-    "eventum": {
+    "arbitrum": {
       "tokens": [
-        ADDRESSES.eventum.USDT
+        ADDRESSES.arbitrum.USDT
       ],
       "owners": [
-        "0x1DC14e4261eCd7747Cbf6D2C8538a73371405D76",
-        "0x5e023c31E1d3dCd08a1B3e8c96f6EF8Aa8FcaCd1",
-        "0x026968b5cED079ECCD6CC78f35a5Dfddc13F9Af8",
-        "0x0a9591c64Fd9e8C1f9A81DB1B668a5f211b5735A"
+        "0xFF1968ae4F91efCCf4d5cef823EeCd46fbe114c3",
+        "0x4E682602EE3CF8550BC4fEe46F50cc0C0a41B116",
+        "0x071360b37F6Db934F857E6B33AD705fEee63Be14",
+        "0xf911C309B851Db55b97F4E2c7599a3733C2DAC69",
+        "0xB54D6207365a8CD40A90F880B2f61d931af7d6E8",
+        "0xDBB435e9ed5096006EAae14F99775D12cCa645D9"
       ]
     },
   },

--- a/registries/sumTokens/covalent.js
+++ b/registries/sumTokens/covalent.js
@@ -326,15 +326,6 @@ module.exports = {
       ]
     },
   },
-  "eventum": {
-    "arbitrum": {
-      "owners": [
-        "0x8D21dfEA9231Db85dCe72b8d9F18e917d833d4B1",
-        "0xAD3026961087eccEC0508D411bb9fb405E086B38"
-      ],
-      "fetchCoValentTokens": true
-    },
-  },
   "flooring-io": {
     "ethereum": {
       "tvl": {

--- a/registries/treasury.js
+++ b/registries/treasury.js
@@ -1868,9 +1868,12 @@ const configs = {
     },
   },
   'treasury/evedex': {
-    eventum: {
-      tokens: [ADDRESSES.eventum.USDT],
-      owners: ['0x77075c627e51145d54e4EDD54Afa169DA7ff8A17'],
+    arbitrum: {
+      tokens: [ADDRESSES.arbitrum.USDT],
+      owners: [
+        '0x0a9591c64Fd9e8C1f9A81DB1B668a5f211b5735A',
+        '0x16a4f9904e222D298Ac71aA3E3Bd5C19B902C595',
+      ],
     },
   },
   'treasury/evmos-dao': {

--- a/registries/treasury.js
+++ b/registries/treasury.js
@@ -1869,7 +1869,7 @@ const configs = {
   },
   'treasury/evedex': {
     arbitrum: {
-      tokens: [ADDRESSES.arbitrum.USDT],
+      tokens: [ADDRESSES.arbitrum.USDT, ADDRESSES.arbitrum.USDC_CIRCLE],
       owners: [
         '0x16a4f9904e222D298Ac71aA3E3Bd5C19B902C595',
       ],

--- a/registries/treasury.js
+++ b/registries/treasury.js
@@ -1871,7 +1871,6 @@ const configs = {
     arbitrum: {
       tokens: [ADDRESSES.arbitrum.USDT],
       owners: [
-        '0x0a9591c64Fd9e8C1f9A81DB1B668a5f211b5735A',
         '0x16a4f9904e222D298Ac71aA3E3Bd5C19B902C595',
       ],
     },


### PR DESCRIPTION
Name (to be shown on DefiLlama):
Evedex


Evedex migrated from its custom Eventum L3 to Arbitrum One. Update TVL and treasury adapters to the new Arbitrum contracts and remove the now-defunct eventum chain (chain adapter, chains list, core assets).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an outdated network from supported chain lists.
  * Updated token and treasury configurations to replace the previous network-specific setup with the correct network mapping.
  * Cleaned up registry entries so the updated network appears consistently across related configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->