### PR TITLE
accountable: add Robinhood Chain

### DIFF
--- a/projects/accountable/index.js
+++ b/projects/accountable/index.js
@@ -19,6 +19,11 @@ const FACTORIES = {
         '0x2f5CAc28cf80D465d7C8D67a49c8e36710a4B83B',
         '0x9f1EB2be7b6a7e611c270bbdb0A3358786769518', // yield factory
     ],
+    robinhood: [
+        '0x017273Eeb06Ee9f863020269417DB9559FD94173',
+        '0x474B612F970491801743BF0e4B9153620FC36096',
+        '0xA4d6a4aD35fc632aEE1dC48A2aEc2aaa37B51F9f', // yield factory
+    ],
 }
 
 const EXTRA_VAULTS = {
@@ -111,6 +116,10 @@ module.exports = {
         borrowed: tvl(true)
     },
     citrea: {
+        tvl: tvl(false),
+        borrowed: tvl(true)
+    },
+    robinhood: {
         tvl: tvl(false),
         borrowed: tvl(true)
     },


### PR DESCRIPTION
Adds Robinhood Chain (chain id 4663) to the Accountable adapter.

Accountable deployed its v1.1 strategy factories on Robinhood Chain, and the first vault there (Meridian Liquidity Provider, USDe) is live. Without this the vault is missing from Accountable's TVL entirely.

Only the v1.1 factories are listed, since the v1.0 FixedTerm/OpenTerm factories were never deployed on this chain. Same shape as the existing `citrea` entry.

No methodology change: the vault is discovered through the existing `strategyProxies` / `strategyVaults` factory enumeration and valued via `convertToAssets` like every other chain.

Verified with `node test.js projects/accountable`:

```
robinhood                 288.15 k
robinhood-borrowed        100.00
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for discovering strategy vaults on the Robinhood chain.
  * Enabled reporting of both standard and borrowed total value locked (TVL) for Robinhood.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->