### PR TITLE
Add Dungeon DEX

### DIFF
--- a/projects/dungeon-dex/index.js
+++ b/projects/dungeon-dex/index.js
@@ -1,0 +1,20 @@
+const { getFactoryTvl } = require('../terraswap/factoryTvl')
+
+const factory = 'dungeon1643rdx7yzxfhmy6ru6456t2twxhshtt9k394jh8u7qk59qfgz0esjku43x'
+// These active pools predate the current factory migration and remain available in the DEX UI.
+// Source: https://dex.dungeongames.io/mainnet/dungeon-1/pools_list.json
+const legacyPairs = [
+  'dungeon1726r6fgz7xvmr57c0jnxpjq4u32wnd37zev5xq0t57g5g5t6s5vqvkkpld',
+  'dungeon1qydhnhax5sqn7n9syjvz90z2a24ja798nwgt0fuytx5j7ptkqrtsz0dh5v',
+  'dungeon1dy4udqns392grdwkjqgm6kd7k6cqzxr0rah6eetxskhfr0lq406ssfmtyr',
+  'dungeon1qlzmxgu32sdww5fa6yw0hcxetj5pl6fjucug0vmksr9qkllgpwgs7qx260',
+]
+
+module.exports = {
+  timetravel: false,
+  misrepresentedTokens: true,
+  methodology: 'Liquidity in constant-product pools registered by the Dungeon DEX factory plus active legacy pools from before the current factory migration.',
+  dungeon: {
+    tvl: getFactoryTvl(factory, { extraPairs: legacyPairs }),
+  },
+}

--- a/projects/helper/chain/cosmos.js
+++ b/projects/helper/chain/cosmos.js
@@ -64,6 +64,7 @@ const endPoints = {
   band: 'https://laozi1.bandchain.org/api',
   celestia: 'https://celestia-rest.publicnode.com',
   dydx: 'https://dydx-rest.publicnode.com',
+  dungeon: 'https://api.dungeongames.io',
   carbon: 'https://api.carbon.network',
   evmos: 'https://evmos-api.polkachu.com',
   regen: 'https://rest-regen.ecostake.com',

--- a/projects/helper/chains.json
+++ b/projects/helper/chains.json
@@ -131,6 +131,7 @@
   "doma",
   "dsc",
   "duckchain",
+  "dungeon",
   "dydx",
   "dymension",
   "echelon",

--- a/projects/helper/coreAssets.json
+++ b/projects/helper/coreAssets.json
@@ -750,6 +750,9 @@
     "USK": "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk",
     "FUZION": "factory/kujira1sc6a0347cc5q3k890jj0pf3ylx2s38rh4sza4t/ufuzn"
   },
