### PR TITLE
add giga dex (refactor)

### DIFF
--- a/registries/uniswapV2.js
+++ b/registries/uniswapV2.js
@@ -3045,6 +3045,9 @@ const uniV2Configs = {
   'wraithswap': {
     fantom: { factory: '0xCC738D2fDE18fe66773b84c8E6C869aB233766D1', staking: ['0x37b106f101a63D9d06e53140E52Eb6F8A3aC5bBc', '0x4cf098d3775bd78a4508a13e126798da5911b6cd'] },
   },
+  'giga-dex': {
+    robinhood: '0x6Fdf38f92eAd1adFc04B73aaa947ab254f6c0916'
+  }
 }
 
 module.exports = buildProtocolExports(uniV2Configs, uniV2ExportFn)

--- a/registries/uniswapV3.js
+++ b/registries/uniswapV3.js
@@ -1760,6 +1760,9 @@ const uniV3Configs = {
       eventAbi: 'event PoolCreated(address indexed token0, address indexed token1, int24 indexed tickSpacing, address pool)',
       topics: ['0xab0d57f0df537bb25e80245ef7748fa62353808c54d6e528a9dd20887aed9ac2'],
     },
+  },
+  'giga-dex-cl': {
+    robinhood: { factory: '0xEce6eCd61177336ea6Fb9b17937AC439D85EE20B', fromBlock: 10357399 }
   }
 }
 


### PR DESCRIPTION
resolves #20142

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Giga DEX protocol on the Robinhood chain.

* **Bug Fixes**
  * Corrected configuration boundaries for an existing Uniswap V3 protocol adapter, ensuring adapters load correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->