### PR TITLE
feat: add TurboLoop TVL adapter (BSC fixed-term yield)

### DIFF
--- a/projects/turboloop/index.js
+++ b/projects/turboloop/index.js
@@ -1,0 +1,29 @@
+// DefiLlama TVL Adapter for TurboLoop
+// Protocol: TurboLoop — Fixed-Term Passive Income on BNB Smart Chain
+// Website: https://turboloop.tech
+// Chain: BNB Smart Chain (BSC)
+// Contract (verified on BscScan): 0xc90E5785632dAaB9Cb61F5050dA393090541A76D
+// Audit: Haze Crypto — https://turboloop.tech/security
+//
+// TVL methodology: Total USDT deposited in active TurboLoop investment plans.
+// Users deposit USDT into fixed-term plans (7/30/60/90 days) and the protocol
+// deploys capital into PancakeSwap V3 concentrated liquidity positions.
+
+const { sumTokensExport } = require('../helper/unwrapLPs');
+
+const TURBOLOOP_CONTRACT = '0xc90E5785632dAaB9Cb61F5050dA393090541A76D';
+const USDT_BSC = '0x55d398326f99059fF775485246999027B3197955'; // BSC-Peg USDT
+
+module.exports = {
+  methodology:
+    'TVL is calculated as the total USDT locked in active TurboLoop investment plans on BNB Smart Chain. ' +
+    'Users deposit USDT into fixed-term plans (7, 30, 60, or 90 days). The protocol deploys capital into ' +
+    'PancakeSwap V3 concentrated liquidity positions to generate yield. ' +
+    'Smart contract is audited (Haze Crypto), ownership renounced, and LP locked.',
+  bsc: {
+    tvl: sumTokensExport({
+      owners: [TURBOLOOP_CONTRACT],
+      tokens: [USDT_BSC],
+    }),
+  },
+};


### PR DESCRIPTION
## TurboLoop — Fixed-Term Passive Income on BNB Smart Chain

**Website:** https://turboloop.tech
**Chain:** BNB Smart Chain (BSC)
**Category:** Yield / Fixed-Term

### What is TurboLoop?

TurboLoop is a decentralised fixed-term yield protocol on BNB Smart Chain. Users deposit USDT into one of four fixed-term plans (7, 30, 60, or 90 days) and the protocol automatically deploys capital into PancakeSwap V3 concentrated liquidity positions to generate yield.

**Fixed returns:**
- Sprint (7 days): 3%
- Boost (30 days): 10%
- Power (60 days): 24%
- Ultimate (90 days): 54%

### Security
- Smart contract audited by Haze Crypto (public report: https://turboloop.tech/security)
- Ownership renounced — contract is immutable
- 100% LP locked on-chain (verifiable on BscScan)
- $100,000 bug bounty programme

### Contracts
- **Main contract:** `0xc90E5785632dAaB9Cb61F5050dA393090541A76D` ([BscScan](https://bscscan.com/address/0xc90e5785632daab9cb61f5050da393090541a76d#code))
- **USDT (BSC-Peg):** `0x55d398326f99059fF775485246999027B3197955`

### TVL Methodology
TVL = total USDT locked in active investment plans in the TurboLoop contract.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for the TurboLoop protocol on BNB Smart Chain.
  * Reports USDT holdings across TurboLoop’s active investment plans.
  * Includes protocol metadata and TVL calculation details for improved transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->