### PR TITLE
fix: improve bitcoin duplicate checker

### DIFF
--- a/projects/helper/bitcoin-book/fetchers.js
+++ b/projects/helper/bitcoin-book/fetchers.js
@@ -278,7 +278,7 @@ module.exports = {
   rskBridge: async (api) => {
     return getConfig('rsk-bridge', undefined, {
       fetcher: async () => {
-        api = new sdk.ChainApi({ chain: 'rsk', timestamp: api.timestamp })
+        api = new sdk.ChainApi({ chain: 'rsk', timestamp: api?.timestamp })
         await api.getBlock()
         const addr = await api.call({  abi: 'string:getFederationAddress', target:'0x0000000000000000000000000000000001000006' })
         return [addr]

--- a/utils/scripts/checkBTCDupsv2.js
+++ b/utils/scripts/checkBTCDupsv2.js
@@ -3,14 +3,16 @@ const addressBook = require('../../projects/helper/bitcoin-book/index');
 const { getEnv } = require('../../projects/helper/env');
 const Bucket = "tvl-adapter-cache";
 
-console.log('project count: ', Object.keys(addressBook).length);
+const projectKeys = Object.keys(addressBook).filter(project => project !== 'getBTCExport');
+
+console.log('project count: ', projectKeys.length);
 const addressProjectMap = {}
 
 const projectData = {}
 
 async function run() {
 
-  await Promise.all(Object.keys(addressBook).map(async project => {
+  await Promise.all(projectKeys.map(async project => {
 
     try {
 
@@ -27,7 +29,8 @@ async function run() {
 
       for (let address of addresses) {
         if (addressProjectMap[address]) {
-          addressProjectMap[address].push(project);
+          if (!addressProjectMap[address].includes(project))
+            addressProjectMap[address].push(project);
         } else {
           addressProjectMap[address] = [project];
         }


### PR DESCRIPTION
## Summary

- Excludes the `getBTCExport` helper from Bitcoin address-source iteration.
- Allows `rskBridge` to run without an adapter API context.
- Prevents same-project address repetitions from appearing as cross-project duplicates.

## Why

The checker treated every enumerable Bitcoin address-book export as an address source. This caused errors for `getBTCExport` and `rskBridge`, and produced false positives such as `kucoin, kucoin`.

This was discovered while investigating #12913. This PR only improves the checker and does not change any protocol’s TVL accounting.

## Validation

- `pnpm exec eslint projects/helper/bitcoin-book/fetchers.js utils/scripts/checkBTCDupsv2.js`
- `pnpm check-bitcoin-duplicates`
  - `getBTCExport` and `rskBridge` errors are removed.
  - Same-project false positives are removed.
  - The existing `teleswap` API-response error remains unrelated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved bridge data retrieval when optional API details are unavailable, preventing request failures.
  - Corrected project processing during Bitcoin address checks by excluding non-applicable entries.
  - Prevented duplicate project associations for the same Bitcoin address, resulting in cleaner and more accurate results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->