### PR TITLE
Add BlueFun TVL adapter

### DIFF
--- a/projects/bluefun/index.js
+++ b/projects/bluefun/index.js
@@ -1,0 +1,29 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+
+// BlueFun bonding curves custody native assets until a token graduates into a
+// Uniswap v4 pool. Graduated liquidity is counted by the DEX, not here.
+const markets = {
+  base: [
+    '0xb503b0ef06ec10554f4d960e08869877a41498dd', // legacy
+    '0x7d42dd1435e9567C1edFb513C45c8eA82fe03a38', // vNext
+  ],
+  robinhood: [
+    '0x2d6d77652facbbcae05c0dc3aed792b94cd61fa8', // legacy
+    '0x2F46a783C1314e160d673F927464d85B7364D807', // vNext
+  ],
+}
+
+async function tvl(api) {
+  return api.sumTokens({
+    owners: markets[api.chain],
+    tokens: [ADDRESSES.null],
+  })
+}
+
+module.exports = {
+  // Direct and graduated pools are already included in Uniswap v4's TVL.
+  doublecounted: true,
+  methodology: 'Counts native assets held in BlueFun bonding-curve markets on Base and Robinhood Chain before graduation. Assets are withdrawn from a curve as it graduates into Uniswap v4, whose pool liquidity is counted by the DEX adapter instead.',
+  base: { tvl },
+  robinhood: { tvl },
+}


### PR DESCRIPTION
## New listing

##### Name (to be shown on DefiLlama):
BlueFun

##### Twitter Link:
https://x.com/BluefunLaunch

##### List of audit links if any:
No public audit reports are being submitted with this listing.

##### Website Link:
https://funblue.xyz

##### Logo (High resolution, will be shown with rounded borders):
https://funblue.xyz/brand/bluelogo.webp

##### Current TVL:
~0.80 ETH at adapter test time (on-chain bonding-curve reserves; changes with user activity).

##### Treasury Addresses (if the protocol has treasury):
Not included in this TVL adapter. It counts only user-facing pre-graduation bonding-curve reserves.

##### Chain:
Base, Robinhood Chain

##### Coingecko ID:
N/A

##### Coinmarketcap ID:
N/A

##### Short Description:
Fair multichain token launchpad for Base and Robinhood Chain, offering bonding-curve and direct Uniswap v4 launches with permanently locked LP principal.

##### Token address and ticker if any:
BLUE — Base — 0xb200000000000000000000Af2d07754b927109bc

##### Category:
Launchpad

##### Oracle Provider(s):
None. This adapter reads native-asset balances directly from the bonding-curve contracts.

##### Implementation Details:
The adapter sums native assets held by the legacy and vNext BlueFun bonding-curve markets on Base and Robinhood Chain. Direct and graduated Uniswap v4 pool liquidity is not included to avoid double counting with DEX TVL.

##### Documentation/Proof:
https://funblue.xyz/docs
https://github.com/ereyli/DefiLlama-Adapters/blob/bluefun-defillama-adapter/projects/bluefun/index.js

##### forkedFrom:
No

##### methodology:
Counts native assets in BlueFun bonding curves before graduation. Assets exit the bonding curve on graduation to Uniswap v4, whose LP liquidity is counted by the DEX adapter instead.

##### Github org/user:
N/A

##### Does this project have a referral program?
No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added BlueFun TVL tracking for Base and Robinhood.
  * Includes native assets held in BlueFun bonding-curve custody markets.
  * Documents how pre-graduation custody and Uniswap v4 liquidity are counted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->