### PR TITLE
Add Atoma vault TVL adapter

### DIFF
--- a/registries/erc4626.js
+++ b/registries/erc4626.js
@@ -401,6 +401,14 @@ const configs = {
   'secured-finance-vaults': {
     ethereum: ['0x7a6E3635694952dC00F6bA4d4AD1a7B892028789']
   },
+  'atoma': {
+    methodology: "TVL is the sum of totalAssets() across both Atoma ERC-4626 vaults on Arbitrum. Deposited USDC is held idle in the vault or deployed as margin/equity on perpetual exchanges (Extended, Nado, Lighter, XYZ) via an operator-controlled trading account; totalAssets is updated on-chain roughly hourly to reflect off-chain venue equity plus idle USDC.",
+    start: '2026-05-05',
+    arbitrum: [
+      '0xCC56410e1a136aF0eCEb7241c6aE394F4d8b581c', // Vault 1 - Extended x Nado
+      '0x1C788E14d8e5B446e3F71B5142e2edaBcAB36da1', // Vault 2 - Lighter x XYZ
+    ],
+  },
 }
 
 module.exports = buildProtocolExports(configs, erc4626ExportFn)


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).

2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** Please send a mail to metadata@defillama.com
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes

---
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama): ATOMA

##### Twitter Link: https://x.com/atoma_fi

##### List of audit links if any:

##### Website Link: https://atoma.fi

##### Logo (High resolution, will be shown with rounded borders): https://app.atoma.fi/assets/atoma_token_logo.png

##### Current TVL: ~$75,234 (USDC on Arbitrum, sum of both vaults' totalAssets)

##### Treasury Addresses (if the protocol has treasury):

##### Chain: Arbitrum

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):

##### Short Description (to be shown on DefiLlama): ATOMA runs delta-neutral basis-trading vaults: users deposit USDC into ERC-4626 vaults on Arbitrum, and the protocol deploys that capital as margin on perpetual venues to capture funding-rate arbitrage and cross-exchange spread yield across Extended, Nado, Lighter and trade.xyz.

##### Token address and ticker if any:

##### Category (full list at https://defillama.com/categories) *Please choose only one: Basis Trading

##### Oracle Provider(s):

##### Implementation Details:

##### Documentation/Proof:

##### forkedFrom (Does your project originate from another project):

##### methodology (what is being counted as tvl, how is tvl being calculated): TVL is the sum of totalAssets() across both ATOMA ERC-4626 vaults on Arbitrum. Deposited USDC is either held idle in the vault or deployed as margin/equity on perpetual exchanges (Extended, Nado, Lighter, XYZ) via an operator-controlled trading account; totalAssets is updated on-chain roughly hourly to reflect off-chain venue equity plus idle USDC. Read directly from the contracts, no off-chain API.

##### Github org/user (Optional, if your code is open source, we can track activity):

##### Does this project have a referral program? Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for tracking Atoma’s ERC-4626 vaults on Arbitrum.
  - Atoma vault balances will now be included in ERC-4626 total value locked calculations starting May 5, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->