### PR TITLE
accountable: add aHYPER Looping Vault

### DIFF
--- a/projects/accountable/index.js
+++ b/projects/accountable/index.js
@@ -21,6 +21,12 @@ const FACTORIES = {
     ],
 }
 
+const EXTRA_VAULTS = {
+    monad: [
+        '0x23b148d8f389C5821739381f1FF87bB7e1162566',
+    ],
+}
+
 const abis = {
     strategyProxies: 'function strategyProxies(uint256) view returns (address)',
     strategyVaults: 'function strategyVaults(address) view returns (address)',
@@ -61,6 +67,9 @@ async function getVaults(api) {
             })
         }
     }
+
+    for (const vault of (EXTRA_VAULTS[api.chain] || []))
+        vaults.add(vault.toLowerCase())
 
     return Array.from(vaults)
 }


### PR DESCRIPTION
Adds the aHYPER Looping Vault (`0x23b148d8f389C5821739381f1FF87bB7e1162566`, Monad) to the Accountable adapter. It is deployed directly, not via a registered factory, so it isn't discoverable through `strategyProxies`/`strategyVaults` — added explicitly. TVL uses the same path as other vaults; verified +$7.55M on the test harness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing additional vault addresses during vault discovery on the Monad chain.
  * Included vaults discovered through these additional addresses in TVL calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->