### PR TITLE
Add USDAX Finance APX staking adapter (Robinhood Chain)

### DIFF
--- a/projects/usdax-finance/index.js
+++ b/projects/usdax-finance/index.js
@@ -1,0 +1,20 @@
+const APX_STAKING = "0x00b6792ac02caf607d0b6ea4a6f572a83472412f";
+const APX_TOKEN   = "0x42523E3e454B97ff8651926685aFAD61C950Ab2F";
+
+async function tvl(api) {
+  const totalStaked = await api.call({
+    abi:    "uint256:totalStaked",
+    target: APX_STAKING,
+  });
+  api.add(APX_TOKEN, totalStaked);
+}
+
+module.exports = {
+  methodology:
+    "Tracks APX tokens actively staked by users in the USDAX Finance APXStaking contract on Robinhood Chain Mainnet. " +
+    "Only active stake (accruing rewards) is counted — cooldown positions and the protocol reward pool are excluded.",
+  robinhoodchain: {
+    tvl,
+    staking: tvl,
+  },
+};

--- a/projects/usdax-finance/index.js
+++ b/projects/usdax-finance/index.js
@@ -1,18 +1,54 @@
+// USDAX Finance — APX Staking TVL Adapter
+// Chain: Robinhood Chain Mainnet (chainId 4663)
+// Contract: APXStaking at 0x00b6792ac02caf607d0b6ea4a6f572a83472412f
+//
+// TVL accounting:
+//   The APXStaking contract holds three categories of APX:
+//     1. totalStaked    — actively staking, accruing rewards
+//     2. cooldownAmount — per-user amounts in the 7-day cooldown window (not accruing, but locked)
+//     3. rewardsPool    — protocol-owned emission reserve (not user deposits)
+//
+//   We want (1) + (2) — all user-deposited APX regardless of accrual state.
+//   Rather than enumerating per-user cooldown amounts, we derive it as:
+//     userDeposited = balanceOf(contract) - rewardsPool
+//
+//   This approach is also resilient to the case where totalStaked = 0 (pool
+//   not yet funded / no stakers), which caused the previous adapter to revert.
+
 const APX_STAKING = "0x00b6792ac02caf607d0b6ea4a6f572a83472412f";
 const APX_TOKEN   = "0x42523E3e454B97ff8651926685aFAD61C950Ab2F";
 
 async function tvl(api) {
-  const totalStaked = await api.call({
-    abi:    "uint256:totalStaked",
-    target: APX_STAKING,
-  });
-  api.add(APX_TOKEN, totalStaked);
+  try {
+    const [contractBalance, rewardsPool] = await Promise.all([
+      api.call({
+        abi:    "erc20:balanceOf",
+        target: APX_TOKEN,
+        params: [APX_STAKING],
+      }),
+      api.call({
+        abi:    "uint256:rewardsPool",
+        target: APX_STAKING,
+      }),
+    ]);
+
+    // user-deposited APX = total contract balance minus protocol reward reserve
+    const userAPX = BigInt(contractBalance) - BigInt(rewardsPool);
+    if (userAPX > 0n) {
+      api.add(APX_TOKEN, userAPX.toString());
+    }
+  } catch (_) {
+    // Contract not yet funded or no stakers — report 0, do not throw
+  }
 }
 
 module.exports = {
   methodology:
-    "Tracks APX tokens actively staked by users in the USDAX Finance APXStaking contract on Robinhood Chain Mainnet. " +
-    "Only active stake (accruing rewards) is counted — cooldown positions and the protocol reward pool are excluded.",
+    "Tracks APX tokens deposited by users in the USDAX Finance APXStaking contract " +
+    "on Robinhood Chain Mainnet (chain ID 4663). TVL is derived as the contract's total " +
+    "APX balance minus the protocol-owned reward pool, capturing both actively staking " +
+    "positions and amounts currently in the 7-day cooldown window. " +
+    "Protocol reward reserves are excluded.",
   robinhoodchain: {
     tvl,
     staking: tvl,

--- a/projects/usdax-finance/index.js
+++ b/projects/usdax-finance/index.js
@@ -8,37 +8,36 @@
 //     2. cooldownAmount — per-user amounts in the 7-day cooldown window (not accruing, but locked)
 //     3. rewardsPool    — protocol-owned emission reserve (not user deposits)
 //
-//   We want (1) + (2) — all user-deposited APX regardless of accrual state.
-//   Rather than enumerating per-user cooldown amounts, we derive it as:
-//     userDeposited = balanceOf(contract) - rewardsPool
+//   TVL = (1) + (2) — all user-deposited APX regardless of accrual state.
+//   Derived as: balanceOf(contract) - rewardsPool
+//   This avoids enumerating per-user cooldown amounts and never relies on
+//   totalStaked() which excludes cooldown positions by design.
 //
-//   This approach is also resilient to the case where totalStaked = 0 (pool
-//   not yet funded / no stakers), which caused the previous adapter to revert.
+//   Neither balanceOf nor rewardsPool can revert (ERC-20 standard + public
+//   storage getter), so no error suppression is needed. Unexpected failures
+//   propagate so DeFiLlama retains the last known-good TVL.
 
 const APX_STAKING = "0x00b6792ac02caf607d0b6ea4a6f572a83472412f";
 const APX_TOKEN   = "0x42523E3e454B97ff8651926685aFAD61C950Ab2F";
 
 async function tvl(api) {
-  try {
-    const [contractBalance, rewardsPool] = await Promise.all([
-      api.call({
-        abi:    "erc20:balanceOf",
-        target: APX_TOKEN,
-        params: [APX_STAKING],
-      }),
-      api.call({
-        abi:    "uint256:rewardsPool",
-        target: APX_STAKING,
-      }),
-    ]);
+  const [contractBalance, rewardsPool] = await Promise.all([
+    api.call({
+      abi:    "erc20:balanceOf",
+      target: APX_TOKEN,
+      params: [APX_STAKING],
+    }),
+    api.call({
+      abi:    "uint256:rewardsPool",
+      target: APX_STAKING,
+    }),
+  ]);
 
-    // user-deposited APX = total contract balance minus protocol reward reserve
-    const userAPX = BigInt(contractBalance) - BigInt(rewardsPool);
-    if (userAPX > 0n) {
-      api.add(APX_TOKEN, userAPX.toString());
-    }
-  } catch (_) {
-    // Contract not yet funded or no stakers — report 0, do not throw
+  // User-deposited APX = total contract balance minus protocol reward reserve.
+  // Covers both active stake and cooldown-locked positions.
+  const userAPX = BigInt(contractBalance) - BigInt(rewardsPool);
+  if (userAPX > 0n) {
+    api.add(APX_TOKEN, userAPX.toString());
   }
 }
 


### PR DESCRIPTION
**NOTE**
#### Please enable "Allow edits by maintainers" while putting up the PR.

---

## (Needs to be filled only for new listings):

##### Name (to be shown on DefiLlama):
USDAX Finance

##### Twitter Link:
https://x.com/Usdax_Finance

##### Link to the docs:
https://usdax.finance/docs

##### Is it built on top of/forked from another protocol? If yes, what changes are there?
No. Custom Synthetix-model staking contract, built from scratch.

##### Contract address and blockchain:
APXStaking: 0x00b6792ac02caf607d0b6ea4a6f572a83472412f
Chain: Robinhood Chain Mainnet (chainId 4663)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tracking for USDAX Finance APX staking TVL and staking balances.
  * TVL now reflects user-deposited APX across actively staked and 7-day cooldown-locked positions, while excluding protocol-owned emission reserves.
* **Bug Fixes / Improvements**
  * Improved robustness of TVL computation by deriving net user APX from contract balance minus rewards pool, and only reporting positive net amounts.
* **Documentation**
  * Updated methodology details to document the TVL derivation rules and inclusion/exclusion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->