### PR TITLE
add usdc to evedex treasury

### DIFF
--- a/registries/treasury.js
+++ b/registries/treasury.js
@@ -1873,7 +1873,7 @@ const configs = {
       owners: ['0x77075c627e51145d54e4EDD54Afa169DA7ff8A17'],
     },
     arbitrum: {
-      tokens: [ADDRESSES.arbitrum.USDT],
+      tokens: [ADDRESSES.arbitrum.USDT, ADDRESSES.arbitrum.USDC_CIRCLE],
       owners: ['0x16a4f9904e222D298Ac71aA3E3Bd5C19B902C595'],
     },
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for tracking Circle-issued USDC alongside USDT in the Arbitrum treasury configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->