### PR TITLE
fix(mev-capital): add 3 missing MEV Capital Morpho vaults on ethereum

### DIFF
--- a/projects/mev-capital/index.js
+++ b/projects/mev-capital/index.js
@@ -203,6 +203,9 @@ const configs = {
           '0xda4063ec62c3f3c1d2bdbf7dbfb2b2c906f8e8b2', // MORPHO USDT
           '0xc0a14627d6a23f70c809777ced873238581c1032', // MORPHO USD0
           '0x8e3c0a68f8065dc666065f16cf902596a60d540e', // MORPHO WBTC
+        '0x34eCe536d2ae03192B06c0A67030D1Faf4c0Ba43', // MEV Capital sgfEURCV
+        '0x5593bf07cB1aDa24462EF23240c530441BBAd3e8', // MEV Capital sgfUSDCV
+        '0x1c530D6de70c05A81bF1670157b9d928e9699089', // MEV Capital MCwBTC
       ],
       mellow: [
         '0x5fd13359ba15a84b76f7f87568309040176167cd', // Amphor Restaked ETH


### PR DESCRIPTION
The MEV Capital adapter hardcodes its Morpho vault list per chain, so any vault MEV curates that isn't in the list is silently excluded from TVL.

Cross-checking the on-chain MetaMorpho factories (`CreateMetaMorpho` events from V1.0 `0xa9c3…41101` + V1.1 `0x1897…5c24`) and the Morpho API against the adapter's ethereum list: MEV Capital currently owns 18 ethereum Morpho vaults, but only 11 active ones were listed. Three of the missing vaults hold meaningful TVL, and each has `owner()` = MEV Capital's vault owner:

| vault | symbol | ~TVL |
|---|---|---|
| `0x34eCe536d2ae03192B06c0A67030D1Faf4c0Ba43` | sgfEURCV | ~$181k |
| `0x5593bf07cB1aDa24462EF23240c530441BBAd3e8` | sgfUSDCV | ~$19k |
| `0x1c530D6de70c05A81bF1670157b9d928e9699089` | MCwBTC | ~$1.7k |

~$202k of curated TVL was under-reported. All other chains in the adapter (base, arbitrum, hyperliquid, unichain, polygon) are fully tracked at the address level.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three MEV Capital vaults to the Ethereum Morpho vault listings: sgfEURCV, sgfUSDCV, and MCwBTC.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->