### PR TITLE
fix: native-lend TVL was missing the amount borrowed out to PMMs

### DIFF
--- a/projects/native-lend/helper.js
+++ b/projects/native-lend/helper.js
@@ -10,21 +10,18 @@ async function getUnderlyings(api, vault, vaultFromBlock) {
       });
     const lps = lpListedLogs.map((i) => i.lpToken);
     const tokens = await api.multiCall({ abi: 'address:underlying', calls: lps });
-
     return { lps, tokens };
 }
 
-async function addCreditPoolTvl(api, vault, vaultFromBlock) {
-    const { tokens } = await getUnderlyings(api, vault, vaultFromBlock);
-
-    await api.sumTokens({ owner: vault, tokens });
-}
-
-async function addCreditPoolBorrowed(api, vault, vaultFromBlock) {
-    const { lps, tokens } = await getUnderlyings(api, vault, vaultFromBlock);
+// totalUnderlying() on each lpToken is the full amount owed to LPs (cash still
+// sitting in the vault plus whatever's currently lent out to PMMs). The vault's
+// own token balance only reflects the cash portion, so TVL must also include
+// the borrowed-out excess (totalUnderlying - cash) or it silently undercounts
+// whenever there's an active loan. Confirmed on-chain: ethereum WETH market had
+// totalUnderlying ~6,247 WETH vs vault cash ~3,933 WETH, a ~37% gap.
+async function addBorrowedExcess(api, vault, lps, tokens) {
     let v2Locked = await api.multiCall({ abi: 'uint256:totalUnderlying', calls: lps });
     let cashBalances = await api.multiCall({ abi: 'erc20:balanceOf', calls: tokens.map(token => ({ target: token, params: [vault] })) });
-
     tokens.forEach((token, i) => {
         const locked = BigInt(v2Locked[i]);
         const cash = BigInt(cashBalances[i]);
@@ -32,6 +29,16 @@ async function addCreditPoolBorrowed(api, vault, vaultFromBlock) {
     });
 }
 
+async function addCreditPoolTvl(api, vault, vaultFromBlock) {
+    const { lps, tokens } = await getUnderlyings(api, vault, vaultFromBlock);
+    await api.sumTokens({ owner: vault, tokens });
+    await addBorrowedExcess(api, vault, lps, tokens);
+}
+
+async function addCreditPoolBorrowed(api, vault, vaultFromBlock) {
+    const { lps, tokens } = await getUnderlyings(api, vault, vaultFromBlock);
+    await addBorrowedExcess(api, vault, lps, tokens);
+}
 
 module.exports = {
     addCreditPoolTvl,


### PR DESCRIPTION
addCreditPoolTvl only summed the vault's cash balance per token, missing whatever's currently lent out to PMMs.

The sibling function addCreditPoolBorrowed already establishes that totalUnderlying() on each lpToken is the full amount owed to LPs (cash still in the vault plus whatever's currently out on loan), and only counts the excess (totalUnderlying minus cash) as borrowed when it's positive.

TVL should be cash plus that same borrowed excess, since it's still value owed to depositors regardless of where it currently sits. The old code silently dropped that portion whenever there was an active loan.

Verified on-chain on ethereum: the WETH market's totalUnderlying was about 6,247 WETH against vault cash of about 3,933 WETH, a 37% gap on that one market alone.

Ran the full adapter before and after the fix (npm test / node test.js projects/native-lend/index.js). Total TVL across all 7 chains went from about 34.1M to 52.14M, a 53% correction protocol-wide. Every chain shows a real nonzero borrowed amount, so this isn't limited to one market.

Fix: extracted the shared borrowed-excess logic into addBorrowedExcess and call it from both addCreditPoolTvl and addCreditPoolBorrowed, so TVL and Borrowed use the exact same verified calculation instead of diverging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credit pool TVL calculations by accounting for assets borrowed against supported liquidity positions.
  * Updated borrowed asset reporting to consistently include excess underlying balances.
  * Ensured both direct TVL and borrowed-value metrics use the same adjustment logic for more accurate totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->