### PR TITLE
Add AgentRanking launchpad TVL (Solana + Robinhood)

### DIFF
--- a/projects/agentranking/index.js
+++ b/projects/agentranking/index.js
@@ -1,0 +1,65 @@
+/**
+ * DefiLlama TVL adapter — AgentRanking Launchpad
+ *
+ * Chains:
+ *  - solana: SOL in Pump.fun bonding curves for AgentRanking launches
+ *  - robinhood: WETH in Uniswap V3 pools for AgentRanking launches
+ *
+ * Copy this folder to DefiLlama/DefiLlama-Adapters/projects/agentranking/
+ * then: node test.js projects/agentranking/index.js
+ *
+ * Branding: AgentRanking / Robinhood Chain only.
+ */
+
+const ADDRESSES = require('../helper/coreAssets.json')
+const { sumTokens2 } = require('../helper/solana')
+const { getConfig } = require('../helper/cache')
+
+const EXPORT_URL = 'https://agentranking.io/api/public/defillama/launches'
+
+const ROBINHOOD_WETH = ADDRESSES.robinhood?.WETH || '0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73'
+const ROBINHOOD_FACTORY = '0xaA8Af274bba2b9dE53119CB117C8AC6A39e6F5Aa'
+const ROBINHOOD_LP_LOCKER = '0x38daBB90C96eea7B90613ABbf019ABCe0808CF12'
+
+async function loadExport() {
+  return getConfig('agentranking-launch-tvl', EXPORT_URL)
+}
+
+async function solanaTvl(api) {
+  const data = await loadExport()
+  const owners = data?.chains?.solana?.bondingCurves
+  if (!Array.isArray(owners) || owners.length === 0) return {}
+  return sumTokens2({
+    api,
+    solOwners: owners,
+    allowError: true,
+  })
+}
+
+async function robinhoodTvl(api) {
+  const data = await loadExport()
+  const pools = data?.chains?.robinhoodchain?.pools
+  const weth = data?.chains?.robinhoodchain?.weth || ROBINHOOD_WETH
+  if (!Array.isArray(pools) || pools.length === 0) return {}
+  return api.sumTokens({
+    owners: pools,
+    tokens: [weth],
+  })
+}
+
+module.exports = {
+  timetravel: false,
+  misrepresentedTokens: false,
+  methodology:
+    'Solana TVL is SOL locked in Pump.fun bonding-curve accounts for AgentRanking-indexed mainnet launches. Robinhood Chain TVL is WETH held in Uniswap V3 pools created by the AgentRanking launch factory.',
+  solana: { tvl: solanaTvl },
+  // DefiLlama chain key (matches NOXA / coreAssets): "robinhood"
+  robinhood: { tvl: robinhoodTvl },
+}
+
+module.exports._contracts = {
+  robinhoodFactory: ROBINHOOD_FACTORY,
+  robinhoodLpLocker: ROBINHOOD_LP_LOCKER,
+  robinhoodWeth: ROBINHOOD_WETH,
+  exportUrl: EXPORT_URL,
+}

--- a/projects/agentranking/index.js
+++ b/projects/agentranking/index.js
@@ -5,9 +5,6 @@
  *  - solana: SOL in Pump.fun bonding curves for AgentRanking launches
  *  - robinhood: WETH in Uniswap V3 pools for AgentRanking launches
  *
- * Copy this folder to DefiLlama/DefiLlama-Adapters/projects/agentranking/
- * then: node test.js projects/agentranking/index.js
- *
  * Branding: AgentRanking / Robinhood Chain only.
  */
 
@@ -18,8 +15,6 @@ const { getConfig } = require('../helper/cache')
 const EXPORT_URL = 'https://agentranking.io/api/public/defillama/launches'
 
 const ROBINHOOD_WETH = ADDRESSES.robinhood?.WETH || '0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73'
