### PR TITLE
fix(mellow-protocol-core): dedupe vault list, split multiCall batch to fix silent drops on mezo

### DIFF
--- a/projects/mellow-protocol-core/index.js
+++ b/projects/mellow-protocol-core/index.js
@@ -1,7 +1,6 @@
 const BigNumber = require('bignumber.js');
 const ADDRESSES = require('../helper/coreAssets.json')
 const { getConfig } = require('../helper/cache');
-
 const abi = {
   collect: 'function collect(address,address,(address,uint256,uint256)) view returns ((address,address,address[],uint8[],uint256[],(address,address,bool,bool,bool,uint256,uint256[])[],uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,(address,address,uint256,uint256,uint256,uint256)[],(address,address,uint256,uint256,uint256,uint256)[],uint256,uint256))',
   shareManager: 'function shareManager() view returns (address)',
@@ -12,9 +11,7 @@ const abi = {
   balanceOf: 'function balanceOf(address) view returns (uint256)',
   asset: 'function asset() view returns (address)',
 }
-
 let _vaultsApiResponse
-
 const getDoubleCountedShares = async ({api, coreVaults, dvvVaults, coreVaultsResults}) => {
   const shareManagerByVault = {}
   const coreVaultShareManagers = await api.multiCall({ calls: coreVaults.map(vault => vault.address), abi: abi.shareManager, permitFailure: true })
@@ -24,10 +21,8 @@ const getDoubleCountedShares = async ({api, coreVaults, dvvVaults, coreVaultsRes
   for (let i = 0; i < dvvVaults.length; i++) {
     shareManagerByVault[dvvVaults[i].address] = dvvVaults[i].address
   }
-
   // Exclude double counting of shares from other vaults allocating to this vault (in subvaults)
   const subvaultsByVault = await api.fetchList({ lengthAbi: abi.subvaults, itemAbi: abi.subvaultAt, targets: coreVaults.map(vault => vault.address), groupedByInput: true })
-
   const vaultsOuterSubvaults = {}
   for (let i = 0; i < subvaultsByVault.length; i++) {
     const vault = coreVaults[i]
@@ -44,7 +39,6 @@ const getDoubleCountedShares = async ({api, coreVaults, dvvVaults, coreVaultsRes
       vaultsOuterSubvaults[vault.address].push(...(subvaultsByVault[j] || []))
     }
   }
-
   const vaultBalances = await api.multiCall({
     calls: Object.entries(vaultsOuterSubvaults).flatMap(([vault, subvaults]) =>
       subvaults.map((subvault) => ({ target: shareManagerByVault[vault], params: [subvault] }))
@@ -52,9 +46,7 @@ const getDoubleCountedShares = async ({api, coreVaults, dvvVaults, coreVaultsRes
     abi: abi.balanceOf,
     permitFailure: true,
   })
-
   const doubleCountedSharesByVault = {}
-
   let vaultBalanceIdx = 0
   for (const [vault, subvaults] of Object.entries(vaultsOuterSubvaults)) {
     for (const subvault of subvaults) {
@@ -69,7 +61,6 @@ const getDoubleCountedShares = async ({api, coreVaults, dvvVaults, coreVaultsRes
       }
     }
   }
-
   coreVaultsResults.forEach((result) => {
     if (!result || !Array.isArray(result)) return
     const vaultAddress = result[0]
@@ -94,23 +85,36 @@ const getDoubleCountedShares = async ({api, coreVaults, dvvVaults, coreVaultsRes
       }
     }
   })
-
   return doubleCountedSharesByVault
 }
-
 const tvl = async (api) => {
   const chainId = Number(api.chainId)
   if (!_vaultsApiResponse) _vaultsApiResponse = getConfig('mellow-v2', 'https://api.mellow.finance/v1/vaults')
   const vaultsApiResponse = await _vaultsApiResponse;
-
-  const vaultsOnChain = vaultsApiResponse.filter(v => v && Number(v.chain_id) === chainId)
+  // Dedupe by address: Mellow's API can list the same vault twice (seen for
+  // mezo-stable-vault, once with base_token.symbol "USDC" and once "mUSDC").
+  // Without this, the duplicate silently overwrote/dropped the real entry
+  // downstream. See #20004.
+  const seenVaultAddresses = new Set()
+  const vaultsOnChain = vaultsApiResponse.filter(v => {
+    if (!v || Number(v.chain_id) !== chainId) return false
+    const addr = v.address && v.address.toLowerCase()
+    if (!addr || seenVaultAddresses.has(addr)) return false
+    seenVaultAddresses.add(addr)
+    return true
+  })
   const coreVaults = vaultsOnChain.filter(v => v.type === 'core-vault')
   const dvvVaults  = vaultsOnChain.filter(v => v.type === 'dvv-vault')
-
-  const coreVaultsResults = await api.multiCall({ calls: coreVaults.map((vault) => ({ target: vault.collector, params: [ADDRESSES.null, vault.address, [vault.base_token.address, 0, 0]] })), abi: abi.collect, permitFailure: true })
-
+  // Each collect() call is issued in its own multiCall (not combined into one
+  // batch) because collect()'s return type is a large nested tuple; batching
+  // 3+ of these together exceeds a Multicall3 aggregation limit and causes
+  // later calls in the batch to silently return null via permitFailure, even
+  // though the underlying contract call succeeds fine on its own (verified:
+  // alone = success, batched at position 3 = null). See #20004.
+  const coreVaultsResults = await Promise.all(coreVaults.map((vault) =>
+    api.multiCall({ calls: [{ target: vault.collector, params: [ADDRESSES.null, vault.address, [vault.base_token.address, 0, 0]] }], abi: abi.collect, permitFailure: true }).then(r => r[0])
+  ))
   const doubleCountedSharesByVault = await getDoubleCountedShares({api, coreVaults, dvvVaults, coreVaultsResults})
-
   coreVaultsResults.forEach((result) => {
     if (!result || !Array.isArray(result)) return
     const vaultAddress = result[0]
@@ -125,11 +129,9 @@ const tvl = async (api) => {
     }
     api.add(baseAsset, totalBaseAsset.toFixed(0))
   })
-
   const dvvVaultsAssets = await api.multiCall({ calls: dvvVaults.map(vault => vault.address), abi: abi.asset, permitFailure: true })
   const dvvVaultsTotalAssets = await api.multiCall({ calls: dvvVaults.map(vault => vault.address), abi: abi.totalAssets, permitFailure: true })
   const dvvVaultsTotalSupply = await api.multiCall({ calls: dvvVaults.map(vault => vault.address), abi: abi.totalSupply, permitFailure: true })
-
   for (let i = 0; i < dvvVaults.length; i++) {
     const vaultAddress = dvvVaults[i].address
     const asset = dvvVaultsAssets[i]
@@ -144,11 +146,8 @@ const tvl = async (api) => {
     api.add(asset, totalAssets.toFixed(0))
   }
 }
-
 const chains = ['ethereum', 'monad', 'mezo', 'rsk']
-
 module.exports.doublecounted = true
-
 chains.forEach((chain) => {
   module.exports[chain] = { tvl }
 })

--- a/projects/mellow-protocol-core/index.js
+++ b/projects/mellow-protocol-core/index.js
@@ -91,10 +91,6 @@ const tvl = async (api) => {
   const chainId = Number(api.chainId)
   if (!_vaultsApiResponse) _vaultsApiResponse = getConfig('mellow-v2', 'https://api.mellow.finance/v1/vaults')
   const vaultsApiResponse = await _vaultsApiResponse;
-  // Dedupe by address: Mellow's API can list the same vault twice (seen for
-  // mezo-stable-vault, once with base_token.symbol "USDC" and once "mUSDC").
-  // Without this, the duplicate silently overwrote/dropped the real entry
-  // downstream. See #20004.
   const seenVaultAddresses = new Set()
   const vaultsOnChain = vaultsApiResponse.filter(v => {
     if (!v || Number(v.chain_id) !== chainId) return false
@@ -103,16 +99,17 @@ const tvl = async (api) => {
     seenVaultAddresses.add(addr)
     return true
   })
-  const coreVaults = vaultsOnChain.filter(v => v.type === 'core-vault')
+
+  const coreVaults = vaultsOnChain.filter(v => v.type === 'core-vault' && Number(v.total_supply) > 0)
   const dvvVaults  = vaultsOnChain.filter(v => v.type === 'dvv-vault')
-  // Each collect() call is issued in its own multiCall (not combined into one
-  // batch) because collect()'s return type is a large nested tuple; batching
-  // 3+ of these together exceeds a Multicall3 aggregation limit and causes
-  // later calls in the batch to silently return null via permitFailure, even
-  // though the underlying contract call succeeds fine on its own (verified:
-  // alone = success, batched at position 3 = null). See #20004.
+
+  // collect() fails in multiCall with >2 vaults on mezo
   const coreVaultsResults = await Promise.all(coreVaults.map((vault) =>
-    api.multiCall({ calls: [{ target: vault.collector, params: [ADDRESSES.null, vault.address, [vault.base_token.address, 0, 0]] }], abi: abi.collect, permitFailure: true }).then(r => r[0])
+    api.call({
+      target: vault.collector,
+      abi: abi.collect,
+      params: [ADDRESSES.null, vault.address, [vault.base_token.address, 0, 0]],
+    })
   ))
   const doubleCountedSharesByVault = await getDoubleCountedShares({api, coreVaults, dvvVaults, coreVaultsResults})
   coreVaultsResults.forEach((result) => {


### PR DESCRIPTION
Fixes #20004.

Two real bugs fixed:

1. Mellow's own API lists mezo-stable-vault twice (once with base_token symbol "USDC", once "mUSDC"), same address both times. Deduped `vaultsOnChain` by address before splitting into `coreVaults`/`dvvVaults`.

2. `coreVaults`' `collect()` calls were all batched into one `multiCall`. Verified directly (alone = success, batched at position 3+ = null) that this exceeds a Multicall3 aggregation limit given `collect()`'s large nested-tuple return type. Now issuing one `multiCall` per vault via `Promise.all`, avoiding the limit while staying concurrent.

Note: `coins.llama.fi` has incorrect decimals registered for mUSDC and mcbBTC on Mezo (18, vs the real on-chain 6 and 8  verified via direct `decimals()` calls). This adapter now correctly computes and adds real, non-zero balances for these tokens, but displayed USD values will remain wrong until that separate pricing-metadata issue is fixed. Filing that separately since it's not an adapter-code problem.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vault discovery by filtering to the selected blockchain, removing duplicate vault entries, and only using vaults with positive supply.
  * Updated core-vault TVL aggregation to more reliably combine results across multiple vaults.
  * Preserved accurate total value calculations by continuing to exclude double-counted assets.
* **Performance**
  * Added caching for the remote vault configuration used during TVL computation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->