### PR TITLE
fix(mainstreet): stop valuing msUSD at the USDC peg (~$51M overstated)

### DIFF
--- a/projects/mainstreet/index.js
+++ b/projects/mainstreet/index.js
@@ -1,9 +1,17 @@
 module.exports = {
   misrepresentedTokens: false,
+  hallmarks: [
+    ['2026-06-20', 'msUSD depegged after PoR provider termination'],
+  ],
   ethereum: { tvl }
 }
 
+const MSUSD = '0x4ba01f22827018b4772CD326C7627FB4956A7C00'
+
 async function tvl(api) {
-  const supply = await api.call({ abi: 'uint256:totalSupply', target: '0x4ba01f22827018b4772CD326C7627FB4956A7C00' })
-  api.addCGToken('usd-coin', supply / 1e18)
+  const supply = await api.call({ abi: 'uint256:totalSupply', target: MSUSD })
+  // Reserves are off-chain and unverifiable since the PoR provider dropped Mainstreet on
+  // 2026-06-20, and msUSD has traded far below the peg since. Value the supply at msUSD's
+  // market price instead of assuming 1:1 USDC backing.
+  api.add(MSUSD, supply)
 }


### PR DESCRIPTION
Mainstreet's TVL is computed as msUSD.totalSupply valued at USDC ($1). That assumption broke on 2026-06-20: Accountable terminated its proof-of-reserves agreement and msUSD depegged ~85%. Three weeks later it still trades around $0.31 (coins.llama.fi prices it with 0.99 confidence), the team's daily yield distributions stopped on 2026-06-21 (last mintRewards from keeper 0x19f63dda, no msUSD mints since), and the reserves are off-chain with no working verification.

So the page currently shows ~$74M for a protocol the market values at ~$23M.

This changes the adapter to add the msUSD token itself so the supply gets valued at market price, and adds a depeg hallmark. Tested: adapter now returns $22.86M (74.2M × $0.308).

If they restore verification and the peg recovers, the same code follows it back up, no peg assumption in either direction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated msUSD valuation to reflect its market price rather than assuming one-to-one backing.
  * Improved reporting of msUSD reserves following the termination of the proof-of-reserves provider.

* **Documentation**
  * Added a historical note documenting the msUSD depeg event on June 20, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->