### PR TITLE
Add NOTCH

### DIFF
--- a/projects/notch/index.js
+++ b/projects/notch/index.js
@@ -1,0 +1,27 @@
+const ADDRESSES = require('./helper/coreAssets.json')
+const { getConnection } = require('./helper/solana')
+const { PublicKey } = require('@solana/web3.js')
+
+// NOTCH (notch.fund): token launchpad on Solana. Every token trades on an
+// on-chain bonding curve backed by a SOL vault held in a program-owned PDA,
+// and any sell redeems against the vault at the floor price or better, so
+// the SOL in curve accounts is the protocol TVL.
+const NOTCH_PROGRAM = 'DQf1BBhRNnhthJUmsCT6Rt2whodZyNLbsqKQ3kHYUU6N'
+const CURVE_SIZE = 147
+
+async function tvl(api) {
+  const connection = getConnection()
+  const accounts = await connection.getProgramAccounts(new PublicKey(NOTCH_PROGRAM), {
+    filters: [{ dataSize: CURVE_SIZE }],
+    dataSlice: { offset: 0, length: 0 },
+  })
+  const lamports = accounts.reduce((sum, a) => sum + a.account.lamports, 0)
+  api.add(ADDRESSES.solana.SOL, lamports)
+}
+
+module.exports = {
+  timetravel: false,
+  methodology:
+    'TVL is the SOL held in NOTCH bonding curve vault accounts (PDAs owned by the NOTCH program). Every launched token is backed by its own vault and any sell redeems against it at the floor price or better.',
+  solana: { tvl },
+}

--- a/projects/notch/index.js
+++ b/projects/notch/index.js
@@ -1,5 +1,5 @@
-const ADDRESSES = require('./helper/coreAssets.json')
-const { getConnection } = require('./helper/solana')
+const ADDRESSES = require('../helper/coreAssets.json')
+const { getConnection } = require('../helper/solana')
 const { PublicKey } = require('@solana/web3.js')
 
 // NOTCH (notch.fund): token launchpad on Solana. Every token trades on an


### PR DESCRIPTION
Adds a TVL adapter for NOTCH (https://notch.fund), a token launchpad on Solana where every token trades on an on-chain bonding curve backed by a SOL vault, and any sell redeems against the vault at the floor price or better.

- Category: Launchpad
- Chain: Solana
- TVL: SOL held in curve vault accounts, PDAs owned by program `DQf1BBhRNnhthJUmsCT6Rt2whodZyNLbsqKQ3kHYUU6N` (verified build with on-chain security.txt)
- Website: https://notch.fund
- Twitter: https://x.com/NotchFund
- Logo: https://notch.fund/logos/notch-transparent-512.png
- Program source: https://github.com/sam3dsol/notch

Current TVL at submission time is about 141 SOL across 32 curve accounts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DefiLlama-style TVL tracking for the NOTCH protocol on Solana.
  * Calculates TVL in SOL by aggregating lamports held in the protocol’s bonding-curve accounts.
  * Includes TVL methodology and protocol metadata to support transparent reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->