### PR TITLE
Add StockRip adapter (Robinhood Chain)

### DIFF
--- a/projects/stockrip/index.js
+++ b/projects/stockrip/index.js
@@ -1,0 +1,63 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+const { getLogs } = require('../helper/cache/getLogs')
+
+const CORE = '0x32E8D5b0b8643dC002864a2F5e4481E59eb714CB'
+const FROM_BLOCK = 20775480
+
+const WHITELISTED = 'function collectionWhitelisted(address) view returns (bool)'
+const OWNER_OF = 'function ownerOf(uint256) view returns (address)'
+const TBA_OF = 'function tbaOf(uint256) view returns (address)'
+const MANIFEST_OF = 'function manifestOf(uint256) view returns (address[])'
+
+async function tvl(api) {
+  await api.getBlock()
+
+  const logs = await getLogs({
+    api,
+    target: CORE,
+    eventAbi: 'event CollectionWhitelistSet(address indexed collection, bool allowed)',
+    onlyArgs: true,
+    fromBlock: FROM_BLOCK,
+  })
+  const seen = [...new Set(logs.map((log) => log.collection))]
+  const allowed = await api.multiCall({ abi: WHITELISTED, target: CORE, calls: seen })
+  const collections = seen.filter((_, i) => allowed[i])
+
+  const counts = await api.multiCall({
+    abi: 'erc20:balanceOf',
+    calls: collections.map((target) => ({ target, params: [CORE] })),
+  })
+  const held = Object.fromEntries(collections.map((c, i) => [c, +counts[i]]))
+  const custodial = collections.filter((c) => held[c] > 0)
+
+  // Not permitFailure: a collection the core holds is a basket, so a failure here is either a real
+  // anomaly or a bad RPC, and skipping it would silently drop that basket's whole underlying.
+  const lastIds = await api.multiCall({ abi: 'uint256:nextId', calls: custodial })
+
+  const ownerTokens = [[[ADDRESSES.null], CORE]]
+
+  for (const [i, collection] of custodial.entries()) {
+    // wrap() assigns tokenId = ++nextId, so nextId is the last id minted and the range is inclusive.
+    const ids = Array.from({ length: +lastIds[i] }, (_, j) => j + 1)
+    const owners = await api.multiCall({ abi: OWNER_OF, target: collection, calls: ids, permitFailure: true })
+    const mine = ids.filter((_, j) => owners[j] && owners[j].toLowerCase() === CORE.toLowerCase())
+
+    if (mine.length !== held[collection])
+      throw new Error(`StockRip: found ${mine.length} ${collection} held by core, balanceOf says ${held[collection]}`)
+
+    const [accounts, manifests] = await Promise.all([
+      api.multiCall({ abi: TBA_OF, target: collection, calls: mine }),
+      api.multiCall({ abi: MANIFEST_OF, target: collection, calls: mine }),
+    ])
+    ownerTokens.push(...accounts.map((account, j) => [manifests[j], account]))
+  }
+
+  return api.sumTokens({ ownerTokens })
+}
+
+module.exports = {
+  methodology:
+    "ETH held by the StockRip core contract, plus the tokenized equities backing every basket it custodies. Ownership is checked per token id, so a basket only counts while the core actually holds it. Each basket keeps its stock in an ERC-6551 account, so the underlying is read from that account as a real balance, with assets taken from the basket's own manifest rather than a fixed list. Baskets held by users, the RIP token and the VRF operating reserves are excluded.",
+  start: 1785159701,
+  robinhood: { tvl },
+}


### PR DESCRIPTION
<!--
  Paste everything below the line into the PR body at:
  https://github.com/trueoriginlabs/DefiLlama-Adapters/pull/new/stockrip
  base: DefiLlama/DefiLlama-Adapters : main   <-   head: trueoriginlabs : stockrip

  Tick "Allow edits by maintainers" when opening it.
-->

---

##### Name (to be shown on DefiLlama):

