### PR TITLE
add katana perps and bowstop

### DIFF
--- a/registries/sumTokens.js
+++ b/registries/sumTokens.js
@@ -2676,6 +2676,27 @@ const configs = {
       ]
     },
   },
+  "bowstop": {
+    "robinhood": {
+      "tvl": {
+        "owners": [
+          "0x7323e2B2B9cafdceE28DD57Eaf7357F0D19d8e57",
+          "0x3230b8F6fF97366E9ccD3BDaD5F57C6Def569D10",
+          "0xDD4799dfB8E345734ec8e801eCDBaF551360C3e7",
+          "0xc4BC321B0a9059D413c77E2306905166Fe3F83ea",
+        ],
+        "tokens": [ADDRESSES.null]
+      },
+      "staking": {
+        "owners": ["0xD3287B613FdB7a735221C7851c37475C22583621"],
+        "tokens": ["0x507B757cf2157f6357DC385b8096d7daFAefDaAA"]
+      },
+      "pool2": {
+        "owners": ["0x807C8fA32F44D4d38865a76443d4D1D49A5F3BA1"],
+        "tokens": ["0x0555921631F8A2f3b900178b2F02D70353396F7F"]
+      },
+    },
+  },
   "bracket-fi": {
     "ethereum": {
       "owner": "0x9b9d7297C3374DaFA2A609d47C79904e467970Bc",
@@ -16796,6 +16817,13 @@ const configs = {
     "blast": {
       "owner": "0xd97cbc833643dc458849d5b96dea100f13b08402",
       "resolveUniV3": true
+    },
+  },
+  "katana-perps": {
+    "methodology": "TVL counts the USDC (Vault Bridge USDC) held in the Katana Perps contract on the Katana chain.",
+    "katana": {
+      "owner": "0x23317197cf82a14d7b7a671c23b94d39f6a2fa22",
+      "tokens": [ADDRESSES.katana.VB_USDC]
     },
   },
   "kavafc": {


### PR DESCRIPTION
resolves #20241
resolves #20244


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tracking support for Bowstop contracts, including Robinhood TVL, staking, and pool configurations.
  * Added tracking support for Katana perpetuals using VB USDC token data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->