### PR TITLE
term-structure: add Robinhood chain support

### DIFF
--- a/projects/term-structure/index.js
+++ b/projects/term-structure/index.js
@@ -352,6 +352,23 @@ const ADDRESSES = {
       { address: "0xa50929A67daF9Ff3567e2Bb3411204A134f72546", fromBlock: 43289755 },
     ],
   },
+  robinhood: {
+    FactoryV2: [
+      {
+        address: "0x03c4FCF963E5FBC0dC5851d2340624E70492acb9",
+        fromBlock: 21550658,
+      },
+    ],
+    VaultFactoryV2: [
+      {
+        address: "0x276C0E52508d94ff2D4106b1559c8c4Bc3a75dec",
+        fromBlock: 21550718,
+      },
+    ],
+    TermMax4626Factory: [
+      { address: "0xa50929A67daF9Ff3567e2Bb3411204A134f72546", fromBlock: 21550753 },
+    ],
+  },
 };
 
 const VAULT_BLACKLIST = {


### PR DESCRIPTION
Adds Robinhood chain (chainId 4663) to the `term-structure` (TermMax) adapter.

The TermMax V2 factories are deployed and verified on-chain; `fromBlock` values are the actual contract creation blocks (2026-07-28):

| Contract | Address | fromBlock |
| --- | --- | --- |
| `TermMaxFactoryV2` | `0x03c4FCF963E5FBC0dC5851d2340624E70492acb9` | 21550658 |
| `TermMaxVaultFactoryV2` | `0x276C0E52508d94ff2D4106b1559c8c4Bc3a75dec` | 21550718 |
| `TermMax4626Factory` | `0xa50929A67daF9Ff3567e2Bb3411204A134f72546` | 21550753 |

The chain slug `robinhood` and its RPC are already present in the repo, so no helper changes are needed.

Note: no markets or vaults have been created on these factories yet, so the chain currently reports 0 TVL. This lands the tracking config so TVL is picked up as soon as the first market/vault is deployed.

`node test.js projects/term-structure/index.js` runs clean with `robinhood` / `robinhood-borrowed` listed at 0.00.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Robinhood chain.
  * TermMax markets and vaults on Robinhood can now be indexed for total value locked and borrowed amounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->