### PR TITLE
Add Reflect V1 + V2 TVL adapters (Solana)

### DIFF
--- a/projects/reflect/index.js
+++ b/projects/reflect/index.js
@@ -1,0 +1,7 @@
+// The `reflect` folder hosts two independent Reflect dashboards with different on-chain
+// account schemas, tracked as separate adapters:
+//   - ./v2.js — Reflect V2 (current deployment)
+//   - ./v1.js — Reflect V1 (original deployment; discontinued after the 2026-04-01 Drift exploit)
+// The folder's default adapter is the current version (V2). V1 is listed separately from ./v1.js
+// (it also carries a `deadFrom` and historical-backfill logic that should not merge into V2).
+module.exports = require("./v2.js");

--- a/projects/reflect/v1.js
+++ b/projects/reflect/v1.js
@@ -1,0 +1,161 @@
+const { getProvider } = require("../helper/solana");
+const { queryAllium } = require("../helper/allium");
+const { PublicKey } = require("@solana/web3.js");
+const { bs58 } = require("@project-serum/anchor/dist/cjs/utils/bytes");
+
+// Reflect V1 core program (https://reflect.money), the original deployment.
+// Separate program and DefiLlama dashboard from V2 (./v2.js). V1 uses a DIFFERENT on-chain
+// account schema than V2, so this adapter is intentionally standalone and shares no decoding
+// with v2.js. Like V2, users deposit an SPL (USDC, USDT) into a lending strategy that routes
+// the collateral across external yield venues; TVL is read entirely from on-chain account
+// data, deserialised manually (no IDL/anchor coder).
+const PROGRAM_ID = new PublicKey("rFLctqnUuxLmYsW5r9zNujfJx9hGpnP1csXr9PYwVgX");
+
+// Historical backfill: getProgramAccounts has no time-travel, so for past dates we proxy TVL
+// by each strategy's receipt-token supply (every receipt token is minted 1:1 against deposited
+// collateral, so circulating supply ≈ collateral, within accrued yield ≈ a few %). The supply
+// per day is summed from Allium's solana.assets.balances_daily and valued in the underlying
+// stablecoin (both are 6-decimal, so raw receipt units map 1:1 to underlying units).
+// NOTE: this relies on Allium's balances_daily being a FULL daily snapshot (one row per holder
+// per day, carried forward) — the same assumption the repo's sumTokens2_historical makes — so a
+// plain `SUM(raw_amount) WHERE date = T` equals total supply. (Some providers' daily-balance
+// tables are change-based and would need a carry-forward; Allium's is not.)
+// Curve cross-validated two ways (cumulative mint−burn, and carry-forward balances): peak
+// ~$10.0M on 2025-10-31, ~$1.90M today (matches the live receipt supply), launch 2025-09-11.
+const RECEIPT_TO_UNDERLYING = {
+  usd63SVWcKqLeyNHpmVhZGYAqfE5RHE8jwqjRA2ida2: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", // USDC+ -> USDC
+  uSDtYeMVYuQwhziLKMpdMz74WPFNytoWLGGiU9SDnZx: "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB", // USDT+ -> USDT
+};
+
+// 8-byte account discriminators.
+const MAIN_DISC = Buffer.from([103, 173, 93, 26, 84, 137, 56, 96]); // Anchor `Main`
+const STRATEGY_CONTROLLER_DISC = Buffer.from([13, 167, 93, 202, 196, 161, 163, 0]);
+
+// `Main` layout (Borsh): disc(8) + bump(1) + AccessControl(362) + spls_main: Vec<SplMain> ...
+// V1's AccessControl is 362 bytes (vs 386 in V2), so the vec length prefix sits at offset 371.
+const SPLS_MAIN_OFFSET = 8 + 1 + 362; // 371
+
+// `StrategyController` layout: disc(8) + Base + Rack registry + component data region.
+// Base starts with bump(u8) index(u8) status(u8) mint([u8;32]) ...  (V2 has strategy_type
+// where V1 has status; both are 1-byte, so the mint offset is unchanged.)
+const STRATEGY_INDEX_OFFSET = 9; // disc(8) + bump(1)
+// V1's Base is a fixed 1018 bytes (vs 1100 in V2), shifting the rack down accordingly.
+const RACK_OFFSET = 8 + 1018; // 1026 - start of the 8-entry component registry
+const RACK_REGISTRY_SIZE = 8 * 6; // 8 components * (type u8 + offset u16 + size u16 + version u8)
+const COMPONENT_DATA_OFFSET = RACK_OFFSET + RACK_REGISTRY_SIZE; // 1074
+const COMPONENT_TYPE_AUTOCOMPOUND = 1;
+
+// Map each strategy index -> its underlying collateral mint, from Main's SPL registry.
+// V1 SplMain (Borsh): main_spl_index(u8) mint([u8;32]) oracle([u8;32]) fee(u64) precision(u8)
+//                     strategy_indices: Vec<u8> deposits_suspended(bool)
+// (V1 carries an extra `oracle` pubkey that V2's SplMain does not.)
+function parseStrategyMints(data) {
+  let o = SPLS_MAIN_OFFSET;
+  const count = data.readUInt32LE(o);
+  o += 4;
+  const strategyToMint = {};
+  for (let i = 0; i < count; i++) {
+    o += 1; // main_spl_index
+    const mint = new PublicKey(data.slice(o, o + 32)).toBase58();
+    o += 32;
+    o += 32; // oracle
+    o += 8; // fee
+    o += 1; // precision (DefiLlama applies token decimals at pricing time)
+    const indicesLen = data.readUInt32LE(o);
+    o += 4;
+    for (let j = 0; j < indicesLen; j++) {
+      const strategyIndex = data[o + j];
+      if (strategyToMint[strategyIndex] === undefined) strategyToMint[strategyIndex] = mint;
+    }
+    o += indicesLen;
+    o += 1; // deposits_suspended
+  }
+  return strategyToMint;
+}
+
+// Walk the strategy controller's component registry and return the
+// AutoCompound component's `deposited_vault_value` (first u64): the total
+// collateral currently attributed to vault holders, in the underlying's base units.
+function readDepositedVaultValue(data) {
+  for (let i = 0; i < 8; i++) {
+    const entry = RACK_OFFSET + i * 6;
+    const componentType = data[entry];
+    if (componentType === 0) break; // registry is contiguous; None marks the end
+    if (componentType === COMPONENT_TYPE_AUTOCOMPOUND) {
+      const componentOffset = data.readUInt16LE(entry + 1);
+      return data.readBigUInt64LE(COMPONENT_DATA_OFFSET + componentOffset);
+    }
+  }
+  return 0n;
+}
+
+// Hard stop. On the evening of 2026-04-01 the strategy's capital allocated to Drift Protocol was
+// lost in the Drift exploit and the protocol was frozen. Because it is frozen, the on-chain
+// deposited_vault_value (and the receipt-token supply) are stuck at their pre-exploit value and
+// no longer reflect reality — real TVL is 0 once the loss landed. April 1 still shows its
+// pre-hack value; we force 0 from 2026-04-02 onward, regardless of the (stale) on-chain field.
+const EXPLOIT_DATE = "2026-04-01"; // chart annotation: when the Drift exploit happened
+const DEAD_FROM = "2026-04-02"; // first fully-zero day (hack landed the evening before)
+const DEAD_FROM_TS = Math.floor(Date.parse(DEAD_FROM + "T00:00:00Z") / 1000);
+
+const SECONDS_PER_DAY = 86400;
+const startOfTodayUTC = () => Math.floor(Math.floor(Date.now() / 1000) / SECONDS_PER_DAY) * SECONDS_PER_DAY;
+
+// Historical path: sum each receipt token's circulating supply on the requested day from
+// Allium and value it in the underlying stablecoin. Requires ALLIUM_API_KEY in the env.
+async function tvlHistorical(api) {
+  const date = new Date(api.timestamp * 1000).toISOString().slice(0, 10);
+  const mints = Object.keys(RECEIPT_TO_UNDERLYING).map((m) => `'${m}'`).join(", ");
+  const sql = `
+    SELECT mint, SUM(raw_amount) AS supply
+    FROM solana.assets.balances_daily
+    WHERE date = '${date}'
+      AND mint IN (${mints})
+    GROUP BY mint`.trim();
+  const rows = await queryAllium(sql);
+  for (const row of rows || []) {
+    const underlying = RECEIPT_TO_UNDERLYING[row.mint];
+    if (underlying && row.supply) api.add(underlying, String(row.supply));
+  }
+}
+
+async function tvl(api) {
+  // Hard stop: at/after the Drift-exploit cutoff, real TVL is 0 — never report the frozen value.
+  if (api.timestamp >= DEAD_FROM_TS) return;
+
+  // DefiLlama backfills by re-running at past timestamps; route those to the supply proxy.
+  if (api.timestamp && api.timestamp < startOfTodayUTC()) return tvlHistorical(api);
+
+  const connection = getProvider().connection;
+
+  // Filter by discriminator: V1 has thousands of UserPermissions accounts, so never fetch
+  // the whole program — only the single Main account and the handful of strategy controllers.
+  const mainAccounts = await connection.getProgramAccounts(PROGRAM_ID, {
+    filters: [{ memcmp: { offset: 0, bytes: bs58.encode(MAIN_DISC) } }],
+  });
+  if (!mainAccounts.length) throw new Error("Reflect V1: Main account not found");
+  const strategyToMint = parseStrategyMints(mainAccounts[0].account.data);
+
+  const controllers = await connection.getProgramAccounts(PROGRAM_ID, {
+    filters: [{ memcmp: { offset: 0, bytes: bs58.encode(STRATEGY_CONTROLLER_DISC) } }],
+  });
+
+  for (const { account: { data } } of controllers) {
+    const strategyIndex = data[STRATEGY_INDEX_OFFSET];
+    const mint = strategyToMint[strategyIndex];
+    if (!mint) continue; // no underlying collateral registered for this strategy
+    const deposited = readDepositedVaultValue(data);
+    if (deposited > 0n) api.add(mint, deposited.toString());
+  }
+}
+
+module.exports = {
+  timetravel: true,
+  start: 1757548800, // 2025-09-11, first strategy / receipt mint creation
+  deadFrom: DEAD_FROM, // 2026-04-02: first fully-zero day after the 2026-04-01 evening Drift exploit
+  hallmarks: [[EXPLOIT_DATE, "Drift Protocol exploit; strategy funds lost and protocol frozen"]],
+  methodology:
+    "Live TVL is the total collateral attributed to vault holders across Reflect V1's lending strategies, read on-chain from each strategy controller's AutoCompound deposited_vault_value field and valued in that strategy's underlying SPL (USDC, USDT) resolved from the Main account's SPL registry. Historical TVL (backfill) proxies each strategy by its receipt-token circulating supply for that day (summed from Allium), valued 1:1 in the underlying stablecoin — supply tracks deposited collateral within accrued yield (~a few %). On the evening of 2026-04-01 the capital allocated to Drift was lost in the Drift exploit and the protocol was frozen; because it is frozen the on-chain value is stale, so TVL is forced to 0 from 2026-04-02 onward (deadFrom). Deposited collateral was routed into external venues listed separately on DefiLlama, so TVL is marked doublecounted.",
+  doublecounted: true,
+  solana: { tvl },
+};

