### PR TITLE
Add Katana Perps TVL adapter

### DIFF
--- a/projects/katana-perps/index.js
+++ b/projects/katana-perps/index.js
@@ -1,0 +1,12 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+const { sumTokensExport } = require('../helper/sumTokens')
+
+const OWNER = '0x23317197cf82a14d7b7a671c23b94d39f6a2fa22'
+
+module.exports = {
+  methodology:
+    'TVL counts the USDC (Vault Bridge USDC) held in the Katana Perps contract on the Katana chain.',
+  katana: {
+    tvl: sumTokensExport({ owner: OWNER, tokens: [ADDRESSES.katana.VB_USDC] }),
+  },
+}


### PR DESCRIPTION
Adds a TVL adapter for [Katana Perps](https://defillama.com/protocol/katana-perps).

TVL is the USDC (VB_USDC) held in the protocol's contract `0x23317197cf82a14d7b7a671c23b94d39f6a2fa22` on the Katana chain.

Tested with `node test.js projects/katana-perps/index.js` → ~$3.02M.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for the Katana Perps contract.
  * TVL now reflects USDC held by the contract on the Katana chain.
  * Included methodology details describing how the TVL is calculated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->