### PR TITLE
Remove B2 Buzz non-BTC chain configs (BNB/Ethereum/Polygon)

### DIFF
--- a/projects/bsquared/index.js
+++ b/projects/bsquared/index.js
@@ -1,10 +1,7 @@
 const sdk = require('@defillama/sdk');
 const { sumTokensExport: sumBRC20TokensExport } = require("../helper/chain/brc20");
 const { sumTokensExport } = require('../helper/sumTokens');
-const ADDRESSES = require('../helper/coreAssets.json')
 const bitcoinAddressBook = require('../helper/bitcoin-book/index.js')
-
-const ADDRESSES_ETHEREUM_STONE = '0x7122985656e38BDC0302Db86685bb972b145bD3C';
 
 module.exports = {
   hallmarks: [
@@ -16,26 +13,5 @@ module.exports = {
       sumTokensExport({ owners: bitcoinAddressBook.bsquaredBTC }),
       // sumBRC20TokensExport({ owners: bitcoinAddressBook.bsquaredBRC20 }),  // disable brc20
     ]),
-  },
-  ethereum: {
-    tvl: sumTokensExport({
-      ownerTokens: [
-        [[ADDRESSES_ETHEREUM_STONE, ADDRESSES.ethereum.USDC, ADDRESSES.ethereum.USDT, ADDRESSES.ethereum.WBTC], "0xeea3A032f381AB1E415e82Fe08ebeb20F513c42c",], //Ethereum Multisignature Address (WBTC)
-      ]
-    }),
-  },
-  polygon: {
-    tvl: sumTokensExport({
-      ownerTokens: [
-        [[ADDRESSES.null], "0x01cE88498ED095d386e09834D32Fd8f1FeCd184a",],
-      ]
-    }),
-  },
-  bsc: {
-    tvl: sumTokensExport({
-      ownerTokens: [
-        [[ADDRESSES.bsc.BTCB, ADDRESSES.ethereum.FDUSD], "0x0A80028d73Faaee6e57484E3335BeFda0de7f455",], //BNB Chain Multisig Address (BTCB)
-      ]
-    }),
   },
 };


### PR DESCRIPTION
Removes the BNB Chain, Ethereum and Polygon configs from projects/bsquared/index.js (the STONE/FDUSD/POL balances, ~$250K total), plus the now-unused coreAssets and STONE-address imports that only served those blocks. Bitcoin tracking is left completely untouched.

Context from #20208:
- Stonepapa (original B² Buzz adapter author, #8992) confirmed the B² Buzz pre-deposit event has ended.
- The assets on BNB Chain, Ethereum and Polygon are managed by a third-party bridge, not the official B² Network bridge.
- After I flagged that the Bitcoin leg (~2,814.70 BTC, ~$183.77M via the bsquaredBTC address list in bitcoin-book/index.js) is only counted by this adapter and nothing else, Stonepapa confirmed the correct scope is to keep bsquared/index.js and only remove the BNB/Ethereum/Polygon configs. Bitcoin stays as-is.

Verification:
- node test.js projects/bsquared/index.js runs clean after the change.
- Post-change TVL is bitcoin-only: ~$182.8M (2.81k BTC), matching the pre-change Bitcoin figure. The BNB/Ethereum/Polygon totals are gone.
- Confirmed nothing else in the repo consumes bsquaredBTC or references the removed multisig addresses, so no other adapter is affected.

Closes #20208

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the staking TVL display to include only Bitcoin-based TVL.
  - Removed Ethereum, Polygon, and BSC TVL calculations from the reported configuration.
  - Kept the BRC20 TVL calculation disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->