### PR TITLE
Add H00D TVL adapter

### DIFF
--- a/registries/sumTokens.js
+++ b/registries/sumTokens.js
@@ -15461,6 +15461,16 @@ const configs = {
       ]
     },
   },
+  "h00d": {
+    "methodology": "Every token launched through H00D seeds a Uniswap V3 pool whose LP NFT is held by the H00D LaunchLocker. The adapter enumerates those locked positions on Robinhood Chain and values only their WETH principal; launched tokens and unclaimed trading fees are ignored. The same liquidity is part of Uniswap V3 TVL, hence doublecounted.",
+    "doublecounted": true,
+    "robinhood": {
+      "owner": "0xfdc4f4733a4485e1DC8dF0aDc8BEDfBAf2e23754",
+      "resolveUniV3": true,
+      "uniV3WhitelistedTokens": [ADDRESSES.robinhood.WETH],
+      "uniV3ExtraConfig": { "nftAddress": "0x73991a25C818Bf1f1128dEAaB1492D45638DE0D3" }
+    }
+  },
   "h2odata": {
     "ethereum": {
       "owner": "0x13288BD148160f76B37Bea93861cA61BAea120D1",
@@ -15986,16 +15996,6 @@ const configs = {
         ]
       ]
     },
-  },
-  "h00d": {
-    "methodology": "Every token launched through H00D seeds a Uniswap V3 pool whose LP NFT is held by the H00D LaunchLocker. The adapter enumerates those locked positions on Robinhood Chain and values only their WETH principal; launched tokens and unclaimed trading fees are ignored. The same liquidity is part of Uniswap V3 TVL, hence doublecounted.",
-    "doublecounted": true,
-    "robinhood": {
-      "owner": "0xfdc4f4733a4485e1DC8dF0aDc8BEDfBAf2e23754",
-      "resolveUniV3": true,
-      "uniV3WhitelistedTokens": [ADDRESSES.robinhood.WETH],
-      "uniV3ExtraConfig": { "nftAddress": "0x73991a25C818Bf1f1128dEAaB1492D45638DE0D3" }
-    }
   },
   "hoodpump": {
     "methodology": "TVL is the WETH side of the Uniswap V3 liquidity positions locked in the HoodPump Liquidity Locker. Each HoodPump launch locks its LP NFT in the locker; only the WETH across those positions is counted (HoodPump-launched tokens are excluded). Liquidity lives in Uniswap V3 pools, so this is flagged doublecounted.",

--- a/registries/sumTokens.js
+++ b/registries/sumTokens.js
@@ -15987,6 +15987,16 @@ const configs = {
       ]
     },
   },
+  "h00d": {
+    "methodology": "Every token launched through H00D seeds a Uniswap V3 pool whose LP NFT is held by the H00D LaunchLocker. The adapter enumerates those locked positions on Robinhood Chain and values only their WETH principal; launched tokens and unclaimed trading fees are ignored. The same liquidity is part of Uniswap V3 TVL, hence doublecounted.",
+    "doublecounted": true,
+    "robinhood": {
+      "owner": "0xfdc4f4733a4485e1DC8dF0aDc8BEDfBAf2e23754",
+      "resolveUniV3": true,
+      "uniV3WhitelistedTokens": [ADDRESSES.robinhood.WETH],
+      "uniV3ExtraConfig": { "nftAddress": "0x73991a25C818Bf1f1128dEAaB1492D45638DE0D3" }
+    }
+  },
   "hoodpump": {
     "methodology": "TVL is the WETH side of the Uniswap V3 liquidity positions locked in the HoodPump Liquidity Locker. Each HoodPump launch locks its LP NFT in the locker; only the WETH across those positions is counted (HoodPump-launched tokens are excluded). Liquidity lives in Uniswap V3 pools, so this is flagged doublecounted.",
     "doublecounted": true,


### PR DESCRIPTION
# Add H00D TVL adapter

**NOTE:** Please keep “Allow edits by maintainers” enabled for this PR.

## Summary

This PR adds a registry-backed TVL adapter for H00D, a token launchpad on Robinhood Chain. It uses DefiLlama’s standard Uniswap V3 NFT resolver to count only the WETH principal represented by LP NFTs held by the H00D LaunchLocker at each queried block.

## New listing information

##### Name (to be shown on DefiLlama):

H00D

##### Twitter Link:

https://x.com/h00dtrading

##### List of audit links if any:

None — unaudited.

##### Website Link:

https://h00d.trade

##### Logo (High resolution, will be shown with rounded borders):

https://h00d.trade/h00d-mark.svg?v=3b

##### Current TVL:

Approximately $232.91 in the latest live adapter run on 2026-07-19. At comparison block `13079705`, the standard DefiLlama helper reported `0.115134094181073980 WETH`. Refresh the live value immediately before submission because it changes with LP activity and market prices.

##### Treasury Addresses (if the protocol has treasury)

`0xDf7A5BD255239b108d89e71D0e832A3cE10f383d`

##### Chain:

Robinhood Chain (chain ID `4663`)

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)



