### PR TITLE
rubicon: add treasury registry entry

### DIFF
--- a/projects/helper/utils.js
+++ b/projects/helper/utils.js
@@ -58,7 +58,7 @@ function isLP(symbol, token, chain) {
   if (chain === 'aurora' && ['wLP'].includes(symbol)) return true
   if (chain === 'oasis' && ['LPT', 'GLP'].includes(symbol)) return true
   if (chain === 'iotex' && ['MIMO-LP'].includes(symbol)) return true
-  if (chain === 'base' && ['RCKT-V2'].includes(symbol)) return true
+  if (chain === 'base' && ['RCKT-V2', 'RUBI-AMM'].includes(symbol)) return true
   if (chain === 'wan' && ['WSLP'].includes(symbol)) return true
   if (chain === 'telos' && ['zLP'].includes(symbol)) return true
   if (chain === 'fuse' && ['VLP'].includes(symbol)) return true

--- a/registries/treasury.js
+++ b/registries/treasury.js
@@ -4871,6 +4871,48 @@ const configs = {
       owners: ['0xdb8f4c4c68e5e5eb501fee1adaa87ee767bcade7'],
     },
   },
+  'treasury/rubicon': {
+    ethereum: {
+      tokens: [nullAddress],
+      owners: [
+        '0x752748deaf25cf58b60d4c4209d7f200aee4ef14', // protocol fee EOA (same address on all 4 chains)
+        '0x8c1ACB63a021BD8c990744C07bc53A3Ec3C03af4', // treasury Safe (2-of-3, same address + owners on all 4 chains)
+      ],
+      ownTokens: ['0x7483e83b481c69a93cb025395194e0dc4F32d9C4'], // RUBI (canonical L1 token)
+    },
+    optimism: {
+      tokens: [nullAddress],
+      owners: [
+        '0x752748deaf25cf58b60d4c4209d7f200aee4ef14',
+        '0x8c1ACB63a021BD8c990744C07bc53A3Ec3C03af4',
+      ],
+    },
+    arbitrum: {
+      tokens: [nullAddress],
+      owners: [
+        '0x752748deaf25cf58b60d4c4209d7f200aee4ef14',
+        '0x8c1ACB63a021BD8c990744C07bc53A3Ec3C03af4',
+      ],
+    },
+    base: {
+      tokens: [
+        nullAddress,
+        '0xd8eDF10E243e2A176789D2AD1CB47151e76e8865', // Aquila WETH/RUBI LP (accrued by fee collector)
+        '0xa883C11a3742f74F0b29750764146e8675306e24', // Aquila USDC/RUBI LP (accrued by fee collector)
+      ],
+      resolveLP: true, // Aquila (uniV2 fork) factory.feeTo() mints LP tokens to the fee collector
+      owners: [
+        '0x752748deaf25cf58b60d4c4209d7f200aee4ef14',
+        '0x8c1ACB63a021BD8c990744C07bc53A3Ec3C03af4',
+        '0x1db5b42e760072bd981ae67435f73884aa659cba', // Aquila Base fee collector (accumulator, never forwards)
+      ],
+      ownTokens: ['0xb3836098d1e94EC651D74D053d4a0813316B2a2f'], // RUBI on Base (protocol listing token)
+      uniV3nftsAndOwners: [
+        ['0x03a520b32C04BF3bEEf7BEb72E919cf822Ed34f1', '0x8c1ACB63a021BD8c990744C07bc53A3Ec3C03af4'], // canonical UniV3 NFPM
+        ['0xF75a94E360502618c838219f8954Ce8b7666b42F', '0x8c1ACB63a021BD8c990744C07bc53A3Ec3C03af4'], // Rubicon CLMM NFPM
+      ],
+    },
+  },
   'treasury/saddle': {
     arbitrum: {
       tokens: [


### PR DESCRIPTION
Adds a `treasury/rubicon` entry to `registries/treasury.js`.

### Wallets
- **Protocol fee EOA** and **treasury Safe** — same addresses on all four chains (ETH/OP/Arb/Base).
- **Base Aquila fee collector** — accrues UniswapV2-fork fee-mint LP tokens and never forwards, so its Aquila LP holdings are unwrapped via `resolveLP`.

### Buckets
- **ownTokens**: RUBI (the protocol's own token) on Ethereum and Base.
- **treasury**: native gas token + the unwrapped Aquila LP positions; on Base, the Safe's CLMM LP positions via `uniV3nftsAndOwners`.

### One-line helper change
The Aquila pair token symbol is `RUBI-AMM`, which stock `isLP()` doesn't recognize — without it `resolveLP` silently no-ops. Added alongside the existing `'RCKT-V2'` Base entry in `projects/helper/utils.js` (the precedented pattern).

Verified 2026-07-17 against live on-chain balances.

Website: https://rubicon.finance

Allowing edits by maintainers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Rubicon treasury tracking across Ethereum, Optimism, Arbitrum, and Base.
  * Added support for recognizing RUBI-AMM liquidity pools on Base.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->