### PR TITLE
fix sommelier oracle-failing cellars

### DIFF
--- a/projects/sommelier/index.js
+++ b/projects/sommelier/index.js
@@ -1,3 +1,5 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+
 const abiCellarV0815 = {
   "asset": "address:asset",
   "totalAssets": "uint256:totalAssets",
@@ -117,8 +119,61 @@ const {
 
 const blacklistCellars = ['0x9a7b4980C6F0FCaa50CD5f288Ad7038f434c692e', '0x5195222f69c5821f8095ec565e71e18ab6a2298f', '0xdAdC82e26b3739750E036dFd9dEfd3eD459b877A', '0x1dffb366b5c5A37A12af2C127F31e8e0ED86BDbe']
 
+// These legacy Cellars are unwound into their base assets, but totalAssets()
+// reverts because a zero/dust nested position depends on a stale oracle.
+const oracleFailureCellars = [
+  '0xb5b29320d2dde5ba5bafa1ebcd270052070483ec', // Real Yield ETH
+  '0x4068bdd217a45f8f668ef19f1e3a1f043e4c4934', // Real Yield LINK
+  '0x0274a704a6d9129f90a62ddc6f6024b33ecdad36', // Real Yield BTC
+  '0x6c51041a91c91c86f3f08a72cb4d3f67f1208897', // ETH Trend Growth
+  '0xc7372ab5dd315606db799246e8aa112405abaeff', // Turbo stETH (stETH Deposit)
+]
+const oracleFailureCellarSet = new Set(oracleFailureCellars)
+
+async function splitOracleFailureCellars(api, cellars) {
+  const candidates = cellars.filter(cellar => oracleFailureCellarSet.has(cellar.toLowerCase()))
+  const totalAssets = await api.multiCall({
+    abi: 'uint256:totalAssets',
+    calls: candidates,
+    permitFailure: true,
+  })
+  const fallbackSet = new Set(candidates
+    .filter((_, i) => totalAssets[i] == null)
+    .map(cellar => cellar.toLowerCase()))
+
+  return {
+    healthy: cellars.filter(cellar => !fallbackSet.has(cellar.toLowerCase())),
+    fallback: cellars.filter(cellar => fallbackSet.has(cellar.toLowerCase())),
+  }
+}
+
+async function sumDirectV2CellarAssets(api, cellars) {
+  const assets = await api.multiCall({
+    abi: 'function getPositionAssets() view returns (address[])',
+    calls: cellars,
+  })
+  return api.sumTokens({ ownerTokens: cellars.map((cellar, i) => [assets[i], cellar]) })
+}
+
+async function sumDirectV2p5CellarAssets(api, cellars) {
+  const assets = await api.multiCall({ abi: 'address:asset', calls: cellars })
+  return api.sumTokens({
+    ownerTokens: cellars.map((cellar, i) => [[assets[i], ADDRESSES.ethereum.WETH], cellar]),
+  })
+}
+
 async function ethereum_tvl(api) {
   const block = await api.getBlock();
+  const activeV2Cellars = filterActiveCellars(cellarsV2, block)
+  const activeV2p5Cellars = filterActiveCellars(cellarsV2p5, block)
+  const [v2Cellars, v2p5Cellars] = await Promise.all([
+    splitOracleFailureCellars(api, activeV2Cellars),
+    splitOracleFailureCellars(api, activeV2p5Cellars),
+  ])
+  const fallbackSet = new Set(v2Cellars.fallback
+    .concat(v2p5Cellars.fallback)
+    .map(cellar => cellar.toLowerCase()))
+
   // Sum TVL for all v0.8.15 Cellars
   await v0815.sumTvl({
     api,
@@ -133,15 +188,23 @@ async function ethereum_tvl(api) {
 
   await v2.sumTvl({
     api,
-    cellars: filterActiveCellars(cellarsV2, block),
+    cellars: v2Cellars.healthy,
     ownersToDedupe: cellarsV2.concat(cellarsV2p5),
   });
+
+  // Count the fully unwound Cellars from their direct base-asset balances.
+  // Their remaining nested Sommelier shares stay included in the underlying
+  // Cellars below by excluding these owners from the share de-duplication.
+  await sumDirectV2CellarAssets(api, v2Cellars.fallback)
+  await sumDirectV2p5CellarAssets(api, v2p5Cellars.fallback)
 
   // no change in sumTvl implementation from v2 to v2.5
   await v2.sumTvl({
     api,
-    cellars: filterActiveCellars(cellarsV2p5, block),
-    ownersToDedupe: cellarsV2.concat(cellarsV2p5),
+    cellars: v2p5Cellars.healthy,
+    ownersToDedupe: cellarsV2
+      .concat(cellarsV2p5)
+      .filter(({ id }) => !fallbackSet.has(id.toLowerCase()))
   });
 }
 

--- a/projects/sommelier/index.js
+++ b/projects/sommelier/index.js
@@ -173,6 +173,9 @@ async function ethereum_tvl(api) {
   const fallbackSet = new Set(v2Cellars.fallback
     .concat(v2p5Cellars.fallback)
     .map(cellar => cellar.toLowerCase()))
+  const ownersToDedupe = cellarsV2
+    .concat(cellarsV2p5)
+    .filter(({ id }) => !fallbackSet.has(id.toLowerCase()))
 
   // Sum TVL for all v0.8.15 Cellars
   await v0815.sumTvl({
@@ -189,7 +192,7 @@ async function ethereum_tvl(api) {
   await v2.sumTvl({
     api,
     cellars: v2Cellars.healthy,
-    ownersToDedupe: cellarsV2.concat(cellarsV2p5),
+    ownersToDedupe,
   });
 
   // Count the fully unwound Cellars from their direct base-asset balances.
@@ -202,9 +205,7 @@ async function ethereum_tvl(api) {
   await v2.sumTvl({
     api,
     cellars: v2p5Cellars.healthy,
-    ownersToDedupe: cellarsV2
-      .concat(cellarsV2p5)
-      .filter(({ id }) => !fallbackSet.has(id.toLowerCase()))
+    ownersToDedupe,
   });
 }
 


### PR DESCRIPTION
Fixes #19034.

## What changed

- Detect the five known legacy Cellars whose `totalAssets()` can revert with `Cellar__OracleFailure()`.
- Keep using normal `totalAssets()` accounting whenever it succeeds, including at historical blocks.
- When the oracle failure is present, count the Cellar's directly held position assets on-chain instead.
- Exclude fallback Cellars from nested-share de-duplication so their internal Sommelier positions remain counted once through the healthy underlying Cellar.

## Why

Three v2 and two v2.5 Cellars retain zero, dust, or nested positions that depend on stale oracle configuration. Their `totalAssets()` reverts, which caused the complete Ethereum bucket to fail even though the Cellars still hold WETH, LINK, WBTC, USDC, and stETH.

The fallback is limited to the known affected Cellars and activates only when the on-chain `totalAssets()` call fails. This preserves the original invested-position methodology for historical blocks where the oracle still worked.

## Impact

The current adapter once again reports Ethereum TVL instead of dropping the chain. At validation time it reported approximately:

- Ethereum: $749k
- Arbitrum: $132k
- Optimism: $24k
- Total: $905k

No unknown-token or pricing warnings were emitted.

## Validation

```sh
node test.js projects/sommelier/index.js
node test.js projects/sommelier/index.js 2025-01-01
npx eslint projects/sommelier/index.js
git diff --check
```

The historical run reported approximately $52.86M, confirming that historical `totalAssets()` accounting remains active when it succeeds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ethereum TVL reporting for legacy Cellars impacted by stale oracle data.
  * When standard asset valuation isn’t available, TVL now uses a fallback calculation based on available underlying asset balances.
  * Added deduplication to prevent double counting of nested Sommelier-share exposure, improving both completeness and accuracy of reported TVL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->