### PR TITLE
Bitget SOL: read TVL from the stake pool instead of an unrelated sSOL token account

### DIFF
--- a/registries/solanaStakePool.js
+++ b/registries/solanaStakePool.js
@@ -75,6 +75,9 @@ const configs = {
   'bonk-sol': {
     solana: 'ArAQfbzsdotoKB5jJcZa3ajQrrPcWr2YQoDAEAiFxJAC',
   },
+  'bgsol': {
+    solana: '9qrFrE5qoZ3QfYZrZoeXFNRWfErpjzZKudCAoBTvgKjb',
+  },
   'jpool': {
     methodology: "JSOL total supply as it's equal to the SOL staked",
     solana: 'CtMyWsrUtAwXWiGr9WjHT5fC3p3fgV8cyGpLTo2LJzG1',

--- a/registries/sumTokens/data1.js
+++ b/registries/sumTokens/data1.js
@@ -11,12 +11,6 @@ module.exports = {
     "timetravel": false,
     "solana": { "tokenAccounts": ["FhTJEGXVwj4M6NQ1tPu9jgDZUXWQ9w2hP89ebZHwrJPS"] }
   },
-  "bgsol": {
-    "timetravel": false,
-    "doublecounted": true,
-    "methodology": "Bitget Staked SOL (BGSOL) is a tokenized representation on your staked sSOL",
-    "solana": { "tokenAccounts": ["Ejg5vqsthntG8wJDijzgEWvdvhoAh8pzu4Q4r4MqsdkR"] }
-  },
   "asol": {
     "timetravel": false,
     "methodology": "aSOL TVL is computed by looking at the token balances of the accounts holding the stake pool tokens backing the aSOL Crate. The token accounts come from https://asol.so/#/admin.",


### PR DESCRIPTION
Bitget SOL reports **$107,577** of TVL. Its stake pool holds **181,320.221154 SOL (~$13.6M)**. The reported figure is not Bitget's staked SOL at all — it is 1,237 sSOL, which is Solayer's token.

### What is being reported today

The adapter lives in `registries/sumTokens/data1.js` and sums a single token account:

```json
"bgsol": {
  "doublecounted": true,
  "methodology": "Bitget Staked SOL (BGSOL) is a tokenized representation on your staked sSOL",
  "solana": { "tokenAccounts": ["Ejg5vqsthntG8wJDijzgEWvdvhoAh8pzu4Q4r4MqsdkR"] }
}
```

Reading that account on-chain:

```
Ejg5vqsthntG8wJDijzgEWvdvhoAh8pzu4Q4r4MqsdkR  = 1237.168968409
  its mint = sSo14endRuUbvQaJS3dq36Q829a3A6BEfoeeRGJywEh   (Solayer sSOL)
```

which matches what `/protocol/bitget-sol` publishes as its token balance:

```
2026-07-16  { SSOL: 1237.25 }
2026-07-17  { SSOL: 1237.17 }
2026-07-18  { SSOL: 1237.17 }
```

So the number on the page is a holding of another protocol's LST, not the SOL staked with Bitget.

### The pool that actually backs BGSOL

`9qrFrE5qoZ3QfYZrZoeXFNRWfErpjzZKudCAoBTvgKjb`, owned by the SPL stake pool program `SPoo1Ku8WFXoNDMHPsrGSTSG1Y47rzgn41SLUNakuHy`. What identifies it as Bitget's is that the account holds, at the standard `StakePool` offsets, exactly the three addresses the `bitget-staked-sol` fees adapter in dimension-adapters already uses:

```
offset 130  reserve stake        2nWzbtYUUX5ZDiJEqvqsJJZgddY1xfJJJP1SLWyLePVU
offset 162  pool mint            bgSoLfRx1wRPehwC9TyG568AGjnf1sQG1MYa8s3FbfY   (BGSOL)
offset 194  manager fee account  APWc1VvzLXV5rKTq5mz87GmNn36cLW9v94nLkKwpJzPC

total_lamports     = 181,320.221154 SOL
pool_token_supply  = 155,897.343878 BGSOL
last_update_epoch  = 1004   (current epoch, so the pool is live)
```

Those are the `stakePoolReserveAccount`, `lstMint` and `lstFeeTokenAccount` in that fees adapter. The fees side of this protocol has been reading the right pool the whole time; only the TVL side was pointed elsewhere.

### Change

Moves `bgsol` out of the `sumTokens` registry and into `registries/solanaStakePool.js`, alongside the other SPL stake pool LSTs (`bonk-sol`, `dSOL`, `phantom-sol`, `helius-sol`, ...), so it reads `totalLamports` off the pool via `getSolBalanceFromStakePool`.

The removal from `sumTokens/data1.js` is required, not cosmetic: `registries/index.js` loads `solanaStakePool.js` before `sumTokens.js`, so a leftover `bgsol` key in sumTokens silently overwrites the stake pool entry ("Duplicate protocol key ... will overwrite the previous entry").

```
$ node test.js projects/bgsol
Loaded module bgsol from registry
--- solana ---
SOL                       13.80 M

------ TVL ------
solana                    13.80 M
```

which matches 181,320.22 SOL at the current SOL price.

I also dropped the `doublecounted: true` flag the old entry carried. That flag was appropriate when the adapter was counting Solayer's sSOL, which Solayer already counts. The BGSOL stake pool is on the standard SPL program, so it is not inside the Sanctum aggregate or any other tracked total, and the SOL is Bitget's own.