### PR TITLE
Add RH.fun

### DIFF
--- a/projects/rhfun/index.js
+++ b/projects/rhfun/index.js
@@ -10,7 +10,6 @@ const { getLogs2 } = require('../helper/cache/getLogs')
 // per-token TaxProcessor / Dividend clones, and optional market vaults receive
 // the native market bucket — all enumerated from factory events and counted.
 const FACTORY = '0x32a00Df7C511A882f3A7a18bcD69367880239726' // FACTORY_PROXY
-const WETH = '0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73'
 const FROM_BLOCK = 12923899 // block of the first NewRHTokenCurveParams event
 
 const CURVE_EVENT = 'event NewRHTokenCurveParams(address indexed addr, address indexed bondingCurve, uint256 initialTokenSupply, uint256 virtualCollateralReservesInitial, uint256 virtualTokenReservesInitial, uint256 feeBPS, uint256 mcLowerLimit, uint256 mcUpperLimit, uint256 tokensMigrationThreshold, uint256 fixedMigrationFee, uint256 firstBuyFee, uint256 targetCollectionAmount, address collateralToken)'
@@ -29,7 +28,7 @@ async function tvl(api) {
   curveLogs.forEach((log) => tokensAndOwners.push([log.collateralToken, log.bondingCurve]))
   // Tax markets accrue tax in the quote token (WETH for native markets) on TaxProcessor/Dividend clones.
   taxLogs.forEach((log) => {
-    const quote = log.collateralToken === ADDRESSES.null ? WETH : log.collateralToken
+    const quote = log.collateralToken === ADDRESSES.null ? ADDRESSES.robinhood.WETH : log.collateralToken
     tokensAndOwners.push([quote, log.taxProcessor])
     if (log.dividendContract !== ADDRESSES.null) tokensAndOwners.push([quote, log.dividendContract])
   })

--- a/projects/rhfun/index.js
+++ b/projects/rhfun/index.js
@@ -1,0 +1,46 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+const { getLogs2 } = require('../helper/cache/getLogs')
+
+// RH.fun — bonding-curve token launchpad on Robinhood Chain (4663).
+// Each token launches its own BondingCurve clone that custodies the collateral
+// (native ETH or USDG) until the curve reaches its target and graduates; the
+// graduation tx migrates the liquidity to the chain's Uniswap V2 DEX and drains
+// the curve to zero, so graduated liquidity is no longer counted here.
+// Tax markets additionally accrue quote-token tax (WETH for native markets) on
+// per-token TaxProcessor / Dividend clones, and optional market vaults receive
+// the native market bucket — all enumerated from factory events and counted.
+const FACTORY = '0x32a00Df7C511A882f3A7a18bcD69367880239726' // FACTORY_PROXY
+const WETH = '0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73'
+const FROM_BLOCK = 12923899 // block of the first NewRHTokenCurveParams event
+
+const CURVE_EVENT = 'event NewRHTokenCurveParams(address indexed addr, address indexed bondingCurve, uint256 initialTokenSupply, uint256 virtualCollateralReservesInitial, uint256 virtualTokenReservesInitial, uint256 feeBPS, uint256 mcLowerLimit, uint256 mcUpperLimit, uint256 tokensMigrationThreshold, uint256 fixedMigrationFee, uint256 firstBuyFee, uint256 targetCollectionAmount, address collateralToken)'
+const TAX_EVENT = 'event NewRHTaxTokenParams(address indexed token, address indexed bondingCurve, address indexed collateralToken, address mainPool, address taxProcessor, address dividendContract, uint16 taxRateBps, uint64 taxDuration, uint64 antiFarmerDuration, uint256 minBuyBackQuote, uint16 processorFeeRateCurve, uint16 processorFeeRateDex, uint16 processorMarketBps, uint16 processorDeflationBps, uint16 processorLpBps, uint16 processorDividendBps, uint256 minimumShareBalance, address marketAddress)'
+const VAULT_EVENT = 'event MarketVaultCreated(address indexed token, address indexed vaultFactory, address vault, bytes marketVaultData)'
+
+async function tvl(api) {
+  const [curveLogs, taxLogs, vaultLogs] = await Promise.all([
+    getLogs2({ api, factory: FACTORY, eventAbi: CURVE_EVENT, fromBlock: FROM_BLOCK, extraKey: 'curves' }),
+    getLogs2({ api, factory: FACTORY, eventAbi: TAX_EVENT, fromBlock: FROM_BLOCK, extraKey: 'tax' }),
+    getLogs2({ api, factory: FACTORY, eventAbi: VAULT_EVENT, fromBlock: FROM_BLOCK, extraKey: 'vaults' }),
+  ])
+
+  const tokensAndOwners = []
+  // Un-graduated curves hold their raw collateral: native ETH (collateralToken = 0x0) or USDG.
+  curveLogs.forEach((log) => tokensAndOwners.push([log.collateralToken, log.bondingCurve]))
+  // Tax markets accrue tax in the quote token (WETH for native markets) on TaxProcessor/Dividend clones.
+  taxLogs.forEach((log) => {
+    const quote = log.collateralToken === ADDRESSES.null ? WETH : log.collateralToken
+    tokensAndOwners.push([quote, log.taxProcessor])
+    if (log.dividendContract !== ADDRESSES.null) tokensAndOwners.push([quote, log.dividendContract])
+  })
+  // Optional market vaults (gift / snowball / burn-dividend / split) receive the native market bucket.
+  vaultLogs.forEach((log) => tokensAndOwners.push([ADDRESSES.null, log.vault]))
+
+  return api.sumTokens({ tokensAndOwners })
+}
+
+module.exports = {
+  methodology:
+    'Counts collateral held by RH.fun market contracts on Robinhood Chain, enumerated from factory events: ETH/USDG in un-graduated bonding-curve clones (NewRHTokenCurveParams), quote-token tax accrued on per-token TaxProcessor and Dividend clones (NewRHTaxTokenParams), and native balances of market vaults (MarketVaultCreated). When a curve graduates, its liquidity migrates to the chain\'s Uniswap V2 DEX and the curve is drained to zero in the same transaction, so graduated liquidity is no longer counted here. Locked allocations of launched tokens themselves are excluded.',
+  robinhood: { tvl },
+}


### PR DESCRIPTION
- Name (to be shown on DefiLlama): RH.fun
- Twitter Link: https://x.com/RHdotfun
- List of audit links if any: None
- Website Link: https://rh.fun
- Logo (High resolution, will be shown with rounded borders): https://rh.fun/rh/icon-512x512.png
- Current TVL: ~$5,400
- Treasury Addresses (if the protocol has treasury): -
- Chain: Robinhood Chain
- Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): -
- Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): -
- Short Description (to be shown on DefiLlama): RH.fun is a bonding-curve token launchpad on Robinhood Chain. Anyone can launch a token in seconds; tokens graduate to Uniswap V2 once the curve target is reached. Supports ETH and USDG markets.
- Token address and ticker if any: None (no protocol token)
- Category (full list at https://defillama.com/categories): Launchpad
- forkedFrom (Does your project originate from another project): No
- methodology (what is being counted as tvl, how is tvl being calculated): Counts collateral held by RH.fun market contracts on Robinhood Chain, enumerated from factory events: ETH/USDG in un-graduated bonding-curve clones (NewRHTokenCurveParams), quote-token tax accrued on per-token TaxProcessor and Dividend clones (NewRHTaxTokenParams), and native balances of market vaults (MarketVaultCreated). When a curve graduates, its liquidity migrates to the chain's Uniswap V2 DEX and the curve is drained to zero in the same transaction, so graduated liquidity is no longer counted here. Locked allocations of launched tokens themselves are excluded.
- Github org/user (Optional, if your code is open source): rhdotfun
- Does this project have a referral program? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for RH.fun on Robinhood Chain.
  * Includes assets held in bonding curves, tax processors/dividend contracts, and market vaults.
  * Added methodology details describing how RH.fun’s TVL is calculated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->