### PR TITLE
feat: add popi.wtf launchpad adapter (Solana + Robinhood Chain 4663)

### DIFF
--- a/projects/popi/index.js
+++ b/projects/popi/index.js
@@ -1,0 +1,102 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+const { getConnection, sumTokens2 } = require('../helper/solana')
+const { PublicKey } = require('@solana/web3.js')
+
+// popi (popi.wtf) — a gacha bonding-curve memecoin launchpad deployed on two
+// chains with the SAME lifecycle. A launch raises the quote asset (ETH on
+// Robinhood Chain, SOL on Solana) into an escrow while it is BONDING; when the
+// curve reaches its graduation threshold the launch migrates and its liquidity
+// is atomically moved OUT of popi into the chain's DEX (Uniswap v3 on Robinhood,
+// PumpSwap on Solana). TVL here is therefore the quote asset still escrowed in
+// popi for launches that have NOT yet graduated — i.e. value locked in live
+// bonding curves. Graduated launches hold nothing in popi (their raise left for
+// the DEX at migration), so they fall out of TVL automatically.
+
+// ----------------------------------------------------------------------------
+// Robinhood Chain (chainId 4663) — single UUPS proxy custodies every launch.
+// ----------------------------------------------------------------------------
+// Unlike per-launch clones, ALL popi launches on Robinhood live in ONE contract
+// (the Solana single-program model, ported). Every bonding deposit is booked
+// into that proxy's native-ETH balance (`totalBooked`); `migrate` subtracts the
+// graduated launch's `claimableEth` from the proxy and sends it to the Uniswap
+// v3 pool, and failed-launch refunds also leave the proxy. So the proxy's live
+// native-ETH balance == Σ escrow of all still-bonding launches. Verified live:
+// balance == totalBooked() to within ~1863 wei of dust.
+const ROBIN_LAUNCHPAD = '0xae7f18c0d1a66aad8bfec77b0bbf779e03571b06'
+
+async function robinhoodTvl(api) {
+  // Native ETH held in the launchpad proxy. ADDRESSES.null (0x0) is priced as
+  // the chain's gas token (ETH) by the SDK — same treatment rhfun uses for its
+  // native bonding curves on this chain. WETH is not held at rest (migrate wraps
+  // ammEth and forwards it to the pool in the same tx), so native ETH is the
+  // whole escrow.
+  return api.sumTokens({ tokensAndOwners: [[ADDRESSES.null, ROBIN_LAUNCHPAD]] })
+}
+
+// ----------------------------------------------------------------------------
+// Solana (program BNtfydNwzthyGfH1LMxt5AzQkJo7iyfGFbjjNKuHFH6M) — per-launch
+// vault PDA custodies each launch's SOL.
+// ----------------------------------------------------------------------------
+// Each launch has a System-owned vault PDA at seeds ["vault", launchPubkey] that
+// holds the raised SOL. `migrate` drains that vault into the PumpSwap pool and
+// flips phase -> Graduated (+ migrated = true); close_failed_launch closes the
+// vault entirely. We enumerate live Launch accounts (Anchor discriminator), skip
+// the Graduated ones, derive each survivor's vault PDA, and sum the vaults'
+// native SOL via sumTokens2({ solOwners }).
+const SOL_PROGRAM_ID = new PublicKey('BNtfydNwzthyGfH1LMxt5AzQkJo7iyfGFbjjNKuHFH6M')
+// Anchor account discriminator for `Launch` = sha256("account:Launch")[..8],
+// base58-encoded for the getProgramAccounts memcmp filter.
+const LAUNCH_DISCRIMINATOR_B58 = 'R7vQE78exjo'
+const PHASE_GRADUATED = 3 // Phase enum: 0 BondingCurve | 1 Settle | 2 Gacha | 3 Graduated
+
+// Read the `phase` byte out of a borsh-serialized Launch account. Layout:
+//   8 disc | 32 creator | 8 created_at | 8 created_at_slot |
+//   (4+len) name | (4+len) symbol | (4+len) uri | 32 mint | 1 phase | ...
+// name/symbol/uri are variable-length strings, so phase sits at a dynamic offset
+// that we walk to. Returns 255 if the buffer is too short to parse (treated as
+// non-graduated so its vault is still counted — fail safe, never drops funds).
+function decodeLaunchPhase(data) {
+  try {
+    let o = 8 + 32 + 8 + 8
+    o += 4 + data.readUInt32LE(o) // name
+    o += 4 + data.readUInt32LE(o) // symbol
+    o += 4 + data.readUInt32LE(o) // uri
+    o += 32 // mint
+    return data.readUInt8(o)
+  } catch (e) {
+    return 255
+  }
+}
+
+async function solanaTvl(api) {
+  const connection = getConnection()
+  const accounts = await connection.getProgramAccounts(SOL_PROGRAM_ID, {
+    filters: [{ memcmp: { offset: 0, bytes: LAUNCH_DISCRIMINATOR_B58 } }],
+  })
+
+  const vaults = []
+  for (const { pubkey, account } of accounts) {
+    if (decodeLaunchPhase(account.data) === PHASE_GRADUATED) continue // liquidity already on PumpSwap
+    const [vault] = PublicKey.findProgramAddressSync(
+      [Buffer.from('vault'), pubkey.toBuffer()],
+      SOL_PROGRAM_ID,
+    )
+    vaults.push(vault.toString())
+  }
+
+  // Native SOL held across all live (non-graduated) launch vaults. Includes each
+  // vault's tiny rent-exempt reserve (~0.00089 SOL) and any earmarked dev-fee /
+  // community lamports physically parked in the vault, but is dominated by the
+  // bonding-curve deposits.
+  return sumTokens2({ api, solOwners: vaults })
+}
+
+module.exports = {
+  // Solana TVL reads current program state (getProgramAccounts), which cannot be
+  // queried historically, so this adapter does not support timetravel.
+  timetravel: false,
+  methodology:
+    'popi is a bonding-curve memecoin launchpad on two chains. TVL is the quote asset escrowed in live (still-bonding, not-yet-graduated) launches. Robinhood Chain: all launches share one UUPS launchpad proxy (0xae7f18c0d1a66aad8bfec77b0bbf779e03571b06); we count the native ETH held by that proxy, which equals the sum of every bonding launch\'s escrow (migrate moves a graduated launch\'s liquidity out to the Uniswap v3 pool and failed-launch refunds leave the proxy, so only live escrow remains). Solana: each launch owns a System-owned vault PDA (seeds ["vault", launchPubkey]) under program BNtfydNwzthyGfH1LMxt5AzQkJo7iyfGFbjjNKuHFH6M; we enumerate Launch accounts, exclude Graduated ones (their SOL has already migrated to PumpSwap), and sum the native SOL in the surviving vaults. Launched tokens themselves and post-graduation DEX liquidity are not counted here.',
+  robinhood: { tvl: robinhoodTvl },
+  solana: { tvl: solanaTvl },
+}

