### PR TITLE
fix(circle): split the shared Gateway wallet between USDCx and Circle Gateway

### DIFF
--- a/projects/circle-gateway/index.js
+++ b/projects/circle-gateway/index.js
@@ -1,0 +1,30 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+const { sumTokensExport } = require('../helper/unwrapLPs')
+
+const GATEWAY_WALLET = '0x77777777Dcc4d5A8B6E418Fd04D8997ef11000eE'
+const XRESERVE = '0x8888888199b2Df864bf678259607d6D5EBb4e3Ce'
+const DOMAINS = Array.from({ length: 30 }, (_, i) => 10001 + i)
+
+async function ethereumTvl(api) {
+  const [walletBalance, collateral] = await Promise.all([
+    api.call({ abi: 'erc20:balanceOf', target: ADDRESSES.ethereum.USDC, params: [GATEWAY_WALLET] }),
+    api.multiCall({
+      calls: DOMAINS.map((domain) => ({ target: XRESERVE, params: [ADDRESSES.ethereum.USDC, domain] })),
+      abi: 'function balanceOfNativeCollateral(address token, uint32 domain) view returns (uint256)',
+      permitFailure: true,
+    }),
+  ])
+  // the gateway wallet also custodies the USDC backing USDCx, which is tracked
+  // under circle-xreserve - only count the remainder here
+  const xReserveCollateral = collateral.reduce((sum, balance) => sum + (balance ? Number(balance) : 0), 0)
+  const net = Number(walletBalance) - xReserveCollateral
+  if (net > 0) api.add(ADDRESSES.ethereum.USDC, net)
+}
+
+module.exports = {
+  methodology:
+    'USDC held by the Circle Gateway wallet, minus the USDCx collateral portion tracked under USDCx (circle-xreserve) to avoid double counting the same custody wallet.',
+  ethereum: { tvl: ethereumTvl },
+  base: { tvl: sumTokensExport({ owner: GATEWAY_WALLET, tokens: [ADDRESSES.base.USDC] }) },
+  avax: { tvl: sumTokensExport({ owner: GATEWAY_WALLET, tokens: [ADDRESSES.avax.USDC] }) },
+}

--- a/projects/circle-gateway/index.js
+++ b/projects/circle-gateway/index.js
@@ -16,9 +16,9 @@ async function ethereumTvl(api) {
   ])
   // the gateway wallet also custodies the USDC backing USDCx, which is tracked
   // under circle-xreserve - only count the remainder here
-  const xReserveCollateral = collateral.reduce((sum, balance) => sum + (balance ? Number(balance) : 0), 0)
-  const net = Number(walletBalance) - xReserveCollateral
-  if (net > 0) api.add(ADDRESSES.ethereum.USDC, net)
+  const xReserveCollateral = collateral.reduce((sum, balance) => sum + (balance ? BigInt(balance) : 0n), 0n)
+  const net = BigInt(walletBalance) - xReserveCollateral
+  if (net > 0n) api.add(ADDRESSES.ethereum.USDC, net.toString())
 }
 
 module.exports = {

--- a/projects/circle-xreserve/index.js
+++ b/projects/circle-xreserve/index.js
@@ -1,0 +1,24 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+
+const XRESERVE = '0x8888888199b2Df864bf678259607d6D5EBb4e3Ce'
+
+// USDCx destination domains live on the reserve today are 10001-10005, probe a
+// wider range so newly added domains get picked up without a code change
+const DOMAINS = Array.from({ length: 30 }, (_, i) => 10001 + i)
+
+async function tvl(api) {
+  const balances = await api.multiCall({
+    calls: DOMAINS.map((domain) => ({ target: XRESERVE, params: [ADDRESSES.ethereum.USDC, domain] })),
+    abi: 'function balanceOfNativeCollateral(address token, uint32 domain) view returns (uint256)',
+    permitFailure: true,
+  })
+  balances.forEach((balance) => {
+    if (balance) api.add(ADDRESSES.ethereum.USDC, balance)
+  })
+}
+
+module.exports = {
+  methodology:
+    'USDC collateral backing USDCx, read per destination domain from the xReserve contract via balanceOfNativeCollateral. The collateral is physically custodied in the shared Circle Gateway wallet, which Circle Gateway tracks net of this amount to avoid double counting.',
+  ethereum: { tvl },
+}

--- a/registries/sumTokens.js
+++ b/registries/sumTokens.js
@@ -7132,12 +7132,6 @@ const configs = {
       "token": "0x5dF82810CB4B8f3e0Da3c031cCc9208ee9cF9500"
     },
   },
-  "circle-xreserve": {
-    "ethereum": {
-      "owner": "0x77777777Dcc4d5A8B6E418Fd04D8997ef11000eE",
-      "token": ADDRESSES.ethereum.USDC
-    }
-  },
   "citadao": {
     "ethereum": {
       "tvl": {
@@ -41682,9 +41676,6 @@ const configs = {
       "owner": "0xFDBC53080AFb08d7a3A2420e902c8AeC05E4aE73",
       "resolveUniV3": true
     },
-  },
-  "circle-gateway": {
-    ethereum: { owner: '0x77777777Dcc4d5A8B6E418Fd04D8997ef11000eE', token: ADDRESSES.ethereum.USDC },
   },
   "robinhood-bridge": {
     ethereum: { owner: '0xDf8755334ce7A73cCF6b581C02eA649AE3E864b3', token: ADDRESSES.null },


### PR DESCRIPTION
Fixes #20100; USDCx (circle-xreserve) and Circle Gateway both counted the full 56M USDC in the shared Circle wallet 0x77777777Dcc4d5A8B6E418Fd04D8997ef11000eE, so both pages showed the identical $55,980,370.56.

The wallet custodies two products' funds. Per the xReserve contract's own accounting (balanceOfNativeCollateral, the source the original #19788 PR description pointed at), 54.89M backs USDCx across domains 10001-10005 and the rest is Gateway deposits.

Changes:
- projects/circle-xreserve: sum balanceOfNativeCollateral(USDC, domain) over domains 10001+ on the xReserve contract, USDCx now reports the collateral that actually backs it
- projects/circle-gateway: Gateway wallet balance minus that collateral, plus the base and avax gateway wallets (same vanity address, pure Gateway deposits, previously untracked)
- registries/sumTokens.js: both entries removed in favour of the project files

Test runs (twice, stable):
```
circle-xreserve: ethereum 54.86 M
circle-gateway:  ethereum 1.10 M, base 293.77 k, avax 365 -> 1.39 M
```
Sum matches the wallet balances, nothing double counted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for Circle Gateway across Ethereum, Base, and Avalanche (USDC-based).
  * Added Ethereum TVL tracking for Circle XReserve across supported destination domains (USDC collateral).
* **Bug Fixes**
  * Improved USDC accounting to prevent double-counting between related Circle custody sources by adjusting for overlapping collateral handling.
* **Chores**
  * Removed obsolete token registry entries so Circle Gateway and Circle XReserve report via their dedicated adapters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->