### PR TITLE
royco-v2: add base markets + srRoyUSDC & RoyWstEth vaults (dedupe double-counting)

### DIFF
--- a/projects/royco-v2/index.js
+++ b/projects/royco-v2/index.js
@@ -183,23 +183,25 @@ const getStrategyNav = async (api) => {
     const tranches = [...seniorTranches, ...juniorTranches];
     if (!tranches.length) return 0n;
 
+    // These are de-duplication calls: a failed call must fail the whole refresh (DefiLlama then
+    // retries), never be silently skipped. Skipping would under-subtract the overlap and publish
+    // inflated, double-counted TVL — so no permitFailure here.
     let nav = 0n;
     for (const strategy of srRoyUsdcStrategies) {
         const shares = await api.multiCall({
             abi: 'erc20:balanceOf',
             calls: tranches.map(tranche => ({ target: tranche, params: [strategy] })),
-            permitFailure: true,
         });
 
         // balanceOf returns shares; convert only the non-zero positions to their USDC value (nav).
         const claimsCalls = tranches
             .map((tranche, i) => ({ target: tranche, params: [shares[i]] }))
-            .filter((_, i) => shares[i] && BigInt(shares[i]) > 0n);
+            .filter((_, i) => BigInt(shares[i]) > 0n);
         if (!claimsCalls.length) continue;
 
-        const claims = await api.multiCall({ abi: convertToAssetsAbi, calls: claimsCalls, permitFailure: true });
+        const claims = await api.multiCall({ abi: convertToAssetsAbi, calls: claimsCalls });
         claims.forEach(claim => {
-            if (claim) nav += BigInt(claim.nav);
+            nav += BigInt(claim.nav);
         });
     }
     return nav;
@@ -214,19 +216,20 @@ const addRoyWstEth = async (api) => {
     api.add(royWstEth.asset, totalAssets);
 
     // srRoyUSDC shares held by the vault's strategies, valued in USDC via srRoyUSDC.convertToAssets.
+    // No permitFailure: this is a de-duplication call, so a failed call must fail the refresh rather
+    // than skip the subtraction and leave the borrowed leg double-counted.
     const shares = await api.multiCall({
         abi: 'erc20:balanceOf',
         calls: royWstEth.strategies.map(strategy => ({ target: srRoyUsdc.address, params: [strategy] })),
-        permitFailure: true,
     });
     const assetCalls = royWstEth.strategies
         .map((_, i) => ({ target: srRoyUsdc.address, params: [shares[i]] }))
-        .filter((_, i) => shares[i] && BigInt(shares[i]) > 0n);
+        .filter((_, i) => BigInt(shares[i]) > 0n);
     if (!assetCalls.length) return;
 
-    const positions = await api.multiCall({ abi: srRoyUsdcConvertToAssetsAbi, calls: assetCalls, permitFailure: true });
+    const positions = await api.multiCall({ abi: srRoyUsdcConvertToAssetsAbi, calls: assetCalls });
     positions.forEach(usdc => {
-        if (usdc) api.add(srRoyUsdc.asset, -BigInt(usdc)); // remove the already-counted srRoyUSDC leg
+        api.add(srRoyUsdc.asset, -BigInt(usdc)); // remove the already-counted srRoyUSDC leg
     });
 };
 

--- a/projects/royco-v2/index.js
+++ b/projects/royco-v2/index.js
@@ -1,4 +1,37 @@
+const sdk = require("@defillama/sdk");
 const { getLogs2 } = require("../helper/cache/getLogs");
+
+// =============================================================================================
+// TVL METHODOLOGY — NO DOUBLE-COUNTING
+//
+// Every dollar in this adapter is counted exactly once. TVL comes from three sources:
+//
+//   (1) Royco V2 markets (all chains): sum of senior + junior tranche `totalAssets()`.
+//       This is the single source of truth for value held INSIDE Royco markets.
+//
+//   (2) srRoyUSDC vault (mainnet only): a Royco-issued vault product. Users deposit USDC and
+//       receive the srRoyUSDC token; the vault custodies and manages those deposits, allocating
+//       them across Royco markets and other yield venues. This whole vault balance is Royco's
+//       OWN TVL — the same convention DefiLlama applies to curated-vault / aggregator products
+//       such as Yearn vaults, whose deposited assets count toward the issuing protocol's TVL even
+//       when the vault forwards them into underlying venues. So (2) is Royco TVL, not a third
+//       party's.
+//
+//   (3) RoyWstEth vault (mainnet only): a Royco-issued wstETH vault. Users deposit wstETH; its
+//       strategies supply it as Morpho collateral, borrow stablecoins, swap to USDC, and deposit
+//       that USDC into the srRoyUSDC vault (2). We count the vault's wstETH NAV. Also Royco TVL.
+//
+// THE OVERLAPS (why subtractions are needed): a higher layer deposits into a lower one, so the same
+// value can otherwise appear twice INSIDE Royco (this is internal de-duplication, not cross-protocol):
+//   - (2) into (1): srRoyUSDC's strategies deposit into Royco markets, inflating the tranches'
+//     `totalAssets()`. Fixed in `addSrRoyUsdc`: (2) contributes
+//         srRoyUSDC.totalAssets()  -  (value its strategies hold inside Royco markets)
+//     read on-chain from those strategies' tranche positions (balanceOf -> convertToAssets().nav).
+//   - (3) into (2): RoyWstEth's strategies park borrowed USDC in srRoyUSDC, which (2) already counts.
+//     Fixed in `addRoyWstEth`: we add (3)'s wstETH NAV and subtract that srRoyUSDC position
+//     (balanceOf -> convertToAssets, in USDC) back out of (2).
+// Net effect: every deposit is counted once at its lowest layer, and NOTHING is counted twice.
+// =============================================================================================
 
 const config = {
     "ethereum": {
@@ -13,23 +46,82 @@ const config = {
         factoryAddress: "0x7cc6fb28ec7b5e7afc3cb3986141797ffc27253c",
         factoryFromBlock: 441493793,
     },
+    "base": {
+        factoryAddress: "0x568c9709daa2f7b7cc66abc3e41da0f0a339551a",
+        factoryFromBlock: 48111449,
+    },
 };
 
-const tvl = async (api) => {
-    // Market Vaults
-    const { factoryFromBlock, factoryAddress } = config[api.chain];
+const marketDeployedEventAbi = "event MarketDeployed((address seniorTranche, address juniorTranche, address kernel, address accountant) roycoMarket, (string seniorTrancheName, string seniorTrancheSymbol, string juniorTrancheName, string juniorTrancheSymbol, address seniorTrancheImplementation, address juniorTrancheImplementation, address kernelImplementation, address accountantImplementation, bytes seniorTrancheInitializationData, bytes juniorTrancheInitializationData, bytes kernelInitializationData, bytes accountantInitializationData, bytes32 seniorTrancheProxyDeploymentSalt, bytes32 juniorTrancheProxyDeploymentSalt, bytes32 kernelProxyDeploymentSalt, bytes32 accountantProxyDeploymentSalt, (address target, bytes4[] selectors, uint64[] roles)[] roles) params)";
 
+const totalAssetsAbi = "function totalAssets() view returns ((uint256 stAssets, uint256 jtAssets, uint256 nav))";
+// convertToAssets(shares) -> AssetClaims. `nav` is the position's value in USDC, expressed in
+// the protocol's 18-decimal NAV_UNIT. stAssets/jtAssets are denominated in the tranche's own
+// (post-swap) deposit token, so only `nav` is usable as a USDC figure here.
+const convertToAssetsAbi = "function convertToAssets(uint256 _shares) view returns ((uint256 stAssets, uint256 jtAssets, uint256 nav))";
+
+// srRoyUSDC vault (mainnet only), a Royco-issued vault product. Users deposit USDC and receive the
+// srRoyUSDC token; the vault custodies and manages those deposits, allocating them across Royco
+// markets and other yield venues. The full vault balance is Royco's OWN TVL (the same way
+// Yearn-style vault deposits count toward the issuing protocol, even when forwarded to underlying
+// venues). It is added to TVL MINUS the portion already counted inside Royco markets (see
+// addSrRoyUsdc), purely so that in-market slice is not counted twice WITHIN Royco.
+const srRoyUsdc = {
+    chain: "ethereum",
+    address: "0xcd9f5907f92818bc06c9ad70217f089e190d2a32",
+    asset: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // USDC
+};
+
+// Accounts through which srRoyUSDC holds its positions inside Royco markets. Their tranche
+// positions are exactly the overlap between srRoyUSDC and the market TVL, so they are what gets
+// subtracted to avoid double-counting. Queried on every market chain; balanceOf simply returns 0
+// on chains where a given strategy holds nothing.
+const srRoyUsdcStrategies = [
+    "0x170ff06326ebb64bf609a848fc143143994af6c8", // multisig
+    "0x5476f4e23daa093ce6700e1026013c55f7af9083", // makina caliber
+];
+
+// NAV_UNIT (18 decimals, USDC-denominated) -> USDC (6 decimals)
+const NAV_TO_USDC = 10n ** 12n;
+
+// RoyWstEth vault (mainnet only), a Royco-issued wstETH vault. Users deposit wstETH; its strategies
+// supply it as Morpho collateral, borrow stablecoins, swap to USDC, and deposit that USDC into the
+// srRoyUSDC vault. Its wstETH NAV is Royco's own TVL; the borrowed USDC it parks in srRoyUSDC is
+// already counted there, so we subtract that position to avoid double-counting the leveraged leg.
+const royWstEth = {
+    chain: "ethereum",
+    address: "0x41ce72e04d349eb957bdc373baa9c69207032c56",
+    asset: "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0", // wstETH
+    strategies: [
+        "0xed45292eeac48324dabf7c76c2bd71b194a3f97d", // multisig
+        "0x3d8e2497497a3e29ad5391c08db2a1b3c32598c0", // makina caliber
+    ],
+};
+
+// srRoyUSDC is a standard ERC4626 vault (asset = USDC), so its convertToAssets(shares) returns a
+// plain USDC amount — unlike the market tranches' convertToAssets, which returns the struct above.
+const srRoyUsdcConvertToAssetsAbi = "function convertToAssets(uint256 shares) view returns (uint256 assets)";
+
+const getTranches = async (api) => {
+    const { factoryAddress, factoryFromBlock } = config[api.chain];
     const marketDeployedLogs = await getLogs2({
         api,
         target: factoryAddress,
-        eventAbi: "event MarketDeployed((address seniorTranche, address juniorTranche, address kernel, address accountant) roycoMarket, (string seniorTrancheName, string seniorTrancheSymbol, string juniorTrancheName, string juniorTrancheSymbol, address seniorTrancheImplementation, address juniorTrancheImplementation, address kernelImplementation, address accountantImplementation, bytes seniorTrancheInitializationData, bytes juniorTrancheInitializationData, bytes kernelInitializationData, bytes accountantInitializationData, bytes32 seniorTrancheProxyDeploymentSalt, bytes32 juniorTrancheProxyDeploymentSalt, bytes32 kernelProxyDeploymentSalt, bytes32 accountantProxyDeploymentSalt, (address target, bytes4[] selectors, uint64[] roles)[] roles) params)",
+        eventAbi: marketDeployedEventAbi,
         fromBlock: factoryFromBlock,
     });
+    return {
+        seniorTranches: marketDeployedLogs.map(log => log.roycoMarket.seniorTranche),
+        juniorTranches: marketDeployedLogs.map(log => log.roycoMarket.juniorTranche),
+    };
+};
 
-    const seniorTranches = marketDeployedLogs.map(log => log.roycoMarket.seniorTranche);
-    const juniorTranches = marketDeployedLogs.map(log => log.roycoMarket.juniorTranche);
-
-    const totalAssetsAbi = "function totalAssets() view returns ((uint256 stAssets, uint256 jtAssets, uint256 nav))";
+const tvl = async (api) => {
+    // Source (1): value held INSIDE Royco markets, counted exactly once here from the tranches.
+    // Any srRoyUSDC deposits routed into these same tranches are captured by this sum, and are
+    // therefore removed from the srRoyUSDC figure below (see addSrRoyUsdc) so they are not counted
+    // a second time.
+    const { seniorTranches, juniorTranches } = await getTranches(api);
 
     const seniorAssets = await api.multiCall({ abi: 'address:asset', calls: seniorTranches });
     const juniorAssets = await api.multiCall({ abi: 'address:asset', calls: juniorTranches });
@@ -43,11 +135,106 @@ const tvl = async (api) => {
     jtTotalAssets.forEach((result, i) => {
         api.add(juniorAssets[i], BigInt(result.jtAssets));
     });
+
+    // Source (2): srRoyUSDC lives on mainnet only; account for it once, when tvl runs for its
+    // chain. addSrRoyUsdc subtracts the part already counted above so there is no double-counting.
+    if (api.chain === srRoyUsdc.chain) {
+        await addSrRoyUsdc(api);
+    }
+
+    // Source (3): RoyWstEth (mainnet only) — adds its wstETH NAV and removes the srRoyUSDC position
+    // its strategies hold (already counted in (2)), so the borrowed leg is not double-counted.
+    if (api.chain === royWstEth.chain) {
+        await addRoyWstEth(api);
+    }
+};
+
+// Adds srRoyUSDC's value to TVL WITHOUT double-counting. The full vault balance is Royco's own TVL,
+// but `totalDeposits` (the vault's totalAssets) already includes the USDC the vault has placed into
+// Royco markets — value that tvl()'s tranche sums above ALREADY count. We measure that in-market
+// portion on-chain and subtract it, so the vault contributes only its remaining (not-yet-counted)
+// deposits here. In-market dollars stay counted once (in the tranches), never twice.
+const addSrRoyUsdc = async (api) => {
+    // Total USDC held by the vault (Royco-market allocations + other yield venues + idle USDC).
+    // This full balance is Royco's own TVL; we only net out the already-counted market slice below.
+    const totalDeposits = BigInt(await api.call({ abi: 'uint256:totalAssets', target: srRoyUsdc.address }));
+
+    // The exact slice already counted by (1): the strategies' positions across every market chain,
+    // summed as USDC (nav) and converted from NAV_UNIT (18 decimals) to USDC (6 decimals). This is
+    // the in-Royco overlap we cancel out — subtracting it makes the two Royco sources mutually
+    // exclusive.
+    let navInMarkets = 0n;
+    for (const chain of Object.keys(config)) {
+        const chainApi = chain === api.chain ? api : new sdk.ChainApi({ chain, timestamp: api.timestamp });
+        navInMarkets += await getStrategyNav(chainApi);
+    }
+    const depositsInMarkets = navInMarkets / NAV_TO_USDC;
+
+    // totalDeposits − depositsInMarkets = srRoyUSDC value that is NOT already in the tranche sums.
+    api.add(srRoyUsdc.asset, totalDeposits - depositsInMarkets);
+};
+
+// Measures the exact value srRoyUSDC's strategies hold inside Royco markets on `api.chain`, summed
+// in NAV_UNIT (18-decimal, USDC-denominated) across all senior + junior tranches. This is the
+// amount tvl()'s tranche sums already count for these strategies; addSrRoyUsdc subtracts it, which
+// is what prevents srRoyUSDC and the markets from double-counting the same deposits.
+const getStrategyNav = async (api) => {
+    const { seniorTranches, juniorTranches } = await getTranches(api);
+    const tranches = [...seniorTranches, ...juniorTranches];
+    if (!tranches.length) return 0n;
+
+    let nav = 0n;
+    for (const strategy of srRoyUsdcStrategies) {
+        const shares = await api.multiCall({
+            abi: 'erc20:balanceOf',
+            calls: tranches.map(tranche => ({ target: tranche, params: [strategy] })),
+            permitFailure: true,
+        });
+
+        // balanceOf returns shares; convert only the non-zero positions to their USDC value (nav).
+        const claimsCalls = tranches
+            .map((tranche, i) => ({ target: tranche, params: [shares[i]] }))
+            .filter((_, i) => shares[i] && BigInt(shares[i]) > 0n);
+        if (!claimsCalls.length) continue;
+
+        const claims = await api.multiCall({ abi: convertToAssetsAbi, calls: claimsCalls, permitFailure: true });
+        claims.forEach(claim => {
+            if (claim) nav += BigInt(claim.nav);
+        });
+    }
+    return nav;
+};
+
+// Adds the RoyWstEth vault WITHOUT double-counting. `totalAssets()` is the wstETH NAV (already net
+// of the strategies' Morpho debt) — Royco's own TVL. Its strategies also hold a srRoyUSDC position
+// funded with USDC borrowed against that wstETH; srRoyUSDC (2) already counts that USDC, so we
+// subtract it back out of (2) here so the leveraged leg is not counted twice within Royco.
+const addRoyWstEth = async (api) => {
+    const totalAssets = await api.call({ abi: 'uint256:totalAssets', target: royWstEth.address });
+    api.add(royWstEth.asset, totalAssets);
+
+    // srRoyUSDC shares held by the vault's strategies, valued in USDC via srRoyUSDC.convertToAssets.
+    const shares = await api.multiCall({
+        abi: 'erc20:balanceOf',
+        calls: royWstEth.strategies.map(strategy => ({ target: srRoyUsdc.address, params: [strategy] })),
+        permitFailure: true,
+    });
+    const assetCalls = royWstEth.strategies
+        .map((_, i) => ({ target: srRoyUsdc.address, params: [shares[i]] }))
+        .filter((_, i) => shares[i] && BigInt(shares[i]) > 0n);
+    if (!assetCalls.length) return;
+
+    const positions = await api.multiCall({ abi: srRoyUsdcConvertToAssetsAbi, calls: assetCalls, permitFailure: true });
+    positions.forEach(usdc => {
+        if (usdc) api.add(srRoyUsdc.asset, -BigInt(usdc)); // remove the already-counted srRoyUSDC leg
+    });
 };
 
 module.exports = {
-    methodology: "TVL is computed by reading MarketDeployed events from the Royco V2 factory and summing totalAssets() across senior and junior tranches.",
+    start: '2026-01-27', // first TVL: srRoyUsdc vault's first deposit (block 24328493), predates the markets
+    methodology: "Value is counted exactly once, with no double-counting. (1) Royco V2 market TVL is read from MarketDeployed events on each factory and summed as totalAssets() across senior and junior tranches on every chain - the single source of truth for value inside Royco markets. (2) The srRoyUSDC vault (mainnet) is a Royco-issued vault product whose deposits are Royco's own TVL - the same convention DefiLlama applies to curated-vault/aggregator products such as Yearn vaults, whose deposits count toward the issuing protocol even when forwarded to underlying venues. The vault allocates user USDC across Royco markets and other yield venues; the portion already sitting in Royco markets is measured on-chain (its strategies' tranche positions via balanceOf -> convertToAssets().nav, across all chains) and subtracted, so that slice is never counted twice within Royco. (3) The RoyWstEth vault (mainnet) is a Royco-issued wstETH vault whose strategies supply the wstETH as Morpho collateral, borrow stablecoins, swap to USDC and deposit it into srRoyUSDC; its wstETH NAV is added, and the srRoyUSDC position its strategies hold (already counted in (2)) is subtracted back out so the borrowed leg is not double-counted.",
     ethereum: { tvl },
     avax: { tvl },
     arbitrum: { tvl },
+    base: { tvl },
 }

--- a/projects/royco-v2/index.js
+++ b/projects/royco-v2/index.js
@@ -1,41 +1,14 @@
 const sdk = require("@defillama/sdk");
 const { getLogs2 } = require("../helper/cache/getLogs");
 
-// =============================================================================================
-// TVL METHODOLOGY — NO DOUBLE-COUNTING
-//
-// Every dollar in this adapter is counted exactly once. TVL comes from three sources:
-//
-//   (1) Royco V2 markets (all chains): sum of senior + junior tranche `totalAssets()`.
-//       This is the single source of truth for value held INSIDE Royco markets.
-//
-//   (2) srRoyUSDC vault (mainnet only): a Royco-issued vault product. Users deposit USDC and
-//       receive the srRoyUSDC token; the vault custodies and manages those deposits, allocating
-//       them across Royco markets and other yield venues. This whole vault balance is Royco's
-//       OWN TVL — the same convention DefiLlama applies to curated-vault / aggregator products
-//       such as Yearn vaults, whose deposited assets count toward the issuing protocol's TVL even
-//       when the vault forwards them into underlying venues. So (2) is Royco TVL, not a third
-//       party's.
-//
-//   (3) RoyWstEth vault (mainnet only): a Royco-issued wstETH vault. Users deposit wstETH; its
-//       strategies supply it as Morpho collateral, borrow stablecoins, swap to USDC, and deposit
-//       that USDC into the srRoyUSDC vault (2). We count the vault's wstETH NAV. Also Royco TVL.
-//
-// THE OVERLAPS (why subtractions are needed): a higher layer deposits into a lower one, so the same
-// value can otherwise appear twice INSIDE Royco (this is internal de-duplication, not cross-protocol):
-//   - (2) into (1): srRoyUSDC's strategies deposit into Royco markets, inflating the tranches'
-//     `totalAssets()`. Fixed in `addSrRoyUsdc`: (2) contributes
-//         srRoyUSDC.totalAssets()  -  (value its strategies hold inside Royco markets)
-//     read on-chain from those strategies' tranche positions (balanceOf -> convertToAssets().nav).
-//   - (3) into (2): RoyWstEth's strategies park borrowed USDC in srRoyUSDC, which (2) already counts.
-//     Fixed in `addRoyWstEth`: we add (3)'s wstETH NAV and subtract that srRoyUSDC position
-//     (balanceOf -> convertToAssets, in USDC) back out of (2).
-// The position-holder addresses used for these subtractions are discovered ON-CHAIN, never
-// hardcoded: vault.getStrategies(), resolving each Makina CROSSCHAIN strategy to its machine's hub
-// caliber (getMakinaMachine().hubCaliber()) and leaving self-custody strategies as-is (see
-// resolveStrategies). So the adapter self-updates if a vault's strategies change.
-// Net effect: every deposit is counted once at its lowest layer, and NOTHING is counted twice.
-// =============================================================================================
+// TVL is counted once, at its lowest layer. Three sources, with subtractions where a higher layer
+// deposits into a lower one (internal de-dup within Royco, not cross-protocol):
+//   (1) Royco V2 markets (all chains): senior + junior tranche totalAssets().
+//   (2) srRoyUSDC vault (mainnet): a Royco-issued USDC vault. Its full balance is Royco's own TVL
+//       (Yearn-style: deposits count toward the issuing protocol even when forwarded elsewhere),
+//       minus the slice its strategies already hold inside (1).
+//   (3) RoyWstEth vault (mainnet): a Royco-issued wstETH vault. Its wstETH NAV is Royco TVL, minus
+//       the srRoyUSDC position its strategies hold (already counted in (2)).
 
 const config = {
     "ethereum": {
@@ -58,45 +31,28 @@ const config = {
 
 const marketDeployedEventAbi = "event MarketDeployed((address seniorTranche, address juniorTranche, address kernel, address accountant) roycoMarket, (string seniorTrancheName, string seniorTrancheSymbol, string juniorTrancheName, string juniorTrancheSymbol, address seniorTrancheImplementation, address juniorTrancheImplementation, address kernelImplementation, address accountantImplementation, bytes seniorTrancheInitializationData, bytes juniorTrancheInitializationData, bytes kernelInitializationData, bytes accountantInitializationData, bytes32 seniorTrancheProxyDeploymentSalt, bytes32 juniorTrancheProxyDeploymentSalt, bytes32 kernelProxyDeploymentSalt, bytes32 accountantProxyDeploymentSalt, (address target, bytes4[] selectors, uint64[] roles)[] roles) params)";
 
+// Both return (stAssets, jtAssets, nav). stAssets/jtAssets are in the tranche's own deposit token;
+// only `nav` is a USDC figure, in the protocol's 18-decimal NAV_UNIT.
 const totalAssetsAbi = "function totalAssets() view returns ((uint256 stAssets, uint256 jtAssets, uint256 nav))";
-// convertToAssets(shares) -> AssetClaims. `nav` is the position's value in USDC, expressed in
-// the protocol's 18-decimal NAV_UNIT. stAssets/jtAssets are denominated in the tranche's own
-// (post-swap) deposit token, so only `nav` is usable as a USDC figure here.
 const convertToAssetsAbi = "function convertToAssets(uint256 _shares) view returns ((uint256 stAssets, uint256 jtAssets, uint256 nav))";
 
-// srRoyUSDC vault (mainnet only), a Royco-issued vault product. Users deposit USDC and receive the
-// srRoyUSDC token; the vault custodies and manages those deposits, allocating them across Royco
-// markets and other yield venues. The full vault balance is Royco's OWN TVL (the same way
-// Yearn-style vault deposits count toward the issuing protocol, even when forwarded to underlying
-// venues). It is added to TVL MINUS the portion already counted inside Royco markets (see
-// addSrRoyUsdc), purely so that in-market slice is not counted twice WITHIN Royco.
 const srRoyUsdc = {
     chain: "ethereum",
     address: "0xcd9f5907f92818bc06c9ad70217f089e190d2a32",
     asset: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // USDC
 };
 
-// The srRoyUSDC and RoyWstEth vaults route deposits through on-chain "strategy" contracts, and
-// whatever a strategy custodies inside a lower Royco layer is exactly the overlap we must
-// de-duplicate. We DISCOVER the current position-holding addresses on-chain (never hardcode them)
-// so the adapter self-updates if a vault's strategies change. The same resolved holder set is
-// queried on every market chain; balanceOf simply returns 0 where a holder holds nothing.
-//
-// A strategy's positions do NOT necessarily sit at the strategy contract itself:
-//   - CROSSCHAIN strategies are executed through a Makina hub-and-spoke machine, so their Royco
-//     positions are custodied by the machine's hub caliber -> getMakinaMachine().hubCaliber().
-//   - ATOMIC/ASYNC strategies self-custody, so the holder is the strategy address itself.
-// enum StrategyType { ATOMIC, ASYNC, CROSSCHAIN } (from the Royco strategy contracts).
+// A vault routes deposits through on-chain "strategy" contracts; whatever a strategy holds inside a
+// lower Royco layer is the overlap to de-dup. Holders are resolved on-chain (never hardcoded) so the
+// adapter self-updates: CROSSCHAIN strategies run through a Makina machine, so the holder is the
+// machine's hub caliber (getMakinaMachine().hubCaliber()); ATOMIC/ASYNC strategies self-custody.
+// enum StrategyType { ATOMIC, ASYNC, CROSSCHAIN }.
 const STRATEGY_TYPE_CROSSCHAIN = 2;
 const getStrategiesAbi = "function getStrategies() view returns (address[])";
 const strategyTypeAbi = "function strategyType() view returns (uint8)";
 const getMakinaMachineAbi = "function getMakinaMachine() view returns (address)";
 const hubCaliberAbi = "function hubCaliber() view returns (address)";
 
-// Resolves a vault's current position-holding addresses on-chain (see the StrategyType note above).
-// These feed the de-duplication subtractions, so every call here is dedup-critical: NO
-// permitFailure — a failure must fail the whole refresh rather than silently drop a holder and
-// publish inflated, double-counted TVL.
 const resolveStrategies = async (api, vault) => {
     const strategies = await api.call({ abi: getStrategiesAbi, target: vault });
     if (!strategies.length) return [];
@@ -106,7 +62,6 @@ const resolveStrategies = async (api, vault) => {
     const selfCustody = strategies.filter((_, i) => Number(types[i]) !== STRATEGY_TYPE_CROSSCHAIN);
     if (!crosschain.length) return selfCustody;
 
-    // CROSSCHAIN => Makina: the real position-holder is the machine's hub caliber, not the strategy.
     const machines = await api.multiCall({ abi: getMakinaMachineAbi, calls: crosschain });
     const calibers = await api.multiCall({ abi: hubCaliberAbi, calls: machines });
     return [...selfCustody, ...calibers];
@@ -115,18 +70,14 @@ const resolveStrategies = async (api, vault) => {
 // NAV_UNIT (18 decimals, USDC-denominated) -> USDC (6 decimals)
 const NAV_TO_USDC = 10n ** 12n;
 
-// RoyWstEth vault (mainnet only), a Royco-issued wstETH vault. Users deposit wstETH; its strategies
-// supply it as Morpho collateral, borrow stablecoins, swap to USDC, and deposit that USDC into the
-// srRoyUSDC vault. Its wstETH NAV is Royco's own TVL; the borrowed USDC it parks in srRoyUSDC is
-// already counted there, so we subtract that position to avoid double-counting the leveraged leg.
 const royWstEth = {
     chain: "ethereum",
     address: "0x41ce72e04d349eb957bdc373baa9c69207032c56",
     asset: "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0", // wstETH
 };
 
-// srRoyUSDC is a standard ERC4626 vault (asset = USDC), so its convertToAssets(shares) returns a
-// plain USDC amount — unlike the market tranches' convertToAssets, which returns the struct above.
+// srRoyUSDC is a standard ERC4626 (asset = USDC), so convertToAssets returns a plain USDC amount —
+// unlike the tranches' convertToAssets, which returns the struct above.
 const srRoyUsdcConvertToAssetsAbi = "function convertToAssets(uint256 shares) view returns (uint256 assets)";
 
 const getTranches = async (api) => {
@@ -144,10 +95,7 @@ const getTranches = async (api) => {
 };
 
 const tvl = async (api) => {
-    // Source (1): value held INSIDE Royco markets, counted exactly once here from the tranches.
-    // Any srRoyUSDC deposits routed into these same tranches are captured by this sum, and are
-    // therefore removed from the srRoyUSDC figure below (see addSrRoyUsdc) so they are not counted
-    // a second time.
+    // (1) value held inside Royco markets, counted once from the tranches.
     const { seniorTranches, juniorTranches } = await getTranches(api);
 
     const seniorAssets = await api.multiCall({ abi: 'address:asset', calls: seniorTranches });
@@ -163,37 +111,24 @@ const tvl = async (api) => {
         api.add(juniorAssets[i], BigInt(result.jtAssets));
     });
 
-    // Source (2): srRoyUSDC lives on mainnet only; account for it once, when tvl runs for its
-    // chain. addSrRoyUsdc subtracts the part already counted above so there is no double-counting.
+    // (2) and (3) live on mainnet only; each subtracts the part already counted above.
     if (api.chain === srRoyUsdc.chain) {
         await addSrRoyUsdc(api);
     }
-
-    // Source (3): RoyWstEth (mainnet only) — adds its wstETH NAV and removes the srRoyUSDC position
-    // its strategies hold (already counted in (2)), so the borrowed leg is not double-counted.
     if (api.chain === royWstEth.chain) {
         await addRoyWstEth(api);
     }
 };
 
-// Adds srRoyUSDC's value to TVL WITHOUT double-counting. The full vault balance is Royco's own TVL,
-// but `totalDeposits` (the vault's totalAssets) already includes the USDC the vault has placed into
-// Royco markets — value that tvl()'s tranche sums above ALREADY count. We measure that in-market
-// portion on-chain and subtract it, so the vault contributes only its remaining (not-yet-counted)
-// deposits here. In-market dollars stay counted once (in the tranches), never twice.
+// srRoyUSDC's full balance is Royco's own TVL, but totalAssets() already includes the USDC the vault
+// placed into Royco markets — value the tranche sums above already count. Measure that in-market
+// slice on-chain and subtract it, so the vault contributes only its not-yet-counted deposits.
 const addSrRoyUsdc = async (api) => {
-    // Total USDC held by the vault (Royco-market allocations + other yield venues + idle USDC).
-    // This full balance is Royco's own TVL; we only net out the already-counted market slice below.
     const totalDeposits = BigInt(await api.call({ abi: 'uint256:totalAssets', target: srRoyUsdc.address }));
 
-    // Discover srRoyUSDC's current position-holders once, on mainnet (api.chain === srRoyUsdc.chain
-    // here, and the vault lives there). The resolved set is reused on every market chain below.
+    // Resolve holders once, on mainnet; reuse across every market chain below.
     const strategies = await resolveStrategies(api, srRoyUsdc.address);
 
-    // The exact slice already counted by (1): the strategies' positions across every market chain,
-    // summed as USDC (nav) and converted from NAV_UNIT (18 decimals) to USDC (6 decimals). This is
-    // the in-Royco overlap we cancel out — subtracting it makes the two Royco sources mutually
-    // exclusive.
     let navInMarkets = 0n;
     for (const chain of Object.keys(config)) {
         const chainApi = chain === api.chain ? api : new sdk.ChainApi({ chain, timestamp: api.timestamp });
@@ -201,23 +136,16 @@ const addSrRoyUsdc = async (api) => {
     }
     const depositsInMarkets = navInMarkets / NAV_TO_USDC;
 
-    // totalDeposits − depositsInMarkets = srRoyUSDC value that is NOT already in the tranche sums.
     api.add(srRoyUsdc.asset, totalDeposits - depositsInMarkets);
 };
 
-// Measures the exact value the given `strategies` (srRoyUSDC's on-chain-resolved position-holders)
-// hold inside Royco markets on `api.chain`, summed in NAV_UNIT (18-decimal, USDC-denominated) across
-// all senior + junior tranches. This is the amount tvl()'s tranche sums already count for those
-// holders; addSrRoyUsdc subtracts it, which is what prevents srRoyUSDC and the markets from
-// double-counting the same deposits.
+// Value the given strategies hold inside Royco markets on api.chain, summed in NAV_UNIT across all
+// tranches. addSrRoyUsdc subtracts this to keep srRoyUSDC and the markets mutually exclusive.
 const getStrategyNav = async (api, strategies) => {
     const { seniorTranches, juniorTranches } = await getTranches(api);
     const tranches = [...seniorTranches, ...juniorTranches];
     if (!tranches.length) return 0n;
 
-    // These are de-duplication calls: a failed call must fail the whole refresh (DefiLlama then
-    // retries), never be silently skipped. Skipping would under-subtract the overlap and publish
-    // inflated, double-counted TVL — so no permitFailure here.
     let nav = 0n;
     for (const strategy of strategies) {
         const shares = await api.multiCall({
@@ -225,7 +153,7 @@ const getStrategyNav = async (api, strategies) => {
             calls: tranches.map(tranche => ({ target: tranche, params: [strategy] })),
         });
 
-        // balanceOf returns shares; convert only the non-zero positions to their USDC value (nav).
+        // convert only the non-zero positions to their USDC value (nav).
         const claimsCalls = tranches
             .map((tranche, i) => ({ target: tranche, params: [shares[i]] }))
             .filter((_, i) => BigInt(shares[i]) > 0n);
@@ -239,18 +167,12 @@ const getStrategyNav = async (api, strategies) => {
     return nav;
 };
 
-// Adds the RoyWstEth vault WITHOUT double-counting. `totalAssets()` is the wstETH NAV (already net
-// of the strategies' Morpho debt) — Royco's own TVL. Its strategies also hold a srRoyUSDC position
-// funded with USDC borrowed against that wstETH; srRoyUSDC (2) already counts that USDC, so we
-// subtract it back out of (2) here so the leveraged leg is not counted twice within Royco.
+// RoyWstEth's totalAssets() is its wstETH NAV (net of Morpho debt) — Royco's own TVL. Its strategies
+// also park borrowed USDC in srRoyUSDC, which (2) already counts, so subtract that leg back out.
 const addRoyWstEth = async (api) => {
     const totalAssets = await api.call({ abi: 'uint256:totalAssets', target: royWstEth.address });
     api.add(royWstEth.asset, totalAssets);
 
-    // Discover the vault's current position-holders on-chain (mainnet-only vault), then value the
-    // srRoyUSDC shares they hold in USDC via srRoyUSDC.convertToAssets. No permitFailure: these are
-    // de-duplication calls, so a failure must fail the refresh rather than skip the subtraction and
-    // leave the borrowed leg double-counted.
     const strategies = await resolveStrategies(api, royWstEth.address);
     const shares = await api.multiCall({
         abi: 'erc20:balanceOf',
@@ -268,8 +190,8 @@ const addRoyWstEth = async (api) => {
 };
 
 module.exports = {
-    start: '2026-01-27', // first TVL: srRoyUsdc vault's first deposit (block 24328493), predates the markets
-    methodology: "Value is counted exactly once, with no double-counting. (1) Royco V2 market TVL is read from MarketDeployed events on each factory and summed as totalAssets() across senior and junior tranches on every chain - the single source of truth for value inside Royco markets. (2) The srRoyUSDC vault (mainnet) is a Royco-issued vault product whose deposits are Royco's own TVL - the same convention DefiLlama applies to curated-vault/aggregator products such as Yearn vaults, whose deposits count toward the issuing protocol even when forwarded to underlying venues. The vault allocates user USDC across Royco markets and other yield venues; the portion already sitting in Royco markets is measured on-chain - the vault's strategies are discovered via getStrategies() (each Makina cross-chain strategy resolved to its machine's hub caliber via getMakinaMachine().hubCaliber(), self-custody strategies used as-is) and their tranche positions read via balanceOf -> convertToAssets().nav across all chains - then subtracted, so that slice is never counted twice within Royco. (3) The RoyWstEth vault (mainnet) is a Royco-issued wstETH vault whose strategies supply the wstETH as Morpho collateral, borrow stablecoins, swap to USDC and deposit it into srRoyUSDC; its wstETH NAV is added, and the srRoyUSDC position its strategies hold (strategies discovered on-chain the same way; already counted in (2)) is subtracted back out so the borrowed leg is not double-counted.",
+    start: '2026-01-27', // srRoyUSDC's first deposit (block 24328493), predates the markets
+    methodology: "(1) Royco V2 market TVL: totalAssets() summed across senior and junior tranches (from MarketDeployed factory events) on every chain. (2) The srRoyUSDC vault (mainnet) allocates USDC across Royco markets and other venues; its balance is added minus the portion already sitting in Royco markets, so that slice is not counted twice. (3) The RoyWstEth vault (mainnet) adds its wstETH NAV minus the srRoyUSDC position it holds (already counted in (2)).",
     ethereum: { tvl },
     avax: { tvl },
     arbitrum: { tvl },

--- a/projects/royco-v2/index.js
+++ b/projects/royco-v2/index.js
@@ -30,6 +30,10 @@ const { getLogs2 } = require("../helper/cache/getLogs");
 //   - (3) into (2): RoyWstEth's strategies park borrowed USDC in srRoyUSDC, which (2) already counts.
 //     Fixed in `addRoyWstEth`: we add (3)'s wstETH NAV and subtract that srRoyUSDC position
 //     (balanceOf -> convertToAssets, in USDC) back out of (2).
+// The position-holder addresses used for these subtractions are discovered ON-CHAIN, never
+// hardcoded: vault.getStrategies(), resolving each Makina CROSSCHAIN strategy to its machine's hub
+// caliber (getMakinaMachine().hubCaliber()) and leaving self-custody strategies as-is (see
+// resolveStrategies). So the adapter self-updates if a vault's strategies change.
 // Net effect: every deposit is counted once at its lowest layer, and NOTHING is counted twice.
 // =============================================================================================
 
@@ -72,14 +76,41 @@ const srRoyUsdc = {
     asset: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // USDC
 };
 
-// Accounts through which srRoyUSDC holds its positions inside Royco markets. Their tranche
-// positions are exactly the overlap between srRoyUSDC and the market TVL, so they are what gets
-// subtracted to avoid double-counting. Queried on every market chain; balanceOf simply returns 0
-// on chains where a given strategy holds nothing.
-const srRoyUsdcStrategies = [
-    "0x170ff06326ebb64bf609a848fc143143994af6c8", // multisig
-    "0x5476f4e23daa093ce6700e1026013c55f7af9083", // makina caliber
-];
+// The srRoyUSDC and RoyWstEth vaults route deposits through on-chain "strategy" contracts, and
+// whatever a strategy custodies inside a lower Royco layer is exactly the overlap we must
+// de-duplicate. We DISCOVER the current position-holding addresses on-chain (never hardcode them)
+// so the adapter self-updates if a vault's strategies change. The same resolved holder set is
+// queried on every market chain; balanceOf simply returns 0 where a holder holds nothing.
+//
+// A strategy's positions do NOT necessarily sit at the strategy contract itself:
+//   - CROSSCHAIN strategies are executed through a Makina hub-and-spoke machine, so their Royco
+//     positions are custodied by the machine's hub caliber -> getMakinaMachine().hubCaliber().
+//   - ATOMIC/ASYNC strategies self-custody, so the holder is the strategy address itself.
+// enum StrategyType { ATOMIC, ASYNC, CROSSCHAIN } (from the Royco strategy contracts).
+const STRATEGY_TYPE_CROSSCHAIN = 2;
+const getStrategiesAbi = "function getStrategies() view returns (address[])";
+const strategyTypeAbi = "function strategyType() view returns (uint8)";
+const getMakinaMachineAbi = "function getMakinaMachine() view returns (address)";
+const hubCaliberAbi = "function hubCaliber() view returns (address)";
+
+// Resolves a vault's current position-holding addresses on-chain (see the StrategyType note above).
+// These feed the de-duplication subtractions, so every call here is dedup-critical: NO
+// permitFailure — a failure must fail the whole refresh rather than silently drop a holder and
+// publish inflated, double-counted TVL.
+const resolveStrategies = async (api, vault) => {
+    const strategies = await api.call({ abi: getStrategiesAbi, target: vault });
+    if (!strategies.length) return [];
+
+    const types = await api.multiCall({ abi: strategyTypeAbi, calls: strategies });
+    const crosschain = strategies.filter((_, i) => Number(types[i]) === STRATEGY_TYPE_CROSSCHAIN);
+    const selfCustody = strategies.filter((_, i) => Number(types[i]) !== STRATEGY_TYPE_CROSSCHAIN);
+    if (!crosschain.length) return selfCustody;
+
+    // CROSSCHAIN => Makina: the real position-holder is the machine's hub caliber, not the strategy.
+    const machines = await api.multiCall({ abi: getMakinaMachineAbi, calls: crosschain });
+    const calibers = await api.multiCall({ abi: hubCaliberAbi, calls: machines });
+    return [...selfCustody, ...calibers];
+};
 
 // NAV_UNIT (18 decimals, USDC-denominated) -> USDC (6 decimals)
 const NAV_TO_USDC = 10n ** 12n;
@@ -92,10 +123,6 @@ const royWstEth = {
     chain: "ethereum",
     address: "0x41ce72e04d349eb957bdc373baa9c69207032c56",
     asset: "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0", // wstETH
-    strategies: [
-        "0xed45292eeac48324dabf7c76c2bd71b194a3f97d", // multisig
-        "0x3d8e2497497a3e29ad5391c08db2a1b3c32598c0", // makina caliber
-    ],
 };
 
 // srRoyUSDC is a standard ERC4626 vault (asset = USDC), so its convertToAssets(shares) returns a
@@ -159,6 +186,10 @@ const addSrRoyUsdc = async (api) => {
     // This full balance is Royco's own TVL; we only net out the already-counted market slice below.
     const totalDeposits = BigInt(await api.call({ abi: 'uint256:totalAssets', target: srRoyUsdc.address }));
 
+    // Discover srRoyUSDC's current position-holders once, on mainnet (api.chain === srRoyUsdc.chain
+    // here, and the vault lives there). The resolved set is reused on every market chain below.
+    const strategies = await resolveStrategies(api, srRoyUsdc.address);
+
     // The exact slice already counted by (1): the strategies' positions across every market chain,
     // summed as USDC (nav) and converted from NAV_UNIT (18 decimals) to USDC (6 decimals). This is
     // the in-Royco overlap we cancel out — subtracting it makes the two Royco sources mutually
@@ -166,7 +197,7 @@ const addSrRoyUsdc = async (api) => {
     let navInMarkets = 0n;
     for (const chain of Object.keys(config)) {
         const chainApi = chain === api.chain ? api : new sdk.ChainApi({ chain, timestamp: api.timestamp });
-        navInMarkets += await getStrategyNav(chainApi);
+        navInMarkets += await getStrategyNav(chainApi, strategies);
     }
     const depositsInMarkets = navInMarkets / NAV_TO_USDC;
 
@@ -174,11 +205,12 @@ const addSrRoyUsdc = async (api) => {
     api.add(srRoyUsdc.asset, totalDeposits - depositsInMarkets);
 };
 
-// Measures the exact value srRoyUSDC's strategies hold inside Royco markets on `api.chain`, summed
-// in NAV_UNIT (18-decimal, USDC-denominated) across all senior + junior tranches. This is the
-// amount tvl()'s tranche sums already count for these strategies; addSrRoyUsdc subtracts it, which
-// is what prevents srRoyUSDC and the markets from double-counting the same deposits.
-const getStrategyNav = async (api) => {
+// Measures the exact value the given `strategies` (srRoyUSDC's on-chain-resolved position-holders)
+// hold inside Royco markets on `api.chain`, summed in NAV_UNIT (18-decimal, USDC-denominated) across
+// all senior + junior tranches. This is the amount tvl()'s tranche sums already count for those
+// holders; addSrRoyUsdc subtracts it, which is what prevents srRoyUSDC and the markets from
+// double-counting the same deposits.
+const getStrategyNav = async (api, strategies) => {
     const { seniorTranches, juniorTranches } = await getTranches(api);
     const tranches = [...seniorTranches, ...juniorTranches];
     if (!tranches.length) return 0n;
@@ -187,7 +219,7 @@ const getStrategyNav = async (api) => {
     // retries), never be silently skipped. Skipping would under-subtract the overlap and publish
     // inflated, double-counted TVL — so no permitFailure here.
     let nav = 0n;
-    for (const strategy of srRoyUsdcStrategies) {
+    for (const strategy of strategies) {
         const shares = await api.multiCall({
             abi: 'erc20:balanceOf',
             calls: tranches.map(tranche => ({ target: tranche, params: [strategy] })),
@@ -215,14 +247,16 @@ const addRoyWstEth = async (api) => {
     const totalAssets = await api.call({ abi: 'uint256:totalAssets', target: royWstEth.address });
     api.add(royWstEth.asset, totalAssets);
 
-    // srRoyUSDC shares held by the vault's strategies, valued in USDC via srRoyUSDC.convertToAssets.
-    // No permitFailure: this is a de-duplication call, so a failed call must fail the refresh rather
-    // than skip the subtraction and leave the borrowed leg double-counted.
+    // Discover the vault's current position-holders on-chain (mainnet-only vault), then value the
+    // srRoyUSDC shares they hold in USDC via srRoyUSDC.convertToAssets. No permitFailure: these are
+    // de-duplication calls, so a failure must fail the refresh rather than skip the subtraction and
+    // leave the borrowed leg double-counted.
+    const strategies = await resolveStrategies(api, royWstEth.address);
     const shares = await api.multiCall({
         abi: 'erc20:balanceOf',
-        calls: royWstEth.strategies.map(strategy => ({ target: srRoyUsdc.address, params: [strategy] })),
+        calls: strategies.map(strategy => ({ target: srRoyUsdc.address, params: [strategy] })),
     });
-    const assetCalls = royWstEth.strategies
+    const assetCalls = strategies
         .map((_, i) => ({ target: srRoyUsdc.address, params: [shares[i]] }))
         .filter((_, i) => BigInt(shares[i]) > 0n);
     if (!assetCalls.length) return;
@@ -235,7 +269,7 @@ const addRoyWstEth = async (api) => {
 
 module.exports = {
     start: '2026-01-27', // first TVL: srRoyUsdc vault's first deposit (block 24328493), predates the markets
-    methodology: "Value is counted exactly once, with no double-counting. (1) Royco V2 market TVL is read from MarketDeployed events on each factory and summed as totalAssets() across senior and junior tranches on every chain - the single source of truth for value inside Royco markets. (2) The srRoyUSDC vault (mainnet) is a Royco-issued vault product whose deposits are Royco's own TVL - the same convention DefiLlama applies to curated-vault/aggregator products such as Yearn vaults, whose deposits count toward the issuing protocol even when forwarded to underlying venues. The vault allocates user USDC across Royco markets and other yield venues; the portion already sitting in Royco markets is measured on-chain (its strategies' tranche positions via balanceOf -> convertToAssets().nav, across all chains) and subtracted, so that slice is never counted twice within Royco. (3) The RoyWstEth vault (mainnet) is a Royco-issued wstETH vault whose strategies supply the wstETH as Morpho collateral, borrow stablecoins, swap to USDC and deposit it into srRoyUSDC; its wstETH NAV is added, and the srRoyUSDC position its strategies hold (already counted in (2)) is subtracted back out so the borrowed leg is not double-counted.",
+    methodology: "Value is counted exactly once, with no double-counting. (1) Royco V2 market TVL is read from MarketDeployed events on each factory and summed as totalAssets() across senior and junior tranches on every chain - the single source of truth for value inside Royco markets. (2) The srRoyUSDC vault (mainnet) is a Royco-issued vault product whose deposits are Royco's own TVL - the same convention DefiLlama applies to curated-vault/aggregator products such as Yearn vaults, whose deposits count toward the issuing protocol even when forwarded to underlying venues. The vault allocates user USDC across Royco markets and other yield venues; the portion already sitting in Royco markets is measured on-chain - the vault's strategies are discovered via getStrategies() (each Makina cross-chain strategy resolved to its machine's hub caliber via getMakinaMachine().hubCaliber(), self-custody strategies used as-is) and their tranche positions read via balanceOf -> convertToAssets().nav across all chains - then subtracted, so that slice is never counted twice within Royco. (3) The RoyWstEth vault (mainnet) is a Royco-issued wstETH vault whose strategies supply the wstETH as Morpho collateral, borrow stablecoins, swap to USDC and deposit it into srRoyUSDC; its wstETH NAV is added, and the srRoyUSDC position its strategies hold (strategies discovered on-chain the same way; already counted in (2)) is subtracted back out so the borrowed leg is not double-counted.",
     ethereum: { tvl },
     avax: { tvl },
     arbitrum: { tvl },


### PR DESCRIPTION
Update to the **existing** `royco-v2` TVL adapter (not a new listing). Only `projects/royco-v2/index.js` changes — no new npm deps, no `pnpm-lock.yaml` / `pnpm-workspace.yaml` edits.

### What changed
1. **Base markets** — added the Royco V2 base factory (`0x568c9709daa2f7b7cc66abc3e41da0f0a339551a`) so base markets are tracked alongside ethereum / avax / arbitrum.
2. **srRoyUSDC vault** (mainnet, `0xcd9f5907f92818bc06c9ad70217f089e190d2a32`) — a Royco-issued USDC vault. We count its USDC deposits, **minus** the slice its strategies already hold inside Royco markets (measured on-chain via `balanceOf -> convertToAssets().nav` across all market chains), so the in-market portion isn't counted twice.
3. **RoyWstEth vault** (mainnet, `0x41ce72e04d349eb957bdc373baa9c69207032c56`) — a Royco-issued wstETH vault. We count its wstETH NAV, **minus** the srRoyUSDC position its strategies fund with borrowed USDC (already counted in srRoyUSDC), so the leveraged leg isn't double-counted.
4. **`start`** set to `2026-01-27` (srRoyUSDC's first deposit, which predates the first market).

### Methodology
Value is counted exactly once **within Royco**. (1) Royco V2 market TVL = sum of senior + junior tranche `totalAssets()` per chain. (2) srRoyUSDC deposits − its in-market slice. (3) RoyWstEth wstETH NAV − its srRoyUSDC position. Each higher-layer vault's deposit into a lower Royco layer is subtracted so no Royco deposit is counted twice. See the header comment in `projects/royco-v2/index.js` for the full derivation.

### Validation
`node test.js projects/royco-v2/index.js` passes — ethereum / avax / arbitrum / base all report; total ≈ $22.5M.

##### Chain:
ethereum, avax, arbitrum, base

##### methodology (what is being counted as tvl, how is tvl being calculated):
See "Methodology" above — Royco V2 market tranche `totalAssets()` plus the srRoyUSDC and RoyWstEth curated vaults, with internal double-counting removed by subtracting each vault's positions in lower Royco layers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for reporting TVL on Base for the Royco V2 adapter.
  * Added an exported reporting start date for the Royco V2 adapter.
* **Documentation**
  * Updated the exported TVL methodology text to more clearly describe the no-double-counting/overlap handling across the adapter’s valuation components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->