### PR TITLE
sanctum-validator-lsts: flag as doublecounted, it overlaps the individually tracked LSTs

### DIFF
--- a/projects/sanctum-validator-lsts/index.js
+++ b/projects/sanctum-validator-lsts/index.js
@@ -50,6 +50,10 @@ async function tvl() {
 
 module.exports = {
   timetravel: false,
+  // Most of the SOL in these pools is already tracked under the individual LSTs that were
+  // deployed on the Sanctum programs (jupSOL, dSOL, bbSOL, hSOL, dfdvSOL, bonkSOL, hyloSOL,
+  // CDCSOL all have their own adapters), so this total overlaps with theirs.
+  doublecounted: true,
   methodology:
     "Uses GPA to fetch the total supply of deposited SOL into the various Sanctum LSTs",
   solana: {


### PR DESCRIPTION
This adapter sums every stake pool deployed on the two Sanctum programs. Eight of those pools are LSTs that DefiLlama already tracks with their own TVL adapters, so their SOL is counted twice in any total that adds protocols together.

This adds `doublecounted: true`. It does not change the number on Sanctum's own page.

### The sum includes everything on both programs

The adapter does a GPA over `SP12tWFxD9oJsVWNavTTBZvMbA6gkAmxtVgxdqvyvhY` and `SPMBzsVUuoHA4Jm6KunbsotaahvVikZs1JyTW6iJvbn` (dataSize 611) and subtracts the portion sitting inside Infinity. Reading those two programs directly:

```
sanctum-spl     1399 pools   10,845,175 SOL
sanctum-multi     56 pools    5,892,121 SOL
                            ------------
combined                    16,737,296 SOL
```

DefiLlama currently reports 14,723,813 SOL for this protocol and 2,027,914 SOL for Sanctum Infinity, which sums to 16,751,727 SOL. That is within 0.09% of the on-chain figure (the two were read a few minutes apart), which confirms the total is the whole program set with only the Infinity slice removed.

### What overlaps

Each of these has its own TVL module, so the same SOL is already counted under its own protocol:

| LST | pool SOL | ~USD | program | its own module |
|---|---|---|---|---|
| jupSOL | 5,245,217 | $394.9M | sanctum-multi | `jupSOL/index.js` |
| dSOL | 2,803,899 | $211.1M | sanctum-spl | `dSOL/index.js` |
| bbSOL | 1,212,429 | $91.3M | sanctum-spl | `bybitSOL/index.js` |
| hSOL | 877,803 | $66.1M | sanctum-spl | `helius-sol/index.js` |
| dfdvSOL | 839,296 | $63.2M | sanctum-spl | `dfdv-staked-sol/index.js` |
| hyloSOL | 185,592 | $14.0M | sanctum-multi | `hyloSOL/index.js` |
| bonkSOL | 138,805 | $10.4M | sanctum-spl | `bonk-sol/index.js` |
| CDCSOL | 50,696 | $3.8M | sanctum-spl | `cdc-eth/index.js` |

**11,353,738 SOL (~$854.7M), which is 77.1%** of what this adapter reports.

The other large pools on these programs — fwdSOL, gtSOL, definSOL, bpSOL — are `dummy.js` on the TVL side, so those are not double counted and correctly belong here.

### Why the flag rather than excluding the pools

The adapter already nets out the Infinity overlap, so the intent to avoid counting the same SOL twice is clearly there; this just extends that to the LSTs that got their own adapters later. Subtracting them from the sum instead would cut the reported figure by 77% and change what the protocol's page shows, which seemed like the wrong call for something Sanctum genuinely provides the infrastructure for. The flag leaves the page as it is and only affects totals that add protocols up.

Worth noting that chain TVL already excludes liquid staking, so the Solana chain page is unaffected either way. What this changes is the category and cross-protocol totals, where `isDoubleCounted` reads `module.doublecounted` and "Liquid Staking" is not in the auto-flagged category set.

Adapter output is unchanged:

```
$ node test.js projects/sanctum-validator-lsts/index.js
--- tvl ---
SOL                       1.11 B
Total: 1.11 B
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that reported totals for Sanctum validator LSTs may overlap with totals from individual Sanctum LST listings.
* **Bug Fixes**
  * Updated reporting metadata to prevent overlapping assets from being interpreted as additional unique value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->