### PR TITLE
fix k3 vault address

### DIFF
--- a/projects/k3/index.js
+++ b/projects/k3/index.js
@@ -79,7 +79,7 @@ const configs = {
     },
     monad: {
       accountableVaults: [
-        "0x77410132Fd468d67B820314d378bE1fDbfA2bAa4",
+        "0x0143C3eF3a76Ed825Fd5201953f65b52aCEfD799",
       ],
       eulerVaultOwners: [
         "0x987C5739F3905FbA98eCCf4aceBc88730E0eE53D",


### PR DESCRIPTION
updated to `0x77410132Fd468d67B820314d378bE1fDbfA2bAa4.vault()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the EulerDAO sunset configuration for the Monad network with the correct vault owner address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->