### PR TITLE
Add YeetLaunch (Solana) TVL adapter

### DIFF
--- a/projects/yeetlaunch/index.js
+++ b/projects/yeetlaunch/index.js
@@ -1,0 +1,49 @@
+const { PublicKey } = require('@solana/web3.js')
+const { getConnection, sumTokens2 } = require('../helper/solana')
+
+// YeetAMM — bonding curve and AMM in a single Solana program. A pool starts in
+// DBC mode and converts in place to a constant-product AMM pool, so both stages
+// hold their reserves in the same pair of program-owned token vaults.
+const PROGRAM_ID = 'yeetaecvxpd7DFzZAYTEYracRt1WYJ7DfMVjEeEt2Cp'
+
+// Anchor discriminator for the `Pool` account (sha256("account:Pool")[0..8]),
+// base58-encoded for the memcmp filter. Filtering on the discriminator rather
+// than on dataSize keeps this correct across pool struct versions, which have
+// grown by appending fields (545 -> 577 -> 593 bytes).
+const POOL_DISCRIMINATOR = 'hQrXeCntzbV'
+
+// Byte offsets into the Pool account. These sit below 545 bytes and have not
+// moved across struct versions, since newer fields were appended.
+const OFFSET_VAULT_A = 74
+const OFFSET_VAULT_B = 106
+const OFFSET_IS_INITIALIZED = 414
+
+async function tvl(api) {
+  const connection = getConnection()
+  const accounts = await connection.getProgramAccounts(new PublicKey(PROGRAM_ID), {
+    filters: [{ memcmp: { offset: 0, bytes: POOL_DISCRIMINATOR } }],
+  })
+
+  const tokenAccounts = []
+  for (const { account } of accounts) {
+    const data = account.data
+    // Skip pools whose accounts exist but were never fully set up; their vaults
+    // are empty and may not be valid token accounts yet.
+    if (data.length <= OFFSET_IS_INITIALIZED || data[OFFSET_IS_INITIALIZED] !== 1) continue
+    tokenAccounts.push(new PublicKey(data.subarray(OFFSET_VAULT_A, OFFSET_VAULT_A + 32)).toString())
+    tokenAccounts.push(new PublicKey(data.subarray(OFFSET_VAULT_B, OFFSET_VAULT_B + 32)).toString())
+  }
+
+  // Balances come from the vaults themselves, never from the pool's bookkept
+  // reserve fields. Pools also carry virtual reserves used only to shape the
+  // bonding curve price; those are not assets and must not be counted. Reading
+  // the vaults excludes them structurally rather than by subtraction.
+  return sumTokens2({ api, tokenAccounts, onlyTrustedTokens: true })
+}
+
+module.exports = {
+  timetravel: false,
+  methodology:
+    'TVL is the balance of the SOL-side and token-side vaults owned by the YeetAMM program (yeetaecvxpd7DFzZAYTEYracRt1WYJ7DfMVjEeEt2Cp), covering both bonding-curve pools and graduated AMM pools. Pool accounts are discovered on-chain by their Anchor discriminator and vault balances are read directly from the token accounts. Virtual reserves, which the program stores to shape the bonding curve price but which hold no assets, are excluded. Newly launched tokens with no external market are not counted, as only trusted/priced tokens contribute.',
+  solana: { tvl },
+}

--- a/projects/yeetlaunch/index.js
+++ b/projects/yeetlaunch/index.js
@@ -21,27 +21,12 @@ const OFFSET_VAULT_A = 74
 const OFFSET_VAULT_B = 106
 const OFFSET_IS_INITIALIZED = 414
 
-// Only the quote side of each pool is counted. Every pool pairs a freshly
-// launched token against one of these, and the launch token has no market
-// outside its own pool, so including its vault would assign value to supply
-// that cannot be sold anywhere else.
 const QUOTE_MINTS = new Set([
   ADDRESSES.solana.SOL,
   ADDRESSES.solana.USDC,
   ADDRESSES.solana.USDT,
 ])
 
