### PR TITLE
Add Textile (on-chain FX DEX) TVL adapter

### DIFF
--- a/projects/textile/index.js
+++ b/projects/textile/index.js
@@ -1,0 +1,45 @@
+const { graphQuery } = require("../helper/http");
+
+// Textile is a non-custodial on-chain FX DEX. Market makers ("Stitch" bots) quote
+// both sides of each corridor from their own wallets, and swaps settle atomically
+// through a stateless reactor, so nothing is custodied in protocol contracts. TVL is
+// the inventory those makers hold in the corridor tokens on each chain. The maker set
+// and the corridor tokens are read from the Textile subgraph, then balances are summed
+// on-chain per chain (so it self-updates as makers and corridors change).
+const ENDPOINT = "https://api.textilecredit.com/graphql";
+
+const CHAINS = {
+  ethereum: 1,
+  bsc: 56,
+  base: 8453,
+  celo: 42220,
+};
+
+async function tvl(api) {
+  const chainId = CHAINS[api.chain];
+
+  const { settlementMakerStats } = await graphQuery(
+    ENDPOINT,
+    "{ settlementMakerStats { makers { wallet } } }"
+  );
+  const owners = settlementMakerStats.makers.map((m) => m.wallet);
+
+  const { settlementV3Pools } = await graphQuery(
+    ENDPOINT,
+    `{ settlementV3Pools(chainId: ${chainId}) { collateralAsset debtAsset } }`
+  );
+  const tokens = [
+    ...new Set(settlementV3Pools.flatMap((p) => [p.collateralAsset, p.debtAsset])),
+  ];
+
+  return api.sumTokens({ owners, tokens });
+}
+
+module.exports = {
+  methodology:
+    "Textile is a non-custodial FX DEX; market makers (Stitch bots) quote from their own wallets and swaps settle atomically through a stateless reactor, so no funds sit in protocol contracts. TVL is the corridor-token inventory those makers hold on each chain, read from the Textile subgraph (makers + pools) and summed on-chain.",
+};
+
+Object.keys(CHAINS).forEach((chain) => {
+  module.exports[chain] = { tvl };
+});


### PR DESCRIPTION
Adds a TVL adapter for **Textile**, an on-chain FX liquidity network (FX DEX).

**Site:** https://app.textilecredit.com · **Docs:** https://docs.textilecredit.com

**Methodology:** Textile is non-custodial. Market makers ("Stitch" bots) quote both sides of each FX corridor from their own wallets, and swaps settle atomically through a stateless reactor, so no funds are custodied in protocol contracts. TVL is the corridor-token inventory those makers hold on each chain. The adapter reads the maker set and the corridor tokens from the Textile subgraph, then sums balances on-chain per chain, so it self-updates as makers and corridors change.

**Chains:** Ethereum, BSC, Base, Celo (per-chain, as DefiLlama expects).

Corridors include cNGN, wARS, wBRL (local-currency stablecoins), XAUt (gold), and WETH, quoted against USDT/USDC.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for Textile across Ethereum, BNB Chain, Base, and Celo.
  * Added support for calculating TVL from supported collateral and debt tokens.
  * Added methodology information describing Textile’s TVL calculation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->