### PR TITLE
Kerne Protocol: add live mint PSM to TVL after minter rotation

### DIFF
--- a/projects/kerne-protocol/index.js
+++ b/projects/kerne-protocol/index.js
@@ -1,20 +1,33 @@
 const ADDRESSES = require('../helper/coreAssets.json')
 
+// Kerne mints kUSD 1:1 from USDC through a Peg Stability Module (PSM). The USDC
+// received sits in the PSM contract and backs circulating kUSD 1:1, so TVL is the
+// sum of USDC held across Kerne's PSM contracts. The kUSD supply itself is not
+// added (that would double count). This matches the published headline TVL at
+// kerne.fi/api/stats and the reserve breakdown at kerne.fi/api/por.
+//
+// The mint PSM is rotated across module upgrades and each PSM retains the USDC it
+// received, so every PSM that holds reserves is summed:
+//   PSM (live mint)   0xaBDE1138aa1Ce88d1dF06422C0c3b05D70569803  current minter (MINTER_ROLE on kUSD)
+//   PSM (prior mint)  0x07eBb486e11BD217e6085eb5ab663e4517595993  retains USDC from earlier mints
+//   PSM (redeem)      0xFf3025ec18e301855aB0f36Ec6ECa115a29A5Fbc  redeem reserve
+// If the minter is rotated again, add the new PSM address here.
+//
 // The v1 KerneVault (0x8005bc7A86AD904C20fd62788ABED7546c1cF2AC) is intentionally
-// NOT counted: it is in a known degraded accounting state (share supply does not
-// reconcile with its WETH backing), deposits are disabled pending a v2 redeploy,
-// and KerneVault.totalAssets() additionally includes off-chain CEX / Hyperliquid
-// hedge balances that are not on-chain TVL.
+// NOT counted: it has been superseded by a v2 redeploy and its deposits are
+// disabled, and KerneVault.totalAssets() reports off-chain balances that are not
+// part of the on-chain PSM reserves.
 
-const KUSD_PSM_MINT = '0x07eBb486e11BD217e6085eb5ab663e4517595993';
-const KUSD_PSM_REDEEM = '0xFf3025ec18e301855aB0f36Ec6ECa115a29A5Fbc';
+const KUSD_PSM_MINT = '0xaBDE1138aa1Ce88d1dF06422C0c3b05D70569803';        // live mint PSM (current minter)
+const KUSD_PSM_MINT_PRIOR = '0x07eBb486e11BD217e6085eb5ab663e4517595993'; // prior mint PSM (retains earlier USDC)
+const KUSD_PSM_REDEEM = '0xFf3025ec18e301855aB0f36Ec6ECa115a29A5Fbc';     // redeem reserve
 
 async function tvl(api) {
-  await api.sumTokens({ tokens: [ADDRESSES.base.USDC], owners: [KUSD_PSM_MINT, KUSD_PSM_REDEEM] })
+  await api.sumTokens({ tokens: [ADDRESSES.base.USDC], owners: [KUSD_PSM_MINT, KUSD_PSM_MINT_PRIOR, KUSD_PSM_REDEEM] })
 }
 
 module.exports = {
   methodology:
-    'TVL is the USDC reserve held by Kerne\'s Peg Stability Module (PSM) contracts on Base, which back all circulating kUSD 1:1. kUSD is minted 1:1 from USDC through the mint PSM (0x07eBb486) and redeemed 1:1 back to USDC through the redeem PSM (0xFf3025ec); both hold USDC backing and are summed. The kUSD supply itself is not added (counting both would double count). This matches the published headline TVL at kerne.fi/api/stats. The v1 KerneVault is intentionally excluded: it is in a known degraded accounting state, deposits are disabled pending a v2 redeploy, and its totalAssets() includes off-chain hedge balances that are not on-chain TVL.',
+    'TVL is the USDC reserve held by Kerne\'s Peg Stability Module (PSM) contracts on Base, which back all circulating kUSD 1:1. kUSD is minted 1:1 from USDC through the live mint PSM (0xaBDE1138) and redeemed 1:1 back to USDC through the redeem PSM (0xFf3025ec); a prior mint PSM (0x07eBb486) still retains USDC from earlier mints. All PSM USDC reserves are summed; the kUSD supply itself is not added (that would double count). This matches the published headline TVL at kerne.fi/api/stats. The v1 KerneVault is intentionally excluded: it has been superseded by a v2 redeploy, its deposits are disabled, and its totalAssets() reports off-chain balances that are not part of the on-chain PSM reserves.',
   base: { tvl },
 };


### PR DESCRIPTION
Small maintenance edit to the already-merged `kerne-protocol` adapter (not a new listing).

### What changed
Kerne's mint-side PSM was rotated in a module upgrade. The adapter was still reading the previous mint PSM (`0x07eBb486`) plus the redeem reserve (`0xFf3025ec`), and did not read the new live mint PSM (`0xaBDE1138`). New kUSD mints route through the live mint PSM, so their USDC backing would not be counted once reserves move to the new module. This PR adds the live mint PSM to the summed owners so new mints are counted as soon as they land.

### On-chain evidence (Base)
- `kUSD.hasRole(MINTER_ROLE, 0xaBDE1138aa1Ce88d1dF06422C0c3b05D70569803)` = `true` (current minter)
- `kUSD.hasRole(MINTER_ROLE, 0x07eBb486e11BD217e6085eb5ab663e4517595993)` = `false` (retired minter, still retains earlier USDC)
- USDC balances: live mint `0xaBDE1138` = 0, prior mint `0x07eBb486` = 998.00, redeem `0xFf3025ec` = 117.85, total 1,115.85, matching circulating kUSD supply 1,114.74 and `kerne.fi/api/por`.

### Effect
Reported Base TVL is unchanged today (~$1,116) because the prior mint PSM still holds the reserves. The change ensures TVL keeps matching circulating kUSD once new mints accrue in the live mint PSM. `node test.js projects/kerne-protocol/index.js` returns base ~$1,116.

Also softened the v1 KerneVault exclusion note in the methodology to neutral wording (no behavior change).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated Kerne kUSD Base TVL reporting to include USDC reserves from the live mint, prior mint, and redeem stability modules.
  - Improved TVL methodology details to clarify the included reserves and exclusion of the v1 KerneVault.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->