--- a/projects/popi/index.js
+++ b/projects/popi/index.js
@@ -2,47 +2,12 @@ const ADDRESSES = require('../helper/coreAssets.json')
 const { getConnection, sumTokens2 } = require('../helper/solana')
 const { PublicKey } = require('@solana/web3.js')
 
-// popi (popi.wtf) — a gacha bonding-curve memecoin launchpad deployed on two
-// chains with the SAME lifecycle. A launch raises the quote asset (ETH on
-// Robinhood Chain, SOL on Solana) into an escrow while it is BONDING; when the
-// curve reaches its graduation threshold the launch migrates and its liquidity
-// is atomically moved OUT of popi into the chain's DEX (Uniswap v3 on Robinhood,
-// PumpSwap on Solana). TVL here is therefore the quote asset still escrowed in
-// popi for launches that have NOT yet graduated — i.e. value locked in live
-// bonding curves. Graduated launches hold nothing in popi (their raise left for
-// the DEX at migration), so they fall out of TVL automatically.
-
-// ----------------------------------------------------------------------------
-// Robinhood Chain (chainId 4663) — single UUPS proxy custodies every launch.
-// ----------------------------------------------------------------------------
-// Unlike per-launch clones, ALL popi launches on Robinhood live in ONE contract
-// (the Solana single-program model, ported). Every bonding deposit is booked
-// into that proxy's native-ETH balance (`totalBooked`); `migrate` subtracts the
-// graduated launch's `claimableEth` from the proxy and sends it to the Uniswap
-// v3 pool, and failed-launch refunds also leave the proxy. So the proxy's live
-// native-ETH balance == Σ escrow of all still-bonding launches. Verified live:
-// balance == totalBooked() to within ~1863 wei of dust.
 const ROBIN_LAUNCHPAD = '0xae7f18c0d1a66aad8bfec77b0bbf779e03571b06'
 
 async function robinhoodTvl(api) {
-  // Native ETH held in the launchpad proxy. ADDRESSES.null (0x0) is priced as
-  // the chain's gas token (ETH) by the SDK — same treatment rhfun uses for its
-  // native bonding curves on this chain. WETH is not held at rest (migrate wraps
-  // ammEth and forwards it to the pool in the same tx), so native ETH is the
-  // whole escrow.
   return api.sumTokens({ tokensAndOwners: [[ADDRESSES.null, ROBIN_LAUNCHPAD]] })
 }
 
