### PR TITLE
Add fry.farm

### DIFF
--- a/projects/fry-farm/index.js
+++ b/projects/fry-farm/index.js
@@ -1,0 +1,72 @@
+const { get } = require('../helper/http')
+const { sumTokens, getApplicationAddress, getAppGlobalState } = require('../helper/chain/algorand')
+
+// Fry Networks own/reward tokens — counted as staking, not TVL
+const FRY2 = '2485314946'
+const FRY3 = '3612979527'
+const FNODE = '2485202024'
+const FVPN = '2485198745'
+const OWN_TOKENS = [FRY2, FRY3, FNODE, FVPN]
+
+let poolsPromise
+async function getPools() {
+  if (!poolsPromise) poolsPromise = _getPools()
+  return poolsPromise
+
+  async function _getPools() {
+    const [farming, staking] = await Promise.all([
+      get('https://fry.farm/api/farming/all'),
+      get('https://fry.farm/api/staking/all'),
+    ])
+    const pairMap = {}
+    const ids = new Set()
+    for (const p of farming.data ?? []) {
+      if (!p.appId) continue
+      ids.add(+p.appId)
+      if (p.lpToken) pairMap[+p.appId] = [String(p.lpToken.tokenA), String(p.lpToken.tokenB)]
+    }
+    for (const p of staking.data ?? [])
+      if (p.stakingContractId && p.chainId === 'algorand-mainnet') ids.add(+p.stakingContractId)
+
+    const pools = []
+    for (const id of ids) {
+      const state = await getAppGlobalState(id)
+      if (!state.stake_token) continue
+      pools.push({ id, address: getApplicationAddress(id), stakeToken: String(state.stake_token), pair: pairMap[id] })
+    }
+    return pools
+  }
+}
+
+// Only the staked token is counted at each pool account, so pre-funded reward
+// balances sitting in the same account are excluded.
+async function tvl(api) {
+  const pools = await getPools()
+  const tokensAndOwners = []
+  const tinymanLps = []
+  for (const p of pools) {
+    if (OWN_TOKENS.includes(p.stakeToken)) continue
+    tokensAndOwners.push([p.stakeToken, p.address])
+    if (p.pair && !p.pair.includes(p.stakeToken)) {
+      // staked token is an LP ASA — resolve to underlyings, doubling the priced side when paired with an own token
+      const unknown = p.pair.find(t => OWN_TOKENS.includes(t))
+      tinymanLps.push([p.stakeToken, unknown])
+    }
+  }
+  return sumTokens({ api, tokensAndOwners, tinymanLps, blacklistedTokens: OWN_TOKENS, blacklistOnLpAsWell: true })
+}
+
+async function staking(api) {
+  const pools = await getPools()
+  const tokensAndOwners = pools
+    .filter(p => OWN_TOKENS.includes(p.stakeToken))
+    .map(p => [p.stakeToken, p.address])
+  return sumTokens({ api, tokensAndOwners })
+}
+
+module.exports = {
+  timetravel: false,
+  methodology:
+    'TVL sums the staked assets (USDC, Tinyman LP tokens and other ASAs) held by fry.farm staking and farming pool application accounts on Algorand. Pool app ids come from the public fry.farm pool registry (fry.farm/api/farming/all and /api/staking/all); the staked asset of each pool and all balances are read on-chain. LP positions are resolved to their underlying assets. Fry Networks own tokens (FRY, fNODE, fVPN) staked in pools are reported under staking.',
+  algorand: { tvl, staking },
+}

--- a/projects/fry-farm/index.js
+++ b/projects/fry-farm/index.js
@@ -1,4 +1,4 @@
-const { get } = require('../helper/http')
+const { getConfig } = require('../helper/cache')
 const { sumTokens, getApplicationAddress, getAppGlobalState } = require('../helper/chain/algorand')
 
 // Fry Networks own/reward tokens — counted as staking, not TVL
@@ -15,8 +15,8 @@ async function getPools() {
 
   async function _getPools() {
     const [farming, staking] = await Promise.all([
-      get('https://fry.farm/api/farming/all'),
-      get('https://fry.farm/api/staking/all'),
+      getConfig('fry-farm/farming', 'https://fry.farm/api/farming/all'),
+      getConfig('fry-farm/staking', 'https://fry.farm/api/staking/all'),
     ])
     const pairMap = {}
     const ids = new Set()
@@ -28,12 +28,13 @@ async function getPools() {
     for (const p of staking.data ?? [])
       if (p.stakingContractId && p.chainId === 'algorand-mainnet') ids.add(+p.stakingContractId)
 
+    const states = await Promise.all([...ids].map(id => getAppGlobalState(id)))
     const pools = []
-    for (const id of ids) {
-      const state = await getAppGlobalState(id)
-      if (!state.stake_token) continue
+    ;[...ids].forEach((id, i) => {
+      const state = states[i]
+      if (!state.stake_token) return
       pools.push({ id, address: getApplicationAddress(id), stakeToken: String(state.stake_token), pair: pairMap[id] })
-    }
+    })
     return pools
   }
 }


### PR DESCRIPTION
## Add fry.farm

**Project:** fry.farm — DeFi staking & yield farming platform by Fry Networks on Algorand (site metadata also lists Voi).
**Site:** https://fry.farm · **Docs:** https://docs.frynetworks.com · **X:** https://x.com/FryNetworks · **GitHub:** https://github.com/Fry-Foundation/
**Token:** FRY (Algorand ASA 2485314946 current / 3612979527 v3)

**TVL methodology:**
- Pool app ids are read from the public pool registry (`fry.farm/api/farming/all`, `fry.farm/api/staking/all`). The registry is API-sourced because pool creation on fry.farm is permissionless (multiple creator addresses), so creator-based enumeration is not possible. All balances are read on-chain via the Algorand indexer helper.
- For each pool, only its on-chain `stake_token` balance at the pool's application account is counted, so pre-funded reward balances are excluded.
- Tinyman LP stakes are resolved to underlying assets (`tinymanLps` helper).
- Fry Networks' own tokens (FRY, fNODE, fVPN) staked in pools are reported under `staking`.

**Note for reviewers:** the `staking` bucket currently prices to $0 because FRY/fNODE/fVPN have no price feed on DefiLlama yet. FRY2 (2485314946) can be priced from the Tinyman FRY2/USDC pool (LP ASA 3367918007) — happy to adjust if you prefer a different treatment.

Local `node test.js projects/fry-farm/index.js` output: TVL ≈ $2.05k (USDC + LP-resolved), staking balances collected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Fry Farm reporting for Algorand TVL and staking activity.
  * Improved asset attribution by valuing pooled positions, including Tinyman liquidity-pool holdings.
  * Added token exclusions to prevent counting Fry-related tokens and avoid double-counting through LP-as-underlying valuation.
  * Included a clear methodology description for how TVL and staking are computed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->