### PR TITLE
add stonkbrokers

### DIFF
--- a/projects/stonkbrokers/index.js
+++ b/projects/stonkbrokers/index.js
@@ -1,17 +1,17 @@
 const { nullAddress, sumTokens2 } = require('../helper/unwrapLPs')
 
 /**
- * StonkBrokers — Anvil NFTFi market on Robinhood Chain.
+ * StonkBrokers — Anvil NFTFi market on Robinhood Chain (NftFi).
  *
- * TVL sources:
- *  1. $STONKBROKER locked in the TokenEscrowReserve (AMM + loan buckets)
- *  2. ETH + stock tokens held by StockBooster (pending dividend drops)
- *  3. ETH held by ProtocolFeeSink
- *  4. Inventory NFTs in the AMM vault + collateral NFTs in the loan vault,
- *     valued at the vault's ethNotionalPerNFT oracle/fallback
+ * TVL sources (all on-chain, Robinhood mainnet):
+ *  1. $STONKBROKER locked in TokenEscrowReserve (AMM inventory + loan float)
+ *  2. ETH + AAPL/AMZN/NVDA (+ WETH) held by StockBooster (pending Clock In drops)
+ *  3. ETH held by ProtocolFeeSink treasury
+ *  4. AMM vault inventory NFTs + loan-vault collateral NFTs, valued at
+ *     ethNotionalPerNFT (TWAP/fallback oracle)
  *
- * Spot Uniswap V4 ETH/STONKBROKER LP is intentionally excluded (already
- * counted under Uniswap).
+ * Spot Uniswap V4 ETH/$STONKBROKER LP is excluded (already counted under Uniswap).
+ * Activated broker TBA wallets are user-owned and excluded (not protocol-controlled).
  */
 const STONKBROKER = '0xe934e36A439C94017B64a3FecE66AF12099aBF50'
 const COLLECTION = '0x539CdD042c2f3d93EbC5BE7DfFf0c79F3B4fAbF0'
@@ -21,7 +21,6 @@ const LOAN_VAULT = '0xa7B9AC696B252B79568A5a01b2Fd02177EF23664'
 const STOCK_BOOSTER = '0x038a7F4E4E89448ad74e044337C9aC25C11e726B'
 const FEE_SINK = '0x16027b596e210c63f750E0bdD156f00bb2749868'
 
