### PR TITLE
Add BakeYourStake (bCOOK liquid staking) TVL adapter

### DIFF
--- a/projects/bakeyourstake/index.js
+++ b/projects/bakeyourstake/index.js
@@ -13,6 +13,8 @@ const WRAPPED_COOK = 'So11111111111111111111111111111111111111112' // native COO
 async function tvl(api) {
   const connection = getConnection(api.chain)
   const acc = await connection.getAccountInfo(STAKE_POOL)
+  if (!acc || acc.data.length < TOTAL_LAMPORTS_OFFSET + 8)
+    throw new Error('bakeyourstake: stake pool account missing or malformed')
   const totalLamports = acc.data.readBigUInt64LE(TOTAL_LAMPORTS_OFFSET)
   api.add(WRAPPED_COOK, totalLamports.toString())
 }

--- a/projects/bakeyourstake/index.js
+++ b/projects/bakeyourstake/index.js
@@ -1,0 +1,24 @@
+const { PublicKey } = require('@solana/web3.js')
+const { getConnection } = require('../helper/solana')
+
+// bCOOK is the liquid staking token of Cookie Chain, built on the canonical SPL
+// Stake Pool program. The StakePool account tracks `totalLamports` — the total
+// native COOK under management across the reserve and all validator stake
+// accounts — which is exactly the protocol's TVL. In the StakePool struct that
+// u64 sits at offset 258 (after accountType + 8 pubkeys + withdrawBumpSeed).
+const STAKE_POOL = new PublicKey('GxbNKNYdtNXQkhDkpHdLDAMX64GxaECgANqdfp6cUGH4')
+const TOTAL_LAMPORTS_OFFSET = 258
+const WRAPPED_COOK = 'So11111111111111111111111111111111111111112' // native COOK
+
+async function tvl(api) {
+  const connection = getConnection(api.chain)
+  const acc = await connection.getAccountInfo(STAKE_POOL)
+  const totalLamports = acc.data.readBigUInt64LE(TOTAL_LAMPORTS_OFFSET)
+  api.add(WRAPPED_COOK, totalLamports.toString())
+}
+
+module.exports = {
+  timetravel: false,
+  methodology: 'TVL is the total native COOK staked in the bCOOK SPL stake pool, read as the StakePool account\'s totalLamports on Cookie Chain.',
+  cookiechain: { tvl },
+}


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
BakeYourStake

##### Twitter Link:
https://x.com/TheCookieChain

##### List of audit links if any:
None. Built on the canonical, unmodified SPL Stake Pool program (mainnet bytecode).

##### Website Link:
https://bakeyourstake.xyz

##### Logo (High resolution, will be shown with rounded borders):
https://bakeyourstake.xyz/bcook.png

##### Current TVL:
~57.9M COOK staked in the pool

##### Chain:
Cookie Chain (cookiechain)

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):
cookie-2

##### Short Description (to be shown on DefiLlama):
BakeYourStake is the liquid staking protocol of Cookie Chain. Staking COOK mints bCOOK, a yield-bearing liquid staking token whose exchange rate against COOK rises as staking rewards accrue.

##### Token address and ticker if any:
bCOOK - EkPafx58mgwkEnGwo62jXhXDAdJ37Z8G8MFBRPsr9uhz (9 decimals)

##### Category (full list at https://defillama.com/categories):
Liquid Staking

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
None. No oracle is used; the exchange rate is read directly from on-chain SPL Stake Pool state.

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
N/A - no oracle. bCOOK/COOK is derived on-chain as totalLamports / poolTokenSupply from the stake pool account.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
N/A

##### forkedFrom (Does your project originate from another project):
SPL Stake Pool (canonical Solana Program Library stake pool program, deployed unmodified on Cookie Chain)

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL is the total native COOK staked in the bCOOK stake pool. It is read as the StakePool account's totalLamports field (all COOK held across the reserve stake account and every validator stake account) and valued as COOK.
Stake pool: GxbNKNYdtNXQkhDkpHdLDAMX64GxaECgANqdfp6cUGH4;
Program: GZgs5uREPp6BvDt8eysmhavQPAHBAtjePgV4zfhgd9pH.

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/cookiechain

##### Does this project have a referral program?
No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Cookie Chain TVL tracking for the BakeYourStake project.
  - TVL now accounts for assets held via the bCOOK staking pool and reports in the wrapped native COOK denomination.
  - Included clear methodology describing how TVL is derived, with non–time travel behavior for the calculation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->