### PR TITLE
Add Obligate (oTFY) adapter

### DIFF
--- a/projects/obligate/index.js
+++ b/projects/obligate/index.js
@@ -1,0 +1,44 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+const { getTokenSupplies } = require('../helper/solana')
+const { get } = require('../helper/http')
+
+// https://explorer.solana.com/address/BwB3tNH92jKw6naNGDYDbDwRo8bvYxZVvZjRZRcoWR2h
+const OTFY_MINT = 'BwB3tNH92jKw6naNGDYDbDwRo8bvYxZVvZjRZRcoWR2h'
+const OTFY_DECIMALS = 9
+
+// oTFY isn't priced by DefiLlama, so its NAV is applied here and reported as USDC.
+const USDC = ADDRESSES.solana.USDC
+const USDC_DECIMALS = 6
+
+// Public, unauthenticated NAV feed for the oTFY eTracker, keyed by its stable token id.
+const NAV_API =
+  'https://api.obligate.com/platform/etracker/token/3cef0789-88b8-4374-b818-73f9fed942af'
+
+async function tvl(api) {
+  const otfy = await get(NAV_API)
+  if (!otfy || otfy.symbol !== 'oTFY') throw new Error('Unexpected Obligate eTracker API response for oTFY')
+
+  // Fail loudly if the eTracker is reissued, rather than misreporting TVL.
+  if (otfy.contract !== OTFY_MINT)
+    throw new Error(`oTFY mint changed: API reports ${otfy.contract}, adapter uses ${OTFY_MINT}`)
+  if (Number(otfy.decimals) !== OTFY_DECIMALS)
+    throw new Error(`oTFY decimals changed: API reports ${otfy.decimals}, adapter uses ${OTFY_DECIMALS}`)
+
+  const nav = Number(otfy.valuation) // USDC per token, treated 1:1 with USD
+  if (!nav) throw new Error(`Invalid oTFY NAV from Obligate API: ${otfy.valuation}`)
+
+  const supplies = await getTokenSupplies([OTFY_MINT])
+  const rawSupply = supplies[OTFY_MINT]
+  if (rawSupply === undefined) throw new Error(`Failed to read oTFY mint supply: ${OTFY_MINT}`)
+  const supply = Number(rawSupply) / 10 ** OTFY_DECIMALS
+
+  api.add(USDC, Math.round(supply * nav * 10 ** USDC_DECIMALS))
+}
+
+module.exports = {
+  methodology:
+    'TVL is the total oTFY supply read on-chain from its Solana mint, multiplied by the latest per-token NAV published by Obligate (USDC-denominated), then reported in USDC.',
+  misrepresentedTokens: true, // oTFY value is reported under USDC's mint
+  timetravel: false, // the NAV feed only exposes the current valuation
+  solana: { tvl },
+}

--- a/projects/obligate/index.js
+++ b/projects/obligate/index.js
@@ -15,17 +15,20 @@ const NAV_API =
   'https://api.obligate.com/platform/etracker/token/3cef0789-88b8-4374-b818-73f9fed942af'
 
 async function tvl(api) {
-  const otfy = await get(NAV_API)
+  const otfy = await get(NAV_API, { timeout: 30000 })
   if (!otfy || otfy.symbol !== 'oTFY') throw new Error('Unexpected Obligate eTracker API response for oTFY')
 
-  // Fail loudly if the eTracker is reissued, rather than misreporting TVL.
+  // Fail loudly if the eTracker is reissued or redenominated, rather than misreporting TVL.
   if (otfy.contract !== OTFY_MINT)
     throw new Error(`oTFY mint changed: API reports ${otfy.contract}, adapter uses ${OTFY_MINT}`)
   if (Number(otfy.decimals) !== OTFY_DECIMALS)
     throw new Error(`oTFY decimals changed: API reports ${otfy.decimals}, adapter uses ${OTFY_DECIMALS}`)
+  if (otfy.currency !== 'USDC')
+    throw new Error(`oTFY NAV currency changed: API reports ${otfy.currency}, adapter assumes USDC`)
 
   const nav = Number(otfy.valuation) // USDC per token, treated 1:1 with USD
-  if (!nav) throw new Error(`Invalid oTFY NAV from Obligate API: ${otfy.valuation}`)
+  if (!Number.isFinite(nav) || nav <= 0)
+    throw new Error(`Invalid oTFY NAV from Obligate API: ${otfy.valuation}`)
 
   const supplies = await getTokenSupplies([OTFY_MINT])
   const rawSupply = supplies[OTFY_MINT]


### PR DESCRIPTION
Adds a TVL adapter for **Obligate** — a regulated on-chain debt capital markets platform — starting with its first eTracker product, **oTFY** (Obligate Trade Finance Yield).

**What oTFY is:** an SPL security token on Solana issued by a Luxembourg securitization vehicle, representing a claim on the NAV of a revolving portfolio of investment-grade trade-finance bonds. Obligate AG (Zurich) is the product sponsor.
Mint: `BwB3tNH92jKw6naNGDYDbDwRo8bvYxZVvZjRZRcoWR2h`

**Chain:** Solana. Launched 2026-06-29.

**Methodology:** total oTFY supply is read on-chain from the Solana mint and multiplied by the latest per-token net asset value published by Obligate. NAV is USDC-denominated and treated 1:1 with USD. Supply is verifiable on-chain; the NAV feed is public and unauthenticated:
https://api.obligate.com/platform/etracker/token/3cef0789-88b8-4374-b818-73f9fed942af

**Why the NAV is applied inside the adapter:** oTFY is not currently priced by DefiLlama (`coins.llama.fi` returns no entry for `solana:BwB3tNH92jKw6naNGDYDbDwRo8bvYxZVvZjRZRcoWR2h`), so adding the raw mint supply would report $0. The adapter therefore applies the issuer's published NAV and reports the result under USDC's Solana mint (the NAV is USDC-denominated), with `misrepresentedTokens: true` set — the same pattern as `projects/anemoy-capital` and `projects/alcum`. Happy to switch to plain supply reporting if you'd rather add oTFY to the pricing pipeline instead.

**`timetravel: false`:** the NAV feed only exposes the current valuation, so historical values can't be backfilled.

Only the tokenized representation is counted — the underlying bond portfolio is not included, per the RWA edge case in the TVL docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for Obligate’s oTFY token on Solana using the latest published NAV and the token’s on-chain supply.
  * Enhanced valuation handling by validating the NAV and token details before computing TVL.

* **Bug Fixes**
  * Improved NAV request reliability with a stricter HTTP timeout.
  * Tightened NAV checks to require a finite value strictly greater than zero, and added clearer errors when the NAV currency is not USDC.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->