### PR TITLE
cassa: add RWA market collateral vaults on mainnet

### DIFF
--- a/registries/curators.js
+++ b/registries/curators.js
@@ -236,7 +236,9 @@ const configs = {
       blockchains: {
         ethereum: {
           euler: [
-            '0xBc79C4DA0452152D2C329ADE328C79705a964CEE'
+            '0xBc79C4DA0452152D2C329ADE328C79705a964CEE',
+            '0x61332fE07Ee0faa8a087ba00f43d581871441139',
+            '0x6876374E4AC054bfCA389109570Ae15b4d25e279',
           ],
         },
       },


### PR DESCRIPTION
Adds two vaults to the `cassa` curator entry:

- `0x61332fE07Ee0faa8a087ba00f43d581871441139` ewSTRCx-1
- `0x6876374E4AC054bfCA389109570Ae15b4d25e279` ePT-reUSD-10DEC2026-1

Both are under the `cassa-rwa` product in [euler-labels](https://github.com/euler-xyz/euler-labels/blob/7506a06aa42483c343d9ece711c65c290516f8e3/1/products.json#L914-L943).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Added two additional vault owners to the Cassa curator configuration for Ethereum under Euler.
  * Existing curator configurations remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->