### PR TITLE
Add TartSwap (BSC)

### DIFF
--- a/projects/tartswap/index.js
+++ b/projects/tartswap/index.js
@@ -1,0 +1,26 @@
+// TartSwap — DefiLlama adapter
+// Submit as: projects/tartswap/index.js in a fork of github.com/DefiLlama/DefiLlama-Adapters
+//
+// Contracts (BSC mainnet, verified on-chain 2026-07-26):
+//   TartStakingVault  0x20940d3573F1629F6c5226C2DDa2e9a28b364B33  (~$71k, 169 stakers)
+//   CREPE token       0xeb2B7d5691878627eff20492cA7c9a71228d931D  (9 decimals)
+//
+// Methodology note: the vault stakes CREPE — TartSwap's ecosystem token — so per
+// DefiLlama policy it belongs under `staking`, not headline TVL. LP farms exist
+// but currently stream no rewards and hold ~no deposits; add a pool2/tvl section
+// when they actually hold value. DEX pair liquidity lives on PancakeSwap pairs
+// and is deliberately NOT claimed as TartSwap TVL.
+
+const { staking } = require("../helper/staking");
+
+const TART_STAKING_VAULT = "0x20940d3573F1629F6c5226C2DDa2e9a28b364B33";
+const CREPE = "0xeb2B7d5691878627eff20492cA7c9a71228d931D";
+
+module.exports = {
+  methodology:
+    "Staking counts CREPE deposited in the TartStakingVault contract (single-token, reward-streaming vault funded by protocol swap fees). DEX pair liquidity is not double-counted as TartSwap TVL.",
+  bsc: {
+    tvl: async () => ({}),
+    staking: staking(TART_STAKING_VAULT, CREPE),
+  },
+};

--- a/projects/tartswap/index.js
+++ b/projects/tartswap/index.js
@@ -1,7 +1,7 @@
 // TartSwap — DefiLlama adapter
 // Submit as: projects/tartswap/index.js in a fork of github.com/DefiLlama/DefiLlama-Adapters
 //
-// Contracts (BSC mainnet, verified on-chain 2026-07-26):
+// Contracts (BSC mainnet, verified on-chain 2026-07-25):
 //   TartStakingVault  0x20940d3573F1629F6c5226C2DDa2e9a28b364B33  (~$71k, 169 stakers)
 //   CREPE token       0xeb2B7d5691878627eff20492cA7c9a71228d931D  (9 decimals)
 //


### PR DESCRIPTION
## TartSwap

Self-custody DeFi suite on BNB Chain: swap, real-yield single-token staking, OTC desk, and on-chain parimutuel games.

- Website: https://tartswap.com
- Twitter: https://x.com/tartswap
- Chain: BSC (56)

### What this adapter counts

`staking`: CREPE deposited in the TartStakingVault contract (single-token, reward-streaming vault funded by protocol swap fees).

- TartStakingVault: `0x20940d3573F1629F6c5226C2DDa2e9a28b364B33` (verified on BscScan; ~169 stakers)
- CREPE token: `0xeb2B7d5691878627eff20492cA7c9a71228d931D`

CREPE is the protocol's ecosystem token, so the vault is reported under `staking` rather than headline TVL. `tvl` is currently empty on purpose: LP farms exist but hold ~no deposits today, and DEX pair liquidity lives on PancakeSwap pairs, which we deliberately do not claim as TartSwap TVL. We'll extend the adapter (pool2/tvl) when the farms hold real value.

Listing metadata (logo, description) will be sent to metadata@defillama.com after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TartSwap coverage to the DeFi analytics platform.
  * Added BSC staking reporting for TartSwap.
  * Non-staking TVL is not currently reported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->