### PR TITLE
Fix Ravenhood TVL (was always returning $0)

### DIFF
--- a/projects/ravenhood/index.js
+++ b/projects/ravenhood/index.js
@@ -1,10 +1,20 @@
+const { unwrapUniswapV3NFT } = require('../helper/unwrapLPs')
+
 const RVH_TOKEN = '0x96765066f6a040a21EB027167D2315B707c82633'
 const STAKING_POOL = '0xAc558b558E228DE033Cd97C580618C4403CB05a6'
+// RavenhoodVault: immutable custodian holding the protocol's single permanently-locked
+// RVH/WETH Uniswap V3 position (95% of supply, single-sided at launch, tokenId 17757).
+const VAULT = '0x5e1485137E025bf7774F52DE4E33fa6E498f6ede'
+const POSITION_MANAGER = '0x73991a25C818Bf1f1128dEAaB1492D45638DE0D3'
 
 module.exports = {
-  methodology: 'Staking is RVH deposited into RVHStakingPool.',
+  methodology: 'TVL is the RVH/WETH locked in the Uniswap V3 position held by RavenhoodVault (the permanently-locked launch liquidity). Staking is RVH deposited into RVHStakingPool.',
   robinhood: {
-    tvl: () => ({}),
+    tvl: async (api) => {
+      const balances = {}
+      await unwrapUniswapV3NFT({ balances, api, owner: VAULT, nftAddress: POSITION_MANAGER })
+      return balances
+    },
     staking: async (api) => {
       const staked = await api.call({ target: STAKING_POOL, abi: 'uint256:totalStaked' })
       api.add(RVH_TOKEN, staked)


### PR DESCRIPTION
## Summary
Ravenhood's `tvl()` function was left as a stub (`tvl: () => ({})`) while `staking` was implemented correctly, so the protocol's TVL always showed $0 on the site despite 95% of RVH's supply being permanently locked as launch liquidity.

This now unwraps the Uniswap V3 position (tokenId 17757, RVH/WETH 1% pool) held by `RavenhoodVault` - an immutable custodian contract that can never release the locked NFT (verified: [RavenhoodVault source](https://robinhoodchain.blockscout.com/address/0x5e1485137E025bf7774F52DE4E33fa6E498f6ede)).

## Test plan
Ran locally with `node test.js projects/ravenhood/index.js`:
```
--- robinhood ---
RVH                       34.37 k
WETH                      22.42 k
Total: 56.79 k

--- staking ---
RVH                       1.31 k
Total: 1.31 k
```
`staking` output is unchanged from before this fix; `tvl` now returns the real locked-liquidity value instead of `$0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL reporting for Ravenhood’s permanently locked RVH/WETH Uniswap V3 position.
  * Included the position’s assets alongside RVH staking in the TVL methodology.
  * Improved TVL data accuracy by returning balances from the locked liquidity position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->