### PR TITLE
add Keep TVL on Robinhood Chain

### DIFF
--- a/projects/keep-protocol/index.js
+++ b/projects/keep-protocol/index.js
@@ -1,12 +1,12 @@
 const { PublicKey } = require("@solana/web3.js");
 const { getConnection, sumTokens2 } = require("../helper/solana");
+const ADDRESSES = require("../helper/coreAssets.json");
 
 const PROGRAM_ID = new PublicKey("ETVtC29T7ExxYyWSkpzKPxzrL3SRyrGPRhZe3FwXmFAo");
 
 // Robinhood Chain production deployment (2026-07-15). Each project is an
 // independent Launchpad clone that directly holds refundable Paxos USDG.
 const RH_FACTORY = "0x032EAfc08388283e94E44Fb0eA26A004D44ba40d";
-const RH_USDG = "0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168";
 
 // Anchor account discriminator for LaunchpadState (base58 of the first 8 bytes).
 const LAUNCHPAD_DISC = "VgW83Wf4icd";
@@ -37,13 +37,6 @@ async function tvl(api) {
   await sumTokens2({ api, tokenAccounts: usdcVaults });
 }
 
-/**
- * Keep TVL on Robinhood Chain: enumerate every production Launchpad clone from
- * KeepFactoryV4 and sum the canonical USDG held directly by those clones.
- * Fundraising and cancelled launches hold refundable deposits; failure states
- * hold their refund pool. Uniswap V4 pool liquidity is excluded because it is
- * counted by Uniswap and is permanently locked after a successful launch.
- */
 async function robinhoodTvl(api) {
   const launchpads = await api.fetchList({
     target: RH_FACTORY,
@@ -51,7 +44,7 @@ async function robinhoodTvl(api) {
     itemAbi: "function launchpadOf(uint64) view returns (address)",
   });
 
-  await api.sumTokens({ owners: launchpads, tokens: [RH_USDG] });
+  await api.sumTokens({ owners: launchpads, tokens: [ADDRESSES.robinhood.USDG] });
 }
 
 module.exports = {

--- a/projects/keep-protocol/index.js
+++ b/projects/keep-protocol/index.js
@@ -3,6 +3,11 @@ const { getConnection, sumTokens2 } = require("../helper/solana");
 
 const PROGRAM_ID = new PublicKey("ETVtC29T7ExxYyWSkpzKPxzrL3SRyrGPRhZe3FwXmFAo");
 
+// Robinhood Chain production deployment (2026-07-15). Each project is an
+// independent Launchpad clone that directly holds refundable Paxos USDG.
+const RH_FACTORY = "0x032EAfc08388283e94E44Fb0eA26A004D44ba40d";
+const RH_USDG = "0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168";
+
 // Anchor account discriminator for LaunchpadState (base58 of the first 8 bytes).
 const LAUNCHPAD_DISC = "VgW83Wf4icd";
 
@@ -32,14 +37,31 @@ async function tvl(api) {
   await sumTokens2({ api, tokenAccounts: usdcVaults });
 }
 
+/**
+ * Keep TVL on Robinhood Chain: enumerate every production Launchpad clone from
+ * KeepFactoryV4 and sum the canonical USDG held directly by those clones.
+ * Fundraising and cancelled launches hold refundable deposits; failure states
+ * hold their refund pool. Uniswap V4 pool liquidity is excluded because it is
+ * counted by Uniswap and is permanently locked after a successful launch.
+ */
+async function robinhoodTvl(api) {
+  const launchpads = await api.fetchList({
+    target: RH_FACTORY,
+    lengthAbi: "uint64:nextProjectId",
+    itemAbi: "function launchpadOf(uint64) view returns (address)",
+  });
+
+  await api.sumTokens({ owners: launchpads, tokens: [RH_USDG] });
+}
+
 module.exports = {
   methodology:
-    "TVL is the total refundable USDC held in Keep's own per-launch program vaults " +
-    "(the usdc_vault PDA of each LaunchpadState account, enumerated via getProgramAccounts " +
-    "on the Keep program). It covers escrowed USDC in active raises, post-bootstrap refund " +
-    "reserves, cancelled-raise balances and failed-raise refund pools — all withdrawable by " +
-    "depositors. Liquidity Keep seeds into Raydium is excluded (that is Raydium's TVL), and " +
-    "Keep burns 100% of that LP, so it is not withdrawable and is never counted here.",
+    "TVL is the refundable stablecoin held in keep.coffee's own per-launch vaults/contracts: " +
+    "USDC vault PDAs on Solana and Paxos USDG held directly by Launchpad clones on Robinhood " +
+    "Chain. It covers active raises, post-bootstrap refund reserves, cancelled-raise balances " +
+    "and failed-raise refund pools. Liquidity seeded into Raydium or Uniswap V4 is excluded " +
+    "because it is counted by those protocols and is permanently locked after success.",
   timetravel: false,
   solana: { tvl },
+  robinhood: { tvl: robinhoodTvl },
 };


### PR DESCRIPTION
## What changed

- adds Robinhood Chain TVL tracking for keep.coffee
- enumerates production `KeepFactoryV4` launchpads
- sums canonical Paxos USDG held directly by launchpad contracts
- updates the methodology for Solana and Robinhood Chain

## Why

The original Keep adapter merged on July 12 and covered Solana. keep.coffee's Robinhood Chain production deployment went live on July 15, so the live DefiLlama page currently reports only one of the two production networks.

## Methodology

Refundable USDG is held directly by each launchpad contract. Uniswap V4 liquidity is excluded to avoid double-counting and because it is permanently locked after a successful launch, matching the adapter's existing treatment of Raydium liquidity on Solana.

## Verification

- production factory: `0x032EAfc08388283e94E44Fb0eA26A004D44ba40d`
- canonical Paxos USDG: `0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168`
- factory `nextProjectId`: `1`
- launchpad `#0` is enumerable; its current USDG balance is zero after cancellation/refund
- `ROBINHOOD_RPC=https://rpc.mainnet.chain.robinhood.com node test.js projects/keep-protocol/index.js`
  - Solana: `0.50`
  - Robinhood: `0.00`
- ESLint passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for the Robinhood Chain.
  * TVL now includes USDG held directly by production Launchpad clones.
  * Existing Solana TVL tracking remains available.
* **Documentation**
  * Updated the TVL methodology description to cover both supported chains and the expanded calculation scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->