### PR TITLE
Add Curve treasury sfrxUSD, sDOLA, and COW

### DIFF
--- a/registries/treasury.js
+++ b/registries/treasury.js
@@ -1408,6 +1408,9 @@ const configs = {
       tokens: [
         nullAddress,
         ADDRESSES.ethereum.CRVUSD,
+        '0xcf62F905562626CfcDD2261162a51fd02Fc9c5b6', // sfrxUSD
+        '0xb45ad160634c528Cc3D2926d9807104FA3157305', // sDOLA
+        '0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab', // COW
       ],
     },
   },


### PR DESCRIPTION
## Summary

- Add Ethereum sfrxUSD to the Curve treasury token allowlist
- Add Ethereum sDOLA to the Curve treasury token allowlist
- Add Ethereum COW to the Curve treasury token allowlist

## Testing

- node test.js projects/treasury/curve.js
- pnpm exec eslint registries/treasury.js
- git diff --check

The treasury test detected sfrxUSD, sDOLA, and COW balances.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for three additional tokens in the Ethereum Curve Treasury configuration: sfrxUSD, sDOLA, and COW.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->