### PR TITLE
Add surgecredit adapter

### DIFF
--- a/projects/surgecredit/index.js
+++ b/projects/surgecredit/index.js
@@ -1,0 +1,36 @@
+const sdk = require('@defillama/sdk')
+
+// Surge Credit — BTC-collateralized USDC lending on Base (chainId 8453).
+// Slug `surgecredit` (bare `surge` is taken by an unrelated Arbitrum lender).
+
+const VAULT_MANAGER = '0x0D5D12de1cC71060A38F25DD9d24DA1DD6eB705a'
+const USDC = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'
+
+// VaultManager keeps the protocol-wide aggregate: BTC collateral in satoshis
+// (1e8) and USDC debt (1e6). Collateral lives in per-loan, non-custodial Taproot
+// vaults with deterministic addresses derived off-chain (no public address set to
+// sum UTXOs over), so the on-chain aggregate is the canonical figure.
+const GET_TOTALS_ABI =
+  'function getTotals() view returns (uint256 totalCollateral, uint256 totalDebt)'
+
+// TVL: native BTC collateral locked in the Taproot vaults (satoshis -> BTC).
+// Read from Base (VaultManager), credited as native bitcoin.
+async function bitcoinTvl(api) {
+  const baseApi = new sdk.ChainApi({ chain: 'base', timestamp: api.timestamp })
+  const totals = await baseApi.call({ target: VAULT_MANAGER, abi: GET_TOTALS_ABI })
+  api.addCGToken('bitcoin', totals.totalCollateral / 1e8)
+}
+
+// Borrowed: outstanding USDC debt across all positions — the active credit.
+// This is what DeFiLlama renders on the "Active Loans" tab.
+async function baseBorrowed(api) {
+  const totals = await api.call({ target: VAULT_MANAGER, abi: GET_TOTALS_ABI })
+  api.add(USDC, totals.totalDebt)
+}
+
+module.exports = {
+  methodology:
+    'TVL is the native BTC collateral locked in per-loan non-custodial Taproot vaults, read from the protocol-wide on-chain aggregate VaultManager.getTotals() (satoshis) on Base. Borrowed is the outstanding USDC debt across all positions (the active credit). Idle USDC lending liquidity is not counted in TVL.',
+  bitcoin: { tvl: bitcoinTvl },
+  base: { borrowed: baseBorrowed },
+}

--- a/projects/surgecredit/index.js
+++ b/projects/surgecredit/index.js
@@ -1,81 +1,36 @@
-const { post } = require('../helper/http')
 const { sumTokens } = require('../helper/chain/bitcoin')
-
-// Surge Credit: BTC-collateralized USDC lending on Base (chainId 8453).
-// Slug `surgecredit` (bare `surge` is taken by an unrelated Arbitrum lender).
+const { cachedGraphQuery } = require('../helper/cache')
+const ADDRESSES = require('../helper/coreAssets.json')
 
 const VAULT_MANAGER = '0x0D5D12de1cC71060A38F25DD9d24DA1DD6eB705a'
-const USDC = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'
+const GET_TOTALS_ABI = 'function getTotals() view returns (uint256 totalCollateral, uint256 totalDebt)'
 
-const GET_TOTALS_ABI =
-  'function getTotals() view returns (uint256 totalCollateral, uint256 totalDebt)'
-
-// Each loan's collateral lives in its own non-custodial Taproot (P2TR) vault. The
-// vault address is deterministic (derived from the borrower's on-chain x-only pubkey
-// and EVM address), computed by our indexer at loan creation and exposed as
-// Loan.btcVaultAddress. We fetch the live address set and sum the actual UTXO balances
-// on Bitcoin L1 (per PR #20190: track BTC via the custody addresses, compute TVL on-chain).
+// Each loan's collateral sits in its own Taproot vault (Loan.btcVaultAddress from the Surge indexer).
+// fetchById paginates by an `id` cursor (id_gt $lastId), so the query must expose and order by `id`.
 const INDEXER = 'https://indexer.surge.build/v1/graphql'
