### PR TITLE
Add prynt — bonding-curve launchpad on Robinhood Chain (TVL)

### DIFF
--- a/projects/prynt/index.js
+++ b/projects/prynt/index.js
@@ -1,31 +1,17 @@
-// prynt — bonding-curve memecoin launchpad on Robinhood Chain (Arbitrum Orbit L2, chainId 4663).
-//
-// TVL model: every token launches on its own BondingCurve, which custodies real ETH against a
-// constant-product curve until it graduates to Uniswap V2. By the contract's invariant the curve's
-// native ETH balance == its real ETH reserve right up until migration, at which point the ETH leaves
-// the curve for a Uniswap V2 pool (that pool is attributed to Uniswap, not prynt — so we do NOT count
-// it here and there is no double counting). TVL is therefore the sum of native ETH held across every
-// still-active bonding curve. Curves are discovered from the factory's TokenCreated logs.
-//
-// Destination file in the PR: projects/prynt/index.js
-//
-// -----------------------------------------------------------------------------------------------------
-const { getLogs } = require("../helper/cache/getLogs");
-const { nullAddress } = require("../helper/sumTokens"); // canonical native-ETH sentinel for sumTokens
+const { getLogs2 } = require("../helper/cache/getLogs");
+const { nullAddress } = require("../helper/sumTokens");
 
 const FACTORY = "0x5c0cdFA92C6645b6ee83e686598DbC29260F885d";
-const FROM_BLOCK = 4394643; // factory deployment block on Robinhood Chain
-
+const FROM_BLOCK = 4394643;
 const TOKEN_CREATED =
   "event TokenCreated(address indexed token, address indexed creator, address indexed curve, string name, string symbol, string metadataURI, uint256 timestamp)";
 
 async function tvl(api) {
-  const logs = await getLogs({
+  const logs = await getLogs2({
     api,
     target: FACTORY,
     fromBlock: FROM_BLOCK,
     eventAbi: TOKEN_CREATED,
-    onlyArgs: true,
   });
   const curves = logs.map((l) => l.curve);
   // Native ETH held by each live curve. Migrated curves hold ~0, so they contribute nothing.
@@ -36,7 +22,5 @@ module.exports = {
   methodology:
     "TVL is the native ETH escrowed in each active bonding curve before graduation. A curve's ETH balance equals its real ETH reserve until it graduates to a Uniswap V2 pool, at which point the ETH exits the curve; the resulting Uniswap LP is counted under Uniswap, not prynt, so there is no double counting.",
   start: "2026-07-07",
-  robinhood: {
-    tvl,
-  },
+  robinhood: { tvl },
 };

--- a/projects/prynt/index.js
+++ b/projects/prynt/index.js
@@ -1,0 +1,43 @@
+// prynt — bonding-curve memecoin launchpad on Robinhood Chain (Arbitrum Orbit L2, chainId 4663).
+//
+// TVL model: every token launches on its own BondingCurve, which custodies real ETH against a
+// constant-product curve until it graduates to Uniswap V2. By the contract's invariant the curve's
+// native ETH balance == its real ETH reserve right up until migration, at which point the ETH leaves
+// the curve for a Uniswap V2 pool (that pool is attributed to Uniswap, not prynt — so we do NOT count
+// it here and there is no double counting). TVL is therefore the sum of native ETH held across every
+// still-active bonding curve. Curves are discovered from the factory's TokenCreated logs.
+//
+// Destination file in the PR: projects/prynt/index.js
+//
+// -----------------------------------------------------------------------------------------------------
+const { getLogs } = require("../helper/cache/getLogs");
+
+const NULL = "0x0000000000000000000000000000000000000000"; // native ETH sentinel for sumTokens
+
+const FACTORY = "0x5c0cdFA92C6645b6ee83e686598DbC29260F885d";
+const FROM_BLOCK = 4394643; // factory deployment block on Robinhood Chain
+
+const TOKEN_CREATED =
+  "event TokenCreated(address indexed token, address indexed creator, address indexed curve, string name, string symbol, string metadataURI, uint256 timestamp)";
+
+async function tvl(api) {
+  const logs = await getLogs({
+    api,
+    target: FACTORY,
+    fromBlock: FROM_BLOCK,
+    eventAbi: TOKEN_CREATED,
+    onlyArgs: true,
+  });
+  const curves = logs.map((l) => l.curve);
+  // Native ETH held by each live curve. Migrated curves hold ~0, so they contribute nothing.
+  return api.sumTokens({ owners: curves, tokens: [NULL] });
+}
+
+module.exports = {
+  methodology:
+    "TVL is the native ETH escrowed in each active bonding curve before graduation. A curve's ETH balance equals its real ETH reserve until it graduates to a Uniswap V2 pool, at which point the ETH exits the curve; the resulting Uniswap LP is counted under Uniswap, not prynt, so there is no double counting.",
+  start: "2026-07-07",
+  robinhood: {
+    tvl,
+  },
+};

--- a/projects/prynt/index.js
+++ b/projects/prynt/index.js
@@ -11,8 +11,7 @@
 //
 // -----------------------------------------------------------------------------------------------------
 const { getLogs } = require("../helper/cache/getLogs");
-
-const NULL = "0x0000000000000000000000000000000000000000"; // native ETH sentinel for sumTokens
+const { nullAddress } = require("../helper/sumTokens"); // canonical native-ETH sentinel for sumTokens
 
 const FACTORY = "0x5c0cdFA92C6645b6ee83e686598DbC29260F885d";
 const FROM_BLOCK = 4394643; // factory deployment block on Robinhood Chain
@@ -30,7 +29,7 @@ async function tvl(api) {
   });
   const curves = logs.map((l) => l.curve);
   // Native ETH held by each live curve. Migrated curves hold ~0, so they contribute nothing.
-  return api.sumTokens({ owners: curves, tokens: [NULL] });
+  return api.sumTokens({ owners: curves, tokens: [nullAddress] });
 }
 
 module.exports = {


### PR DESCRIPTION
Adds a TVL adapter for **prynt**, a bonding-curve memecoin launchpad on **Robinhood Chain** (Arbitrum Orbit L2, chainId 4663 — chain key `robinhood`).

**Methodology:** TVL is the native ETH escrowed in each active bonding curve before graduation. A curve's ETH balance equals its real ETH reserve until it graduates to a Uniswap V2 pool, at which point the ETH exits the curve (that LP is counted under Uniswap, not prynt — no double counting). Curves are discovered from the factory's `TokenCreated` logs.

- Chain: `robinhood`
- Factory: `0x5c0cdFA92C6645b6ee83e686598DbC29260F885d`
- Site: https://www.prynt.fun

Tested with `node test.js projects/prynt/index.js` (runs clean, chain detected, ETH priced).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tracking TVL for the PRYNT bonding-curve ecosystem.
  * TVL now aggregates native ETH balances held by the relevant bonding-curve addresses.
  * Included protocol metadata, including the adapter methodology and the tracking start date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->