### PR TITLE
fix: cookiechain-bridge and add Hyperlane escrow to Solana-side TVL

### DIFF
--- a/projects/cookiechain-bridge/index.js
+++ b/projects/cookiechain-bridge/index.js
@@ -1,36 +1,31 @@
-const { PublicKey } = require('@solana/web3.js')
-const { getConnection, sumTokens2 } = require('../helper/solana')
+const { sumTokens2 } = require('../helper/solana')
 
-// Cookie Bridge is a Hyperlane warp route between Solana and Cookie Chain (a
-// Solana / Agave fork). It is collateral <-> collateral: SPL COOK is locked in
-// a warp escrow on Solana, native COOK is locked in a warp collateral PDA on
-// Cookie Chain, and the relayer releases 1:1 from the destination pool. Nothing
-// synthetic is minted, so summing both locked pools is the TVL with no
-// double-counting. Both chains are indexed and priced by DefiLlama (COOK,
-// confidence ~0.99), so each pool is reported under its own chain.
+// Cookie Bridge moves COOK between Solana and Cookie Chain (a Solana / Agave fork)
+// 1:1 — it is the same asset on both chains. TVL is measured on the canonical
+// Solana side only (counting the mirrored Cookie Chain balance too would
+// double-count the same COOK). This continues the bridge's original methodology
+// ("COOK locked in the Solana bridge"), which counted the Squads multi-sig; with
+// the migration to Hyperlane the bridge now also escrows COOK in a Hyperlane warp
+// PDA on Solana, so that PDA is added alongside the multi-sig.
 
-// Solana side: warp escrow token account holding SPL COOK (Token-2022, 6dp).
-const SOLANA_ESCROW = '88q7zoKctwAQRsoTxkMJy95sNE3tntuyEhSrhvR1eZwq'
+// SPL COOK (Token-2022, 6dp).
+const SOLANA_COOK = '36ZrtQoab5MhhySaP1YSTwUahSk6GRVUTtZ6cuVfm9e1'
+// Squads multi-sig that custodies bridge COOK (original bridge reserve).
+const SQUADS_MULTISIG = 'DoYYCtcG2vfrE3HtxBBXiNVieMutvWBXsgbF3SKtYCyx'
+// Hyperlane warp escrow token account (added with the Hyperlane migration).
+const HYPERLANE_PDA = '88q7zoKctwAQRsoTxkMJy95sNE3tntuyEhSrhvR1eZwq'
 
-// Cookie Chain side: native-collateral PDA holding native COOK (9dp). Native
-// COOK is priced as the wrapped mint (Solana fork => same address as wSOL).
-const COOKIE_COLLATERAL_PDA = new PublicKey('CL2JoQ5jdTpRNKshWhaTihuooT4qrKdLUiPsqKj3yAKz')
-const WRAPPED_COOK = 'So11111111111111111111111111111111111111112'
-
-async function solanaTvl(api) {
-  await sumTokens2({ api, tokenAccounts: [SOLANA_ESCROW] })
-}
-
-async function cookiechainTvl(api) {
-  const connection = getConnection(api.chain)
-  const lamports = await connection.getBalance(COOKIE_COLLATERAL_PDA)
-  api.add(WRAPPED_COOK, lamports)
+async function tvl(api) {
+  return sumTokens2({
+    api,
+    tokenAccounts: [HYPERLANE_PDA],                    // Hyperlane warp escrow (is itself the token account)
+    tokensAndOwners: [[SOLANA_COOK, SQUADS_MULTISIG]], // Squads multi-sig -> its COOK account(s)
+  })
 }
 
 module.exports = {
   timetravel: false,
   methodology:
-    'TVL counts the COOK locked as collateral in the Hyperlane warp route that bridges COOK between Solana and Cookie Chain: SPL COOK held in the escrow on Solana plus native COOK held on Cookie Chain. Bridging locks and releases the same COOK 1:1 with no wrapped or minted supply.',
-  solana: { tvl: solanaTvl },
-  cookiechain: { tvl: cookiechainTvl },
+    'TVL is the COOK locked in the bridge on Solana: SPL COOK held in the Hyperlane warp escrow PDA plus the Squads multi-sig that custodies the bridge reserve. COOK bridges 1:1 and is the same asset on Cookie Chain, so the mirrored Cookie Chain balances are not counted again.',
+  solana: { tvl },
 }

--- a/registries/sumTokens.js
+++ b/registries/sumTokens.js
@@ -11941,15 +11941,6 @@ const configs = {
       }
     },
   },
