### PR TITLE
add hoodswap

### DIFF
--- a/registries/uniswapV2.js
+++ b/registries/uniswapV2.js
@@ -2883,7 +2883,7 @@ const uniV2Configs = {
   'robinswap': {
     robinhood: '0xa95DA9b9fCef09A07F99444fE9304457d6ECdccA',
   },
-   'hoodswap': {
+  'hoodswap': {
     robinhood: '0xE7206Ecac3A51afe7e6179182ad4130A26068dD1',
   },
 }

--- a/registries/uniswapV2.js
+++ b/registries/uniswapV2.js
@@ -2883,6 +2883,9 @@ const uniV2Configs = {
   'robinswap': {
     robinhood: '0xa95DA9b9fCef09A07F99444fE9304457d6ECdccA',
   },
+   'hoodswap': {
+    robinhood: '0xE7206Ecac3A51afe7e6179182ad4130A26068dD1',
+  },
 }
 
 module.exports = buildProtocolExports(uniV2Configs, uniV2ExportFn)

--- a/registries/uniswapV3.js
+++ b/registries/uniswapV3.js
@@ -1748,6 +1748,9 @@ const uniV3Configs = {
   },
   'robinswap-v3': {
     robinhood: { factory: '0xea561e058313b96011e5070ca7d0f027a44e3748', fromBlock: 6027503 },
+  },
+  'hoodswap-v3': {
+    robinhood: { factory: '0x0Ec554F0BfF0Be6C99d1e95C8015bb0950f6A2C7', fromBlock: 6052562 },
   }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added tracking for HoodSwap liquidity pools on Robinhood via Uniswap V2 and Uniswap V3.
  - Enabled detection of HoodSwap V3 pools starting from their deployment block for more reliable discovery.
- **Configuration Updates**
  - Included the required Robinhood contract address so these pools can be located automatically.
  - Pools should now appear in supported views without additional setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->