### PR TITLE
Prismapad: add v3 launchpad to owners

### DIFF
--- a/registries/sumTokens/data1.js
+++ b/registries/sumTokens/data1.js
@@ -82,13 +82,15 @@ module.exports = {
     // Prismapad launchpad on Stable (chain id 988).
     // v1 (bonding curve, legacy):
     // https://stablescan.xyz/address/0xdcb881fc8b472eb7797687b237e6cb123c425ff7#code
-    // v2 (direct-to-DEX — every token launches straight into an official
-    // StableSwap (Uniswap v3) pool; the LP position is locked in the launchpad):
+    // v2 / v3 (direct-to-DEX — every token launches straight into an official
+    // StableSwap (Uniswap v3) pool; the LP position is locked in the launchpad).
+    // v3 supersedes v2 for new launches; v2 stays live for its existing tokens:
     // https://stablescan.xyz/address/0xa96d9eadc4d6eed50fa408a33585c5f1df039db5#code
+    // https://stablescan.xyz/address/0x7c1628681c18884a1a90977fdae034282892c842#code
     "doublecounted": true,
     "methodology": 'TVL is the USDT0 side of Prismapad liquidity: the bonding-curve reserves held by the legacy v1 launchpad, plus the USDT0 in the locked v3 NFTs',
     "stable": {
-      owners: ['0xdcb881fc8b472eb7797687b237e6cb123c425ff7', '0xa96d9eadc4d6eed50fa408a33585c5f1df039db5'],
+      owners: ['0xdcb881fc8b472eb7797687b237e6cb123c425ff7', '0xa96d9eadc4d6eed50fa408a33585c5f1df039db5', '0x7c1628681c18884a1a90977fdae034282892c842'],
       resolveUniV3: true,
       tokens: [ADDRESSES.stable.USDT0],
       uniV3WhitelistedTokens: [ADDRESSES.stable.USDT0],


### PR DESCRIPTION
Prismapad deployed a v3 launchpad on Stable (chain 988). It is mechanically identical to v2 — the full 1B supply is minted as single-sided liquidity into an official StableSwap (Uniswap v3) pool and the position NFT is locked in the launchpad. The only difference is how token addresses are derived: CREATE2 over a per-creator salt rather than the contract nonce.

v3 handles new launches. v2 stays live for the tokens already launched on it, so both are listed as owners and `resolveUniV3` picks up every locked position.

- v3: `0x7c1628681c18884a1a90977fdae034282892c842`
- v2: `0xa96d9eadc4d6eed50fa408a33585c5f1df039db5` (unchanged)
- v1: `0xdcb881fc8b472eb7797687b237e6cb123c425ff7` (unchanged)

One-line change to the `owners` array; `doublecounted`, methodology and token config are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Stable pool tracking for Prisma Pad by recognizing an additional contract owner.
  * Updated launchpad behavior documentation for greater clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->