### PR TITLE
Add ParitySwap V2 + V3 (Robinhood Chain)

### DIFF
--- a/registries/uniswapV2.js
+++ b/registries/uniswapV2.js
@@ -1488,6 +1488,9 @@ const uniV2Configs = {
     },
     monad: '0x6DBb0b5B201d02aD74B137617658543ecf800170',
   },
+  'parityswap-v2': {
+    robinhood: '0xaA5f8c18EF9be81ffED30c223F9CD0D012a2AdB9',
+  },
   'PattieSwap': {
     bsc: '0x71f6a913b317d2BF0Bf51Fd48d90e4cC6e62C4Dd',
   },

--- a/registries/uniswapV3.js
+++ b/registries/uniswapV3.js
@@ -1760,6 +1760,9 @@ const uniV3Configs = {
       eventAbi: 'event PoolCreated(address indexed token0, address indexed token1, int24 indexed tickSpacing, address pool)',
       topics: ['0xab0d57f0df537bb25e80245ef7748fa62353808c54d6e528a9dd20887aed9ac2'],
     },
+  },
+  'parityswap-v3': {
+    robinhood: { factory: '0xd479E71C45aEB1E846A7B549c346D62fE77B39bA', fromBlock: 14320075 },
   }
 }
 


### PR DESCRIPTION
Adds TVL adapters for **ParitySwap**, a Uniswap V2 + V3 fork DEX live on Robinhood Chain (already supported as `robinhood`): `projects/parityswap-v2` and `projects/parityswap-v3`.

## Listing details

- **Protocol names:** ParitySwap V2, ParitySwap V3 — please group under a parent protocol **ParitySwap**
- **Category:** Dexs
- **Chain:** Robinhood Chain
- **Website:** https://app.parityswap.io
- **Discord:** https://discord.gg/nVGjaA3ngU
- **Fork of:** Uniswap V2 / Uniswap V3 (`forkedFrom`)
- **Description:** ParitySwap is a Uniswap V2 + V3 fork DEX on Robinhood Chain for swapping ETH, USDG, and Robinhood Chain tokens.
- **Oracles:** none
- **Audit:** none beyond upstream — contracts are a faithful Uniswap V2/V3 fork; the only change is protocol-fee configuration (V2 `feeTo` enabled at deploy; V3 pools initialize with `feeProtocol = 68`, i.e. 25% of swap fees to the protocol)
- **Treasury (V2 `feeTo` / protocol fee recipient):** `0x468Cc05a64d44b6CE108BF0e9E927f9B32AF32DE`
- **Methodology:** TVL = token balances held in V2 pairs / V3 pools, enumerated from the factories

## Contracts (Blockscout-verified: https://robinhoodchain.blockscout.com)

| Contract | Address | Deploy block |
|---|---|---|
| UniswapV2Factory | `0xaA5f8c18EF9be81ffED30c223F9CD0D012a2AdB9` | 14320587 |
| UniswapV3Factory | `0xd479E71C45aEB1E846A7B549c346D62fE77B39bA` | 14320075 |

Deployed 2026-07-20.

## Test output (`node test.js projects/parityswap-*/index.js`)

```
parityswap-v2:  robinhood TVL $37.78  (WETH + USDG)
parityswap-v3:  robinhood TVL $1.24k  (WETH + USDG)
```

## Logo (400×400)

![ParitySwap logo](https://raw.githubusercontent.com/JosephSaw/DefiLlama-Adapters/pr-assets/parityswap-logo-400.png)

A dimension-adapters PR for volume/fees follows once this is merged (the uniV3 log adapter reads the pool-log cache this adapter populates).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tracking ParitySwap V2 and V3 deployments on Robinhood.
  * Enabled TVL monitoring for the newly supported protocol pools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->