### PR TITLE
Add Ammalgam TVL adapter

### DIFF
--- a/projects/ammalgam/index.js
+++ b/projects/ammalgam/index.js
@@ -1,10 +1,6 @@
 const FACTORY = '0x1a411b0fd1f368d2f413a8cbb6aad425c923015b'
-const VAULTS = [
-  '0x8417430a31851ae0a36a854394227c5d86be8fc9', // USDC
-  '0xbb211be8664128e30c6adcd5998eca9592be272f', // WETH
-]
 
-async function tvl(api) {
+async function getPairData(api) {
   const pairs = await api.fetchList({
     target: FACTORY,
     lengthAbi: 'uint256:allPairsLength',
@@ -14,18 +10,32 @@ async function tvl(api) {
     abi: 'function underlyingTokens() view returns (address, address)',
     calls: pairs,
   })
+  return { pairs, underlyingTokens }
+}
+
+async function tvl(api) {
+  const { pairs, underlyingTokens } = await getPairData(api)
   const tokensAndOwners = pairs.flatMap((pair, i) =>
     underlyingTokens[i].map(token => [token, pair]))
+  return api.sumTokens({ tokensAndOwners })
+}
 
-  await api.sumTokens({ tokensAndOwners })
-  return api.erc4626Sum({
-    calls: VAULTS,
-    tokenAbi: 'address:asset',
-    balanceAbi: 'uint256:totalAssets',
+async function borrowed(api) {
+  const { pairs, underlyingTokens } = await getPairData(api)
+  // totalAssetsAndShares returns 6 token types: [depositL, depositX, depositY, borrowL, borrowX, borrowY]
+  // borrowX/borrowY (indices 4/5) are the borrowed amounts of the two underlying tokens.
+  const allAssets = await api.multiCall({
+    abi: 'function totalAssetsAndShares(bool withInterest) view returns (uint112[6] allAssets, uint112[6] allShares)',
+    calls: pairs.map(pair => ({ target: pair, params: [true] })),
+  })
+  pairs.forEach((_, i) => {
+    const [tokenX, tokenY] = underlyingTokens[i]
+    api.add(tokenX, allAssets[i].allAssets[4])
+    api.add(tokenY, allAssets[i].allAssets[5])
   })
 }
 
 module.exports = {
-  methodology: 'Counts the underlying token balances held by every pair created by the Ammalgam factory and the reported total assets of the Ammalgam USDC and WETH vaults. Assets borrowed out of the pairs are excluded from TVL.',
-  ethereum: { tvl },
+  methodology: 'TVL counts the underlying token balances held by every pair created by the Ammalgam factory. Borrowed counts the assets borrowed out of the pairs.',
+  ethereum: { tvl, borrowed },
 }

--- a/projects/ammalgam/index.js
+++ b/projects/ammalgam/index.js
@@ -1,0 +1,31 @@
+const FACTORY = '0x1a411b0fd1f368d2f413a8cbb6aad425c923015b'
+const VAULTS = [
+  '0x8417430a31851ae0a36a854394227c5d86be8fc9', // USDC
+  '0xbb211be8664128e30c6adcd5998eca9592be272f', // WETH
+]
+
+async function tvl(api) {
+  const pairs = await api.fetchList({
+    target: FACTORY,
+    lengthAbi: 'uint256:allPairsLength',
+    itemAbi: 'function allPairs(uint256) view returns (address)',
+  })
+  const underlyingTokens = await api.multiCall({
+    abi: 'function underlyingTokens() view returns (address, address)',
+    calls: pairs,
+  })
+  const tokensAndOwners = pairs.flatMap((pair, i) =>
+    underlyingTokens[i].map(token => [token, pair]))
+
+  await api.sumTokens({ tokensAndOwners })
+  return api.erc4626Sum({
+    calls: VAULTS,
+    tokenAbi: 'address:asset',
+    balanceAbi: 'uint256:totalAssets',
+  })
+}
+
+module.exports = {
+  methodology: 'Counts the underlying token balances held by every pair created by the Ammalgam factory and the reported total assets of the Ammalgam USDC and WETH vaults. Assets borrowed out of the pairs are excluded from TVL.',
+  ethereum: { tvl },
+}

--- a/registries/erc4626.js
+++ b/registries/erc4626.js
@@ -387,7 +387,14 @@ const configs = {
     base: ['0xeA8FB89F44A1fa47E52354D44E7e6D4682C8529a','0x87922c630A980e431fb045A178e53F58d3f07F85'],
     arbitrum: ['0x94f89d1E2825d40627CD2aE24Eba8590F675049C'],
     bsc: ['0x27DB5a2B203D6bd3C9490E8EA4488B968675f5Bf'],
-  }
+  },
+  'ammalgam-vaults': {
+    methodology: 'Counts the reported total assets of the Ammalgam USDC and WETH ERC-4626 vaults.',
+    ethereum: [
+      '0x8417430a31851ae0a36a854394227c5d86be8fc9', // USDC
+      '0xbb211be8664128e30c6adcd5998eca9592be272f', // WETH
+    ],
+  },
 }
 
 module.exports = buildProtocolExports(configs, erc4626ExportFn)


### PR DESCRIPTION
## Summary

Adds an Ethereum TVL adapter for Ammalgam.

The adapter:

- Discovers DLEX pairs on-chain through the Ammalgam factory.
- Counts the underlying token balances held by each pair.
- Excludes assets that have been borrowed out of the pairs.
- Includes the reported `totalAssets()` of the Ammalgam USDC and WETH vaults.
- Uses only on-chain contract calls and adds no dependencies.

## Testing

```text
pnpm exec eslint -c eslint.config.js projects/ammalgam/index.js
Exit code: 0
```

```text
node test.js projects/ammalgam/index.js

--- ethereum ---
WETH                      1.31 M
USDC                      154.70 k
Total: 1.46 M

--- tvl ---
WETH                      1.31 M
USDC                      154.70 k
Total: 1.46 M

------ TVL ------
ethereum                  1.46 M

total                     1.46 M
```

## New listing details

##### Name (to be shown on DefiLlama):

Ammalgam

##### Twitter Link:

https://x.com/ammalgam

##### List of audit links if any:

- https://cantina.xyz/competitions/02c29467-cb27-4beb-b2ef-500ad95e1a51
- https://drive.google.com/file/d/1p3MtFZslf7sDdCoR6HH-sC8p3g-wENRR/view
- https://0xmacro.notion.site/Ammalgam-1-Preliminary-Audit-Report-external-private-1ac72f2c7fd18016a750eafdc4739b59

##### Website Link:

https://ammalgam.xyz/

##### Logo (High resolution, will be shown with rounded borders):

https://avatars.githubusercontent.com/u/104873477?v=4

##### Current TVL:

Approximately $1.46M at the time of testing.

##### Treasury Addresses (if the protocol has treasury):

N/A

##### Chain:

Ethereum

##### Coingecko ID:

N/A - no protocol token is currently listed.

##### Coinmarketcap ID:

N/A - no protocol token is currently listed.

##### Short Description (to be shown on DefiLlama):

Ammalgam is a decentralized lending exchange that combines trading and lending in unified liquidity pools, allowing deposited liquidity to simultaneously support swaps and borrowing.

##### Token address and ticker if any:

N/A

##### Category:

Dexes

##### Oracle Provider(s):

The core DLEX is oracle-free and does not rely on an external price-oracle provider. The Ammalgam vaults use Lagoon ERC-7540 infrastructure, where a valuation manager proposes the vault NAV and the curator settles it on-chain.

##### Implementation Details:

The DLEX derives pricing and risk information from its own liquidity and pool state rather than external price feeds. For the managed vaults, the adapter reads the settled on-chain `totalAssets()` value reported by the Lagoon vault contracts.

##### Documentation/Proof:

- https://docs.ammalgam.xyz/
- https://github.com/Ammalgam-Protocol/core-v1
- https://github.com/Ammalgam-Protocol/docs/blob/main/docs/developer-guide/deployed-contracts.md
- https://docs.lagoon.finance/vault/vault-valuation
- https://app.lagoon.finance/vault/1/0x8417430a31851ae0a36a854394227c5d86be8fc9
- https://app.lagoon.finance/vault/1/0xbb211be8664128e30c6adcd5998eca9592be272f

##### forkedFrom:

No. Ammalgam's core DLEX is an original protocol. Its managed vault products use Lagoon's ERC-7540 vault infrastructure.

##### methodology:

TVL includes the underlying ERC-20 balances held by every pair created through the Ammalgam Ethereum factory, plus the settled `totalAssets()` reported by the Ammalgam USDC and WETH vaults. Assets borrowed out of DLEX pairs are excluded from TVL.

##### Github org/user:

https://github.com/Ammalgam-Protocol

##### Does this project have a referral program?

No known referral program.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Ethereum TVL tracking for Ammalgam using automatic discovery of all pair contracts from the factory.
  * Added a new Ammalgam **borrowed** metric derived from pairs’ reported total assets and shares.
  * Expanded ERC-4626 coverage with the Ammalgam vaults for **USDC** and **WETH**.
* **Documentation**
  * Updated methodology notes to describe how TVL and borrowed figures are calculated from on-chain pair data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->