### PR TITLE
originarm: support multi-base ARMs

### DIFF
--- a/projects/originarm/index.js
+++ b/projects/originarm/index.js
@@ -1,55 +1,78 @@
 const ADDRESSES = require('../helper/coreAssets.json')
 
+const OETH = "0x856c4Efb76C1D1AE02e20CEB03A2A6a08b0b8dC3"
+const OS = "0xb1e25689D55734FD3ffFc939c4C3Eb52DFf8A794"
+const NULL_ADDRESS = "0x0000000000000000000000000000000000000000"
+
+// Multi-base ARM (upgraded AbstractARM) reads. Legacy ARMs revert on getBaseAssets().
+const baseAssetConfigsAbi = "function baseAssetConfigs(address asset) view returns (uint128 buyPrice, uint128 sellPrice, uint128 buyLiquidityRemaining, uint128 sellLiquidityRemaining, uint128 crossPrice, uint120 pendingRedeemAssets, bool peggedToLiquidityAsset, address adapter)"
+const convertToAssetsAbi = "function convertToAssets(uint256 shares) view returns (uint256 assets)"
+
+// Every Origin ARM. Each is either still on its original single-base implementation (a
+// protocol-specific withdrawal queue) or upgraded to the multi-base AbstractARM
+// (getBaseAssets / baseAssetConfigs). Which one is detected at runtime per ARM, so the rollout
+// can proceed without touching this adapter. `liquidity`/`base`/`legacyOutstanding` are only
+// used on the legacy path; the multi-base path reads liquidityAsset() and getBaseAssets() live.
+const ARMS = {
+  ethereum: [
+    // Lido ARM
+    { arm: "0x85b78aca6deae198fbf201c82daf6ca21942acc6", liquidity: ADDRESSES.ethereum.WETH, base: ADDRESSES.ethereum.STETH, legacyOutstanding: "uint256:lidoWithdrawalQueueAmount" },
+    // OETH ARM
+    { arm: "0x6bac785889A4127dB0e0CeFEE88E0a9F1Aaf3cC7", liquidity: ADDRESSES.ethereum.WETH, base: OETH, legacyOutstanding: "uint256:vaultWithdrawalAmount" },
+    // Ether.fi ARM
+    { arm: "0xfB0A3CF9B019BFd8827443d131b235B3E0FC58d2", liquidity: ADDRESSES.ethereum.WETH, base: ADDRESSES.ethereum.EETH, legacyOutstanding: "uint256:etherfiWithdrawalQueueAmount" },
+    // Ethena ARM
+    { arm: "0xCEDa2d856238aA0D12f6329de20B9115f07C366d", liquidity: ADDRESSES.ethereum.USDe, base: ADDRESSES.ethereum.sUSDe, legacyOutstanding: "uint256:liquidityAmountInCooldown" },
+  ],
+  sonic: [
+    // OS ARM
+    { arm: "0x2F872623d1E1Af5835b08b0E49aAd2d81d649D30", liquidity: ADDRESSES.sonic.wS, base: OS, legacyOutstanding: "uint256:vaultWithdrawalAmount" },
+  ],
+}
+
+const armsTvl = async (api) => {
+  const arms = ARMS[api.chain]
+  // getBaseAssets() reverts on not-yet-upgraded ARMs -> null; a non-null array marks a multi-base ARM.
+  const baseAssetsList = await api.multiCall({ abi: "address[]:getBaseAssets", calls: arms.map((a) => a.arm), permitFailure: true })
+
+  const tokensAndOwners = []
+  await Promise.all(arms.map(async ({ arm, liquidity, base, legacyOutstanding }, i) => {
+    const baseAssets = baseAssetsList[i]
+
+    if (baseAssets) {
+      // Multi-base ARM. Everything is valued in liquidity-asset terms, mirroring the contract's
+      // _availableAssets(): idle liquidity + on-hand base assets + lending market + pending redemptions.
+      const [liquidityAsset, activeMarket] = await Promise.all([
+        api.call({ abi: "address:liquidityAsset", target: arm }),
+        api.call({ abi: "address:activeMarket", target: arm }),
+      ])
+      // On-hand liquidity asset + every registered base asset (each priced natively by DefiLlama).
+      tokensAndOwners.push([liquidityAsset, arm], ...baseAssets.map((b) => [b, arm]))
+      // Lending-market position: value the ARM's ERC4626 shares in liquidity-asset terms.
+      if (activeMarket && activeMarket.toLowerCase() !== NULL_ADDRESS) {
+        const shares = await api.call({ abi: "erc20:balanceOf", target: activeMarket, params: [arm] })
+        if (shares !== "0") {
+          const marketAssets = await api.call({ abi: convertToAssetsAbi, target: activeMarket, params: [shares] })
+          api.add(liquidityAsset, marketAssets)
+        }
+      }
+      // Pending protocol redemptions per base asset (adapter withdrawal queues). pendingRedeemAssets
+      // is already liquidity-denominated (the assets expected back from the adapter), so add it as the
+      // liquidity asset rather than the base asset.
+      const configs = await api.multiCall({ abi: baseAssetConfigsAbi, target: arm, calls: baseAssets.map((b) => ({ params: [b] })) })
+      configs.forEach((cfg) => api.add(liquidityAsset, cfg.pendingRedeemAssets))
+    } else {
+      // Legacy single-base ARM: outstanding protocol withdrawal is denominated in the base asset.
+      const outstanding = await api.call({ abi: legacyOutstanding, target: arm })
+      api.add(base, outstanding)
+      tokensAndOwners.push([liquidity, arm], [base, arm])
+    }
+  }))
+
+  return api.sumTokens({ tokensAndOwners })
+}
+
 module.exports = {
-  ethereum: {
-    tvl: async (api) => {
-      const OETH = "0x856c4Efb76C1D1AE02e20CEB03A2A6a08b0b8dC3"
-
-      const lidoArm = "0x85b78aca6deae198fbf201c82daf6ca21942acc6";
-      const oethArm = "0x6bac785889A4127dB0e0CeFEE88E0a9F1Aaf3cC7";
-      const etherfiArm = "0xfB0A3CF9B019BFd8827443d131b235B3E0FC58d2";
-      const ethenaArm = "0xCEDa2d856238aA0D12f6329de20B9115f07C366d";
-
-      const outstanding_STETH = await api.call({ abi: 'uint256:lidoWithdrawalQueueAmount', target: lidoArm });
-      api.add(ADDRESSES.ethereum.STETH, outstanding_STETH);
-
-      const outstanding_OETH = await api.call({ abi: 'uint256:vaultWithdrawalAmount', target: oethArm });
-      api.add(OETH, outstanding_OETH);
-
-      const outstanding_EETH = await api.call({ abi: 'uint256:etherfiWithdrawalQueueAmount', target: etherfiArm });
-      api.add(ADDRESSES.ethereum.EETH, outstanding_EETH);
-
-      const outstanding_sUSDe = await api.call({ abi: 'uint256:liquidityAmountInCooldown', target: ethenaArm });
-      api.add(ADDRESSES.ethereum.sUSDe, outstanding_sUSDe);
-
-      return api.sumTokens({ tokensAndOwners: [
-        // Lido ARM
-        [ADDRESSES.ethereum.WETH, lidoArm],
-        [ADDRESSES.ethereum.STETH, lidoArm],
-        // OETH ARM
-        [ADDRESSES.ethereum.WETH, oethArm],
-        [OETH, oethArm],     
-        // Etherfi ARM
-        [ADDRESSES.ethereum.WETH, etherfiArm],
-        [ADDRESSES.ethereum.EETH, etherfiArm],
-        // Ethena ARM
-        [ADDRESSES.ethereum.USDe, ethenaArm],
-        [ADDRESSES.ethereum.sUSDe, ethenaArm],
-      ]});
-    },
-  },
-  sonic: {
-    tvl: async (api) => {
-      const OS = "0xb1e25689D55734FD3ffFc939c4C3Eb52DFf8A794"
-      // OS ARM
-      const osArm = "0x2F872623d1E1Af5835b08b0E49aAd2d81d649D30";
-      const outstandingOs = await api.call({ abi: 'uint256:vaultWithdrawalAmount', target: osArm });
-      api.add(OS, outstandingOs);
-      return api.sumTokens({ tokensAndOwners: [
-        // OS ARM
-        [ADDRESSES.sonic.wS, osArm],
-        [OS, osArm],
-      ]});
-    },
-  },
-};
+  ethereum: { tvl: armsTvl },
+  sonic: { tvl: armsTvl },
+}

