### PR TITLE
morpho-blue: add XDC

### DIFF
--- a/projects/morpho-blue/index.js
+++ b/projects/morpho-blue/index.js
@@ -221,6 +221,10 @@ const config = {
     morphoBlue: '0x18120312A7cf44DcfEc6dCe5632a431579ED9100',
     fromBlock: 	18930057,
   },
+  xdc: {
+    morphoBlue: "0xEa49B0fE898aF913A3826F9f462eE2cDcb854fD9",
+    fromBlock: 101757515,
+  },
 }
 
 const eventAbis = {


### PR DESCRIPTION
Adds the Morpho Blue deployment on XDC (chain id 50) to the morpho-blue adapter.

- Morpho core: `0xEa49B0fE898aF913A3826F9f462eE2cDcb854fD9` (listed under Morpho Blue on https://docs.morpho.org/get-started/resources/addresses/)
- Deployed at block `101757515` (2026-04-22)
- 5 markets created so far; the active ones are USDC/WXDC (38.5% LLTV, ~100% utilization) and USDC/wsrUSD (91.5% LLTV)

## Test

Ran the adapter for xdc only (full `node test.js projects/morpho-blue/index.js` currently aborts on klaytn multicall failures on master, unrelated to this change):

```
tvl => $384,624   (WXDC $364.6k collateral, USDC $20.0k, wsrUSD $2)
borrowed => $79,986   (USDC)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Morpho Blue support for the XDC network.
  * XDC liquidity and borrowing metrics are now available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->