### PR TITLE
feat: add feather megaeth markets

### DIFF
--- a/registries/curators.js
+++ b/registries/curators.js
@@ -415,6 +415,11 @@ const configs = {
             '0x6Ba8f7039bC7d79c1959cB8E409Dff2ba05A133E',
           ],
         },
+        megaeth: {
+          morpho: [
+            '0x85fCb4604f25e17Ae4e1EAc202adba4F999d7FF5', // Feather MegaETH vault
+          ],
+        },
       }
     },
     _meta: {


### PR DESCRIPTION
Adds MegaETH support to the Feather curator.

- **Chain:** MegaETH (chainId 4326)
- **Vault:** `0x85fCb4604f25e17Ae4e1EAc202adba4F999d7FF5` — Feather USDm (asset: USDm), which allocates to two Morpho markets on MegaETH.

The vault is added under the `morpho` key (explicit ERC-4626 vault list), consistent with the existing Feather Ethereum/Sei entries. TVL is read directly from the vault's `totalAssets`, so no additional MorphoConfigs factory entry is required.

Verified on-chain: `asset()`, `totalAssets()`, and `name()` all resolve on MegaETH mainnet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MegaETH support to the Feather curator configuration.
  * Included the specified Morpho vault in Feather’s exported vault listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->