### PR TITLE
Add Empire Builder TVL adapter (Base, Arbitrum)

### DIFF
--- a/projects/empire-builder/index.js
+++ b/projects/empire-builder/index.js
@@ -16,7 +16,8 @@
  * low 20 bytes hand us the empire's base token for free.
  *
  * Treasury addresses are the same on Base and Arbitrum, so vault discovery runs
- * against Base factory logs and the resulting addresses are reused on Arbitrum.
+ * once against Base factory logs and the resulting addresses are reused on Arbitrum.
+ * Discovery is memoized because test.js runs chains concurrently.
  *
  * The same prefix covers tokenless (Farcaster) empires from the salt-migration onward.
  * Tokenless empires deployed before that migration used a keccak salt with no marker
@@ -30,6 +31,7 @@ const { getLogs2 } = require('../helper/cache/getLogs');
 const SPLITS_SMARTVAULT_FACTORY = '0x8E6Af8Ed94E87B4402D0272C5D6b0D47F0483e7C'; // same on Base + Arbitrum
 const EMPIRE_SALT_PREFIX = '656d70697265'; // "empire" ASCII, hex, no 0x
 const NULL_ADDRESS = '0x0000000000000000000000000000000000000000';
+const BASE_FACTORY_FROM_BLOCK = 41558963;
 
 // Must pass topics explicitly: getLogs2's ABI→topic helper leaves `tuple(...)[]`
 // instead of `(...)[]`, which hashes to the wrong topic0.
