### PR TITLE
Add BowStop game contract implementation

### DIFF
--- a/projects/bowstop/index.js
+++ b/projects/bowstop/index.js
@@ -1,0 +1,34 @@
+const BOW_TOKEN      = '0x507B757cf2157f6357DC385b8096d7daFAefDaAA';
+const BOW_RANGE      = '0x7323e2B2B9cafdceE28DD57Eaf7357F0D19d8e57';
+const SHERIFFS_PURSE = '0x3230b8F6fF97366E9ccD3BDaD5F57C6Def569D10';
+const GROWTH_FUND    = '0xDD4799dfB8E345734ec8e801eCDBaF551360C3e7';
+const AUTO_MINE_VAULT = '0xc4BC321B0a9059D413c77E2306905166Fe3F83ea';
+const BOW_VOTE_ESCROW = '0xD3287B613FdB7a735221C7851c37475C22583621';
+const BOW_LP_STAKING  = '0x807C8fA32F44D4d38865a76443d4D1D49A5F3BA1';
+const LP_TOKEN        = '0x0555921631F8A2f3b900178b2F02D70353396F7F'; // BOW/WETH pair, via BowLPStaking.lpToken()
+
+async function tvl(api) {
+  for (const addr of [BOW_RANGE, SHERIFFS_PURSE, GROWTH_FUND, AUTO_MINE_VAULT]) {
+    const bal = await api.getBalance(addr);
+    api.addGasToken(bal);
+  }
+}
+
+async function staking(api) {
+  const lockedBow = await api.call({ abi: 'erc20:balanceOf', target: BOW_TOKEN, params: [BOW_VOTE_ESCROW] });
+  api.add(BOW_TOKEN, lockedBow);
+}
+
+async function pool2(api) {
+  const stakedLp = await api.call({ abi: 'erc20:balanceOf', target: LP_TOKEN, params: [BOW_LP_STAKING] });
+  api.add(LP_TOKEN, stakedLp);
+}
+
+module.exports = {
+  methodology: 'TVL sums the native ETH held by the BowStop game contracts on behalf of users: live volley pots and carryover (BowRange), the unclaimed Sheriff\'s Purse prize pool (SheriffsPurse), undistributed growth-fund revenue (GrowthFund), and auto-mine deposits (AutoMineVault). Staking counts BOW locked into permanent veBOW positions (BowVoteEscrow). Pool2 counts BOW/WETH LP staked in BowLPStaking.',
+  robinhood: {
+    tvl,
+    staking,
+    pool2,
+  },
+};


### PR DESCRIPTION
This file contains the implementation for the BowStop game contracts, including functions for total value locked (TVL), staking, and pool2 calculations.

**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).
2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** Please send a mail to metadata@defillama.com
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes

---

## (Needs to be filled only for new listings)
##### Name (to be shown on DefiLlama): BowStop
##### Twitter Link: https://x.com/BowStopApp
##### List of audit links if any: None yet (automated scanner review only, no formal audit)
##### Website Link: https://bowstop.xyz
##### Logo (High resolution, will be shown with rounded borders): 
##### Current TVL: computed live via the adapter above
##### Treasury Addresses (if the protocol has treasury): 0xDD4799dfB8E345734ec8e801eCDBaF551360C3e7 (GrowthFund)
##### Chain: Robinhood Chain
##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)
##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
##### Short Description (to be shown on DefiLlama): BowStop is a gamified mining game on Robinhood Chain where players commit ETH to a 25-target grid each 1-minute volley; resolved volleys mint BOW rewards, distribute a Sheriff's Purse jackpot, and permanently lock a share of BOW into veBOW positions for protocol-yield stakers.
##### Token address and ticker if any: 0x507B757cf2157f6357DC385b8096d7daFAefDaAA (BOW)
##### Category (full list at https://defillama.com/categories) \*Please choose only one: Gamified Mining
##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.): drand (via a verified DrandRandomnessProvider oracle deployed on Robinhood Chain mainnet)
##### Implementation Details: Briefly describe how the oracle is integrated into your project: BowRange and SheriffsPurse use a two-phase commit/reveal pattern: requestRandomness() commits to a future drand round, the keeper relays the settled BLS signature via settleRandomness(), and getRandomness() returns the verified value used to resolve each volley/epoch draw.
##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage: https://robinhoodchain.blockscout.com/address/0x7323e2B2B9cafdceE28DD57Eaf7357F0D19d8e57?tab=contract
##### forkedFrom (Does your project originate from another project): No
##### methodology (what is being counted as tvl, how is tvl being calculated): TVL sums the native ETH held by the BowStop game contracts on behalf of users: live volley pots and carryover (BowRange), the unclaimed Sheriff's Purse prize pool (SheriffsPurse), undistributed growth-fund revenue (GrowthFund), and auto-mine deposits (AutoMineVault). Staking counts BOW locked into permanent veBOW positions (BowVoteEscrow). Pool2 counts BOW/WETH LP staked in BowLPStaking.
##### Github org/user (Optional, if your code is open source, we can track activity): 
##### Does this project have a referral program? No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit
* **New Features**
  * Added support for tracking BowStop DeFi metrics.
  * Introduced TVL, staking, and pool liquidity metrics, including ETH, locked BOW, and staked LP balances.
  * Added methodology details for the reported metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->