### PR TITLE
Add Ravenhood (RVH) - Robinhood Chain

### DIFF
--- a/projects/ravenhood/index.js
+++ b/projects/ravenhood/index.js
@@ -1,0 +1,23 @@
+const { unwrapUniswapV3NFT } = require('../helper/unwrapLPs')
+
+// RavenhoodVault — permanently locked RVH/WETH Uniswap V3 position.
+// Verified on-chain 2026-07-11: holds exactly 1 NFT on the position manager below.
+const VAULT = '0x5e1485137E025bf7774F52DE4E33fa6E498f6ede'
+const UNISWAP_V3_NFT_MANAGER = '0x73991a25C818Bf1f1128dEAaB1492D45638DE0D3'
+const RVH_TOKEN = '0x96765066f6a040a21EB027167D2315B707c82633'
+const STAKING_POOL = '0xAc558b558E228DE033Cd97C580618C4403CB05a6'
+
+module.exports = {
+  methodology: 'TVL is the RVH/WETH Uniswap V3 position permanently locked in RavenhoodVault (seeded single-sided at launch with 95M RVH, now accumulating both sides from swap fees and buybacks). Staking is RVH deposited into RVHStakingPool.',
+  robinhood: {
+    tvl: async (api) => {
+      await unwrapUniswapV3NFT({ api, owner: VAULT, nftAddress: UNISWAP_V3_NFT_MANAGER })
+      return api.getBalances()
+    },
+    staking: async (api) => {
+      const staked = await api.call({ target: STAKING_POOL, abi: 'uint256:totalStaked' })
+      api.add(RVH_TOKEN, staked)
+      return api.getBalances()
+    },
+  },
+}

--- a/projects/ravenhood/index.js
+++ b/projects/ravenhood/index.js
@@ -1,19 +1,10 @@
-const { unwrapUniswapV3NFT } = require('../helper/unwrapLPs')
-
-// RavenhoodVault — permanently locked RVH/WETH Uniswap V3 position.
-// Verified on-chain 2026-07-11: holds exactly 1 NFT on the position manager below.
-const VAULT = '0x5e1485137E025bf7774F52DE4E33fa6E498f6ede'
-const UNISWAP_V3_NFT_MANAGER = '0x73991a25C818Bf1f1128dEAaB1492D45638DE0D3'
 const RVH_TOKEN = '0x96765066f6a040a21EB027167D2315B707c82633'
 const STAKING_POOL = '0xAc558b558E228DE033Cd97C580618C4403CB05a6'
 
 module.exports = {
-  methodology: 'TVL is the RVH/WETH Uniswap V3 position permanently locked in RavenhoodVault (seeded single-sided at launch with 95M RVH, now accumulating both sides from swap fees and buybacks). Staking is RVH deposited into RVHStakingPool.',
+  methodology: 'Staking is RVH deposited into RVHStakingPool.',
   robinhood: {
-    tvl: async (api) => {
-      await unwrapUniswapV3NFT({ api, owner: VAULT, nftAddress: UNISWAP_V3_NFT_MANAGER })
-      return api.getBalances()
-    },
+    tvl: () => ({}),
     staking: async (api) => {
       const staked = await api.call({ target: STAKING_POOL, abi: 'uint256:totalStaked' })
       api.add(RVH_TOKEN, staked)

--- a/projects/treasury/ravenhood.js
+++ b/projects/treasury/ravenhood.js
@@ -1,0 +1,14 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+const { sumTokensExport } = require('../helper/unwrapLPs')
+
+// RavenhoodVault — permanently locked, protocol-owned RVH/WETH Uniswap V3 position
+const VAULT = '0x5e1485137E025bf7774F52DE4E33fa6E498f6ede'
+const UNISWAP_V3_NFT_MANAGER = '0x73991a25C818Bf1f1128dEAaB1492D45638DE0D3'
+const RVH_TOKEN = '0x96765066f6a040a21EB027167D2315B707c82633'
+
+module.exports = {
+  robinhood: {
+    tvl: sumTokensExport({ owner: VAULT, resolveUniV3: true, uniV3ExtraConfig: { nftAddress: UNISWAP_V3_NFT_MANAGER }, blacklistedTokens: [RVH_TOKEN] }),
+    ownTokens: sumTokensExport({ owner: VAULT, resolveUniV3: true, uniV3ExtraConfig: { nftAddress: UNISWAP_V3_NFT_MANAGER }, blacklistedTokens: [ADDRESSES.robinhood.WETH] }),
+  },
+}


### PR DESCRIPTION
### Project information

- **Name (to be shown on defillama)**: Ravenhood
- **Twitter**: https://x.com/RVHProtocol
- **Telegram**: https://t.me/RVHProtocol
- **Website**: https://ravenhood.xyz
- **Logo (high resolution)**: https://ravenhood.xyz/ravenhoodbrandkit/RavenhoodCoinMark.png
- **Short description**: Deflationary treasury protocol on Robinhood Chain. Permissionless, immutable burn engine buys back and burns RVH using treasury LP fee revenue; 95% of supply was seeded as single-sided, permanently-locked liquidity at launch.
- **Category**: Not fully sure which existing category fits best (closest to a locked-liquidity / treasury-buyback protocol) — happy to take reviewer guidance here.

### Technical information

- **Chain**: Robinhood Chain (chain key `robinhood` in this repo)
- **Token address / ticker**: `0x96765066f6a040a21EB027167D2315B707c82633` / RVH
- **CoinGecko ID**: ravenhood
- **Current TVL**: ~$30-75k (the locked RVH/WETH position; grows as swap fees/buybacks accrue)
- **Methodology**: TVL is the RVH/WETH Uniswap V3 position permanently locked in RavenhoodVault (`0x5e1485137E025bf7774F52DE4E33fa6E498f6ede`), seeded single-sided with 95M RVH at launch and now accumulating both sides from swap fees and buybacks. A separate `staking` category tracks RVH deposited into RVHStakingPool (`0xAc558b558E228DE033Cd97C580618C4403CB05a6`).
- **forkedFrom**: No — original contracts, though the project migrated from an earlier deployment on Monad (rebranded/relaunched on Robinhood Chain).
- **Audit links**: None yet (internal review only so far).

### Notes

- Uses the shared `unwrapUniswapV3NFT` helper from `projects/helper/unwrapLPs.js` against the vault's known locked NFT position.
- Robinhood Chain's Uniswap V3 factory address used elsewhere in this repo (`0x1f7d7550B1b028f7571E69A784071F0205FD2EfA`, see `projects/uniswap/index.js`) matches what I've independently verified on-chain, so I'm confident the `robinhood` chain key/factory wiring here is consistent with the rest of the repo.
- Tested locally: `LLAMA_DEBUG_MODE=true node test.js projects/ravenhood/index.js` — correctly reads the vault's locked position (WETH + RVH) and the staking pool's total staked RVH. RVH itself doesn't have a resolvable price in the local test sandbox yet (brand new token), so the local TVL print undercounts until your production price indexer picks it up — this doesn't require any adapter change.

Allow edits by maintainers is enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Ravenhood TVL tracking, including assets held in a permanently locked Uniswap V3 vault/position.
  * Added RVH staking tracking by reading the staking pool’s total staked amount and reporting it as token balances.
  * Added Ravenhood methodology information for the reported TVL and staking metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->