### PR TITLE
mark usdcx doublecounted

### DIFF
--- a/registries/sumTokens.js
+++ b/registries/sumTokens.js
@@ -7133,6 +7133,7 @@ const configs = {
     },
   },
   "circle-xreserve": {
+    "doublecounted": true,
     "ethereum": {
       "owner": "0x77777777Dcc4d5A8B6E418Fd04D8997ef11000eE",
       "token": ADDRESSES.ethereum.USDC


### PR DESCRIPTION
resolves #20101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated token registry metadata to correctly account for double-counted reserves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->