### PR TITLE
Add wstGBP TVL adapter

### DIFF
--- a/projects/wstgbp/index.js
+++ b/projects/wstgbp/index.js
@@ -1,0 +1,12 @@
+const { sumTokensExport } = require('../helper/unwrapLPs')
+
+const wstGBP = '0x57C3571f10767E49C9d7b60feb6c67804783B7aE'
+const tGBP = '0x27f6c8289550fCE67f6B50BeD1F519966aFE5287'
+
+module.exports = {
+  methodology: 'TVL is the tGBP reserve held by the Ethereum wstGBP contract. wstGBP is a non-rebasing token whose redemption value accrues through an oracle-updated NAV: minting deposits tGBP, while redeeming burns wstGBP and pays tGBP at NAV less the configured redemption fee. Canonically bridged wstGBP on L2s and sidechains is excluded because the corresponding Ethereum wstGBP is locked in bridge escrow and remains backed by the same tGBP reserve.',
+  start: '2026-04-10',
+  ethereum: {
+    tvl: sumTokensExport({ owner: wstGBP, tokens: [tGBP] }),
+  },
+}


### PR DESCRIPTION
## Summary

Adds a TVL adapter for wstGBP on Ethereum.

The adapter reads the tGBP reserve held directly by the wstGBP contract using on-chain `balanceOf` data. Canonically bridged wstGBP is excluded because the corresponding L1 wstGBP is held in bridge escrow and remains backed by the same Ethereum reserve.

## Testing

- `npx eslint projects/wstgbp/index.js`
- `node test.js projects/wstgbp/index.js`
- Historical execution tested from `2026-04-10`

Current adapter output: approximately $27.1k TVL.

---

## New listing information

##### Name (to be shown on DefiLlama):

wstGBP

##### Twitter Link:

https://x.com/wstgbp

##### List of audit links if any:

https://docs.wstgbp.com/audits/2026-04-29-prototech-wstgbp-audit.pdf

##### Website Link:

https://wstgbp.com

##### Logo (High resolution, will be shown with rounded borders):

https://docs.wstgbp.com/icon-512.png

##### Current TVL:

Approximately $27.1k at the time of submission (20,118.72 tGBP held in reserve).

Live protocol data: https://api.arb.capital/api/tokens/wstgbp

##### Treasury Addresses (if the protocol has treasury):

N/A. Protocol backing is held directly by the wstGBP contract.

##### Chain:

Ethereum

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):


##### Short Description (to be shown on DefiLlama):

wstGBP is a non-rebasing, NAV-accruing wrapper for tGBP. Its GBP-denominated redemption value accrues through regular oracle updates while token balances remain constant.

##### Token address and ticker if any:

- wstGBP: `0x57C3571f10767E49C9d7b60feb6c67804783B7aE`
- Underlying tGBP: `0x27f6c8289550fCE67f6B50BeD1F519966aFE5287`

##### Category (full list at https://defillama.com/categories) *Please choose only one:

RWA

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

Custom protocol oracle (`pip` module). No third-party oracle provider is used.

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

The wstGBP contract holds an immutable reference to the `pip` price-oracle module. The oracle publishes an 18-decimal NAV that is updated off-chain on a regular cadence, currently weekly. Minting uses `mintcost()`, while redemptions use `burncost()`, which applies the configured redemption fee to the oracle NAV. This allows redemption value to accrue without rebasing user balances.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

- Architecture: https://docs.wstgbp.com/architecture
- Contract reference: https://docs.wstgbp.com/reference/contracts
- Verified contract: https://etherscan.io/address/0x57c3571f10767e49c9d7b60feb6c67804783b7ae#code

##### forkedFrom (Does your project originate from another project):

Built using the Maseer One modular tokenization framework under license; not a fork of another listed DeFi protocol.

##### methodology (what is being counted as tvl, how is tvl being calculated):

TVL is the tGBP reserve held by the Ethereum wstGBP contract. The adapter reads the contract's on-chain tGBP balance. wstGBP is a non-rebasing token whose redemption value accrues through an oracle-updated NAV: minting deposits tGBP, while redeeming burns wstGBP and pays tGBP at NAV less the configured redemption fee. Canonically bridged wstGBP on L2s and sidechains is excluded because the corresponding Ethereum wstGBP is locked in bridge escrow and remains backed by the same tGBP reserve.

##### Github org/user (Optional, if your code is open source, we can track activity):

Arb-Capital

##### Does this project have a referral program?

No.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL reporting for the wstGBP protocol on Ethereum.
  * TVL reflects the tGBP reserves held by the wstGBP contract.
  * Added methodology details and reporting start date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->