### PR TITLE
templarfi: skip gov proxies, new oracle proxies and pyth-lazer

### DIFF
--- a/projects/templarfi/index.js
+++ b/projects/templarfi/index.js
@@ -11,7 +11,7 @@ const CALL_TIMEOUT_MS = 30000
 
 const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms))
 
-// These are proxy oracles, adapters and deleted test markets
+// These are proxy oracles, gov proxies, adapters, price feeds and deleted test markets
 const CONTRACTS_TO_SKIP = new Set([
   'liqtest-ixlm-ixlmusdc.v1.tmplr.near',
   'proxy-oracle-ixlmcetes-ixlmusdc.v1.tmplr.near',
@@ -24,7 +24,24 @@ const CONTRACTS_TO_SKIP = new Set([
   'proxy-oracle-ixrp-ixlmusdc.v1.tmplr.near',
   'proxy-oracle-izec-ixlmusdc.v1.tmplr.near',
   'proxy-oracle-linear-usdt.v1.tmplr.near',
-  'proxy-oracle-stnear-usdt.v1.tmplr.near'
+  'proxy-oracle-stnear-usdt.v1.tmplr.near',
+  'proxy-oracle-ixlm-ixlmusdc-1.v1.tmplr.near',
+  'proxy-oracle-iethhemibtc-iethusdc.v1.tmplr.near',
+  'proxy-oracle-iethwbtc-ixlmusdc.v1.tmplr.near',
+  'proxy-gov-ibtc-ixlmusdc.v1.tmplr.near',
+  'proxy-gov-ixlmcetes-ixlmusdc.v1.tmplr.near',
+  'proxy-gov-ixlmustry-ixlmusdc.v1.tmplr.near',
+  'proxy-gov-iethhemibtc-iethusdc.v1.tmplr.near',
+  'proxy-gov-iada-ixlmusdc.v1.tmplr.near',
+  'proxy-gov-ixlm-ixlmusdc-1.v1.tmplr.near',
+  'proxy-gov-ixrp-ixlmusdc.v1.tmplr.near',
+  'proxy-gov-izec-ixlmusdc.v1.tmplr.near',
+  'proxy-gov-iethwbtc-ixlmusdc.v1.tmplr.near',
+  'proxy-gov-linear-usdt.v1.tmplr.near',
+  'proxy-gov-stnear-usdt.v1.tmplr.near',
+  'proxy-gov-idoge-ixlmusdc.v1.tmplr.near',
+  'proxy-gov-iltc-ixlmusdc.v1.tmplr.near',
+  'pyth-lazer.v1.tmplr.near',
 ]);
 
 const FAST_FAIL_PATTERNS = ['does not exist', 'Buffer', 'Received undefined']


### PR DESCRIPTION
Adds newly deployed non-market contracts on the Templar registry to the adapter's skip list: `proxy-gov-*` governance proxies, three new `proxy-oracle-*` deployments, and `pyth-lazer.v1.tmplr.near`. These are not markets and fail `get_current_snapshot`, producing "skipped (not a market)" Buffer errors on every run.

Verified with `node test.js projects/templarfi/index.js` — all listed contracts are now filtered up front and TVL computes normally (~$32.9M).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment processing to skip additional governance proxy and price feed contracts.
  * Clarified the types of contracts excluded from deployment processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->