### PR TITLE
byzanlink: Add byzanlink vaults

### DIFF
--- a/projects/byzanlink/index.js
+++ b/projects/byzanlink/index.js
@@ -1,43 +1,25 @@
-const ADDRESSES = require('../helper/coreAssets.json')
 const { sumERC4626VaultsExport2 } = require('../helper/erc4626')
-const { sumTokens2 } = require('../helper/solana')
+const { sumTokensExport } = require('../helper/solana')
 
-const vaultsByChain = {
+const vaults = {
   hedera: [
-    { name: 'Credible Payfi Vault', address: '0x6b8dfA6aa5f803a886Beb2492eF3307EC0Ee16FB' },
+    "0x6b8dfA6aa5f803a886Beb2492eF3307EC0Ee16FB", // Credible Payfi Vault
   ],
   ethereum: [
-    { name: 'Byzanlink SyrupUSDC Vault', address: '0xA5cDEE01aA7A5E0620df5f27F26E552fdf7f5F20' },
+    "0xA5cDEE01aA7A5E0620df5f27F26E552fdf7f5F20", // Byzanlink SyrupUSDC Vault
   ],
 }
 
-const solanaVault = {
-  name: 'Credible Payfi Vault',
-  tokenAccounts: [
-    'H77JK9eoCRPyEty5yXkm6hXMadn6isfYmDqaB3t5m4RM',
-    'EjwW5YHMCdHcymXw3awB3dVrcda6y2PKUfsqUkEsN6RK',
-  ],
-  payfiReceiptToken: 'EnGJvwX84JwV91Nzci5wrKFsxefwFtyFDJMaEi3wsbGz',
-}
-
-async function solanaTvl(api) {
-  await sumTokens2({ api, tokenAccounts: solanaVault.tokenAccounts })
-  const balances = api.getBalances()
-  const receiptKey = `solana:${solanaVault.payfiReceiptToken}`
-  if (balances[receiptKey]) {
-    api.add(ADDRESSES.solana.USDC, balances[receiptKey])
-    delete balances[receiptKey]
-  }
-}
+const solanaTokenAccounts = [
+  'H77JK9eoCRPyEty5yXkm6hXMadn6isfYmDqaB3t5m4RM',
+  'EjwW5YHMCdHcymXw3awB3dVrcda6y2PKUfsqUkEsN6RK',
+]
 
 module.exports = {
-  methodology:
-    'Total value of assets deposited in the Byzanlink vaults, read on-chain and valued in USD.',
-  solana: { tvl: solanaTvl },
-  ...Object.fromEntries(
-    Object.entries(vaultsByChain).map(([chain, vaults]) => [
-      chain,
-      { tvl: sumERC4626VaultsExport2({ vaults: vaults.map((v) => v.address) }) },
-    ])
-  ),
+  methodology: 'Total value of assets deposited in the Byzanlink vaults, read on-chain and valued in USD.',
+  solana: { tvl: sumTokensExport({ tokenAccounts: solanaTokenAccounts }) },
 }
+
+Object.keys(vaults).forEach(chain => {
+  module.exports[chain] = { tvl: sumERC4626VaultsExport2({ vaults: vaults[chain] }) }
+})

--- a/projects/byzanlink/index.js
+++ b/projects/byzanlink/index.js
@@ -1,0 +1,43 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+const { sumERC4626VaultsExport2 } = require('../helper/erc4626')
+const { sumTokens2 } = require('../helper/solana')
+
+const vaultsByChain = {
+  hedera: [
+    { name: 'Credible Payfi Vault', address: '0x6b8dfA6aa5f803a886Beb2492eF3307EC0Ee16FB' },
+  ],
+  ethereum: [
+    { name: 'Byzanlink SyrupUSDC Vault', address: '0xA5cDEE01aA7A5E0620df5f27F26E552fdf7f5F20' },
+  ],
+}
+
+const solanaVault = {
+  name: 'Credible Payfi Vault',
+  tokenAccounts: [
+    'H77JK9eoCRPyEty5yXkm6hXMadn6isfYmDqaB3t5m4RM',
+    'EjwW5YHMCdHcymXw3awB3dVrcda6y2PKUfsqUkEsN6RK',
+  ],
+  payfiReceiptToken: 'EnGJvwX84JwV91Nzci5wrKFsxefwFtyFDJMaEi3wsbGz',
+}
+
+async function solanaTvl(api) {
+  await sumTokens2({ api, tokenAccounts: solanaVault.tokenAccounts })
+  const balances = api.getBalances()
+  const receiptKey = `solana:${solanaVault.payfiReceiptToken}`
+  if (balances[receiptKey]) {
+    api.add(ADDRESSES.solana.USDC, balances[receiptKey])
+    delete balances[receiptKey]
+  }
+}
+
+module.exports = {
+  methodology:
+    'Total value of assets deposited in the Byzanlink vaults, read on-chain and valued in USD.',
+  solana: { tvl: solanaTvl },
+  ...Object.fromEntries(
+    Object.entries(vaultsByChain).map(([chain, vaults]) => [
+      chain,
+      { tvl: sumERC4626VaultsExport2({ vaults: vaults.map((v) => v.address) }) },
+    ])
+  ),
+}

--- a/registries/erc4626.js
+++ b/registries/erc4626.js
@@ -285,11 +285,6 @@ const configs = {
     base: ['0x00325d9da832b38179ed2f0dabd4062d93e325a7'],
     methodology: 'TVL is calculated as the total USDC held in the ArcisVault contract, including both reserve and deployed capital across yield strategies.'
   },
-  'byzanlink': {
-    hedera: ['0x6b8dfA6aa5f803a886Beb2492eF3307EC0Ee16FB'],
-    ethereum: ['0xA5cDEE01aA7A5E0620df5f27F26E552fdf7f5F20'],
-    methodology: 'Total value of assets deposited in the Byzanlink vaults, read on-chain and valued in USD.'
-  },
   'crystalclear': {
     methodology: "TVL is the sum of totalAssets() across all live CrystalClear ERC-4626 vaults on HyperEVM. Each vault holds USDC and trades perpetuals on Hyperliquid via a delegated agent.",
     hyperliquid: [


### PR DESCRIPTION
The new Solana vault is not ERC4626, so it needs a custom tvl function that the registry cannot express. Hedera and Ethereum vaults are carried over unchanged.

Solana TVL is the idle USDC held by the vault authority plus the PayFi pool receipt token, counted 1:1 against USDC (current pool NAV).

Byzanlink is already listed (#19946), so this is a chain addition rather than a new listing. The metadata below is included for reference — `Chain` now covers Hedera, Ethereum and Solana.

**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).

2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** Please send a mail to metadata@defillama.com
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes

---
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
Byzanlink RWA Markets

##### Twitter Link:
https://x.com/byzanlink

##### List of audit links if any:
1. https://sherlock-files.ams3.digitaloceanspaces.com/reports/2026.01.19%20-%20Final%20-%20Byzanlink%20Collaborative%20Audit%20Report%201768840093.pdf
2. https://sherlock-files.ams3.digitaloceanspaces.com/reports/2026.01.19%20-%20Final%20-%20Byzanlink%20Collaborative%20Audit%20Report%201768839590.pdf

##### Website Link:
https://markets.byzanlink.com

##### Logo (High resolution, will be shown with rounded borders):
https://markets.byzanlink.com/byzanlink-logo-without-text.svg

##### Current TVL:
~$1.17M (Hedera ~$1.16M, Solana ~$5.3k, Ethereum ~$2.1k)

##### Treasury Addresses (if the protocol has treasury)
NA

##### Chain:
Hedera, Ethereum, Solana

##### Coingecko ID:
byzanlink

##### Coinmarketcap ID:
NA

##### Short Description (to be shown on DefiLlama):
Byzanlink RWA Markets is a decentralised, non-custodial RWA yield platform where users access curated tokenised real-world yield strategies through standardised onchain vaults.

##### Token address and ticker if any:
BYZAN

##### Category (full list at https://defillama.com/categories) \*Please choose only one:
Private Credit

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
NA

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
NA

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
NA

##### forkedFrom (Does your project originate from another project):
Morpho (https://github.com/morpho-org/vault-v2) - EVM Vaults
kvault (https://github.com/Kamino-Finance/kvault) - Solana Vaults

##### methodology (what is being counted as tvl, how is tvl being calculated):
**EVM (Hedera, Ethereum):** TVL is the `totalAssets()` of each ERC-4626 vault. The fund manager updates the underlying asset values every two days based on the latest private credit returns. These NAV updates are performed through the adapter. The vault's TVL is calculated using the real-time asset value reported by the adapter, reflecting the latest NAV. The vault has a `MAX_RATE` of 20% configured for `accrueInterest`, which serves as the upper bound on the interest accrual rate between NAV updates. Additionally, a 10% performance fee is applied during the `accrueInterest` process, ensuring that the fund manager receives their share of generated returns before the updated asset value is reflected in the vault.

```math
\text{totalAssets} =
\min\left(
\text{vaultBalance} + \sum \text{adapter.realAssets()},
\;
\text{lastTotalAssets} \times \left(1 + \text{maxRate} \times \Delta t\right)
\right)
```

**Solana:** the vault is not ERC-4626, so TVL is read from the token accounts of the vault authority PDA `HoFghuEh8JnnvCDGTQAeC9wJ3YJpRnMJUXVSV6Vmzd9J` — the idle USDC buffer plus the receipt token for USDC deployed into the PayFi pool `51rijLDcbYubsyJNuAdsut1MpDFFeLQaY9iGDVEVmmiX`. 

##### Github org/user (Optional, if your code is open source, we can track activity):
NA

##### Does this project have a referral program?
NA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Byzanlink TVL tracking on Hedera and Ethereum (ERC-4626 vaults).
  * Added Byzanlink TVL tracking for Solana using the supported token accounts and receipt-token handling.
  * Included methodology details for how Byzanlink TVL is calculated.

* **Refactor**
  * Updated the ERC-4626 registry to remove the standalone Byzanlink block and rely on the dedicated Byzanlink integration instead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->