+  "dungeon": {
+    "DGN": "udgn"
+  },
   "injective": {
     "INJ": "inj",
     "USDT": "factory/inj14ejqjyq8um4p3xfqj74yld5waqljf88f9eneuk/inj1q6zlut7gtkzknkk773jecujwsdkgq882akqksk",

--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -40,14 +40,6 @@ const ibcMappings = {
 }
 
 const fixBalancesTokens = {
-  dungeon: {
-    'udgn': { coingeckoId: 'dragon-coin-2', decimals: 6 },
-    'ibc:489C406A3029B50486F991E468CB8A7D5F039757327A40B0684C530BFF96C543': { coingeckoId: 'usd-coin', decimals: 6 },
-    'ibc:C3988DBA4BA195F3514EA2E02497B9F66019CE53EFB96D4982CE95CA6A51BBCE': { coingeckoId: 'cosmos', decimals: 6 },
-    'ibc:295196BD505E32B9679BA0CFDB70B4FF2AADE80A3B73A2F234284D7A709844DA': { coingeckoId: 'atomone', decimals: 6 },
-    'ibc:B80E4B088852B8CE07A8E6A8A579B4945CC4ABD7B3AB8287E3A2E15805F8D521': { coingeckoId: 'wrapped-bitcoin', decimals: 8 },
-    'factory:dungeon1wtzjvusmm6r370k0nfwtejywl4qklf7rmhf0ng43tdsqh70cljjqc7gh6q:wbtc': { coingeckoId: 'wrapped-bitcoin', decimals: 8 },
-  },
   inri: {
     '0x116b2ff23e062a52e2c0ea12df7e2638b62fa0fc': {
       coingeckoId: 'tether',

--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -20,7 +20,7 @@ coreAssets = JSON.parse(JSON.stringify(coreAssets))
 
 const ibcChains = ['ibc', 'terra', 'terra2', 'crescent', 'osmosis', 'kujira', 'stargaze', 'juno', 'injective', 'cosmos', 'provenance', 'comdex', 'umee', 'orai', 'persistence', 'fxcore', 'neutron', 'quasar', 'chihuahua', 'sei', 'archway', 'migaloo', 'secret', 'aura', 'xpla', 'bostrom', 'joltify', 'nibiru',
   'kopi', 'elys', "pryzm", "mantra", 'agoric', 'band', 'axiome',
-  'celestia', 'dydx', 'carbon', 'milkyway', 'regen', 'sommelier', 'stride', 'prom', 'babylon', 'xion', 'zigchain'
+  'celestia', 'dydx', 'dungeon', 'carbon', 'milkyway', 'regen', 'sommelier', 'stride', 'prom', 'babylon', 'xion', 'zigchain'
 ]
 const caseSensitiveChains = [...ibcChains, ...svmChains, 'tezos', 'ton', 'algorand', 'aptos', 'near', 'bitcoin', 'waves', 'tron', 'litecoin', 'polkadot', 'ripple', 'elrond', 'cardano', 'stacks', 'sui', 'ergo', 'mvc', 'renec', 'doge', 'stellar', 'massa', 'aleo',
   'eclipse', 'acala', 'aelf', 'aeternity', 'alephium', 'bifrost', 'bittensor', 'verus', 'dash',
@@ -40,6 +40,14 @@ const ibcMappings = {
 }
 
 const fixBalancesTokens = {
+  dungeon: {
+    'udgn': { coingeckoId: 'dragon-coin-2', decimals: 6 },
+    'ibc:489C406A3029B50486F991E468CB8A7D5F039757327A40B0684C530BFF96C543': { coingeckoId: 'usd-coin', decimals: 6 },
+    'ibc:C3988DBA4BA195F3514EA2E02497B9F66019CE53EFB96D4982CE95CA6A51BBCE': { coingeckoId: 'cosmos', decimals: 6 },
+    'ibc:295196BD505E32B9679BA0CFDB70B4FF2AADE80A3B73A2F234284D7A709844DA': { coingeckoId: 'atomone', decimals: 6 },
+    'ibc:B80E4B088852B8CE07A8E6A8A579B4945CC4ABD7B3AB8287E3A2E15805F8D521': { coingeckoId: 'wrapped-bitcoin', decimals: 8 },
+    'factory:dungeon1wtzjvusmm6r370k0nfwtejywl4qklf7rmhf0ng43tdsqh70cljjqc7gh6q:wbtc': { coingeckoId: 'wrapped-bitcoin', decimals: 8 },
+  },
   inri: {
     '0x116b2ff23e062a52e2c0ea12df7e2638b62fa0fc': {
       coingeckoId: 'tether',

--- a/projects/terraswap/factoryTvl.js
+++ b/projects/terraswap/factoryTvl.js
@@ -16,7 +16,7 @@ function getAssetInfo(asset) {
   return [extractTokenInfo(asset), Number(asset.amount)]
 }
 
-async function getAllPairs(factory, chain, { blacklistedPairs = [] } = {}) {
+async function getAllPairs(factory, chain, { blacklistedPairs = [], extraPairs = [] } = {}) {
   const blacklist = new Set(blacklistedPairs)
   let allPairs = []
   let currentPairs;
@@ -26,6 +26,8 @@ async function getAllPairs(factory, chain, { blacklistedPairs = [] } = {}) {
     currentPairs = (await queryContract({ contract: factory, chain, data: queryStr })).pairs
     allPairs.push(...currentPairs.filter(pair => !blacklist.has(pair.contract_addr)))
   } while (currentPairs.length > 0)
+  const knownPairs = new Set(allPairs.map(pair => pair.contract_addr))
+  allPairs.push(...extraPairs.filter(contract => !knownPairs.has(contract)).map(contract_addr => ({ contract_addr })))
   const dtos = []
   const getPairPool = (async (pair) => {
     const pairRes = await queryContractWithRetries({ contract: pair.contract_addr, chain, data: { pool: {} } })
@@ -51,9 +53,9 @@ async function getAllPairs(factory, chain, { blacklistedPairs = [] } = {}) {
 
 const isNotXYK = (pair) => pair.pair_type && pair.pair_type.custom === 'concentrated'
 
-function getFactoryTvl(factory, { blacklistedPairs = [] } = {}) {
+function getFactoryTvl(factory, { blacklistedPairs = [], extraPairs = [] } = {}) {
   return async (api) => {
-    const pairs = (await getAllPairs(factory, api.chain, { blacklistedPairs })).filter(pair => (pair.assets[0].balance && pair.assets[1].balance))
+    const pairs = (await getAllPairs(factory, api.chain, { blacklistedPairs, extraPairs })).filter(pair => (pair.assets[0].balance && pair.assets[1].balance))
 
     const otherPairs = pairs.filter(isNotXYK)
     const xykPairs = pairs.filter(pair => !isNotXYK(pair))

--- a/projects/terraswap/factoryTvl.js
+++ b/projects/terraswap/factoryTvl.js
@@ -55,7 +55,7 @@ const isNotXYK = (pair) => pair.pair_type && pair.pair_type.custom === 'concentr
 
 function getFactoryTvl(factory, { blacklistedPairs = [], extraPairs = [] } = {}) {
   return async (api) => {
-    const pairs = (await getAllPairs(factory, api.chain, { blacklistedPairs, extraPairs })).filter(pair => (pair.assets[0].balance && pair.assets[1].balance))
+    const pairs = (await getAllPairs(factory, api.chain, { blacklistedPairs, extraPairs })).filter(pair => (pair.assets[0]?.balance && pair.assets[1]?.balance))
 
     const otherPairs = pairs.filter(isNotXYK)
     const xykPairs = pairs.filter(pair => !isNotXYK(pair))


### PR DESCRIPTION
## New listing: Dungeon DEX

##### Name (to be shown on DefiLlama):
Dungeon DEX

##### Twitter Link:
https://x.com/cryptodungeonma

##### List of audit links if any:
None. No third-party audit has been completed; the current security posture is documented at https://dungeongames.io/whitepaper/#10-security-posture

##### Website Link:
https://dex.dungeongames.io/dungeon/pools

##### Logo (High resolution, will be shown with rounded borders):
https://dungeongames.io/brand/dgn-logo.png

##### Current TVL:
Approximately $70.07k at the time of submission, as returned by `node test.js projects/dungeon-dex/index.js`.

##### Treasury Addresses (if the protocol has treasury)
`dungeon1ctzzm9rvdtzqd9j46tj9ezrfyzfe2vr7fqyv8j`

##### Chain:
Dungeon (`dungeon-1`)

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):
`dragon-coin-2`

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):
`38411`

##### Short Description (to be shown on DefiLlama):
Permissionless CosmWasm AMM on Dungeon Chain with constant-product pools, LP incentives, and self-custodial swaps.

##### Token address and ticker if any:
Base denom `udgn`; ticker `DGN`.

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Dexs

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
None.

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
The AMM does not use an external oracle. Pool spot prices are determined by reserve ratios. The TVL adapter queries each pair contract's on-chain `pool` state and returns the underlying token balances for DefiLlama to price.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
https://dungeongames.io/whitepaper/

Factory contract: `dungeon1643rdx7yzxfhmy6ru6456t2twxhshtt9k394jh8u7qk59qfgz0esjku43x`

Public pool registry: https://dex.dungeongames.io/mainnet/dungeon-1/pools_list.json

##### forkedFrom (Does your project originate from another project):
White Whale AMM.

##### methodology (what is being counted as tvl, how is tvl being calculated):
Counts both sides of each active constant-product liquidity pool registered by the Dungeon DEX factory, plus active legacy pools that predate the current factory migration. Balances are read directly from CosmWasm pair contracts through the public Dungeon LCD endpoint.

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/Ninjaxan

##### Does this project have a referral program?
No.

## Validation

`node test.js projects/dungeon-dex/index.js`

Result at submission: Dungeon TVL approximately `$70.07k`; five tokens priced; no adapter errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Dungeon chain, including a dedicated API endpoint and core token mapping for DGN (udgn).
  * Enabled Dungeon DEX coverage with TVL reporting for both active liquidity and selected legacy pools.
  * Extended factory TVL calculations to optionally include pre-known legacy pair contracts.

* **Bug Fixes**
  * Improved liquidity pool processing to prevent TVL calculations from failing when asset balance details are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->