### PR TITLE
Add Windfall Lotto TVL adapter

### DIFF
--- a/projects/windfall-lotto/index.js
+++ b/projects/windfall-lotto/index.js
@@ -1,0 +1,24 @@
+const WINDFALL_LOTTO =
+  "0x9650D206c6e0093FBc1D623b2A1e03984D24d3f1";
+
+const POLYGON_DAI =
+  "0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063";
+
+async function tvl(api) {
+  return api.sumTokens({
+    owner: WINDFALL_LOTTO,
+    tokens: [POLYGON_DAI],
+  });
+}
+
+module.exports = {
+  methodology:
+    "Counts DAI held by the Windfall Lotto smart contract on Polygon, " +
+    "including jackpot funds, rollovers, donations, and unclaimed prizes.",
+
+  start: 1775388703,
+
+  polygon: {
+    tvl,
+  },
+};


### PR DESCRIPTION
## Windfall Lotto TVL Adapter

This PR adds a Polygon TVL adapter for Windfall Lotto.

---

## New listing information

##### Name (to be shown on DefiLlama):

Windfall Lotto

##### Twitter Link:

https://x.com/WindfallPolygon

##### List of audit links if any:

https://windfall-lotto.com/Audit_v2.2_Final.pdf

##### Website Link:

https://windfall-lotto.com/

##### Logo (High resolution, will be shown with rounded borders):

https://windfall-lotto.com/windfall_lotto_logo.png

##### Current TVL:

Approximately **$1.38 k**, consisting of DAI held by the Windfall Lotto contract on Polygon.

TVL changes dynamically as tickets are purchased, donations are received, prizes are claimed, and jackpot funds roll over between draws.

##### Treasury Addresses (if the protocol has treasury):

Windfall Lotto does not include an externally owned treasury wallet in the reported TVL.

The following fee-distribution contract receives the protocol fee and is intentionally excluded from TVL:

* WindfallFeeShare: `0x8d1e76657F469932Dd04d0Bad2f0FCE0bbDb22a5`

The main TVL-holding contract is:

* WindfallLotto: `0x9650D206c6e0093FBc1D623b2A1e03984D24d3f1`

##### Chain:

Polygon

##### Coingecko ID:

Not applicable. Windfall Lotto does not have a native fungible token listed on CoinGecko.

##### Coinmarketcap ID:

Not applicable. Windfall Lotto does not have a native fungible token listed on CoinMarketCap.

##### Short Description (to be shown on DefiLlama):

Windfall Lotto is a transparent on-chain lottery protocol on Polygon. Lottery tickets are issued as NFTs, jackpots are denominated in DAI, draw operations are publicly executable, and randomness is provided through independent verifiable-randomness systems with an emergency fallback.

##### Token address and ticker if any:

Windfall Lotto does not have a native protocol token.

The protocol uses DAI on Polygon for ticket purchases, jackpot funding, donations, and prize payments:

* Token: DAI
* Ticker: DAI
* Address: `0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063`

##### Category:

yield-lottery

##### Oracle Provider(s): Specify the oracle(s) used:

* Chainlink VRF v2.5 — primary randomness provider
* Supra dVRF — secondary randomness provider
* Polygon blockhash — emergency final fallback

The protocol does not use a price oracle for its TVL calculation because its locked asset is DAI. DeFiLlama obtains the asset valuation independently.

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

When a draw closes, the Windfall Lotto contract requests randomness from Chainlink VRF v2.5.

If the primary request cannot be fulfilled according to the protocol’s retry and fallback rules, the protocol can use Supra dVRF as an independent secondary randomness source.

A future Polygon blockhash is available only as the final emergency fallback if both verifiable-randomness paths fail.

The randomness output is converted into the five winning numbers used to determine the active winner tier and prize distribution.

The randomness providers do not affect the adapter’s TVL calculation. TVL is calculated directly from the on-chain DAI balance held by the Windfall Lotto contract.

##### Documentation/Proof: Provide links verifying oracle usage:

* Main contract on PolygonScan:
  https://polygonscan.com/address/0x9650D206c6e0093FBc1D623b2A1e03984D24d3f1#code

* Website:
  https://windfall-lotto.com/

* ENS:
  https://windfall-lotto.eth/

* Audit:
  https://windfall-lotto.com/Audit_v2.2_Final.pdf

* Additional technical documentation:
  https://github.com/windfall-lotto/windfall-lotto.eth

##### forkedFrom (Does your project originate from another project):

No. Windfall Lotto is an independently developed protocol and is not a fork of another lottery protocol.

##### methodology (what is being counted as TVL, how is TVL being calculated):

TVL counts the DAI balance held directly by the main Windfall Lotto smart contract on Polygon:

`0x9650D206c6e0093FBc1D623b2A1e03984D24d3f1`

This balance can include:

* Funds allocated to the current jackpot
* Jackpot funds rolled over from earlier draws
* Direct DAI jackpot donations
* Finalized prizes that remain unclaimed and are still held by the contract

The adapter obtains the ERC-20 DAI balance directly from Polygon blockchain state.

The following are excluded:

* DAI already paid to winners
* NFT ticket valuations
* Draw NFT valuations
* Externally owned wallet balances
* The WindfallFeeShare contract balance
* Internal accounting values that would duplicate DAI already counted through the contract balance

Rollovers do not create additional TVL because they only reclassify DAI already held by the contract. TVL decreases when DAI leaves the contract through a valid winner claim or another authorized transfer.

##### Github org/user (Optional, if your code is open source, we can track activity):

https://github.com/windfall-lotto/

##### Does this project have a referral program?

No.

---

## Contracts

* WindfallLotto:
  `0x9650D206c6e0093FBc1D623b2A1e03984D24d3f1`

* WindfallTicket:
  `0x8A1E8B8c54338bAa7B239dB845316A37BCb07C41`

* WindfallDrawNFT:
  `0x120C9ce64cfd6A2B173A6B44dc6aCFA5fEB556c1`

* WindfallFeeShare:
  `0x8d1e76657F469932Dd04d0Bad2f0FCE0bbDb22a5`

* Polygon DAI:
  `0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063`

---

## Testing

The adapter was tested with:

```bash
node test.js projects/windfall-lotto/index.js
```

The reported Polygon TVL corresponds to the DAI balance held by the main Windfall Lotto contract.