### PR TITLE
Add Catnip (Robinhood Chain)

### DIFF
--- a/projects/catnip/index.js
+++ b/projects/catnip/index.js
@@ -1,0 +1,53 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+const { transformDexBalances } = require('../helper/portedTokens')
+const { stakingPriceLP } = require('../helper/staking')
+
+const FACTORY = '0x002EC9782d70f4e79396c58964D4691cA648FB49'
+const NIP = '0xb06f3BE6d2b2D04e6e9276d99b3F134F5429934b'
+const CACHE = '0x5d00D31C9A464d51679A88d0F073401aA6Fc5d6B'
+const CATNIP_WETH = '0xc08751E47611F035B958889557EDBBE33d4a8Bce'
+const NIP_USDG_LP = '0xde3a686CAa73e6CCc6072Fb6880c82Fe106dDcB7'
+
+const remap = (token) =>
+  token.toLowerCase() === CATNIP_WETH.toLowerCase()
+    ? ADDRESSES.robinhood.WETH
+    : token
+
+async function tvl(api) {
+  const pairLength = await api.call({ target: FACTORY, abi: 'uint256:allPairsLength' })
+  const pairIndexes = Array.from({ length: Number(pairLength) }, (_, i) => i)
+  const pairs = await api.multiCall({
+    target: FACTORY,
+    abi: 'function allPairs(uint256) view returns (address)',
+    calls: pairIndexes,
+  })
+  const token0s = await api.multiCall({ abi: 'address:token0', calls: pairs })
+  const token1s = await api.multiCall({ abi: 'address:token1', calls: pairs })
+  const bals0 = await api.multiCall({
+    abi: 'erc20:balanceOf',
+    calls: pairs.map((pair, i) => ({ target: token0s[i], params: pair })),
+  })
+  const bals1 = await api.multiCall({
+    abi: 'erc20:balanceOf',
+    calls: pairs.map((pair, i) => ({ target: token1s[i], params: pair })),
+  })
+
+  const data = pairs.map((_, i) => ({
+    token0: remap(token0s[i]),
+    token1: remap(token1s[i]),
+    token0Bal: bals0[i],
+    token1Bal: bals1[i],
+  }))
+
+  return transformDexBalances({ api, data })
+}
+
+module.exports = {
+  methodology:
+    'Counts tokens locked in Alley Uniswap-V2-style liquidity pools. Catnip WETH balances are mapped 1:1 to Robinhood Chain WETH for pricing. Staking counts NIP deposited in the Cache (xNIP) vault, priced via the NIP/USDG pool.',
+  start: 1784035294,
+  robinhood: {
+    tvl,
+    staking: stakingPriceLP(CACHE, NIP, NIP_USDG_LP),
+  },
+}


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
Catnip

##### Twitter Link:
https://x.com/catnipexchange


##### List of audit links if any:
None

##### Website Link:
http://catnipexchange.com/

##### Logo (High resolution, will be shown with rounded borders):
https://raw.githubusercontent.com/satorioshi/DefiLlama-Adapters/listing-assets/catnip-logo.png

##### Current TVL:
~0.6k (adapter `node test.js projects/catnip/index.js` at submit time)

##### Treasury Addresses (if the protocol has treasury)
PantryTimelock: `0x9375A7Bc2EF67dEa56010D7FfD6b38F9AC52A470`

##### Chain:
Robinhood Chain

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):


##### Short Description (to be shown on DefiLlama):
Catnip is a Uniswap V2-style DEX (Alley), farms (MasterProwl), and xNIP vault (Cache) on Robinhood Chain.

##### Token address and ticker if any:
NIP — `0xb06f3BE6d2b2D04e6e9276d99b3F134F5429934b` (Robinhood Chain)

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Dexs

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
None (constant-product AMM)

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
N/A

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
N/A

##### forkedFrom (Does your project originate from another project):
Uniswap V2 (via TenXSwap/VenomSwap parity)

##### methodology (what is being counted as tvl, how is tvl being calculated):
Counts tokens locked in Alley Uniswap-V2-style liquidity pools (factory `0x002EC9782d70f4e79396c58964D4691cA648FB49`). Catnip's deployed WETH is mapped 1:1 to Robinhood Chain WETH for pricing. Staking counts NIP deposited in Cache (`0x5d00D31C9A464d51679A88d0F073401aA6Fc5d6B`), priced via the NIP/USDG pool.

##### Github org/user (Optional, if your code is open source, we can track activity):
satorioshi

##### Does this project have a referral program?
No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for Catnip liquidity pools on the Robinhood chain.
  * Added staking valuation for NIP deposited in the Catnip cache vault.
  * Added token mapping to support accurate WETH pricing across the chain.
  * Included methodology and tracking start-date information for the integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
