### PR TITLE
term-finance: enable arbitrum

### DIFF
--- a/projects/term-finance/index.js
+++ b/projects/term-finance/index.js
@@ -10,10 +10,11 @@ const graphs = {
     "https://api.subgraph.ormilabs.com/api/public/05e9a4e2-103b-4163-a81e-3b1b038d0055/subgraphs/term-finance-base/latest/gn",
   plasma:
     "https://api.subgraph.ormilabs.com/api/public/05e9a4e2-103b-4163-a81e-3b1b038d0055/subgraphs/term-finance-plasma/latest/gn",
+  arbitrum:
+    "https://api.subgraph.ormilabs.com/api/public/05e9a4e2-103b-4163-a81e-3b1b038d0055/subgraphs/term-finance-arbitrum/latest/gn",
+  // bsc has no repo/auction deployments (vaults-only chain)
   // bsc:
   //   "https://api.subgraph.ormilabs.com/api/public/05e9a4e2-103b-4163-a81e-3b1b038d0055/subgraphs/term-finance-bnb/latest/gn",
-  // arbitrum:
-  //   "https://api.subgraph.ormilabs.com/api/public/05e9a4e2-103b-4163-a81e-3b1b038d0055/subgraphs/term-finance-arbitrum/latest/gn",
 };
 
 const query = `


### PR DESCRIPTION
Updates the existing **TermFinance Lend** adapter (no new listing).

Term repo auctions are live on Arbitrum (16 deployed terms) and indexed by the `term-finance-arbitrum` subgraph, but the chain was commented out in the adapter. This enables it; `graphStartBlock.arbitrum` was already present. BSC stays excluded — it has no repo/auction deployments (vaults-only chain), noted in a comment.

Small numbers today (auctions are just ramping there), but this makes TVL/borrowed appear as soon as they fill.

Test output (`node test.js projects/term-finance/index.js`):

```
------ TVL ------
ethereum                  2.00 M
ethereum-borrowed         1.73 M
arbitrum                  41.00
arbitrum-borrowed         23.00
plasma                    44.00

total                    2.00 M
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking Term Finance data on the Arbitrum network.
  * Arbitrum now includes TVL and borrowed balance metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->