### PR TITLE
Multipli major update: on-chain V2 yield + rwaUSDi child adapter

### DIFF
--- a/projects/multipli-rwausdi/accounting.js
+++ b/projects/multipli-rwausdi/accounting.js
@@ -29,23 +29,32 @@ async function calculateSupply(api, config) {
 
   const totalSupply = asBigInt(value, `${api.chain}.totalSupply`)
   const seen = new Set()
-  let excluded = 0n
+  const holders = config.excludedHolders || []
 
-  for (const holder of config.excludedHolders || []) {
+  for (const holder of holders) {
     assertAddress(holder.address, `${api.chain}.excludedHolder`)
     if (!holder.role || !holder.evidence)
       throw new Error(`rwaUSDi: ${holder.address} lacks role/evidence`)
     const key = holder.address.toLowerCase()
     if (seen.has(key)) throw new Error(`rwaUSDi: duplicate ${holder.address}`)
     seen.add(key)
-    excluded += asBigInt(
-      await api.call({
+  }
+
+  let excluded = 0n
+  if (holders.length) {
+    const balances = await api.multiCall({
+      abi: BALANCE_OF,
+      calls: holders.map(holder => ({
         target: config.token,
-        abi: BALANCE_OF,
         params: [holder.address],
-      }),
-      `${api.chain}.${holder.address}.balance`
-    )
+      })),
+    })
+    holders.forEach((holder, i) => {
+      excluded += asBigInt(
+        balances[i],
+        `${api.chain}.${holder.address}.balance`
+      )
+    })
   }
 
   if (excluded > totalSupply)

--- a/projects/multipli-rwausdi/accounting.js
+++ b/projects/multipli-rwausdi/accounting.js
@@ -1,0 +1,57 @@
+'use strict'
+
+const TOTAL_SUPPLY = 'erc20:totalSupply'
+const BALANCE_OF = 'erc20:balanceOf'
+
+function asBigInt(value, label) {
+  if (value === null || value === undefined)
+    throw new Error(`rwaUSDi: missing ${label}`)
+  try {
+    return BigInt(value.toString())
+  } catch {
+    throw new Error(`rwaUSDi: invalid integer for ${label}`)
+  }
+}
+
+function assertAddress(value, label) {
+  if (!value || !/^0x[a-fA-F0-9]{40}$/.test(value))
+    throw new Error(`rwaUSDi: invalid ${label}: ${value}`)
+}
+
+async function calculateSupply(api, config) {
+  assertAddress(config.token, `${api.chain}.token`)
+  const [value] = await api.multiCall({
+    abi: TOTAL_SUPPLY,
+    calls: [config.token],
+    permitFailure: true,
+  })
+  if (value === null || value === undefined) return
+
+  const totalSupply = asBigInt(value, `${api.chain}.totalSupply`)
+  const seen = new Set()
+  let excluded = 0n
+
+  for (const holder of config.excludedHolders || []) {
+    assertAddress(holder.address, `${api.chain}.excludedHolder`)
+    if (!holder.role || !holder.evidence)
+      throw new Error(`rwaUSDi: ${holder.address} lacks role/evidence`)
+    const key = holder.address.toLowerCase()
+    if (seen.has(key)) throw new Error(`rwaUSDi: duplicate ${holder.address}`)
+    seen.add(key)
+    excluded += asBigInt(
+      await api.call({
+        target: config.token,
+        abi: BALANCE_OF,
+        params: [holder.address],
+      }),
+      `${api.chain}.${holder.address}.balance`
+    )
+  }
+
+  if (excluded > totalSupply)
+    throw new Error(`rwaUSDi: exclusions exceed supply on ${api.chain}`)
+
+  api.add(config.token, (totalSupply - excluded).toString())
+}
+
+module.exports = { calculateSupply }

--- a/projects/multipli-rwausdi/config.js
+++ b/projects/multipli-rwausdi/config.js
@@ -1,0 +1,27 @@
+'use strict'
+
+module.exports = {
+  ethereum: {
+    token: '0xA39986F96B80d04e8d7AeAaF47175F47C23FD0f4',
+    excludedHolders: [],
+  },
+  base: {
+    token: '0xd74FB32112b1eF5b4C428Fead8dA8d85A0019009',
+    excludedHolders: [],
+    reviewOnlyWrappers: [
+      '0xed5AA9b6eb62298492c7246FE724ee088A760155',
+    ],
+  },
+  monad: {
+    token: '0x650b616b46fF94000Eb115926aB8393B90788D76',
+    excludedHolders: [],
+    chainlink: {
+      nav: 'https://data.chain.link/feeds/monad/monad/rwausdi-nav',
+      por: 'https://data.chain.link/feeds/monad/monad/rwausdi-por',
+    },
+  },
+  arbitrum: {
+    token: '0xA39986F96B80d04e8d7AeAaF47175F47C23FD0f4',
+    excludedHolders: [],
+  },
+}

--- a/projects/multipli-rwausdi/config.js
+++ b/projects/multipli-rwausdi/config.js
@@ -24,4 +24,8 @@ module.exports = {
     token: '0xA39986F96B80d04e8d7AeAaF47175F47C23FD0f4',
     excludedHolders: [],
   },
+  pharos: {
+    token: '0xA39986F96B80d04e8d7AeAaF47175F47C23FD0f4',
+    excludedHolders: [],
+  },
 }

--- a/projects/multipli-rwausdi/index.js
+++ b/projects/multipli-rwausdi/index.js
@@ -1,0 +1,15 @@
+'use strict'
+
+const CONFIG = require('./config')
+const { calculateSupply } = require('./accounting')
+
+for (const [chain, config] of Object.entries(CONFIG)) {
+  module.exports[chain] = { tvl: api => calculateSupply(api, config) }
+}
+
+module.exports.methodology =
+  'TVL is the total supply of rwaUSDi on Ethereum, Base, Monad and ' +
+  'Arbitrum, priced at net asset value via the Chainlink NAV feed. Wrapped ' +
+  'versions of the token (such as the AFI wrapper on Base) are not counted ' +
+  'again, and reserve attestations like Chainlink Proof of Reserve are not ' +
+  'added as extra TVL.'

--- a/projects/multipli-rwausdi/index.js
+++ b/projects/multipli-rwausdi/index.js
@@ -8,8 +8,8 @@ for (const [chain, config] of Object.entries(CONFIG)) {
 }
 
 module.exports.methodology =
-  'TVL is the total supply of rwaUSDi on Ethereum, Base, Monad and ' +
-  'Arbitrum, priced at net asset value via the Chainlink NAV feed. Wrapped ' +
+  'TVL is the total supply of rwaUSDi on Ethereum, Base, Monad, Arbitrum ' +
+  'and Pharos, priced at net asset value via the Chainlink NAV feed. Wrapped ' +
   'versions of the token (such as the AFI wrapper on Base) are not counted ' +
   'again, and reserve attestations like Chainlink Proof of Reserve are not ' +
   'added as extra TVL.'

--- a/projects/multipli/accounting.js
+++ b/projects/multipli/accounting.js
@@ -1,0 +1,87 @@
+'use strict'
+
+const ASSET = 'address:asset'
+const TOTAL_ASSETS = 'uint256:totalAssets'
+
+function assertAddress(value, label) {
+  if (!value || !/^0x[a-fA-F0-9]{40}$/.test(value))
+    throw new Error(`Multipli: invalid ${label}: ${value}`)
+}
+
+function sameAddress(a, b) {
+  return a.toLowerCase() === b.toLowerCase()
+}
+
+function validateVaultRegistry(chain, vaults) {
+  const seen = new Set()
+  for (const vault of vaults || []) {
+    if (!vault.id) throw new Error(`Multipli: ${chain} vault is missing id`)
+    assertAddress(vault.address, `${vault.id}.address`)
+    assertAddress(vault.expectedAsset, `${vault.id}.expectedAsset`)
+    const key = vault.address.toLowerCase()
+    if (seen.has(key)) throw new Error(`Multipli: duplicate vault ${vault.address}`)
+    seen.add(key)
+  }
+}
+
+async function addV2(api, config) {
+  const vaults = config.v2Vaults || []
+  if (!vaults.length) return
+
+  validateVaultRegistry(api.chain, vaults)
+  const blocked = new Set(
+    (config.blockedAssets || []).map(address => {
+      assertAddress(address, `${api.chain}.blockedAsset`)
+      return address.toLowerCase()
+    })
+  )
+
+  const [assets, totals] = await Promise.all([
+    api.multiCall({
+      abi: ASSET,
+      calls: vaults.map(vault => vault.address),
+    }),
+    api.multiCall({
+      abi: TOTAL_ASSETS,
+      calls: vaults.map(vault => vault.address),
+    }),
+  ])
+
+  if (assets.length !== vaults.length || totals.length !== vaults.length)
+    throw new Error(`Multipli: incomplete ${api.chain} V2 multicall response`)
+
+  vaults.forEach((vault, index) => {
+    const asset = assets[index]
+    const amount = totals[index]
+    assertAddress(asset, `${vault.id}.asset()`)
+
+    if (!sameAddress(asset, vault.expectedAsset))
+      throw new Error(
+        `Multipli: ${vault.id} asset mismatch: ${asset} != ${vault.expectedAsset}`
+      )
+    if (blocked.has(asset.toLowerCase()))
+      throw new Error(`Multipli: ${vault.id} uses blocked asset ${asset}`)
+    if (amount === null || amount === undefined || !/^\d+$/.test(amount.toString()))
+      throw new Error(`Multipli: ${vault.id} returned invalid totalAssets`)
+
+    api.add(asset, amount.toString())
+  })
+}
+
+async function addV1(api, config, getLegacyBalances) {
+  const v1 = config.v1
+  if (!v1 || !v1.enabled) return
+  if (!v1.disjointFromV2)
+    throw new Error(`Multipli: ${api.chain} V1/V2 disjointness not asserted`)
+
+  const balances = await getLegacyBalances(api.chain, v1, config.blockedAssets)
+  api.addBalances(balances)
+}
+
+async function calculateTvl(api, config, getLegacyBalances) {
+  await addV2(api, config)
+  await addV1(api, config, getLegacyBalances)
+  return api.getBalances ? api.getBalances() : undefined
+}
+
+module.exports = { addV1, addV2, calculateTvl, sameAddress }

--- a/projects/multipli/config.js
+++ b/projects/multipli/config.js
@@ -1,0 +1,119 @@
+'use strict'
+
+const TOKENS = {
+  ethereum: {
+    USDC: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+    USDT: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+    WBTC: '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599',
+    rwaUSDi: '0xA39986F96B80d04e8d7AeAaF47175F47C23FD0f4',
+  },
+  bsc: {
+    BTCB: '0x7130d2A12B9bCBfAe4f2634d864A1Ee1Ce3Ead9c',
+    WBTC: '0x0555E30da8f98308EdB960aa94C0Db47230d2B9c',
+    USDT: '0x55d398326f99059fF775485246999027B3197955',
+    USDC: '0x8AC76a51cc950d9822D68b83Fe1Ad97B32Cd580d',
+  },
+  avax: {
+    USDC: '0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E',
+    BTCb: '0x152b9d0FdC40C096757F570A51E494bD4B943E50',
+  },
+  monad: {
+    USDC: '0x754704Bc059F8C67012fEd69BC8A327a5aafb603',
+    rwaUSDi: '0x650b616b46fF94000Eb115926aB8393B90788D76',
+  },
+}
+
+const chains = {
+  ethereum: {
+    v2Vaults: [
+      {
+        id: 'ethereum-xUSDC-v2',
+        address: '0x133229E0AdFf22c6F1AD287D199ea09d35E4427B',
+        expectedAsset: TOKENS.ethereum.USDC,
+      },
+      {
+        id: 'ethereum-xUSDT-v2',
+        address: '0x3f453133ea14550B883805672B2871B0Ac295462',
+        expectedAsset: TOKENS.ethereum.USDT,
+      },
+      {
+        id: 'ethereum-xWBTC-v2',
+        address: '0xeA1EF816ddfA86a8E9690423C88C1512c01d1799',
+        expectedAsset: TOKENS.ethereum.WBTC,
+      },
+    ],
+    v1: {
+      enabled: true,
+      disjointFromV2: true,
+      allowedAssets: [
+        TOKENS.ethereum.USDC,
+        TOKENS.ethereum.USDT,
+        TOKENS.ethereum.WBTC,
+      ],
+    },
+    blockedAssets: [TOKENS.ethereum.rwaUSDi],
+  },
+
+  bsc: {
+    v2Vaults: [
+      {
+        // Vault symbol is xWBTC; underlying is WBTC on BSC, not BTCB.
+        id: 'bsc-xWBTC-v2',
+        address: '0x41DbD2BaC7F0dd7A3F0De5329eCb57c9afE14C5C',
+        expectedAsset: TOKENS.bsc.WBTC,
+      },
+      {
+        id: 'bsc-xUSDT-v2',
+        address: '0xdA0dF997CE0253e979a1E892a0468DBf45A3Dcb8',
+        expectedAsset: TOKENS.bsc.USDT,
+      },
+      {
+        id: 'bsc-xUSDC-v2',
+        address: '0x468e0dAbd55772775A9cD4c39fB0d4586B8aEdAe',
+        expectedAsset: TOKENS.bsc.USDC,
+      },
+    ],
+    v1: {
+      enabled: true,
+      disjointFromV2: true,
+      allowedAssets: [
+        TOKENS.bsc.BTCB,
+        TOKENS.bsc.WBTC,
+        TOKENS.bsc.USDT,
+        TOKENS.bsc.USDC,
+      ],
+    },
+    blockedAssets: [],
+  },
+
+  avax: {
+    v2Vaults: [
+      {
+        id: 'avax-xUSDC-v2',
+        address: '0xCF0Eb4ac018C06a16ED5c63484823C7805e7599D',
+        expectedAsset: TOKENS.avax.USDC,
+      },
+      {
+        id: 'avax-xBTCb-v2',
+        address: '0x468BbabAEf852C134b584382C0fef83F2954Cd5c',
+        expectedAsset: TOKENS.avax.BTCb,
+      },
+    ],
+    v1: { enabled: false, disjointFromV2: true, allowedAssets: [] },
+    blockedAssets: [],
+  },
+
+  monad: {
+    v2Vaults: [
+      {
+        id: 'monad-xUSDC-onchain-vault',
+        address: '0xd74FB32112b1eF5b4C428Fead8dA8d85A0019009',
+        expectedAsset: TOKENS.monad.USDC,
+      },
+    ],
+    v1: { enabled: false, disjointFromV2: true, allowedAssets: [] },
+    blockedAssets: [TOKENS.monad.rwaUSDi],
+  },
+}
+
+module.exports = { chains, TOKENS }

--- a/projects/multipli/index.js
+++ b/projects/multipli/index.js
@@ -1,27 +1,22 @@
-const axios = require('axios')
-const API = "https://api.multipli.fi/multipli/v1/external-aggregator/defillama/tvl/"
+'use strict'
 
-// API was reporting rwaUSDi total supply in balances
-const rwaUSDis = {
-  ethereum: '0xa39986f96b80d04e8d7aeaaf47175f47c23fd0f4',
-  base: '0xd74FB32112b1eF5b4C428Fead8dA8d85A0019009',
-  monad: '0x650b616b46ff94000eb115926ab8393b90788d76',
-  arbitrum: '0xA39986F96B80d04e8d7AeAaF47175F47C23FD0f4'
-}
+const { chains } = require('./config')
+const { calculateTvl } = require('./accounting')
+const { getLegacyBalances } = require('./legacy-v1')
 
-const tvl = async (api) => {
-  const { data } = await axios.get(API)
-  const balances = data.payload[api.chain] ?? {}
-  const blacklisted = rwaUSDis[api.chain]?.toLowerCase()
-  if (blacklisted) {
-    const target = `${api.chain}:${blacklisted}`
-    for (const key of Object.keys(balances)) {
-      if (key.toLowerCase() === target) delete balances[key]
-    }
+for (const [chain, config] of Object.entries(chains)) {
+  module.exports[chain] = {
+    tvl: api => calculateTvl(api, config, getLegacyBalances),
   }
-  return balances
 }
 
-const chains = ['ethereum', 'bsc', 'avax', 'base', 'monad', 'arbitrum']
+// V1 is a current-state endpoint until the remaining cohort is migrated.
 module.exports.timetravel = false
-chains.forEach(chain => { module.exports[chain] = { tvl } })
+
+module.exports.methodology =
+  'TVL is the underlying assets (USDC, USDT, BTC variants) held in Multipli ' +
+  'V2 yield vaults, read on-chain via totalAssets(), plus legacy V1 user ' +
+  'balances on Ethereum and BNB Chain that have not yet migrated, reported ' +
+  'by the Multipli API. Nothing is counted twice: V1 and V2 balances never ' +
+  'overlap, vault share tokens (xTokens) are excluded, and rwaUSDi is ' +
+  'tracked separately under the Multipli rwaUSDi child protocol.'

--- a/projects/multipli/legacy-v1.js
+++ b/projects/multipli/legacy-v1.js
@@ -1,0 +1,106 @@
+'use strict'
+
+const API =
+  'https://api.multipli.fi/multipli/v1/external-aggregator/defillama/tvl/'
+
+let payloadPromise
+
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function normalizeInteger(value, label) {
+  let normalized
+  if (typeof value === 'string') normalized = value
+  else if (typeof value === 'number' && Number.isSafeInteger(value))
+    normalized = String(value)
+  else throw new Error(`Multipli V1: invalid balance for ${label}`)
+
+  if (!/^\d+$/.test(normalized))
+    throw new Error(`Multipli V1: invalid balance for ${label}`)
+
+  return normalized.replace(/^0+(?=\d)/, '')
+}
+
+function addressSet(addresses, label) {
+  return new Set(
+    (addresses || []).map(address => {
+      if (!/^0x[a-fA-F0-9]{40}$/.test(address))
+        throw new Error(`Multipli V1: invalid ${label} address ${address}`)
+      return address.toLowerCase()
+    })
+  )
+}
+
+async function fetchPayload() {
+  if (!payloadPromise) {
+    // Lazy require keeps the validation helpers independently testable.
+    const { get } = require('../helper/http')
+    payloadPromise = get(API, {
+      timeout: 15_000,
+      headers: { accept: 'application/json' },
+    })
+      .then(data => {
+        if (!isPlainObject(data) || !isPlainObject(data.payload))
+          throw new Error('Multipli V1: malformed API response')
+        return data.payload
+      })
+      .catch(error => {
+        payloadPromise = undefined
+        throw error
+      })
+  }
+  return payloadPromise
+}
+
+function sanitizeChainBalances(chain, rawBalances, v1Config, blockedAssets) {
+  if (!isPlainObject(rawBalances))
+    throw new Error(`Multipli V1: malformed ${chain} balances`)
+
+  const allowed = addressSet(v1Config.allowedAssets, 'allowed')
+  const blocked = addressSet(blockedAssets, 'blocked')
+  const result = {}
+
+  for (const [rawKey, rawValue] of Object.entries(rawBalances)) {
+    const match = rawKey.match(/^([a-z0-9-]+):(0x[a-fA-F0-9]{40})$/)
+    if (!match) throw new Error(`Multipli V1: invalid key ${rawKey}`)
+
+    const [, keyChain, address] = match
+    if (keyChain !== chain)
+      throw new Error(`Multipli V1: ${rawKey} returned for ${chain}`)
+
+    const normalizedAddress = address.toLowerCase()
+    if (blocked.has(normalizedAddress)) continue
+    if (!allowed.has(normalizedAddress))
+      throw new Error(
+        `Multipli V1: unapproved ${chain} asset ${address}; update registry first`
+      )
+
+    const key = `${chain}:${normalizedAddress}`
+    result[key] = normalizeInteger(rawValue, key)
+  }
+
+  return result
+}
+
+async function getLegacyBalances(chain, v1Config, blockedAssets) {
+  const payload = await fetchPayload()
+  return sanitizeChainBalances(
+    chain,
+    payload[chain] || {},
+    v1Config,
+    blockedAssets
+  )
+}
+
+function resetCacheForTests() {
+  payloadPromise = undefined
+}
+
+module.exports = {
+  API,
+  getLegacyBalances,
+  normalizeInteger,
+  resetCacheForTests,
+  sanitizeChainBalances,
+}


### PR DESCRIPTION

> "Allow edits by maintainers" is enabled.

## Summary

- **`projects/multipli`** (existing listing): TVL moves from fully self-reported API data to
  on-chain. V2 ERC-4626 vaults are read via `asset()`/`totalAssets()` from a fixed per-chain
  registry, with hard failures on asset mismatch, blocked assets, or malformed responses.
- **`projects/multipli-rwausdi`** (new child): primary rwaUSDi `totalSupply` on Ethereum,
  Base, Monad and Arbitrum. Please add a price listing using the live
  [Chainlink NAV feed](https://data.chain.link/feeds/monad/monad/rwausdi-nav).
- **Restructure request**: parent `Multipli`, with
  the existing listing renamed to child **Multipli Yield** and the new **Multipli rwaUSDi**
  child. Parent = sum; children are disjoint.

## Why this change?

- **Why the V1 API fetch is retained (temporarily):** a non-migrated V1 cohort still exists
  on Ethereum and BNB Chain only; its balances sit in off-chain accounting and cannot yet be
  derived on-chain. The endpoint is no longer trusted: strict chain/asset allowlists (unknown
  assets throw instead of being counted), rwaUSDi exclusion, and full response validation.
  V1 and V2 are disjoint cohorts. Net effect: API-sourced TVL drops from 100% today to the
  shrinking V1 remainder, then to zero. `timetravel = false` stays until then.
- **No double counting:** vault share tokens are never added (only underlying
  `totalAssets`); rwaUSDi is on the yield adapter's blocked list on every chain where it
  exists; the Base AFI wrapper is not a second issuance layer; Chainlink PoR
  ([feed](https://data.chain.link/feeds/monad/monad/rwausdi-por)), AFI and Chainrisk are
  verification evidence, not extra TVL.
- **Chain changes:** Base and Arbitrum leave `projects/multipli` (they only carried
  rwaUSDi); Avalanche and Monad V2 vaults are added. The BSC vault `0x41DbD2…` is registered
  as `xWBTC`/WBTC (verified on-chain via `symbol()`/`asset()`) — it was previously
  mislabeled BTCB.
---

## New listing: Multipli rwaUSDi

##### Name (to be shown on DefiLlama):
Multipli rwaUSDi

##### Twitter Link:
https://x.com/multiplifi

##### Website Link:
https://multipli.fi

##### Logo (High resolution, will be shown with rounded borders):
https://app.multipli.fi/assets/images/rwa.RRSt7J5g.png

##### Current TVL:
~$360m

##### Treasury Addresses (if the protocol has treasury)


##### Chain:
Ethereum, Base, Monad, Arbitrum

##### Coingecko ID (leave empty if not listed):


##### Coinmarketcap ID (leave empty if not listed):


##### Short Description (to be shown on DefiLlama):
rwaUSDi is Multipli's yield-bearing token backed by tokenized real-world assets. TVL is the
primary token supply across Ethereum, Base, Monad and Arbitrum, priced at NAV.

##### Token address and ticker if any:
rwaUSDi 
ethereum/arbitrum: 0xA39986F96B80d04e8d7AeAaF47175F47C23FD0f4,
base: 0xd74FB32112b1eF5b4C428Fead8dA8d85A0019009,
monad: 0x650b616b46fF94000Eb115926aB8393B90788D76

##### Category (choose only one):
RWA

##### Oracle Provider(s):
Chainlink

##### Implementation Details:
Live Chainlink NAV feed prices rwaUSDi; Chainlink Proof of Reserve attests backing.
NAV: https://data.chain.link/feeds/monad/monad/rwausdi-nav
PoR: https://data.chain.link/feeds/monad/monad/rwausdi-por

##### Documentation/Proof:
https://docs.multipli.fi/

##### forkedFrom (Does your project originate from another project):
No

##### methodology (what is being counted as tvl, how is tvl being calculated):
Primary rwaUSDi totalSupply on Ethereum, Base, Monad and Arbitrum, minus documented
non-circulating balances (currently none), priced via the Chainlink NAV feed.


##### Does this project have a referral program?
No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added config-driven TVL tracking for Multipli using a vault registry that combines V1 legacy balances with V2 vault assets.
  - Added net circulating RWA USDi supply tracking across Ethereum, Base, Monad, Arbitrum, and Pharos, supporting optional excluded-holder netting.
  - Published updated methodology descriptions for both adapters.
- **Bug Fixes**
  - Strengthened validation for addresses, integer-like balances, vault/asset matching, and deduplication to prevent double counting.
  - Improved resilience when legacy balance fetching fails by clearing cached results for retry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->