### PR TITLE
vishwa: re-add BTCvc adapter + migrate BTC address API to vishwalab.com

### DIFF
--- a/projects/helper/bitcoin-book/fetchers.js
+++ b/projects/helper/bitcoin-book/fetchers.js
@@ -248,7 +248,7 @@ module.exports = {
   vishwa: async () => {
     const staticAddresses = await getConfig('vishwa', undefined, {
       fetcher: async () => {
-        const { data } = await axios.get('https://api.btcvc.vishwanetwork.xyz/btc/address')
+        const { data } = await axios.get('https://vault.vishwalab.com/vapi/btc/address')
         return data.data
       }
     })

--- a/projects/vishwa/index.js
+++ b/projects/vishwa/index.js
@@ -1,0 +1,33 @@
+// Vishwa — BTCvc (zk light-client proof-of-asset BTC)
+//
+// BTCvc is Vishwa's verifiable-reserve BTC product: BTC held in custody is proven on-chain by
+// Vishwa's zk light client, and BTCvc (the receipt on Sui) is a 1:1 claim on that reserve.
+//
+// METHODOLOGY (no double-count):
+//   TVL = the BTC reserve backing BTCvc, counted on Bitcoin (its native chain). The BTCvc
+//   receipt on Sui is a 1:1 claim on the same BTC and is deliberately NOT counted.
+//   The custody set (bitcoinAddressBook.vishwa()) is the set the light client proves.
+//
+// This adapter was removed in an upstream clean-up after the previous version returned an
+// empty address array (which reads as a false $0). This version throws when the address API
+// returns empty, so a transient API outage keeps the last good value instead of zeroing TVL.
+//
+// Separate product from Naro / BTCvp (projects/naro): separate custody, no cross-count.
+
+const { sumTokens } = require("../helper/chain/bitcoin");
+const bitcoinAddressBook = require("../helper/bitcoin-book/index.js");
+
+module.exports = {
+  methodology:
+    "TVL is the BTC reserve backing BTCvc, counted on Bitcoin and verified on-chain by " +
+    "Vishwa's zk light client. The BTCvc receipt token (Sui) is a 1:1 claim on this reserve " +
+    "and is not counted separately, to avoid double-counting.",
+  bitcoin: {
+    tvl: async () => {
+      const owners = await bitcoinAddressBook.vishwa();
+      if (!owners || !owners.length)
+        throw new Error("vishwa: BTC address API returned empty; skipping to avoid a false $0");
+      return sumTokens({ owners });
+    },
+  },
+};


### PR DESCRIPTION
We're migrating our sites from vishwanetwork.xyz to vishwalab.com, and adapting the API fetching domain too.

This re-adds the Vishwa BTCvc adapter, which was removed in the 2026-07-09 clean-up after the previous version returned an empty address array (it had been disabled in "break vishwa"). This version throws when the BTC address API returns an empty list, so a transient API outage keeps the last good value instead of reporting a false $0.

- Migrates the custody address API from `api.btcvc.vishwanetwork.xyz` to `vault.vishwalab.com` (part of the vishwanetwork.xyz -> vishwalab.com domain migration). Verified both endpoints return the identical 13-address set, summing ~$58.8M, indicating behaviour-preserving.
- Methodology unchanged: TVL = the BTC reserve backing BTCvc, counted on Bitcoin. The BTCvc receipt on Sui is a 1:1 claim on the same reserve and is not counted, to avoid double-counting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Vishwa — BTCvc reserve tracking to display Bitcoin-backed value.
  * Added safeguards to prevent unavailable reserve data from being reported as zero.
  * Updated the data source used to retrieve Vishwa Bitcoin addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->