### PR TITLE
temp break metapool mpsol

### DIFF
--- a/projects/empire-builder/index.js
+++ b/projects/empire-builder/index.js
@@ -62,7 +62,7 @@ async function staking(api) {
 
   const vaults = await getEmpireVaults(api);
   const ownerTokens = vaults.filter((v) => !quote.has(v.baseToken.toLowerCase())).map((v) => [[v.baseToken], v.vault]);
-  if (ownerTokens.length) await api.sumTokens({ ownerTokens });
+  if (ownerTokens.length) await api.sumTokens({ ownerTokens, permitFailure: true });
 
   const logs = await getLogs2({
     api,
@@ -72,7 +72,7 @@ async function staking(api) {
     extraKey: 'empire-staked-tokens',
   });
   const stakedTokens = [...new Set(logs.map((l) => l.token.toLowerCase()))].filter((t) => !quote.has(t));
-  if (stakedTokens.length) await api.sumTokens({ owner: cfg.stakingLocker, tokens: stakedTokens });
+  if (stakedTokens.length) await api.sumTokens({ owner: cfg.stakingLocker, tokens: stakedTokens, permitFailure: true });
 }
 
 module.exports = {

--- a/projects/metapool-mpsol/index.js
+++ b/projects/metapool-mpsol/index.js
@@ -40,6 +40,7 @@ async function getBackingSolValue(api) {
  * @param {Object} api - DefiLlama API context (optional)
  */
 async function tvl(api) {
+  throw new Error('Temporarily disabled to investigate spike in tvl ($100k -> $140M)')
   await getBackingSolValue(api)
 }
 


### PR DESCRIPTION
also adds essential permitFailure to empirebuilder (some empires are tokenless)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved staking data processing by tolerating individual token-summing failures.
  - Temporarily disabled Metapool mSOL TVL reporting while an anomalous TVL spike is investigated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->