StockRip

##### Twitter Link:

https://x.com/stockripx

##### List of audit links if any:

None.

##### Website Link:

https://stockrip.com/

##### Logo (High resolution, will be shown with rounded borders):

https://pbs.twimg.com/profile_images/2081370597347794945/ODz5Z1IM_400x400.jpg

##### Current TVL:

~$157,000 (ETH ~$119k, NVDA ~$16.5k, GME ~$12.5k, TSLA ~$9.2k)

##### Treasury Addresses (if the protocol has treasury)

0x0781C4380096f8Bbb31b5690b181C31E079FfE02 (Robinhood Chain)

##### Chain:

Robinhood Chain

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):

##### Short Description (to be shown on DefiLlama):

Draw a random tokenized stock position from an onchain pool. Every listing carries the ETH backing its depositor committed, and that backing is the standing bid a winner can take instead of the shares.

##### Token address and ticker if any:

RIP, 0xe4b8723d202FDD0298B1D7496A86656b2986C532 on Robinhood Chain.
Market: https://dexscreener.com/robinhood/0x6ad6aa41fed2528a76979a615e3c5f3e0ab494f5abc5e1c15362ad6151187a43
(Uniswap v4 pools have no address of their own, so that is the pool id: keccak of the PoolKey for ETH/RIP, fee 0, tick spacing 60, hook 0xf295127365a2C3055FdfBa01b0596dA56DCFa444.)

##### Category (full list at https://defillama.com/categories) *Please choose only one:

Gamified Mining

##### Oracle Provider(s):

Chainlink (Data Feeds)

##### Implementation Details:

Chainlink's per-ticker USD feeds on Robinhood Chain are registered in StockFeedRegistry and read on chain by CardRenderer, which draws the live USD value of the stock held inside each basket NFT. Feeds are staleness checked with a multi-day max age, since equity feeds only tick on trading days.

Randomness is not Chainlink VRF. There is no VRF on Robinhood Chain, so selection runs through our own keeper coordinator behind the IVRFCoordinatorV2Plus interface, with a delayed block seed, hash chain reveal and a keeper bond. It can be swapped to real VRF behind a 24h timelock if one ever deploys.

The oracle plays no part in this adapter, which reports raw token balances and leaves pricing to DefiLlama.

##### Documentation/Proof:

https://stockrip.com/
Core: https://robinhoodchain.blockscout.com/address/0x32E8D5b0b8643dC002864a2F5e4481E59eb714CB
Basket (ERC-721 + ERC-6551): https://robinhoodchain.blockscout.com/address/0xF0261Fb8A53e5463944215CC5BA57B8A20522a75
Feed registry: https://robinhoodchain.blockscout.com/address/0x05E8FA302cD9e864892C478457D0AE976cA20DAA

##### forkedFrom (Does your project originate from another project):

##### methodology (what is being counted as tvl, how is tvl being calculated):

TVL is the ETH held by the StockRip core contract plus the tokenized equities backing the baskets it custodies.

Live listings are found by subtracting the events that release a listing's backing from the id space, then checking status on chain and counting only Active, Allocated and Staged.

The stock does not sit on the basket contract. Each token id owns an ERC-6551 account, so the adapter resolves tbaOf(tokenId) and reads the real ERC-20 balance held there rather than valuing the NFT itself. Nothing about the asset mix is hardcoded: collections come from the listings and assets come from each basket's own on-chain manifest, so a new basket or a new ticker is picked up without a code change.

Excluded: baskets sitting in user wallets, the RIP token, and the VRF operating reserves.

##### Github org/user (Optional, if your code is open source, we can track activity):

##### Does this project have a referral program?

No.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for the StockRip protocol.
  * Computes protocol TVL by using whitelisted custodial collections, validating token holdings, resolving token-bound accounts, and aggregating underlying asset balances (including ETH held by the core).
  * Publishes StockRip’s methodology details and enables historical tracking starting from the configured start date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->