-// ----------------------------------------------------------------------------
-// Solana (program BNtfydNwzthyGfH1LMxt5AzQkJo7iyfGFbjjNKuHFH6M) — per-launch
-// vault PDA custodies each launch's SOL.
-// ----------------------------------------------------------------------------
-// Each launch has a System-owned vault PDA at seeds ["vault", launchPubkey] that
-// holds the raised SOL. `migrate` drains that vault into the PumpSwap pool and
-// flips phase -> Graduated (+ migrated = true); close_failed_launch closes the
-// vault entirely. We enumerate live Launch accounts (Anchor discriminator), skip
-// the Graduated ones, derive each survivor's vault PDA, and sum the vaults'
-// native SOL via sumTokens2({ solOwners }).
 const SOL_PROGRAM_ID = new PublicKey('BNtfydNwzthyGfH1LMxt5AzQkJo7iyfGFbjjNKuHFH6M')
 // Anchor account discriminator for `Launch` = sha256("account:Launch")[..8],
 // base58-encoded for the getProgramAccounts memcmp filter.
@@ -52,20 +17,14 @@ const PHASE_GRADUATED = 3 // Phase enum: 0 BondingCurve | 1 Settle | 2 Gacha | 3
 // Read the `phase` byte out of a borsh-serialized Launch account. Layout:
 //   8 disc | 32 creator | 8 created_at | 8 created_at_slot |
 //   (4+len) name | (4+len) symbol | (4+len) uri | 32 mint | 1 phase | ...
-// name/symbol/uri are variable-length strings, so phase sits at a dynamic offset
-// that we walk to. Returns 255 if the buffer is too short to parse (treated as
-// non-graduated so its vault is still counted — fail safe, never drops funds).
+// name/symbol/uri are variable-length strings, so phase sits at a dynamic offset that we walk to.
 function decodeLaunchPhase(data) {
-  try {
-    let o = 8 + 32 + 8 + 8
-    o += 4 + data.readUInt32LE(o) // name
-    o += 4 + data.readUInt32LE(o) // symbol
-    o += 4 + data.readUInt32LE(o) // uri
-    o += 32 // mint
-    return data.readUInt8(o)
-  } catch (e) {
-    return 255
-  }
+  let o = 8 + 32 + 8 + 8
+  o += 4 + data.readUInt32LE(o) // name
+  o += 4 + data.readUInt32LE(o) // symbol
+  o += 4 + data.readUInt32LE(o) // uri
+  o += 32 // mint
+  return data.readUInt8(o)
 }
 
 async function solanaTvl(api) {
@@ -84,19 +43,12 @@ async function solanaTvl(api) {
     vaults.push(vault.toString())
   }
 
-  // Native SOL held across all live (non-graduated) launch vaults. Includes each
-  // vault's tiny rent-exempt reserve (~0.00089 SOL) and any earmarked dev-fee /
-  // community lamports physically parked in the vault, but is dominated by the
-  // bonding-curve deposits.
   return sumTokens2({ api, solOwners: vaults })
 }
 
 module.exports = {
-  // Solana TVL reads current program state (getProgramAccounts), which cannot be
-  // queried historically, so this adapter does not support timetravel.
   timetravel: false,
-  methodology:
-    'popi is a bonding-curve memecoin launchpad on two chains. TVL is the quote asset escrowed in live (still-bonding, not-yet-graduated) launches. Robinhood Chain: all launches share one UUPS launchpad proxy (0xae7f18c0d1a66aad8bfec77b0bbf779e03571b06); we count the native ETH held by that proxy, which equals the sum of every bonding launch\'s escrow (migrate moves a graduated launch\'s liquidity out to the Uniswap v3 pool and failed-launch refunds leave the proxy, so only live escrow remains). Solana: each launch owns a System-owned vault PDA (seeds ["vault", launchPubkey]) under program BNtfydNwzthyGfH1LMxt5AzQkJo7iyfGFbjjNKuHFH6M; we enumerate Launch accounts, exclude Graduated ones (their SOL has already migrated to PumpSwap), and sum the native SOL in the surviving vaults. Launched tokens themselves and post-graduation DEX liquidity are not counted here.',
+  methodology: 'popi is a bonding-curve memecoin launchpad on two chains. TVL is the quote asset escrowed in live (still-bonding, not-yet-graduated) launches. Robinhood Chain: we count the native ETH held by the shared UUPS launchpad proxy, which equals the sum of every bonding launch\'s escrow excluding graduated funds (migrated to Uniswap). Solana: each launch owns a System-owned vault PDA (seeds ["vault", launchPubkey]); we enumerate Launch accounts, exclude Graduated ones (migrated to PumpSwap), and sum the native SOL in the surviving vaults. Launched tokens themselves and post-graduation DEX liquidity are not counted here.',
   robinhood: { tvl: robinhoodTvl },
   solana: { tvl: solanaTvl },
 }


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

