### PR TITLE
quainance: permit failed balanceOf calls to avoid zeroing the whole adapter

### DIFF
--- a/projects/quainance/index.js
+++ b/projects/quainance/index.js
@@ -1,7 +1,6 @@
 const { getLogs2 } = require('../helper/cache/getLogs')
 const { transformDexBalances } = require('../helper/portedTokens')
 
-
 module.exports = {
   misrepresentedTokens: true,
   quai: {
@@ -17,15 +16,14 @@ async function tvl(api) {
     eventAbi: 'event PairCreated(address indexed token0, address indexed token1, address pair, uint256 )',
     fromBlock: 8906017,
   })
-  const tok0Bals = await api.multiCall({ abi: 'erc20:balanceOf', calls: logs.map(i => ({ target: i.token0, params: i.pair })) })
-  const tok1Bals = await api.multiCall({ abi: 'erc20:balanceOf', calls: logs.map(i => ({ target: i.token1, params: i.pair })) })
+  const tok0Bals = await api.multiCall({ abi: 'erc20:balanceOf', calls: logs.map(i => ({ target: i.token0, params: i.pair })), permitFailure: true })
+  const tok1Bals = await api.multiCall({ abi: 'erc20:balanceOf', calls: logs.map(i => ({ target: i.token1, params: i.pair })), permitFailure: true })
   return transformDexBalances({
     chain: api.chain, data: logs.map((log, i) => ({
       token0: log.token0,
       token0Bal: tok0Bals[i],
       token1: log.token1,
       token1Bal: tok1Bals[i],
-    }))
+    })).filter(d => d.token0Bal != null && d.token1Bal != null)
   })
-
 }


### PR DESCRIPTION
Both `api.multiCall` calls in `tvl()` (fetching token0/token1 balances
per pair) had no `permitFailure`, so a single reverting `balanceOf`
call - a dead pair, a blacklisted address, a non-standard token -
would throw and cause the entire Quai chain adapter to report zero
TVL, instead of just skipping that one bad pair.

`registries/uniswapV2.js` already sets `permitFailure: true` for
several existing UniV2-clone adapters (`baseswap`, `cubiswap`,
`elvesdex`) for exactly this reason - this is a known, recurring
failure mode for this adapter shape across the repo, not a
hypothetical one specific to this protocol.

Fix: added `permitFailure: true` to both `multiCall` calls, and
filter out any pair where either balance comes back `null` before
passing to `transformDexBalances`.

Verified locally: `node test.js projects/quainance/index.js` still
runs clean, same ~$4.24k total TVL across both currently-tracked
pools - no live pair is failing right now, this is a preventive fix
for a real, established failure class on this adapter shape, not a
fix for a currently-visible crash.

Note: rewrote the whole file rather than a line-patch, which
incidentally dropped a blank line after the imports and added the
missing trailing newline at EOF - happy to revert either if preferred.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DEX balance data handling by tolerating individual token balance lookup failures.
  * Excluded incomplete balance records from calculations to prevent inaccurate results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->