### PR TITLE
Add Diggers (launchpad on Robinhood Chain) TVL adapter

### DIFF
--- a/projects/diggers/index.js
+++ b/projects/diggers/index.js
@@ -1,0 +1,48 @@
+const { getLogs2 } = require('../helper/cache/getLogs')
+
+// Diggers launchpad on Robinhood Chain (https://diggers.fun).
+// One singleton contract is factory + swap router + sole LP of every launched token:
+// each launch mints a fixed 1B supply and seeds ALL of it as single-sided liquidity
+// in a hookless Uniswap V4 pool (ETH is currency0). Liquidity can never be removed.
+// https://robinhoodchain.blockscout.com/address/0x4190a197e9c7c8D9ce1095c32e6666A13A996580
+const DIGGERS = '0x4190a197e9c7c8D9ce1095c32e6666A13A996580'
+const DEPLOY_BLOCK = 12296204
+
+const CREATED_EVENT =
+  'event Created(address indexed token, address indexed creator, string name, string symbol, string metadataURI, bytes32 poolId, uint160 startSqrtPriceX96, uint24 poolFee, uint128 burnShareWad)'
+
+// Per-pool reserves attributable to the Diggers position inside the shared
+// Uniswap V4 PoolManager singleton, computed on-chain from slot0 + liquidity.
+const POOL_STATE_ABI =
+  'function poolState(address token) view returns (uint160 sqrtPriceX96, int24 tick, uint128 liquidity, uint256 ethInPool, uint256 tokenInPool)'
+
+async function tvl(api) {
+  const logs = await getLogs2({
+    api,
+    target: DIGGERS,
+    eventAbi: CREATED_EVENT,
+    fromBlock: DEPLOY_BLOCK,
+  })
+  const tokens = logs.map((log) => log.token)
+  if (!tokens.length) return
+
+  const states = await api.multiCall({ abi: POOL_STATE_ABI, target: DIGGERS, calls: tokens })
+  for (let i = 0; i < tokens.length; i++) {
+    // ETH side of the pool (currency0). The token side is the launched meme
+    // token itself and is deliberately not counted (unpriced own-supply).
+    api.addGasToken(states[i].ethInPool)
+  }
+
+  // ETH escrowed on the launchpad: harvested-but-unclaimed creator/team fees
+  // (pull-payment model) and pending initial-buy distributions.
+  await api.sumTokens({ owner: DIGGERS, tokens: [require('../helper/coreAssets.json').null] })
+}
+
+module.exports = {
+  methodology:
+    'TVL is the ETH side of every Diggers pool, read on-chain via the launchpad`s poolState() view (Diggers is the only LP of each Uniswap V4 pool it creates, and liquidity is locked forever), plus ETH held by the launchpad awaiting pull-payment fee claims. Launched tokens themselves are not counted.',
+  doublecounted: true, // pools live inside the canonical Uniswap V4 PoolManager, so this ETH is also part of Uniswap TVL
+  robinhood: {
+    tvl,
+  },
+}


### PR DESCRIPTION
**NOTE**

"Allow edits by maintainers" is enabled.

---

Adds a TVL adapter for **Diggers**, a token launchpad on Robinhood Chain built natively on Uniswap V4.

How it works: one singleton contract (`0x4190a197e9c7c8D9ce1095c32e6666A13A996580`) is factory + swap router + the **only LP of every pool it creates**. Each launch mints a fixed 1B supply and seeds the entire supply as single-sided liquidity in a hookless Uniswap V4 pool (ETH is currency0). Liquidity can never be removed — only fees are collected.

Adapter methodology:
- Enumerates launched tokens from the singleton's `Created` events (cached via `getLogs2`).
- For each token, reads the launchpad's `poolState(token)` view, which computes the pool's ETH reserve on-chain from slot0 + position liquidity inside the shared V4 PoolManager, and counts the ETH side (`addGasToken`).
- Adds ETH held by the launchpad itself (harvested-but-unclaimed pull-payment fees).
- The launched tokens themselves are **not** counted (unpriced own-supply).
- `doublecounted: true` since the pools live inside the canonical Uniswap V4 PoolManager, so the same ETH is part of Uniswap TVL.

`node test.js projects/diggers/index.js` output:

```
--- robinhood ---
ETH                       6.33 k
Total: 6.33 k

------ TVL ------
robinhood                 6.33 k

total                    6.33 k
```

---
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
Diggers

##### Twitter Link:
https://x.com/diggersdotfun

##### List of audit links if any:
None

##### Website Link:
https://diggers.fun

##### Logo (High resolution, will be shown with rounded borders):
https://diggers.fun/diggers-flat-pickaxe.png

##### Current TVL:
~$6.3k (young protocol, launched 2026-07-17)

##### Treasury Addresses (if the protocol has treasury)


##### Chain:
Robinhood Chain

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):


##### Short Description (to be shown on DefiLlama):
Diggers is a fair-launch token launchpad on Robinhood Chain built natively on Uniswap V4: every token's full 1B supply is seeded as permanently locked single-sided liquidity at creation — no bonding curve, no migration. Trading fees are split between token creators and the protocol, and tokens run an on-chain daily traders-airdrop leaderboard.

##### Token address and ticker if any:
robinhood:0x4a64812c952c4684cb0C5169d57f3D0f95dC06e2 — DIG

##### Category (full list at https://defillama.com/categories) \*Please choose only one:
Launchpad

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
None — all pricing is pool-native (Uniswap V4 slot0), no external oracle.

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
N/A

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
N/A

##### forkedFrom (Does your project originate from another project):
No — original codebase built directly on Uniswap V4 (contracts: https://github.com/DIGGERSdotFUN/diggersV1)

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL = the ETH side of every Diggers-created Uniswap V4 pool, read on-chain via the launchpad's `poolState()` view (Diggers is the sole LP of each pool and liquidity is locked forever), plus ETH held by the launchpad awaiting pull-payment fee claims. The launched meme tokens themselves are not counted. Marked `doublecounted` because the pools live inside the canonical Uniswap V4 PoolManager.

##### Github org/user (Optional, if your code is open source, we can track activity):
DIGGERSdotFUN

##### Does this project have a referral program?
No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added TVL tracking for the Robinhood Chain Diggers launchpad.
  - Includes ETH reserves across launched pools and additional ETH held by the launchpad.
  - Reports the methodology and identifies potential overlap with Uniswap V4 PoolManager TVL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->