-/**
- * Sums the quote-asset balances held in YeetAMM pool vaults.
- *
- * Pools are discovered by their Anchor discriminator, and balances are read
- * from the vault token accounts rather than from the pool's bookkept reserve
- * fields, because pools also store virtual reserves that shape the bonding
- * curve price while holding no assets.
- *
- * @param {object} api DefiLlama chain api
- * @returns {Promise<object>} balances keyed by token
- */
 async function tvl(api) {
   const connection = getConnection()
   const accounts = await connection.getProgramAccounts(new PublicKey(PROGRAM_ID), {
@@ -51,8 +36,7 @@ async function tvl(api) {
   const tokenAccounts = []
   for (const { account } of accounts) {
     const data = account.data
-    // Skip pools whose accounts exist but were never fully set up; their vaults
-    // are empty and may not be valid token accounts yet.
+    // Skip uninitialized pools; their vaults are empty and may not be valid token accounts yet.
     if (data.length <= OFFSET_IS_INITIALIZED || data[OFFSET_IS_INITIALIZED] !== 1) continue
 
     const readPubkey = (offset) => new PublicKey(data.subarray(offset, offset + 32)).toString()
@@ -69,6 +53,6 @@ async function tvl(api) {
 module.exports = {
   timetravel: false,
   methodology:
-    'TVL is the quote-asset balance of the vaults owned by the YeetAMM program (yeetaecvxpd7DFzZAYTEYracRt1WYJ7DfMVjEeEt2Cp), covering both bonding-curve pools and graduated AMM pools, which share the same vaults. Pool accounts are discovered on-chain by their Anchor discriminator, and balances are read directly from the vault token accounts rather than from the pool\'s bookkept reserve fields. Pools also store virtual reserves, which the program uses to shape the bonding curve price but which hold no assets; reading the vaults excludes those structurally. Only the quote side of each pool is counted, so freshly launched tokens — which have no market outside their own pool — are not assigned value.',
+    'TVL is the quote-asset (SOL/USDC/USDT) balance held in the YeetAMM program vaults, covering both bonding-curve and graduated AMM pools (which share the same vaults). Only the quote side of each pool is counted, so freshly launched tokens — which have no market outside their own pool — are not assigned value.',
   solana: { tvl },
 }

--- a/projects/yeetlaunch/index.js
+++ b/projects/yeetlaunch/index.js
@@ -1,4 +1,5 @@
 const { PublicKey } = require('@solana/web3.js')
+const ADDRESSES = require('../helper/coreAssets.json')
 const { getConnection, sumTokens2 } = require('../helper/solana')
 
 // YeetAMM — bonding curve and AMM in a single Solana program. A pool starts in
@@ -14,10 +15,33 @@ const POOL_DISCRIMINATOR = 'hQrXeCntzbV'
 
 // Byte offsets into the Pool account. These sit below 545 bytes and have not
 // moved across struct versions, since newer fields were appended.
+const OFFSET_MINT_A = 10
+const OFFSET_MINT_B = 42
 const OFFSET_VAULT_A = 74
 const OFFSET_VAULT_B = 106
 const OFFSET_IS_INITIALIZED = 414
 
+// Only the quote side of each pool is counted. Every pool pairs a freshly
+// launched token against one of these, and the launch token has no market
+// outside its own pool, so including its vault would assign value to supply
+// that cannot be sold anywhere else.
+const QUOTE_MINTS = new Set([
+  ADDRESSES.solana.SOL,
+  ADDRESSES.solana.USDC,
+  ADDRESSES.solana.USDT,
+])
+
+/**
+ * Sums the quote-asset balances held in YeetAMM pool vaults.
+ *
+ * Pools are discovered by their Anchor discriminator, and balances are read
+ * from the vault token accounts rather than from the pool's bookkept reserve
+ * fields, because pools also store virtual reserves that shape the bonding
+ * curve price while holding no assets.
+ *
+ * @param {object} api DefiLlama chain api
+ * @returns {Promise<object>} balances keyed by token
+ */
 async function tvl(api) {
   const connection = getConnection()
   const accounts = await connection.getProgramAccounts(new PublicKey(PROGRAM_ID), {
@@ -30,20 +54,21 @@ async function tvl(api) {
     // Skip pools whose accounts exist but were never fully set up; their vaults
     // are empty and may not be valid token accounts yet.
     if (data.length <= OFFSET_IS_INITIALIZED || data[OFFSET_IS_INITIALIZED] !== 1) continue
-    tokenAccounts.push(new PublicKey(data.subarray(OFFSET_VAULT_A, OFFSET_VAULT_A + 32)).toString())
-    tokenAccounts.push(new PublicKey(data.subarray(OFFSET_VAULT_B, OFFSET_VAULT_B + 32)).toString())
+
+    const readPubkey = (offset) => new PublicKey(data.subarray(offset, offset + 32)).toString()
+    const sides = [[OFFSET_MINT_A, OFFSET_VAULT_A], [OFFSET_MINT_B, OFFSET_VAULT_B]]
+    for (const [mintOffset, vaultOffset] of sides) {
+      if (!QUOTE_MINTS.has(readPubkey(mintOffset))) continue
+      tokenAccounts.push(readPubkey(vaultOffset))
+    }
   }
 
-  // Balances come from the vaults themselves, never from the pool's bookkept
-  // reserve fields. Pools also carry virtual reserves used only to shape the
-  // bonding curve price; those are not assets and must not be counted. Reading
-  // the vaults excludes them structurally rather than by subtraction.
-  return sumTokens2({ api, tokenAccounts, onlyTrustedTokens: true })
+  return sumTokens2({ api, tokenAccounts })
 }
 
 module.exports = {
   timetravel: false,
   methodology:
-    'TVL is the balance of the SOL-side and token-side vaults owned by the YeetAMM program (yeetaecvxpd7DFzZAYTEYracRt1WYJ7DfMVjEeEt2Cp), covering both bonding-curve pools and graduated AMM pools. Pool accounts are discovered on-chain by their Anchor discriminator and vault balances are read directly from the token accounts. Virtual reserves, which the program stores to shape the bonding curve price but which hold no assets, are excluded. Newly launched tokens with no external market are not counted, as only trusted/priced tokens contribute.',
+    'TVL is the quote-asset balance of the vaults owned by the YeetAMM program (yeetaecvxpd7DFzZAYTEYracRt1WYJ7DfMVjEeEt2Cp), covering both bonding-curve pools and graduated AMM pools, which share the same vaults. Pool accounts are discovered on-chain by their Anchor discriminator, and balances are read directly from the vault token accounts rather than from the pool\'s bookkept reserve fields. Pools also store virtual reserves, which the program uses to shape the bonding curve price but which hold no assets; reading the vaults excludes those structurally. Only the quote side of each pool is counted, so freshly launched tokens — which have no market outside their own pool — are not assigned value.',
   solana: { tvl },
 }


### PR DESCRIPTION
Adds a TVL adapter for YeetLaunch, a Solana token launchpad where the bonding curve and the AMM are the same on-chain program.

**Name (to be shown on DefiLlama):**
YeetLaunch

**Twitter Link:**
https://x.com/yeet_Launch

**List of audit links if any:**
None. The protocol has not had a third-party audit.

**Website Link:**
https://yeetlaunch.io

**Logo (High resolution, will be shown with rounded borders):**
https://yeetlaunch.io/logo-1024.png

**Current TVL:**
~$83 (1.13 SOL). The protocol has only been live on Solana mainnet since 18 July 2026, so TVL is genuinely this small — the adapter output is not a bug. It reads live on-chain vault balances and will track upward with no change to the adapter.

**Treasury Addresses (if the protocol has treasury):**
None to report for TVL purposes. Protocol fees accrue to `yEETuHiTQyd3avaa3jRU4B8T5Cbt5CyvnNDqQjdQRJk`, which this adapter does not count as TVL.

**Chain:**
Solana

**Coingecko ID:**
(not listed)

**Coinmarketcap ID:**
(not listed)

**Short Description (to be shown on DefiLlama):**
Solana token launchpad where the bonding curve and the AMM are the same on-chain program. Tokens trade on a bonding curve and convert in place to a constant-product AMM pool atomically, in the same transaction that crosses the graduation threshold.

**Token address and ticker if any:**
None. YeetLaunch has no protocol token.

**Category:**
Dexs

Happy to be re-filed as `Launchpad` if you prefer. I chose `Dexs` because this adapter reports pool liquidity, and the launchpad-categorised bonding curves (pump.fun, Meteora Dynamic Bonding Curve) don't report TVL, whereas the listings that do are all under `Dexs`.

**Oracle Provider(s):**
None. Price is determined entirely by the on-chain curve and pool reserves; the protocol consumes no external price oracle.

**Implementation Details:**
N/A — no oracle is used.

**Documentation/Proof:**
- Integration and parsing spec: https://yeetlaunch.io/docs/yeet-amm-integration.md
- Developer portal: https://yeetlaunch.io/dev
- Anchor IDL: https://yeetlaunch.io/idl/yeet-amm.json
- Program: `yeetaecvxpd7DFzZAYTEYracRt1WYJ7DfMVjEeEt2Cp`

**forkedFrom:**
Not a fork. The bonding curve and AMM are a single original Anchor program.

**methodology:**
TVL is the balance of the SOL-side and token-side vaults owned by the YeetAMM program (`yeetaecvxpd7DFzZAYTEYracRt1WYJ7DfMVjEeEt2Cp`), covering both bonding-curve pools and graduated AMM pools, which share the same vaults.

Pool accounts are discovered on-chain with `getProgramAccounts` filtered on the Anchor `Pool` discriminator, and vault balances are read directly from the token accounts — never from the pool's bookkept reserve fields.

Pools also store **virtual reserves**, which the program uses to shape the bonding curve price but which hold no assets. These are excluded. Reading the vaults excludes them structurally rather than by subtraction, so they cannot leak into the total. This matters: `virtual_reserve_b` is 22 SOL per pool against real balances of 0.019–0.64 SOL, so an adapter reading the reserve fields would report ~88 SOL instead of ~1.13 SOL.

`onlyTrustedTokens` is set, so freshly launched tokens with no external market don't inflate TVL. In practice TVL is currently the WSOL held across all pools.

**Github org/user:**
https://github.com/YeetLaunch (protocol source is not public, so there won't be much activity to track)

**Does this project have a referral program?**
There is a 0.05 SOL bonus paid to a referrer when a referred token graduates. It is not a trading rebate and does not affect TVL.

---

**Validation**

```
$ node test.js projects/yeetlaunch/index.js
------ TVL ------
solana                    83.00
total                     83.49
```

- `npx eslint -c eslint.config.js projects/yeetlaunch/index.js` — clean
- Only `projects/yeetlaunch/index.js` is added. No dependency or lockfile changes; `pnpm-lock.yaml` is untouched.
- The discriminator used in the memcmp filter was verified to equal both `sha256("account:Pool")[0..8]` and the first 8 bytes of a live pool account.
- Filtering on the discriminator rather than `dataSize` keeps the adapter correct across pool struct versions (545 → 577 → 593 bytes), which have only ever appended fields.
- Every asset-bearing account the program owns was enumerated to confirm nothing material is missed. Creator-fee vaults hold ~0.0024 SOL of accrued fees (excluded: owed out, not liquidity), and the lock/vesting vaults hold LP tokens, which are claims on the pool vaults already counted — including them would double-count.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Solana TVL tracking for YeetAMM pools.
  * TVL counts only the pool’s quote-side vault balances for SOL/USDC/USDT.
  * Updated counting to include relevant quote vaults without the previous trusted/priced-token restriction, and to exclude freshly launched tokens.
* **Documentation**
  * Refreshed the methodology text to match the new quote-side vault counting behavior and the “freshly launched tokens” exclusion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->