### PR TITLE
yieldyak: add Base (yiUSD milk vault) TVL

### DIFF
--- a/projects/yieldyak/index.js
+++ b/projects/yieldyak/index.js
@@ -3,6 +3,7 @@ const { cachedGraphQuery, getConfig } = require('../helper/cache')
 const sdk = require('@defillama/sdk')
 
 const graphUrl = sdk.graph.modifyEndpoint('https://gateway.thegraph.com/api/[api-key]/subgraphs/id/YC6LMdHjtWZ2cCq7YKFmDcDt2eCcBvSNSiWi56bnqoW')
+const graphUrlBase = sdk.graph.modifyEndpoint('https://gateway.thegraph.com/api/[api-key]/subgraphs/id/B2yrwHavBLPWtn5jMbttVWnvznibtKXbhuP4n89JU7DZ')
 const graphQuery = `
 {
   yakMilkVaults(first: 1000) {
@@ -70,6 +71,18 @@ async function mantleTvl(api) {
   });
 }
 
+async function baseTvl(api) {
+  // Same Milk-vault logic as Avalanche, pointed at the Base subgraph.
+  const excludedSymbol = 'YAK';
+
+  const { yakMilkVaults } = await cachedGraphQuery('yieldyak/milk-vaults-base', graphUrlBase, graphQuery)
+
+  yakMilkVaults.forEach((vault, i) => {
+    if (vault.accountant.base.symbol === excludedSymbol) return;
+    api.add(vault.accountant.base.id, vault.totalSupply * vault.accountant.exchangeRate / 10 ** vault.decimals);
+  });
+}
+
 const masterYak = "0x0cf605484A512d3F3435fed77AB5ddC0525Daf5f"
 const yakToken = "0x59414b3089ce2af0010e7523dea7e2b35d776ec7"
 const arbiYyStaking = "0xbb82b43Bf2057B804253D5Db8c18A647fC1f3403"
@@ -88,5 +101,8 @@ module.exports = {
   mantle: {
     tvl: mantleTvl,
     staking: staking(mantleYyStaking, bridgedYakToken),
+  },
+  base: {
+    tvl: baseTvl,
   }
 }


### PR DESCRIPTION
Adds Base chain TVL for Yield Yak — specifically the new yiUSD Milk vault (BoringVault-style).

This is an update to an already-listed protocol (Yield Yak), not a new listing, so the new-listing metadata fields below are left blank where they already exist in DefiLlama's config.

What changed: projects/yieldyak/index.js — added a baseTvl export that reads the Yield Yak Base Milk-vaults subgraph, using the exact same yakMilkVaults query and math as the existing Avalanche path. No new npm dependencies, no lockfile changes.

Chain: Base

Current TVL: ~$40k on Base (yiUSD), part of Yield Yak's ~$13.4M total

Methodology (what is being counted as tvl, how is tvl being calculated):

yiUSD's TVL is computed from on-chain data via the Yield Yak Base subgraph (yakMilkVaults): vault.totalSupply × accountant.exchangeRate ÷ 10^decimals, credited to the vault's underlying base asset (USDC on Base). This mirrors the existing Avalanche Milk-vault calculation already in the adapter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for YieldYak on the Base network.
  * Base TVL now includes milk vault balances while excluding YAK tokens from the calculation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->