### PR TITLE
treasury helper: keep token auto-discovery out of the ownTokens bucket

### DIFF
--- a/projects/helper/treasury.js
+++ b/projects/helper/treasury.js
@@ -55,7 +55,9 @@ function treasuryExports(config) {
     }
 
     if (ownTokens.length > 0) {
-      const { solOwners, ...other } = config[chain];
+      // token auto-discovery must not run here: this bucket is meant to hold ownTokens
+      // only, and anything it finds is already counted in the tvl bucket above
+      const { solOwners, fetchCoValentTokens, tokenConfig, ...other } = config[chain];
       const opts = {
         ...other,
         owners: [...owners, ...ownTokenOwners],


### PR DESCRIPTION
`treasuryExports` builds the `ownTokens` export by spreading the chain config and then setting `tokens: ownTokens`:

```js
const { solOwners, ...other } = config[chain];
const opts = {
  ...other,
  owners: [...owners, ...ownTokenOwners],
  tokens: ownTokens,
  chain,
  uniV3WhitelistedTokens: ownTokens,
};
exportObj[chain].ownTokens = sumTokensExport(opts);
```

If the adapter set `fetchCoValentTokens: true`, that flag rides along in `...other`, so token auto-discovery runs for the own-token bucket too and `tokens: ownTokens` stops being a restriction. The bucket then fills with whatever the owners happen to hold.

Usual is where this shows up. Its published `Ethereum-OwnTokens`:

```
USUAL 73,422,088.61   USUALX 10,241,982.45
EUSD0-4 1,761,610.56  USD0 1,574,300.46  USDC 827,979.37
U0R 798,104.51        USUAL_MV 412,612.96  EUTBL 319,929.17
```

Only USUAL and USUALX are own tokens (`projects/treasury/usual.js` line 62). The rest appear with byte-identical amounts in the `Ethereum` tvl bucket — `EUSD0-4 1,761,610.56`, `USDC 827,979.37`, `U0R 798,104.51`, `USUAL_MV 412,612.96`, `EUTBL 319,929.17` — so the same assets are counted in both buckets.

### Change

Drop `fetchCoValentTokens` and `tokenConfig` when building the own-token opts, so the bucket can only contain what `ownTokens` lists.

### Blast radius

One adapter. The helper sets `fetchCoValentTokens` on `tvlConfig`, which is a copy, so `other` only carries it when an adapter sets it itself — and `grep -rln "fetchCoValentTokens: true" projects/treasury/` returns only `usual.js`. `tokenConfig` appears only in `turtleclub.js`, which carries its own copy of this logic rather than calling this helper.

### Result

```
$ node test.js projects/treasury/usual.js

------ TVL ------
ethereum                  19.87 M
ethereum-ownTokens        779.72 k
```

`Ethereum-OwnTokens` goes from the published $10,424,037 to $779,720, which is USUAL plus USUALX and nothing else. The `ethereum` tvl bucket is unchanged at 19.87 M against the published $19,884,726, so nothing was removed from the treasury total — only the duplicate in the own-token bucket.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token export handling to prevent duplicate or unnecessary token auto-discovery when using own-token configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->