-// StockBooster dividend stocks (AAPL / AMZN / NVDA) + WETH dust
 const BOOSTER_TOKENS = [
   nullAddress,
   '0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73', // WETH
@@ -31,7 +30,6 @@ const BOOSTER_TOKENS = [
 ]
 
 async function tvl(api) {
-  // Escrow holds the AMM + loan $STONKBROKER float; fee sinks hold ETH/stocks.
   await sumTokens2({
     api,
     tokensAndOwners: [
@@ -53,6 +51,7 @@ async function tvl(api) {
 
 module.exports = {
   methodology:
-    'TVL is $STONKBROKER locked in the Anvil NFTFi escrow, ETH/stock inventory in StockBooster and the protocol fee sink, plus AMM inventory and loan-collateral StonkBroker NFTs valued at ethNotionalPerNFT. Uniswap V4 spot LP is excluded to avoid double-counting.',
+    'TVL = $STONKBROKER locked in the Anvil NFTFi escrow (AMM + loan float) + ETH/stock inventory in StockBooster (pending dividend drops) + ETH in ProtocolFeeSink + AMM inventory and loan-collateral StonkBroker NFTs valued at ethNotionalPerNFT. Uniswap V4 spot LP excluded to avoid double-counting. Broker TBA wallets are user-owned and excluded.',
+  start: 1752710400, // 2026-07-17
   robinhood: { tvl },
 }

--- a/projects/stonkbrokers/index.js
+++ b/projects/stonkbrokers/index.js
@@ -1,0 +1,58 @@
+const { nullAddress, sumTokens2 } = require('../helper/unwrapLPs')
+
+/**
+ * StonkBrokers — Anvil NFTFi market on Robinhood Chain.
+ *
+ * TVL sources:
+ *  1. $STONKBROKER locked in the TokenEscrowReserve (AMM + loan buckets)
+ *  2. ETH + stock tokens held by StockBooster (pending dividend drops)
+ *  3. ETH held by ProtocolFeeSink
+ *  4. Inventory NFTs in the AMM vault + collateral NFTs in the loan vault,
+ *     valued at the vault's ethNotionalPerNFT oracle/fallback
+ *
+ * Spot Uniswap V4 ETH/STONKBROKER LP is intentionally excluded (already
+ * counted under Uniswap).
+ */
+const STONKBROKER = '0xe934e36A439C94017B64a3FecE66AF12099aBF50'
+const COLLECTION = '0x539CdD042c2f3d93EbC5BE7DfFf0c79F3B4fAbF0'
+const ESCROW = '0x799AE26fA515ceF145e8bC8636F7fFF87B05Cf62'
+const AMM_VAULT = '0xE302733accF4800146E55fC45B46b4E4fFC032D2'
+const LOAN_VAULT = '0xa7B9AC696B252B79568A5a01b2Fd02177EF23664'
+const STOCK_BOOSTER = '0x038a7F4E4E89448ad74e044337C9aC25C11e726B'
+const FEE_SINK = '0x16027b596e210c63f750E0bdD156f00bb2749868'
+
+// StockBooster dividend stocks (AAPL / AMZN / NVDA) + WETH dust
+const BOOSTER_TOKENS = [
+  nullAddress,
+  '0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73', // WETH
+  '0xaF3D76f1834A1d425780943C99Ea8A608f8a93f9', // AAPL
+  '0x12f190a9F9d7D37a250758b26824B97CE941bF54', // AMZN
+  '0xd0601CE157Db5bdC3162BbaC2a2C8aF5320D9EEC', // NVDA
+]
+
+async function tvl(api) {
+  // Escrow holds the AMM + loan $STONKBROKER float; fee sinks hold ETH/stocks.
+  await sumTokens2({
+    api,
+    tokensAndOwners: [
+      [STONKBROKER, ESCROW],
+      [nullAddress, FEE_SINK],
+      ...BOOSTER_TOKENS.map((t) => [t, STOCK_BOOSTER]),
+    ],
+  })
+
+  const [ethNotional, inventoryCount, loanNfts] = await Promise.all([
+    api.call({ target: AMM_VAULT, abi: 'uint256:ethNotionalPerNFT' }),
+    api.call({ target: AMM_VAULT, abi: 'uint256:inventoryCount' }),
+    api.call({ target: COLLECTION, abi: 'erc20:balanceOf', params: LOAN_VAULT }),
+  ])
+
+  const nftTvl = (BigInt(inventoryCount) + BigInt(loanNfts)) * BigInt(ethNotional)
+  if (nftTvl > 0n) api.add(nullAddress, nftTvl.toString())
+}
+
+module.exports = {
+  methodology:
+    'TVL is $STONKBROKER locked in the Anvil NFTFi escrow, ETH/stock inventory in StockBooster and the protocol fee sink, plus AMM inventory and loan-collateral StonkBroker NFTs valued at ethNotionalPerNFT. Uniswap V4 spot LP is excluded to avoid double-counting.',
+  robinhood: { tvl },
+}


### PR DESCRIPTION
## Summary
Add **StonkBrokers** TVL adapter for Robinhood Chain (`robinhood` / chainId 4663).

**Please categorize as `NftFi` (not Launchpad).** Fees + volume are already live, but https://defillama.com/protocol/stonkbrokers shows a blank TVL chart because this adapter is still pending (`module: dummy.js`).

StonkBrokers is an Anvil NFTFi market: fixed-supply StonkBroker NFTs trade against `$STONKBROKER` in an NFT AMM, with ETH trade/loan fees funding StockBooster stock-token dividends to activated broker TBAs.

### TVL methodology
- `$STONKBROKER` locked in `TokenEscrowReserve` (AMM + loan buckets)
- ETH + AAPL/AMZN/NVDA (+ WETH) held by `StockBooster` (pending Clock In drops)
- ETH held by `ProtocolFeeSink`
- AMM inventory + loan-collateral NFTs valued at `ethNotionalPerNFT`
- **Excludes** Uniswap V4 ETH/STONKBROKER spot LP (already counted under Uniswap)
- **Excludes** user-owned broker TBA wallets

### Addresses (Robinhood mainnet)
| Contract | Address |
|----------|---------|
| CollectionToken ($STONKBROKER) | `0xe934e36A439C94017B64a3FecE66AF12099aBF50` |
| Collection NFT | `0x539CdD042c2f3d93EbC5BE7DfFf0c79F3B4fAbF0` |
| TokenEscrowReserve | `0x799AE26fA515ceF145e8bC8636F7fFF87B05Cf62` |
| StonkNFTAMMVault | `0xE302733accF4800146E55fC45B46b4E4fFC032D2` |
| StonkLoanVault | `0xa7B9AC696B252B79568A5a01b2Fd02177EF23664` |
| StockBooster | `0x038a7F4E4E89448ad74e044337C9aC25C11e726B` |
| ProtocolFeeSink | `0x16027b596e210c63f750E0bdD156f00bb2749868` |

### Related (already live)
- Fees: https://defillama.com/protocol/fees/stonkbrokers (~$57k/24h)
- Volume: https://defillama.com/protocol/dexs/stonkbrokers (~$550k+/24h)
- Fees adapter: https://github.com/DefiLlama/dimension-adapters/pull/8260

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for the Anvil NFTFi market on Robinhood Chain.
  * TVL calculation now accounts for deposited holdings, fee-related balances, AMM NFT inventory, and loan-collateral NFTs.
  * Added published methodology describing how the TVL value is derived and reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->