### PR TITLE
Add more Makina strategies

### DIFF
--- a/projects/makina-finance/index.js
+++ b/projects/makina-finance/index.js
@@ -1,18 +1,22 @@
 // https://docs.makina.finance/
-// https://app.makina.finance/
+// https://makina.finance/
 
 // Makina TVL Adapter - External Pricing Version
 const DUSD_TOKEN = '0x1e33e98af620f1d563fcd3cfd3c75ace841204ef';
 const DETH_TOKEN = '0x871ab8e36cae9af35c6a3488b049965233deb7ed';
 const DBIT_TOKEN = '0x972966bcc17f7d818de4f27dc146ef539c231bdf';
 const usdSHFmk_TOKEN = '0xac499adf00a54044b988a59b19016655c3494b06';
+const intMkSrRoyUSDC_TOKEN = '0x1004D230aCA4b781d0049AFD6D0b1ee8ed3A6787';
+const DQAeETH_TOKEN = '0x2b24dFcE3a6AEF36E147C692Fa32d484ec538FC1';
 
 async function tvl(api) {
-  const [dusdSupply, dethSupply, dbitSupply, usdSHFmkSupply] = await Promise.all([
+  const [dusdSupply, dethSupply, dbitSupply, usdSHFmkSupply, intMkSrRoyUSDCSupply, DQAeETHSupply] = await Promise.all([
     api.call({ abi: 'erc20:totalSupply', target: DUSD_TOKEN }),
     api.call({ abi: 'erc20:totalSupply', target: DETH_TOKEN }),
     api.call({ abi: 'erc20:totalSupply', target: DBIT_TOKEN }),
     api.call({ abi: 'erc20:totalSupply', target: usdSHFmk_TOKEN }),
+    api.call({ abi: 'erc20:totalSupply', target: intMkSrRoyUSDC_TOKEN }),
+    api.call({ abi: 'erc20:totalSupply', target: DQAeETH_TOKEN }),
   ]);
 
   return {
@@ -20,6 +24,8 @@ async function tvl(api) {
     [DETH_TOKEN]: dethSupply,
     [DBIT_TOKEN]: dbitSupply,
     [usdSHFmk_TOKEN]: usdSHFmkSupply,
+    [intMkSrRoyUSDC_TOKEN]: intMkSrRoyUSDCSupply,
+    [DQAeETH_TOKEN]: DQAeETHSupply,
   };
 }
 


### PR DESCRIPTION
This PR is to add 2 more strategies from Makina:

- https://makina.finance/strategy/dqaeeth
- https://makina.finance/strategy/intmksrroyusdc

Ultimately we connect this script to our indexer / API to have it dynamically loaded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Makina Finance TVL tracking to include two additional share tokens.
* **Documentation**
  * Updated the referenced Makina Finance website address in the adapter documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->