### PR TITLE
Add Apyee TVL adapter

### DIFF
--- a/projects/apyee/index.js
+++ b/projects/apyee/index.js
@@ -1,0 +1,30 @@
+const { sumERC4626VaultsExport2 } = require('../helper/erc4626')
+
+// Apyee — non-custodial multi-chain USDC yield aggregator.
+// Immutable ERC-4626 Vaults deposit USDC into whitelisted DeFi strategies
+// (Aave V3, Compound V3, Morpho MetaMorpho, Fluid, Venus, Spark).
+// Prod deployment: v2.1.3 (2026-07-13). Owner = Gnosis Safe multi-sig 2/3.
+// Audited by Soken (4 reports, final PASS 91/100). Source verified on each explorer.
+// https://apyee.com/security
+const vaults = {
+  ethereum: ['0xE46aac58214B963125a3A88541e1DBE56c4eD5f7'],
+  base: [
+    '0xeA8FB89F44A1fa47E52354D44E7e6D4682C8529a', // balanced
+    '0x87922c630A980e431fb045A178e53F58d3f07F85', // aggressive
+  ],
+  arbitrum: ['0x94f89d1E2825d40627CD2aE24Eba8590F675049C'],
+  bsc: ['0x27DB5a2B203D6bd3C9490E8EA4488B968675f5Bf'],
+}
+
+module.exports = Object.fromEntries(
+  Object.entries(vaults).map(([chain, addrs]) => [
+    chain,
+    { tvl: sumERC4626VaultsExport2({ vaults: addrs }) },
+  ])
+)
+
+module.exports.methodology =
+  'Sum of totalAssets() reported by each Apyee VaultV2 across supported chains — includes idle USDC plus assets currently deployed into whitelisted DeFi lending strategies (Aave V3, Compound V3, Morpho MetaMorpho, Fluid, Venus, Spark). USDC decimals differ per chain (6 on Ethereum/Base/Arbitrum, 18 on BNB Chain); the helper resolves this via asset().decimals().'
+
+module.exports.doublecounted = true
+module.exports.start = '2026-07-13'


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
Apyee

##### Twitter Link:
https://x.com/apyee_com

##### List of audit links if any:
https://apyee.com/security (Soken, 4 reports, final PASS 91/100) — also published by the auditor: https://github.com/sokenteam/Soken.io-smart_contract_audits/blob/main/Apyee_Security_Audit_v2.1.3.pdf

##### Website Link:
https://apyee.com

##### Logo (High resolution, will be shown with rounded borders):
https://apyee.com/icon-512.png

##### Current TVL:
~$17.19K (on-chain measurement at submission; Soft Launch, per-chain $500K deposit cap)

##### Treasury Addresses:
0xEC4d3B6a39D61B85dF61cCb35CE693517992A98e (Gnosis Safe multi-sig 2/3, identical across all 4 chains)

##### Chain:
Ethereum, Base, Arbitrum, BNB Chain

##### Coingecko ID:
N/A (no protocol token)

##### Coinmarketcap ID:
N/A (no protocol token)

##### Short Description:
Non-custodial multi-chain USDC yield aggregator. Immutable ERC-4626 Vaults route deposits into whitelisted DeFi lending strategies (Aave V3, Compound V3, Morpho MetaMorpho, Fluid, Venus, Spark). Operator cannot withdraw user funds — enforced at bytecode level.

##### Token address and ticker if any:
N/A (no token)

##### Category:
Yield Aggregator

##### Oracle Provider(s):
Chainlink (COMP/USD feed on Ethereum), plus internal fallback price + slippage floor

##### Implementation Details:
Reward token min-out floor computed from Chainlink price with fallback to Owner-set static price; hard 10% slippage cap enforced at contract level.

##### Documentation/Proof:
https://apyee.com/security — audit reports (Soken PASS 91/100) + trust model + verified source links

##### forkedFrom:
N/A

##### methodology:
Sum of `totalAssets()` reported by each Apyee VaultV2 across supported chains. Includes idle USDC plus assets currently deployed into whitelisted DeFi lending strategies (Aave V3, Compound V3, Morpho MetaMorpho, Fluid, Venus, Spark). USDC decimals differ per chain (6 on Ethereum/Base/Arbitrum, 18 on BNB Chain); the helper resolves this via `asset().decimals()`. Marked `doublecounted: true` because vault assets are deployed into protocols already listed on DefiLlama.

##### Github org/user:
coinlive-apyee (https://github.com/coinlive-apyee/apyee-protocol, tag v2.1.3, commit e737779, source-verified on all 4 chain explorers)

##### Does this project have a referral program?
No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Apyee’s multi-chain USDC yield aggregator to platform coverage.
  * Added total value locked (TVL) tracking across supported chains and participating vaults.
  * Included methodology and start-date metadata for clearer reporting and historical context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->