--- a/projects/originarm/index.js
+++ b/projects/originarm/index.js
@@ -2,7 +2,6 @@ const ADDRESSES = require('../helper/coreAssets.json')
 
 const OETH = "0x856c4Efb76C1D1AE02e20CEB03A2A6a08b0b8dC3"
 const OS = "0xb1e25689D55734FD3ffFc939c4C3Eb52DFf8A794"
-const NULL_ADDRESS = "0x0000000000000000000000000000000000000000"
 
 // Multi-base ARM (upgraded AbstractARM) reads. Legacy ARMs revert on getBaseAssets().
 const baseAssetConfigsAbi = "function baseAssetConfigs(address asset) view returns (uint128 buyPrice, uint128 sellPrice, uint128 buyLiquidityRemaining, uint128 sellLiquidityRemaining, uint128 crossPrice, uint120 pendingRedeemAssets, bool peggedToLiquidityAsset, address adapter)"
@@ -30,7 +29,7 @@ const ARMS = {
   ],
 }
 
-const armsTvl = async (api) => {
+const tvl = async (api) => {
   const arms = ARMS[api.chain]
   // getBaseAssets() reverts on not-yet-upgraded ARMs -> null; a non-null array marks a multi-base ARM.
   const baseAssetsList = await api.multiCall({ abi: "address[]:getBaseAssets", calls: arms.map((a) => a.arm), permitFailure: true })
@@ -49,7 +48,7 @@ const armsTvl = async (api) => {
       // On-hand liquidity asset + every registered base asset (each priced natively by DefiLlama).
       tokensAndOwners.push([liquidityAsset, arm], ...baseAssets.map((b) => [b, arm]))
       // Lending-market position: value the ARM's ERC4626 shares in liquidity-asset terms.
-      if (activeMarket && activeMarket.toLowerCase() !== NULL_ADDRESS) {
+      if (activeMarket && activeMarket.toLowerCase() !== ADDRESSES.null) {
         const shares = await api.call({ abi: "erc20:balanceOf", target: activeMarket, params: [arm] })
         if (shares !== "0") {
           const marketAssets = await api.call({ abi: convertToAssetsAbi, target: activeMarket, params: [shares] })
@@ -73,6 +72,7 @@ const armsTvl = async (api) => {
 }
 
 module.exports = {
-  ethereum: { tvl: armsTvl },
-  sonic: { tvl: armsTvl },
+  misrepresentedTokens: true,
+  ethereum: { tvl },
+  sonic: { tvl },
 }


### PR DESCRIPTION
The Ethena ARM was recently updated to new multi-base contracts which broke processing here.

These changes auto-detect per ARM whether it has been upgraded to the multi-base AbstractARM (getBaseAssets/baseAssetConfigs) or is still on its legacy single-base implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unified TVL reporting across Ethereum and Sonic.
  * Added support for multi-base assets, including liquidity holdings, lending positions, and pending redemptions.
  * Added flexible ARM configuration to support additional chains and assets.

* **Bug Fixes**
  * Preserved accurate TVL calculations for legacy single-base assets.
  * Improved handling when multi-base asset data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->