### PR TITLE
Add fetch function to retrieve TVL data

### DIFF
--- a/projects/helper/chains.json
+++ b/projects/helper/chains.json
@@ -354,6 +354,7 @@
   "plasma",
   "plume",
   "plume_mainnet",
+  "plus",
   "pokt",
   "polis",
   "polkadex",

--- a/projects/plus-autobot/index.js
+++ b/projects/plus-autobot/index.js
@@ -9,5 +9,5 @@ module.exports = {
   timetravel: false,
   misrepresentedTokens: true,
   methodology: "TVL includes Base Genesis Node Staking, Ecosystem Treasury Liquidity, and Live User Deposits tracked via the official PLUS Hybrid DEX API.",
-  tv1: fetch
+  tvl: fetch
 };

--- a/projects/plus-autobot/index.js
+++ b/projects/plus-autobot/index.js
@@ -2,7 +2,11 @@ const { fetchURL } = require("../helper/utils");
 
 async function fetch() {
   const response = await fetchURL("https://bot.plusmain.net/api/defillama/tvl");
-  return response.data.tvl;
+  
+  // 핵심 포인트: 단순 숫자가 아닌, tether(USDT 단위) 객체 형태로 반환해야 봇이 인식합니다!
+  return { 
+    tether: response.data.tvl 
+  };
 }
 
 module.exports = {

--- a/projects/plus-autobot/index.js
+++ b/projects/plus-autobot/index.js
@@ -9,5 +9,5 @@ module.exports = {
   timetravel: false,
   misrepresentedTokens: true,
   methodology: "TVL includes Base Genesis Node Staking, Ecosystem Treasury Liquidity, and Live User Deposits tracked via the official PLUS Hybrid DEX API.",
-  fetch
+  tv1: fetch
 };

--- a/projects/plus-autobot/index.js
+++ b/projects/plus-autobot/index.js
@@ -2,7 +2,6 @@ const { fetchURL } = require("../helper/utils");
 
 async function fetch() {
   const response = await fetchURL("https://bot.plusmain.net/api/defillama/tvl");
-  // axios의 response 구조에 맞게 데이터를 추출하여 리턴합니다.
   return response.data.tvl;
 }
 
@@ -10,6 +9,7 @@ module.exports = {
   timetravel: false,
   misrepresentedTokens: true,
   methodology: "TVL includes Base Genesis Node Staking, Ecosystem Treasury Live User Deposits managed off-chain.",
-  // API를 통해 통합 TVL 단순 숫자를 가져올 때는 루트 레벨에 fetch를 위치시켜야 합니다.
-  fetch: fetch
+  plus: {
+    tvl: fetch
+  }
 };

--- a/projects/plus-autobot/index.js
+++ b/projects/plus-autobot/index.js
@@ -2,14 +2,14 @@ const { fetchURL } = require("../helper/utils");
 
 async function fetch() {
   const response = await fetchURL("https://bot.plusmain.net/api/defillama/tvl");
+  // axios의 response 구조에 맞게 데이터를 추출하여 리턴합니다.
   return response.data.tvl;
 }
 
 module.exports = {
   timetravel: false,
   misrepresentedTokens: true,
-  methodology: "TVL includes Base Genesis Node Staking, Ecosystem Treasury Liquidity, and Live User Deposits tracked via the official PLUS Hybrid DEX API.",
-  plus: {
-    tvl: fetch
-  }
+  methodology: "TVL includes Base Genesis Node Staking, Ecosystem Treasury Live User Deposits managed off-chain.",
+  // API를 통해 통합 TVL 단순 숫자를 가져올 때는 루트 레벨에 fetch를 위치시켜야 합니다.
+  fetch: fetch
 };

--- a/projects/plus-autobot/index.js
+++ b/projects/plus-autobot/index.js
@@ -9,5 +9,7 @@ module.exports = {
   timetravel: false,
   misrepresentedTokens: true,
   methodology: "TVL includes Base Genesis Node Staking, Ecosystem Treasury Liquidity, and Live User Deposits tracked via the official PLUS Hybrid DEX API.",
-  tvl: fetch
+  plus: {
+    tvl: fetch
+  }
 };

--- a/projects/plus-autobot/index.js
+++ b/projects/plus-autobot/index.js
@@ -1,0 +1,13 @@
+const { fetchURL } = require("../helper/utils");
+
+async function fetch() {
+  const response = await fetchURL("https://bot.plusmain.net/api/defillama/tvl");
+  return response.data.tvl;
+}
+
+module.exports = {
+  timetravel: false,
+  misrepresentedTokens: true,
+  methodology: "TVL includes Base Genesis Node Staking, Ecosystem Treasury Liquidity, and Live User Deposits tracked via the official PLUS Hybrid DEX API.",
+  fetch
+};


### PR DESCRIPTION
**Note to maintainers:** 
This project is an institutional-grade, off-chain HFT statistical arbitrage engine (100% Non-Custodial). Since user liquidity and trading volumes are managed dynamically across 120+ centralized exchanges via our universal CCXT protocol, we must use a fetch adapter to provide accurate real-time data from our official API.
---
## (Needs to be filled only for new listings)
- **Name (to be shown on DefiLlama):** PLUS Autobot
- **Twitter Link:** https://twitter.com/plusfoundation
- **List of audit links if any:** CertiK Smart Contract Audit (In Progress)
- **Website Link:** https://bot.plusmain.net
- **Logo:** https://plusmain.net/plus_coin_logo.png
- **Current TVL:** ~$27,500,000 (Genesis Node Staking + Ecosystem Treasury + Live User Deposits)
- **Treasury Addresses (if the protocol has treasury):** 
- **Chain:** PLUS Mainnet
- **Coingecko ID:** 
- **Coinmarketcap ID:**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live TVL tracking for PLUS using data from the PLUS TVL endpoint.
  * PLUS TVL is now included in the app’s standard TVL views.
  * Added adapter-level methodology information and token representation handling to improve clarity and consistency.
  * Registered the PLUS network identifier so it appears in supported chain selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->