### PR TITLE
Add BowYard

### DIFF
--- a/projects/bowyard/index.js
+++ b/projects/bowyard/index.js
@@ -1,0 +1,26 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+
+const LAUNCHPAD = '0x0F724aED8961C0446Cf73E9C45be562BEB22e774'
+const LAUNCH_AGENT = '0x821de9ff15B0d1f31795822e5E4107FF060e9E37'
+const AGENT_LAUNCHPAD = '0xc5e8ee1D72f08a29CCEB465BeFf0B4b830D63750'
+const DEX_FACTORY = '0x27275079932d9a5cBA34Cb40Bf86084bDdD89241'
+
+async function tvl(api) {
+  const dexPairs = await api.fetchList({
+    target: DEX_FACTORY,
+    lengthAbi: 'uint256:pairCount',
+    itemAbi: 'function pairAt(uint256) view returns (address)',
+  })
+
+  return api.sumTokens({
+    owners: [LAUNCHPAD, LAUNCH_AGENT, AGENT_LAUNCHPAD, ...dexPairs],
+    tokens: [ADDRESSES.robinhood.USDG],
+  })
+}
+
+module.exports = {
+  methodology:
+    'Counts canonical USDG held in BowYard bonding curves, user-funded Launch Agent budgets, Agent Launchpad V2 curves, and the USDG side of permanently locked BowYard DEX pools on Robinhood Chain. BowYard-launched tokens, fee and revenue vaults, and protocol treasury balances are excluded.',
+  start: '2026-07-26',
+  robinhood: { tvl },
+}


### PR DESCRIPTION
## Summary

Adds an on-chain TVL adapter for BowYard on Robinhood Chain. The adapter conservatively counts only canonical USDG held by BowYard contracts and excludes launched tokens, protocol treasury balances, fee vaults, and revenue vaults.

## Listing information

##### Name (to be shown on DefiLlama):

BowYard

##### Twitter Link:

https://x.com/BowYardAI

##### List of audit links if any:

None. No audit is claimed.

##### Website Link:

https://bowyard.fun

##### Logo (High resolution, will be shown with rounded borders):

https://bowyard.fun/bowyard-mark.svg

##### Current TVL:

5.142292 USDG at Robinhood Chain block 20613099 when validated on 2026-07-27.

##### Treasury Addresses (if the protocol has treasury):

Robinhood Chain: `0x2418746dc419761a1E0AAEF4E39fB7E5253E1BC1` (excluded from TVL)

##### Chain:

Robinhood Chain

##### Coingecko ID:

Not listed.

##### Coinmarketcap ID:

Not listed.

##### Short Description (to be shown on DefiLlama):

Non-custodial launchpad for meme tokens, RWA projects, useful agents, and USDG markets on Robinhood Chain.

##### Token address and ticker if any:

No BowYard protocol token. Tokens created by users are excluded from TVL.

##### Category:

Launchpad

##### Oracle Provider(s):

None. BowYard's curve accounting and the adapter are denominated directly in canonical USDG.

##### Implementation Details:

The adapter reads canonical USDG balances directly on Robinhood Chain. It includes the core bonding-curve launchpad, user-funded Launch Agent budgets, Agent Launchpad V2 curves, and the USDG side of permanently locked BowYard DEX pairs enumerated by `pairCount`/`pairAt` from the DEX factory.

##### Documentation/Proof:

- https://bowyard.fun/integrations
- https://bowyard.fun/api/v1/contracts
- https://bowyard.fun/api/v1/abi
- https://robinhoodchain.blockscout.com/address/0x0F724aED8961C0446Cf73E9C45be562BEB22e774
- https://robinhoodchain.blockscout.com/address/0x27275079932d9a5cBA34Cb40Bf86084bDdD89241

##### forkedFrom:

No.

##### methodology:

Counts canonical USDG held in BowYard bonding curves, user-funded Launch Agent budgets, Agent Launchpad V2 curves, and the USDG side of permanently locked BowYard DEX pools on Robinhood Chain. BowYard-launched tokens, fee and revenue vaults, and protocol treasury balances are excluded.

##### Github org/user:

Omitted because the application repository is private.

##### Does this project have a referral program?

No.

## Validation

- `node --check projects/bowyard/index.js`
- Live RPC compatibility harness returned 5.142292 USDG on chain ID 4663 at block 20613099.
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added BowYard TVL tracking on Robinhood Chain.
  * Includes USDG balances held by launch-related contracts and discovered decentralized exchange pairs.
  * Added methodology details and tracking start date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->