### PR TITLE
term-finance: count purchase tokens held in TermRepoLockers

### DIFF
--- a/projects/term-finance/index.js
+++ b/projects/term-finance/index.js
@@ -31,6 +31,23 @@ query poolQuery($lastId: ID) {
   }
 }`
 
+// The TermRepoLocker also holds purchase tokens: lender offers locked during a
+// live auction, and repaid loans awaiting lender redemption after maturity.
+const repoQuery = `
+query repoQuery($lastId: ID) {
+  termRepos(
+    first: 1000,
+    where: {
+      id_gt: $lastId,
+      delisted: false,
+    }
+  ) {
+    id
+    termRepoLocker
+    purchaseToken
+  }
+}`
+
 const borrowedQuery = `
 query borrowedQuery($lastId: ID, $block: Int) {
   termRepoExposures(
@@ -78,7 +95,7 @@ const graphStartBlock = {
 }
 
 module.exports = {
-  methodology: `Counts the collateral tokens locked in Term Finance's term repos and purchase tokens locked in Term Finance's vaults.`,
+  methodology: `Counts tokens held by Term Finance's term repo lockers: collateral backing open loans, plus purchase tokens locked as auction offers or repaid and awaiting lender redemption.`,
   // hallmarks: [['2020-05-04', "TermFinance Launch"]],
 };
 
@@ -88,7 +105,10 @@ Object.keys(graphs).forEach(chain => {
     tvl: async (api) => {
       // Auctions/Repos TVL
       const data = await cachedGraphQuery(`term-finance-${chain}`, host, query, { fetchById: true })
-      return sumTokens2({ api, tokensAndOwners: data.map(i => [i.collateralToken, i.term.termRepoLocker]), permitFailure: true })
+      const repos = await cachedGraphQuery(`term-finance-repos-${chain}`, host, repoQuery, { fetchById: true })
+      const tokensAndOwners = data.map(i => [i.collateralToken, i.term.termRepoLocker])
+      repos.filter(i => i.termRepoLocker).forEach(i => tokensAndOwners.push([i.purchaseToken, i.termRepoLocker]))
+      return sumTokens2({ api, tokensAndOwners, permitFailure: true })
     },
     borrowed: async (api) => {
       let data


### PR DESCRIPTION
Updates the existing **TermFinance Lend** adapter (no new listing).

The `TermRepoLocker` is the single token custodian per term repo. Besides collateral, it also holds **purchase tokens** in two states the adapter previously missed:

- lender offers locked while an auction is live, and
- repaid loans sitting in the locker awaiting lender redemption after maturity.

This PR adds a second paged query for `termRepos { termRepoLocker purchaseToken }` (same `delisted: false` filter as the collateral query) and includes those `[purchaseToken, locker]` pairs in `sumTokens2`. No overlap with `borrowed`: `repoExposure` decrements at the same moment repayments enter the locker.

Effect at time of writing: Ethereum TVL $1.96M → $3.36M (≈$1.4M of repaid-awaiting-redemption/auction-locked purchase tokens now counted). Methodology string updated to match what is actually counted.

Test output (`node test.js projects/term-finance/index.js`):

```
------ TVL ------
ethereum                  3.36 M
ethereum-borrowed         1.73 M
borrowed                  1.73 M
plasma                    479.00
base                      54.00
avax                      20.00

total                    3.36 M
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved total value reporting for Term Finance by including purchase tokens held by Term Repo lockers.
  * Added coverage for purchase tokens locked in auction offers and awaiting redemption after maturity.

* **Documentation**
  * Updated the methodology description to clarify which tokens are included in reported totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->