### PR TITLE
steakhouse: add Robinhood vaults

### DIFF
--- a/registries/curators.js
+++ b/registries/curators.js
@@ -956,6 +956,13 @@ const configs = {
             '0xBEEf0F82E269760429BE6255Fa00821b7e4b592A', // Steakhouse Prime
           ],
         },
+        robinhood: {
+          morpho: [
+            '0xBeEff033F34C046626B8D0A041844C5d1A5409dd', // Steakhouse USDG
+            '0xbEeFF0fb1Dc19344A87b8479dAb60A2e16160737', // Ethena x Steakhouse USDG
+            '0xBEEff039907422219Fb367e525954DDC092854d9', // Grove x Steakhouse USDG
+          ],
+        },
         solana: {
           kaminoLendVaultAdmins: [
             '9ceRgz579BcfWogs3RE11FKNQaWW7Lmtnev3MXspxUjF',

--- a/registries/curators.js
+++ b/registries/curators.js
@@ -961,6 +961,7 @@ const configs = {
             '0xBeEff033F34C046626B8D0A041844C5d1A5409dd', // Steakhouse USDG
             '0xbEeFF0fb1Dc19344A87b8479dAb60A2e16160737', // Ethena x Steakhouse USDG
             '0xBEEff039907422219Fb367e525954DDC092854d9', // Grove x Steakhouse USDG
+            '0xbeEfFF136E3684273e6aA75A1669B784B373A4FD', // Steakhouse Turbo USDG
           ],
         },
         solana: {


### PR DESCRIPTION
## Existing listing update

Updates the existing Steakhouse Financial curator registry to include Robinhood Chain vault coverage.

### Summary

- Add explicit Steakhouse Morpho V2 vaults on Robinhood Chain.
- Include the Steakhouse USDG, Ethena x Steakhouse USDG, Grove x Steakhouse USDG, and USDG Turbo vaults.

### Source / verification

- Vault addresses were verified against public Morpho Robinhood Chain vault data and onchain ERC-4626 contract calls.
- Final diff changes only `registries/curators.js`; no package or lockfile changes.
- USDG Turbo contract was checked on Robinhood Chain via ERC-4626 methods and resolves to USDG as the underlying asset.

### Tests

- `node --check registries/curators.js`
- `eslint -c eslint.config.js .` — passes with unrelated existing warnings in `projects/helper/dune.js` and `registries/sumTokens.js`.
- `node test.js steakhouse` — returned Robinhood balances, including USDG TVL.

---

## (Needs to be filled only for new listings)

N/A — this is an update to an existing listing.
