### PR TITLE
Add Feather mainnet market

### DIFF
--- a/registries/curators.js
+++ b/registries/curators.js
@@ -390,6 +390,11 @@ const configs = {
   "feather": {
     config: {
       blockchains: {
+        ethereum: {
+          morpho: [
+            '0x9f3BEbF1159323f78E5c97Cc30f10907B71fCf8C', // Feather USDC vault
+          ],
+        },
         sei: {
           morpho: [
             '0x015F10a56e97e02437D294815D8e079e1903E41C',


### PR DESCRIPTION
## Summary

Adds Feather's Ethereum mainnet market to the Feather curator config.

- Tracks the **Feather USDC** MetaMorpho vault (`0x9f3BEbF1159323f78E5c97Cc30f10907B71fCf8C`, asset: USDC) under a new `ethereum` block in `registries/curators.js`.
- The vault's collateral market uses **USDi** (`0xAf1157149ff040DAd186a0142a796d901bEF1cf1`), which is [already tracked on DefiLlama](https://defillama.com/rwa/asset/USDI).

TVL is read from the vault's `totalAssets()` via the existing `getCuratorExport` / Morpho ERC-4626 logic — the associated Morpho V1 adapter (`0xa4A6194b4EBB77CA74b6cf7e2D9cEAc023cFa7F8`, `parentVault` = the Feather USDC vault) is already accounted for in the parent vault's `totalAssets`, so only the vault is listed.

## Test plan

- Verified `registries/curators.js` loads and exposes `feather.ethereum.tvl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated curator configuration to recognize an additional Ethereum Morpho vault owner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->