### PR TITLE
fix vara bridge

### DIFF
--- a/projects/vara-ethereum-bridge/index.js
+++ b/projects/vara-ethereum-bridge/index.js
@@ -4,12 +4,15 @@ const { post } = require('../helper/http')
 
 const ERC20_MANAGER = '0x16fCff97822fcf3345Fa76D29c229b11C49EaE12';
 
-// Storage key: SYSTEM_ACCOUNT_PREFIX + blake2_128(TOKENIZED_VARA) + TOKENIZED_VARA
-// 1. SYSTEM_ACCOUNT_PREFIX: 26aa394eea5630e07c48ae0c9558cef7b99d880ec681799c0cf30e8886371da9 - xxHash128("System") + xxHash128("Account"): https://github.com/paritytech/polkadot-sdk/blob/master/substrate/frame/system/src/lib.rs#L977
-// 2. blake2_128(tokenized_vara): 2be216337508815d413700122d15f57f - prefix for the AccountId key: https://github.com/paritytech/polkadot-sdk/blob/master/substrate/frame/support/src/hash.rs#L143
-// 3. TOKENIZED_VARA: 29c42c668012b1ce20720e4615229215023281ef4676fdc77bf047d7fbcb9d17
-const VARA_BALANCE_STORAGE_KEY = '0x26aa394eea5630e07c48ae0c9558cef7b99d880ec681799c0cf30e8886371da92be216337508815d413700122d15f57f29c42c668012b1ce20720e4615229215023281ef4676fdc77bf047d7fbcb9d17';
 const VARA_RPC = 'https://rpc.vara.network'
+const WVARA_VFT = '0x29c42c668012b1ce20720e4615229215023281ef4676fdc77bf047d7fbcb9d17'
+const VFT_MANAGER = '0xe01ddc667f80cf57704352b557668b710c345395abcac0752c01402d16e3e81b'
+const GAS_LIMIT = 750000000000
+
+// SCALE-encode a string: https://github.com/paritytech/parity-scale-codec
+function scaleStr(s) { const b = Buffer.from(s, 'utf8'); return Buffer.concat([Buffer.from([b.length << 2]), b]) }
+// A sails request/reply is prefixed with its route (e.g. Vft::BalanceOf): https://github.com/gear-tech/sails/blob/master/js/src/prefix.ts
+const ROUTE = Buffer.concat([scaleStr('Vft'), scaleStr('BalanceOf')])
 
 async function tvl(api) {
     await sumTokens2({
@@ -25,22 +28,24 @@ async function tvl(api) {
 }
 
 async function varaTvl(api) {
-    const { result } = await post(VARA_RPC, {
-        jsonrpc: '2.0', id: 1, method: 'state_getStorage', params: [VARA_BALANCE_STORAGE_KEY],
+    const account = Buffer.from(VFT_MANAGER.slice(2), 'hex')
+    const reqPayload = '0x' + Buffer.concat([ROUTE, account]).toString('hex')
+    const { result, error } = await post(VARA_RPC, {
+        jsonrpc: '2.0', id: 1, method: 'gear_calculateReplyForHandle',
+        params: ['0x' + '0'.repeat(64), WVARA_VFT, reqPayload, GAS_LIMIT, 0],
     })
-    if (!result) return
+    if (error || !result || !result.payload || result.payload === '0x')
+        throw new Error(`vara: failed to read vft-manager WVARA balance: ${JSON.stringify(error || (result && result.code))}`)
 
-    // AccountInfo<u32, AccountData<u128>>: nonce u32, consumers u32, providers u32, sufficients u32,
-    // then AccountData { free u128, reserved u128, frozen u128, flags u128 } — free starts at byte 16.
-    // AccountInfo: https://github.com/paritytech/polkadot-sdk/blob/master/substrate/frame/system/src/lib.rs#L1236
-    // AccountData: https://github.com/paritytech/polkadot-sdk/blob/master/substrate/frame/balances/src/types.rs#L109
-    const bytes = Buffer.from(result.slice(2), 'hex')
-    const free = bytes.readBigUInt64LE(16) | (bytes.readBigUInt64LE(24) << 64n)
-    api.addCGToken('vara-network', Number(free) / 1e12)
+    // returned as <route><balance> so we strip route prefix
+    const bytes = Buffer.from(result.payload.slice(2), 'hex').slice(ROUTE.length)
+    let bal = 0n
+    for (let i = bytes.length - 1; i >= 0; i--) bal = (bal << 8n) | BigInt(bytes[i])
+    api.addCGToken('vara-network', Number(bal) / 1e12)
 }
 
 module.exports = {
-    methodology: 'TVL is calculated as the sum of the value of tokens locked on the ERC20Manager contract and the value of VARA tokens bridged from the Vara Network. Only tokens officially supported by the Vara ⇌ Ethereum Bridge are counted.',
+    methodology: 'On Ethereum, TVL is the value of tokens locked in the ERC20Manager contract (which back their tokenized versions on Vara). On Vara, TVL is the value of VARA bridged to Ethereum, measured as the WVARA locked in the vft-manager (the collateral backing WVARA minted on Ethereum). Only tokens officially supported by the Vara ⇌ Ethereum Bridge are counted.',
     ethereum: { tvl },
     vara: { tvl: varaTvl },
 };


### PR DESCRIPTION
track wvara inside the VFTManager instead of vara in wvara: https://wiki.gear.foundation/docs/vara-network/bridge/developer_hub#vara-mainnet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Vara-side TVL calculation by fetching the WVARA balance through a live JSON-RPC query instead of relying on a stored balance value.
  * Added response checks and safer balance parsing to avoid incorrect totals when the remote call returns an error or empty result.

* **Documentation**
  * Updated the methodology description to provide a clearer explanation of how TVL is calculated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->