### PR TITLE
Add RobinSwap TVL adapter

### DIFF
--- a/projects/robinswap/index.js
+++ b/projects/robinswap/index.js
@@ -1,0 +1,28 @@
+const { uniTvlExports } = require('../helper/unknownTokens')
+const { uniV3Export } = require('../helper/uniswapV3')
+
+const V2_FACTORY = '0xa95DA9b9fCef09A07F99444fE9304457d6ECdccA'
+const V3_FACTORY = '0xea561e058313b96011e5070ca7d0f027a44e3748'
+
+// RobinSwap runs independent V2 and V3 factories on Robinhood Chain.
+// Both helpers add balances to the supplied API instance, so calling them in
+// sequence produces one combined protocol TVL figure without double-counting.
+const v2 = uniTvlExports({ robinhood: V2_FACTORY }, { useDefaultCoreAssets: true })
+const v3 = uniV3Export({
+  robinhood: {
+    factory: V3_FACTORY,
+    fromBlock: 6027468,
+    permitFailure: true,
+  },
+})
+
+module.exports = {
+  methodology: 'Counts token balances held by every RobinSwap V2 pair and V3 pool on Robinhood Chain.',
+  misrepresentedTokens: false,
+  robinhood: {
+    tvl: async (api) => {
+      await v2.robinhood.tvl(api)
+      await v3.robinhood.tvl(api)
+    },
+  },
+}

--- a/projects/robinswap/index.js
+++ b/projects/robinswap/index.js
@@ -12,7 +12,6 @@ const v3 = uniV3Export({
   robinhood: {
     factory: V3_FACTORY,
     fromBlock: 6027468,
-    permitFailure: true,
   },
 })
 


### PR DESCRIPTION
## RobinSwap TVL adapter

Adds combined Robinhood Chain TVL accounting for the deployed RobinSwap V2 factory and V3 factory.

- V2 factory: `0xa95DA9b9fCef09A07F99444fE9304457d6ECdccA`
- V3 factory: `0xea561e058313b96011e5070ca7d0f027a44e3748`
- Chain: Robinhood (`robinhood`)

The adapter enumerates all V2 pairs and V3 pools and sums the underlying token balances. Robinhood core assets are already present upstream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RobinSwap TVL tracking on Robinhood Chain.
  * Combined liquidity data from both V2 and V3 sources into a single TVL result.
  * Included methodology and token representation metadata for clearer reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->