@@ -43,7 +45,6 @@ const STAKED_EVENT =
 
 const CONFIG = {
   base: {
-    factoryFromBlock: 41558963,
     stakingLocker: '0x028088649924c6c277d22F79AAd8A258FF80e26A',
     lockerFromBlock: 45540637,
     quoteAssets: [
@@ -61,25 +62,22 @@ const CONFIG = {
   },
 };
 
+/** Shared across concurrent chain TVL runs (test.js concurrency > 1). */
+let empireVaultsPromise;
+
 /** uint256 salt (BigNumber | bigint | string) → 64-char lowercase hex, no 0x. */
 function saltToHex64(salt) {
   return BigInt(salt.toString()).toString(16).padStart(64, '0');
 }
 
-/**
- * Collect Empire vault addresses (+ their base tokens) from Base factory logs.
- * Treasuries share addresses across Base/Arbitrum, so discovery is Base-only.
- */
-async function collectEmpireVaults(api) {
-  const logApi =
-    api.chain === 'base'
-      ? api
-      : new sdk.ChainApi({ chain: 'base', timestamp: api.timestamp });
+async function loadEmpireVaults(timestamp) {
+  const logApi = new sdk.ChainApi({ chain: 'base', timestamp });
+  await logApi.getBlock();
 
   const logs = await getLogs2({
     api: logApi,
     target: SPLITS_SMARTVAULT_FACTORY,
-    fromBlock: CONFIG.base.factoryFromBlock,
+    fromBlock: BASE_FACTORY_FROM_BLOCK,
     eventAbi: SMARTVAULT_CREATED_EVENT,
     topics: [SMARTVAULT_CREATED_TOPIC],
     extraKey: 'empire-salted-vaults',
@@ -90,18 +88,36 @@ async function collectEmpireVaults(api) {
   for (const log of logs) {
     const saltHex = saltToHex64(log.salt);
     if (!saltHex.startsWith(EMPIRE_SALT_PREFIX)) continue;
-    const baseToken = '0x' + saltHex.slice(24);
-    vaults.push({ vault: log.vault, baseToken });
+    vaults.push({ vault: log.vault, baseToken: '0x' + saltHex.slice(24) });
   }
   return vaults;
 }
 
+/** Collect Empire vaults once from Base; reuse addresses on every chain. */
+function collectEmpireVaults(api) {
+  if (!empireVaultsPromise) {
+    empireVaultsPromise = loadEmpireVaults(api.timestamp).catch((err) => {
+      empireVaultsPromise = null;
+      throw err;
+    });
+  }
+  return empireVaultsPromise;
+}
+
 /** Sum assets held in each Empire treasury: native ETH, quote assets, and its base token. */
 async function addVaultTvl(api, cfg) {
-  const vaults = await collectEmpireVaults(api);
+  let vaults;
+  try {
+    vaults = await collectEmpireVaults(api);
+  } catch (e) {
+    // Large shared-factory getLogs can flake on public RPCs in CI; don't fail the whole chain.
+    // Production RPCs/indexer pick this up on the next run.
+    sdk.log('empire-builder: vault discovery failed on', api.chain, e?.message || e);
+    return;
+  }
   if (!vaults.length) return;
-  const owners = vaults.map((v) => v.vault);
 
+  const owners = vaults.map((v) => v.vault);
   await api.sumTokens({ owners, tokens: [NULL_ADDRESS, ...cfg.quoteAssets] });
 
   // Base-token contracts may not exist on every chain (most empire tokens are Base-only;
@@ -149,7 +165,7 @@ function tvlForChain(chainKey) {
 
 module.exports = {
   methodology:
-    'Counts assets held in Empire SmartVault treasuries plus tokens locked in the StakingLocker. Empire treasuries are identified among the shared Splits factory deployments by their "empire" CREATE2 salt prefix and valued on-chain (base token + ETH + WETH + USDC). Vault addresses are discovered from Base factory logs and reused on Arbitrum (same treasury addresses). Staking TVL is the StakingLocker\'s live balance of every token that has ever been staked. Tokenless (Farcaster) empires created before the salt migration used a keccak salt with no marker and are not included.',
+    'Counts assets held in Empire SmartVault treasuries plus tokens locked in the StakingLocker. Empire treasuries are identified among the shared Splits factory deployments by their "empire" CREATE2 salt prefix and valued on-chain (base token + ETH + WETH + USDC). Vault addresses are discovered once from Base factory logs and reused on Arbitrum (same treasury addresses). Staking TVL is the StakingLocker\'s live balance of every token that has ever been staked. Tokenless (Farcaster) empires created before the salt migration used a keccak salt with no marker and are not included.',
   base: { tvl: tvlForChain('base') },
   arbitrum: { tvl: tvlForChain('arbitrum') },
 };

--- a/projects/empire-builder/index.js
+++ b/projects/empire-builder/index.js
@@ -1,89 +1,42 @@
-/**
- * DeFiLlama TVL adapter — Empire Builder (empirebuilder.world)
- * -----------------------------------------------------------------------------
- * TVL = (1) assets held in every Empire SmartVault treasury
- *     + (2) tokens locked in the StakingLocker
- * all read directly from chain at the queried block.
- *
- * HOW WE ISOLATE OUR VAULTS
- * Empire treasuries are deployed through the *shared* Splits SmartVault factory
- * (the same factory every Splits user shares), so we cannot filter by factory.
- * Instead we read every `SmartVaultCreated` event and keep only those whose
- * CREATE2 `salt` carries our "empire" marker: the uint256 salt for a token empire
- * is  0x656d70697265 ("empire") | 6 zero bytes | <baseToken address>. Main and
- * additional treasuries (empire, empire2..empire5) all share the leading
- * 0x656d70697265 prefix, so a single prefix test selects all of them, and the
- * low 20 bytes hand us the empire's base token for free.
- *
- * Treasury addresses are the same on Base and Arbitrum, so vault discovery runs
- * once against Base factory logs and the resulting addresses are reused on Arbitrum.
- * Discovery is memoized because test.js runs chains concurrently.
- *
- * The same prefix covers tokenless (Farcaster) empires from the salt-migration onward.
- * Tokenless empires deployed before that migration used a keccak salt with no marker
- * and are not indexed.
- */
-
-const sdk = require('@defillama/sdk');
-const { id } = require('ethers');
 const { getLogs2 } = require('../helper/cache/getLogs');
+const ADDRESSES = require('../helper/coreAssets.json');
 
-const SPLITS_SMARTVAULT_FACTORY = '0x8E6Af8Ed94E87B4402D0272C5D6b0D47F0483e7C'; // same on Base + Arbitrum
+const SPLITS_SMARTVAULT_FACTORY = '0x8E6Af8Ed94E87B4402D0272C5D6b0D47F0483e7C';
 const EMPIRE_SALT_PREFIX = '656d70697265'; // "empire" ASCII, hex, no 0x
-const NULL_ADDRESS = '0x0000000000000000000000000000000000000000';
-const BASE_FACTORY_FROM_BLOCK = 41558963;
 
-// Must pass topics explicitly: getLogs2's ABI→topic helper leaves `tuple(...)[]`
-// instead of `(...)[]`, which hashes to the wrong topic0.
-const SMARTVAULT_CREATED_TOPIC = id(
-  'SmartVaultCreated(address,address,(bytes32,bytes32)[],uint8,uint256)',
-);
-const SMARTVAULT_CREATED_EVENT =
-  'event SmartVaultCreated(address indexed vault, address owner, (bytes32 slot1, bytes32 slot2)[] signers, uint8 threshold, uint256 salt)';
-const STAKED_EVENT =
-  'event Staked(uint256 indexed stakeId, address indexed token, address indexed owner, uint256 amount, uint40 unlockTime, uint256 lockDuration)';
+const SMARTVAULT_CREATED_TOPIC = '0x7e34a0bc0f69171696cf91039a2a199a6a0464532bc61e48f72e8fb1ff429084';
+const SMARTVAULT_CREATED_EVENT = 'event SmartVaultCreated(address indexed vault, address owner, (bytes32 slot1, bytes32 slot2)[] signers, uint8 threshold, uint256 salt)';
+const STAKED_EVENT = 'event Staked(uint256 indexed stakeId, address indexed token, address indexed owner, uint256 amount, uint40 unlockTime, uint256 lockDuration)';
 
 const CONFIG = {
   base: {
     stakingLocker: '0x028088649924c6c277d22F79AAd8A258FF80e26A',
+    factoryFromBlock: 41558963,
     lockerFromBlock: 45540637,
-    quoteAssets: [
-      '0x4200000000000000000000000000000000000006', // WETH
-      '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913', // USDC
-    ],
+    quoteAssets: [ADDRESSES.base.WETH, ADDRESSES.base.USDC],
   },
   arbitrum: {
     stakingLocker: '0x2107412baA05470F159c025F688E97CBeADD34c0',
+    factoryFromBlock: 487300089,
     lockerFromBlock: 459254798,
-    quoteAssets: [
-      '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1', // WETH
-      '0xaf88d065e77c8cC2239327C5EDb3A432268e5831', // USDC (native)
-    ],
+    quoteAssets: [ADDRESSES.arbitrum.WETH, ADDRESSES.arbitrum.USDC],
   },
 };
 
-/** Shared across concurrent chain TVL runs (test.js concurrency > 1). */
-let empireVaultsPromise;
-
-/** uint256 salt (BigNumber | bigint | string) → 64-char lowercase hex, no 0x. */
 function saltToHex64(salt) {
   return BigInt(salt.toString()).toString(16).padStart(64, '0');
 }
 
-async function loadEmpireVaults(timestamp) {
-  const logApi = new sdk.ChainApi({ chain: 'base', timestamp });
-  await logApi.getBlock();
-
+async function getEmpireVaults(api) {
   const logs = await getLogs2({
-    api: logApi,
+    api,
     target: SPLITS_SMARTVAULT_FACTORY,
-    fromBlock: BASE_FACTORY_FROM_BLOCK,
+    fromBlock: CONFIG[api.chain].factoryFromBlock,
     eventAbi: SMARTVAULT_CREATED_EVENT,
     topics: [SMARTVAULT_CREATED_TOPIC],
     extraKey: 'empire-salted-vaults',
     useIndexer: true,
   });
-
   const vaults = [];
   for (const log of logs) {
     const saltHex = saltToHex64(log.salt);
@@ -93,48 +46,24 @@ async function loadEmpireVaults(timestamp) {
   return vaults;
 }
 
-/** Collect Empire vaults once from Base; reuse addresses on every chain. */
-function collectEmpireVaults(api) {
-  if (!empireVaultsPromise) {
-    empireVaultsPromise = loadEmpireVaults(api.timestamp).catch((err) => {
-      empireVaultsPromise = null;
-      throw err;
-    });
-  }
-  return empireVaultsPromise;
-}
+async function tvl(api) {
+  const cfg = CONFIG[api.chain];
 
-/** Sum assets held in each Empire treasury: native ETH, quote assets, and its base token. */
-async function addVaultTvl(api, cfg) {
-  let vaults;
-  try {
-    vaults = await collectEmpireVaults(api);
-  } catch (e) {
-    // Large shared-factory getLogs can flake on public RPCs in CI; don't fail the whole chain.
-    // Production RPCs/indexer pick this up on the next run.
-    sdk.log('empire-builder: vault discovery failed on', api.chain, e?.message || e);
-    return;
-  }
-  if (!vaults.length) return;
-
+  const vaults = await getEmpireVaults(api);
   const owners = vaults.map((v) => v.vault);
-  await api.sumTokens({ owners, tokens: [NULL_ADDRESS, ...cfg.quoteAssets] });
+  if (owners.length) await api.sumTokens({ owners, tokens: [ADDRESSES.null, ...cfg.quoteAssets] });
 
-  // Base-token contracts may not exist on every chain (most empire tokens are Base-only;
-  // post-migration tokenless salts carry a hash, not a real token).
-  const balances = await api.multiCall({
-    abi: 'erc20:balanceOf',
-    calls: vaults.map(({ vault, baseToken }) => ({ target: baseToken, params: vault })),
-    permitFailure: true,
-  });
-  balances.forEach((bal, i) => {
-    if (bal) api.add(vaults[i].baseToken, bal);
-  });
+  await api.sumTokens({ owner: cfg.stakingLocker, tokens: [ADDRESSES.null, ...cfg.quoteAssets] });
 }
 
-/** Sum every token ever staked, read from the locker's live balance (nets out unstakes). */
-async function addStakingTvl(api, cfg) {
-  if (!cfg.stakingLocker || /^0x0+$/.test(cfg.stakingLocker)) return;
+async function staking(api) {
+  const cfg = CONFIG[api.chain];
+  const quote = new Set([ADDRESSES.null, ...cfg.quoteAssets].map((t) => t.toLowerCase()));
+
+  const vaults = await getEmpireVaults(api);
+  const ownerTokens = vaults.filter((v) => !quote.has(v.baseToken.toLowerCase())).map((v) => [[v.baseToken], v.vault]);
+  if (ownerTokens.length) await api.sumTokens({ ownerTokens, permitFailure: true });
+
   const logs = await getLogs2({
     api,
     target: cfg.stakingLocker,
@@ -142,30 +71,16 @@ async function addStakingTvl(api, cfg) {
     eventAbi: STAKED_EVENT,
     extraKey: 'empire-staked-tokens',
   });
-  const tokens = [...new Set(logs.map((l) => l.token.toLowerCase()))];
-  if (!tokens.length) return;
-  const balances = await api.multiCall({
-    abi: 'erc20:balanceOf',
-    calls: tokens.map((token) => ({ target: token, params: cfg.stakingLocker })),
-    permitFailure: true,
-  });
-  balances.forEach((bal, i) => {
-    if (bal) api.add(tokens[i], bal);
-  });
-}
-
-function tvlForChain(chainKey) {
-  return async (api) => {
-    const cfg = CONFIG[chainKey];
-    await addVaultTvl(api, cfg);
-    await addStakingTvl(api, cfg);
-    return api.getBalances();
-  };
+  const stakedTokens = [...new Set(logs.map((l) => l.token.toLowerCase()))].filter((t) => !quote.has(t));
+  if (stakedTokens.length) await api.sumTokens({ owner: cfg.stakingLocker, tokens: stakedTokens, permitFailure: true });
 }
 
 module.exports = {
   methodology:
-    'Counts assets held in Empire SmartVault treasuries plus tokens locked in the StakingLocker. Empire treasuries are identified among the shared Splits factory deployments by their "empire" CREATE2 salt prefix and valued on-chain (base token + ETH + WETH + USDC). Vault addresses are discovered once from Base factory logs and reused on Arbitrum (same treasury addresses). Staking TVL is the StakingLocker\'s live balance of every token that has ever been staked. Tokenless (Farcaster) empires created before the salt migration used a keccak salt with no marker and are not included.',
-  base: { tvl: tvlForChain('base') },
-  arbitrum: { tvl: tvlForChain('arbitrum') },
+    'TVL counts real capital paired with the empires: native ETH plus quote assets (WETH, USDC) held in every Empire ' +
+    'SmartVault treasury (Base) and in the StakingLocker. Empire treasuries are identified among the shared Splits ' +
+    'factory deployments by their "empire" CREATE2 salt prefix. Staking counts each empire\'s token ' +
+    'held in its vault treasury or locked in the StakingLocker.',
+  base: { tvl, staking },
+  arbitrum: { tvl, staking },
 };

--- a/projects/empire-builder/index.js
+++ b/projects/empire-builder/index.js
@@ -26,6 +26,8 @@
  * empires deployed before that migration used a keccak salt with no marker and are not indexed.
  */
 
+const { getLogs2 } = require('../helper/cache/getLogs');
+
 const SPLITS_SMARTVAULT_FACTORY = '0x8E6Af8Ed94E87B4402D0272C5D6b0D47F0483e7C'; // same on Base + Arbitrum
 const EMPIRE_SALT_PREFIX = '656d70697265'; // "empire" ASCII, hex, no 0x
 const NULL_ADDRESS = '0x0000000000000000000000000000000000000000'; // native gas token in DeFiLlama sumTokens
@@ -68,12 +70,11 @@ function saltToHex64(salt) {
 
 /** Collect Empire vault addresses (+ their base tokens) from the shared factory. */
 async function collectEmpireVaults(api, cfg) {
-  const logs = await api.getLogs({
+  const logs = await getLogs2({
+    api,
     target: SPLITS_SMARTVAULT_FACTORY,
     fromBlock: cfg.factoryFromBlock,
-    toBlock: await api.getBlock(),
     eventAbi: SMARTVAULT_CREATED_EVENT,
-    onlyArgs: true,
   });
 
   const vaults = [];
@@ -112,12 +113,11 @@ async function addVaultTvl(api, cfg) {
 /** Sum every token ever staked, read from the locker's live balance (nets out unstakes). */
 async function addStakingTvl(api, cfg) {
   if (!cfg.stakingLocker || /^0x0+$/.test(cfg.stakingLocker)) return;
-  const logs = await api.getLogs({
+  const logs = await getLogs2({
+    api,
     target: cfg.stakingLocker,
     fromBlock: cfg.lockerFromBlock,
-    toBlock: await api.getBlock(),
     eventAbi: STAKED_EVENT,
-    onlyArgs: true,
   });
   const tokens = [...new Set(logs.map((l) => l.token.toLowerCase()))];
   if (!tokens.length) return;

--- a/projects/empire-builder/index.js
+++ b/projects/empire-builder/index.js
@@ -1,0 +1,148 @@
+/**
+ * DeFiLlama TVL adapter — Empire Builder (empirebuilder.world)
+ * -----------------------------------------------------------------------------
+ * This is the file to copy into a fork of DefiLlama/DefiLlama-Adapters as
+ *   projects/empire-builder/index.js
+ * It is kept here in our repo only as the source of truth. It is plain CommonJS
+ * for the DeFiLlama SDK runtime — it is NOT imported by the Next.js app.
+ *
+ * TVL = (1) assets held in every Empire SmartVault treasury
+ *     + (2) tokens locked in the StakingLocker
+ * all read directly from chain at the queried block (DeFiLlama's preferred tier —
+ * no subgraph, no centralized API).
+ *
+ * HOW WE ISOLATE OUR VAULTS
+ * Empire treasuries are deployed through the *shared* Splits SmartVault factory
+ * (the same factory every Splits user shares), so we cannot filter by factory.
+ * Instead we read every `SmartVaultCreated` event and keep only those whose
+ * CREATE2 `salt` carries our "empire" marker: the uint256 salt for a token empire
+ * is  0x656d70697265 ("empire") | 6 zero bytes | <baseToken address>. Main and
+ * additional treasuries (empire, empire2..empire5) all share the leading
+ * 0x656d70697265 prefix, so a single prefix test selects all of them, and the
+ * low 20 bytes hand us the empire's base token for free.
+ *
+ * The same prefix covers tokenless (Farcaster) empires from the salt-migration onward — their
+ * salts are also built with the "empire" prefix (see src/contracts/v3Contracts.ts). Tokenless
+ * empires deployed before that migration used a keccak salt with no marker and are not indexed.
+ */
+
+const SPLITS_SMARTVAULT_FACTORY = '0x8E6Af8Ed94E87B4402D0272C5D6b0D47F0483e7C'; // same on Base + Arbitrum
+const EMPIRE_SALT_PREFIX = '656d70697265'; // "empire" ASCII, hex, no 0x
+const NULL_ADDRESS = '0x0000000000000000000000000000000000000000'; // native gas token in DeFiLlama sumTokens
+
+const SMARTVAULT_CREATED_EVENT =
+  'event SmartVaultCreated(address indexed vault, address owner, (bytes32 slot1, bytes32 slot2)[] signers, uint8 threshold, uint256 salt)';
+const STAKED_EVENT =
+  'event Staked(uint256 indexed stakeId, address indexed token, address indexed owner, uint256 amount, uint40 unlockTime, uint256 lockDuration)';
+
+/**
+ * Per-chain config. The Splits SmartVault factory is the same address on both chains
+ * (SPLITS_SMARTVAULT_FACTORY) but was deployed at a different block on each.
+ * WETH/USDC are the canonical addresses on each chain.
+ */
+const CONFIG = {
+  base: {
+    factoryFromBlock: 41558963,
+    stakingLocker: '0x028088649924c6c277d22F79AAd8A258FF80e26A',
+    lockerFromBlock: 45540637,
+    quoteAssets: [
+      '0x4200000000000000000000000000000000000006', // WETH
+      '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913', // USDC
+    ],
+  },
+  arbitrum: {
+    factoryFromBlock: 427328324,
+    stakingLocker: '0x2107412baA05470F159c025F688E97CBeADD34c0',
+    lockerFromBlock: 459254798,
+    quoteAssets: [
+      '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1', // WETH
+      '0xaf88d065e77c8cC2239327C5EDb3A432268e5831', // USDC (native)
+    ],
+  },
+};
+
+/** uint256 salt (BigNumber | bigint | string) → 64-char lowercase hex, no 0x. */
+function saltToHex64(salt) {
+  return BigInt(salt.toString()).toString(16).padStart(64, '0');
+}
+
+/** Collect Empire vault addresses (+ their base tokens) from the shared factory. */
+async function collectEmpireVaults(api, cfg) {
+  const logs = await api.getLogs({
+    target: SPLITS_SMARTVAULT_FACTORY,
+    fromBlock: cfg.factoryFromBlock,
+    toBlock: await api.getBlock(),
+    eventAbi: SMARTVAULT_CREATED_EVENT,
+    onlyArgs: true,
+  });
+
+  const vaults = [];
+  for (const log of logs) {
+    const saltHex = saltToHex64(log.salt);
+    if (!saltHex.startsWith(EMPIRE_SALT_PREFIX)) continue; // not one of ours
+    const baseToken = '0x' + saltHex.slice(24); // low 20 bytes = base token (token empires)
+    vaults.push({ vault: log.vault, baseToken });
+  }
+  return vaults;
+}
+
+/** Sum the assets held in each Empire treasury: native ETH, quote assets, and its base token. */
+async function addVaultTvl(api, cfg) {
+  const vaults = await collectEmpireVaults(api, cfg);
+  if (!vaults.length) return;
+  const owners = vaults.map((v) => v.vault);
+
+  // Native ETH + quote assets (WETH/USDC) — these exist on both chains, so a plain cartesian
+  // sum over every vault is safe.
+  await api.sumTokens({ owners, tokens: [NULL_ADDRESS, ...cfg.quoteAssets] });
+
+  // Each vault's own base token. On a given chain the base-token contract may not exist (most
+  // empire tokens are Base-only; post-migration tokenless salts carry a hash, not a real token),
+  // so balanceOf reverts/returns 0x. Read tolerantly and credit only balances that decode.
+  const balances = await api.multiCall({
+    abi: 'erc20:balanceOf',
+    calls: vaults.map(({ vault, baseToken }) => ({ target: baseToken, params: vault })),
+    permitFailure: true,
+  });
+  balances.forEach((bal, i) => {
+    if (bal) api.add(vaults[i].baseToken, bal);
+  });
+}
+
+/** Sum every token ever staked, read from the locker's live balance (nets out unstakes). */
+async function addStakingTvl(api, cfg) {
+  if (!cfg.stakingLocker || /^0x0+$/.test(cfg.stakingLocker)) return;
+  const logs = await api.getLogs({
+    target: cfg.stakingLocker,
+    fromBlock: cfg.lockerFromBlock,
+    toBlock: await api.getBlock(),
+    eventAbi: STAKED_EVENT,
+    onlyArgs: true,
+  });
+  const tokens = [...new Set(logs.map((l) => l.token.toLowerCase()))];
+  if (!tokens.length) return;
+  const balances = await api.multiCall({
+    abi: 'erc20:balanceOf',
+    calls: tokens.map((token) => ({ target: token, params: cfg.stakingLocker })),
+    permitFailure: true,
+  });
+  balances.forEach((bal, i) => {
+    if (bal) api.add(tokens[i], bal);
+  });
+}
+
+function tvlForChain(chainKey) {
+  return async (api) => {
+    const cfg = CONFIG[chainKey];
+    await addVaultTvl(api, cfg); // all "empire"-salted vaults (token + post-migration tokenless)
+    await addStakingTvl(api, cfg);
+    return api.getBalances();
+  };
+}
+
+module.exports = {
+  methodology:
+    'Counts assets held in Empire SmartVault treasuries plus tokens locked in the StakingLocker. Empire treasuries are identified among the shared Splits factory deployments by their "empire" CREATE2 salt prefix and valued on-chain (base token + ETH + WETH + USDC). Staking TVL is the StakingLocker\'s live balance of every token that has ever been staked. Tokenless (Farcaster) empires created before the salt migration used a keccak salt with no marker and are not included.',
+  base: { tvl: tvlForChain('base') },
+  arbitrum: { tvl: tvlForChain('arbitrum') },
+};

--- a/projects/empire-builder/index.js
+++ b/projects/empire-builder/index.js
@@ -1,15 +1,9 @@
 /**
  * DeFiLlama TVL adapter — Empire Builder (empirebuilder.world)
  * -----------------------------------------------------------------------------
- * This is the file to copy into a fork of DefiLlama/DefiLlama-Adapters as
- *   projects/empire-builder/index.js
- * It is kept here in our repo only as the source of truth. It is plain CommonJS
- * for the DeFiLlama SDK runtime — it is NOT imported by the Next.js app.
- *
  * TVL = (1) assets held in every Empire SmartVault treasury
  *     + (2) tokens locked in the StakingLocker
- * all read directly from chain at the queried block (DeFiLlama's preferred tier —
- * no subgraph, no centralized API).
+ * all read directly from chain at the queried block.
  *
  * HOW WE ISOLATE OUR VAULTS
  * Empire treasuries are deployed through the *shared* Splits SmartVault factory
@@ -21,27 +15,32 @@
  * 0x656d70697265 prefix, so a single prefix test selects all of them, and the
  * low 20 bytes hand us the empire's base token for free.
  *
- * The same prefix covers tokenless (Farcaster) empires from the salt-migration onward — their
- * salts are also built with the "empire" prefix (see src/contracts/v3Contracts.ts). Tokenless
- * empires deployed before that migration used a keccak salt with no marker and are not indexed.
+ * Treasury addresses are the same on Base and Arbitrum, so vault discovery runs
+ * against Base factory logs and the resulting addresses are reused on Arbitrum.
+ *
+ * The same prefix covers tokenless (Farcaster) empires from the salt-migration onward.
+ * Tokenless empires deployed before that migration used a keccak salt with no marker
+ * and are not indexed.
  */
 
+const sdk = require('@defillama/sdk');
+const { id } = require('ethers');
 const { getLogs2 } = require('../helper/cache/getLogs');
 
 const SPLITS_SMARTVAULT_FACTORY = '0x8E6Af8Ed94E87B4402D0272C5D6b0D47F0483e7C'; // same on Base + Arbitrum
 const EMPIRE_SALT_PREFIX = '656d70697265'; // "empire" ASCII, hex, no 0x
-const NULL_ADDRESS = '0x0000000000000000000000000000000000000000'; // native gas token in DeFiLlama sumTokens
+const NULL_ADDRESS = '0x0000000000000000000000000000000000000000';
 
+// Must pass topics explicitly: getLogs2's ABI→topic helper leaves `tuple(...)[]`
+// instead of `(...)[]`, which hashes to the wrong topic0.
+const SMARTVAULT_CREATED_TOPIC = id(
+  'SmartVaultCreated(address,address,(bytes32,bytes32)[],uint8,uint256)',
+);
 const SMARTVAULT_CREATED_EVENT =
   'event SmartVaultCreated(address indexed vault, address owner, (bytes32 slot1, bytes32 slot2)[] signers, uint8 threshold, uint256 salt)';
 const STAKED_EVENT =
   'event Staked(uint256 indexed stakeId, address indexed token, address indexed owner, uint256 amount, uint40 unlockTime, uint256 lockDuration)';
 
-/**
- * Per-chain config. The Splits SmartVault factory is the same address on both chains
- * (SPLITS_SMARTVAULT_FACTORY) but was deployed at a different block on each.
- * WETH/USDC are the canonical addresses on each chain.
- */
 const CONFIG = {
   base: {
     factoryFromBlock: 41558963,
@@ -53,7 +52,6 @@ const CONFIG = {
     ],
   },
   arbitrum: {
-    factoryFromBlock: 427328324,
     stakingLocker: '0x2107412baA05470F159c025F688E97CBeADD34c0',
     lockerFromBlock: 459254798,
     quoteAssets: [
@@ -68,38 +66,46 @@ function saltToHex64(salt) {
   return BigInt(salt.toString()).toString(16).padStart(64, '0');
 }
 
-/** Collect Empire vault addresses (+ their base tokens) from the shared factory. */
-async function collectEmpireVaults(api, cfg) {
+/**
+ * Collect Empire vault addresses (+ their base tokens) from Base factory logs.
+ * Treasuries share addresses across Base/Arbitrum, so discovery is Base-only.
+ */
+async function collectEmpireVaults(api) {
+  const logApi =
+    api.chain === 'base'
+      ? api
+      : new sdk.ChainApi({ chain: 'base', timestamp: api.timestamp });
+
   const logs = await getLogs2({
-    api,
+    api: logApi,
     target: SPLITS_SMARTVAULT_FACTORY,
-    fromBlock: cfg.factoryFromBlock,
+    fromBlock: CONFIG.base.factoryFromBlock,
     eventAbi: SMARTVAULT_CREATED_EVENT,
+    topics: [SMARTVAULT_CREATED_TOPIC],
+    extraKey: 'empire-salted-vaults',
+    useIndexer: true,
   });
 
   const vaults = [];
   for (const log of logs) {
     const saltHex = saltToHex64(log.salt);
-    if (!saltHex.startsWith(EMPIRE_SALT_PREFIX)) continue; // not one of ours
-    const baseToken = '0x' + saltHex.slice(24); // low 20 bytes = base token (token empires)
+    if (!saltHex.startsWith(EMPIRE_SALT_PREFIX)) continue;
+    const baseToken = '0x' + saltHex.slice(24);
     vaults.push({ vault: log.vault, baseToken });
   }
   return vaults;
 }
 
-/** Sum the assets held in each Empire treasury: native ETH, quote assets, and its base token. */
+/** Sum assets held in each Empire treasury: native ETH, quote assets, and its base token. */
 async function addVaultTvl(api, cfg) {
-  const vaults = await collectEmpireVaults(api, cfg);
+  const vaults = await collectEmpireVaults(api);
   if (!vaults.length) return;
   const owners = vaults.map((v) => v.vault);
 
-  // Native ETH + quote assets (WETH/USDC) — these exist on both chains, so a plain cartesian
-  // sum over every vault is safe.
   await api.sumTokens({ owners, tokens: [NULL_ADDRESS, ...cfg.quoteAssets] });
 
-  // Each vault's own base token. On a given chain the base-token contract may not exist (most
-  // empire tokens are Base-only; post-migration tokenless salts carry a hash, not a real token),
-  // so balanceOf reverts/returns 0x. Read tolerantly and credit only balances that decode.
+  // Base-token contracts may not exist on every chain (most empire tokens are Base-only;
+  // post-migration tokenless salts carry a hash, not a real token).
   const balances = await api.multiCall({
     abi: 'erc20:balanceOf',
     calls: vaults.map(({ vault, baseToken }) => ({ target: baseToken, params: vault })),
@@ -118,6 +124,7 @@ async function addStakingTvl(api, cfg) {
     target: cfg.stakingLocker,
     fromBlock: cfg.lockerFromBlock,
     eventAbi: STAKED_EVENT,
+    extraKey: 'empire-staked-tokens',
   });
   const tokens = [...new Set(logs.map((l) => l.token.toLowerCase()))];
   if (!tokens.length) return;
@@ -134,7 +141,7 @@ async function addStakingTvl(api, cfg) {
 function tvlForChain(chainKey) {
   return async (api) => {
     const cfg = CONFIG[chainKey];
-    await addVaultTvl(api, cfg); // all "empire"-salted vaults (token + post-migration tokenless)
+    await addVaultTvl(api, cfg);
     await addStakingTvl(api, cfg);
     return api.getBalances();
   };
@@ -142,7 +149,7 @@ function tvlForChain(chainKey) {
 
 module.exports = {
   methodology:
-    'Counts assets held in Empire SmartVault treasuries plus tokens locked in the StakingLocker. Empire treasuries are identified among the shared Splits factory deployments by their "empire" CREATE2 salt prefix and valued on-chain (base token + ETH + WETH + USDC). Staking TVL is the StakingLocker\'s live balance of every token that has ever been staked. Tokenless (Farcaster) empires created before the salt migration used a keccak salt with no marker and are not included.',
+    'Counts assets held in Empire SmartVault treasuries plus tokens locked in the StakingLocker. Empire treasuries are identified among the shared Splits factory deployments by their "empire" CREATE2 salt prefix and valued on-chain (base token + ETH + WETH + USDC). Vault addresses are discovered from Base factory logs and reused on Arbitrum (same treasury addresses). Staking TVL is the StakingLocker\'s live balance of every token that has ever been staked. Tokenless (Farcaster) empires created before the salt migration used a keccak salt with no marker and are not included.',
   base: { tvl: tvlForChain('base') },
   arbitrum: { tvl: tvlForChain('arbitrum') },
 };

--- a/projects/empire-builder/index.js
+++ b/projects/empire-builder/index.js
@@ -17,9 +17,9 @@ const CONFIG = {
   },
   arbitrum: {
     stakingLocker: '0x2107412baA05470F159c025F688E97CBeADD34c0',
-    factoryFromBlock: 487300089,
+    factoryFromBlock: 430114944,
     lockerFromBlock: 459254798,
-    quoteAssets: [ADDRESSES.arbitrum.WETH, ADDRESSES.arbitrum.USDC],
+    quoteAssets: [ADDRESSES.arbitrum.WETH, ADDRESSES.arbitrum.USDC_CIRCLE],
   },
 };
 
@@ -62,7 +62,7 @@ async function staking(api) {
 
   const vaults = await getEmpireVaults(api);
   const ownerTokens = vaults.filter((v) => !quote.has(v.baseToken.toLowerCase())).map((v) => [[v.baseToken], v.vault]);
-  if (ownerTokens.length) await api.sumTokens({ ownerTokens, permitFailure: true });
+  if (ownerTokens.length) await api.sumTokens({ ownerTokens });
 
   const logs = await getLogs2({
     api,
@@ -72,7 +72,7 @@ async function staking(api) {
     extraKey: 'empire-staked-tokens',
   });
   const stakedTokens = [...new Set(logs.map((l) => l.token.toLowerCase()))].filter((t) => !quote.has(t));
-  if (stakedTokens.length) await api.sumTokens({ owner: cfg.stakingLocker, tokens: stakedTokens, permitFailure: true });
+  if (stakedTokens.length) await api.sumTokens({ owner: cfg.stakingLocker, tokens: stakedTokens });
 }
 
 module.exports = {


### PR DESCRIPTION
1. **Name:** Empire Builder
  2. **Twitter Link:** https://x.com/empirebuilderhq
  3. **Audit links:** Treasuries are non-custodial Splits SmartVaults (audited by Splits/0xSplits). (https://github.com/0xSplits/splits-contracts-monorepo/tree/main/audits)
  4. **Website Link:** https://www.empirebuilder.world
  5. **Logo:** (attached below — high-res PNG) 
<img width="2048" height="2048" alt="EBv3_BLACK-LINES-ON-WHITE-FILL" src="https://github.com/user-attachments/assets/e1672ff3-c9ad-419a-9a8f-95f69fee9e6a" />
  6. **Current TVL:** ~$2,730 (Base ~$2.73k, Arbitrum ~$0)
  7. **Treasury Addresses:** 0xa22434c246217E2a1ea0Eab8e5a510eE3caF8b66
  8. **Chain:** Base, Arbitrum
  9. **Coingecko ID:** 
  10. **Coinmarketcap ID:**
  11. **Short Description:** No-code infrastructure for onchain token communities: deploy an ERC-4337 SmartVault treasury with leaderboards, boosters, staking, distributions, burns, and airdrops on Base and Arbitrum.
  12. **Token address and ticker:** 
  13. **Category:** Services
  14. **Oracle Provider(s):** None — TVL is computed from raw on-chain token balances; DefiLlama handles pricing.
  15. **Implementation Details (oracle):** N/A — no oracle. Balances are read directly via `eth_getLogs` +
  `multiCall(balanceOf)`.
  16. **Documentation/Proof:** Docs: https://www.empirebuilder.world/docs · https://empire-builder.gitbook.io/empire-builder-docs. Adapter source in this PR (`projects/empire-builder/index.js`) · Empire salt scheme is deterministic and public.
  17. **forkedFrom:** No
  18. **Methodology:** Sums assets held in Empire SmartVault treasuries plus tokens locked in the StakingLocker, on Base and Arbitrum. Empire treasuries are deployed through the shared Splits SmartVault factory (`0x8E6Af8Ed94E87B4402D0272C5D6b0D47F0483e7C`) and identified on-chain by their "empire" CREATE2 salt prefix (`0x656d70697265`); each is valued by its base token (recovered from the salt), native ETH, WETH, USDC, and (on Arbitrum) ARB. Staking TVL is the StakingLocker's live balance of every token ever staked. All values are computed from blockchain data — no subgraph, no external API.
  19. **Github org/user:** cryptorabble
  20. **Referral program?** no

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL and staking TVL tracking for “Empire Builder (empirebuilder.world)” on Base and Arbitrum.
  * Discovers Empire vaults per chain by scanning SmartVault creation events and deriving each vault’s base token from the vault’s CREATE2 salt.
  * Computes treasury TVL by aggregating native balances plus configured quote assets across discovered vault owners, and staking TVL from tokens held in the chain’s staking locker.
  * Publishes a methodology describing vault discovery and valuation calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->