### PR TITLE
stakewise: stop counting exited v2 solo validators

### DIFF
--- a/projects/stakewise/index.js
+++ b/projects/stakewise/index.js
@@ -5,7 +5,6 @@ const CONFIG = {
   ethereum: {
     rETH2: '0x20BC832ca081b91433ff6c17f85701B6e92486c5',
     sETH2: '0xFe2e637202056d30016725477c5da089Ab0A043A',
-    validator: '0xEadCBA8BF9ACA93F627F31fB05470F5A0686CEca',
     factory: '0x3a0008a588772446f6e656133c2d5029cc4fc20e',
     blacklist: ['0x09e84205df7c68907e619d07afd90143c5763605']
   },
@@ -16,15 +15,15 @@ const CONFIG = {
 }
 
 const topic = {
-  validatorRegistered: 'ValidatorRegistered(bytes32,bytes,uint256,address)',
   vaultAdded: 'VaultAdded(address,address)'
 }
 
 const ethTvl = async (api) => {
-  const { rETH2, sETH2, validator, factory, blacklist } = CONFIG[api.chain]
+  // The v2 solo-staking registry is not counted: every validator ever registered through it
+  // has exited the beacon chain, and each one's stake withdraws to the operator's own address
+  // rather than to StakeWise, so none of it is held here.
+  const { rETH2, sETH2, factory, blacklist } = CONFIG[api.chain]
   const lsBals = await api.multiCall({ abi: 'erc20:totalSupply', calls: [rETH2, sETH2]})
-  const solosValidators = await getLogs({ api, target: validator, topic: topic.validatorRegistered, fromBlock: 11726299 })
-  lsBals.push(solosValidators.length * 32e18)
   const vaults = await getLogs({ api, target: factory, topic: topic.vaultAdded, fromBlock: 18470078 })
 
   const assets = await api.multiCall({


### PR DESCRIPTION
`ethTvl` adds 32 ETH for every `ValidatorRegistered` event the v2 solo registry has ever emitted:

```js
const solosValidators = await getLogs({ api, target: validator, topic: topic.validatorRegistered, fromBlock: 11726299 })
lsBals.push(solosValidators.length * 32e18)
```

That is a cumulative count with nothing to account for validators leaving. There are 381 such events (the last at block 13,859,423, early 2022), so it contributes a fixed **12,192 ETH** regardless of what those validators are doing now.

### Every one of them has exited

Querying the beacon chain for all 381 public keys decoded from those events (`ethereum-beacon-api.publicnode.com`, `/eth/v1/beacon/states/head/validators`), 381/381 resolved:

| status | count |
|---|---|
| `withdrawal_done` (exited, balance 0) | 367 |
| `withdrawal_possible` (exited, awaiting sweep) | 14 |
| `active_ongoing` | **0** |

Total live balance across all 381: **520.42 ETH**, against the 12,192 ETH booked.

### And the remainder isn't StakeWise's

The 14 that still hold a balance withdraw to **12 distinct operator addresses**, and all have exit epochs already in the past:

```
idx=90605   37.75 ETH  ->  0x6b917e680e9f6dfcf6422a03c8879f0c9e9b00f6   exitEpoch 369920
idx=91593   37.73 ETH  ->  0x00aad4c0fd130a2f923932f1e5537c652299feb6   exitEpoch 369920
idx=103728  37.66 ETH  ->  0x3faf3905f46514cd2892bc94661aca736273e5e5   exitEpoch 369923
...
```

366 of the 381 carry `0x01` withdrawal credentials pointing at an execution address. These were solo operators running their own validators registered through v2 — the stake returns to them, not to StakeWise, so the correct contribution here is zero rather than 520 ETH.

### Verification

`node test.js projects/stakewise`, both runs at the same ETH price ($1,895.53):

```
before:  379.33 k WETH   $719.04 M
after:   367.14 k WETH   $695.93 M
```

A difference of exactly 12,192 ETH (**$23.11M**, 3.2% of reported Ethereum TVL), matching the 381 × 32 term.

The v3 vault leg (`totalAssets` over `VaultAdded`) and the rETH2/sETH2 legs are untouched, and Gnosis is unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Ethereum total value locked calculations to use current rETH2 and sETH2 supply plus eligible vault assets.
  * Removed outdated validator registration data from the calculation.
  * Excluded blacklisted vaults from reported totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->