-const INDEXER_TIMEOUT = 15000
-const VAULTS_QUERY = `query ($limit: Int!, $offset: Int!) {
+const VAULTS_QUERY = `query ($lastId: String!) {
   Loan(
-    where: { chainId: { _eq: 8453 } }
-    limit: $limit
-    offset: $offset
-    order_by: { nftId: asc }
-  ) { btcVaultAddress }
+    where: { chainId: { _eq: 8453 }, id: { _gt: $lastId } }
+    order_by: { id: asc }
+    limit: 1000
+  ) { id btcVaultAddress }
 }`
 
-async function getVaultAddresses() {
-  const owners = []
-  const seen = new Set()
-  const pageSize = 1000
-  const maxPages = 100 // safety bound (~100k loans) so a misbehaving API cannot loop forever
-  // Paginate; the vault set grows one address per loan.
-  for (let page = 0; page < maxPages; page++) {
-    const res = await post(
-      INDEXER,
-      { query: VAULTS_QUERY, variables: { limit: pageSize, offset: page * pageSize } },
-      { timeout: INDEXER_TIMEOUT },
-    )
-    // Fail closed: a GraphQL error comes back HTTP 200 with res.errors, and a bad
-    // response has no Loan array. Neither is "zero vaults" (which would silently
-    // report 0 TVL), so throw and let DefiLlama keep the last good value.
-    if (res && res.errors) {
-      throw new Error(`Surge indexer GraphQL error: ${JSON.stringify(res.errors).slice(0, 300)}`)
-    }
-    const rows = res && res.data && res.data.Loan
-    if (!Array.isArray(rows)) {
-      throw new Error('Surge indexer returned no Loan array')
-    }
-    for (const r of rows) {
-      const addr = r.btcVaultAddress
-      if (addr && !seen.has(addr)) {
-        seen.add(addr)
-        owners.push(addr)
-      }
-    }
-    if (rows.length < pageSize) return owners
-  }
-  throw new Error('Surge indexer pagination exceeded safety bound')
-}
-
-// TVL: native BTC held on-chain across every per-loan Taproot vault address.
 async function bitcoinTvl(api) {
-  const owners = await getVaultAddresses()
+  const loans = await cachedGraphQuery('surgecredit/btc-vaults', INDEXER, VAULTS_QUERY, { fetchById: true })
+  const owners = [...new Set(loans.map(l => l.btcVaultAddress).filter(Boolean))]
   return sumTokens({ owners, timestamp: api.timestamp })
 }
 
 // Borrowed: outstanding USDC debt across all positions (the active credit).
-// This is what DeFiLlama renders on the "Active Loans" tab.
 async function baseBorrowed(api) {
   const totals = await api.call({ target: VAULT_MANAGER, abi: GET_TOTALS_ABI })
-  api.add(USDC, totals.totalDebt)
+  api.add(ADDRESSES.base.USDC, totals.totalDebt)
 }
 
 module.exports = {
-  methodology:
-    'TVL is the native BTC collateral locked in per-loan non-custodial Taproot vaults, summed directly from the vault addresses on Bitcoin L1. Each vault address is derived deterministically from the borrower on-chain pubkey and served by the Surge indexer (Loan.btcVaultAddress). Borrowed is the outstanding USDC debt across all positions (the active credit), read from VaultManager.getTotals() on Base. Idle USDC lending liquidity is not counted in TVL.',
+  methodology: 'TVL is the native BTC collateral locked in per-loan non-custodial Taproot vaults, summed directly from the vault addresses on Bitcoin L1. Each vault address is derived deterministically from the borrower on-chain pubkey and served by the Surge indexer (Loan.btcVaultAddress). Borrowed is the outstanding USDC debt across all positions (the active credit), read from VaultManager.getTotals() on Base. Idle USDC lending liquidity is not counted in TVL.',
+  timetravel: false,
   bitcoin: { tvl: bitcoinTvl },
   base: { borrowed: baseBorrowed },
 }

--- a/projects/surgecredit/index.js
+++ b/projects/surgecredit/index.js
@@ -1,27 +1,59 @@
-const sdk = require('@defillama/sdk')
+const { post } = require('../helper/http')
+const { sumTokens } = require('../helper/chain/bitcoin')
 
-// Surge Credit — BTC-collateralized USDC lending on Base (chainId 8453).
+// Surge Credit: BTC-collateralized USDC lending on Base (chainId 8453).
 // Slug `surgecredit` (bare `surge` is taken by an unrelated Arbitrum lender).
 
 const VAULT_MANAGER = '0x0D5D12de1cC71060A38F25DD9d24DA1DD6eB705a'
 const USDC = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'
 
-// VaultManager keeps the protocol-wide aggregate: BTC collateral in satoshis
-// (1e8) and USDC debt (1e6). Collateral lives in per-loan, non-custodial Taproot
-// vaults with deterministic addresses derived off-chain (no public address set to
-// sum UTXOs over), so the on-chain aggregate is the canonical figure.
 const GET_TOTALS_ABI =
   'function getTotals() view returns (uint256 totalCollateral, uint256 totalDebt)'
 
-// TVL: native BTC collateral locked in the Taproot vaults (satoshis -> BTC).
-// Read from Base (VaultManager), credited as native bitcoin.
-async function bitcoinTvl(api) {
-  const baseApi = new sdk.ChainApi({ chain: 'base', timestamp: api.timestamp })
-  const totals = await baseApi.call({ target: VAULT_MANAGER, abi: GET_TOTALS_ABI })
-  api.addCGToken('bitcoin', totals.totalCollateral / 1e8)
+// Each loan's collateral lives in its own non-custodial Taproot (P2TR) vault. The
+// vault address is deterministic (derived from the borrower's on-chain x-only pubkey
+// and EVM address), computed by our indexer at loan creation and exposed as
+// Loan.btcVaultAddress. We fetch the live address set and sum the actual UTXO balances
+// on Bitcoin L1 (per PR #20190: track BTC via the custody addresses, compute TVL on-chain).
+const INDEXER = 'https://indexer.surge.build/v1/graphql'
+
+async function getVaultAddresses() {
+  const owners = []
+  const seen = new Set()
+  const pageSize = 1000
+  let offset = 0
+  // Paginate; the vault set grows one address per loan.
+  for (;;) {
+    const query = `query ($limit: Int!, $offset: Int!) {
+      Loan(
+        where: { chainId: { _eq: 8453 } }
+        limit: $limit
+        offset: $offset
+        order_by: { nftId: asc }
+      ) { btcVaultAddress }
+    }`
+    const res = await post(INDEXER, { query, variables: { limit: pageSize, offset } })
+    const rows = (res && res.data && res.data.Loan) || []
+    for (const r of rows) {
+      const addr = r.btcVaultAddress
+      if (addr && !seen.has(addr)) {
+        seen.add(addr)
+        owners.push(addr)
+      }
+    }
+    if (rows.length < pageSize) break
+    offset += pageSize
+  }
+  return owners
 }
 
-// Borrowed: outstanding USDC debt across all positions — the active credit.
+// TVL: native BTC held on-chain across every per-loan Taproot vault address.
+async function bitcoinTvl(api) {
+  const owners = await getVaultAddresses()
+  return sumTokens({ owners, timestamp: api.timestamp })
+}
+
+// Borrowed: outstanding USDC debt across all positions (the active credit).
 // This is what DeFiLlama renders on the "Active Loans" tab.
 async function baseBorrowed(api) {
   const totals = await api.call({ target: VAULT_MANAGER, abi: GET_TOTALS_ABI })
@@ -30,7 +62,7 @@ async function baseBorrowed(api) {
 
 module.exports = {
   methodology:
-    'TVL is the native BTC collateral locked in per-loan non-custodial Taproot vaults, read from the protocol-wide on-chain aggregate VaultManager.getTotals() (satoshis) on Base. Borrowed is the outstanding USDC debt across all positions (the active credit). Idle USDC lending liquidity is not counted in TVL.',
+    'TVL is the native BTC collateral locked in per-loan non-custodial Taproot vaults, summed directly from the vault addresses on Bitcoin L1. Each vault address is derived deterministically from the borrower on-chain pubkey and served by the Surge indexer (Loan.btcVaultAddress). Borrowed is the outstanding USDC debt across all positions (the active credit), read from VaultManager.getTotals() on Base. Idle USDC lending liquidity is not counted in TVL.',
   bitcoin: { tvl: bitcoinTvl },
   base: { borrowed: baseBorrowed },
 }

--- a/projects/surgecredit/index.js
+++ b/projects/surgecredit/index.js
@@ -16,24 +16,38 @@ const GET_TOTALS_ABI =
 // Loan.btcVaultAddress. We fetch the live address set and sum the actual UTXO balances
 // on Bitcoin L1 (per PR #20190: track BTC via the custody addresses, compute TVL on-chain).
 const INDEXER = 'https://indexer.surge.build/v1/graphql'
+const INDEXER_TIMEOUT = 15000
+const VAULTS_QUERY = `query ($limit: Int!, $offset: Int!) {
+  Loan(
+    where: { chainId: { _eq: 8453 } }
+    limit: $limit
+    offset: $offset
+    order_by: { nftId: asc }
+  ) { btcVaultAddress }
+}`
 
 async function getVaultAddresses() {
   const owners = []
   const seen = new Set()
   const pageSize = 1000
-  let offset = 0
+  const maxPages = 100 // safety bound (~100k loans) so a misbehaving API cannot loop forever
   // Paginate; the vault set grows one address per loan.
-  for (;;) {
-    const query = `query ($limit: Int!, $offset: Int!) {
-      Loan(
-        where: { chainId: { _eq: 8453 } }
-        limit: $limit
-        offset: $offset
-        order_by: { nftId: asc }
-      ) { btcVaultAddress }
-    }`
-    const res = await post(INDEXER, { query, variables: { limit: pageSize, offset } })
-    const rows = (res && res.data && res.data.Loan) || []
+  for (let page = 0; page < maxPages; page++) {
+    const res = await post(
+      INDEXER,
+      { query: VAULTS_QUERY, variables: { limit: pageSize, offset: page * pageSize } },
+      { timeout: INDEXER_TIMEOUT },
+    )
+    // Fail closed: a GraphQL error comes back HTTP 200 with res.errors, and a bad
+    // response has no Loan array. Neither is "zero vaults" (which would silently
+    // report 0 TVL), so throw and let DefiLlama keep the last good value.
+    if (res && res.errors) {
+      throw new Error(`Surge indexer GraphQL error: ${JSON.stringify(res.errors).slice(0, 300)}`)
+    }
+    const rows = res && res.data && res.data.Loan
+    if (!Array.isArray(rows)) {
+      throw new Error('Surge indexer returned no Loan array')
+    }
     for (const r of rows) {
       const addr = r.btcVaultAddress
       if (addr && !seen.has(addr)) {
@@ -41,10 +55,9 @@ async function getVaultAddresses() {
         owners.push(addr)
       }
     }
-    if (rows.length < pageSize) break
-    offset += pageSize
+    if (rows.length < pageSize) return owners
   }
-  return owners
+  throw new Error('Surge indexer pagination exceeded safety bound')
 }
 
 // TVL: native BTC held on-chain across every per-loan Taproot vault address.


### PR DESCRIPTION
##### Name:
Surge Credit

##### Twitter Link:
https://x.com/surge_credit

##### List of audit links if any:
- Reardencode
- CredShields

##### Website Link:
[https://surge.credit](https://surge.credit)

##### Logo (High resolution, will be shown with rounded borders):
Sent to metadata@defillama.com

##### Current TVL:
11.34 BTC (~$742k), plus $352k USDC borrowed (Active Loans)

##### Treasury Addresses (if the protocol has treasury):
n/a

##### Chain:
Bitcoin, Base

##### Coingecko ID (leave empty if not listed):
(empty - no token)

##### Coinmarketcap ID (leave empty if not listed):
(empty - no token)

##### Short Description (to be shown on DefiLlama):
BTC-collateralized USDC lending. Users deposit native BTC into non-custodial
Taproot vaults and borrow USDC on Base against it.

##### Token address and ticker if any:
none

##### Category (choose only one):
Lending

##### Oracle Provider(s):
Chainlink (BTC/USD)

##### Implementation Details:
The lending contracts price BTC collateral and drive liquidation health checks off
a Chainlink BTC/USD feed, read through Surge's on-chain oracle on Base.

##### Documentation/Proof:
Oracle contract (Base): https://basescan.org/address/0x54DE003026dCa32E7cb28BDC79dDDcdB1bc1194D

##### forkedFrom:
No

##### methodology (what is counted as TVL, how TVL is calculated):
TVL is the native BTC collateral locked in per-loan non-custodial Taproot vaults, read from the protocol-wide on-chain aggregate `VaultManager.getTotals()` (satoshis) on Base and credited as native bitcoin. Borrowed is the outstanding
USDC debt across all positions (the Active Loans metric). Idle USDC lending liquidity is not counted in TVL.

##### Github org/user (optional):
surgecredit

##### Does this project have a referral program?
Upcoming

---

**Contracts (Base mainnet, 8453):**
- VaultManager `0x0D5D12de1cC71060A38F25DD9d24DA1DD6eB705a`
- USDC `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`

**Adapter:** `projects/surgecredit/index.js`
**Test:** `node test.js projects/surgecredit/index.js`

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added DeFiLlama coverage for Surge Credit on Base.
  * Added Bitcoin TVL reporting by discovering related Taproot vaults and summing BTC balances across them.
  * Added “borrowed” reporting by pulling total debt totals and presenting them in USDC.
  * Included methodology details for the reported Bitcoin TVL and borrowed metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->