### PR TITLE
Add ProsperaVest FGN T-Bills Vault (prosperavest-fgntbill)

### DIFF
--- a/projects/prosperavest-fgntbill/index.js
+++ b/projects/prosperavest-fgntbill/index.js
@@ -1,0 +1,26 @@
+const ENSC = "0xF50FFf154E63E510e494929E9eab1E9C5047429E";
+
+const TREASURY_MANAGER = {
+  lisk: "0xCEAE041EF1002E8Ba508FD3e657016420E5da88a",
+  base: "0xb48EF45E1bB7895332BcC23426093378cCB051fc",
+};
+
+const abi = {
+  getTbillTVL: "function getTbillTVL() view returns (uint256)",
+};
+
+async function tvl(api) {
+  const locked = await api.call({
+    target: TREASURY_MANAGER[api.chain],
+    abi: abi.getTbillTVL,
+  });
+  api.add(ENSC, locked);
+}
+
+module.exports = {
+  methodology:
+    "Sums the ENSC deposited into each ProsperaVest FGNTBILL vault. Vaults are enumerated on-chain via the Treasury Manager aggregator, which totals the ENSC held by every ENSC-backed vault. ENSC is priced by DefiLlama's price service.",
+  timetravel: false,
+  lisk: { tvl },
+  base: { tvl },
+};


### PR DESCRIPTION
---
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama): ProsperaVest FGN T-Bills Vault
##### Twitter Link: https://x.com/prosperavest
##### List of audit links if any: https://prosperavest.com/transparency
##### Website Link: https://prosperavest.com
##### Logo (High resolution, will be shown with rounded borders): 
##### Current TVL: $0 - vaults are deployed on Lisk and Base but hold no deposits yet
##### Treasury Addresses (if the protocol has treasury): none
##### Chain: Lisk, Base
##### Coingecko ID:
##### Coinmarketcap ID:
##### Short Description (to be shown on DefiLlama): ProsperaVest FGN Treasury Bill vaults. Own tokenized Real World Assets (RWA) such as the Nigerian government Treasury Bills. Each FGNTBILL token represents a fractional position in a sovereign backed instrument held in institutional grade custody.
##### Token address and ticker if any: none - FGNTBILL vault shares are issued per series, one ERC-20 per T-Bill series. ENSC (0xF50FFf154E63E510e494929E9eab1E9C5047429E) is the deposited asset, listed separately in peggedassets-server PR #881.
##### Category (full list at https://defillama.com/categories) *Please choose only one: RWA
##### Oracle Provider(s): None. TVL is read directly from on-chain contract state, no oracle is involved.
##### Implementation Details: N/A - no oracle used currently (in pipeline).
##### Documentation/Proof: https://prosperavest.com/transparency
##### forkedFrom (Does your project originate from another project): none
##### methodology (what is being counted as tvl, how is tvl being calculated): Sums the ENSC deposited into each ProsperaVest FGNTBILL vault. Vaults are enumerated on-chain via the Treasury Manager aggregator, which totals the ENSC held by every ENSC-backed vault. ENSC is priced by DefiLlama's price service. Reads $0 currently as no deposits have occurred.
##### Github org/user (Optional): https://github.com/Prospera-Vest
##### Does this project have a referral program? No

---
Note: ENSC is not on CoinGecko yet. An on-chain pricing request for its Velodrome Slipstream ENSC/USDT pool on Lisk is open in Discord #api. Until that lands the adapter reports ENSC amounts with no USD value attached. The companion stablecoin listing is peggedassets-server PR #881.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added TVL tracking for the Prosperavest T-Bill product across the Lisk and Base networks.
  - Reports locked ENSC assets using on-chain treasury data.
  - Includes methodology details and disables historical time-travel calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->