### PR TITLE
fix: use a unique cache key for TeleSwap lockers

### DIFF
--- a/projects/helper/bitcoin-book/fetchers.js
+++ b/projects/helper/bitcoin-book/fetchers.js
@@ -272,7 +272,7 @@ module.exports = {
     })
   },
   teleswap: async () => {
-    const  { data: { lockers } } = await getConfig('yala/bitcoin', 'https://api.teleportdao.xyz/api/v1/teleswap/lockers/')
+    const  { data: { lockers } } = await getConfig('teleswap/bitcoin', 'https://api.teleportdao.xyz/api/v1/teleswap/lockers/')
     return lockers.filter(l => l.type === 'BTC').map(l => l.sourceAddress)
   },
   rskBridge: async (api) => {


### PR DESCRIPTION
## Summary

Give TeleSwap its own cache key instead of sharing `yala/bitcoin`.

## Problem

Yala and TeleSwap are fetched concurrently by the Bitcoin duplicate checker. Because both used the same cache key, the cached Yala address array could be returned to TeleSwap, causing:

`TypeError: Cannot read properties of undefined (reading 'lockers')`

## Validation

- Reproduced the failure with `Promise.all([f.yala(), f.teleswap()])`
- Confirmed the same concurrent call returns independent address lists after the fix
- `pnpm exec eslint projects/helper/bitcoin-book/fetchers.js`
- `git diff --check`

No dependencies or lockfiles were changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected configuration and cache loading for Bitcoin locker data.
  * Preserved existing locker retrieval and filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->