### PR TITLE
feat(peridot): add Stellar Soroban markets, move out of compound registry

### DIFF
--- a/projects/peridot/index.js
+++ b/projects/peridot/index.js
@@ -1,0 +1,34 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+const { compoundExports2 } = require('../helper/compound')
+const { callSoroban } = require('../helper/chain/stellar')
+
+// Peridot on Stellar is a Soroban deployment (not a Compound fork port): each market is a
+// ReceiptVault contract that custodies the underlying SAC and tracks its own debt ledger.
+// https://github.com/PeridotFinance/Peridot-Soroban/blob/main/peridot-contracts/contracts/receipt-vault/src/lib.rs
+const stellarMarkets = [
+  { vault: 'CBU4Y7CJFOUZZE3QBOXTKM54UTUYW3SDJWTNMDGJBNCR5HS5UCEKV3BE', underlying: ADDRESSES.stellar.XLM },
+  { vault: 'CBVUJJIJTRJNOORPPCVH72DP7YDCOMDHI6WYKP3WOFVEPSCVP3TBXHIN', underlying: ADDRESSES.stellar.USDC },
+  { vault: 'CD3WN3PLW63HFZXE56OTRLMBV46WG54TFPGRL4RDQ43HQTTWVB4RPO3G', underlying: ADDRESSES.stellar.EURC },
+]
+
+// Underlying sitting in the vault, i.e. the Soroban equivalent of Compound's getCash().
+async function stellarTvl(api) {
+  await Promise.all(stellarMarkets.map(async ({ vault, underlying }) => {
+    const cash = await callSoroban(underlying, 'balance', [vault])
+    api.add(underlying, cash.toString())
+  }))
+}
+
+async function stellarBorrowed(api) {
+  await Promise.all(stellarMarkets.map(async ({ vault, underlying }) => {
+    const borrowed = await callSoroban(vault, 'get_total_borrowed')
+    api.add(underlying, borrowed.toString())
+  }))
+}
+
+module.exports = {
+  methodology: 'TVL is the underlying held by the protocol: on BSC and Monad the cash of every Peridot market listed on the comptroller, on Stellar the underlying balance custodied by each Soroban ReceiptVault. Outstanding debt is reported separately as borrowed.',
+  bsc: compoundExports2({ comptroller: '0x6fC0c15531CB5901ac72aB3CFCd9dF6E99552e14' }),
+  monad: compoundExports2({ comptroller: '0x6D208789f0a978aF789A3C8Ba515749598940716', blacklistedMarkets: ['0xf8255935e62aa000c89de46a97d2f00bfff147e7'], cether: '0x2FB2861402A22244464435773dd1C6951735CdF7' }),
+  stellar: { tvl: stellarTvl, borrowed: stellarBorrowed },
+}

--- a/registries/compound.js
+++ b/registries/compound.js
@@ -52,11 +52,7 @@ const configs = {
       ],
     },
   },
-  'peridot': {
-    methodology: 'TVL is calculated by summing the underlying token balances of all markets in the Peridot lending protocol. Borrowed balances are also tracked separately.',
-    bsc: { comptroller: '0x6fC0c15531CB5901ac72aB3CFCd9dF6E99552e14' },
-    monad: { comptroller: '0x6D208789f0a978aF789A3C8Ba515749598940716', blacklistedMarkets: ['0xf8255935e62aa000c89de46a97d2f00bfff147e7'], cether: '0x2FB2861402A22244464435773dd1C6951735CdF7' },
-  },
+  // 'peridot' moved to projects/peridot/index.js: it also has non-Compound Soroban markets on Stellar
   'hover': {
     kava: { comptroller: '0x3A4Ec955a18eF6eB33025599505E7d404a4d59eC', cether: '0xb51eFaF2f7aFb8a2F5Be0b730281E414FB487636' },
   },


### PR DESCRIPTION
Peridot (already listed, id 7223) has a deployment on Stellar that this PR adds.

The Stellar markets are Soroban `ReceiptVault` contracts, not Compound `cToken` markets, so they cannot be expressed through `registries/compound.js` (a `stellar` key there would be passed to `compoundExports2`). This PR therefore moves the `peridot` key out of the compound registry into `projects/peridot/index.js`. The protocol's `module` in the DefiLlama config is already `peridot/index.js`, so no config change should be needed on your side.

The BSC and Monad config is carried over unchanged (same comptrollers, same `blacklistedMarkets` / `cether`), so their numbers are unaffected — verified below.

**Changed files**
- `projects/peridot/index.js` (new)
- `registries/compound.js` (`peridot` entry removed)

No dependency or lockfile changes.

### Stellar methodology

TVL is the underlying custodied by each of the three ReceiptVaults (XLM, USDC, EURC), read on-chain with `callSoroban(underlying, 'balance', [vault])` via `helper/chain/stellar` — the Soroban equivalent of Compound's `getCash()`. Outstanding debt is read from the vault's `get_total_borrowed()` and reported in the separate `borrowed` bucket, not in TVL.

Note: the vault also exposes `get_total_underlying()` (cash + borrows + accrued interest − reserves − fees). That is deliberately **not** used — it counts accrued interest that is not backed by assets in the vault, which would overstate TVL.

### Validation

`node test.js projects/peridot/index.js`

```
bsc                       324.00
bsc-borrowed              11.32 k
monad                     738.00
monad-borrowed            491.00
stellar                   264.00
stellar-borrowed          1.00

total                     1.32 k
```

BSC and Monad match the values currently reported on https://defillama.com/protocol/peridot (Binance 323.12, Monad 733.57), i.e. no regression from the registry → folder move.

Stellar per-market breakdown: USDC 117.19, EURC 124.83, XLM 20.02. TVL there is small today (~$264) because the deployment is new; the three vaults are live and in production use.

### Contracts (Stellar mainnet)

| Market | ReceiptVault | Underlying (SAC) |
| --- | --- | --- |
| XLM | `CBU4Y7CJFOUZZE3QBOXTKM54UTUYW3SDJWTNMDGJBNCR5HS5UCEKV3BE` | `ADDRESSES.stellar.XLM` |
| USDC | `CBVUJJIJTRJNOORPPCVH72DP7YDCOMDHI6WYKP3WOFVEPSCVP3TBXHIN` | `ADDRESSES.stellar.USDC` |
| EURC | `CD3WN3PLW63HFZXE56OTRLMBV46WG54TFPGRL4RDQ43HQTTWVB4RPO3G` | `ADDRESSES.stellar.EURC` |

Contract source: https://github.com/PeridotFinance/Peridot-Soroban (vault: `peridot-contracts/contracts/receipt-vault/src/lib.rs`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL and borrowed-value tracking for Peridot markets on Stellar.
  * Added Peridot coverage for BSC and Monad, including chain-specific market configuration.
  * Consolidated Peridot’s cross-chain methodology and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->