### PR TITLE
Update zensats: new TVL adapters for V2 (WBTC/wstETH/XAUT + StakeDao)

### DIFF
--- a/registries/erc4626.js
+++ b/registries/erc4626.js
@@ -202,10 +202,15 @@ const configs = {
   'zensats': {
     doublecounted: true,
     methodology: "TVL is the total assets held in ZenSats ERC4626 vaults, measured via totalAssets().",
+    hallmarks: [
+      ['2026-06-13', 'V2 launch — StakeDao Llamaloan Strategy vaults (WBTC/wstETH)'],
+    ],
     ethereum: [
       "0x617A6877f0a55D1eF2B64b5861A2bB5Fe6FEB739",
       "0xbaEc8343B610A5ee7Ca2c5b93507AC7def98E2B1",
       "0x7d5281D590Fb0647aDc7d8494a2c8Fb8C2B23cBD",
+      "0x18E2F4F2E6565187fce73ECC707579E5F7933f74", // ZenjiWbtcLlamaUsdtStakeDao (V2 - StakeDao Llamaloan Strategy)
+      "0x23F189dE34EED95f6303CfF1C77f7676F211Dd2c", // ZenjiWstEthLlamaUsdtStakeDao (V2 - StakeDao Llamaloan Strategy)
     ],
   },
   'loopfi-site': {


### PR DESCRIPTION
TVL adapter for ZenSats ERC4626 leverage vaults on Ethereum: WBTC, wstETH, XAUT,
and the two new StakeDao Llamaloan Strategy vaults (Zenji WBTC/wstETH, V2 launch
2026-06-13).

- `ZenjiWbtcLlamaUsdtStakeDao` — `0x18E2F4F2E6565187fce73ECC707579E5F7933f74`
- `ZenjiWstEthLlamaUsdtStakeDao` — `0x23F189dE34EED95f6303CfF1C77f7676F211Dd2c`

Both are standard ERC4626 vaults, using the same
`erc4626Sum2` methodology already used for the other ZenSats vaults. Added a
`hallmarks` entry marking 2026-06-13 as the V2 launch date, since that's when
TVL jumps from the new vaults going live.

Tested locally:
```
node test.js projects/zensats/index.js
```
```
--- ethereum ---
WBTC                      10.02 k
wstETH                    1.04 k
xaut                      145.10
Total: 11.21 k
```

Added to registries file because thats where zensats was already living in defillama.
The main difference between V1 and V2 is some security fixes and targeting the USDT/crvUSD pool for stability instead of pmUSD/crvUSD. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for two new Zensats Ethereum vaults for the StakeDao Llamaloan Strategy, covering WBTC and wstETH.
  * Added a milestone entry for the V2 strategy launch on June 13, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->