### PR TITLE
Add Cookie Bridge (Hyperlane warp route) TVL adapter

### DIFF
--- a/projects/cookiechain-bridge/index.js
+++ b/projects/cookiechain-bridge/index.js
@@ -1,0 +1,36 @@
+const { PublicKey } = require('@solana/web3.js')
+const { getConnection, sumTokens2 } = require('../helper/solana')
+
+// Cookie Bridge is a Hyperlane warp route between Solana and Cookie Chain (a
+// Solana / Agave fork). It is collateral <-> collateral: SPL COOK is locked in
+// a warp escrow on Solana, native COOK is locked in a warp collateral PDA on
+// Cookie Chain, and the relayer releases 1:1 from the destination pool. Nothing
+// synthetic is minted, so summing both locked pools is the TVL with no
+// double-counting. Both chains are indexed and priced by DefiLlama (COOK,
+// confidence ~0.99), so each pool is reported under its own chain.
+
+// Solana side: warp escrow token account holding SPL COOK (Token-2022, 6dp).
+const SOLANA_ESCROW = '88q7zoKctwAQRsoTxkMJy95sNE3tntuyEhSrhvR1eZwq'
+
+// Cookie Chain side: native-collateral PDA holding native COOK (9dp). Native
+// COOK is priced as the wrapped mint (Solana fork => same address as wSOL).
+const COOKIE_COLLATERAL_PDA = new PublicKey('CL2JoQ5jdTpRNKshWhaTihuooT4qrKdLUiPsqKj3yAKz')
+const WRAPPED_COOK = 'So11111111111111111111111111111111111111112'
+
+async function solanaTvl(api) {
+  await sumTokens2({ api, tokenAccounts: [SOLANA_ESCROW] })
+}
+
+async function cookiechainTvl(api) {
+  const connection = getConnection(api.chain)
+  const lamports = await connection.getBalance(COOKIE_COLLATERAL_PDA)
+  api.add(WRAPPED_COOK, lamports)
+}
+
+module.exports = {
+  timetravel: false,
+  methodology:
+    'TVL counts the COOK locked as collateral in the Hyperlane warp route that bridges COOK between Solana and Cookie Chain: SPL COOK held in the escrow on Solana plus native COOK held on Cookie Chain. Bridging locks and releases the same COOK 1:1 with no wrapped or minted supply.',
+  solana: { tvl: solanaTvl },
+  cookiechain: { tvl: cookiechainTvl },
+}


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
CookieChain Hyperlane

If possible, please label our community bridge as deprecated on DefiLlama:
- https://defillama.com/protocol/cookiechain-bridge

##### Twitter Link:
https://x.com/TheCookieChain

##### List of audit links if any:
None specific to this deployment. Built on Hyperlane's Sealevel warp route programs (collateral <-> collateral lock/release).

##### Website Link:
https://hyperlane.cookiechain.wtf

##### Logo (High resolution, will be shown with rounded borders):
https://raw.githubusercontent.com/cookiechain/apps/refs/heads/main/logos/hyperlane.png

##### Current TVL:
~52.03M COOK (~$4.1k) — Solana escrow ~33.94M + Cookie Chain collateral ~18.09M

##### Chain:
Solana, Cookie Chain

##### Coingecko ID:
https://www.coingecko.com/en/coins/cookie-2

##### Short Description (to be shown on DefiLlama):
Cookie Bridge is a Hyperlane warp route that bridges COOK between Solana and Cookie Chain. COOK is locked as collateral on the source chain and released 1:1 on the destination, with no wrapped or minted supply.

##### Token address and ticker if any:
- COOK — solana:36ZrtQoab5MhhySaP1YSTwUahSk6GRVUTtZ6cuVfm9e1 (Token-2022, 6 decimals)
- native COOK on Cookie Chain (9 decimals)

##### Category (full list at https://defillama.com/categories):
Bridge

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
None. No oracle is used; TVL is read directly from the two on-chain collateral accounts.

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
N/A — no oracle. The adapter reads the locked collateral balances directly via RPC.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
N/A. Verify by reading the two collateral accounts on-chain:
- Solana escrow 88q7zoKctwAQRsoTxkMJy95sNE3tntuyEhSrhvR1eZwq
- Cookie Chain collateral PDA CL2JoQ5jdTpRNKshWhaTihuooT4qrKdLUiPsqKj3yAKz

##### forkedFrom (Does your project originate from another project):
Hyperlane (Sealevel warp route)

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL counts the COOK locked as collateral in the Hyperlane warp route that bridges COOK between Solana and Cookie Chain: SPL COOK held in the escrow token account on Solana plus native COOK held in the collateral PDA on Cookie Chain. Both balances are read directly on-chain. Bridging locks and releases the same COOK 1:1 with no wrapped or minted supply, so nothing is double-counted.

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/cookiechain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for the Hyperlane COOK bridge between Solana and Cookie Chain.
  * Reports locked COOK and native collateral balances across both networks.
  * Includes methodology details describing the bridge’s 1:1 collateral accounting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->