### PR TITLE
add Coinmerce Capital curator

### DIFF
--- a/registries/curators.js
+++ b/registries/curators.js
@@ -364,6 +364,18 @@ const configs = {
       ],
     },
   },
+  "coinmerce-capital": {
+    config: {
+      methodology: 'Count all assets are deposited in all vaults curated by Coinmerce Capital.',
+      blockchains: {
+        hyperliquid: {
+          upshiftV2: [
+            '0xcfe06d2499aE635830D11859941e76354D5717CC', // co-curator with clearstar
+          ],
+        },
+      }
+    },
+  },
   "cozy-v3": {
     config: {
       methodology: "Count all assets deposited in Euler vaults curated by Cozy.",


### PR DESCRIPTION
Adds Coinmerce Capital as a risk curator.

Config-only change: one entry in `registries/curators.js`, tracking the Upshift vault Coinmerce Capital curates on HyperEVM.

Validated with `node test.js coinmerce-capital`:

```
--- hyperliquid ---
USDC                      2.02 M
Total: 2.02 M

------ TVL ------
hyperliquid               2.02 M
total                     2.02 M
```

Note for maintainers: the vault (`0xcfe06d2499aE635830D11859941e76354D5717CC`) is co-curated with Clearstar. It is not currently tracked under the `clearstar` entry, and TVL is intentionally attributed to Coinmerce Capital only.

---
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
Coinmerce Capital

##### Twitter Link:
https://x.com/coinmerce

LinkedIn: https://www.linkedin.com/company/coinmercecapital/

##### List of audit links if any:
None. Coinmerce Capital has no smart-contract audits of its own; the vault runs on Upshift's infrastructure.

##### Website Link:
https://coinmerce.capital/en/home

##### Logo (High resolution, will be shown with rounded borders):
Attached to the PR. 
<img width="1000" height="1000" alt="Coinmerce-Capital-DefiLlama-logo" src="https://github.com/user-attachments/assets/639542b7-4d45-45e8-8bbb-e1cabd3fae22" />


##### Current TVL:
$2.02M

##### Treasury Addresses (if the protocol has treasury)
None

##### Chain:
Hyperliquid (HyperEVM)

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):
None

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):
None

##### Short Description (to be shown on DefiLlama):
TODO - confirm or replace. Draft: Coinmerce Capital is a Netherlands-based, AFM-registered crypto investment fund manager operating since 2017, curating DeFi lending vaults.

##### Token address and ticker if any:
None

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Risk Curators

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
None involved in the TVL figure. TVL is read directly on-chain from `getTotalAssets()` on the Upshift vault, denominated in the vault's underlying asset (USDC, `0xb88339CB7199b77E23DB6E890353E22632Ba630f`, 6 decimals). The lending markets the vault allocates into use their own oracles.

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
No oracle is integrated for TVL purposes. The vault is a non-ERC4626 Upshift multiAssetVault exposing `asset()` and `getTotalAssets()`; the adapter sums `getTotalAssets()` via the existing `upshiftV2` handler in `projects/helper/curators/index.js`. Pricing of the resulting USDC balance is handled by DefiLlama's own pricing layer.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
Vault: https://app.upshift.finance/pools/999/0xcfe06d2499aE635830D11859941e76354D5717CC

##### forkedFrom (Does your project originate from another project):
N/A

##### methodology (what is being counted as tvl, how is tvl being calculated):
Count all assets are deposited in all vaults curated by Coinmerce Capital. Sums `getTotalAssets()` across the curated Upshift vaults, denominated in the vault's underlying asset.

##### Github org/user (Optional, if your code is open source, we can track activity):
None - no public repos.

##### Does this project have a referral program?
No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Coinmerce Capital as a supported curator.
  * Added Hyperliquid curator address configuration for improved protocol attribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->