### PR TITLE
Add Orchard TVL adapter (Robinhood Chain)

### DIFF
--- a/projects/orchard/index.js
+++ b/projects/orchard/index.js
@@ -1,0 +1,33 @@
+const AAPL = '0xaF3D76f1834A1d425780943C99Ea8A608f8a93f9' // Apple stock token issued by Robinhood
+const SEED = '0x5eED45d9cD4c21280db5b190D9c263f086401b9D' // Orchard's own token
+const ORCHARD = '0xEbB8b167c0992cFdc497A995a8Cf7167acAA0A1A'
+const SEED_STAKING = '0xd5d5f5Dff96E53fc6337b4aCf549d61b12882F2b'
+
+// Orchard is a 5x5 plot game. ETH planted on a plot is swapped to AAPL inside the same
+// transaction, so the whole game balance is held as AAPL: the pot of rounds that have not
+// been revealed yet, the Golden Apple jackpot, and every harvest share still unclaimed.
+// treasuryAccrued/adminAccrued are protocol-owned fees waiting to be swept, so they are
+// subtracted. The staking contract holds the staker rake already flushed to it, also in AAPL.
+async function tvl(api) {
+  const [pot, stakerRewards, treasury, admin] = await Promise.all([
+    api.call({ abi: 'erc20:balanceOf', target: AAPL, params: ORCHARD }),
+    api.call({ abi: 'erc20:balanceOf', target: AAPL, params: SEED_STAKING }),
+    api.call({ abi: 'uint256:treasuryAccrued', target: ORCHARD }),
+    api.call({ abi: 'uint256:adminAccrued', target: ORCHARD }),
+  ])
+  const userOwned = BigInt(pot) - BigInt(treasury) - BigInt(admin) + BigInt(stakerRewards)
+  api.add(AAPL, userOwned.toString())
+}
+
+// SEED staked for a share of the game's rake
+const staking = async (api) => api.sumTokens({ owner: SEED_STAKING, tokens: [SEED] })
+
+module.exports = {
+  methodology:
+    'TVL is the AAPL held by the Orchard game contract - the pot of rounds not yet revealed, ' +
+    'the Golden Apple jackpot and every harvest share still unclaimed - plus the AAPL already ' +
+    'flushed to the SeedStaking contract as staker rewards. Fees accrued to the treasury and to ' +
+    'the admin are protocol-owned and are subtracted. Staking is the SEED staked in SeedStaking.',
+  start: '2026-07-22',
+  robinhood: { tvl, staking },
+}


### PR DESCRIPTION
Adds a TVL adapter for **Orchard**, a plot game on Robinhood Chain (chainId 4663).

Validated locally with `node test.js projects/orchard/index.js` — ~$10.8k TVL on `robinhood`.
No npm dependencies added; no lockfile changes.

---
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
Orchard

##### Twitter Link:
https://x.com/orcharddotgold

##### List of audit links if any:
No third-party audit. Internal security review only (manual review + Slither 0.11.5 + `forge lint`, 126 tests).

##### Website Link:
https://orchard.gold

##### Logo (High resolution, will be shown with rounded borders):
https://orchard.gold/icon.png

##### Current TVL:
~$10,800 (32.2 AAPL)

##### Treasury Addresses (if the protocol has treasury)
(none) — there is no standing treasury wallet. Treasury fees accrue inside the Orchard contract itself (`treasuryAccrued`) and are either burned via `buybackSeed()` (AAPL swapped for SEED, SEED sent to `0x…dEaD`) or withdrawn by the owner to a destination passed at call time via `collectTreasury(address)`. These balances are excluded from the TVL figure.

##### Chain:
Robinhood Chain (`robinhood`, chainId 4663)

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):
(none)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):
(none)

##### Short Description (to be shown on DefiLlama):
Orchard is a 5x5 plot game on Robinhood Chain. Players plant ETH on a plot; the ETH is swapped to AAPL (Apple stock token) in the same transaction. Each 75-second round one plot blooms and the players who planted there split the harvest from the other 24 plots, minus a 10% rake that funds SEED stakers, the Golden Apple jackpot and the treasury.

##### Token address and ticker if any:
SEED — `0x5eED45d9cD4c21280db5b190D9c263f086401b9D` (name "Orchard", 18 decimals) on Robinhood Chain

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Gamified Mining

##### Oracle Provider(s):
None. Orchard uses no price oracle. Round randomness comes from EIP-2935 historical block hashes on-chain (`Arb2935Randomness`, commit/seal -> reveal), and all swaps go through the on-chain DEX router.

##### Implementation Details:
N/A — no oracle integration.

##### Documentation/Proof:
N/A — no oracle integration.

##### forkedFrom (Does your project originate from another project):
(none — the contracts are original Solidity written for this project, not a code fork)

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL is the AAPL held by the Orchard game contract (`0xEbB8b167c0992cFdc497A995a8Cf7167acAA0A1A`) — the pot of rounds not yet revealed, the Golden Apple jackpot, and every harvest share still unclaimed — plus the AAPL already flushed to the SeedStaking contract (`0xd5d5f5Dff96E53fc6337b4aCf549d61b12882F2b`) as staker rewards. Fees accrued to the treasury (`treasuryAccrued`) and the admin (`adminAccrued`) are protocol-owned and are subtracted. Staking is the SEED staked in SeedStaking.

Contract balance is read rather than the internal accumulators because ETH planted in a round that has not been revealed yet is already held as AAPL but is not yet booked to any accumulator — roughly 18% of the balance at time of writing.

##### Github org/user (Optional, if your code is open source, we can track activity):
(none — repository is private)

##### Does this project have a referral program?
No

---

All contracts are verified on Blockscout:
- Orchard: https://robinhoodchain.blockscout.com/address/0xEbB8b167c0992cFdc497A995a8Cf7167acAA0A1A
- SeedStaking: https://robinhoodchain.blockscout.com/address/0xd5d5f5Dff96E53fc6337b4aCf549d61b12882F2b
- SEED: https://robinhoodchain.blockscout.com/address/0x5eED45d9cD4c21280db5b190D9c263f086401b9D


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking Orchard’s total value locked (TVL), including applicable protocol fees and staking rewards.
  * Added reporting for SEED tokens held and staked in the Orchard staking contract.
  * Added Robinhood chain metrics for the Orchard game.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->