### PR TITLE
Add StockWorks (SPCXSTR) adapter — Robinhood Chain

### DIFF
--- a/projects/stockworks/index.js
+++ b/projects/stockworks/index.js
@@ -1,0 +1,19 @@
+const { sumTokensExport } = require('../helper/unwrapLPs')
+const ADDRESSES = require('../helper/coreAssets.json')
+
+// StockWorks (SPCXSTR) — stock-token strategy flywheel on Robinhood Chain.
+// A 10% pool-level swap tax accumulates ETH in the SpcxController treasury,
+// which runs a standing Chainlink-capped bid for SPCX (Robinhood tokenized
+// SpaceX stock), relists acquisitions at a premium, and burns SPCXSTR with
+// 100% of sale proceeds.
+const CONTROLLER = '0x57024Aae99f709Bd399252767DDC6487Aa3881De'
+const SPCX = '0x4a0E65A3EcceC6dBe60AE065F2e7bb85Fae35eEa'
+
+module.exports = {
+  methodology:
+    'TVL is the protocol treasury (SpcxController): native ETH accumulated from the swap tax forming the standing SPCX bid, plus SPCX (Robinhood tokenized SpaceX stock) acquired by the flywheel and listed for resale.',
+  start: '2026-07-20',
+  robinhood: {
+    tvl: sumTokensExport({ owner: CONTROLLER, tokens: [ADDRESSES.null, SPCX] }),
+  },
+}


### PR DESCRIPTION
## Project info

- **Name:** StockWorks
- **Token:** SPCXSTR — `0xEE236D1c14C9AC8546D9Aeec32fEC275FB00C402` (Robinhood Chain, chainId 4663)
- **Website:** https://stockworks.fun
- **Twitter:** https://x.com/stock_works
- **Logo:** https://stockworks.fun/logo-256.png
- **Category:** Treasury Manager (comparable: PunkStrategy)
- **Chain:** robinhood (already supported)

## What it does

Stock-token strategy flywheel on Robinhood Chain: a 10% pool-level swap tax (Uniswap v4 hook) accumulates ETH in the SpcxController treasury, which runs a standing Chainlink-capped bid for SPCX (Robinhood tokenized SpaceX stock), relists acquisitions at a premium, and burns SPCXSTR with 100% of sale proceeds.

## Methodology

TVL = the SpcxController treasury (`0x57024Aae99f709Bd399252767DDC6487Aa3881De`): native ETH (the standing SPCX bid) + SPCX held/listed for resale. The protocol's own token (SPCXSTR) is never counted.

Pre-verified before submitting: both assets price on coins.llama.fi (`robinhood:0x4a0E…5eEa` SPCX and native ETH, confidence 0.99). Controller is source-verified on Blockscout. Expected TVL at submission ≈ $31k and growing (launched 2026-07-20).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for StockWorks (SPCXSTR).
  * Added support for monitoring native and SPCX token balances through the Robinhood integration.
  * Included methodology and tracking start-date metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->