### PR TITLE
feat: add Lista Pre-IPO TVL adapter

### DIFF
--- a/projects/lista-pre-ipo/index.js
+++ b/projects/lista-pre-ipo/index.js
@@ -1,0 +1,27 @@
+const DISTRIBUTOR = '0x9f7526EDAa18278D4bC1fA6b63B749A649Cb1844'
+
+// On-chain saleId is 0-indexed (backend project IDs start at 1).
+// Add new sale IDs here when future Pre-IPO projects launch on Lista.
+const SALE_IDS = [0]
+
+const abi = {
+  getSale:
+    'function getSale(uint64 saleId) view returns (address depositToken, bytes32 whitelistRoot, uint256 startTime, uint256 endTime, uint256 minDeposit, uint256 totalDeposits, bool paused, uint256 pubStartTime, uint256 pubEndTime, uint256 pubTotalDeposits)',
+}
+
+async function tvl(api) {
+  const sales = await api.multiCall({
+    target: DISTRIBUTOR,
+    abi: abi.getSale,
+    calls: SALE_IDS,
+  })
+  const tokens = [...new Set(sales.map(s => s.depositToken))]
+  return api.sumTokens({ tokens, owner: DISTRIBUTOR })
+}
+
+module.exports = {
+  methodology:
+    'TVL counts the deposit tokens locked in the PreIPO distributor contract during active subscription rounds',
+  start: '2025-07-01',
+  bsc: { tvl },
+}

--- a/projects/lista-pre-ipo/index.js
+++ b/projects/lista-pre-ipo/index.js
@@ -1,20 +1,14 @@
 const DISTRIBUTOR = '0x9f7526EDAa18278D4bC1fA6b63B749A649Cb1844'
 
-// On-chain saleId is 0-indexed (backend project IDs start at 1).
-// Add new sale IDs here when future Pre-IPO projects launch on Lista.
-const SALE_IDS = [0]
-
 const abi = {
-  getSale:
-    'function getSale(uint64 saleId) view returns (address depositToken, bytes32 whitelistRoot, uint256 startTime, uint256 endTime, uint256 minDeposit, uint256 totalDeposits, bool paused, uint256 pubStartTime, uint256 pubEndTime, uint256 pubTotalDeposits)',
+  getSale: 'function getSale(uint64 saleId) view returns (address depositToken, bytes32 whitelistRoot, uint256 startTime, uint256 endTime, uint256 minDeposit, uint256 totalDeposits, bool paused, uint256 pubStartTime, uint256 pubEndTime, uint256 pubTotalDeposits)',
+  nextSaleId: 'uint64:nextSaleId',
 }
 
 async function tvl(api) {
-  const sales = await api.multiCall({
-    target: DISTRIBUTOR,
-    abi: abi.getSale,
-    calls: SALE_IDS,
-  })
+  const nextSaleId = await api.call({ target: DISTRIBUTOR, abi: abi.nextSaleId })
+  const saleIds = [...Array(+nextSaleId).keys()]
+  const sales = await api.multiCall({ target: DISTRIBUTOR, abi: abi.getSale, calls: saleIds })
   const tokens = [...new Set(sales.map(s => s.depositToken))]
   return api.sumTokens({ tokens, owner: DISTRIBUTOR })
 }


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
Lista Pre-IPO

##### Twitter Link:
https://twitter.com/lista_dao

##### List of audit links if any:
https://github.com/lista-dao/lista-dao-contracts/tree/master/audits

##### Website Link:
https://lista.org/pre-ipo

##### Logo (High resolution, will be shown with rounded borders):
https://icons.llama.fi/lista-dao.png

##### Current TVL:
~$200k

##### Chain:
BSC

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):
lista

##### Short Description (to be shown on DefiLlama):
Lista Pre-IPO lets users subscribe USDT to acquire pre-IPO equity tokens for early-stage companies (starting with Kalshi Series I). Funds are locked in the distributor contract during subscription rounds and released via a whitelist-weighted allocation + public round, with unclaimed deposits refunded after settlement.

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Launchpad

##### forkedFrom (Does your project originate from another project):
No

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL counts the USDT balance held by the PreIPODistributor contract (0x9f7526EDAa18278D4bC1fA6b63B749A649Cb1844) on BSC. The contract receives deposits from both the whitelist round and public round, and releases them as refunds + equity token settlements. The balance therefore reflects genuine locked user capital at any point in time.

##### Github org/user (Optional, if your code is open source, we can track activity):
lista-dao

---

**Implementation notes:**
- Reads `getSale(saleId)` to discover the deposit token address per sale dynamically (supports future projects with different tokens)
- Uses `api.sumTokens` on the distributor contract — on-chain balance approach, no external fetch
- On-chain saleId is 0-indexed; `SALE_IDS` array should be updated as new Pre-IPO projects launch
- Parent protocol: `Lista DAO` (already listed)

**Test output:**
```
--- bsc ---
USDT   200.72 k
Total: 200.72 k

total  200.72 k
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for Lista Pre-IPO on BNB Chain.
  * The tracker identifies supported deposit tokens and reports balances held by the distributor contract.
  * Included methodology details and historical tracking from the specified start date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->