### PR TITLE
Add MomoSwap TVL on Cookie Chain

### DIFF
--- a/projects/momoswap/index.js
+++ b/projects/momoswap/index.js
@@ -1,0 +1,67 @@
+const { PublicKey } = require('@solana/web3.js')
+const { getConnection, getTokenAccountBalances } = require('../helper/solana')
+
+// MomoSwap launchpad on Cookie Chain. Tokens launch on a bonding curve;
+// the COOK raised from buyers is held in each pool's `payment_vault`
+// TVL = COOK held in the payment vaults of pools that have not graduated,
+// which includes expired pools: expiry snapshots the vault balance as
+// `expiry_liquidity` and leaves the COOK in place for participants to claim.
+const LAUNCHPAD = 'momoL7wu4TrXjnXMLCLzGsbx8Pm7XGgoYo7FVqDoqcw'
+
+// Anchor account discriminator for `Pool` = sha256("account:Pool")[:8].
+const POOL_DISCRIMINATOR_HEX = 'f19a6d0411b16dbc'
+const POOL_DISCRIMINATOR_B58 = 'hQrXeCntzbV' // base58 of the 8 discriminator bytes, for the memcmp filter
+
+// PoolState enum: 0 = Created, 1 = Open, 2 = Graduated, 3 = Expired.
+const POOL_STATE_GRADUATED = 2
+
+// `Pool` starts with three fixed pubkeys + pool_id, then three variable-length
+// strings (name/symbol/uri), so `payment_vault` and `state` are at data-dependent
+// offsets — the account is allocated at a fixed size (the strings are space-reserved at
+// their maximum lengths) but serialized at their real lengths, so a fixed offset would
+// read garbage. Walk past the strings, then read the fixed tail. Layout (after the 8-byte
+// discriminator): config(32) creator(32) creator_payment_account(32) pool_id(8)
+// name(str) symbol(str) uri(str) token_mint(32) payment_mint(32) token_vault(32)
+// payment_vault(32) launch_ts(8) end_ts(8) duration_secs(8) expiry_mode(1)
+// migratable(1) anti_snipe(1) state(1) ...
+function parsePool(data) {
+  let o = 8 + 32 + 32 + 32 + 8 // skip discriminator + config + creator + creator_payment_account + pool_id
+  for (let i = 0; i < 3; i++) { // name, symbol, uri
+    if (o + 4 > data.length) return null
+    o += 4 + data.readUInt32LE(o)
+  }
+  const paymentVaultOffset = o + 96 // skip token_mint + payment_mint + token_vault
+  const stateOffset = o + 96 + 32 + 24 + 3 // skip payment_vault + launch/end/duration + expiry/migratable/anti_snipe
+  if (stateOffset >= data.length) return null
+  return {
+    paymentVault: new PublicKey(data.subarray(paymentVaultOffset, paymentVaultOffset + 32)).toBase58(),
+    state: data[stateOffset],
+  }
+}
+
+async function tvl(api) {
+  const connection = getConnection(api.chain)
+  const accounts = await connection.getProgramAccounts(new PublicKey(LAUNCHPAD), {
+    filters: [{ memcmp: { offset: 0, bytes: POOL_DISCRIMINATOR_B58 } }],
+  })
+  const vaults = []
+  for (const { account } of accounts) {
+    // Re-check the discriminator: the program also owns `UserPosition` accounts, and an
+    // RPC that ignored the memcmp filter would otherwise feed them to parsePool.
+    if (account.data.subarray(0, 8).toString('hex') !== POOL_DISCRIMINATOR_HEX) continue
+    const pool = parsePool(account.data)
+    if (!pool) continue
+    if (pool.state === POOL_STATE_GRADUATED) continue // graduated
+    vaults.push(pool.paymentVault)
+  }
+  if (vaults.length) {
+    const balances = await getTokenAccountBalances(vaults, { chain: api.chain, allowError: true })
+    for (const [mint, amount] of Object.entries(balances)) api.add(mint, amount)
+  }
+}
+
+module.exports = {
+  timetravel: false,
+  methodology: 'Counts the COOK held in the payment vault of every MomoSwap bonding-curve launch that has not graduated — launches still raising on the curve, plus expired launches whose raised COOK stays in the vault until participants claim it.',
+  cookiechain: { tvl },
+}

--- a/projects/momoswap/index.js
+++ b/projects/momoswap/index.js
@@ -60,6 +60,10 @@ async function tvl(api) {
     // so a missing or undecodable vault means a bad RPC response or a struct-layout drift that broke
     // `parsePool` — both of which must fail loudly rather than silently under-report TVL.
     const balances = await getTokenAccountBalances(vaults, { chain: api.chain })
+    // Every vault necessarily holds the same mint, so this loop yields a single entry: the singleton
+    // `config` PDA (seeds ["config"], `init`-once, and `payment_mint` is never touched by
+    // `update_config`) pins `create_pool`'s payment_mint via `address = config.payment_mint`, and the
+    // payment_vault is `init`ed with `token::mint = payment_mint`. Today that mint is wrapped COOK.
     for (const [mint, amount] of Object.entries(balances)) api.add(mint, amount)
   }
 }

--- a/projects/momoswap/index.js
+++ b/projects/momoswap/index.js
@@ -55,7 +55,11 @@ async function tvl(api) {
     vaults.push(pool.paymentVault)
   }
   if (vaults.length) {
-    const balances = await getTokenAccountBalances(vaults, { chain: api.chain, allowError: true })
+    // No `allowError`: every vault pubkey comes out of a live `Pool` account and the program never
+    // closes a `payment_vault` (its only `close` is on `Session`, and it makes no `CloseAccount` CPI),
+    // so a missing or undecodable vault means a bad RPC response or a struct-layout drift that broke
+    // `parsePool` — both of which must fail loudly rather than silently under-report TVL.
+    const balances = await getTokenAccountBalances(vaults, { chain: api.chain })
     for (const [mint, amount] of Object.entries(balances)) api.add(mint, amount)
   }
 }


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):

MomoSwap

##### Twitter Link:

https://x.com/momoswapdotfun

##### Website Link:

https://www.momoswap.fun/

##### Logo (High resolution, will be shown with rounded borders):

https://github.com/cookiechain/apps/blob/main/logos/momoswap.png

##### Current TVL:

0

##### Chain:

Cookie Chain

##### Short Description (to be shown on DefiLlama):

MomoSwap is a bonding-curve launchpad on Cookie Chain. Mint a token in under a minute, trade it on the curve, and graduate straight to a real DEX.

##### Category (full list at https://defillama.com/categories):

Launchpad

##### methodology (what is being counted as tvl, how is tvl being calculated):

Counts the COOK held in the payment vault of every MomoSwap bonding-curve launch that has not graduated — launches still raising on the curve, plus expired launches whose raised COOK stays in the vault until participants claim it.

##### IDL

https://gist.github.com/fibanachos/753c16e0a037ae124a5fa499f2f2adcb

##### Github org/user (Optional, if your code is open source, we can track activity):

https://github.com/develop-momo

##### Does this project have a referral program?

https://www.momoswap.fun/docs#referrals

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Cookie Chain TVL tracking for MomoSwap launchpad pools.
  * TVL now aggregates COOK token balances held in pool vaults for active, non-graduated pools only.
  * Published an updated methodology describing how COOK is counted for MomoSwap TVL.
  * Set the integration to reflect current on-chain state (no historical time travel).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->