### PR TITLE
track gate earn tvl

### DIFF
--- a/projects/gate-io/index.js
+++ b/projects/gate-io/index.js
@@ -1948,7 +1948,11 @@ Object.entries(earnReceiptTokens).forEach(([chain, { owners }]) => {
   if (!cfg.owners.length) delete config[chain]
 })
 
-const stakedEthTvl = getStakedEthTVL({ withdrawalAddresses: ['0x287a66c7d9cba7504e90fa638911d74c4dc6a147', '0xbcf03ce48091e6b820a7c33e166e5d0109d8e712', '0x7a3f9b7120386249528c93e5eb373b78e54d5ba9'], sleepTime: 20_000, size: 200, proxy: true })
+const stakedEthTvl = getStakedEthTVL({ withdrawalAddresses: [
+  '0x287a66c7d9cba7504e90fa638911d74c4dc6a147', '0xbcf03ce48091e6b820a7c33e166e5d0109d8e712', '0x7a3f9b7120386249528c93e5eb373b78e54d5ba9',
+  '0xD6A8047940a1F71df5f809919c10D9Ba0A88786e',
+  '0xB04B2B81f65baCc8f29F411A1344f78Bff7A36A2',
+], sleepTime: 20_000, size: 200, proxy: true })
 
 // mergeExports sums the *returned* balances, so every tvl has to hand them back
 const earnTvl = fn => async (api) => {

--- a/projects/gate-io/index.js
+++ b/projects/gate-io/index.js
@@ -3,6 +3,7 @@ const bitcoinAddressBook = require("../helper/bitcoin-book/index.js");
 const { mergeExports, getStakedEthTVL } = require("../helper/utils");
 const { cosmosStaked, suiStaked, aptosStaked, nearStaked, bittensorStaked, confluxStaked, cardanoStaked, algorandStaked, starknetStaked, aleoStaked, neo3Staked } = require("../helper/stakingHelper");
 const { sumTokens2: solanaSumTokens } = require("../helper/solana");
+const { unwrapDolomiteDeposits } = require("../helper/unwrapLPs.js");
 
 const config = {
   "ethereum": {
@@ -1964,6 +1965,10 @@ const gateEarnTvl = {
   ethereum: {
     tvl: earnTvl(async (api) => {
       await stakedEthTvl(api)
+      await unwrapDolomiteDeposits({ api, owners: [
+        '0x37E1BF9Ab62E523f358daFacA86151519F0a2f8D',
+        '0xe39BA3F5BCbF0eF7ED31A07e799B8D2010c885CF',
+      ], })
       await api.sumTokens(earnReceiptTokens.ethereum)
     }),
   },
@@ -1991,4 +1996,3 @@ Object.entries(earnReceiptTokens).forEach(([chain, args]) => {
 })
 
 module.exports = mergeExports([cexExports(config), gateEarnTvl]);
-

--- a/projects/gate-io/index.js
+++ b/projects/gate-io/index.js
@@ -51,7 +51,9 @@ const config = {
       "0x66bbafc7269f1a9e5b454445585275f2b4ead28e",
       "0xd6a8047940a1f71df5f809919c10d9ba0a88786e",
       "0xcf6f5ec73942314c3ec864202b40dcbb1f9477a0",
-      "0x76bbb8D5dbedde9cB34882c9588DFa9dEF00B8bc"
+      "0x76bbb8D5dbedde9cB34882c9588DFa9dEF00B8bc",
+      "0xccc5eeebe15291620be733997af60735618548d7",
+      "0xba622437b70d86EADd6F2f5fB7A5124270c35705",
     ]
   },
   "avax": {

--- a/projects/gate-io/index.js
+++ b/projects/gate-io/index.js
@@ -1,6 +1,8 @@
 const { cexExports } = require("../helper/cex");
 const bitcoinAddressBook = require("../helper/bitcoin-book/index.js");
 const { mergeExports, getStakedEthTVL } = require("../helper/utils");
+const { cosmosStaked, suiStaked, aptosStaked, nearStaked, bittensorStaked, confluxStaked, cardanoStaked, algorandStaked, starknetStaked, aleoStaked, neo3Staked } = require("../helper/stakingHelper");
+const { sumTokens2: solanaSumTokens } = require("../helper/solana");
 
 const config = {
   "ethereum": {
@@ -1793,23 +1795,194 @@ const config = {
 };
 
 // remove chains w/o historical tvl
-const unsupportedChains = ['aeternity', 'beam', 'binance', 'bitchain', 'bitcoincash', 'bittensor', 'bone', 'callisto', 'chainx', 'clv', 'concordium', 'conflux', 'cmp', 'dash', 'cube', 'defichain', 'edg', 'elastos', 'elys', 'equilibrium', 'evmos', 'filecoin', 'findora', 'flow', 'fusion', 'heiko', 'hydra', 'hyperliquid', 'icon', 'icp', 'interlay', 'kadena', 'karura', 'kava', 'kintsugi', 'kusuma', 'manta_atlantic', 'lisk', 'neo', 'neo3', 'near', 'nibiru', 'nuls', 'ontology', 'oasis', 'parallel', 'pokt', 'polkadex', 'proton', 'reef', 'rvn', 'shiden', 'sora', 'stafi', 'starcoin', 'syscoin', 'stellar', 'telos', 'thorchain', 'velas', 'venom', 'vite', 'waves', 'wax', 'zilliqa', 'secret', 'etn', 'tara', 'zkfair',
-  'vinu', 'rollux', 'syscoin', 'aelf', 'ailayer', 'heco', 'archway',
+const unsupportedChains = ['aeternity', 'beam', 'binance', 'bitchain', 'bitcoincash', 'bittensor', 'bone', 'callisto', 'clv', 'concordium', 'conflux', 'cmp', 'dash', 'defichain', 'edg', 'elastos', 'elys', 'equilibrium', 'filecoin', 'findora', 'flow', 'fusion', 'heiko', 'hydra', 'icon', 'icp', 'interlay', 'karura', 'kava', 'kintsugi', 'kusuma', 'manta_atlantic', 'lisk', 'neo', 'neo3', 'near', 'nibiru', 'ontology', 'oasis', 'parallel', 'pokt', 'polkadex', 'proton', 'reef', 'rvn', 'shiden', 'sora', 'stafi', 'starcoin', 'syscoin', 'stellar', 'telos', 'thorchain', 'velas', 'venom', 'vite', 'waves', 'wax', 'zilliqa', 'secret', 'etn', 'zkfair', 'acala', 'harmony',
+  'vinu', 'rollux', 'aelf', 'ailayer', 'archway',
   'ton', // never had any tvl
-  'enuls', 'kardia'
 ]
 
-// export 0 to preserve historical tvl
-const deadChains = ['airdao', 'eos_evm', 'kroma']
+unsupportedChains.forEach(chain => delete config[chain]);
 
-const allChains = [...unsupportedChains, ...deadChains];
-allChains.forEach(chain => delete config[chain]);
+/**
+ * Gate Earn: reserves put to work rather than sitting liquid in the hot wallets.
+ *
+ * Two kinds of holdings, both invisible to the plain balance lookups above:
+ *  - L1 native staking (delegated/bonded stake) - pulled via stakingHelper.
+ *  - yield-bearing receipt tokens (Aave aTokens, Compound cTokens, Spark/Sky
+ *    savings wrappers) - the underlying is in the protocol, so the CEX token
+ *    list only sees the receipt if it is listed explicitly.
+ *
+ * Chains where staking does NOT move the balance out of the account (cardano,
+ * algorand) are deliberately absent: cexExports already counts those in full,
+ * so adding them here would double-count.
+ */
+const earnStakers = {
+  celestia: ['celestia10v2gu0vvdeuv8pexnl98lmyva4cq8jkavlk9w4'],
+  cosmos: ['cosmos10v2gu0vvdeuv8pexnl98lmyva4cq8jkaa4845c'],
+  injective: ['inj10v2gu0vvdeuv8pexnl98lmyva4cq8jkahus3xq'],
+  dydx: ['dydx10v2gu0vvdeuv8pexnl98lmyva4cq8jka5vf350'],
+  sui: ['0x6edd3be944aeaa90f86f95008b852308e5ab48dc6d2df756e92e11c1ec73b8c0'],
+}
 
-const deadChainsExports = {};
-deadChains.forEach(chain => { deadChainsExports[chain] = { tvl: async () => ({}) }; });
+/**
+ * Earn addresses whose *whole* balance is reported by the earn exports below, so
+ * cexExports must not look at them too.
+ *
+ * These are chains where staking leaves the tokens in the account (aleo, neo3,
+ * cardano, algorand, starknet) or where the position is a receipt/LST the earn
+ * side prices directly (solana gtSOL). Listing an address here removes it from
+ * the plain-balance config, which keeps the earn export the single source of
+ * truth instead of both sides counting the same tokens.
+ */
+const earnOnlyOwners = {
+  starknet: ['0x003cb9938085c5b9f15a02c46ec8eadfe9c418ba49290c02d77187fb0d5f142a'],
+  aleo: ['aleo18lpsmdx0hzwhw6ejaad5j8hjngwddyn0ap8ws8cr0z7gls4k4s9qz5ww07'],
+  neo3: ['NKvKqGs9yPGct37ybza71DsgLSPAKn34ko'],
+  cardano: [
+    'addr1q9lqxlvk2dk8sffhr56gc4c4lckpv56l4r7wwh474caywurve9ssnt966vmezsfsppfm5sxgu5sqxacp8t7kpjzp9yxqn24ckj',
+    'addr1qyxuqrcjfyyz99yx4s307x33tu45944j607cywzvh3ykxw8c0cqknc77ed7uu7v465ufhkuu73ve6x7r9emq8vfkhxts23pyk4',
+  ],
+  algorand: ['4EHCQSBDXQDSR4MFASDP2TGNKVDCJEKA5FUCHLAJ7FVTANR42JISNPV6UU'],
+  solana: ['DevD35PrcsJfg9CwpypmrD7GsYMRQpZQx6rfeSbkVtFp'],
+}
 
-module.exports = mergeExports([
-  cexExports(config),
-  deadChainsExports,
-  { ethereum: { tvl: getStakedEthTVL({ withdrawalAddresses: ['0x287a66c7d9cba7504e90fa638911d74c4dc6a147', '0xbcf03ce48091e6b820a7c33e166e5d0109d8e712', '0x7a3f9b7120386249528c93e5eb373b78e54d5ba9'], sleepTime: 20_000, size: 200, proxy: true }) } },
-]);
+Object.entries(earnOnlyOwners).forEach(([chain, owners]) => {
+  const cfg = config[chain]
+  if (!cfg?.owners) return
+  const drop = new Set(owners.map(i => i.toLowerCase()))
+  cfg.owners = cfg.owners.filter(owner => !drop.has(owner.toLowerCase()))
+  if (!cfg.owners.length) delete config[chain]
+})
+
+// delegation pools have to be named explicitly - a delegator's stake is stored
+// per-pool, there is no "list my pools" view on chain
+const aptosDelegators = [{
+  owner: '0x664208180d23956463ab9bf0a8f2a8f095bca2e27ac9c60623a4e22e78456d3f',
+  pools: ['0xdb5247f859ce63dbe8940cf8773be722a60dcc594a8be9aca4b76abceb251b8e'],
+}]
+
+const nearDelegators = [{
+  owner: 'e10e284823bc0728f1850486fd4ccd5546249140e96823ac09f96b30363cd251',
+  pools: ['gtnode-0.poolv1.near'],
+}]
+
+// bittensor coldkey as a 32-byte pubkey (SS58 5H9nqVMLfYWN6MiiCLrWjR1ADjR7V7FcBEenBY66NiHeKucE)
+const bittensorColdkeys = ['e10e284823bc0728f1850486fd4ccd5546249140e96823ac09f96b30363cd251']
+
+// conflux stakes into a separate staking-balance slot, so the cex config's plain
+// balance lookup misses it entirely
+const confluxStakers = ['cfx:aam0nuzv9bu14e68xb390bjcc3t6du0bn2tcy8rde0']
+
+// Gate stakes SOL through its own liquid-staking token rather than native stake
+// accounts, so the position shows up as a gtSOL balance.
+const solanaLsts = {
+  owners: ['DevD35PrcsJfg9CwpypmrD7GsYMRQpZQx6rfeSbkVtFp'],
+  tokens: ['gateMurAxe4YFoUR6J63gXGKtkbTfdkMdLjZrCmThFP'], // gtSOL
+}
+
+// receipt tokens per chain, discovered by enumerating the earn addresses' holdings
+const earnReceiptTokens = {
+  ethereum: {
+    owners: [
+      '0xa10eca918c71806ac55083d8ac942d4674b0f9ef',
+      '0xb11c93f04bb7cc8d2d4aba47fcf73170bcea940d',
+      '0x68cdf5d77e75515edf7aa564d36fe3cbe751226e',
+      '0x444c55075086f531a1c02730f41c46b9bbb00a39',
+      '0x356b9e62b20f4666e914fb99a9f651e5574f2bf7',
+      '0x8cd6437feaeb1a3a0cd65a16de2ad26bff1f5e43',
+    ],
+    tokens: [
+      '0x23878914efe38d27c4d67ab83ed1b93a74d4086a', // aEthUSDT (Aave v3)
+      '0x4da27a545c0c5b758a6ba100e3a049001de870f5', // stkAAVE
+      '0xe2e7a17dFf93280dec073C995595155283e3C372', // spUSDT  (Spark savings USDT)
+      '0x23f5E9c35820f4baB695Ac1F19c203cC3f8e1e11', // skyMoneyUsdtSavings
+      '0xE1753F2e00940cC31213dd92013cF019DFE4ca1d', // sGHO   (Aave savings GHO)
+      '0xC02aB1A5eaA8d1B114EF786D9bde108cD4364359', // spUSDS (Spark savings USDS)
+    ],
+  },
+  arbitrum: {
+    owners: [
+      '0xc7adfda3aa8525fea8fed6a02134297ffaca3463',
+      '0x44b28845422204c81bfe0687f0a987a444c14e67',
+      '0x45b48b43a410b6374a16176acef0b72d41a56996',
+    ],
+    tokens: [
+      '0xd98Be00b5D27fc98112BdE293e487f8D4cA57d07', // cUSDTv3 (Compound v3)
+      '0x9c4ec768c28520B50860ea7a15bd7213a9fF58bf', // cUSDCv3 (Compound v3)
+      '0x724dc807b04555b71ed48a6896b6F41593b8C637', // aArbUSDC (Aave v3)
+    ],
+  },
+  avax: {
+    owners: [
+      '0xba7946e3aeffe2145e68cd227f113e0038d43d9b',
+      '0xb05ebe4b470c4fbc0a5f4a6293741c7985c6a016',
+      '0x20ddf011b00e6f134ae10bdb73146500a69c453e',
+    ],
+    tokens: [
+      '0x6ab707Aca953eDAeFBc4fD23bA73294241490620', // aAvaUSDT (Aave v3)
+      '0x625E7708f30cA75bfd92586e17077590C60eb4cD', // aAvaUSDC (Aave v3)
+      '0x28B3a8fb53B741A8Fd78c0fb9A6B2393d896a43d', // spUSDC   (Spark savings USDC)
+    ],
+  },
+  plasma: {
+    owners: [
+      '0x603162847ead68a883f9595fe5981dfd1d545a53',
+      '0x4c6158236fe1ac71ca8c00b64864ad6d7eb0bfb4',
+    ],
+    tokens: [
+      '0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb', // USDT0
+      '0x6100e367285b01f48d07953803a2d8dca5d19873', // WXPL
+      '0x5d72a9d9a9510cd8cbdba12ac62593a58930a948', // aPlaUSDT0 (Aave v3)
+    ],
+  },
+}
+
+// receipt-token owners are handled by the earn exports, so drop them from the plain
+// balance config - otherwise both sides count the same addresses
+Object.entries(earnReceiptTokens).forEach(([chain, { owners }]) => {
+  const cfg = config[chain]
+  if (!cfg?.owners) return
+  const drop = new Set(owners.map(i => i.toLowerCase()))
+  cfg.owners = cfg.owners.filter(owner => !drop.has(owner.toLowerCase()))
+  if (!cfg.owners.length) delete config[chain]
+})
+
+const stakedEthTvl = getStakedEthTVL({ withdrawalAddresses: ['0x287a66c7d9cba7504e90fa638911d74c4dc6a147', '0xbcf03ce48091e6b820a7c33e166e5d0109d8e712', '0x7a3f9b7120386249528c93e5eb373b78e54d5ba9'], sleepTime: 20_000, size: 200, proxy: true })
+
+// mergeExports sums the *returned* balances, so every tvl has to hand them back
+const earnTvl = fn => async (api) => {
+  await fn(api)
+  return api.getBalances()
+}
+
+const gateEarnTvl = {
+  ethereum: {
+    tvl: earnTvl(async (api) => {
+      await stakedEthTvl(api)
+      await api.sumTokens(earnReceiptTokens.ethereum)
+    }),
+  },
+  aptos: { tvl: earnTvl(api => aptosStaked(api, aptosDelegators)) },
+  sui: { tvl: earnTvl(api => suiStaked(api, earnStakers.sui)) },
+  near: { tvl: earnTvl(api => nearStaked(api, nearDelegators)) },
+  bittensor: { tvl: earnTvl(api => bittensorStaked(api, bittensorColdkeys)) },
+  conflux: { tvl: earnTvl(api => confluxStaked(api, confluxStakers)) },
+  solana: { tvl: earnTvl(api => solanaSumTokens({ api, ...solanaLsts })) },
+  cardano: { tvl: earnTvl(api => cardanoStaked(api, earnOnlyOwners.cardano)) },
+  algorand: { tvl: earnTvl(api => algorandStaked(api, earnOnlyOwners.algorand)) },
+  starknet: { tvl: earnTvl(api => starknetStaked(api, earnOnlyOwners.starknet)) },
+  aleo: { tvl: earnTvl(api => aleoStaked(api, earnOnlyOwners.aleo)) },
+  neo3: { tvl: earnTvl(api => neo3Staked(api, earnOnlyOwners.neo3)) },
+}
+
+Object.entries(earnStakers).forEach(([chain, owners]) => {
+  if (chain === 'sui') return // sui staking uses its own rpc method, set above
+  gateEarnTvl[chain] = { tvl: earnTvl(api => cosmosStaked(api, owners)) }
+})
+
+Object.entries(earnReceiptTokens).forEach(([chain, args]) => {
+  if (chain === 'ethereum') return // merged with the beacon-chain staking above
+  gateEarnTvl[chain] = { tvl: earnTvl(api => api.sumTokens(args)) }
+})
+
+module.exports = mergeExports([cexExports(config), gateEarnTvl]);
+

--- a/projects/helper/stakingHelper.js
+++ b/projects/helper/stakingHelper.js
@@ -1,0 +1,283 @@
+/**
+ * L1 native-staking helpers.
+ *
+ * These pull *delegated / bonded* stake, which is invisible to the usual
+ * balance lookups (cosmos bank module, bittensor System.Account, ...). Meant for
+ * CEX adapters where a chunk of the reserves sits with validators.
+ */
+const sdk = require('@defillama/sdk')
+const ADDRESSES = require('./coreAssets.json')
+const { get, post } = require('./http')
+const { getEnv } = require('./env')
+const { queryV1Beta1V2 } = require('./chain/cosmos')
+const bittensor = require('./chain/bittensor')
+const starknet = require('./chain/starknet')
+
+// ---------------------------------------------------------------- cosmos-sdk
+
+// Bonded stake per delegator. Excludes tokens in the unbonding queue - those are
+// picked up by cosmosUnbonding.
+async function cosmosStaked(api, owners) {
+  for (const owner of owners) {
+    const delegations = await queryV1Beta1V2({
+      api,
+      url: `staking/v1beta1/delegations/${owner}`,
+      dataKey: 'delegation_responses',
+    })
+    delegations.forEach(({ balance }) => api.add(balance.denom, balance.amount))
+  }
+}
+
+// Tokens mid-unbonding (21d on most chains) still belong to the delegator.
+async function cosmosUnbonding(api, owners) {
+  for (const owner of owners) {
+    const unbondings = await queryV1Beta1V2({
+      api,
+      url: `staking/v1beta1/delegators/${owner}/unbonding_delegations`,
+      dataKey: 'unbonding_responses',
+    })
+    unbondings.forEach(({ entries = [] }) =>
+      entries.forEach(({ balance }) => api.add(api.chain === 'injective' ? 'inj' : undefined, balance))
+    )
+  }
+}
+
+// ---------------------------------------------------------------------- sui
+
+async function suiStaked(api, owners) {
+  for (const owner of owners) {
+    const stakes = await post(getEnv('SUI_RPC'), { jsonrpc: '2.0', id: 1, method: 'suix_getStakes', params: [owner] })
+    for (const pool of stakes.result ?? []) {
+      for (const { principal, estimatedReward } of pool.stakes ?? []) {
+        api.add(ADDRESSES.sui.SUI, principal)
+        if (estimatedReward) api.add(ADDRESSES.sui.SUI, estimatedReward)
+      }
+    }
+  }
+}
+
+// ------------------------------------------------------------------- aptos
+
+const APTOS_RPC = 'https://fullnode.mainnet.aptoslabs.com/v1'
+
+// get_stake returns [active, inactive, pending_inactive] octas for a delegator
+// in a given delegation pool. All three are still the delegator's funds.
+async function aptosStaked(api, delegators) {
+  for (const { owner, pools } of delegators) {
+    for (const pool of pools) {
+      const res = await post(`${APTOS_RPC}/view`, {
+        function: '0x1::delegation_pool::get_stake',
+        type_arguments: [],
+        arguments: [pool, owner],
+      })
+      res.forEach(amount => api.add(ADDRESSES.aptos.APT, amount))
+    }
+  }
+}
+
+// ------------------------------------------------------------------ cardano
+
+// Koios reports the full controlled stake of a payment address, staked or not,
+// so this replaces (rather than supplements) a plain balance lookup.
+async function cardanoStaked(api, owners) {
+  const rows = await post('https://api.koios.rest/api/v1/address_info', { _addresses: owners })
+  rows.forEach(({ balance }) => api.addGasToken(balance))
+}
+
+// ---------------------------------------------------------------- algorand
+
+// An account with status "Online" has its entire balance participating in
+// consensus, so the whole amount is stake.
+async function algorandStaked(api, owners) {
+  for (const owner of owners) {
+    const acc = await get(`https://mainnet-api.algonode.cloud/v2/accounts/${owner}`)
+    if (acc.status === 'Online') api.addCGToken('algorand', acc.amount / 1e6)
+  }
+}
+
+// ------------------------------------------------------------------- near
+
+// A delegator's stake lives inside each staking-pool contract, so the pools have
+// to be named. get_account_total_balance covers staked + unstaked-but-unclaimed.
+async function nearStaked(api, delegators) {
+  for (const { owner, pools } of delegators) {
+    for (const pool of pools) {
+      const total = await nearCall(pool, 'get_account_total_balance', { account_id: owner })
+      api.addCGToken('near', Number(total) / 1e24)
+    }
+  }
+}
+
+async function nearCall(contract, method, args) {
+  const { result } = await post('https://rpc.mainnet.near.org', {
+    jsonrpc: '2.0', id: 1, method: 'query',
+    params: {
+      request_type: 'call_function', finality: 'final', account_id: contract,
+      method_name: method, args_base64: Buffer.from(JSON.stringify(args)).toString('base64'),
+    },
+  })
+  return JSON.parse(Buffer.from(result.result).toString())
+}
+
+// ------------------------------------------------------------------- neo3
+
+// NEO is staked by holding it (voting for a council candidate does not move the
+// balance), so this reports the NEP-17 NEO/GAS holdings of the account. Only the
+// two native assets are counted - the rest of an account's NEP-17 list is spam.
+const NEO3_NATIVE = {
+  '0xd2a4cff31913016155e38e474a2c06d08be276cf': { id: 'gas', decimals: 8 },
+  '0xef4073a0f2b305a38ec4050e4d3d28bc40ea63f5': { id: 'neo', decimals: 0 },
+}
+
+async function neo3Staked(api, owners) {
+  for (const owner of owners) {
+    const { result } = await post('https://mainnet1.neo.coz.io:443', {
+      jsonrpc: '2.0', id: 1, method: 'getnep17balances', params: [owner],
+    })
+    for (const { assethash, amount } of result.balance ?? []) {
+      const native = NEO3_NATIVE[assethash.toLowerCase()]
+      if (native) api.addCGToken(native.id, Number(amount) / 10 ** native.decimals)
+    }
+  }
+}
+
+// --------------------------------------------------------------- starknet
+
+// STRK staking leaves the tokens in the delegator's account, so the STRK balance
+// *is* the staked position. Uses the starknet helper's own rpc/abi handling.
+async function starknetStaked(api, owners) {
+  return starknet.sumTokens({ api, owners, tokens: [ADDRESSES.starknet.STRK] })
+}
+
+// ---------------------------------------------------------------- conflux
+
+async function confluxStaked(api, owners) {
+  for (const owner of owners) {
+    const { result } = await post('https://main.confluxrpc.com', {
+      jsonrpc: '2.0', id: 1, method: 'cfx_getStakingBalance', params: [owner, 'latest_state'],
+    })
+    api.addGasToken(BigInt(result).toString())
+  }
+}
+
+// ------------------------------------------------------------------- aleo
+
+// credits.aleo `bonded` mapping -> plaintext struct { validator, microcredits }
+async function aleoStaked(api, owners) {
+  for (const owner of owners) {
+    const raw = await get(`https://api.explorer.provable.com/v1/mainnet/program/credits.aleo/mapping/bonded/${owner}`)
+    if (!raw) continue
+    const micro = /microcredits:\s*(\d+)u64/.exec(raw)
+    if (micro) api.addCGToken('aleo', Number(micro[1]) / 1e6)
+  }
+}
+
+// -------------------------------------------------------------- bittensor
+
+const {
+  rpc, getFinalizedHead, getStorage, subtensorPrefix, hexToBuf, keyHex, blake128, u16le, u64LE, u128LE,
+} = bittensor
+
+const b2c = (buf) => Buffer.concat([blake128(buf), buf]) // Blake2_128Concat
+const i64LE = (b, o = 0) => { let v = u64LE(b, o); if (v & (1n << 63n)) v -= (1n << 64n); return v }
+// V2 SafeDecimal {mantissa:u128, exponent:i64}: real = m * 2^e
+const fpV2 = (b) => (!b || b.length < 24) ? 0 : Number(u128LE(b, 0)) * Math.pow(2, Number(i64LE(b, 16)))
+// V1 U64F64 {bits:u128}: real = bits / 2^64
+const fpV1 = (b) => (!b || b.length < 16) ? 0 : Number(u128LE(b, 0)) / Math.pow(2, 64)
+
+async function getMany(keyBufs, at) {
+  if (!keyBufs.length) return new Map()
+  const keys = keyBufs.map(keyHex)
+  const res = await rpc('state_queryStorageAt', [keys, at])
+  const out = new Map(keys.map((k) => [k, null]))
+  for (const cs of res) for (const [k, v] of cs.changes) out.set(k, v)
+  return out
+}
+
+async function netuidsUnder(pfx, at) {
+  const out = []; let start = keyHex(pfx)
+  for (;;) {
+    const keys = await rpc('state_getKeysPaged', [keyHex(pfx), 200, start, at])
+    if (!keys.length) break
+    for (const kh of keys) { const t = hexToBuf(kh).subarray(pfx.length); out.push(t[0] | (t[1] << 8)) }
+    if (keys.length < 200) break
+    start = keys[keys.length - 1]
+  }
+  return out
+}
+
+/**
+ * Staked TAO for a coldkey, added as per-subnet alpha (priced via the subnet AMM).
+ *
+ * Staked TAO lives in SubtensorModule dTAO share pools, not System.Account, so
+ * chain/bittensor's free-balance lookup misses all of it. Walks
+ * coldkey -> StakingHotkeys -> Alpha shares -> alpha, pinned to one finalized
+ * block so the multi-step read is a consistent snapshot.
+ */
+async function bittensorStaked(api, coldkeys) {
+  const at = await getFinalizedHead()
+  for (const coldkey of coldkeys) {
+    const cold = hexToBuf(coldkey)
+
+    // Hotkeys this coldkey stakes to: StakingHotkeys(cold) -> Vec<AccountId32>.
+    const shRaw = await getStorage(Buffer.concat([subtensorPrefix('StakingHotkeys'), b2c(cold)]), at)
+    const hotkeys = []
+    if (shRaw) {
+      const b = hexToBuf(shRaw), mode = b[0] & 3
+      let count, off
+      if (mode === 0) { count = b[0] >> 2; off = 1 }
+      else if (mode === 1) { count = (b[0] | (b[1] << 8)) >> 2; off = 2 }
+      else if (mode === 2) { count = (b[0] | (b[1] << 8) | (b[2] << 16) | (b[3] << 24)) >>> 2; off = 4 }
+      else throw new Error('unexpected compact vec length')
+      for (let i = 0; i < count; i++) { hotkeys.push(Buffer.from(b.subarray(off, off + 32))); off += 32 }
+    }
+
+    const aV2 = (hot) => Buffer.concat([subtensorPrefix('AlphaV2'), b2c(hot), b2c(cold)])
+    const aV1 = (hot) => Buffer.concat([subtensorPrefix('Alpha'), b2c(hot), b2c(cold)])
+    const entries = []
+    for (const hot of hotkeys) {
+      for (const n of await netuidsUnder(aV2(hot), at)) entries.push({ hot, net: n, v: 2 })
+      for (const n of await netuidsUnder(aV1(hot), at)) entries.push({ hot, net: n, v: 1 })
+    }
+
+    const reads = []
+    for (const e of entries) {
+      reads.push(e.v === 2 ? Buffer.concat([aV2(e.hot), u16le(e.net)]) : Buffer.concat([aV1(e.hot), u16le(e.net)]))
+      reads.push(Buffer.concat([subtensorPrefix(e.v === 2 ? 'TotalHotkeySharesV2' : 'TotalHotkeyShares'), b2c(e.hot), u16le(e.net)]))
+      reads.push(Buffer.concat([subtensorPrefix('TotalHotkeyAlpha'), b2c(e.hot), u16le(e.net)]))
+    }
+    const vals = await getMany(reads, at)
+    const V = (buf) => vals.get(keyHex(buf))
+
+    for (const e of entries) {
+      let alpha
+      if (e.v === 2) {
+        const share = fpV2(hexToBuf(V(Buffer.concat([aV2(e.hot), u16le(e.net)])) || '0x'))
+        if (!share) continue
+        const totShares = fpV2(hexToBuf(V(Buffer.concat([subtensorPrefix('TotalHotkeySharesV2'), b2c(e.hot), u16le(e.net)])) || '0x'))
+        const taRaw = V(Buffer.concat([subtensorPrefix('TotalHotkeyAlpha'), b2c(e.hot), u16le(e.net)]))
+        const totAlpha = taRaw ? Number(u64LE(hexToBuf(taRaw))) : 0
+        alpha = totShares > 0 ? (share / totShares) * totAlpha : 0
+      } else {
+        alpha = fpV1(hexToBuf(V(Buffer.concat([aV1(e.hot), u16le(e.net)])) || '0x'))
+        if (!alpha) continue
+      }
+      api.add(e.net.toString(), alpha)
+    }
+  }
+}
+
+module.exports = {
+  cosmosStaked,
+  cosmosUnbonding,
+  suiStaked,
+  aptosStaked,
+  nearStaked,
+  neo3Staked,
+  starknetStaked,
+  cardanoStaked,
+  algorandStaked,
+  confluxStaked,
+  aleoStaked,
+  bittensorStaked,
+}

--- a/projects/helper/unwrapLPs.js
+++ b/projects/helper/unwrapLPs.js
@@ -1357,8 +1357,43 @@ async function unwrapStakewiseDeposits({ api, owners = [], vault = '0xAC0F906E43
   assets.forEach(a => api.add(nullAddress, a))
 }
 
+const DOLOMITE_MARGIN = {
+  ethereum: '0x003Ca23Fd5F0ca87D01F6eC6CD14A8AE60c2b97D',
+  arbitrum: '0x6Bd780E7fDf01D77e4d475c821f1e7AE05409072',
+  berachain: '0x003Ca23Fd5F0ca87D01F6eC6CD14A8AE60c2b97D',
+  mantle: '0x003Ca23Fd5F0ca87D01F6eC6CD14A8AE60c2b97D',
+  polygon_zkevm: '0x003Ca23Fd5F0ca87D01F6eC6CD14A8AE60c2b97D',
+  xlayer: '0x003Ca23Fd5F0ca87D01F6eC6CD14A8AE60c2b97D',
+}
+
+const DOLOMITE_GET_ACCOUNT_BALANCES_ABI = 'function getAccountBalances((address owner, uint256 number) account) view returns (uint256[], address[], (bool sign, uint128 value)[], (bool sign, uint256 value)[])'
+
+// unwraps dolomite deposits, pass either `accounts` (list of [owner, accountNumber]) or `owner`/`owners` with a shared `accountNumber`
+async function unwrapDolomiteDeposits({ api, accounts = [], owner, owners = [], accountNumber = 0, dolomiteMargin, onlyPositive = true, }) {
+  const margin = dolomiteMargin ?? DOLOMITE_MARGIN[api.chain]
+  if (!margin) throw new Error('unwrapDolomiteDeposits: missing dolomiteMargin for chain ' + api.chain)
+  if (owner) owners = [...owners, owner]
+  accounts = [...accounts, ...owners.map(i => [i, accountNumber])]
+
+  const res = await api.multiCall({
+    abi: DOLOMITE_GET_ACCOUNT_BALANCES_ABI,
+    target: margin,
+    calls: accounts.map(([owner, number]) => ({ params: [[owner, number]] })),
+  })
+
+  res.forEach(({ [1]: tokens, [3]: weis }) => {
+    tokens.forEach((token, i) => {
+      const { sign, value } = weis[i]
+      if (onlyPositive && !sign) return  // negative balance = borrow
+      api.add(token, sign ? value : -value)
+    })
+  })
+  return api.getBalances()
+}
+
 module.exports = {
   PANCAKE_NFT_ADDRESS,
+  unwrapDolomiteDeposits,
   unwrapUniswapLPs,
   unwrapSlipstreamNFT,
   unwrapUniswapV3NFT,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Gate Earn TVL to include staking, liquid-staking, lending, and receipt-token positions across multiple networks.
  * Added native staking support across Cosmos, Sui, Aptos, Near, Cardano, Algorand, Conflux, Aleo, Bittensor, Starknet, and Neo3.
  * Enhanced Ethereum TVL handling by unwrapping Dolomite deposits during earn calculations.
* **Bug Fixes**
  * Improved TVL accuracy by preventing double counting between earn and cex-style exports.
  * Removed unsupported chain placeholder exports and adjusted which networks are included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->