### PR TITLE
Add AFX LP TVL adapter

### DIFF
--- a/projects/afx-lp/index.js
+++ b/projects/afx-lp/index.js
@@ -1,3 +1,4 @@
+// Uses AFX's public DefiLlama integration endpoint for LP Vault TVL.
 const { get } = require("../helper/http");
 
 const API_URL = "https://api.afx.xyz/info/integrations/defillama/lp/summary";

--- a/projects/afx-lp/index.js
+++ b/projects/afx-lp/index.js
@@ -1,0 +1,22 @@
+const { get } = require("../helper/http");
+
+const API_URL = "https://api.afx.xyz/info/integrations/defillama/lp/summary";
+
+async function tvl(api) {
+  const response = await get(API_URL, {
+    headers: {
+      Accept: "application/json",
+      "User-Agent": "defillama-tvl-adapters/1.0",
+    },
+  });
+  const tvlUsd = Number(response?.data?.summary?.tvl);
+  if (!Number.isFinite(tvlUsd)) {
+    throw new Error("Invalid AFX LP TVL response");
+  }
+  api.addUSDValue(tvlUsd);
+}
+
+module.exports = {
+  methodology: "TVL is the current USD value locked in the AFX LP Vault, as reported by AFX's public DefiLlama integration API.",
+  arbitrum: { tvl },
+};


### PR DESCRIPTION
Adds AFX LP Vault TVL adapter using AFX's public DefiLlama integration endpoint.

Endpoint:
- https://api.afx.xyz/info/integrations/defillama/lp/summary

Methodology:
TVL is the current USD value locked in the AFX LP Vault, as reported by the AFX public API.

Please list AFX LP as a child protocol under AFX Protocol (Combined), alongside AFX Bridge and AFX Perps.

Test:
- node test.js projects/afx-lp/index.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for AFX LP on the Arbitrum network.
  * Integrated live TVL data from the AFX API and exposed it in USD.
  * Included methodology information describing how the TVL is calculated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->