### PR TITLE
Add DAO wallet to Ravenhood treasury tracking

### DIFF
--- a/projects/treasury/ravenhood.js
+++ b/projects/treasury/ravenhood.js
@@ -4,11 +4,33 @@ const { sumTokensExport } = require('../helper/unwrapLPs')
 // RavenhoodVault — permanently locked, protocol-owned RVH/WETH Uniswap V3 position
 const VAULT = '0x5e1485137E025bf7774F52DE4E33fa6E498f6ede'
 const UNISWAP_V3_NFT_MANAGER = '0x73991a25C818Bf1f1128dEAaB1492D45638DE0D3'
+// DAO treasury wallet — interim EOA (moving to a multisig). Holds plain
+// USDG/ETH plus DAO-owned Uniswap V3 LP positions pairing RVH against
+// tokenized stocks/blue chips (the "expansion liquidity" the burn engine
+// funds) -- resolveUniV3 auto-discovers all of them, not just one pair.
+const DAO_WALLET = '0x097ba31b7ACfFd75B909fc7BEf2e55424d2dAcdc'
 const RVH_TOKEN = '0x96765066f6a040a21EB027167D2315B707c82633'
 
 module.exports = {
   robinhood: {
-    tvl: sumTokensExport({ owner: VAULT, resolveUniV3: true, uniV3ExtraConfig: { nftAddress: UNISWAP_V3_NFT_MANAGER }, blacklistedTokens: [RVH_TOKEN] }),
-    ownTokens: sumTokensExport({ owner: VAULT, resolveUniV3: true, uniV3ExtraConfig: { nftAddress: UNISWAP_V3_NFT_MANAGER }, blacklistedTokens: [ADDRESSES.robinhood.WETH] }),
+    tvl: sumTokensExport({
+      owners: [VAULT, DAO_WALLET],
+      tokens: [ADDRESSES.robinhood.USDG, ADDRESSES.null],
+      resolveUniV3: true,
+      uniV3ExtraConfig: { nftAddress: UNISWAP_V3_NFT_MANAGER },
+      blacklistedTokens: [RVH_TOKEN],
+    }),
+    // uniV3WhitelistedTokens (not blacklistedTokens) is required here: the DAO
+    // wallet's LP positions pair RVH against many different tokens (WETH,
+    // VIRTUAL, MSFT, TSLA, AAPL, NVDA, SPY, PLTR, GOOGL, ...), so blacklisting
+    // just one quote token leaks all the others into "ownTokens". Whitelisting
+    // RVH itself keeps this to only the RVH side of every resolved position.
+    ownTokens: sumTokensExport({
+      owners: [VAULT, DAO_WALLET],
+      tokens: [RVH_TOKEN],
+      resolveUniV3: true,
+      uniV3ExtraConfig: { nftAddress: UNISWAP_V3_NFT_MANAGER },
+      uniV3WhitelistedTokens: [RVH_TOKEN],
+    }),
   },
 }


### PR DESCRIPTION
Follow-up to #19978.

The Ravenhood treasury adapter merged in #19978 only tracked the locked vault position (`projects/treasury/ravenhood.js`). It was missing the DAO treasury wallet: `0x097ba31b7ACfFd75B909fc7BEf2e55424d2dAcdc`.

Turns out this wallet holds:
- Plain USDG and native ETH
- Several more Uniswap V3 LP positions pairing RVH against tokenized stocks/blue chips (VIRTUAL, MSFT, TSLA, AAPL, NVDA, SPY, PLTR, GOOGL) — the DAO-owned "expansion liquidity" the protocol's burn engine funds over time

### Change

- Added `DAO_WALLET` to both `tvl` and `ownTokens` via `owners: [VAULT, DAO_WALLET]`
- Switched `ownTokens` from `blacklistedTokens: [WETH]` to `uniV3WhitelistedTokens: [RVH_TOKEN]`. With only one pair (RVH/WETH) blacklisting the other side worked fine, but now that DAO positions pair RVH against many different tokens, blacklisting just one quote token leaked all the others into `ownTokens`. Whitelisting RVH itself keeps this correct regardless of how many pairs the DAO holds.

### Testing

`LLAMA_DEBUG_MODE=true node test.js projects/treasury/ravenhood.js`:

- `tvl`: ~$27.7k (up from ~$24k in the currently-live version — now covers every DAO position, not just the vault)
- `ownTokens`: correctly isolates 34,102,704 RVH total across both addresses (shows $0 locally only because RVH has no price in the local test sandbox — same known limitation noted in #19978, not a bug; the underlying RVH balance is captured correctly per the debug log)

Allow edits by maintainers is enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Robinhood treasury value tracking by including assets held across both treasury and DAO wallets.
  * Updated token accounting to accurately include USDG and supported liquidity positions.
  * Refined owned-token reporting to count only the RVH token in Uniswap V3 positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->