### PR TITLE
add stockworks (refactor)

### DIFF
--- a/registries/treasury.js
+++ b/registries/treasury.js
@@ -5380,6 +5380,12 @@ const configs = {
       ],
     },
   },
+  'treasury/stockworks': {
+    robinhood: {
+      owners: ['0x57024Aae99f709Bd399252767DDC6487Aa3881De'],
+      tokens: [nullAddress, '0x4a0E65A3EcceC6dBe60AE065F2e7bb85Fae35eEa'],
+    }
+  },
   'treasury/stonkbrokers': {
     robinhood: {
       owners: ['0x16027b596e210c63f750E0bdD156f00bb2749868'],


### PR DESCRIPTION
resolves #20147

marked as treasury since the controller is funded by swap fees on the SPCXSTR/ETH pool, and its balance cannot be withdrawn by users (used to buy and sell SPCX to burn SPCXSTR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Stockworks treasury registry.
  * Configured its Robinhood deployment, ownership details, and supported tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->