### PR TITLE
[add] hoodpump - add Robinhood Chain TVL adapter

### DIFF
--- a/projects/hoodpump/index.js
+++ b/projects/hoodpump/index.js
@@ -1,0 +1,26 @@
+const { getLogs2 } = require('../helper/cache/getLogs')
+const { sumTokens2 } = require('../helper/unwrapLPs')
+const ADDRESSES = require('../helper/coreAssets.json')
+
+const LAUNCHPAD = '0x778F7b2d844B7C366b386d8Ce62110ceA301C777'
+const LAUNCHPAD_DEPLOYMENT_BLOCK = 6990219
+const WETH = ADDRESSES.robinhood.WETH
+
+async function tvl(api) {
+  const launches = await getLogs2({
+    api,
+    target: LAUNCHPAD,
+    eventAbi: 'event LaunchCreated(uint256 indexed launchId, address indexed token, address indexed creator, address pool, uint256 positionTokenId, uint256 initialBuyWeth, uint256 initialTokensOut, string name, string symbol)',
+    fromBlock: LAUNCHPAD_DEPLOYMENT_BLOCK,
+  })
+
+  const pools = launches.map((launch) => launch.pool)
+  return sumTokens2({ api, owners: pools, tokens: [WETH] })
+}
+
+module.exports = {
+  doublecounted: true,
+  methodology: 'TVL is the WETH held in Uniswap V3 pools created by the HoodPump Launchpad. Every pool is discovered from the factory\'s LaunchCreated events, and its liquidity position is permanently held by the HoodPump Liquidity Locker. Only WETH is counted; HoodPump-launched tokens are excluded.',
+  start: '2026-07-11',
+  robinhood: { tvl },
+}


### PR DESCRIPTION
## New listing

##### Name (to be shown on DefiLlama):
HoodPump

##### Twitter Link:
https://x.com/hoodpump_fun

##### List of audit links if any:
None

##### Website Link:
https://hoodpump.fun

##### Logo (High resolution, will be shown with rounded borders):
https://hoodpump.fun/hoodpumplogo.png

##### Current TVL:
Approximately $52 at submission time. The adapter test returns non-zero WETH TVL from two live pools.

##### Treasury Addresses (if the protocol has treasury)
- Platform treasury: `0xdAD1d6a2AfF8f9285Fd9C552491538aEcb518888`
- Fee distributor / Community Treasury accounting: `0x453D956057036bd9871D25B965795b883047481D`

##### Chain:
Robinhood Chain

##### Coingecko ID:
None

##### Coinmarketcap ID:
None

##### Short Description (to be shown on DefiLlama):
HoodPump is a community token launchpad on Robinhood Chain. Every launch creates a token/WETH Uniswap V3 pool and permanently locks its liquidity position.

##### Token address and ticker if any:
HoodPump has no protocol token.

##### Category:
Launchpad

##### Oracle Provider(s):
None. Core token launches and swaps do not depend on an external oracle.

##### Implementation Details:
The launchpad creates token/WETH Uniswap V3 pools. The TVL adapter counts only each pool's WETH balance; DefiLlama handles WETH pricing.

##### Documentation/Proof:
- Launchpad/factory: https://robinhoodchain.blockscout.com/address/0x778F7b2d844B7C366b386d8Ce62110ceA301C777
- Liquidity locker: https://robinhoodchain.blockscout.com/address/0x612D7f73CF0148E9a1b639e819D588b9fF915A9d
- Fee distributor: https://robinhoodchain.blockscout.com/address/0x453D956057036bd9871D25B965795b883047481D
- First launch transaction: https://robinhoodchain.blockscout.com/tx/0xa89a39e6aea1b1e2cb611cd45dce4350f8ba8a348b4a118b7620fc7e702d6629

##### forkedFrom (Does your project originate from another project):
No. HoodPump integrates Uniswap V3 pools but is not a fork of Uniswap.

##### methodology (what is being counted as tvl, how is tvl being calculated):
The adapter discovers every HoodPump pool directly from `LaunchCreated` events emitted by the HoodPump factory. It sums only WETH held in those pools. HoodPump-launched token balances are excluded. LP positions are held permanently by the HoodPump Liquidity Locker. The adapter is marked double-counted because the pool liquidity is also attributable to Uniswap V3.

##### Github org/user (Optional, if your code is open source, we can track activity):
Not provided.

##### Does this project have a referral program?
Yes. Referrers receive 25% of the HoodPump platform share from completed trades by referred users. HoodPump also provides volume-based cashback from the platform share.

## Validation

```text
node test.js projects/hoodpump/index.js

robinhood                 52.00
total                     52.11
```

The adapter uses only Robinhood Chain data and automatically includes future tokens launched by the factory.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for HoodPump’s Robinhood launchpad.
  * TVL now reflects WETH held in pools created through the launchpad.
  * Included methodology and tracking start-date metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->