-const ROBINHOOD_FACTORY = '0xaA8Af274bba2b9dE53119CB117C8AC6A39e6F5Aa'
-const ROBINHOOD_LP_LOCKER = '0x38daBB90C96eea7B90613ABbf019ABCe0808CF12'
 
 async function loadExport() {
   return getConfig('agentranking-launch-tvl', EXPORT_URL)
@@ -55,11 +50,4 @@ module.exports = {
   solana: { tvl: solanaTvl },
   // DefiLlama chain key (matches NOXA / coreAssets): "robinhood"
   robinhood: { tvl: robinhoodTvl },
-}
-
-module.exports._contracts = {
-  robinhoodFactory: ROBINHOOD_FACTORY,
-  robinhoodLpLocker: ROBINHOOD_LP_LOCKER,
-  robinhoodWeth: ROBINHOOD_WETH,
-  exportUrl: EXPORT_URL,
 }


### PR DESCRIPTION
## Summary

Add **AgentRanking** launchpad TVL adapter for:

- **Solana** — SOL in Pump.fun bonding curves for AgentRanking-indexed mainnet launches
- **Robinhood Chain** — WETH in Uniswap V3 pools for AgentRanking launches

Universe export (mint/pool allowlist): https://agentranking.io/api/public/defillama/launches  
Balances are read on-chain via DefiLlama helpers (`sumTokens2` / `api.sumTokens`).

## Listing

##### Name (to be shown on DefiLlama):
AgentRanking

##### Twitter Link:
https://x.com/agentranking

##### List of audit links if any:
(none yet)

##### Website Link:
https://agentranking.io

##### Logo (High resolution, will be shown with rounded borders):
https://agentranking.io/logo-icon.png

##### Current TVL:
Run adapter test after merge — SOL in active bonding curves + WETH in Robinhood Uni V3 pools.

##### Treasury Addresses (if the protocol has treasury):
- Robinhood AR fee treasury: `0x575745896498B05537b4abbF3eC9E76652D799E4`

##### Chain:
Solana, Robinhood Chain

##### Coingecko ID:
(leave empty if $AR not listed)

##### Coinmarketcap ID:
(leave empty if not listed)

##### Short Description (to be shown on DefiLlama):
AgentRanking Launchpad — launch and tokenize AI agents on Solana and Robinhood Chain, with fee-share to creators and the AgentRanking treasury.

##### Token address and ticker if any:
$AR on Solana

##### Category:
Launchpad

##### Oracle Provider(s):
None

##### Implementation Details:
N/A

##### Documentation/Proof:
https://agentranking.io/docs  
https://agentranking.io/tokens  
https://agentranking.io/launch/new  
https://agentranking.io/tokens/robinhood

##### forkedFrom:
(none)

##### methodology (what is being counted as tvl, how is tvl being calculated):
- **Solana:** SOL locked in Pump.fun bonding-curve accounts for AgentRanking-indexed mainnet launches. Mint universe from `GET https://agentranking.io/api/public/defillama/launches` (`chains.solana.bondingCurves`); balances read on-chain.
- **Robinhood Chain:** WETH balances in Uniswap V3 pools for AgentRanking launches. Pool universe from the same export (`chains.robinhoodchain.pools`); WETH `balanceOf(pool)` on-chain. Launch factory: `0xaA8Af274bba2b9dE53119CB117C8AC6A39e6F5Aa`. LP locker: `0x38daBB90C96eea7B90613ABbf019ABCe0808CF12`.

##### Github org/user (Optional):
https://github.com/EmmanuelDumitrache/agentranking

##### Does this project have a referral program?
Yes — AgentRanking referral codes for product growth (not a DeFi referral bribe program).

## Test plan

- [ ] `node test.js projects/agentranking/index.js` succeeds
- [ ] Solana TVL reports SOL from bonding-curve owners
- [ ] Robinhood TVL reports WETH from pool owners (may be empty until RH launches exist)
- [ ] Export URL returns 200: https://agentranking.io/api/public/defillama/launches

Please allow edits by maintainers.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for “AgentRanking Launchpad.”
  * Aggregates Solana-equivalent assets from bonding-curve ownership and WETH from Robinhood-related Uniswap V3 liquidity pools.
  * Includes clear reporting methodology and source configuration, with safe handling when required pool/owner data is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->