### PR TITLE
add empire builder treasury

### DIFF
--- a/registries/treasury.js
+++ b/registries/treasury.js
@@ -1701,6 +1701,16 @@ const configs = {
       tokens: [nullAddress],
     },
   },
+  'treasury/empire-builder': {
+    base: {
+      owners: ['0xa22434c246217E2a1ea0Eab8e5a510eE3caF8b66'],
+      tokens: [nullAddress, ADDRESSES.base.WETH],
+    },
+    arbitrum: {
+      owners: ['0xa22434c246217E2a1ea0Eab8e5a510eE3caF8b66'],
+      tokens: [nullAddress, ADDRESSES.arbitrum.WETH],
+    },
+  },
   'treasury/empyreal': {
     arbitrum: {
       tokens: [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Empire Builder treasury on Base and Arbitrum networks.
  * Added recognized token configurations for each network, including WETH.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->