### PR TITLE
Add Curvance vault adapter and configure curvance adaptor to not pull in vault markets

### DIFF
--- a/projects/curvance-vaults/index.js
+++ b/projects/curvance-vaults/index.js
@@ -37,24 +37,26 @@ Object.keys(config).forEach(chain => {
     return uniqueMarkets.filter(m => !blcklistedMarkets.includes(String(m).toLowerCase()))
   }
 
-  async function getMarkets(api) {
+  async function getVaults(api) {
     const markets = await getListedMarkets(api)
-    const optimizerVaultMarkets = new Set((await getOptimizerVaultMarkets(api, markets)).map(m => String(m).toLowerCase()))
-    return markets.filter(m => !optimizerVaultMarkets.has(String(m).toLowerCase()))
+    const vaultMarkets = await getOptimizerVaultMarkets(api, markets)
+    const vaults = await api.multiCall({ abi: 'address:asset', calls: vaultMarkets })
+    return [...new Map(vaults.map(v => [String(v).toLowerCase(), v])).values()]
   }
 
   module.exports[chain] = {
     tvl: async (api) => {
-      const contracts = await getMarkets(api)
-      const tokens = await api.multiCall({ abi: 'address:asset', calls: contracts })
-      return sumTokens2({ api, tokensAndOwners2: [tokens, contracts] })
+      const vaults = await getVaults(api)
+      const tokens = await api.multiCall({ abi: 'address:asset', calls: vaults })
+      const supplies = await api.multiCall({ abi: 'uint256:totalSupply', calls: vaults })
+      const balances = await api.multiCall({
+        abi: 'function convertToAssets(uint256 shares) view returns (uint256)',
+        calls: vaults.map((target, i) => ({ target, params: [supplies[i]] })),
+      })
+      api.add(tokens, balances)
+      return sumTokens2({ api })
     },
-    borrowed: async (api) => {
-      const contracts = await getMarkets(api)
-      const tokens = await api.multiCall({ abi: 'address:asset', calls: contracts })
-      const bals = await api.multiCall({ abi: 'uint256:marketOutstandingDebt', calls: contracts })
-      api.add(tokens, bals)
-      return sumTokens2({ api, })
-    }
   }
 })
+
+module.exports.doublecounted = true


### PR DESCRIPTION
Adds a new `curvance-vaults` adapter for Curvance lending optimizer vault TVL and updates the existing `curvance` adapter to exclude lending optimizer share cToken markets from the parent adapter.

TVL is computed from onchain data. The adapters discover listed Curvance cToken markets from the central registry via `marketManagers()` and `queryTokensListed()`.

For the parent `curvance` adapter:
- listed cToken markets are kept as before
- lending optimizer share cToken markets are excluded programmatically
- detection uses the cToken market name suffix plus an optimizer guard on the cToken asset via `numApprovedMarkets() > 0`

For the new `curvance-vaults` adapter:
- optimizer vaults are discovered from the same listed market set
- TVL is reported from the vault token’s underlying `asset()`
- balances are computed with `totalSupply()` and `convertToAssets(totalSupply)`
- `doublecounted` is set to `true`

Tested with:
- `node test.js projects/curvance/index.js`
- `node test.js projects/curvance-vaults/index.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for Curvance vaults, including support for vault-based market discovery and asset conversion.

* **Bug Fixes**
  * Improved market filtering so certain vault-related markets are excluded from TVL and borrowed calculations.
  * Added safeguards to avoid counting blocked or duplicated markets in totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->