### PR TITLE
raindex: add 10 missing base tokens (+$14k) and the matchain orderbook

### DIFF
--- a/registries/sumTokens.js
+++ b/registries/sumTokens.js
@@ -23315,7 +23315,17 @@ const configs = {
         "0x3d63825b0d8669307366e6c8202f656b9e91d368",
         "0xd262a4c7108c8139b2b189758e8d17c3dfc91a38",
         "0x0c03ce270b4826ec62e7dd007f0b716068639f7b",
-        "0x00000e7efa313f4e11bfff432471ed9423ac6b30"
+        "0x00000e7efa313f4e11bfff432471ed9423ac6b30",
+        ADDRESSES.base.cbBTC,
+        ADDRESSES.base.WBTC,
+        "0x78c31580c97101694c70022c83d570150c11e935",
+        "0x31c2c14134e6e3b7ef9478297f199331133fc2d8",
+        "0x5cda0e1ca4ce2af96315f7f8963c85399c172204",
+        "0x823ff7bbde2869aae73a6cd53e7f614442836757",
+        "0xff05e1bd696900dc6a52ca35ca61bb1024eda8e2",
+        "0x57f5fbd3de65dfc0bd3630f732969e5fb97e6d37",
+        "0xa4a2e2ca3fbfe21aed83471d28b6f65a233c6e00",
+        "0x3722264ab15a1dfce5a5af89e6547f7949a8aba3"
       ],
       "permitFailure": true
     },
@@ -23382,6 +23392,17 @@ const configs = {
         ADDRESSES.linea.WETH,
         ADDRESSES.linea.USDT,
         "0x4ea77a86d6e70ffe8bb947fc86d68a7f086f198a"
+      ],
+      "permitFailure": true
+    },
+    "matchain": {
+      "owners": [
+        "0x40312EDAB8fe65091354172ad79e9459f21094e2"
+      ],
+      "tokens": [
+        ADDRESSES.matchain.WBNB,
+        ADDRESSES.matchain.USDT,
+        ADDRESSES.matchain.MAT
       ],
       "permitFailure": true
     },


### PR DESCRIPTION
Fixes two under-counts in the existing `raindex` entry in `registries/sumTokens.js`. Nothing else in the file is touched.

Raindex is an on-chain orderbook: takers deposit ERC20s into an `OrderBook` contract, which custodies them until an order clears. TVL is the balance of those tokens held by the orderbook contracts, which is exactly what the existing entry does — the entry's owner list is just incomplete in two ways.

---

## 1. Base: 10 held, priceable tokens were missing from the allowlist

The `base` entry lists 9 owners but only 23 hardcoded tokens. I enumerated every ERC20 with a non-zero balance across all 9 listed owners, read each balance back with `eth_call balanceOf` against `https://mainnet.base.org` at block `48998695`, and priced each one through `https://coins.llama.fi/prices/current/base:<addr>`.

286 distinct ERC20s have a non-zero balance. Of those, **10 are priced by DefiLlama and are not in the allowlist**:

| Token | Address | Balance | Llama price | USD |
|---|---|---|---|---|
| wtSGOV | `0x78c31580c97101694c70022c83d570150c11e935` | 36.322213 | $101.17 | **$3,674.70** |
| wtSPYM | `0x31c2c14134e6e3b7ef9478297f199331133fc2d8` | 37.757343 | $88.13 | **$3,327.69** |
| wtCOIN | `0x5cda0e1ca4ce2af96315f7f8963c85399c172204` | 15.644600 | $167.41 | **$2,619.02** |
| wtQQQM | `0x823ff7bbde2869aae73a6cd53e7f614442836757` | 7.470590 | $292.34 | **$2,183.94** |
| wtMSTR | `0xff05e1bd696900dc6a52ca35ca61bb1024eda8e2` | 21.698568 | $99.42 | **$2,157.26** |
| cbBTC | `0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf` | 0.00039528 | $65,658 | **$25.95** |
| TRUMP | `0x57f5fbd3de65dfc0bd3630f732969e5fb97e6d37` | 0.03555 | $0.0264 | $0.0009 |
| WBTC | `0x0555E30da8f98308EdB960aa94C0Db47230d2B9c` | 1e-8 | $65,589 | $0.0007 |
| TIBBIR | `0xa4a2e2ca3fbfe21aed83471d28b6f65a233c6e00` | 1.2e-17 | $0.105 | ~$0 |
| LFI | `0x3722264ab15a1dfce5a5af89e6547f7949a8aba3` | 1.6e-17 | $0.00007 | ~$0 |

Total missing: **$13,988.56**, all of it in the first six rows. The five `wt*` tokens are all held by `0xe522cB4a5fCb2eb31a52Ff41a4653d85A4fd7C9D`, which is already a listed owner — they are wrapped-equity/ETF tokens (e.g. `wtSGOV` = "Wrapped iShares 0-3 Month Treasury Bond ETF ST0x"), all `decimals=18`, all priced by DefiLlama at `confidence: 0.99`. `cbBTC` and `WBTC` were added via the existing `ADDRESSES.base.*` constants.

The last four rows are dust. I included them because the inclusion rule I applied is mechanical and reproducible — *every* token currently held by a listed owner that DefiLlama can price — rather than a hand-picked subset, and because the existing allowlist already contains comparable dust entries (`TIG`, `HYDX`).

**Dropped:** `wtSKHY` (`0xfcd17ac4c4bf6a72c93018096f3fc09e66573ff9`, 33.09 held) and 240 other unlisted tokens, because `coins.llama.fi` returns no price for them. Adding unpriceable tokens would contribute nothing but no-price warnings.

