### PR TITLE
fix(zama): flag as doublecounted, 40% of TVL is Morpho-deployed vault receipts

### DIFF
--- a/projects/zama/index.js
+++ b/projects/zama/index.js
@@ -26,6 +26,7 @@ async function staking(api) {
 }
 
 module.exports = {
+  doublecounted: true,
   methodology: "TVL: total public ERC-20 reserves backing confidential wrappers from the on-chain registry, matching aggregate TVS (excluding ZAMA). Staking: ZAMA held in the cZAMA wrapper, plus the KMS and Coprocessor ProtocolStaking pool contracts.",
   ethereum: { tvl, staking },
 };


### PR DESCRIPTION
Zama's TVL counts steakcUSDC, a Steakhouse Confidential Prime ERC-4626 vault token whose underlying USDC is already counted in Morpho Blue's TVL.

- steakcUSDC: $16.77m, 39.95% of the $41.97m headline
- the steakcUSDC vault holds only about $576k idle out of $23.4M, so 97.5% is deployed
- its deploy adapter (MorphoMarketV1AdapterV2) holds 0 idle USDC and points at the Morpho Blue singleton, which holds $86.6M USDC
- projects/morpho-blue/index.js:327 sums the singleton's USDC into Morpho Blue's TVL, and Ethereum USDC isn't in that adapter's blacklist

So that USDC is counted once in Morpho and a second time here. Wrapping the vault receipt into a confidential token doesn't add capital to DeFi, it just holds the receipt. Zama isn't currently flagged.

To be clear about what this does and doesn't change: both protocols are individually correct. Morpho's TVL is right, Zama's TVL is right, and neither protocol page changes. Only the aggregate DeFi TVL adds the same $16.77m twice.

One caveat I want to state up front, because it cuts against this PR. `doublecounted` is a protocol-level boolean, so setting it removes the whole $41.97m from the aggregate, including about $25.2m of genuinely fresh USDC, USDT, ZAMA, WETH and XAUt that isn't counted anywhere else. At a 40/60 split that over-corrects: it removes roughly 1.5x more than the double count it fixes.

I went with the flag anyway because it's the convention here and there's no per-token mechanism in the repo:

- helper/curators/index.js:644 sets doublecounted: true with the comment "these tvl are double count" on curator vaults that also hold fresh deposits, the same mixed case
- helper/custom-scripts/metadao acknowledges its Meteora LP positions appear in both places and flags rather than carving them out
- 307 project adapters set the flag; none carve out per token

If you'd rather be exact, the alternative is dropping the steakcUSDC pair from the tvl sum. That removes exactly $16.77m from the aggregate and leaves the $25.2m fresh assets counted, but it lowers Zama's own reported TVL to $25.2m, which understates what Zama actually secures. Happy to do it that way instead, or to leave this alone if you think $16.77m isn't worth the trade.

I also checked bbqTGBP ($5.09m), the other Steakhouse vault token here, and it is not double counted: 3.64M of its 3.89M tGBP sits idle in its own vault, and the Morpho Blue singleton holds only 24k tGBP total. So it's excluded from this claim.

Verify it yourself:

- steakcUSDC vault 0xbEEF00A5: idle USDC balanceOf is about $576k of $23.4M
- deploy adapter 0x17bc9aa1: morpho() returns Morpho Blue, parentVault() returns steakcUSDC, 0 idle USDC
- Morpho Blue singleton USDC balance: $86.6M; projects/morpho-blue/index.js:327 sums it
- bbqTGBP vault 0xbeeffABc: totalAssets 3.89M tGBP vs 3.64M idle; Morpho Blue tGBP: 24k
- https://api.llama.fi/protocols: the zama entry has no doublecounted flag
- Breakdown at https://defillama.com/protocol/tvl/zama on 2026-07-15: STEAKCUSDC $16.77m, USDT $8.01m, ZAMA $6.28m, USDC $5.7m, BBQTGBP $5.09m, WETH $53k, XAUT $53k, TGBP $10k, total $41.97m
