### PR TITLE
api3 treasury: add missing wallets, vaults, wstETH, Robinhood chain and MM loans

### DIFF
--- a/projects/treasury/api3.js
+++ b/projects/treasury/api3.js
@@ -14,21 +14,73 @@ const USDC_VAULTS = [
   "0xe2221aa07ec3266da87763e2b1e28d07a8a4e53b", // Api3CoreUSDC v2 vault
   "0x62067831c193810f3b044cc42249632b5d08bc6b", // KabuUSDC v1 vault
   "0x54210d3f1a066413891af9e17210e787d5c6e3f4", // KabuUSDC v2 vault
+  "0x36cfe1568461e499391ef0a555300f1ae2da2439", // Api3 dCOMP USDC vault
+  "0xc92a37fd0250f4eecf092960a2f70a1334217528", // Purinta USDC vault
+]
+
+// Vaults on Robinhood chain that need to be priced via convertToAssets (pegged to USDG)
+const USDG_VAULTS_ROBINHOOD = [
+  "0x37788ff0c1d4e45a7fe06bc7e71e0cc00121d0a8", // Purinta USDG vault
+]
+
+// API3 tokens lent out to market makers (held in MM custody, not visible in DAO wallets)
+// See https://api3dao.github.io/api3-dao-tracker/treasury
+const MM_LOANS_API3 = [
+  2_499_990, // Market maker loan #1, expiry 2028-04-10
+  2_624_713, // Market maker loan #2, expiry 2026-11-17
 ]
 
 const OWNERS = [
-  "0x556ecbb0311d350491ba0ec7e019c354d7723ce0",
-  "0xd9f80bdb37e6bad114d747e60ce6d2aaf26704ae",
+  "0x556ecbb0311d350491ba0ec7e019c354d7723ce0", // Secondary treasury (DAO agent)
+  "0xd9f80bdb37e6bad114d747e60ce6d2aaf26704ae", // Primary treasury (DAO agent)
   "0xe7af7c5982e073ac6525a34821fe1b3e8e432099",
-  "0xbbe0de9757f93e3306adbfebe906ab285edd13da",
-  "0x8e03609ed680b237c7b6f8020472ca0687308b24"
+  "0xbbe0de9757f93e3306adbfebe906ab285edd13da", // Agent multisig
+  "0x8e03609ed680b237c7b6f8020472ca0687308b24", // Vault multisig
+  "0x2df880c697b65b52a79fa3322ee8a2bbff21f0ef", // Emergency liquidation fund
+  "0x98f66287682f2e332125e2364526c334aafa8643", // Gas fund
+  "0x5a9aa3219dd1cbef6a18fd221464e071df2677c2", // MERKL rewards multisig
 ];
