### PR TITLE
Add Hoodit (DLMM DEX on Robinhood Chain)

### DIFF
--- a/registries/traderJoeV2.js
+++ b/registries/traderJoeV2.js
@@ -77,6 +77,9 @@ const configs = {
   'metropolis-exchange-dlmm': {
     sonic: '0x39D966c1BaFe7D3F1F53dA4845805E15f7D6EE43',
   },
+  'hoodit': {
+    robinhood: '0x22602d966DeFd638ee94E97A92e2Eb0934c3fE1B',
+  },
 }
 
 module.exports = buildProtocolExports(configs, joeV2ExportFn)


### PR DESCRIPTION
New protocol listing.

**Name:** Hoodit
**Website:** https://hoodit.xyz
**Docs:** https://hoodit.xyz/docs
**Category:** Dexs
**Chain:** Robinhood Chain (chainId 4663, already supported as `robinhood`)
**Description:** Hoodit is a DLMM (Liquidity Book v2.2 / Trader Joe lineage) exchange on Robinhood Chain — liquidity in discrete price bins, zero slippage within a bin, dynamic volatility fees for LPs. Permissionless pool creation, fee tiers 0.10%–5.00%.
**LBFactory:** `0x22602d966DeFd638ee94E97A92e2Eb0934c3fE1B` (Blockscout-verified: https://robinhoodchain.blockscout.com/address/0x22602d966DeFd638ee94E97A92e2Eb0934c3fE1B)
**Logo:** https://hoodit.xyz/icon.png
**Methodology:** Token balances held by Liquidity Book pair contracts enumerated from the factory (standard `joeV2Export` registry entry).

Adapter is a 3-line entry in `registries/traderJoeV2.js`, same pattern as the other LB v2.2 forks in that registry.

`node test.js hoodit` output:
```
--- robinhood ---
WETH                      214.34
Total: 214.34
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Hoodit protocol and its Robinhood factory address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->