### PR TITLE
Add HypeFuel adapter

### DIFF
--- a/projects/hypefuel/index.js
+++ b/projects/hypefuel/index.js
@@ -1,0 +1,15 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+const { sumTokensExport } = require('../helper/unwrapLPs')
+
+// HypeFuel fills user orders out of its own inventory rather than from an LP pool, so all of
+// the protocol's assets sit in this single proxy: the HYPE left to sell, plus USDC taken in
+// from fills that has not yet been rebalanced back into HYPE.
+const HYPE_FUEL = '0x42b06b1d9a07Fc3925C518dbf9475E7cA80DC8DF'
+
+module.exports = {
+  methodology: 'Counts the native HYPE and USDC held by the HypeFuel contract. HYPE is the inventory sold to users, and USDC is proceeds from fills awaiting the next rebalance back into HYPE.',
+  start: '2026-07-28',
+  hyperliquid: {
+    tvl: sumTokensExport({ owner: HYPE_FUEL, tokens: [ADDRESSES.null, ADDRESSES.hyperliquid.USDC] }),
+  },
+}


### PR DESCRIPTION
New listing. HypeFuel lets someone holding USDC on HyperEVM but no HYPE swap into native HYPE without needing gas first: the user signs an EIP-3009 authorization off-chain and a relayer broadcasts the fill, so the swap costs the user no gas.

Orders are filled from the contract's own HYPE inventory rather than an LP pool, so the protocol's entire balance sheet is the single proxy the adapter reads.

Tested with `node test.js projects/hypefuel/index.js`:

```
--- hyperliquid ---
HYPE                      209.17
USDC                      7.00
Total: 216.17
```

---
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
HypeFuel

##### Twitter Link:
None.

##### List of audit links if any:
None. The contract is unaudited; this is stated plainly on the site and in the repo's SECURITY.md.

##### Website Link:
https://hypefuel.me

##### Logo (High resolution, will be shown with rounded borders):
https://hypefuel.me/favicon/web-app-manifest-512x512.png

##### Current TVL:
~$216 (3.81 HYPE plus 7 USDC). The protocol launched yesterday, so this is genuinely early.

##### Treasury Addresses (if the protocol has treasury)
None.

##### Chain:
HyperEVM (`hyperliquid`)

##### Coingecko ID:
None, no token.

##### Coinmarketcap ID:
None, no token.

##### Short Description (to be shown on DefiLlama):
Swap USDC for native HYPE on HyperEVM without holding any gas.

##### Token address and ticker if any:
None.

##### Category:
Dexs

##### Oracle Provider(s):
HyperCore precompiles, reading the HYPE perp oracle price (`oraclePx`) and the HYPE spot price (`spotPx`).

##### Implementation Details:
Quotes are priced on-chain at fill time. The contract reads both `oraclePx` for the HYPE perp index and `spotPx` for the HYPE spot index from the HyperCore precompiles, and reverts if the two disagree by more than `maxOracleDeviationBps` (currently 500 bps), so a single manipulated feed cannot set the fill price on its own.

##### Documentation/Proof:
Pricing is described under "Pricing" in https://github.com/chase-mew/hype-fuel#readme, and implemented in `packages/contracts/src/HypeFuel.sol`. Contract: https://hyperevmscan.io/address/0x42b06b1d9a07Fc3925C518dbf9475E7cA80DC8DF

##### forkedFrom:
Not a fork.

##### methodology:
Counts the native HYPE and USDC held by the HypeFuel proxy at 0x42b06b1d9a07Fc3925C518dbf9475E7cA80DC8DF. HYPE is the inventory the protocol sells to users, and USDC is proceeds from fills that have not yet been rebalanced back into HYPE.

##### Github org/user:
chase-mew (source at https://github.com/chase-mew/hype-fuel)

##### Does this project have a referral program?
No.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HypeFuel TVL tracking for native HYPE and USDC balances.
  * Included pricing metadata, methodology details, and a tracking start date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->