-  "cookiechain-bridge": {
-    "methodology": "Tracks all COOK locked in the solana bridge.",
-    "solana": {
-      "owner": "DoYYCtcG2vfrE3HtxBBXiNVieMutvWBXsgbF3SKtYCyx",
-      "tokens": [
-        "36ZrtQoab5MhhySaP1YSTwUahSk6GRVUTtZ6cuVfm9e1"
-      ]
-    },
-  },
   "copump": {
     "core": {
       "owner": "0xbEF63121a00916d88c4558F2a92f7d931C67115B",


### PR DESCRIPTION
## Summary

`cookiechain-bridge` currently has **two conflicting definitions** in this repo, and the one that computes is stale. This PR consolidates them into a single, correct adapter and updates the TVL to reflect the bridge's migration to Hyperlane.

- The **CookieChain Bridge** moves COOK between **Solana** and **Cookie Chain** 1:1.
- It has migrated to a **Hyperlane warp route**. The bridge's COOK on Solana now sits in two places: the original **Squads multi-sig** reserve and the new **Hyperlane warp escrow PDA**.

## Changes

### 1. `projects/cookiechain-bridge/index.js` — rewritten
Now counts the bridge's COOK on the **Solana side only**:
- `88q7zoKctwAQRsoTxkMJy95sNE3tntuyEhSrhvR1eZwq` — Hyperlane warp escrow (SPL COOK, Token-2022)
- `DoYYCtcG2vfrE3HtxBBXiNVieMutvWBXsgbF3SKtYCyx` — Squads multi-sig that custodies the bridge reserve

### 2. `registries/sumTokens.js` — removed duplicate entry
Deleted the `"cookiechain-bridge"` block. It was the **original** adapter (added in #19640, migrated into the registry by #19742) that summed only the `DoYYC` multi-sig. Because it shared the `cookiechain-bridge` key with the newer `projects/` file, it shadowed it — so the live protocol was running the stale registry entry, not the intended adapter. Removing it makes `projects/cookiechain-bridge/index.js` the single source of truth.

## Methodology & rationale

**TVL = COOK locked in the bridge on Solana** (Hyperlane warp escrow PDA + Squads multi-sig reserve).

- **Why Solana-only:** COOK bridges 1:1 and is the **same asset** on both chains. Counting the mirrored Cookie Chain balances as well would **double-count** the same COOK, so TVL is measured once, on the canonical Solana side.
- **Continuity:** this extends the bridge's original methodology (*"COOK locked in the Solana bridge"*, which counted the `DoYYC` multi-sig) by adding the **Hyperlane escrow PDA** introduced during the migration. It is a clean continuation of the existing series (~415.7M → ~450M), not a redefinition — no TVL cliff.

## Not counted (intentionally)
- **Cookie Chain side** (`CL2Jo…` Hyperlane PDA, `G3mm…` Squads multi-sig) — mirror of the same 1:1 COOK; would double-count.

## Note for maintainers
The `cookiechain-bridge` protocol is currently flagged **`deprecated`** on the server. That request was intended for the project's *old community bridge* (a separate wallet, not a DefiLlama protocol) — but there is only one `cookiechain-bridge` protocol, so the flag is hiding the **active** Hyperlane bridge. Please **remove the `deprecated` flag** so the live bridge shows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Cookiechain Bridge TVL reporting to measure Solana-side balances only.
  * Improved balance accounting to include bridged escrow and custody holdings without double-counting.
  * Removed the outdated Cookie Chain TVL view from available reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->