### PR TITLE
Split Native monad credit pool into native-lend-monad

### DIFF
--- a/projects/native-lend-monad/index.js
+++ b/projects/native-lend-monad/index.js
@@ -1,26 +1,18 @@
 const { getLogs } = require("../helper/cache/getLogs");
 const { sumTokens2 } = require("../helper/unwrapLPs");
 
+// This vault is curated by Native but whitelabeled/owned by TownSquare on monad,
+// so it is also tracked in projects/townsquare-vaults. Marked doublecounted here
+// to avoid inflating aggregate TVL sums across both adapters.
 module.exports = {
-  methodology: "Gets all the assets deposited by LPs in Native Credit Pool for PMMs to facilitate trades for Native Swap.",
+  doublecounted: true,
+  methodology: "Gets all the assets deposited by LPs in the Native-curated, TownSquare-owned Credit Pool on monad for PMMs to facilitate trades for Native Swap.",
 };
 
 const config = {
-  ethereum: {
-    vault: "0xe3D41d19564922C9952f692C5Dd0563030f5f2EF",
-    vaultFromBlock: 22173196,
-  },
-  bsc: {
-    vault: "0xBA8dB0CAf781cAc69b6acf6C848aC148264Cc05d",
-    vaultFromBlock: 47980948,
-  },
-  base: {
-    vault: "0x74a4Cd023e5AfB88369E3f22b02440F2614a1367",
-    vaultFromBlock: 32578350,
-  },
-  arbitrum: {
-    vault: "0xbA1cf8A63227b46575AF823BEB4d83D1025eff09",
-    vaultFromBlock: 355397381,
+  monad: {
+    vault: "0xcD1D2D602C3e7394515DaAe96e4FFe16DE71e5B4",
+    vaultFromBlock: 70146973,
   },
 };
 
@@ -45,10 +37,10 @@ Object.keys(config).forEach((chain) => {
       const tokens = await api.multiCall({ abi: 'address:underlying', calls: lps });
 
       // use sumTokens2 to for cash balances in vault
-      return sumTokens2({ 
-        api, 
-        owner: vault, 
-        tokens 
+      return sumTokens2({
+        api,
+        owner: vault,
+        tokens
       });
     },
     borrowed: async (api) => {

--- a/projects/native-lend/index.js
+++ b/projects/native-lend/index.js
@@ -22,6 +22,18 @@ const config = {
     vault: "0xbA1cf8A63227b46575AF823BEB4d83D1025eff09",
     vaultFromBlock: 355397381,
   },
+  xlayer: {
+    vault: "0x4Df7557734B382EB542BEa6c74786D398DF4CC19",
+    vaultFromBlock: 59885325,
+  },
+  morph: {
+    vault: "0x4Df7557734B382EB542BEa6c74786D398DF4CC19",
+    vaultFromBlock: 23245775,
+  },
+  robinhood: {
+    vault: "0x57B8f68ef57Af2dB70BC9aAc891836661CA4cB51",
+    vaultFromBlock: 60423,
+  },
 };
 
 Object.keys(config).forEach((chain) => {


### PR DESCRIPTION
## Native Credit Pool: split monad into doublecounted adapter + add xlayer, morph, robinhood

### 1. New `native-lend-monad` adapter (doublecounted)
Moves the monad Credit Vault (`0xcD1D2D602C3e7394515DaAe96e4FFe16DE71e5B4`) out of `native-lend` into a new `native-lend-monad` adapter flagged `doublecounted: true`.

This vault is curated by Native but whitelabeled/owned by TownSquare, who track the same vault in a separate `townsquare-vaults` adapter. Splitting it out as `doublecounted` lets both Native (curator) and TownSquare (protocol owner) attribute the TVL without inflating aggregate DeFi TVL.

### 2. Added remaining Credit Vault chains to `native-lend`
Added the remaining Credit Vaults per the [Native docs](https://docs.native.org/native-dev/resources/addresses):

| Chain | Credit Vault | vaultFromBlock |
|---|---|---|
| xlayer | `0x4Df7557734B382EB542BEa6c74786D398DF4CC19` | 59885325 |
| morph | `0x4Df7557734B382EB542BEa6c74786D398DF4CC19` | 23245775 |
| robinhood | `0x57B8f68ef57Af2dB70BC9aAc891836661CA4cB51` | 60423 |

### Changes
- `projects/native-lend/index.js`: removed monad; added xlayer, morph, robinhood (existing eth/bsc/base/arbitrum unchanged).
- `projects/native-lend-monad/index.js`: new monad-only adapter reusing the existing `MarketListed` / `underlying` / `totalUnderlying` tvl + borrowed logic, with `doublecounted: true` and updated methodology.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Native Lend coverage for Monad, including vault TVL and borrowed balance tracking.
  - Included vault methodology details and protection against aggregated TVL inflation.

- **Updates**
  - Updated the main Native Lend adapter set by removing Monad and adding support for XLayer, Morph, and Robinhood (Arbitrum remains).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->