### PR TITLE
fix(idle): Adaptive Frontier vault is double-counted with pareto (~$2.1M)

### DIFF
--- a/projects/idle/index.js
+++ b/projects/idle/index.js
@@ -73,6 +73,13 @@ const contracts = {
   }
 }
 
+// Pareto credit vaults (app.pareto.credit) are IdleCDO contracts and some are deployed through
+// the same tranche factory, but they are tracked by projects/pareto — skip them here so the
+// same getContractValue isn't counted under both protocols.
+const paretoCreditVaults = new Set([
+  '0x14b8e918848349d1e71e806a52c13d4e0d3246e0', // Adaptive Frontier
+])
+
 const trancheConfig = {
   ethereum: {
     factory: '0x3c9916bb9498f637e2fa86c2028e26275dc9a631',
@@ -160,7 +167,7 @@ async function tvl(api) {
       onlyArgs: true,
       fromBlock,
     })
-    cdos.push(...logs.map(i => i.proxy))
+    cdos.push(...logs.map(i => i.proxy).filter(proxy => !paretoCreditVaults.has(proxy.toLowerCase())))
   }
 
   const [wrap4626Supplies, wrap4626Tokens] = await Promise.all(['uint256:totalSupply', 'address:token'].map( abi => api.multiCall({ abi, calls: wrap4626 }) ))


### PR DESCRIPTION
The Adaptive Frontier credit vault (0x14B8E918848349D1e71e806a52c13D4e0d3246E0) is counted under both the idle and pareto slugs.

It's a Pareto credit vault (listed on app.pareto.credit and hardcoded in projects/pareto/index.js credits), but it was deployed on 2025-06-04 through Idle's tranche factory (0x3c9916bb..., CDODeployed at block 22630503), so the idle adapter also picks it up from the factory logs. Both adapters then add the same getContractValue, so its ~$2.1M shows up twice.

This filters Pareto credit vaults out of idle's log-derived CDO list. Idle's other 39 factory CDOs are untouched, and none of the other Pareto vaults (Fasanara, Bastion, FalconX on any chain) come from Idle factories, I checked the ethereum and optimism factory logs.

Verified by running the ethereum leg before/after: $3,499,479 → $1,373,024, a $2.13M delta matching the vault's current contract value. (Full-suite local run currently fails on polygon_zkevm because the public RPCs are ~7 days behind, unrelated to this change.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Idle TVL calculations to exclude Pareto credit vaults.
  * Improved the accuracy of reported TVL, value, and blacklist totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->