### PR TITLE
Report Ravenhood TVL from RVHStakingPool only

### DIFF
--- a/projects/ravenhood/index.js
+++ b/projects/ravenhood/index.js
@@ -1,14 +1,16 @@
 const RVH_TOKEN = '0x96765066f6a040a21EB027167D2315B707c82633'
 const STAKING_POOL = '0xAc558b558E228DE033Cd97C580618C4403CB05a6'
 
+const stakedBalance = async (api) => {
+  const staked = await api.call({ target: STAKING_POOL, abi: 'uint256:totalStaked' })
+  api.add(RVH_TOKEN, staked)
+  return api.getBalances()
+}
+
 module.exports = {
-  methodology: 'Staking is RVH deposited into RVHStakingPool.',
+  methodology: 'TVL is RVH staked in RVHStakingPool, the only contract users can deposit into and withdraw from. The permanently locked launch-liquidity position is excluded (tracked under the protocol treasury instead).',
   robinhood: {
-    tvl: () => ({}),
-    staking: async (api) => {
-      const staked = await api.call({ target: STAKING_POOL, abi: 'uint256:totalStaked' })
-      api.add(RVH_TOKEN, staked)
-      return api.getBalances()
-    },
+    tvl: stakedBalance,
+    staking: stakedBalance,
   },
 }


### PR DESCRIPTION
## Summary
Follow-up to #20087, which was closed with the note that the locked
launch-liquidity Uniswap V3 position isn't user-deposited/withdrawable,
so it's tracked under the [protocol treasury](https://defillama.com/protocol/treasury/ravenhood)
instead of TVL.

This PR instead makes `tvl` report exactly what `staking` already
reports: RVH staked in `RVHStakingPool`
([0xAc558b558E228DE033Cd97C580618C4403CB05a6](https://robinhoodchain.blockscout.com/address/0xAc558b558E228DE033Cd97C580618C4403CB05a6)),
the only contract users can actually deposit into and withdraw from
(`deposit`/`withdraw`/`emergencyWithdraw`, all permissionless).

## Test plan
Ran locally with `node test.js projects/ravenhood/index.js`:
```
--- robinhood ---
RVH                       6.54 k
Total: 6.54 k 

--- staking ---
RVH                       6.54 k
Total: 6.54 k 

--- tvl ---
RVH                       6.54 k
Total: 6.54 k 
```
`tvl` and `staking` now agree, both reflecting only user-deposited funds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for RVH tokens deposited in the RVH staking pool.
  * Updated staking metrics to reflect the total amount staked.

* **Documentation**
  * Clarified the TVL methodology, including the exclusion of permanently locked launch liquidity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->