### PR TITLE
Add Poppie curator adapter

### DIFF
--- a/registries/curators.js
+++ b/registries/curators.js
@@ -626,6 +626,18 @@ const configs = {
       }
     },
   },
+  "poppie": {
+    config: {
+      methodology: 'Count all assets deposited in Euler vaults curated by Poppie.',
+      blockchains: {
+        bsc: {
+          eulerVaultOwners: [
+            '0xf4d92bC8006836132364B355DB9CfF204466ABc3',
+          ],
+        },
+      },
+    },
+  },
   "re7": {
     config: {
       methodology: 'Count all assets are deposited in all vaults curated by Re7 Labs.',


### PR DESCRIPTION
## Summary

Adds Poppie's BSC Euler V2 vault cluster to the risk-curator registry. The adapter discovers the vaults created by Poppie's deployment EOA and sums their ERC-4626 `totalAssets()` values.

Validation: `node test.js poppie` returns approximately $141.5k TVL across the live BSC vaults.

## New listing

##### Name (to be shown on DefiLlama):
Poppie

##### Twitter Link:
https://x.com/poppiefinance

##### List of audit links if any:
https://github.com/gfx-labs/poppie-oracle/blob/main/audit/poppie-oracle-june-2026-preliminary.pdf

##### Website Link:
https://poppie.io

##### Logo (High resolution, will be shown with rounded borders):
Light SVG: https://poppie.io/landing/poppielogo.svg
Dark SVG: https://poppie.io/landing/poppielogo-dark.svg

##### Current TVL:
Approximately $141.5k at submission, derived from this adapter.

##### Treasury Addresses (if the protocol has treasury)
N/A

##### Chain:
BSC

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):
N/A

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):
N/A

##### Short Description (to be shown on DefiLlama):
A decentralized lending market for borrowing USDT against tokenized equities on BNB Smart Chain.

##### Token address and ticker if any:
N/A

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Lending

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
Poppie\/Chainlink

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
Poppie's oracle adapter writes validated price updates for Ondo tokenized-equity collateral; the Euler oracle router resolves vault prices through this adapter. The borrow asset, USDT, uses a fixed 1:1 USD rate oracle.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
https://github.com/gfx-labs/poppie-oracle
https://poppie.io/landing/docs/

##### forkedFrom (Does your project originate from another project):
Euler V2

##### methodology (what is being counted as tvl, how is tvl being calculated):
The adapter discovers Poppie's Euler vaults from the BSC Euler vault factory using Poppie's deployment EOA as the recorded creator, then sums each vault's ERC-4626 `totalAssets()` by underlying asset.

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/gfx-labs

##### Does this project have a referral program?
No



## Summary by CodeRabbit

* **New Features**
  * Added support for the Poppie protocol.
  * Added configuration for tracking Euler vault owners on BSC.