### PR TITLE
add KOLSwap BSC

### DIFF
--- a/registries/uniswapV2.js
+++ b/registries/uniswapV2.js
@@ -3093,7 +3093,8 @@ const uniV2Configs = {
     robinhood: '0x6Fdf38f92eAd1adFc04B73aaa947ab254f6c0916'
   },
   'kolswap': {
-    robinhood: '0xdB2Ec80E55527b5D858b54173083139679f5DE6f'
+    robinhood: '0xdB2Ec80E55527b5D858b54173083139679f5DE6f',
+    bsc: '0x6af79510599dE74E5922A2771b29160dA8b7b4c1'
   }
 }
 


### PR DESCRIPTION
## Summary
Adds the verified BSC mainnet KOLSwap factory to the existing KOLSwap Uniswap V2 registry entry while retaining Robinhood Chain.

## Onchain evidence
- BSC factory: [0x6af79510599dE74E5922A2771b29160dA8b7b4c1](https://bscscan.com/address/0x6af79510599dE74E5922A2771b29160dA8b7b4c1)
- deployment block: 112369856 (2026-07-27 04:24:45 UTC)
- protocol version: 30200
- factory allPairsLength: 1
- KMT/USDT pair: [0x826bdd9d1070Cdda93282E0108B7C7Cb3Ec90a4D](https://bscscan.com/address/0x826bdd9d1070Cdda93282E0108B7C7Cb3Ec90a4D)
- the pair exposes token0, token1, and getReserves for the registry adapter
- liquidity added in [transaction 0x65a6...f85b](https://bscscan.com/tx/0x65a6075a241a0763090e9e5cc10e815741bc737b68df146186e585b08213f85b)
- after the first real swap, current reserves at block 112877848 are 9901284196560293970106 raw KMT and 1009995000000000010 raw USDT (9901.284196560293970106 KMT / 1.009995000000000010 USDT)
- first swap: [transaction 0xb1d9...b8bf3](https://bscscan.com/tx/0xb1d9f3f435d33791e4e6cf260ca68c78c06de26a64b1e9121b03e8ecd28b8bf3)

## Validation
- node --check registries/uniswapV2.js
- read-only BSC RPC checks for factory bytecode, pair enumeration, pair assets, and reserves
