### PR TITLE
feat: refactor rigoblock adapter

### DIFF
--- a/projects/rigoblock/index.js
+++ b/projects/rigoblock/index.js
@@ -4,133 +4,140 @@ const { sumTokens2 } = require('../helper/unwrapLPs')
 const { getUniqueAddresses } = require('../helper/tokenMapping')
 
 const activeTokensAbi = 'function getActiveTokens() view returns ((address[] activeTokens, address baseToken))'
-const tokenIdsAbi = 'function getUniV4TokenIds() view returns (uint256[])'
-const ownerOfAbi = 'function ownerOf(uint256 tokenId) view returns (address)'
+const activeAppsAbi = 'function getActiveApplications() view returns (uint256)'
+const appBalancesAbi = 'function getAppTokenBalances(uint256) returns (((address,int256)[],uint256)[])'
 
 const REGISTRY = '0x06767e8090bA5c4Eca89ED00C3A719909D503ED6' // same on all chains
 
 module.exports = {
-  methodology: `RigoBlock TVL on Ethereum, Arbitrum, Optimism, BSC, Base, and Unichain pulled from onchain data, including Uniswap V4 liquidity position balances (excluding GRG balances). Staking TVL includes staked GRG, plus GRG balances in Uniswap V4 liquidity positions, and GRG balances held by smart pool contracts.`,
+  methodology: 'RigoBlock TVL is computed by summing the on-chain token balances held by each smart pool and the token balances of its external positions, as reported by the protocol\'s own NAV method. GRG is excluded from TVL and reported separately as staking.',
 }
 
 const config = {
   ethereum: {
     fromBlock: 15817831,
-    GRG_VAULT_ADDRESSES: '0xfbd2588b170Ff776eBb1aBbB58C0fbE3ffFe1931',
-    GRG_TOKEN_ADDRESSES: '0x4FbB350052Bca5417566f188eB2EBCE5b19BC964',
-    UNISWAP_V4_POSM: '0xbD216513d74C8cf14cf4747E6AaA6420FF64ee9e',
+    GRG_TOKEN_ADDRESS: '0x4FbB350052Bca5417566f188eB2EBCE5b19BC964',
   },
   arbitrum: {
     fromBlock: 32290603,
-    GRG_VAULT_ADDRESSES: '0xE86a667F239A2531C9d398E81154ba125030497e',
-    GRG_TOKEN_ADDRESSES: '0x7F4638A58C0615037deCc86f1daE60E55fE92874',
-    UNISWAP_V4_POSM: '0xd88F38F930b7952f2DB2432Cb002E7abbF3dD869',
+    GRG_TOKEN_ADDRESS: '0x7F4638A58C0615037deCc86f1daE60E55fE92874',
   },
   optimism: {
     fromBlock: 31239008,
-    GRG_VAULT_ADDRESSES: '0x5932C223186F7856e08A1D7b35ACc2Aa5fC57BfD',
-    GRG_TOKEN_ADDRESSES: '0xEcF46257ed31c329F204Eb43E254C609dee143B3',
-    UNISWAP_V4_POSM: '0x3C3Ea4B57a46241e54610e5f022E5c45859A1017',
+    GRG_TOKEN_ADDRESS: '0xEcF46257ed31c329F204Eb43E254C609dee143B3',
   },
   bsc: {
     fromBlock: 25550259,
-    GRG_VAULT_ADDRESSES: '0x5494B4193961a467039B92CCfE0138Fe353240d6',
-    GRG_TOKEN_ADDRESSES: '0x3d473C3eF4Cd4C909b020f48477a2EE2617A8e3C',
-    UNISWAP_V4_POSM: '0x7A4a5c919aE2541AeD11041A1AEeE68f1287f95b',
+    GRG_TOKEN_ADDRESS: '0x3d473C3eF4Cd4C909b020f48477a2EE2617A8e3C',
   },
   base: {
     fromBlock: 2568188,
-    GRG_VAULT_ADDRESSES: '0x7a7fa66B97a9e009ecAB4bCD62e87b2c0b65F21D',
-    GRG_TOKEN_ADDRESSES: '0x09188484e1Ab980DAeF53a9755241D759C5B7d60',
-    UNISWAP_V4_POSM: '0x7C5f5A4bBd8fD63184577525326123B519429bDc',
+    GRG_TOKEN_ADDRESS: '0x09188484e1Ab980DAeF53a9755241D759C5B7d60',
   },
   unichain: {
     fromBlock: 16121670,
-    GRG_VAULT_ADDRESSES: '0x448366d7C2e0af67D3723De875b7eAf548474A37',
-    GRG_TOKEN_ADDRESSES: '0x03C2868c6D7fD27575426f395EE081498B1120dd',
-    UNISWAP_V4_POSM: '0x4529A01c7A0410167c5740C487A8DE60232617bf',
+    GRG_TOKEN_ADDRESS: '0x03C2868c6D7fD27575426f395EE081498B1120dd',
+  },
+  polygon: {
+    fromBlock: 34751611,
+    GRG_TOKEN_ADDRESS: '0xbc0bea8e634ec838a2a45f8a43e7e16cd2a8ba99',
   },
 }
 
 Object.keys(config).forEach(chain => {
-  const { fromBlock, GRG_TOKEN_ADDRESSES, GRG_VAULT_ADDRESSES, UNISWAP_V4_POSM } = config[chain]
+  const { fromBlock, GRG_TOKEN_ADDRESS } = config[chain]
+  const poolInfoByBlock = {} // cached per block, shared by tvl and staking
+
+  async function getPoolInfo(api) {
+    const block = api.block
+    if (!poolInfoByBlock[block]) poolInfoByBlock[block] = _getPoolInfo(api)
+    return poolInfoByBlock[block]
+  }
+
   module.exports[chain] = {
     tvl: async (api) => {
-      const { pools, tokens, uniV4Ids } = await getPoolInfo(api)
-      await sumTokens2({ owner: UNISWAP_V4_POSM, tokens, api, blacklistedTokens: [GRG_TOKEN_ADDRESSES], resolveUniV4: true, uniV4ExtraConfig: { positionIds: uniV4Ids } })
-      return sumTokens2({ owners: pools, tokens, api, blacklistedTokens: [GRG_TOKEN_ADDRESSES] })
+      const { pools, tokens, appBalances } = await getPoolInfo(api)
+
+      // Add external application balances (everything except GRG)
+      for (const { token, amount } of appBalances) {
+        if (token.toLowerCase() === GRG_TOKEN_ADDRESS.toLowerCase()) continue
+        if (BigInt(amount) > 0n) api.add(token, amount)
+      }
+
+      // Add smart pool owned token balances (excluding GRG)
+      return sumTokens2({ owners: pools, tokens, api, blacklistedTokens: [GRG_TOKEN_ADDRESS] })
     },
     staking: async (api) => {
-      const { pools, uniV4Ids, UNISWAP_V4_POSM } = await getPoolInfo(api)
-      // Add GRG balances from vaults
-      const bals = await api.multiCall({ abi: 'erc20:balanceOf', calls: pools, target: GRG_VAULT_ADDRESSES })
-      bals.forEach(i => api.add(GRG_TOKEN_ADDRESSES, i))
-      // Aggregate GRG from vaults, ERC20 pool balances, and Uniswap V4 positions in a single call
-      await sumTokens2({ owner: UNISWAP_V4_POSM, tokens: [GRG_TOKEN_ADDRESSES], api, uniV3WhitelistedTokens: [GRG_TOKEN_ADDRESSES], resolveUniV4: true, uniV4ExtraConfig: { positionIds: uniV4Ids } })
-      return sumTokens2({ owners: pools, tokens: [GRG_TOKEN_ADDRESSES], api, uniV3WhitelistedTokens: [GRG_TOKEN_ADDRESSES] })
+      const { pools, appBalances } = await getPoolInfo(api)
+
+      // Add GRG balances from external applications
+      for (const { token, amount } of appBalances) {
+        if (token.toLowerCase() === GRG_TOKEN_ADDRESS.toLowerCase() && BigInt(amount) > 0n) {
+          api.add(GRG_TOKEN_ADDRESS, amount)
+        }
+      }
+
+      // Add GRG balances held directly by smart pools
+      return sumTokens2({ owners: pools, tokens: [GRG_TOKEN_ADDRESS], api })
     },
   }
 
-  async function getPoolInfo(api) {
-    const poolKey = `${api.chain}-${api.block}`
-    if (!poolData[poolKey]) poolData[poolKey] = _getPoolInfo()
-    return poolData[poolKey]
+  async function _getPoolInfo(api) {
+    // Fetch pool addresses from registry logs
+    const registeredLogs = await getLogs({
+      api,
+      target: REGISTRY,
+      fromBlock,
+      topic: 'Registered(address,address,bytes32,bytes32,bytes32)',
+      onlyArgs: true,
+      eventAbi: 'event Registered(address indexed group, address pool, bytes32 indexed name, bytes32 indexed symbol, bytes32 id)'
+    })
+    const pools = registeredLogs.map(i => i.pool)
 
-    async function _getPoolInfo() {
-      // Fetch pool addresses from registry logs
-      const registeredLogs = await getLogs({
-        api,
-        target: REGISTRY,
-        fromBlock,
-        topic: 'Registered(address,address,bytes32,bytes32,bytes32)',
-        onlyArgs: true,
-        eventAbi: 'event Registered(address indexed group, address pool, bytes32 indexed name, bytes32 indexed symbol, bytes32 id)'
-      })
-      const pools = registeredLogs.map(i => i.pool)
-
-      // Fetch active tokens and base token for each pool
-      const tokenData = await api.multiCall({
+    // Fetch active tokens and active application flags for each pool in parallel
+    const [tokenData, appFlags] = await Promise.all([
+      api.multiCall({
         abi: activeTokensAbi,
         calls: pools,
         permitFailure: true, // V3 pools do not have activeTokens
-      })
-      const validTokenData = tokenData.filter(data => data !== null)
-
-      const tokens = validTokenData.flatMap(i => i.activeTokens)
-      const baseTokens = validTokenData.map(i => i.baseToken).filter(Boolean)
-      const allTokens = [...tokens, ...baseTokens]
-
-      // Fetch Uniswap V4 position tokenIds for all pools
-      const tokenIdsData = await api.multiCall({
-        abi: tokenIdsAbi,
+      }),
+      api.multiCall({
+        abi: activeAppsAbi,
         calls: pools,
-        permitFailure: true, // Allow pools without tokenIds
-      })
+        permitFailure: true, // V3 pools do not have getActiveApplications
+      }),
+    ])
 
-      // Prepare Uniswap V4 position IDs
-      const uniV4Ids = []
-      for (let i = 0; i < pools.length; i++) {
-        const pool = pools[i]
-        const tokenIds = tokenIdsData[i] || []
-        if (tokenIds.length === 0) continue
+    const validTokenData = tokenData.filter(data => data !== null)
+    const tokens = validTokenData.flatMap(i => i.activeTokens)
+    const baseTokens = validTokenData.map(i => i.baseToken).filter(Boolean)
+    const uniqueTokens = getUniqueAddresses([...tokens, ...baseTokens])
 
-        // Verify ownership with POSM
-        const owners = await api.multiCall({
-          abi: ownerOfAbi,
-          calls: tokenIds.map(id => ({ target: UNISWAP_V4_POSM, params: [id] })),
-          permitFailure: true,
-        })
+    // Fetch all external application token balances for each pool
+    const appBalancesData = await api.multiCall({
+      abi: appBalancesAbi,
+      calls: pools.map((pool, i) => ({ target: pool, params: [appFlags[i] ?? 0] })),
+      permitFailure: true,
+    })
 
-        // Filter valid tokenIds where pool is the owner
-        const validTokenIds = tokenIds.filter((id, j) => owners[j] === pool)
-        uniV4Ids.push(...validTokenIds)
+    // Aggregate external application balances by token across all pools
+    const appBalanceMap = new Map()
+    for (let i = 0; i < pools.length; i++) {
+      const poolApps = appBalancesData[i]
+      if (!poolApps) continue
+      for (const app of poolApps) {
+        const [balances] = app
+        for (const [token, amount] of balances) {
+          const tokenKey = token.toLowerCase()
+          const current = appBalanceMap.get(tokenKey) || { token, amount: 0n }
+          current.amount += BigInt(amount)
+          appBalanceMap.set(tokenKey, current)
+        }
       }
-
-      const uniqueTokens = getUniqueAddresses(allTokens)
-      sdk.log('chain: ', api.chain, 'pools: ', pools.length, 'tokens: ', uniqueTokens.length, 'valid uniV4 tokenIds: ', uniV4Ids.length, 'uniV4 pools: ', pools.filter((_, i) => tokenIdsData[i]?.length > 0).length)
-      return { pools, tokens: uniqueTokens, uniV4Ids }
     }
+    const appBalances = Array.from(appBalanceMap.values())
+
+    sdk.log('chain: ', api.chain, 'pools: ', pools.length, 'tokens: ', uniqueTokens.length, 'app balance entries: ', appBalances.length)
+    return { pools, tokens: uniqueTokens, appBalances }
   }
 })
-
-const poolData = {}

--- a/projects/rigoblock/index.js
+++ b/projects/rigoblock/index.js
@@ -61,7 +61,7 @@ Object.keys(config).forEach(chain => {
       // Add external application balances (everything except GRG)
       for (const { token, amount } of appBalances) {
         if (token.toLowerCase() === GRG_TOKEN_ADDRESS.toLowerCase()) continue
-        if (BigInt(amount) > 0n) api.add(token, amount)
+        if (BigInt(amount) !== 0n) api.add(token, amount)
       }
 
       // Add smart pool owned token balances (excluding GRG)
@@ -72,7 +72,7 @@ Object.keys(config).forEach(chain => {
 
       // Add GRG balances from external applications
       for (const { token, amount } of appBalances) {
-        if (token.toLowerCase() === GRG_TOKEN_ADDRESS.toLowerCase() && BigInt(amount) > 0n) {
+        if (token.toLowerCase() === GRG_TOKEN_ADDRESS.toLowerCase() && BigInt(amount) !== 0n) {
           api.add(GRG_TOKEN_ADDRESS, amount)
         }
       }


### PR DESCRIPTION
This PR refactors the Rigoblock adapter by substituting manual retrieval of external apps token balances (tokens owned by the Rigoblock smart pools in other contracts - like uniswap LP positions, GMX positions, GRG staking, ...) directly from the smart pools, using the same method that they use internally to update unitary value and execute mint and burn operations.
The method used is defined [here](https://github.com/RigoBlock/v3-contracts/blob/5f6ff38e8d88d66e83d71523d3688c21174837c4/contracts/protocol/extensions/EApps.sol#L53) and retrieves everything with a single rpc call.

- retrieve external app token balances (uniswap lps, staking, gmx, ...) from smart pool express method
- add aggregated (by token) external balances to api balances (excluding or including grg explicitly)
- aggregated getPoolInfo caching instead of per-pool ones

Data returned by the adapter:
```
--- ethereum ---
LIT                       15.14 k
ETH                       11.20 k
WETH                      1.33 k
ENS                       595.69
UNI                       516.59
WBTC                      66.89
USDC                      57.43
ZRX                       0.00
Total: 28.90 k 

--- ethereum-staking ---
GRG                       195.60 k
Total: 195.60 k 

--- optimism ---
ETH                       1.38 k
WBTC                      163.98
OP                        97.50
USDC                      95.31
USDT                      15.44
WETH                      0.50
Total: 1.75 k 

--- optimism-staking ---
GRG                       13.87 k
Total: 13.87 k 

--- arbitrum ---
WETH                      12.31 k
ETH                       2.21 k
USDC                      224.72
ARB                       88.96
USDT0                     73.50
WBTC                      31.45
Total: 14.94 k 

--- arbitrum-staking ---
GRG                       14.66 k
Total: 14.66 k 

--- bsc ---
BNB                       157.34
USDT                      99.51
USDC                      39.82
WBNB                      4.69
WETH                      3.04
Total: 304.41 

--- base ---
WETH                      2.10 k
ETH                       718.13
USDC                      271.58
USDT                      15.11
Total: 3.10 k 

--- base-staking ---
GRG                       20.41 k
Total: 20.41 k 

--- bsc-staking ---
GRG                       18.02 k
Total: 18.02 k 

--- unichain ---
WETH                      2.24 k
ETH                       326.68
UNI                       252.35
USDC                      44.96
WBTC                      38.31
Total: 2.91 k 

--- unichain-staking ---
GRG                       1.80 k
Total: 1.80 k 

--- polygon ---
POL                       75.09
matic                     10.04
WETH                      0.15
USDC                      0.05
WMATIC                    0.00
Total: 85.34 

--- polygon-staking ---
GRG                       422.39
Total: 422.39 

--- tvl ---
WETH                      17.98 k
ETH                       15.84 k
LIT                       15.14 k
UNI                       769.00
USDC                      734.00
ENS                       596.00
WBTC                      300.00
BNB                       157.00
USDT                      130.00
OP                        97.00
ARB                       89.00
POL                       75.00
USDT0                     73.00
matic                     10.00
WBNB                      5.00
Total: 52.00 k 

--- staking ---
GRG                       264.78 k
Total: 264.78 k 

------ TVL ------
staking                   264.78 k
ethereum-staking          195.60 k
ethereum                  28.90 k
base-staking              20.41 k
bsc-staking               18.02 k
arbitrum                  14.95 k
arbitrum-staking          14.66 k
optimism-staking          13.87 k
base                      3.10 k
unichain                  2.91 k
unichain-staking          1.80 k
optimism                  1.75 k
polygon-staking           422.00
bsc                       304.00
polygon                   85.00

total                    52.00 k 
```




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Reworked RigoBlock TVL calculations to use each smart pool’s active token holdings plus balances held in external applications.
  * GRG is now excluded from TVL and reported separately under staking.
  * Removed Uniswap V4 position-based accounting from TVL and staking figures.
  * Clarified published methodology and improved how pool data is gathered and reused within a chain for a given block.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->