### PR TITLE
fix: await floating balance promises (valence, sierra-money)

### DIFF
--- a/projects/sierra-money/index.js
+++ b/projects/sierra-money/index.js
@@ -15,7 +15,7 @@ const owners = [
   "0x2071D1689D85De2b49004D257f99802A25BF4fe7"
 ];
 async function tvl(api) {
-  api.sumTokens({ owners, tokens: [ADDRESSES.avax.USDC] });
+  await api.sumTokens({ owners, tokens: [ADDRESSES.avax.USDC] });
   // get tokens staked in openTrade for each owner across each vault
   const calls = openTradeVaults.flatMap(vault =>
     owners.map(owner => ({ target: vault, params: owner }))

--- a/projects/valence/index.js
+++ b/projects/valence/index.js
@@ -100,7 +100,7 @@ async function getLpTvl(api, chain, dexNames=[]) {
 
     const possibleLpTokens = Object.keys(balances).filter((address) => address.match(dexConfig.regex));
 
-    possibleLpTokens.forEach(async(lpToken)=>{
+    await Promise.all(possibleLpTokens.map(async (lpToken) => {
          // regex method does not guarantee an LP token is valid, so handle the error gracefully and ignore the asset in the valuation if this is the case
          try {
           const lpBalance = balances[lpToken];
@@ -118,7 +118,7 @@ async function getLpTvl(api, chain, dexNames=[]) {
         } catch (e){
           console.log('Warning: Could not query LP share value for',lpToken)
         }
-    })
+    }))
   
 
    


### PR DESCRIPTION
Two adapters kick off an async balance-adding call but return before it settles. The framework reads `api.getBalances()` right after `await tvl(api)`, and pending promises are not tracked — so the balance is silently missing. Neither shows up as a spike (the value is just persistently low/flickery), which is why it slips past review.

### valence (neutron) — deterministic undercount

`getLpTvl` converts astroport LP shares into their underlying value:

```js
possibleLpTokens.forEach(async (lpToken) => {
  const shareValues = await dexConfig.queryShareValue({ ... }); // network
  shareValues.forEach(sv => api.add(sv.denom, sv.amount));
})
// no await after the loop -> getLpTvl returns here
```

`forEach` discards the returned promises and there is no `await` after the loop, so `getLpTvl` returns before any `api.add` runs. Since it's the last call in the neutron `tvl`, the entire astroport-LP underlying value is dropped on every run. Fixed by awaiting `Promise.all(map(...))`.

### sierra-money (avax) — race

```js
api.sumTokens({ owners, tokens: [ADDRESSES.avax.USDC] }); // not awaited
const openTradeBalances = await api.multiCall({ abi, calls });
```

The reserve-USDC `sumTokens` is a floating promise racing the awaited OpenTrade `multiCall`. When the multiCall wins, the reserve USDC (part of the adapter's stated methodology) is dropped before `getBalances()` is read. Fixed by awaiting the call.

Both changes are minimal and leave behavior otherwise unchanged; the try/catch handling in valence is preserved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TVL reporting accuracy by ensuring token and liquidity-pool calculations finish before results are returned.
  * Reduced the risk of incomplete or inconsistent values appearing in dashboard metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->