### PR TITLE
Add SUBFROST

### DIFF
--- a/projects/helper/bitcoin-book/index.js
+++ b/projects/helper/bitcoin-book/index.js
@@ -18,20 +18,6 @@ const bitomato = ["bc1qgmtx3caf8rlxmzw703ga2sljv3rkkj39e4ysk9"];
 
 const lbank = ["1MZwhQkkt9wy8Mwm4rx5W3AYiDCJLasffn"];
 
-// SUBFROST frBTC custody. Neither address is an arbitrary constant: each is the
-// taproot output key of the FROST signer set that holds the BTC backing frBTC.
-// The Alkanes one can be re-derived from Bitcoin L1 at any time: the frBTC alkane
-// [32:0] returns the signer's 32-byte internal pubkey from opcode 103 (GET_SIGNER),
-// and the address is the standard BIP341 tweak of that key (no script tree).
-// Any metashrew/alkanes node can answer it, e.g. https://mainnet.subfrost.io/v4/subfrost
-//   {"method":"alkanes_simulate","params":[{"target":{"block":"32","tx":"0"},
-//    "inputs":["103"],"alkanes":[],"transaction":"0x","block":"0x","height":<tip>,
-//    "txindex":0,"vout":0}]}
-const subfrost = [
-  "bc1p5lushqjk7kxpqa87ppwn0dealucyqa6t40ppdkhpqm3grcpqvw9s3wdsx7", // Alkanes
-  "bc1pxn3gr0hy70exhdqjzawtuygppzdrk3mer3wlaa2gzkmruk3rrt4qga2qaj", // BRC2.0
-];
-
 const stacksSBTC = [
   // https://docs.stacks.co/concepts/sbtc/clarity-contracts/sbtc-deposit
   "bc1pl033nz4lj7u7wz3l2k2ew3f7af4sdja8r25ernl00thflwempayswr5hvc",
@@ -1175,12 +1161,18 @@ module.exports = {
     "3AHghpZ5GAU7rjTXHv4Xmfe6BLavJxnzbo",
     "3Pr9uMzcEtmmCLShywSrsHq6Xqy9taEdXh",
   ],
-  subfrost,
   circleBTC: [
     '1JkKmG26nUBcPS99TsCVsReSXvLkEai4ca',
     '1KVBNjpYfJvASdzeTAwqNbe9WecpKyugM3',
     '1HkJ6hcN4h4PtUYHiSi1hrUEUKQJmedM6z',
     '1FXxhAa9yKCG8WgCTrbSsdGKuC6QzN3Gq9',
+  ],
+  subfrost = [
+    // The FROST signer set's taproot output keys that hold the BTC backing frBTC.
+    // Alkanes custody derived from Bitcoin L1 by reading [32:0] opcode 103 (GET_SIGNER) on any metashrew/alkanes node
+    // for the signer's 32-byte internal pubkey, with standard BIP341-tweak (no script tree).
+    "bc1p5lushqjk7kxpqa87ppwn0dealucyqa6t40ppdkhpqm3grcpqvw9s3wdsx7", // Alkanes
+    "bc1pxn3gr0hy70exhdqjzawtuygppzdrk3mer3wlaa2gzkmruk3rrt4qga2qaj", // BRC2.0
   ],
 };
 

--- a/projects/helper/bitcoin-book/index.js
+++ b/projects/helper/bitcoin-book/index.js
@@ -1167,7 +1167,7 @@ module.exports = {
     '1HkJ6hcN4h4PtUYHiSi1hrUEUKQJmedM6z',
     '1FXxhAa9yKCG8WgCTrbSsdGKuC6QzN3Gq9',
   ],