##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)



##### Short Description (to be shown on DefiLlama):

H00D is a Robinhood Chain token launchpad that creates fixed-supply tokens directly into Uniswap V3 and transfers each launch LP NFT to its LaunchLocker. H00D is implemented in the HoodForge repository.

##### Token address and ticker if any:

N/A — H00D has no protocol token. User-launched tokens are not counted as TVL.

##### Category (full list at https://defillama.com/categories) \*Please choose only one:

Launchpad

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

None.

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

H00D does not integrate an external price oracle. Launches and swaps use on-chain Uniswap V3 pool state and Quoter V2; the TVL adapter reads the locked Uniswap V3 positions and relies on DefiLlama’s standard WETH pricing.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

N/A — no external oracle is used. Source repository: https://github.com/kalhintz/HoodForge

##### forkedFrom (Does your project originate from another project):

No. H00D integrates Uniswap V3 but is not a fork of Uniswap.

##### methodology (what is being counted as tvl, how is tvl being calculated):

TVL is the WETH principal represented by Uniswap V3 LP NFTs owned by the H00D LaunchLocker at each queried block. The adapter enumerates the locker’s NFTs through the position manager, resolves each position’s underlying balances, and retains only Robinhood WETH. It excludes H00D-launched tokens, positions not owned by the locker, ordinary Factory or treasury balances, and all uncollected swap fees. The same LP liquidity is already included in Uniswap V3 TVL, so the adapter is marked `doublecounted: true`.

##### Github org/user (Optional, if your code is open source, we can track activity):

kalhintz

##### Does this project have a referral program?

No.

## Validation performed

All adapter tests below passed with Node `20.20.2` on 2026-07-19:

- `node test.js h00d` — approximately `$212.30` current TVL in the latest run.
- `node test.js h00d 2026-07-14` — `$0.00` before the first H00D launch.
- `node test.js h00d 2026-07-16` — approximately `$0.13` after the first launch.
- `node test.js h00d 2026-07-18` — approximately `$27.48` after multiple positions existed.
- `npm run check-registries-duplicates` — passed.
- `npm run check-core-assets-refs` — passed with zero undefined references.
- `npm run lint` — passed with zero errors and four unrelated pre-existing warnings.
- `git diff --check` — passed.

At Robinhood block `13079705`, the LaunchLocker owned four LP NFTs. An independent integer-math and read-only `decreaseLiquidity` cross-check found `0.115006700131145036 WETH` of principal. DefiLlama’s standard tick-based helper returned `0.115134094181073980 WETH`, a difference of `0.000127394049928944 WETH` (`0.11077098%`) caused by the helper’s tick-to-price approximation. Separately measured uncollected WETH fees of `0.001320099999999997 WETH` are intentionally excluded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for valuing Robinhood-chain Uniswap V3 positions tied to the H00D LaunchLocker.
  * Values only the WETH principal from eligible locked positions.
  * Excludes launched tokens and any unclaimed trading fees from the valuation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->