### PR TITLE
Add Robinhood Chain to T3tris Finance TVL adapter

### DIFF
--- a/projects/t3tris-finance/index.js
+++ b/projects/t3tris-finance/index.js
@@ -3,7 +3,9 @@ const { getConfig } = require("../helper/cache");
 // T3tris ecosystem API — authoritative list of vaults with curation flags
 const VAULTS_API = "https://ecosystem.t3tris.finance/vaults";
 const getGrossTvlAbi = "function getGrossTVL() external view returns (uint256 totalManagedAssets, uint256 pendingDeposits, uint256 claimableRedeems, uint256 grossTVL)";
-const CHAINS = ['arbitrum'];
+// Vaults are auto-discovered from the ecosystem API per chain via api.chainId,
+// so a chain surfaces its TVL as soon as verified vaults are published there.
+const CHAINS = ['arbitrum', 'robinhood'];
 
 async function getVerifiedVaults(chainId) {
   const all = await getConfig("t3tris-finance/vaults", VAULTS_API);


### PR DESCRIPTION
T3tris Finance is now deployed on Robinhood Chain (4663). This adds `robinhood` to the TVL adapter's chain list. Vaults are auto-discovered from the T3tris ecosystem API per chain via `api.chainId` (same curation gate: verified & non-blacklisted), so Robinhood TVL surfaces automatically as verified vaults are published there. No other changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking support for the Robinhood chain.
  * Robinhood vaults are now discovered, verified, and included in TVL reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->