### PR TITLE
tori-finance: TVL = trUSD circulating supply

### DIFF
--- a/projects/tori-finance/index.js
+++ b/projects/tori-finance/index.js
@@ -1,13 +1,18 @@
 const ADDRESSES = require('../helper/coreAssets.json')
 
+// trUSD, the Tori Finance synthetic dollar (Ethereum, 18 decimals).
+const trUSD = '0xd0580192E98eA6CEB9c7b6191Ed2E27560911697'
+
 async function tvl(api) {
-    const assets = await api.call({target: '0xcd69123b3FBBfC666E1f6a501da27B564C00De54', abi: 'uint:getTotalAssets'});
-    api.add(ADDRESSES.ethereum.USDC, assets / 1e12);
+  // TVL is the circulating supply of trUSD, the Tori Finance synthetic dollar, on Ethereum.
+  // trUSD is valued 1:1 in USD (via USDC, which DefiLlama prices at ~$1) until trUSD is
+  // priced directly by DefiLlama's coins oracle. Supply is normalised from 18 to 6 decimals.
+  const supply = await api.call({ target: trUSD, abi: 'erc20:totalSupply' })
+  api.add(ADDRESSES.ethereum.USDC, supply / 1e12)
 }
 
 module.exports = {
-    methodology: 'Counts total value of assets staked into the Upshift Tori ecosystem vault.',
-    doublecounted: true,
-    ethereum: { tvl } // temp until trUSD is priced on dex
-    // ethereum: { tvl: sumERC4626VaultsExport({vaults: ['0xcd69123b3FBBfC666E1f6a501da27B564C00De54'], tokenAbi: 'address:asset', balanceAbi: 'uint:getTotalAssets'}) }
+  methodology: 'TVL is the circulating supply of trUSD, the Tori Finance synthetic dollar, on Ethereum, valued 1:1 in USD. The same supply is reported in the stablecoins dataset, so this protocol is marked doublecounted to avoid inflating aggregate DeFi TVL.',
+  doublecounted: true,
+  ethereum: { tvl },
 }


### PR DESCRIPTION
Reports Tori Finance TVL as the circulating supply of trUSD (the Tori synthetic dollar) on Ethereum, by reading `trUSD.totalSupply()` directly instead of the Upshift ecosystem vault's `getTotalAssets()`. trUSD is valued 1:1 in USD (via USDC) until it is priced by the coins oracle; the protocol stays `doublecounted` since the same supply is reported in the stablecoins dataset. Tested with `node test.js projects/tori-finance/index.js` -> 50.17M.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated Tori Finance TVL reporting to use the circulating supply of trUSD on Ethereum.
  - Improved USDC-equivalent value normalization for more accurate TVL calculations.
  - Updated the displayed methodology to reflect the revised calculation approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->