Effect on the `base` bucket: **$26.21k → $40.20k**.

### Why this stayed an allowlist instead of moving to token discovery

I looked at `fetchCoValentTokens` / `fetchBlockscoutTokens` first, since a hardcoded allowlist on a permissionless deposit contract will obviously drift again. I decided against it here, on evidence:

- Of the 286 ERC20s the Base orderbooks hold, only 10 unlisted ones have a price at all. The overwhelming remainder is unsolicited airdrop spam — token names in the actual balance set include `"Visit https://…"`, `"100$ Reward on…"`, `"REWARD 🎁 Visit…"`, and a dozen homoglyph `"UЅDС | t.me/…"` contracts. Anyone can push a token into an orderbook address, so an unbounded discovery source over these balances is dominated by attacker-controlled contracts. If any of them ever gets a price, it lands straight in TVL.
- `matchain` (added below) is in neither `ankrChainMapping` nor reachable via `getBlockscoutUrl` — its explorer is `https://matchscan.io`, which fails the `/blockscout/i` test in `projects/helper/token.js` even though it is a Blockscout instance. So discovery could not cover the new chain regardless.
- Per `registries/sumTokens/covalent.js`, setting the flag on any one chain means moving the whole protocol into that file, and I could not run it locally to demonstrate the result (no `ANKR_API_KEY`), so I would have been submitting an untested behaviour change.

**So yes — this allowlist will drift again**, and I'd rather say that plainly than pretend otherwise. If you'd prefer discovery anyway, `fetchCoValentTokens: true` on the EVM chains is a small follow-up and you have the key to verify it; happy to do that instead.

## 2. Matchain orderbook was missing entirely

Adds `matchain` with owner `0x40312EDAB8fe65091354172ad79e9459f21094e2`.

Verification that this is a Raindex orderbook and not something else: I fetched `eth_getCode` for it and for the orderbooks already listed under `base`/`bsc`, and compared digests of the runtime bytecode.

| Chain | Address | Runtime size | sha256 (first 16 bytes) |
|---|---|---|---|
| matchain | `0x40312EDAB8fe65091354172ad79e9459f21094e2` | 24551 | `10bc66f3ade35ecb25d0c16c342b302d` |
| base | `0xd2938e7c9fe3597f78832ce780feb61945c377d7` (already listed) | 24551 | `10bc66f3ade35ecb25d0c16c342b302d` |
| bsc | `0xd2938e7c9fe3597f78832ce780feb61945c377d7` (already listed) | 24551 | `10bc66f3ade35ecb25d0c16c342b302d` |

Byte-identical to the orderbook already listed on two chains.

**Its TVL is $28.03 — I want to be upfront that this is not a material number.** At matchain block `136677961` the contract holds 0.049208292 WBNB (`$28.03`) plus three meme tokens (IAMDOG, NEIRO, IMDOG) that `coins.llama.fi` does not price, so they contribute nothing. The case for merging this half is correctness — the chain is a real deployment and is currently invisible — not TVL. If you'd rather not carry a chain worth $28, say so and I'll drop this hunk and leave the Base fix.

Tokens listed are `ADDRESSES.matchain.WBNB` / `.USDT` / `.MAT` from `coreAssets.json`. I confirmed on-chain that USDT and MAT balances are currently zero; they're listed because they're the chain's core assets and are what ordinary deposits would arrive in. `permitFailure: true` matches every other chain in this entry and guards the rest of the adapter against matchain's single public RPC.

---

## Test output

`node test.js raindex`, exit code 0:

```
--- matchain ---
WBNB                      28.03
Total: 28.03

--- base ---
USDC                      26.01 k
wtSGOV                    3.67 k
wtSPYM                    3.33 k
wtCOIN                    2.62 k
wtQQQM                    2.18 k
wtMSTR                    2.16 k
WETH                      110.13
WLTH                      83.66
cbBTC                     25.97
ZORA                      3.71
AKUMA                     0.06
PAID                      0.02
WGC                       0.00
SKYA                      0.00
BASED                     0.00
TRUMP                     0.00
WBTC                      0.00
SKITTEN                   0.00
BOYS                      0.00
CYPR                      0.00
cgUSD                     0.00
TIG                       0.00
TIBBIR                    0.00
HYDX                      0.00
LFI                       0.00
Total: 40.20 k

------ TVL ------
base                      40.20 k
flare                     18.28 k
ethereum                  4.00 k
bsc                       3.33 k
polygon                   909.00
arbitrum                  432.00
linea                     70.00
matchain                  28.00

total                    67.24 k
```

Before this change, the same command on `main` gives:

```
------ TVL ------
base                      26.21 k
flare                     18.28 k
ethereum                  4.01 k
bsc                       3.33 k
polygon                   909.00
arbitrum                  432.00
linea                     70.00

total                    53.24 k
```

No new no-price or unknown-token warnings. Every added token resolves to a price. No new npm dependencies; `package.json`, `pnpm-lock.yaml` and `pnpm-workspace.yaml` are untouched.

##### methodology

Unchanged: "Balance of tokens held by Rain Orderbook contract." This PR only widens which held tokens and which deployed orderbooks are covered.

"Allow edits by maintainers" is enabled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional tokens and addresses in the existing registry.
  * Added Matchain network support with WBNB, USDT, and MAT token entries.
  * Enabled continued processing when token permission checks fail on Matchain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->