### PR TITLE
Add Axiome Chain

### DIFF
--- a/projects/axiome/index.js
+++ b/projects/axiome/index.js
@@ -1,0 +1,17 @@
+const { get } = require('../helper/http')
+
+async function tvl() {
+  const { result } = await get('https://api-chain.axiomechain.org/validators?per_page=200')
+  const bonded = result.validators.reduce(
+    (sum, v) => sum + Number(v.voting_power), 0
+  )
+  return {
+    'axiome': bonded, 
+  }
+}
+
+module.exports = {
+  timetravel: false,
+  methodology: 'TVL equals total staked AXM across all validators, queried from the chain RPC.',
+  axiome: { tvl },
+}

--- a/projects/axiome/index.js
+++ b/projects/axiome/index.js
@@ -1,17 +1,19 @@
 const { get } = require('../helper/http')
 
 async function tvl() {
-  const { result } = await get('https://api-chain.axiomechain.org/validators?per_page=200')
-  const bonded = result.validators.reduce(
-    (sum, v) => sum + Number(v.voting_power), 0
-  )
-  return {
-    'axiome': bonded, 
+  const pairs = await get('https://api-idx.axiomechain.org/swap/pairs')
+
+  let axmReserves = 0
+  for (const pair of pairs) {
+    if (pair.token1.symbol === 'AXM') axmReserves += Number(pair.token1.reserve)
+    if (pair.token2.symbol === 'AXM') axmReserves += Number(pair.token2.reserve)
   }
+
+  return { 'axiome': (axmReserves * 2) / 1e6 }
 }
 
 module.exports = {
   timetravel: false,
-  methodology: 'TVL equals total staked AXM across all validators, queried from the chain RPC.',
+  methodology: 'TVL equals liquidity locked in AxiomeTrade DEX pools on Axiome chain. Calculated as 2x the AXM-side reserves of all 35 pools, queried from the chain indexer.',
   axiome: { tvl },
 }

--- a/projects/helper/chains.json
+++ b/projects/helper/chains.json
@@ -33,6 +33,7 @@
   "aura",
   "aurora",
   "avax",
+  "axiome",
   "babylon",
   "band",
   "base",


### PR DESCRIPTION
Name: Axiome

Twitter Link: https://twitter.com/axiome_pro

Website Link: https://axiome.pro/en

Logo: https://app.axiometrade.pro/icons/axm.png

Current TVL: ~105,900,000 AXM ($115k+)

Chain: Axiome (axiome-1)

Coingecko ID: axiome

Coinmarketcap ID: 31112

Short Description: Axiome is a next-generation financial ecosystem built on its own Layer-1 blockchain (Cosmos SDK). Features Axiome Traide DEX with 35 liquidity pools.

Token address and ticker: uaxm / AXM

Category: Layer 1 (L1)

forkedFrom: Cosmos SDK

methodology: TVL equals liquidity locked in Axiome Traide DEX pools on Axiome chain. Calculated as 2x the AXM-side reserves of all 35 pools, queried from the chain indexer (https://api-idx.axiomechain.org/swap/pairs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for the Axiome protocol.
  * Added Axiome to the supported chain list.
  * TVL is calculated from AXM reserves across available swap pairs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->