--- a/projects/reflect/v2.js
+++ b/projects/reflect/v2.js
@@ -1,0 +1,103 @@
+const { getProvider } = require("../helper/solana");
+const { PublicKey } = require("@solana/web3.js");
+const { bs58 } = require("@project-serum/anchor/dist/cjs/utils/bytes");
+
+// Reflect V2 core program (https://reflect.money). Yield-tokenisation protocol on Solana:
+// users deposit an SPL (e.g. USDC, USDT) into a lending strategy and receive a receipt
+// token; the deposited collateral is routed across external venues (Kamino, Jupiter Lend,
+// MarginFi, Save, Loopscale). TVL is read entirely from on-chain account data and the
+// accounts are deserialised manually (no IDL/anchor coder).
+// V2 and V1 use different on-chain account schemas and are tracked as separate adapters
+// (see ./v1.js) and separate DefiLlama dashboards.
+const PROGRAM_ID = new PublicKey("RfLCtMS8AAqwDyK3RckKk5oarhZoNGx1rkz1BoozRq9");
+
+// 8-byte account discriminators.
+const MAIN_DISC = Buffer.from([103, 173, 93, 26, 84, 137, 56, 96]); // Anchor `Main`
+const STRATEGY_CONTROLLER_DISC = Buffer.from([13, 167, 93, 202, 196, 161, 163, 0]);
+
+// `Main` layout (Borsh): disc(8) + bump(1) + AccessControl(386) + spls_main: Vec<SplMain> ...
+// AccessControl = AccessMap([ActionMapping;48] = 384 + mapping_count 1 = 385) + KillSwitch(1) = 386.
+// Both are fixed-size, so the vec's u32 length prefix sits at a deterministic offset.
+const SPLS_MAIN_OFFSET = 8 + 1 + 386; // 395
+
+// `StrategyController` layout: disc(8) + Base + Rack registry + component data region.
+// Base starts with bump(u8) index(u8) strategy_type(u8) mint([u8;32]) ...
+const STRATEGY_INDEX_OFFSET = 9; // disc(8) + bump(1)
+// Base is a fixed 1100 bytes (STRATEGY_SIZE), then the Rack registry, then component data.
+const RACK_OFFSET = 8 + 1100; // 1108 - start of the 8-entry component registry
+const RACK_REGISTRY_SIZE = 8 * 6; // 8 components * (type u8 + offset u16 + size u16 + version u8)
+const COMPONENT_DATA_OFFSET = RACK_OFFSET + RACK_REGISTRY_SIZE; // 1156
+const COMPONENT_TYPE_AUTOCOMPOUND = 1;
+
+// Map each strategy index -> its underlying collateral mint, from Main's SPL registry.
+// SplMain (Borsh): main_spl_index(u8) mint([u8;32]) fee(u64) precision(u8)
+//                  strategy_indices: Vec<u8> deposits_suspended(bool)
+function parseStrategyMints(data) {
+  let o = SPLS_MAIN_OFFSET;
+  const count = data.readUInt32LE(o);
+  o += 4;
+  const strategyToMint = {};
+  for (let i = 0; i < count; i++) {
+    o += 1; // main_spl_index
+    const mint = new PublicKey(data.slice(o, o + 32)).toBase58();
+    o += 32;
+    o += 8; // fee
+    o += 1; // precision (DefiLlama applies token decimals at pricing time)
+    const indicesLen = data.readUInt32LE(o);
+    o += 4;
+    for (let j = 0; j < indicesLen; j++) {
+      const strategyIndex = data[o + j];
+      if (strategyToMint[strategyIndex] === undefined) strategyToMint[strategyIndex] = mint;
+    }
+    o += indicesLen;
+    o += 1; // deposits_suspended
+  }
+  return strategyToMint;
+}
+
+// Walk the strategy controller's component registry and return the
+// AutoCompound component's `deposited_vault_value` (first u64): the total
+// collateral currently attributed to vault holders, in the underlying's base units.
+function readDepositedVaultValue(data) {
+  for (let i = 0; i < 8; i++) {
+    const entry = RACK_OFFSET + i * 6;
+    const componentType = data[entry];
+    if (componentType === 0) break; // registry is contiguous; None marks the end
+    if (componentType === COMPONENT_TYPE_AUTOCOMPOUND) {
+      const componentOffset = data.readUInt16LE(entry + 1);
+      return data.readBigUInt64LE(COMPONENT_DATA_OFFSET + componentOffset);
+    }
+  }
+  return 0n;
+}
+
+async function tvl(api) {
+  const connection = getProvider().connection;
+
+  const mainAccounts = await connection.getProgramAccounts(PROGRAM_ID, {
+    filters: [{ memcmp: { offset: 0, bytes: bs58.encode(MAIN_DISC) } }],
+  });
+  if (!mainAccounts.length) throw new Error("Reflect: Main account not found");
+  const strategyToMint = parseStrategyMints(mainAccounts[0].account.data);
+
+  const controllers = await connection.getProgramAccounts(PROGRAM_ID, {
+    filters: [{ memcmp: { offset: 0, bytes: bs58.encode(STRATEGY_CONTROLLER_DISC) } }],
+  });
+
+  for (const { account: { data } } of controllers) {
+    const strategyIndex = data[STRATEGY_INDEX_OFFSET];
+    const mint = strategyToMint[strategyIndex];
+    // Strategies with no SPL collateral registered (e.g. the bond basket strategy) are skipped.
+    if (!mint) continue;
+    const deposited = readDepositedVaultValue(data);
+    if (deposited > 0n) api.add(mint, deposited.toString());
+  }
+}
+
+module.exports = {
+  timetravel: false,
+  methodology:
+    "TVL is the total collateral attributed to vault holders across Reflect's lending strategies. For each strategy controller account it is read on-chain from the AutoCompound component's deposited_vault_value field (the underlying collateral's base units) and valued in that strategy's underlying SPL (e.g. USDC, USDT), resolved from the Main account's SPL registry. Deposited collateral is routed into external venues (Kamino, Jupiter Lend, MarginFi, Save, Loopscale) that are listed separately on DefiLlama, so the TVL is marked doublecounted.",
+  doublecounted: true,
+  solana: { tvl },
+};


