### PR TITLE
Mantle treasury: BIT is an own token, and native MNT has to be read on Mantle

### DIFF
--- a/projects/treasury/bitdao.js
+++ b/projects/treasury/bitdao.js
@@ -1,80 +1,64 @@
 const ADDRESSES = require('../helper/coreAssets.json')
-const sdk = require('@defillama/sdk');
-const { nullAddress } = require("../helper/treasury");
 const { getConfig } = require('../helper/cache')
 
 const API_URL = 'https://api.mantle.xyz/api/v2/treasury/tokens';
+
 const MNT = '0x3c3a81e81dc49a522a592e7622a7e711c06bf354';
-// BitDAO's original token, which Mantle rebranded from and converted to MNT
 const BIT = '0x1a4b46696b2bb4794eb3d4c26f1c55f9170fa4c5';
 const USDe = ADDRESSES.ethereum.USDe;
 const COOK = '0x9f0c013016e8656bc256f948cd4b79ab25c7b94d'
 const ethenaFarm = '0x8707f238936c12c309bfc2b9959c35828acfc512';
-const SPECIFIC_TOKENS = ['eth', 'ethena-farming-usde', 'eigen-layer-eth', 'mnt'];
 
 const abi = "function stakes(address, address) view returns (uint256 stakedAmount, uint152 coolingDownAmount, uint104 cooldownStartTimestamp)";
 
-const isSpecificToken = token => SPECIFIC_TOKENS.includes(token);
+const config = {
+  ethereum: { key: 'eth', ownTokens: [MNT, BIT] },
+  mantle: { key: 'mnt', ownTokens: [COOK, 'mnt'] },
+}
 
