### PR TITLE
 add PupCup Hammer bridge TVL adapter (Ethereum + Base)

### DIFF
--- a/projects/pupcup-hammer/index.js
+++ b/projects/pupcup-hammer/index.js
@@ -1,0 +1,17 @@
+const { sumTokensExport } = require('../helper/sumTokens')
+
+module.exports = {
+  methodology: "TVL is the total PUPCUP tokens held in PupCup Hammer's bridge escrow contracts on Ethereum and Base. Tokens are locked in escrow while bridged between chains.",
+  ethereum: {
+    tvl: sumTokensExport({
+      owner: '0x28c0cd9a2cda9f84011a8da9826d2ece5e7bc731',
+      tokens: ['0x884649f1fE3Bf3Ae0Bd720Eaf660cB561dcE39ef'],
+    }),
+  },
+  base: {
+    tvl: sumTokensExport({
+      owner: '0x8c16a30c63964bbe29f83241a574cbeaae2ba6dc',
+      tokens: ['0x42bab297f90e6285546f05abdf4c42d8415e9794'],
+    }),
+  },
+}


### PR DESCRIPTION
Relates to #19347.

Tracks PUPCUP tokens held in PupCup Hammer's bridge escrow contracts on Ethereum and Base — tokens are locked in escrow while bridged between chains.

Verified on-chain:
- Ethereum escrow (0x28c0cd9a...): ~102.4M PUPCUP
- Base escrow (0x8c16a30c...): ~471 PUPCUP (this address uses EIP-7702 delegation to MetaMask's audited Delegation Framework contract  confirmed real, substantial implementation bytecode, not a placeholder)

Note: PUPCUP currently has no price feed in coins.llama.fi, so TVL will show $0 until the token is priced (e.g. CoinGecko listing). Balances are confirmed real and non-zero on-chain via direct balanceOf calls.

Staking vaults (PupCupStakingVaultETH/Base) mentioned in the original issue are not included here  their addresses weren't provided. Happy to add as a follow-up PR once available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for PUPCUP tokens held in bridge escrow across Ethereum and Base.
  * Included methodology details describing how escrowed token balances are calculated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->