### PR DESCRIPTION
Adds two standalone Solana adapters under `projects/reflect/`. TVL is read entirely from on-chain account data, deserialized manually (no new npm deps, Solana-only).

- `v2.js` — **Reflect V2** (current), program `RfLCtMS8AAqwDyK3RckKk5oarhZoNGx1rkz1BoozRq9`
- `v1.js` — **Reflect V1** (original), program `rFLctqnUuxLmYsW5r9zNujfJx9hGpnP1csXr9PYwVgX`; discontinued after the 2026-04-01 Drift exploit

Each file maps to its own DefiLlama dashboard (Reflect V1, Reflect V2).
- `index.js` — folder default (re-exports V2) so the repo's folder-level CI can load the adapter; V1 and V2 remain separate dashboards via `v1.js` / `v2.js`.

### Listing info

- **Name(s):** Reflect V2, Reflect V1
- **Twitter:** https://x.com/reflectmoney
- **Website:** https://reflect.money
- **Audits:** https://github.com/palindrome-eng/audits
- **Chain:** Solana
- **Category:** Yield Aggregator
- **Current TVL:** V2 ≈ $0.01 (infra deploying) · V1 $0 (funds lost in Drift exploit; protocol frozen)
- **Coingecko / CMC:** not listed
- **Treasury:** none · **forkedFrom:** none · **Referral program:** no
- **GitHub:** https://github.com/palindrome-eng
- **Short description:** Reflect is a Solana yield protocol: users deposit stablecoins (USDC/USDT) and receive yield-bearing receipt tokens, with the collateral routed across on-chain lending venues (Kamino, Jupiter Lend, MarginFi, Save, Loopscale). (V1 discontinued following the April 2026 Drift exploit.)
- **Oracle:** Protocol uses **Pyth** price feeds internally. The DefiLlama adapter itself uses no oracle — TVL is read directly from on-chain account balances / vault accounting and priced by DefiLlama.