+
+const ROBINHOOD_OWNERS = [
+  "0x82b4a86c796d9508350d129ba150b5d625ec98a4", // Agent on Robinhood
+  "0xa45314481e2a64f2c8169584bca4ea27ceccfd9e", // MERKL on Robinhood
+];
+
+// Convert ERC-4626 vault shares held by owners into their underlying asset
+async function addVaultAssets(api, { vaults, owners, underlying }) {
+  const calls = []
+  owners.forEach(owner => {
+    vaults.forEach(token => {
+      calls.push({ target: token, params: owner })
+    })
+  })
+  const vaultBalances = await api.multiCall({ abi: 'erc20:balanceOf', calls })
+
+  const activeVaultCalls = []
+  vaultBalances.forEach((bal, i) => {
+    if (bal > 0) {
+      activeVaultCalls.push({
+        target: calls[i].target,
+        params: bal // convertToAssets takes the share amount as input
+      })
+    }
+  })
+
+  if (activeVaultCalls.length > 0) {
+    const underlyingAssets = await api.multiCall({
+      abi: 'function convertToAssets(uint256) view returns (uint256)',
+      calls: activeVaultCalls
+    })
+    underlyingAssets.forEach(amount => api.add(underlying, amount))
+  }
+}
 
 const base = treasuryExports({
   ethereum: {
     tokens: [
       nullAddress,
       ADDRESSES.ethereum.STETH,
+      ADDRESSES.ethereum.WSTETH,
       ADDRESSES.ethereum.USDC,
       "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d", // PNK
     ],
@@ -38,10 +90,19 @@ const base = treasuryExports({
     resolveUniV3: true,
     fetchCoValentTokens: false,
   },
+  robinhood: {
+    tokens: [
+      nullAddress,
+      ADDRESSES.robinhood.USDG,
+    ],
+    owners: ROBINHOOD_OWNERS,
+    fetchCoValentTokens: false,
+  },
 })
 
 const baseTvl = base.ethereum.tvl
 const baseOwnTokens = base.ethereum.ownTokens
+const baseRobinhoodTvl = base.robinhood.tvl
 
 base.ethereum.tvl = async (api) => {
   // 1. Run existing treasury logic (standard ERC20 + LPs + UniV3)
@@ -59,35 +120,14 @@ base.ethereum.tvl = async (api) => {
   })
 
   // 3. Handle unpriced vaults (Morpho/ERC4626)
-  // Step A: Get balances of vault tokens across all owners
-  const calls = []
-  OWNERS.forEach(owner => {
-    USDC_VAULTS.forEach(token => {
-      calls.push({ target: token, params: owner })
-    })
-  })
-  const vaultBalances = await api.multiCall({ abi: 'erc20:balanceOf', calls })
+  await addVaultAssets(api, { vaults: USDC_VAULTS, owners: OWNERS, underlying: ADDRESSES.ethereum.USDC })
 
-  // Step B: Filter for non-zero balances to query convertToAssets
-  const activeVaultCalls = []
-  vaultBalances.forEach((bal, i) => {
-    if (bal > 0) {
-      activeVaultCalls.push({ 
-        target: calls[i].target, 
-        params: bal // convertToAssets takes the share amount as input
-      })
-    }
-  })
+  return api.getBalances()
+}
 
-  // Step C: Convert shares to assets (USDC)
-  if (activeVaultCalls.length > 0) {
-    const underlyingAssets = await api.multiCall({
-      abi: 'function convertToAssets(uint256) view returns (uint256)',
-      calls: activeVaultCalls
-    })
-    underlyingAssets.forEach(amount => api.add(ADDRESSES.ethereum.USDC, amount))
-  }
-
+base.robinhood.tvl = async (api) => {
+  await baseRobinhoodTvl(api)
+  await addVaultAssets(api, { vaults: USDG_VAULTS_ROBINHOOD, owners: ROBINHOOD_OWNERS, underlying: ADDRESSES.robinhood.USDG })
   return api.getBalances()
 }
 
@@ -103,8 +143,12 @@ base.ethereum.ownTokens = async (api) => {
       positionIds: UNI_V4_POSITION_IDS,
     },
     // We blacklist standard tokens here so we don't accidentally count USDC held in the V4 LP as "own tokens"
-    blacklistedTokens: [nullAddress, ADDRESSES.ethereum.USDC, ADDRESSES.ethereum.STETH]
+    blacklistedTokens: [nullAddress, ADDRESSES.ethereum.USDC, ADDRESSES.ethereum.STETH, ADDRESSES.ethereum.WSTETH]
   })
+
+  // Add API3 lent out to market makers (fixed loan amounts, returned at expiry)
+  const API3_DECIMALS = 1e18
+  MM_LOANS_API3.forEach(amount => api.add(API3, BigInt(amount) * BigInt(API3_DECIMALS)))
 
   return api.getBalances()
 }


### PR DESCRIPTION
Updates the existing treasury adapter for API3 (`projects/treasury/api3.js`) so it matches the DAO's actual holdings.

Numbers can be confirmed against the API3 DAO tracker dashboard: https://api3dao.github.io/api3-dao-tracker/treasury

**Changes**
- Add missing treasury wallets: emergency liquidation fund (`0x2df880c697b65b52a79fa3322ee8a2bbff21f0ef`), gas fund (`0x98f66287682f2e332125e2364526c334aafa8643`), MERKL rewards multisig (`0x5a9aa3219dd1cbef6a18fd221464e071df2677c2`)
- Add the Api3 dCOMP USDC (`0x36cfe1568461e499391ef0a555300f1ae2da2439`) and Purinta USDC (`0xc92a37fd0250f4eecf092960a2f70a1334217528`) ERC-4626 vaults (~$4.5M previously missed)
- Add wstETH (~941 wstETH held by the vault multisig; only stETH was tracked before)
- Add Robinhood chain: DAO agent + MERKL Safes and the Purinta USDG vault
- Count API3 lent out to market makers as fixed amounts in ownTokens (loans documented on the tracker, expiry dates in comments)
- Refactor the ERC-4626 share->asset conversion into a reusable helper used for both chains

**Test output** (`node test.js projects/treasury/api3.js`):
- ethereum: USDC 10.75M, wstETH 2.16M, ETH 273k, PNK 12.8k -> **13.19M**
- robinhood: USDG 50k
- ownTokens: API3 **3.15M**

Total matches the DAO tracker's ~$16.35M (previously DefiLlama showed $5.64M treasury + $2.04M own tokens).

No new npm dependencies, no lockfile changes. This updates an existing listing (no new-listing metadata needed).

"Allow edits by maintainers" is enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded treasury coverage for additional ERC-4626 vaults.
  - Added Robinhood USDG vault pricing and treasury tracking.
  - Improved conversion of vault shares into underlying asset values.
  - Added accounting for API3 held in market-maker custody.

- **Bug Fixes**
  - Refined own-token calculations by excluding additional tokens from double counting.
  - Updated treasury owner and vault coverage for more accurate TVL reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->