### PR TITLE
test: allow digit-prefixed module names in the lowercase-guard

### DIFF
--- a/test.js
+++ b/test.js
@@ -132,9 +132,9 @@ function validateHallmarks(hallmark) {
   // key so a treasury entry isn't shadowed by a same-named protocol adapter.
   const registryKey = process.argv[2].replace(/\.js$/, '').replace(/\/index$/, '').replace(/^projects\//, '')
 
-  // throw error if module doesnt start with lowercase letters
-  if (!/^[a-z]/.test(moduleArg) && !process.env.LLAMA_RUN_LOCAL) {
-    throw new Error("Module name should start with a lowercase letter: " + moduleArg);
+  // throw error if module starts with an uppercase letter (digit prefixes are fine: 1inch, 0vix, 40acres, ...)
+  if (!/^[a-z0-9]/.test(moduleArg) && !process.env.LLAMA_RUN_LOCAL) {
+    throw new Error("Module name should not start with an uppercase letter: " + moduleArg);
   }
 
   let module = {};


### PR DESCRIPTION
The module-name guard added in #17131 was aimed at rejecting **uppercase** module names, but `/^[a-z]/` also rejects names starting with a digit. The repo already has many digit-prefixed adapters (`1inch`, `0vix`, `40acres`, `0xdx`, `01`, `3a-dao`, `4mm`, ...), so any PR touching one of them - or adding a sibling like `1inch-aqua` (#20173) - fails CI before the adapter even runs, e.g. #19650 (40acres) which was merged with a red check.

This keeps the guard's intent (no uppercase) while letting digit-prefixed names through:

```js
if (!/^[a-z0-9]/.test(moduleArg) && !process.env.LLAMA_RUN_LOCAL) {
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Relaxed runner module-name validation to allow names that start with a lowercase letter **or a digit** (previously digit-prefixed names were rejected).
  * Updated the associated error message to match the new accepted naming rule, reducing confusion when invalid names are entered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->