### PR TITLE
Add K2 Lend (Stellar) adapter

### DIFF
--- a/projects/k2-lend/index.js
+++ b/projects/k2-lend/index.js
@@ -1,0 +1,40 @@
+const { callSoroban } = require('../helper/chain/stellar')
+const { lendingMarket } = require('../helper/methodologies')
+
+const ROUTER = 'CCTUJZLYFAW7ZNQD2SXMUZIHBUUJJICYRKWLZJ6SK6TGNAWNXOJIV6J7'
+const RAY = 10n ** 27n
+
+// underlying token -> { aToken, debtToken } — from K2 mainnet deployment manifest
+const RESERVES = {
+  // PYUSD
+  CCCRWH6Q3FNP3I2I57BDLM5AFAT7O6OF6GKQOC6SSJNDAVRZ57SPHGU2: { aToken: 'CA7ELGRS4FNCYJPRZSNLF7NDD6VVOFZKFKMY56VVSG3RMNYTFQNNFUTD', debtToken: 'CAVFE34MWBIXT4AOFXPTI7U7JTLPHKG4YWDDMRXVJOIZKG6HFJW3IHXV' },
+  // SolvBTC
+  CBIJBDNZNF4X35BJ4FFZWCDBSCKOP5NB4PLG4SNENRMLAPYG4P5FM6VN: { aToken: 'CDDTJ7OZU2WZAEZNTUZWIRAE4EMP5CF63M3INFQWTLX4ENMYUFK6RCTX', debtToken: 'CADGKVZKBNLPKFIWDWTRSQAPBWH77H2OPJIF3WGVL7VADVLCXDZ5CSNH' },
+  // USDC
+  CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75: { aToken: 'CDHRPTO3NLGQ2CV75LFV6NF6ZMXIPGPID5GTAZTEICBYLMLKJICOMFZK', debtToken: 'CBN4GDHRJN7AIARTSTUD3OK7IOCU5V6HTSOTVARFUA5KVE7XSNBZUQG6' },
+  // XLM
+  CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA: { aToken: 'CDTHJR27QWKAPCFTZWKP7GTX3RZO7HACVAC2KLCW2RENCMOCI35ORU5K', debtToken: 'CC3OKG4VDLGFBS7V6UTSJVP3YL3A4OLV63EMTNUU3MQ2AOAU4M65H7QG' },
+}
+
+async function tvl(api) {
+  for (const [underlying, { aToken }] of Object.entries(RESERVES)) {
+    const bal = await callSoroban(underlying, 'balance', [aToken])
+    api.add(underlying, bal.toString())
+  }
+}
+
+async function borrowed(api) {
+  for (const [underlying, { debtToken }] of Object.entries(RESERVES)) {
+    // NOTE: debtToken.total_supply() re-enters the router and traps in simulation;
+    // scale the stored supply by the current index instead.
+    const scaled = await callSoroban(debtToken, 'scaled_total_supply')
+    const idx = await callSoroban(ROUTER, 'get_current_var_borrow_idx', [underlying])
+    api.add(underlying, ((BigInt(scaled) * BigInt(idx)) / RAY).toString())
+  }
+}
+
+module.exports = {
+  timetravel: false,
+  methodology: `${lendingMarket}. TVL sums the underlying token balances held by each K2 reserve's aToken contract; borrowed sums outstanding variable debt (scaled debt supply times the current borrow index).`,
+  stellar: { tvl, borrowed },
+}


### PR DESCRIPTION
## Summary

   Adds an on-chain TVL adapter for K2 Lend, a Stellar/Soroban lending market. The adapter reads the underlying balances held by each reserve's aToken contract and reports outstanding variable debt in a separate `borrowed`
 bucket.

   Validated with `node test.js projects/k2-lend/index.js` on 2026-07-22:

   - Stellar TVL: $105.32
   - Stellar borrowed: $35.99

   ## New listing

   ##### Name (to be shown on DefiLlama):
   K2 Lend

   ##### Twitter Link:
   https://x.com/K2_Lend

   ##### List of audit links if any:
   https://github.com/code-423n4/2026-04-k2/blob/main/k2-borrow-lend-protocol-ssc.pdf (Halborn)
   https://github.com/code-423n4/2026-04-k2/blob/main/k2-watchpug-audit-report-rev3.pdf (WatchPug)
   https://code4rena.com/audits/2026-04-k2 (Code4rena; report in progress)

   ##### Website Link:
   https://k2lend.com

   ##### Logo (High resolution, will be shown with rounded borders):
   https://k2lend.com/assets/logo.a1176e6315df.svg

   ##### Current TVL:
   $105.32 (live adapter run on 2026-07-22)

   ##### Treasury Addresses (if the protocol has treasury):
   CCQ4J5VLQHM2ORP4K7GBVAJJPK5SGG23DH4RD7QEHAZDHTN7JNESNXKZ (Stellar)

   ##### Chain:
   Stellar

   ##### Coingecko ID:
   None (no protocol token)

   ##### Coinmarketcap ID:
   None (no protocol token)

   ##### Short Description (to be shown on DefiLlama):
   K2 Lend is a lending protocol on Stellar where users supply XLM, USDC, PYUSD, or SolvBTC to earn yield and borrow against collateral.

   ##### Token address and ticker if any:
   None (no protocol token)

   ##### Category:
   Lending

   ##### Oracle Provider(s):
   RedStone and Reflector

   ##### Implementation Details:
   K2 resolves each asset price from RedStone first, then falls back to Reflector when no valid RedStone feed is available. Prices are rejected if stale, zero, or more than 20% away from the last accepted value; the circuit breaker retains the last known-good price.

   ##### Documentation/Proof:
   https://docs.k2lend.com/oracle-and-pricing

   ##### forkedFrom:
   None. K2 uses an Aave-V3-inspired design but is an independent Soroban implementation, not a code fork.

   ##### methodology:
   TVL sums the underlying token balances held by each K2 reserve's aToken contract. Borrowed amounts are reported separately and are calculated as each debt token's scaled total supply multiplied by the current variable borrow index. Borrowed coins are not added to base TVL, avoiding inflation through recursive lending.

   ##### Github org/user:
   Kinetic-K2

   ##### Does this project have a referral program?
   No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added K2 lending analytics for Stellar.
  * Added reporting for total value locked (TVL) across supported reserves.
  * Added reporting for outstanding variable debt using current borrow indexes.
  * Included methodology details explaining the TVL and borrowed calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->