### PR TITLE
Add 1 ETH reserve address and 2 stake withdrawal addresses

### DIFF
--- a/projects/gate-io/index.js
+++ b/projects/gate-io/index.js
@@ -49,7 +49,8 @@ const config = {
       "0x66bbafc7269f1a9e5b454445585275f2b4ead28e",
       "0xd6a8047940a1f71df5f809919c10d9ba0a88786e",
       "0xcf6f5ec73942314c3ec864202b40dcbb1f9477a0",
-      "0x76bbb8D5dbedde9cB34882c9588DFa9dEF00B8bc"
+      "0x76bbb8D5dbedde9cB34882c9588DFa9dEF00B8bc",
+      "0xccc5eeebe15291620be733997af60735618548d7"
     ]
   },
   "avax": {
@@ -1811,5 +1812,5 @@ deadChains.forEach(chain => { deadChainsExports[chain] = { tvl: async () => ({})
 module.exports = mergeExports([
   cexExports(config),
   deadChainsExports,
-  { ethereum: { tvl: getStakedEthTVL({ withdrawalAddresses: ['0x287a66c7d9cba7504e90fa638911d74c4dc6a147', '0xbcf03ce48091e6b820a7c33e166e5d0109d8e712', '0x7a3f9b7120386249528c93e5eb373b78e54d5ba9'], sleepTime: 20_000, size: 200, proxy: true }) } },
+  { ethereum: { tvl: getStakedEthTVL({ withdrawalAddresses: ['0x287a66c7d9cba7504e90fa638911d74c4dc6a147', '0xbcf03ce48091e6b820a7c33e166e5d0109d8e712', '0x7a3f9b7120386249528c93e5eb373b78e54d5ba9','0xD6A8047940a1F71df5f809919c10D9Ba0A88786e','0xB04B2B81f65baCc8f29F411A1344f78Bff7A36A2'], sleepTime: 20_000, size: 200, proxy: true }) } },
 ]);

--- a/projects/gate-io/index.js
+++ b/projects/gate-io/index.js
@@ -50,7 +50,8 @@ const config = {
       "0xd6a8047940a1f71df5f809919c10d9ba0a88786e",
       "0xcf6f5ec73942314c3ec864202b40dcbb1f9477a0",
       "0x76bbb8D5dbedde9cB34882c9588DFa9dEF00B8bc",
-      "0xccc5eeebe15291620be733997af60735618548d7"
+      "0xccc5eeebe15291620be733997af60735618548d7",
+      "0xba622437b70d86EADd6F2f5fB7A5124270c35705"
     ]
   },
   "avax": {


### PR DESCRIPTION
**NOTE**

Add 2 ETH reserve address and 2 stake withdrawal addresses.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).

2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** Please send a mail to metadata@defillama.com
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded Ethereum owner address tracking by adding two additional owner addresses.
  * Improved Ethereum staked TVL reporting by including two additional withdrawal addresses while preserving existing timing and batching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->