### PR TITLE
term-structure: track TermMax V2.01 factories on remaining chains

### DIFF
--- a/projects/term-structure/index.js
+++ b/projects/term-structure/index.js
@@ -67,6 +67,11 @@ const ADDRESSES = {
         address: "0x18b8A9433dBefcd15370F10a75e28149bcc2e301",
         fromBlock: 385228046,
       },
+      // TermMax V2.01 (same MarketCreated event signature)
+      {
+        address: "0xcaF2632BdB12Aa20b17f3E80CeAF9781b4aD4F38",
+        fromBlock: 452316723,
+      },
     ],
     VaultFactory: [
       {
@@ -78,6 +83,11 @@ const ADDRESSES = {
       {
         address: "0xa7c93162962D050098f4BB44E88661517484C5EB",
         fromBlock: 385228046,
+      },
+      // TermMax V2.01 (same VaultCreated event signature)
+      {
+        address: "0x85C5B725841bE392384aa7df599c00aE7516E4d3",
+        fromBlock: 452316743,
       },
     ],
     TermMax4626Factory: [
@@ -172,6 +182,11 @@ const ADDRESSES = {
         address: "0xc53ab74eeb5e818147eb6d06134d81d3ac810987",
         fromBlock: 23488600,
       },
+      // TermMax V2.01 (same MarketCreated event signature)
+      {
+        address: "0xc1E9640F04B802Bbf0B02a4e9Fe394039AbE8B59",
+        fromBlock: 24876010,
+      },
     ],
     VaultFactory: [
       {
@@ -198,6 +213,11 @@ const ADDRESSES = {
         address: "0x5b8B26a6734B5eABDBe6C5A19580Ab2D0424f027",
         fromBlock: 23430000,
       },
+      // TermMax V2.01 (same VaultCreated event signature)
+      {
+        address: "0x5Ad6a60C71AE49e0e6DDb1a4CdC9a1B2a3D5F7d0",
+        fromBlock: 24876015,
+      },
     ],
   },
   berachain: {
@@ -206,11 +226,21 @@ const ADDRESSES = {
         address: "0x4BC4F8f9B212B5a3F9f7Eeb35Ae1A91902670F7f",
         fromBlock: 11541952,
       },
+      // TermMax V2.01 (same MarketCreated event signature)
+      {
+        address: "0x2A15CC106bCa1Ee17a411d77A9C53eC3509d47C2",
+        fromBlock: 19569241,
+      },
     ],
     VaultFactoryV2: [
       {
         address: "0x65fC69DE62E11592E8Acf57a0c97535209090Ef1",
         fromBlock: 11541953,
+      },
+      // TermMax V2.01 (same VaultCreated event signature)
+      {
+        address: "0xd427EBAF1D269b397C454b22791b63534F1ae5B2",
+        fromBlock: 19569247,
       },
     ],
     TermMax4626Factory: [
@@ -237,11 +267,21 @@ const ADDRESSES = {
         address: "0x33931f3898EfB9A42B0D7CFfa9bb50A566A6b421",
         fromBlock: 28981154,
       },
+      // TermMax V2.01 (same MarketCreated event signature)
+      {
+        address: "0x5BA2d33fB50d08D7755787E729183FedD6a3F3e7",
+        fromBlock: 31495773,
+      },
     ],
     VaultFactoryV2: [
       {
         address: "0x276C0E52508d94ff2D4106b1559c8c4Bc3a75dec",
         fromBlock: 28981154,
+      },
+      // TermMax V2.01 (same VaultCreated event signature)
+      {
+        address: "0x3Ebb9e9C855Bd03b275167DD2418193E3b69C22f",
+        fromBlock: 31495780,
       },
     ],
     TermMax4626Factory: [
@@ -254,11 +294,21 @@ const ADDRESSES = {
         address: "0xFaD175CAf9B0Ac0EBca3B1816ec799884EB04B9c",
         fromBlock: 50664655,
       },
+      // TermMax V2.01 (same MarketCreated event signature)
+      {
+        address: "0x3d2C215DE72877c3611cD0A9D8d69f60f1a5dB93",
+        fromBlock: 57387356,
+      },
     ],
     VaultFactoryV2: [
       {
         address: "0x2e1c769A9BA8248C7c8128c2BEBa11331ebF98Aa",
         fromBlock: 50664655,
+      },
+      // TermMax V2.01 (same VaultCreated event signature)
+      {
+        address: "0xcA470095CC2D6aE6382c72bD235a2A5D7E80E1c1",
+        fromBlock: 57387362,
       },
     ],
     TermMax4626Factory: [
@@ -273,9 +323,15 @@ const ADDRESSES = {
       },
       // TermMax V2.01 (same MarketCreated event signature)
       {
+        address: "0x08c50Bd46992d35694208eC3Cf1f1EDcE38f5fd1",
+        fromBlock: 44680217,
+      },
+      // Start of TermMax Alpha
+      {
         address: "0x2aFEf28a8Ab57d2F5A5663Ef69351e9d3abf1779",
         fromBlock: 47709827,
       },
+      // End of TermMax Alpha
     ],
     VaultFactoryV2: [
       {


### PR DESCRIPTION
## What

Extend TermMax **V2.01** factory tracking to the chains that did not have it yet.

BSC (#19551) and Base (#19769) already tracked V2.01 factories. This PR brings the remaining chains up to parity, and backfills one V2.01 factory that was missed on Base.

V2.01 shares the `MarketCreated` / `VaultCreated` event signatures with V2, so the new addresses are appended to the existing `FactoryV2` / `VaultFactoryV2` arrays.

## Factories added

| Chain | Market V2.01 | Vault V2.01 |
|---|---|---|
| arbitrum | `0xcaF2632BdB12Aa20b17f3E80CeAF9781b4aD4F38` | `0x85C5B725841bE392384aa7df599c00aE7516E4d3` |
| ethereum | `0xc1E9640F04B802Bbf0B02a4e9Fe394039AbE8B59` | `0x5Ad6a60C71AE49e0e6DDb1a4CdC9a1B2a3D5F7d0` |
| berachain | `0x2A15CC106bCa1Ee17a411d77A9C53eC3509d47C2` | `0xd427EBAF1D269b397C454b22791b63534F1ae5B2` |
| bsquared | `0x5BA2d33fB50d08D7755787E729183FedD6a3F3e7` | `0x3Ebb9e9C855Bd03b275167DD2418193E3b69C22f` |
| xlayer | `0x3d2C215DE72877c3611cD0A9D8d69f60f1a5dB93` | `0xcA470095CC2D6aE6382c72bD235a2A5D7E80E1c1` |
| base | `0x08c50Bd46992d35694208eC3Cf1f1EDcE38f5fd1` (main; was missed — alpha was already tracked) | already complete |

## Test

`LLAMA_DEBUG_MODE=true node test.js projects/term-structure/index.js` runs clean across all 8 chains, total TVL ~33.9M, no ABI/decode errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional TermMax V2.01 market and vault deployments across multiple chains, improving discovery and scanning coverage for newly created contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->