### PR TITLE
registries/uniswapV2Logs: restore permitFailure + null-filter lost in consolidation

### DIFF
--- a/registries/uniswapV2Logs.js
+++ b/registries/uniswapV2Logs.js
@@ -18,15 +18,15 @@ function uniV2LogsTvl({ factory, fromBlock, useGetLogs2 }) {
       onlyArgs: useGetLogs2 ? undefined : true,
       fromBlock,
     })
-    const tok0Bals = await api.multiCall({ abi: 'erc20:balanceOf', calls: logs.map(i => ({ target: i.token0, params: i.pair })) })
-    const tok1Bals = await api.multiCall({ abi: 'erc20:balanceOf', calls: logs.map(i => ({ target: i.token1, params: i.pair })) })
+    const tok0Bals = await api.multiCall({ abi: 'erc20:balanceOf', calls: logs.map(i => ({ target: i.token0, params: i.pair })), permitFailure: true })
+    const tok1Bals = await api.multiCall({ abi: 'erc20:balanceOf', calls: logs.map(i => ({ target: i.token1, params: i.pair })), permitFailure: true })
     return transformDexBalances({
       chain: api.chain, data: logs.map((log, i) => ({
         token0: log.token0,
         token0Bal: tok0Bals[i],
         token1: log.token1,
         token1Bal: tok1Bals[i],
-      }))
+      })).filter(d => d.token0Bal != null && d.token1Bal != null)
     })
   }
 }


### PR DESCRIPTION

`quainance`'s adapter was fixed in #20011 to add `permitFailure: true`
on both `multiCall` calls plus a null-filter, preventing one bad
pair's reverting `balanceOf` from silently zeroing the whole adapter's
TVL - a real Multicall3 aggregation-limit issue, verified on-chain at
the time.

fe37ed06c consolidated `kaleidoswap`, `mantleswap`, and `quainance`
into a shared `uniV2LogsTvl` factory
(`registries/uniswapV2Logs.js`), deleting `projects/quainance/index.js`
in the process. The new shared function copy-pasted the original,
unfixed shape (matching what `kaleidoswap`/`mantleswap` always had,
neither of which ever received the fix) and lost it.

Since this function is now shared across all three protocols, the
same silent-zero risk applies to all of them, not just quainance.

Fix: re-added `permitFailure: true` to both `multiCall` calls and the
`token0Bal`/`token1Bal` null-filter before `transformDexBalances`.

Verified locally: `node test.js kaleidoswap` / `mantleswap` /
`quainance` all still return the same real, non-zero TVL as before
this commit - no regression, this is a pure safety net for a failure
mode that hasn't triggered yet but is proven real.

cc @g1nt0ki since you authored the consolidation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Uniswap V2 pool balance processing to handle unavailable token balance data gracefully.
  * Excluded pools with incomplete balance information from TVL results, preventing invalid entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->