### PR TITLE
Add DOTT (Dump on the Trenches) — Robinhood Chain launchpad

### DIFF
--- a/projects/dott/index.js
+++ b/projects/dott/index.js
@@ -1,0 +1,31 @@
+// DOTT (Dump on the Trenches) — memecoin launchpad + trading terminal on
+// Robinhood Chain. TVL = ETH held in DumpFactory bonding curves that have not
+// yet graduated (pump.fun-style methodology). Curve addresses are read from the
+// factory's Launched events; native ETH balances are summed. On graduation a
+// token migrates its liquidity to a Uniswap V3 pool (counted by Uniswap), and
+// the curve's ETH balance drops to ~0 — so summing native balances counts only
+// pre-graduation reserves and never double-counts graduated liquidity.
+
+const FACTORY = "0x4B4a24aBbb7b92AFeb12D0Bca3C054fe1E7069E1"; // DumpFactory proxy
+const LAUNCHED_ABI =
+  "event Launched(address indexed token, address indexed curve, address indexed creator, string name, string symbol, string metadata, uint256 firstBuyWei)";
+const START_BLOCK = 5025502; // DumpFactory deploy block
+
+async function tvl(api) {
+  const logs = await api.getLogs({
+    target: FACTORY,
+    fromBlock: START_BLOCK,
+    eventAbi: LAUNCHED_ABI,
+  });
+  const owners = logs.map((l) => l.curve);
+  return api.sumTokens({
+    owners,
+    tokens: ["0x0000000000000000000000000000000000000000"], // native ETH
+  });
+}
+
+module.exports = {
+  methodology:
+    "Counts the ETH held in DOTT (DumpFactory) bonding curves on Robinhood Chain that have not yet graduated. Curve addresses come from the factory's Launched events and their native ETH balances are summed. Graduated tokens migrate liquidity to a Uniswap V3 pool (counted by Uniswap), so only pre-graduation curve reserves are counted here to avoid double-counting.",
+  robinhood: { tvl },
+};

--- a/projects/dott/index.js
+++ b/projects/dott/index.js
@@ -1,34 +1,25 @@
-// DOTT (Dump on the Trenches) — memecoin launchpad + trading terminal on
-// Robinhood Chain. TVL = ETH held in DumpFactory bonding curves that have not
-// yet graduated (pump.fun-style methodology). Curve addresses are read from the
-// factory's Launched events; native ETH balances are summed. On graduation a
-// token migrates its liquidity to a Uniswap V3 pool (counted by Uniswap), and
-// the curve's ETH balance drops to ~0 — so summing native balances counts only
-// pre-graduation reserves and never double-counts graduated liquidity.
+const { getLogs2 } = require('../helper/cache/getLogs')
+const ADDRESSES = require('../helper/coreAssets.json')
 
-const { getLogs2 } = require("../helper/cache/getLogs");
-
-const FACTORY = "0x4B4a24aBbb7b92AFeb12D0Bca3C054fe1E7069E1"; // DumpFactory proxy
-const LAUNCHED_ABI =
-  "event Launched(address indexed token, address indexed curve, address indexed creator, string name, string symbol, string metadata, uint256 firstBuyWei)";
-const START_BLOCK = 5025502; // DumpFactory deploy block
+const FACTORY = "0x4B4a24aBbb7b92AFeb12D0Bca3C054fe1E7069E1";
+const START_BLOCK = 5025894;
+const LAUNCHED_ABI = "event Launched(address indexed token, address indexed curve, address indexed creator, string name, string symbol, string metadata, uint256 firstBuyWei)";
 
 async function tvl(api) {
   const logs = await getLogs2({
     api,
-    factory: FACTORY,
-    eventAbi: LAUNCHED_ABI,
+    target: FACTORY,
     fromBlock: START_BLOCK,
+    eventAbi: LAUNCHED_ABI,
   });
   const owners = logs.map((l) => l.curve);
   return api.sumTokens({
     owners,
-    tokens: ["0x0000000000000000000000000000000000000000"], // native ETH
+    tokens: [ADDRESSES.null],
   });
 }
 
 module.exports = {
-  methodology:
-    "Counts the ETH held in DOTT (DumpFactory) bonding curves on Robinhood Chain that have not yet graduated. Curve addresses come from the factory's Launched events and their native ETH balances are summed. Graduated tokens migrate liquidity to a Uniswap V3 pool (counted by Uniswap), so only pre-graduation curve reserves are counted here to avoid double-counting.",
+  methodology: "Counts the ETH held in DOTT (DumpFactory) bonding curves on Robinhood Chain that have not yet graduated. Curve addresses come from the factory's Launched events and their native ETH balances are summed. Graduated tokens migrate liquidity to a Uniswap V3 pool (counted by Uniswap), so only pre-graduation curve reserves are counted here to avoid double-counting.",
   robinhood: { tvl },
 };

--- a/projects/dott/index.js
+++ b/projects/dott/index.js
@@ -6,16 +6,19 @@
 // the curve's ETH balance drops to ~0 — so summing native balances counts only
 // pre-graduation reserves and never double-counts graduated liquidity.
 
+const { getLogs2 } = require("../helper/cache/getLogs");
+
 const FACTORY = "0x4B4a24aBbb7b92AFeb12D0Bca3C054fe1E7069E1"; // DumpFactory proxy
 const LAUNCHED_ABI =
   "event Launched(address indexed token, address indexed curve, address indexed creator, string name, string symbol, string metadata, uint256 firstBuyWei)";
 const START_BLOCK = 5025502; // DumpFactory deploy block
 
 async function tvl(api) {
-  const logs = await api.getLogs({
-    target: FACTORY,
-    fromBlock: START_BLOCK,
+  const logs = await getLogs2({
+    api,
+    factory: FACTORY,
     eventAbi: LAUNCHED_ABI,
+    fromBlock: START_BLOCK,
   });
   const owners = logs.map((l) => l.curve);
   return api.sumTokens({


### PR DESCRIPTION
Adds a TVL adapter for **DOTT (Dump on the Trenches)**, a memecoin launchpad + self-custodial trading terminal on **Robinhood Chain** (chain key `robinhood`, chain ID 4663).

**Methodology:** TVL = ETH held in DumpFactory bonding curves that have not yet graduated. Curve addresses are read from the factory's `Launched` events and their native ETH balances summed. When a token graduates, its liquidity migrates to a Uniswap V3 pool (already counted by Uniswap's adapter), and the curve's ETH balance drops to ~0 — so summing native balances counts only pre-graduation reserves and never double-counts graduated liquidity (same approach as pump.fun-style launchpads).

**Protocol metadata**
- Name: DOTT (Dump on the Trenches)
- Website: https://dumponthetrenches.com
- Category: Launchpad
- Chain: Robinhood Chain (`robinhood`)
- Twitter: DumpOnTrenches
- Factory (DumpFactory proxy): `0x4B4a24aBbb7b92AFeb12D0Bca3C054fe1E7069E1`

Note: the launchpad is early-stage, so current TVL is small and will grow as usage ramps — the adapter reports it live from on-chain state. Verified the getLogs + native-balance reads work against the configured `ROBINHOOD_RPC`. Happy to adjust naming/category as you prefer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for DOTT on Robinhood Chain.
  * Includes native ETH reserves held by pre-graduation bonding curves while avoiding double-counting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->