### PR TITLE
Add Tirelire (Robinhood Chain)

### DIFF
--- a/projects/tirelire/index.js
+++ b/projects/tirelire/index.js
@@ -1,0 +1,47 @@
+// Tirelire — TVL adapter for DefiLlama-Adapters.
+//
+// TARGET PATH IN THE PR: projects/tirelire/index.js
+// Repo: https://github.com/DefiLlama/DefiLlama-Adapters  (CommonJS)
+//
+// What Tirelire is: an automated Uniswap V3 concentrated-liquidity manager (ALM)
+// on Robinhood Chain (Arbitrum Orbit L2, chainId 4663, DeFiLlama slug "robinhood").
+// It deploys the audited Gamma Hypervisor VERBATIM (config-only, no custom
+// Solidity) and manages USDG/WETH and USDG/NVDA Uniswap V3 positions.
+//
+// TVL model: each Hypervisor holds both tokens across its active Uniswap V3
+// positions (base + limit) plus idle balances plus uncollected fees. The
+// contract exposes this as getTotalAmounts() -> (total0, total1). A plain
+// balanceOf() would MISS the in-range position liquidity, so we must use
+// getTotalAmounts(). This is the same method the canonical Gamma adapter uses.
+
+const HYPERVISORS = [
+  "0xb9F974d19425d93B3a9dC80c8f0d3aE428Cbb2B2", // Tirelire USDG-WETH (0.05%)
+  "0xcFefe9Ee6B45587939debB869394190432e72258", // Tirelire USDG-NVDA (0.05%)
+];
+
+async function tvl(api) {
+  const token0s = await api.multiCall({ abi: "address:token0", calls: HYPERVISORS });
+  const token1s = await api.multiCall({ abi: "address:token1", calls: HYPERVISORS });
+  const totals = await api.multiCall({
+    abi: "function getTotalAmounts() view returns (uint256 total0, uint256 total1)",
+    calls: HYPERVISORS,
+  });
+  totals.forEach((t, i) => {
+    const total0 = t.total0 !== undefined ? t.total0 : t[0];
+    const total1 = t.total1 !== undefined ? t.total1 : t[1];
+    api.add(token0s[i], total0);
+    api.add(token1s[i], total1);
+  });
+  return api.getBalances();
+}
+
+module.exports = {
+  // Tokens live in the Hypervisor's Uniswap V3 positions, valued at spot from
+  // the underlying tokens — no external oracle, no double counting.
+  methodology:
+    "TVL is the value of both tokens held by each Tirelire Hypervisor across its " +
+    "active Uniswap V3 positions, idle balances, and uncollected fees, read " +
+    "on-chain via getTotalAmounts(). Tirelire deploys the audited Gamma Hypervisor " +
+    "verbatim; there is no custom accounting.",
+  robinhood: { tvl },
+};

--- a/projects/tirelire/index.js
+++ b/projects/tirelire/index.js
@@ -1,19 +1,3 @@
-// Tirelire — TVL adapter for DefiLlama-Adapters.
-//
-// TARGET PATH IN THE PR: projects/tirelire/index.js
-// Repo: https://github.com/DefiLlama/DefiLlama-Adapters  (CommonJS)
-//
-// What Tirelire is: an automated Uniswap V3 concentrated-liquidity manager (ALM)
-// on Robinhood Chain (Arbitrum Orbit L2, chainId 4663, DeFiLlama slug "robinhood").
-// It deploys the audited Gamma Hypervisor VERBATIM (config-only, no custom
-// Solidity) and manages USDG/WETH and USDG/NVDA Uniswap V3 positions.
-//
-// TVL model: each Hypervisor holds both tokens across its active Uniswap V3
-// positions (base + limit) plus idle balances plus uncollected fees. The
-// contract exposes this as getTotalAmounts() -> (total0, total1). A plain
-// balanceOf() would MISS the in-range position liquidity, so we must use
-// getTotalAmounts(). This is the same method the canonical Gamma adapter uses.
-
 const HYPERVISORS = [
   "0xb9F974d19425d93B3a9dC80c8f0d3aE428Cbb2B2", // Tirelire USDG-WETH (0.05%)
   "0xcFefe9Ee6B45587939debB869394190432e72258", // Tirelire USDG-NVDA (0.05%)
@@ -32,16 +16,14 @@ async function tvl(api) {
     api.add(token0s[i], total0);
     api.add(token1s[i], total1);
   });
-  return api.getBalances();
 }
 
 module.exports = {
-  // Tokens live in the Hypervisor's Uniswap V3 positions, valued at spot from
-  // the underlying tokens — no external oracle, no double counting.
   methodology:
     "TVL is the value of both tokens held by each Tirelire Hypervisor across its " +
     "active Uniswap V3 positions, idle balances, and uncollected fees, read " +
     "on-chain via getTotalAmounts(). Tirelire deploys the audited Gamma Hypervisor " +
     "verbatim; there is no custom accounting.",
+  doublecounted: true,
   robinhood: { tvl },
 };


### PR DESCRIPTION
## Tirelire — automated Uniswap V3 liquidity manager on Robinhood Chain

Adds a TVL adapter for **Tirelire**, an automated concentrated-liquidity manager (ALM) on **Robinhood Chain** (Arbitrum Orbit L2, chainId 4663 — DeFiLlama slug `robinhood`). Tirelire deploys the audited **Gamma Hypervisor** verbatim (config-only, no custom Solidity) and actively manages Uniswap V3 positions, auto-compounding trading fees.

### Listing metadata
- **Name:** Tirelire
- **Category:** Liquidity manager
- **Chain:** Robinhood
- **Website:** https://tirelire.xyz
- **Twitter:** https://x.com/TirelireXYZ
- **Explorer:** https://robinhoodchain.blockscout.com

### Methodology
TVL is both tokens held by each Hypervisor across its Uniswap V3 positions + idle balances + uncollected fees, read on-chain via `getTotalAmounts()` — the same method the canonical Gamma adapter uses (a plain `balanceOf` would miss in-range position liquidity). No external oracle, no custom accounting.

Vaults tracked:
- `0xb9F974d19425d93B3a9dC80c8f0d3aE428Cbb2B2` — Tirelire USDG-WETH (0.05%)
- `0xcFefe9Ee6B45587939debB869394190432e72258` — Tirelire USDG-NVDA (0.05%)

### Test
```
$ node test.js projects/tirelire/index.js
--- tvl ---
WETH   10.66 k
USDG    6.10 k
NVDA    2.95 k
------ TVL ------
robinhood   19.71 k
total       19.71 k
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for the Tirelire protocol on the Robinhood chain.
  * Included support for reporting holdings from Tirelire’s known hypervisor contracts.
  * Added token balance aggregation across the hypervisors for more accurate TVL reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->