### PR TITLE
Add BetterSwap V3 TVL on VeChain

### DIFF
--- a/registries/uniswapV3.js
+++ b/registries/uniswapV3.js
@@ -45,6 +45,9 @@ const uniV3Configs = {
   'basex': {
     base: { factory: '0x38015d05f4fec8afe15d7cc0386a126574e8077b', fromBlock: 3152527 },
   },
+  'betterswap-v3': {
+    vechain: { factory: '0xf9f1722f95d036efbd1352d84e3a3755f8027b39', fromBlock: 25403238 },
+  },
   'mute-cl': {
     era: { factory: '0x488A92576DA475f7429BC9dec9247045156144D3', fromBlock: 32830523 },
   },


### PR DESCRIPTION
## Summary

This PR adds on-chain TVL tracking for the current BetterSwap V3 deployment on VeChain.

BetterSwap V3 uses the standard Uniswap V3 `PoolCreated` event, so TVL can be calculated directly from the blockchain using the existing `uniV3Export` registry adapter.

- Factory: `0xf9f1722f95d036efbd1352d84e3a3755f8027b39`
- Factory deployment block: `25403238`
- Chain: VeChain
- Registry key: `betterswap-v3`

The configured factory is the current production deployment and replaces the legacy BetterSwap V3 factory.

---

##### Name (to be shown on DefiLlama):

BetterSwap V3

##### Twitter Link:

https://x.com/BetterSwap_io

##### List of audit links if any:

There is currently no V3-specific audit.

The existing BetterSwap V2 contracts were audited by Hacken, but that audit does not cover this V3 deployment:

https://hacken.io/audits/betterswap/sca-betterswap-diff-check-jan2025/

##### Website Link:

https://www.betterswap.io/

##### Logo (High resolution, will be shown with rounded borders):

https://betterswap.io/betterswap-logo.svg

##### Current TVL:

Approximately $7.67k at the time of testing.

##### Treasury Addresses (if the protocol has treasury)

N/A

##### Chain:

VeChain

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

N/A

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

N/A

##### Short Description (to be shown on DefiLlama):

BetterSwap V3 is a concentrated-liquidity decentralized exchange on VeChainThor. It is part of BetterSwap, a DEX and aggregation platform that provides access to liquidity across the VeChain ecosystem.

##### Token address and ticker if any:

N/A

##### Category (full list at https://defillama.com/categories) *Please choose only one:

Dexes

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

Uniswap V3 built-in TWAP oracle.

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

Each V3 pool maintains historical price and liquidity observations using the standard Uniswap V3 oracle implementation.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

https://docs.uniswap.org/concepts/protocol/oracle

##### forkedFrom (Does your project originate from another project):

Uniswap V3

##### methodology (what is being counted as tvl, how is tvl being calculated):

TVL is calculated on-chain by indexing all standard `PoolCreated` events emitted by the current BetterSwap V3 factory and summing the token balances held by the resulting liquidity pool contracts.

##### Github org/user (Optional, if your code is open source, we can track activity):

https://github.com/the-better-collective

##### Does this project have a referral program?

No

---

## V2/V3 listing question

BetterSwap V2 was added in https://github.com/DefiLlama/DefiLlama-Adapters/pull/14490 and is currently registered under the historical `BetterSwap` key in `registries/uniswapV2.js`.

This PR intentionally leaves that existing key unchanged and adds the concentrated-liquidity deployment separately as `betterswap-v3`.

We would like the DefiLlama website to display the two versions consistently as:

- BetterSwap V2
- BetterSwap V3

Should the existing V2 registry key be renamed from `BetterSwap` to `betterswap-v2`, or should its display metadata be updated separately to preserve the existing V2 TVL history?

We did not rename the V2 key in this PR because we want to avoid disconnecting or resetting the historical TVL associated with the existing listing.

## Verification

The factory address and deployment block were verified on-chain. The factory emits the standard Uniswap V3 `PoolCreated` event and had emitted eight pool creation events at the time of testing.

Ran:

```bash
node test.js betterswap-v3
Result:
Loaded module betterswap-v3 from registry

--- vechain ---
BVET                      4.97 k
B3TR                      2.62 k
VTHO                      73.19
Total:                    7.67 k

------ TVL ------
vechain                   7.67 k
total                     7.67 k
Additional checks:
./node_modules/.bin/eslint -c eslint.config.js registries/uniswapV3.js
node utils/scripts/checkRegistriesDups.js
git diff --check
All checks passed. No dependencies or lockfiles were changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the BetterSwap V3 deployment on VeChain, enabling registry discovery from its configured deployment block.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->