### Token addresses (receipt tokens)

- **V2:** `USDvv9Dst5KLrwd61AStBPzLF93MpebsuKDSzJ5xT9i`, `UsdaiNeTrorKL2n7VP5QJRbV2DPz3Ymonk1sP9iajfU`, `bondNKkoPV3axmrdfwV93NAbsWLxKkUPDtzaBFy1Lmc`
- **V1:** `usd63SVWcKqLeyNHpmVhZGYAqfE5RHE8jwqjRA2ida2` (USDC+), `uSDtYeMVYuQwhziLKMpdMz74WPFNytoWLGGiU9SDnZx` (USDT+)
- Underlying collateral counted as TVL: USDC, USDT

### Methodology

- **V2:** sums each strategy controller's `AutoCompound.deposited_vault_value` (collateral attributed to holders), valued in the strategy's underlying SPL (USDC/USDT) resolved from the `Main` account SPL registry.
- **V1:** same live methodology; historical backfill proxies TVL by daily receipt-token supply (via Allium `solana.assets.balances_daily`) valued in the underlying stablecoin. `deadFrom: 2026-04-02` forces TVL to 0 after the Drift loss + freeze (the on-chain field is frozen/stale). Both adapters are `doublecounted` (collateral sits in externally-listed venues).

### Logo

<!-- DRAG Reflect.png (600x600 PNG) HERE -->

---
"Allow edits by maintainers" is enabled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added new Reflect TVL adapters for Solana: V1 (including historical backfill) and V2.
  * V1 reports underlying stablecoin balances derived from on-chain strategy deposits.
  * V2 computes Reflect “V2” TVL from on-chain account data.
  * Updated the Reflect entry point to default to the V2 adapter.
* **Bug Fixes**
  * Prevents outdated V1 TVL reporting after the protocol cutoff date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->