### PR TITLE
Add Parity (Term Finance) Morpho curator adapter

### DIFF
--- a/projects/term-finance-parity/index.js
+++ b/projects/term-finance-parity/index.js
@@ -1,0 +1,19 @@
+const { getCuratorExport } = require("../helper/curators")
+
+// Term Finance's Morpho vault owner (Parity vaults: pcUSDC, pcETH, pcHYUSDC)
+const PARITY_OWNER = '0xbfFcAdCd5549cC378693108BcD4435776A6fa795'
+
+const configs = {
+  methodology: 'Counts all assets deposited in the Parity vaults on Morpho, curated by Term Finance.',
+  start: '2026-04-23',
+  blockchains: {
+    ethereum: {
+      morphoVaultOwners: [PARITY_OWNER],
+    },
+    arbitrum: {
+      morphoVaultOwners: [PARITY_OWNER],
+    },
+  },
+}
+
+module.exports = getCuratorExport(configs)


### PR DESCRIPTION
New **Risk Curators** listing for the Parity vaults on Morpho, curated by Term Finance. Uses the shared curator helper (`getCuratorExport` with `morphoVaultOwners`) — vaults are auto-discovered from `CreateMetaMorpho` logs by initial owner, so future Parity vaults are picked up automatically. `doublecounted` is set by the helper.

Please nest this under the existing **Term Finance** parent (`parent#termfinance`) alongside TermFinance Lend and TermFinance Vaults.

Test output (`node test.js projects/term-finance-parity/index.js`):

```
------ TVL ------
ethereum                  6.49 M
arbitrum                  1.01 k

total                    6.49 M
```

---
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
Parity (Term Finance)

##### Twitter Link:
https://twitter.com/term_labs

##### List of audit links if any:
https://docs.term.finance/protocol/security/audits

##### Website Link:
https://term.finance

##### Logo (High resolution, will be shown with rounded borders):
Same logo as the existing TermFinance listings: https://icons.llamao.fi/icons/protocols/termfinance-lend

##### Current TVL:
~$6.5M

##### Treasury Addresses (if the protocol has treasury)

##### Chain:
Ethereum, Arbitrum

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):

##### Short Description (to be shown on DefiLlama):
Parity vaults are Morpho lending vaults curated by Term Finance.

##### Token address and ticker if any:

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Risk Curators

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

##### forkedFrom (Does your project originate from another project):

##### methodology (what is being counted as tvl, how is tvl being calculated):
Counts all assets deposited in the Morpho vaults whose initial owner is Term Finance's curator address (pcUSDC, pcETH, pcHYUSDC on Ethereum; pcHYUSDC on Arbitrum), valued via the shared curator helper.

##### Github org/user (Optional, if your code is open source, we can track activity):
term-finance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Term Finance parity coverage for supported Ethereum and Arbitrum vaults.
  - Introduced standardized asset-counting methodology and historical start-date tracking for parity reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->