### PR TITLE
Add Barker (zero-TVL listing for Yields dashboard integration)

### DIFF
--- a/projects/barker/index.js
+++ b/projects/barker/index.js
@@ -1,0 +1,23 @@
+/*
+Barker is a non-custodial stablecoin yield distribution layer — it runs boost
+campaigns on top of third-party vaults. User principal is deposited directly
+into the underlying protocol's own vault (Barker contracts never hold user
+funds), and Barker distributes boosted rewards on top. Hence Barker itself
+has no TVL. This adapter was made to integrate Barker in the Yields dashboard.
+For more information on Barker, see https://barker.money
+*/
+
+async function tvl() {
+  return {};
+}
+
+module.exports = {
+  methodology:
+    "Barker is a non-custodial boost/campaign layer on top of third-party vaults: user funds sit in the underlying protocols' own vaults, so Barker has no TVL of its own. See the yield dashboard for a list of Barker-boosted pools.",
+  ethereum: {
+    tvl,
+  },
+  hyperliquid: {
+    tvl,
+  },
+};


### PR DESCRIPTION
## Listing details

- **Name**: Barker
- **Website**: https://barker.money
- **Twitter**: https://x.com/BarkerMoneyX
- **Logo (square)**: https://barker.money/images/brand-assets/logo-square.png
- **Category**: Yield
- **Chains**: Ethereum, Hyperliquid L1
- **Description**: Barker is a non-custodial stablecoin yield distribution layer ("yield primitive for the agent economy"). It runs boost campaigns on top of third-party vaults: user principal is deposited directly into the underlying protocol's own vault, and Barker distributes boosted rewards on top.
- **Methodology**: Barker contracts never hold user funds, so Barker itself has no TVL — same pattern as Merkl. This adapter registers the protocol so Barker-boosted pools can be listed on the Yields dashboard (yield-server adapter to follow).
- **Github**: https://github.com/YBSbarker
- **Oracle**: none · **Forked from**: none · **Audit**: internal review of campaign distributor contracts

Current live boosted pool example: Flowdesk AUSD RWA Strategy (Morpho v2 vault, Ethereum, ~$11M TVL) with Barker reward boost on top — served from the public API at api.barker.money.

🤖 Generated with [Claude Code](https://claude.com/claude-code)