### PR TITLE
Add Valos TVL adapter

### DIFF
--- a/registries/curators.js
+++ b/registries/curators.js
@@ -1136,6 +1136,19 @@ const configs = {
       },
     },
   },
+  "valos": {
+    config: {
+      methodology: 'Counts the AUSD managed by the Valos institutional private credit vault using convertToAssets(totalSupply()).',
+      start: '2026-02-13',
+      blockchains: {
+        monad: {
+          accountableVaults: [
+            '0x8d3F9f9Eb2f5E8B48EFBB4074440D1E2A34Bc365',
+          ],
+        },
+      },
+    },
+  },
   "varlamore-capital": {
     config: {
       methodology: 'Count all assets are deposited in all vaults curated by Varlamore Capital.',


### PR DESCRIPTION
## Summary

- add Valos's institutional private credit vault on Monad
- calculate managed AUSD with the existing Accountable vault integration using `convertToAssets(totalSupply())`
- begin historical tracking on 2026-02-13, the first funded day

## Methodology

The adapter tracks the Valos vUSD vault at `0x8d3F9f9Eb2f5E8B48EFBB4074440D1E2A34Bc365`. Vault shares are converted to their underlying AUSD value so that deployed and idle assets are both represented.

Valos uses Accountable's vault infrastructure, so the adapter is registered as a curator-style integration and excluded from aggregate TVL to avoid duplicating the underlying Accountable lending exposure.

References:

- https://valos.io/announcements-and-insights/valos-launches-institutional-credit-vault-with-real-time-independent-verification
- https://monadscan.com/address/0x8d3F9f9Eb2f5E8B48EFBB4074440D1E2A34Bc365

## Validation

- `node test.js valos` — 111.42M AUSD
- `node test.js valos 2026-02-12` — 0 before the configured start date
- `npx eslint -c eslint.config.js registries/curators.js`
- `npm run check-registries-duplicates`
- `git diff --check`
