### PR TITLE
feat: add AZVerse TVL adapter

### DIFF
--- a/projects/azverse/index.js
+++ b/projects/azverse/index.js
@@ -1,0 +1,47 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+const { sumTokensExport } = require('../helper/sumTokens')
+
+const custodyWallets = [
+  '0x03a7e58745874d49b3acc770c40261a3ce206608',
+  '0xc2a290eceac480f057b6e7b45a7a949535e478ce',
+  '0xdc379823a9a3a2ca9d77c33299551ecdbabf7a41',
+]
+
+const assetVault = '0x91ba525861c16aa8cd4d6974e4058cc846f42ebe'
+
+const configs = {
+  arbitrum: {
+    owners: [assetVault, ...custodyWallets],
+    tokens: [
+      ADDRESSES.null,
+      '0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9',
+      '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+    ],
+  },
+  ethereum: {
+    owners: custodyWallets,
+    tokens: [ADDRESSES.null, ADDRESSES.ethereum.USDT, ADDRESSES.ethereum.USDC],
+  },
+  bsc: {
+    owners: custodyWallets,
+    tokens: [ADDRESSES.null, ADDRESSES.bsc.USDT, ADDRESSES.bsc.USDC],
+  },
+  berachain: {
+    owners: custodyWallets,
+    tokens: ['0x779ded0c9e1022225f8e0630b35a9b54be713736'],
+  },
+}
+
+async function tvl(api) {
+  return api.sumTokens(configs[api.chain])
+}
+
+for (const chain of Object.keys(configs)) {
+  module.exports[chain] = { tvl }
+}
+
+module.exports.bitcoin = {
+  tvl: sumTokensExport({ owners: ['13JJtAGYdjYdHiqBcs9zAy95aWzvbW4Nx6'] }),
+}
+
+module.exports.methodology = 'Counts supported assets in AZVerse’s Arbitrum Asset Vault and third-party qualified-custodian wallets, plus BTC in the designated Bitcoin hot wallet.'


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
  AZverse

  ##### Twitter Link:
  https://x.com/AZverse_Global

  ##### Website Link:
  https://www.azverse.xyz

  ##### Treasury Addresses (if the protocol has treasury)
  N/A — the adapter tracks an operational Asset Vault and qualified-
  custodian wallets, not protocol treasury addresses.

  ##### Chain:
  Arbitrum, Ethereum, BSC, Berachain, Bitcoin

  ##### Short Description (to be shown on DefiLlama):
  AZverse is a DEX infrastructure protocol providing shared liquidity
  and a trading engine for DEX builders.

  ##### Token address and ticker if any:
  None

  ##### Category (full list at https://defillama.com/categories)
  *Please choose only one:
  CeDeFi

  ##### methodology (what is being counted as tvl, how is tvl being
  calculated):
  Counts supported USDT, USDC, and native assets held in AZverse’s
  verified Arbitrum Asset Vault and designated third-party qualified-
  custodian wallets across Arbitrum, Ethereum, BSC, and Berachain,
  plus native BTC held in the designated Bitcoin hot wallet. Only the
  specified supported assets are counted.

  ##### Github org/user (Optional, if your code is open source, we can
  track activity):
  https://github.com/AZVerses/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for supported assets across multiple networks.
  * Added separate Bitcoin TVL reporting for the designated hot wallet.
  * Added methodology details describing which assets are included in calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->