### PR TITLE
nawa: add Ethereum USDT vault TVL

### DIFF
--- a/projects/nawa/index.js
+++ b/projects/nawa/index.js
@@ -115,6 +115,27 @@ async function zigchainTvl(api) {
   }
 }
 
+// ---------- ETHEREUM ----------
+
+// Nawa USDT Vault (UUPS proxy). A share-based USDT vault whose deposits are
+// deployed off-chain into a curated credit strategy; the on-chain contract
+// tracks the assets backing shares in `latestAum` (oracle-reported, USDT).
+const NAWA_USDT_VAULT = '0x6FE78B942C566fE2b8D0881cf3577C1B1511F204'
+const USDT = '0xdAC17F958D2ee523a2206206994597C13D831ec7'
+
+// TVL = assets backing live shares (latestAum) + assets committed to
+// burned-but-unfunded redemptions (pendingRedemptionAum) + funded payouts
+// still held for claim (totalClaimable). The three are disjoint, so their sum
+// is the total USDT value held on behalf of users across the redemption cycle.
+async function ethereumTvl(api) {
+  const [aum, pending, claimable] = await Promise.all([
+    api.call({ abi: 'uint256:latestAum', target: NAWA_USDT_VAULT }),
+    api.call({ abi: 'uint256:pendingRedemptionAum', target: NAWA_USDT_VAULT }),
+    api.call({ abi: 'uint256:totalClaimable', target: NAWA_USDT_VAULT }),
+  ])
+  api.add(USDT, (BigInt(aum) + BigInt(pending) + BigInt(claimable)).toString())
+}
+
 module.exports = {
   timetravel: false,            // ZigChain query is live-state only
   misrepresentedTokens: false,
@@ -125,11 +146,17 @@ module.exports = {
     'cross-chain private credit position), reported as USDC. ' +
     'Core: TVL is calculated by 1) unwrapping Bitflux LP tokens held by Nawa Solv Vault V2 to their underlying assets ' +
     '(e.g. SolvBTC.CORE, WBTC, SolvBTC.b) based on pool reserves and total supply, and 2) tracking dualCore token ' +
-    'holdings in the Core vault address.',
+    'holdings in the Core vault address. ' +
+    'Ethereum: TVL is the USDT held on behalf of users by the Nawa USDT Vault, taken as the sum of assets backing ' +
+    'live shares (latestAum), assets committed to pending redemptions (pendingRedemptionAum) and funded payouts ' +
+    'awaiting claim (totalClaimable), reported as USDT.',
   core: {
     tvl: coreTvl,
   },
   zigchain: {
     tvl: zigchainTvl,
+  },
+  ethereum: {
+    tvl: ethereumTvl,
   },
 };


### PR DESCRIPTION
Adds an `ethereum` chain entry to the existing `nawa` adapter for the newly deployed Nawa USDT Vault.

**Contract:** `0x6FE78B942C566fE2b8D0881cf3577C1B1511F204` (UUPS proxy, mainnet)

**Methodology:** the vault is a share-based USDT vault whose deposits are deployed off-chain into a curated credit strategy; the on-chain contract tracks the assets backing shares. TVL is reported in USDT as the sum of three disjoint on-chain values:
- `latestAum` — assets backing live shares
- `pendingRedemptionAum` — assets committed to burned-but-unfunded redemptions
- `totalClaimable` — funded payouts still held for claim

This mirrors how the adapter's existing ZigChain vault reports its oracle AUM. Verified with the test harness (`node test.js projects/nawa/index.js`): the ethereum entry returns the current AUM and the full adapter still reports all chains.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ethereum TVL tracking for the Nawa USDT Vault.
  * Ethereum TVL now reflects assets under management, pending redemptions, and claimable amounts, reported in USDT.

* **Documentation**
  * Updated the TVL methodology to describe the Ethereum calculation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->