### PR TITLE
spiko: fix truncated UKTBL pricing address on Stellar

### DIFF
--- a/projects/spiko/index.js
+++ b/projects/spiko/index.js
@@ -65,7 +65,7 @@ const config = {
     }, // SPKCC
     {
       contract: "CDT3KU6TQZNOHKNOHNAFFDQZDURVC3MSTL4ML7TUTZGNOPBZCLABP4FR",
-      target: "0xf695Df6c0f3bB45918A7A82e83348FC59517734",
+      target: "0xf695Df6c0f3bB45918A7A82e83348FC59517734E",
     }, // UKTBL
   ],
 };


### PR DESCRIPTION
The Stellar UKTBL entry prices against an address that is one character short, so the balance is dropped entirely.

```js
{
  contract: "CDT3KU6TQZNOHKNOHNAFFDQZDURVC3MSTL4ML7TUTZGNOPBZCLABP4FR",
  target: "0xf695Df6c0f3bB45918A7A82e83348FC59517734",   // 39 hex chars, not 40
}, // UKTBL
```

That value is used as `api.add(\`ethereum:${target}\`, supply, ...)`, so the key never resolves and the supply contributes nothing.

### The full address is the right one

`0xf695Df6c0f3bB45918A7A82e83348FC59517734E` on Ethereum:

```
symbol()   = UKTBL
decimals() = 5
coins.llama.fi/prices/current/ethereum:0xf695...734e  ->  $1.3779 (UKTBL)
```

which matches the entry's own `// UKTBL` comment and its `ethereum:` prefix. The same address already appears (correctly, with the trailing `E`) in the dimension-adapters Spiko fee adapter.

### Effect

Reading the Soroban contract's TotalSupply directly: 13,636,272.25 UKTBL × $1.3779 = **$18,789,453**, or 3.2% of the Stellar leg.

`node test.js projects/spiko`:

```
before                          after
stellar   560.74 M              stellar   579.52 M
UKTBL       2.05 M              UKTBL      20.84 M
total       1.21 B              total       1.23 B
```

The +18.78M shift matches the independently computed $18,789,453.

The other four Stellar assets (USTBL, EUTBL, eurSPKCC, SPKCC) all have valid 40-character targets and are unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Stellar configuration for the SPKCC asset by restoring its complete target address.
  * Ensured related transactions and asset operations are directed to the intended destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->