-const getEthenaFarmingBalance = async (api, wallet) => {
+const toAddress = id => (id === 'eth' || id === 'mnt') ? ADDRESSES.null : id;
+
+async function getWallets(key) {
+  const data = await getConfig('mantle-treasury', API_URL)
+  const walletBalances = {};
+  for (const { chain, id, walletAddress, amount } of data) {
+    if (chain !== key) continue;
+    walletBalances[walletAddress] ??= { owner: walletAddress, tokens: [] };
+    walletBalances[walletAddress].tokens.push({ address: id, amount });
+  }
+  return Object.values(walletBalances);
+};
+
+async function getEthenaFarmingBalance(api, wallet) {
   const { stakedAmount, coolingDownAmount } = await api.call({ target: ethenaFarm, params: [wallet, USDe], abi });
   return Number(stakedAmount) + Number(coolingDownAmount);
 };
 
-const getTvlData = async (api, key, { skipOwnNative = false } = {}) => {
-  const data = await getConfig('mantle-treasury', API_URL)
-  const rawDatas = data.filter(({ chain }) => key === chain);
-  const datas = rawDatas.map(({ id, walletAddress, amount }) => ({ id, walletAddress, amount }));
-
-  const wallets = Object.values(
-    datas.reduce((acc, { id, walletAddress, amount }) => {
-      acc[walletAddress] = acc[walletAddress] || { owner: walletAddress, tokens: [] };
-      acc[walletAddress].tokens.push({ address: id, amount });
-      return acc;
-    }, {})
-  );
-
-  const uniqueOwners = new Set();
-  const uniqueTokens = new Set();
-
-  for (const { owner, tokens } of wallets) {
-    const eigenLayerToken = tokens.find(token => token.address === 'eigen-layer-eth');
-    if (tokens.some(token => token.address === 'eth')) api.add(nullAddress, (await sdk.api.eth.getBalance({ target: owner })).output);
-    // native MNT lives on Mantle, so the balance has to be read there and not on Ethereum.
-    // MNT is an own token, so it is only added on the ownTokens pass.
-    if (!skipOwnNative && tokens.some(token => token.address === 'mnt')) api.add(MNT, (await sdk.api.eth.getBalance({ target: owner, chain: api.chain })).output, { skipChain: true });
-    if (tokens.some(token => token.address === 'ethena-farming-usde')) api.add(USDe, await getEthenaFarmingBalance(api, owner));
-    if (eigenLayerToken) api.add(nullAddress, eigenLayerToken.amount * 10 ** 18);
-
-    const nonSpecificTokens = tokens.filter(token => !isSpecificToken(token.address));
-    if (nonSpecificTokens.length > 0) {
-      uniqueOwners.add(owner);
-      nonSpecificTokens.forEach(token => uniqueTokens.add(token.address));
+async function tvl(api) {
+  const own = config[api.chain].ownTokens;
+  const ownerTokens = [];
+  for (const { owner, tokens } of await getWallets(config[api.chain].key)) {
+    for (const { address, amount } of tokens) {
+      if (own.includes(address)) continue;
+      else if (address === 'ethena-farming-usde') api.add(USDe, await getEthenaFarmingBalance(api, owner));
+      else if (address === 'eigen-layer-eth') api.add(ADDRESSES.null, amount * 10 ** 18);
+      else ownerTokens.push([[toAddress(address)], owner]);
     }
   }
+  await api.sumTokens({ ownerTokens });
+};
 
-  return { owners: Array.from(uniqueOwners), tokens: Array.from(uniqueTokens) };
+async function ownTokens(api) {
+  const own = config[api.chain].ownTokens;
+  const ownerTokens = [];
+  for (const { owner, tokens } of await getWallets(config[api.chain].key)) {
+    for (const { address } of tokens)
+      if (own.includes(address)) ownerTokens.push([[toAddress(address)], owner]);
+  }
+  await api.sumTokens({ ownerTokens });
 };
 
 module.exports = {
-  ethereum: {
-    tvl: sdk.util.sumChainTvls([async ({ api }) => {
-      const { owners, tokens } = await getTvlData(api, 'eth')
-      return api.sumTokens({ owners, tokens, blacklistedTokens: [MNT, BIT] });
-    }]),
-    ownTokens: async ({ api }) => {
-      const { owners } = await getTvlData(api, 'eth')
-      return api.sumTokens({ ownerTokens: owners.map(owner => [[MNT, BIT], owner]) });
-    }
-  },
-  mantle: {
-    tvl: async (api) => {
-      const { owners, tokens } = await getTvlData(api, 'mnt', { skipOwnNative: true })
-      return api.sumTokens({ owners, tokens, blacklistedTokens: [COOK] });
-    },
-    ownTokens: async ({ api }) => {
-      const { owners } = await getTvlData(api, 'mnt')
-      return api.sumTokens({ ownerTokens: owners.map(owner => [[COOK], owner]) });
-    }
-  },
-}
+  ethereum: { tvl, ownTokens },
+  mantle: { tvl, ownTokens },
+};

--- a/projects/treasury/bitdao.js
+++ b/projects/treasury/bitdao.js
@@ -5,6 +5,8 @@ const { getConfig } = require('../helper/cache')
 
 const API_URL = 'https://api.mantle.xyz/api/v2/treasury/tokens';
 const MNT = '0x3c3a81e81dc49a522a592e7622a7e711c06bf354';
+// BitDAO's original token, which Mantle rebranded from and converted to MNT
+const BIT = '0x1a4b46696b2bb4794eb3d4c26f1c55f9170fa4c5';
 const USDe = ADDRESSES.ethereum.USDe;
 const COOK = '0x9f0c013016e8656bc256f948cd4b79ab25c7b94d'
 const ethenaFarm = '0x8707f238936c12c309bfc2b9959c35828acfc512';
@@ -19,7 +21,7 @@ const getEthenaFarmingBalance = async (api, wallet) => {
   return Number(stakedAmount) + Number(coolingDownAmount);
 };
 
-const getTvlData = async (api, key) => {
+const getTvlData = async (api, key, { skipOwnNative = false } = {}) => {
   const data = await getConfig('mantle-treasury', API_URL)
   const rawDatas = data.filter(({ chain }) => key === chain);
   const datas = rawDatas.map(({ id, walletAddress, amount }) => ({ id, walletAddress, amount }));
@@ -38,7 +40,9 @@ const getTvlData = async (api, key) => {
   for (const { owner, tokens } of wallets) {
     const eigenLayerToken = tokens.find(token => token.address === 'eigen-layer-eth');
     if (tokens.some(token => token.address === 'eth')) api.add(nullAddress, (await sdk.api.eth.getBalance({ target: owner })).output);
-    if (tokens.some(token => token.address === 'mnt')) api.add(MNT, (await sdk.api.eth.getBalance({ target: owner })).output, { skipChain: true });
+    // native MNT lives on Mantle, so the balance has to be read there and not on Ethereum.
+    // MNT is an own token, so it is only added on the ownTokens pass.
+    if (!skipOwnNative && tokens.some(token => token.address === 'mnt')) api.add(MNT, (await sdk.api.eth.getBalance({ target: owner, chain: api.chain })).output, { skipChain: true });
     if (tokens.some(token => token.address === 'ethena-farming-usde')) api.add(USDe, await getEthenaFarmingBalance(api, owner));
     if (eigenLayerToken) api.add(nullAddress, eigenLayerToken.amount * 10 ** 18);
 
@@ -56,17 +60,17 @@ module.exports = {
   ethereum: {
     tvl: sdk.util.sumChainTvls([async ({ api }) => {
       const { owners, tokens } = await getTvlData(api, 'eth')
-      return api.sumTokens({ owners, tokens, blacklistedTokens: [MNT] });
+      return api.sumTokens({ owners, tokens, blacklistedTokens: [MNT, BIT] });
     }]),
     ownTokens: async ({ api }) => {
       const { owners } = await getTvlData(api, 'eth')
-      return api.sumTokens({ ownerTokens: owners.map(owner => [[MNT], owner]) });
+      return api.sumTokens({ ownerTokens: owners.map(owner => [[MNT, BIT], owner]) });
     }
   },
   mantle: {
     tvl: async (api) => {
-      const { owners, tokens } = await getTvlData(api, 'mnt')
-      return api.sumTokens({ owners, tokens, blacklistedTokens: [COOK] }); 
+      const { owners, tokens } = await getTvlData(api, 'mnt', { skipOwnNative: true })
+      return api.sumTokens({ owners, tokens, blacklistedTokens: [COOK] });
     },
     ownTokens: async ({ api }) => {
       const { owners } = await getTvlData(api, 'mnt')


### PR DESCRIPTION
Two problems in `projects/treasury/bitdao.js`, both in the own-token accounting.

### 1. BIT is counted as a third-party treasury asset

The Ethereum `tvl` call blacklists only `MNT`, so BIT — the BitDAO token Mantle rebranded from and converted to MNT — lands in the regular treasury bucket. It is the single largest position there:

```
/treasury/bitdao  Ethereum  ->  BIT 105,469,776.02, SUSDE 13,728,908, USDT 11,522,803, ...
```

which is exactly the amount the protocol's own API reports for that wallet:

```
id 0x1a4b46696b2bb4794eb3d4c26f1c55f9170fa4c5  chain eth
wallet 0x78605df795...   amount 105469776.01718912
```

At $0.438479 (CoinGecko, live) that is **$46,246,282** sitting in the non-own treasury figure — 29.5% of the reported $156,856,507 Ethereum bucket.

### 2. Native MNT on Mantle is read from Ethereum

```js
if (tokens.some(token => token.address === 'mnt')) api.add(MNT, (await sdk.api.eth.getBalance({ target: owner })).output, { skipChain: true });
```

`sdk.api.eth.getBalance` with no `chain` reads Ethereum. This branch only fires for the Mantle pass (the API has 58 rows with `id = 'mnt'`, all `chain = 'mnt'`, and none on eth), so what gets added is each Mantle wallet's *Ethereum* balance, labelled as MNT. The published result:

```
/treasury/bitdao  Mantle-OwnTokens  ->  COOK 1,392,892,853.24,  MNT 301.55
```

301.55 MNT, where those wallets actually hold **29,175,917.79** MNT (summed from the same API), worth **$12,303,222** at $0.421691.

### Changes

- add `BIT` to the Ethereum `blacklistedTokens` and to the Ethereum `ownTokens` owner-token list
- pass `chain: api.chain` to the native-MNT `getBalance` so it is read on Mantle
- skip the native-MNT add on the Mantle `tvl` pass via a `skipOwnNative` flag, so MNT is only counted in `ownTokens`

That third change is needed because `getTvlData` mutates `api` and is called by both the `tvl` and `ownTokens` exports. Today that double-counts 301 MNT, which is invisible; once the balance is read correctly it would have put the full $12.3M into both the Mantle tvl bucket and Mantle-OwnTokens. I first tried adding MNT to `blacklistedTokens` on the Mantle tvl call, but that does not filter a balance added through `api.add(..., { skipChain: true })` — the run still showed mantle at 156.16 M — so the add itself has to be skipped.

### Result

```
                     before (published)        after (local run)
ethereum              $156,856,507              110.92 M
ethereum-ownTokens                              1.24 B
mantle                $143,715,743              143.86 M
mantle-ownTokens        $3,637,667               15.94 M
```

Ethereum drops by the $46.2M of BIT, Mantle-OwnTokens gains the $12.3M of native MNT, and the Mantle tvl bucket is left where it was rather than picking up a new double count.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated BitDAO treasury value calculations to properly reflect the BIT token alongside MNT.
  * Improved treasury accounting on both Ethereum and Mantle by more accurately distinguishing owned tokens from native assets.
  * Corrected Mantle handling of COOK and native token balances in reported treasury metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->