-  subfrost = [
+  subfrost: [
     // The FROST signer set's taproot output keys that hold the BTC backing frBTC.
     // Alkanes custody derived from Bitcoin L1 by reading [32:0] opcode 103 (GET_SIGNER) on any metashrew/alkanes node
     // for the signer's 32-byte internal pubkey, with standard BIP341-tweak (no script tree).

--- a/projects/helper/bitcoin-book/index.js
+++ b/projects/helper/bitcoin-book/index.js
@@ -18,6 +18,20 @@ const bitomato = ["bc1qgmtx3caf8rlxmzw703ga2sljv3rkkj39e4ysk9"];
 
 const lbank = ["1MZwhQkkt9wy8Mwm4rx5W3AYiDCJLasffn"];
 
+// SUBFROST frBTC custody. Neither address is an arbitrary constant: each is the
+// taproot output key of the FROST signer set that holds the BTC backing frBTC.
+// The Alkanes one can be re-derived from Bitcoin L1 at any time: the frBTC alkane
+// [32:0] returns the signer's 32-byte internal pubkey from opcode 103 (GET_SIGNER),
+// and the address is the standard BIP341 tweak of that key (no script tree).
+// Any metashrew/alkanes node can answer it, e.g. https://mainnet.subfrost.io/v4/subfrost
+//   {"method":"alkanes_simulate","params":[{"target":{"block":"32","tx":"0"},
+//    "inputs":["103"],"alkanes":[],"transaction":"0x","block":"0x","height":<tip>,
+//    "txindex":0,"vout":0}]}
+const subfrost = [
+  "bc1p5lushqjk7kxpqa87ppwn0dealucyqa6t40ppdkhpqm3grcpqvw9s3wdsx7", // Alkanes
+  "bc1pxn3gr0hy70exhdqjzawtuygppzdrk3mer3wlaa2gzkmruk3rrt4qga2qaj", // BRC2.0
+];
+
 const stacksSBTC = [
   // https://docs.stacks.co/concepts/sbtc/clarity-contracts/sbtc-deposit
   "bc1pl033nz4lj7u7wz3l2k2ew3f7af4sdja8r25ernl00thflwempayswr5hvc",
@@ -1161,6 +1175,7 @@ module.exports = {
     "3AHghpZ5GAU7rjTXHv4Xmfe6BLavJxnzbo",
     "3Pr9uMzcEtmmCLShywSrsHq6Xqy9taEdXh",
   ],
+  subfrost,
   circleBTC: [
     '1JkKmG26nUBcPS99TsCVsReSXvLkEai4ca',
     '1KVBNjpYfJvASdzeTAwqNbe9WecpKyugM3',

--- a/projects/subfrost.js
+++ b/projects/subfrost.js
@@ -1,0 +1,16 @@
+const { sumTokens } = require("./helper/sumTokens");
+const bitcoinAddressBook = require("./helper/bitcoin-book/index.js");
+
+// SUBFROST is a decentralized custodian on Bitcoin L1. It issues frBTC, a synthetic
+// bitcoin pegged 1:1 to BTC, against BTC held by a FROST signer set. frBTC is issued
+// on two Bitcoin metaprotocols, Alkanes and BRC2.0, each with its own custody address.
+const owners = bitcoinAddressBook.subfrost;
+
+async function tvl(api) {
+  return sumTokens({ owners, api });
+}
+
+module.exports = {
+  bitcoin: { tvl },
+  methodology: `TVL is the BTC held in the SUBFROST signer custody addresses that back frBTC, read directly from the Bitcoin chain. Covers both frBTC deployments: Alkanes and BRC2.0. frBTC minted against these deposits is not counted separately, so nothing is double counted.`,
+};

--- a/projects/subfrost/index.js
+++ b/projects/subfrost/index.js
@@ -1,5 +1,5 @@
-const { sumTokens } = require("./helper/sumTokens");
-const bitcoinAddressBook = require("./helper/bitcoin-book/index.js");
+const { sumTokens } = require("../helper/sumTokens");
+const bitcoinAddressBook = require("../helper/bitcoin-book/index.js");
 
 // SUBFROST is a decentralized custodian on Bitcoin L1. It issues frBTC, a synthetic
 // bitcoin pegged 1:1 to BTC, against BTC held by a FROST signer set. frBTC is issued


### PR DESCRIPTION
**SUBFROST** is a decentralized custodian on Bitcoin L1. It issues **frBTC**, a synthetic bitcoin pegged 1:1 to BTC, against BTC held by a FROST signer set (6-of-9 threshold Schnorr).

- Website: https://subfrost.io
- App: https://app.subfrost.io
- Chain: Bitcoin
- Category: Bridge

## Methodology

TVL is the BTC held in the SUBFROST custody addresses that back frBTC, read straight from the Bitcoin chain via `sumTokens`.

frBTC is issued on **two** Bitcoin metaprotocols, Alkanes and BRC2.0, each with its own custody address; both are included. The frBTC minted against those deposits is **not** counted separately, so nothing is double counted.

## On the two addresses

Neither is an arbitrary constant — each is the taproot output key of the signer set. The Alkanes one is re-derivable from Bitcoin L1 at any time: the frBTC alkane `[32:0]` returns the signer's 32-byte internal pubkey from opcode 103 (`GET_SIGNER`), and the address is the standard BIP341 tweak of that key with no script tree. The exact RPC call is in the code comment.

It is pinned in `bitcoin-book` rather than derived at runtime because this repo carries no bitcoin/bech32/secp256k1 dependency to perform the tweak with. Happy to change the approach if you'd prefer it otherwise.

## Testing

```
$ node test.js projects/subfrost.js

--- bitcoin ---
BTC                       6.83 M
Total: 6.83 M

------ TVL ------
bitcoin                   6.83 M
total                     6.83 M
```

`check-bitcoin-duplicates` reports no conflict with an existing entry. Category follows the existing precedent for wrapped-BTC issuers on `chains:["Bitcoin"]` (WBTC, FBTC, sBTC are all Bridge).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Subfrost Bitcoin TVL tracking.
  * TVL now reflects on-chain Bitcoin balances held in Subfrost custody addresses for both frBTC deployments.
  * Added support for two Subfrost Bitcoin custody addresses used to compute TVL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->