## What this PR adds

A single TVL adapter at `projects/popi/index.js` for **popi** (https://popi.wtf) — a gacha bonding-curve memecoin launchpad deployed with the same lifecycle on two chains:

- **Solana** — program `BNtfydNwzthyGfH1LMxt5AzQkJo7iyfGFbjjNKuHFH6M` (Anchor IDL published on-chain and viewable via Solscan / anchor-cli).
- **Robinhood Chain (chainId 4663)** — single UUPS launchpad proxy `0xae7f18c0d1a66aad8bfec77b0bbf779e03571b06` (verified on Blockscout: https://scan.testnet.rhchain.com/address/0xae7f18c0d1a66aad8bfec77b0bbf779e03571b06). Chain 4663 is already registered in DefiLlama's chainlist and recognized by `/v2/chains` under the key `robinhood`.

No new npm dependencies are introduced. The adapter uses only in-repo helpers (`../helper/coreAssets.json`, `../helper/solana`) and `@solana/web3.js`, which is already a repo dependency (used by the sibling `projects/bubblegum` adapter, whose pattern this follows).

## TVL methodology

Every popi launch raises the chain's quote asset (SOL / ETH) into an escrow while it is **BONDING**. When the curve hits its graduation threshold the launch migrates and its liquidity is atomically moved OUT of popi and into the chain's DEX (PumpSwap on Solana, Uniswap v3 on Robinhood Chain). Because migration drains the escrow in the same transaction, TVL cleanly reduces to "the quote asset still escrowed in launches that have NOT yet graduated" — value locked in live bonding curves.

- **Solana (`solana` key).** Each launch owns a System-owned vault PDA at seeds `["vault", launchPubkey]` under the popi program. The adapter enumerates `Launch` accounts via the Anchor discriminator (`sha256("account:Launch")[..8]` → base58 `R7vQE78exjo`), skips `Graduated` ones (their SOL has already migrated to PumpSwap), derives each survivor's vault PDA, and sums the vaults' native SOL via `sumTokens2({ solOwners })`.
- **Robinhood Chain (`robinhood` key).** Unlike per-launch clones, ALL popi launches on Robinhood share ONE UUPS proxy that custodies their ETH — the Solana single-program model ported to EVM. Every bonding deposit is booked into that proxy's native-ETH balance (`totalBooked`); `migrate` subtracts the graduated launch's `claimableEth` from the proxy and forwards it to the Uniswap v3 pool, and failed-launch refunds likewise leave the proxy. So the proxy's live native-ETH balance == Σ escrow of every still-bonding launch, verified live to within ~1863 wei of dust vs the contract's own `totalBooked()` ledger. Priced via `ADDRESSES.null` — the same pattern the sibling `projects/rhfun` adapter uses for native ETH on this chain, so pricing is proven even though chain 4663 has no `gecko_id` in `/v2/chains`.

Post-graduation DEX liquidity is deliberately **excluded** here — it is indexed elsewhere by DefiLlama's PumpSwap and Uniswap v3 adapters and would double-count.

`timetravel: false` because Solana `getProgramAccounts` cannot be queried at a historical slot.

## Local test output (`node test.js projects/popi/index.js`)

```
--- solana ---
SOL                       264.33
Total: 264.33

--- robinhood ---
ETH                       751.54
Total: 751.54

------ TVL ------
robinhood                 752.00
solana                    264.00

total                     1.02 k
```

Raw on-chain balances the adapter reads (2026-07-28):
- **Robinhood Chain:** `0.399139480776003141 ETH` (native balance of the launchpad proxy).
- **Solana:** `3.607751450 SOL` across live (non-graduated) launch vaults.

---
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
popi

##### Twitter Link:
https://x.com/popidotwtf

##### List of audit links if any:
(none public yet)

##### Website Link:
https://popi.wtf

##### Logo (High resolution, will be shown with rounded borders):
(high-res square PNG/SVG to be provided by the maintainer team; contact hello@popi.wtf)

##### Current TVL:
~0.40 ETH (Robinhood Chain) + ~3.61 SOL (Solana) — mainnet test phase

##### Treasury Addresses (if the protocol has treasury):
n/a — bonding escrow is protocol-owned and already counted as TVL, not a separate treasury.

##### Chain:
Robinhood Chain, Solana

##### Coingecko ID:
(empty — no listed token)

##### Coinmarketcap ID:
(empty — no listed token)

##### Short Description (to be shown on DefiLlama):
Gacha bonding-curve memecoin launchpad; raises are escrowed on the curve until graduation, then migrated to the chain's DEX (PumpSwap on Solana, Uniswap v3 on Robinhood Chain).

##### Token address and ticker if any:
n/a — no protocol token.

##### Category:
Launchpad

##### Oracle Provider(s):
n/a for TVL. (Randomness is provided by ORAO VRF on Solana and Pyth Entropy on Robinhood Chain, but neither is used to price TVL.)

##### Implementation Details:
n/a — TVL is read directly from on-chain balances, no price oracle involved.

##### Documentation/Proof:
- Solana program on Solscan: https://solscan.io/account/BNtfydNwzthyGfH1LMxt5AzQkJo7iyfGFbjjNKuHFH6M (on-chain Anchor IDL published)
- Robinhood Chain proxy on Blockscout: https://scan.testnet.rhchain.com/address/0xae7f18c0d1a66aad8bfec77b0bbf779e03571b06 (source verified)

##### forkedFrom:
n/a

##### methodology (what is being counted as tvl, how is tvl being calculated):
popi is a bonding-curve memecoin launchpad on two chains. TVL is the quote asset escrowed in live (still-bonding, not-yet-graduated) launches. Robinhood Chain: all launches share one UUPS launchpad proxy (0xae7f18c0d1a66aad8bfec77b0bbf779e03571b06); we count the native ETH held by that proxy, which equals the sum of every bonding launch's escrow (migrate moves a graduated launch's liquidity out to the Uniswap v3 pool and failed-launch refunds leave the proxy, so only live escrow remains). Solana: each launch owns a System-owned vault PDA (seeds ["vault", launchPubkey]) under program BNtfydNwzthyGfH1LMxt5AzQkJo7iyfGFbjjNKuHFH6M; we enumerate Launch accounts, exclude Graduated ones (their SOL has already migrated to PumpSwap), and sum the native SOL in the surviving vaults. Launched tokens themselves and post-graduation DEX liquidity are not counted here.

##### Github org/user:
(optional)

##### Does this project have a referral program?
Yes (on-chain referral / claim code on Robinhood Chain; disabled on Solana).

##### Contact:
hello@popi.wtf


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for Popi on both Robinhood and Solana.
  * Robinhood tracking totals the chain’s native asset held by the core launchpad escrow.
  * Solana tracking totals native SOL held in vaults for launches that haven’t reached the “Graduated” phase.
  * Included TVL methodology metadata and disabled historical time-travel support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->