### PR TITLE
1inch-aqua: add TVL adapter counting pullable shared liquidity

### DIFF
--- a/projects/1inch-aqua/index.js
+++ b/projects/1inch-aqua/index.js
@@ -91,6 +91,30 @@ function minBigInt(...values) {
   return values.reduce((min, value) => (value < min ? value : min));
 }
 
+// ship() accepts arbitrary token addresses, so a maker can register a
+// strategy with a junk token whose balanceOf/allowance always reverts -
+// failing the whole refill on that would let anyone permanently break the
+// adapter. Such tokens are unpullable (safeTransferFrom would revert too),
+// so 0 is their correct contribution. Transient RPC failures, however, must
+// not silently undercount a refill: retry failed reads once and only treat
+// what still fails as junk.
+async function retryFailedReads(api, { abi, calls, results }) {
+  const failedIndexes = results
+    .map((value, index) => (value === null || value === undefined ? index : -1))
+    .filter((index) => index !== -1);
+  if (!failedIndexes.length) return;
+
+  const retried = await api.multiCall({
+    abi,
+    calls: failedIndexes.map((index) => calls[index]),
+    permitFailure: true,
+  });
+  retried.forEach((value, position) => {
+    if (value !== null && value !== undefined)
+      results[failedIndexes[position]] = value;
+  });
+}
+
 async function tvl(api) {
   // Every (maker, app, strategyHash, token) tuple ever registered appears in
   // Pushed logs: ship() emits one Pushed per strategy token, and push() only
@@ -155,25 +179,37 @@ async function tvl(api) {
     allowanceCalls.push({ key, target: token, params: [maker, registry] });
   }
   const walletPairList = [...walletPairs.values()];
+  const balanceOfCalls = walletPairList.map((i) => ({
+    target: i.token,
+    params: [i.maker],
+  }));
+  const allowanceCallParams = allowanceCalls.map((i) => ({
+    target: i.target,
+    params: i.params,
+  }));
 
   const [walletBalances, allowances] = await Promise.all([
     api.multiCall({
       abi: "erc20:balanceOf",
-      calls: walletPairList.map((i) => ({
-        target: i.token,
-        params: [i.maker],
-      })),
+      calls: balanceOfCalls,
       permitFailure: true,
     }),
     api.multiCall({
       abi: ALLOWANCE_ABI,
-      calls: allowanceCalls.map((i) => ({
-        target: i.target,
-        params: i.params,
-      })),
+      calls: allowanceCallParams,
       permitFailure: true,
     }),
   ]);
+  await retryFailedReads(api, {
+    abi: "erc20:balanceOf",
+    calls: balanceOfCalls,
+    results: walletBalances,
+  });
+  await retryFailedReads(api, {
+    abi: ALLOWANCE_ABI,
+    calls: allowanceCallParams,
+    results: allowances,
+  });
 
   // per (maker, token): registry capacity = min(allowance, virtual sum);
   // pullable = min(wallet balance, sum of registry capacities)

--- a/projects/1inch-aqua/index.js
+++ b/projects/1inch-aqua/index.js
@@ -1,0 +1,212 @@
+const ADDRESSES = require("../helper/coreAssets.json");
+const { getLogs2 } = require("../helper/cache/getLogs");
+
+// 1inch Aqua (https://github.com/1inch/aqua) is a shared liquidity layer:
+// makers keep tokens in their own wallets and grant a revocable ERC20
+// allowance to the Aqua registry. Strategies only record virtual balances on
+// the registry (ship/dock move no tokens); tokens move solely when a swap
+// fills (pull/push). Nothing is ever deposited into protocol contracts, so -
+// like Mangrove's promised orderbook liquidity - TVL here is the liquidity
+// that swaps can actually pull, not a contract balance.
+//
+// Pullable liquidity per maker wallet token =
+//   min(wallet balance, per-registry min(allowance to registry, sum of live
+//   strategies' virtual balances))
+// Virtual balances are NOT summed beyond the wallet balance: one wallet
+// balance can back many strategies at once, and only what the wallet
+// actually holds (and has approved) can be pulled by a swap.
+
+// Both registries are deployed at the same address on every supported chain.
+// The protocol redeployed on 2026-07-19 as AquaRouter with an unchanged
+// event/storage interface (source verified, e.g.
+// https://robinhoodchain.blockscout.com/address/0x1111113CCf1426A8e30e2BFF5e005D929bf6A90A?tab=contract);
+// the original developer-release registry still holds live strategies and is
+// kept so history stays reproducible.
+const OLD_REGISTRY = "0x499943e74fb0ce105688beee8ef2abec5d936d31"; // developer release, 2025-11-17
+const NEW_REGISTRY = "0x1111113ccf1426a8e30e2bff5e005d929bf6a90a"; // AquaRouter, 2026-07-19
+
+const PUSHED_ABI =
+  "event Pushed(address maker, address app, bytes32 strategyHash, address token, uint256 amount)";
+const RAW_BALANCES_ABI =
+  "function rawBalances(address maker, address app, bytes32 strategyHash, address token) view returns (uint248 balance, uint8 tokensCount)";
+const ALLOWANCE_ABI =
+  "function allowance(address owner, address spender) view returns (uint256)";
+
+const DOCKED_SENTINEL = 255;
+
+// chain -> [registry, block just before its deployment on that chain]
+const config = {
+  ethereum: [
+    [OLD_REGISTRY, 23800871],
+    [NEW_REGISTRY, 25555859],
+  ],
+  base: [
+    [OLD_REGISTRY, 38187727],
+    [NEW_REGISTRY, 48771727],
+  ],
+  optimism: [
+    [OLD_REGISTRY, 143783012],
+    [NEW_REGISTRY, 154367012],
+  ],
+  polygon: [
+    [OLD_REGISTRY, 79029890],
+    [NEW_REGISTRY, 90418535],
+  ],
+  arbitrum: [
+    [OLD_REGISTRY, 400333080],
+    [NEW_REGISTRY, 484967779],
+  ],
+  avax: [
+    [OLD_REGISTRY, 71974607],
+    [NEW_REGISTRY, 90579137],
+  ],
+  bsc: [
+    [OLD_REGISTRY, 68218281],
+    [NEW_REGISTRY, 110607518],
+  ],
+  xdai: [
+    [OLD_REGISTRY, 43148907],
+    [NEW_REGISTRY, 47257185],
+  ],
+  linea: [
+    [OLD_REGISTRY, 25662484],
+    [NEW_REGISTRY, 31418431],
+  ],
+  sonic: [
+    [OLD_REGISTRY, 55302991],
+    [NEW_REGISTRY, 76114316],
+  ],
+  unichain: [
+    [OLD_REGISTRY, 32416441],
+    [NEW_REGISTRY, 53584441],
+  ],
+  era: [
+    [OLD_REGISTRY, 66244013],
+    [NEW_REGISTRY, 71209736],
+  ],
+  robinhood: [[NEW_REGISTRY, 13888204]],
+};
+
+function minBigInt(...values) {
+  return values.reduce((min, value) => (value < min ? value : min));
+}
+
+async function tvl(api) {
+  // Every (maker, app, strategyHash, token) tuple ever registered appears in
+  // Pushed logs: ship() emits one Pushed per strategy token, and push() only
+  // accepts tokens already active in a strategy. rawBalances() then gives
+  // both liveness (tokensCount: 0xff = docked) and the current virtual
+  // balance, so Shipped/Docked logs are not needed at all.
+  const tuples = new Map();
+  for (const [registry, fromBlock] of config[api.chain]) {
+    const logs = await getLogs2({
+      api,
+      target: registry,
+      eventAbi: PUSHED_ABI,
+      fromBlock,
+    });
+    for (const log of logs) {
+      const maker = log.maker.toLowerCase();
+      const app = log.app.toLowerCase();
+      const strategyHash = log.strategyHash.toLowerCase();
+      const token = log.token.toLowerCase();
+      if (token === ADDRESSES.null || token === ADDRESSES.GAS_TOKEN_2) continue;
+      tuples.set(`${registry}-${maker}-${app}-${strategyHash}-${token}`, {
+        registry,
+        maker,
+        app,
+        strategyHash,
+        token,
+      });
+    }
+  }
+  const strategyTokens = [...tuples.values()];
+  if (!strategyTokens.length) return;
+
+  const rawBalances = await api.multiCall({
+    abi: RAW_BALANCES_ABI,
+    calls: strategyTokens.map((i) => ({
+      target: i.registry,
+      params: [i.maker, i.app, i.strategyHash, i.token],
+    })),
+  });
+
+  // (maker, token, registry) -> sum of live strategies' virtual balances
+  const virtualByMakerTokenRegistry = new Map();
+  strategyTokens.forEach(({ registry, maker, token }, index) => {
+    const result = rawBalances[index];
+    const tokensCount = Number(result.tokensCount ?? result[1]);
+    if (!tokensCount || tokensCount === DOCKED_SENTINEL) return;
+    const key = `${maker}-${token}-${registry}`;
+    const balance = BigInt(result.balance ?? result[0]);
+    virtualByMakerTokenRegistry.set(
+      key,
+      (virtualByMakerTokenRegistry.get(key) ?? 0n) + balance,
+    );
+  });
+  if (!virtualByMakerTokenRegistry.size) return;
+
+  // wallet balances per unique (maker, token), allowances per (maker, token, registry)
+  const walletPairs = new Map();
+  const allowanceCalls = [];
+  for (const key of virtualByMakerTokenRegistry.keys()) {
+    const [maker, token, registry] = key.split("-");
+    walletPairs.set(`${maker}-${token}`, { maker, token });
+    allowanceCalls.push({ key, target: token, params: [maker, registry] });
+  }
+  const walletPairList = [...walletPairs.values()];
+
+  const [walletBalances, allowances] = await Promise.all([
+    api.multiCall({
+      abi: "erc20:balanceOf",
+      calls: walletPairList.map((i) => ({
+        target: i.token,
+        params: [i.maker],
+      })),
+      permitFailure: true,
+    }),
+    api.multiCall({
+      abi: ALLOWANCE_ABI,
+      calls: allowanceCalls.map((i) => ({
+        target: i.target,
+        params: i.params,
+      })),
+      permitFailure: true,
+    }),
+  ]);
+
+  // per (maker, token): registry capacity = min(allowance, virtual sum);
+  // pullable = min(wallet balance, sum of registry capacities)
+  const capacityByMakerToken = new Map();
+  allowanceCalls.forEach(({ key }, index) => {
+    if (allowances[index] === null || allowances[index] === undefined) return;
+    const [maker, token] = key.split("-");
+    const capacity = minBigInt(
+      BigInt(allowances[index]),
+      virtualByMakerTokenRegistry.get(key),
+    );
+    const pairKey = `${maker}-${token}`;
+    capacityByMakerToken.set(
+      pairKey,
+      (capacityByMakerToken.get(pairKey) ?? 0n) + capacity,
+    );
+  });
+
+  walletPairList.forEach(({ maker, token }, index) => {
+    if (walletBalances[index] === null || walletBalances[index] === undefined)
+      return;
+    const capacity = capacityByMakerToken.get(`${maker}-${token}`) ?? 0n;
+    const pullable = minBigInt(BigInt(walletBalances[index]), capacity);
+    if (pullable > 0n) api.add(token, pullable.toString());
+  });
+}
+
+module.exports = {
+  methodology:
+    "Counts the shared liquidity that Aqua strategies can actually pull at swap time. Aqua is non-custodial: makers never deposit, tokens stay in the maker wallet and the registry only holds a revocable allowance plus per-strategy virtual balances. For each maker wallet token backing at least one live (shipped, not docked) strategy, the adapter counts min(wallet balance, allowance granted to the registry, sum of live strategies virtual balances) - once per wallet token, so liquidity shared across many strategies is never double counted and idle wallet funds beyond what strategies quote are excluded.",
+  start: "2025-11-17", // Aqua developer release: https://blog.1inch.com/aqua-developer-release/
+};
+
+Object.keys(config).forEach((chain) => {
+  module.exports[chain] = { tvl };
+});

--- a/test.js
+++ b/test.js
@@ -132,9 +132,9 @@ function validateHallmarks(hallmark) {
   // key so a treasury entry isn't shadowed by a same-named protocol adapter.
   const registryKey = process.argv[2].replace(/\.js$/, '').replace(/\/index$/, '').replace(/^projects\//, '')
 
-  // throw error if module doesnt start with lowercase letters
-  if (!/^[a-z]/.test(moduleArg) && !process.env.LLAMA_RUN_LOCAL) {
-    throw new Error("Module name should start with a lowercase letter: " + moduleArg);
+  // throw error if module starts with an uppercase letter (digit prefixes are fine: 1inch, 0vix, 40acres, ...)
+  if (!/^[a-z0-9]/.test(moduleArg) && !process.env.LLAMA_RUN_LOCAL) {
+    throw new Error("Module name should not start with an uppercase letter: " + moduleArg);
   }
 
   let module = {};


### PR DESCRIPTION
Adds a TVL adapter for **1inch Aqua** (slug `1inch-aqua`, currently listed with `dummy.js` under the 1inch parent; volume adapter already live via #8103 / #8284 in dimension-adapters).

## Why this isn't a normal "balance of protocol contracts"

Aqua ([github.com/1inch/aqua](https://github.com/1inch/aqua)) is a non-custodial shared-liquidity layer: makers never deposit. Tokens stay in the maker's own wallet; the registry contract only holds a revocable ERC20 allowance and per-strategy *virtual balances* (`ship`/`dock` move no tokens — tokens only move at swap fill via `pull`/`push`). Summing registry contract balances would return ~0, and naively summing virtual balances would overcount badly, because one wallet balance intentionally backs many strategies at once (that's the product's whole point). Closest existing precedent is Mangrove, which also counts promised (not deposited) orderbook liquidity as TVL.

## Methodology

For each maker wallet token backing at least one **live** (shipped, not docked) strategy:

```
pullable = min( wallet balance,
                allowance granted to the registry,
                sum of live strategies' virtual balances )
```

counted **once per wallet token**, so shared liquidity is never double counted and idle wallet funds beyond what strategies actually quote are excluded. This is exactly the amount a swap could pull at fill time — deliberately the most conservative honest number. Registered strategy-token tuples are discovered from `Pushed` logs (ship emits one per strategy token; `push()` only accepts already-registered tokens), liveness + current virtual balance come from the registry's `rawBalances()` getter (`tokensCount == 0xff` means docked). Both registry deployments are covered (developer release 2025-11-17 + the AquaRouter redeployment 2026-07-19, same address on every chain).

## Test output (2026-07-22)

`ethereum $11.05M`, everything else currently small (bsc $274, base $100, arbitrum $88, …) — the protocol is pre-public-launch, liquidity so far is 1inch's own market making. Sanity-checked the top rows independently: e.g. the largest maker's aEthWETH row shows wallet 2,677 / allowance ∞ / virtual-sum 24,013 → counts 2,677 (wallet-bound), i.e. the min() correctly refuses the ~9x shared-liquidity multiplier.

Two notes for the reviewer:

- The digit prefix trips the module-name guard (`/^[a-z]/` also rejects digits, though the intent of #17131 was uppercase — same collateral as existing `1inch`/`40acres`/`1intro` adapters, e.g. #19650 merged with that check red). This PR therefore carries the same one-line guard fix proposed in #20174, so CI runs the adapter for real and is green. If you'd rather merge #20174 separately, I'll drop that commit here and rebase; if this lands first, #20174 can be closed.
- Some maker inventory is yield-bearing receipt tokens (aEthWETH, aEthWBTC…). Left `doublecounted` unset following DEX convention (pools holding aTokens/sDAI don't set it) — happy to set it if you prefer.

Also needs the server-side `module` flip from `dummy.js` → `1inch-aqua/index.js` when merged.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a 1inch Aqua shared-liquidity TVL adapter across supported chains.
  * Automatically discovers active strategies per configured registry and calculates pullable liquidity using wallet balances, registry allowances, and live virtual balances.
  * Supports both the 2025-11-17 developer release and the 2026-07-19 AquaRouter redeployment, including NEW-only handling for specific chains.
  * Provides adapter transparency via methodology and start-date metadata.
* **Bug Fixes**
  * Improved adapter-name validation to accept digit-prefixed module names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
