### PR TITLE
morpho-blue: blacklist msY/USDC market and AZND tokens

### DIFF
--- a/projects/morpho-blue/index.js
+++ b/projects/morpho-blue/index.js
@@ -12,7 +12,8 @@ const config = {
       "0x8413D2a624A9fA8b6D3eC7b22CF7F62E55D6Bc83",
       ADDRESSES.base.USDC,
       ADDRESSES.optimism.WSTETH,
-      '0x84b78bc998e4b1a63f2cf9ebfe76c55fc96a5a9b'
+      '0x84b78bc998e4b1a63f2cf9ebfe76c55fc96a5a9b',
+      '0x52c66b5e7f8fde20843de900c5c8b4b0f23708a0' // AZND token used to artificially inflate Morpho total deposit metric
     ],
     fromBlock: 18883124,
     blacklistedMarketIds: [
@@ -31,6 +32,7 @@ const config = {
       "0x4b86442549b52826e0fc11770ec5154450cb3c5c14dc751a761d81dcfbe7a7b2", // RLP market
       "0xbd1ad3b968f5f0552dbd8cf1989a62881407c5cccf9e49fb3657c8731caf0c1f", // deUSD market
       "0xfd0d72a4f0469598b566b1bc5fe64835f828f90b1fb7d746148c086164cd4cc2", // AZND/USDC market, 0 liquidity and 1 borrower
+      "0x23a7d0ff682b323363fb8ba58327ed87001f6306e09b7fd7413bbe4698e749c8", // msY/USDC market
     ],
   },
   base: {
@@ -174,6 +176,7 @@ const config = {
   },
   monad: {
     morphoBlue: "0xD5D960E8C380B724a48AC59E2DfF1b2CB4a1eAee",
+    blackList: ['0x4917a5ec9fcb5e10f47cbb197abe6ab63be81fe8'], // AZND token used to artificially inflate Morpho total deposit metric
     fromBlock: 31907457,
   },
   stable: {


### PR DESCRIPTION
Syncs the Morpho Blue adapter with Morpho's internal excluded-markets and excluded-assets lists. This is a follow-up to #19553; most prior entries are already upstream, so this only adds the 3 remaining entries not yet reflected in the adapter.

### Changes
- **ethereum** — blacklist `msY/USDC` market `0x23a7d0ff682b323363fb8ba58327ed87001f6306e09b7fd7413bbe4698e749c8`
- **ethereum** — blacklist `AZND` token `0x52c66b5e7f8fde20843de900c5c8b4b0f23708a0` (used to artificially inflate the total deposit metric)
- **monad** — blacklist `AZND` token `0x4917a5ec9fcb5e10f47cbb197abe6ab63be81fe8` (used to artificially inflate the total deposit metric)

Configuration-only change; `node --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated token and market exclusions to improve the accuracy of Morpho deposit metrics across Ethereum and Monad.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->