### PR TITLE
add LiquidCore TVL

### DIFF
--- a/projects/liquidcore/index.js
+++ b/projects/liquidcore/index.js
@@ -1,0 +1,33 @@
+const ROUTER = '0x625aC1D165c776121A52ff158e76e3544B4a0b8B'
+const ROUTER_DEPLOYED_DATE = '2026-03-03'
+// Pools that existed before the router (and its getPools registry) was deployed
+const LEGACY_POOLS = [
+  '0xA7478A5ff7cB27A8008D6D90785db10223bc6087',
+  '0xD3994A6CF46cA91536376f89aCDadf92eD289a9F',
+]
+
+async function tvl(api) {
+  const dateString = new Date(api.timestamp * 1000).toISOString().slice(0, 10)
+  const pools = dateString <= ROUTER_DEPLOYED_DATE
+    ? LEGACY_POOLS
+    : await api.call({ target: ROUTER, abi: 'address[]:getPools' })
+  const tokens = await api.multiCall({
+    abi: 'function getTokens() view returns (address token0, address token1)',
+    calls: pools,
+    permitFailure: true,
+  })
+  const tokensAndOwners = []
+  pools.forEach((pool, i) => {
+    if (!tokens[i]) return
+    tokensAndOwners.push([tokens[i].token0, pool], [tokens[i].token1, pool])
+  })
+  return api.sumTokens({ tokensAndOwners })
+}
+
+module.exports = {
+  methodology: 'Total value of all coins held in the LiquidCore pool contracts.',
+  start: '2025-11-09', // first LiquidCore pool (USD₮0/WHYPE) deployment
+  hyperliquid: {
+    tvl,
+  },
+}

--- a/projects/liquidcore/index.js
+++ b/projects/liquidcore/index.js
@@ -1,20 +1,22 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+
 const ROUTER = '0x625aC1D165c776121A52ff158e76e3544B4a0b8B'
-const ROUTER_DEPLOYED_DATE = '2026-03-03'
-// Pools that existed before the router (and its getPools registry) was deployed
+const ROUTER_FROM_BLOCK = 28736539
 const LEGACY_POOLS = [
   '0xA7478A5ff7cB27A8008D6D90785db10223bc6087',
   '0xD3994A6CF46cA91536376f89aCDadf92eD289a9F',
 ]
 
 async function tvl(api) {
-  const dateString = new Date(api.timestamp * 1000).toISOString().slice(0, 10)
-  const pools = dateString <= ROUTER_DEPLOYED_DATE
-    ? LEGACY_POOLS
-    : await api.call({ target: ROUTER, abi: 'address[]:getPools' })
+  const pools = [...LEGACY_POOLS]
+  if (await api.getBlock() >= ROUTER_FROM_BLOCK) {
+    const registered = await api.call({ target: ROUTER, abi: 'address[]:getPools' })
+    for (const pool of registered)
+      if (pool !== ADDRESSES.null && !pools.includes(pool)) pools.push(pool)
+  }
   const tokens = await api.multiCall({
     abi: 'function getTokens() view returns (address token0, address token1)',
     calls: pools,
-    permitFailure: true,
   })
   const tokensAndOwners = []
   pools.forEach((pool, i) => {
@@ -27,7 +29,5 @@ async function tvl(api) {
 module.exports = {
   methodology: 'Total value of all coins held in the LiquidCore pool contracts.',
   start: '2025-11-09', // first LiquidCore pool (USD₮0/WHYPE) deployment
-  hyperliquid: {
-    tvl,
-  },
+  hyperliquid: { tvl },
 }


### PR DESCRIPTION
Adds TVL metric to [LiquidCore](https://defillama.com/protocol/liquidcore).

Test run on historical data:

<img width="2000" height="1000" alt="liquidcore_tvl copy" src="https://github.com/user-attachments/assets/34f9176d-fe40-4f3e-b262-21e4cc735b12" />

Live page:
https://liqd.ag/pools

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added Hyperliquid TVL support for the Liquidcore project.
  * TVL now automatically accounts for both legacy pools and the newer router-registered pool set to keep totals consistent across upgrades.
  * Includes adapter metadata (including methodology and reporting start) for clearer transparency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->