### PR TITLE
term-finance-vaults: clarify methodology

### DIFF
--- a/projects/term-finance-vaults/index.js
+++ b/projects/term-finance-vaults/index.js
@@ -58,7 +58,7 @@ const vaultsGraphStartBlock = {
 }
 
 module.exports = {
-  methodology: `Counts deposits in Term Strategy Vaults allocated to other protocols.`,
+  methodology: `Counts the liquid balance of Term Strategy Vaults: idle assets plus reserves parked in third party ERC4626 vaults. Capital deployed into Term repo tokens is left out here to avoid double counting, it is tracked by the term-finance adapter as locked purchase tokens and borrowed.`,
   // hallmarks: [['2020-05-04', "TermFinance Launch"]],
 };
 


### PR DESCRIPTION
Went with keeping the vaults adapter liquid-only, so this is now just a methodology string change, no behaviour change.

The old string ("deposits allocated to other protocols") didn't describe what `totalLiquidBalance()` actually returns, and didn't say why deployed capital is left out. New string covers both.

TVL is unchanged:

```
------ TVL ------
ethereum                  6.64 M
bsc                       2.09 M
avax                      1.54 M
plasma                    7.92 k
arbitrum                  1.01 k
base                      0.00

total                    10.28 M
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how Term Strategy Vault balances are calculated: liquid balance now reflects idle assets plus reserves held in third-party ERC4626 vaults.
  * Explicitly notes that capital deployed into Term repo tokens is excluded to prevent double counting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->