### PR TITLE
Add Boardwalk TVL

### DIFF
--- a/projects/boardwalk/index.js
+++ b/projects/boardwalk/index.js
@@ -1,0 +1,46 @@
+const { staking } = require('../helper/staking')
+const { sumUnknownTokens } = require('../helper/unknownTokens')
+const { nullAddress } = require('../helper/tokenMapping')
+
+// BWLK staking (GMX-style reward trackers), Ethereum only.
+// Staked BWLK is held by the staked-BWLK tracker (sBWLK).
+const BWLK = '0xF9a352b7C7B62a852e5C8A64A455246Dd9596461'
+const STAKED_BWLK_TRACKER = '0x3961F92c26724C9d61CED679540F35794d90c576'
+
+// Boardwalk v2 LaunchFactory per chain
+const config = {
+  ethereum: { factory: '0xfAEdbA0E97D5DCD7A29fB6778D7e17b1be35c0b8' },
+  base: { factory: '0x4F7af6f968C30be6FC196Cd5eed68032022AB067' },
+  arbitrum: { factory: '0xe64A71A60D552B56579D8edeB13E86bD6222F882' },
+  robinhood: { factory: '0x177dbEDd02cEe010b80a0A3F284c9FD9F67D8a9e' },
+}
+
+const launchInfoAbi = 'function launches(address) view returns (address token, address feeDistributor, address presaleManager, address vestingStream, address lpStaking, address issuer, uint8 path, uint32 createdAt)'
+
+async function tvl(api) {
+  const { factory } = config[api.chain]
+  const tokens = await api.fetchList({ lengthAbi: 'uint256:launchCount', itemAbi: 'function allLaunches(uint256) view returns (address)', target: factory })
+  if (!tokens.length) return api.getBalances()
+  const launches = await api.multiCall({ abi: launchInfoAbi, calls: tokens, target: factory })
+  const lpStakings = launches.map(i => i.lpStaking)
+  // the staked token is the launch token/WETH Uniswap v2 pair; zero address until liquidity is seeded
+  const lpTokens = await api.multiCall({ abi: 'address:lpToken', calls: lpStakings })
+  const ownerTokens = []
+  lpTokens.forEach((lp, i) => {
+    if (lp !== nullAddress) ownerTokens.push([[lp], lpStakings[i]])
+  })
+  return sumUnknownTokens({ api, ownerTokens, resolveLP: true, useDefaultCoreAssets: true })
+}
+
+module.exports = {
+  misrepresentedTokens: true,
+  doublecounted: true, // staked LP is canonical Uniswap v2 pair liquidity, also counted in the uniswap listing
+  start: '2026-07-18',
+  methodology: 'Counts Uniswap v2 LP tokens from Boardwalk token launches that are staked in each launch\'s LPStaking contract, valued from pair reserves. Staked BWLK on Ethereum is counted under staking.',
+}
+
+Object.keys(config).forEach(chain => {
+  module.exports[chain] = { tvl }
+})
+
+module.exports.ethereum.staking = staking(STAKED_BWLK_TRACKER, BWLK)

--- a/projects/boardwalk/index.js
+++ b/projects/boardwalk/index.js
@@ -1,24 +1,27 @@
 const { staking } = require('../helper/staking')
 const { sumUnknownTokens } = require('../helper/unknownTokens')
 const { nullAddress } = require('../helper/tokenMapping')
+const { getLogs2 } = require('../helper/cache/getLogs')
 
 // BWLK staking (GMX-style reward trackers), Ethereum only.
 // Staked BWLK is held by the staked-BWLK tracker (sBWLK).
 const BWLK = '0xF9a352b7C7B62a852e5C8A64A455246Dd9596461'
 const STAKED_BWLK_TRACKER = '0x3961F92c26724C9d61CED679540F35794d90c576'
 
-// Boardwalk v2 LaunchFactory per chain
+// Boardwalk v2 LaunchFactory per chain, with its deploy block
 const config = {
-  ethereum: { factory: '0xfAEdbA0E97D5DCD7A29fB6778D7e17b1be35c0b8' },
-  base: { factory: '0x4F7af6f968C30be6FC196Cd5eed68032022AB067' },
-  arbitrum: { factory: '0xe64A71A60D552B56579D8edeB13E86bD6222F882' },
-  robinhood: { factory: '0x177dbEDd02cEe010b80a0A3F284c9FD9F67D8a9e' },
+  ethereum: { factory: '0xfAEdbA0E97D5DCD7A29fB6778D7e17b1be35c0b8', deployBlock: 25560628 },
+  base: { factory: '0x4F7af6f968C30be6FC196Cd5eed68032022AB067', deployBlock: 48800691 },
+  arbitrum: { factory: '0xe64A71A60D552B56579D8edeB13E86bD6222F882', deployBlock: 485200176 },
+  robinhood: { factory: '0x177dbEDd02cEe010b80a0A3F284c9FD9F67D8a9e', deployBlock: 13115699 },
 }
 
 const launchInfoAbi = 'function launches(address) view returns (address token, address feeDistributor, address presaleManager, address vestingStream, address lpStaking, address issuer, uint8 path, uint32 createdAt)'
 
+const liquiditySeededAbi = 'event LiquiditySeeded(uint256 raiseAmount, uint256 tokenAmount, uint256 lpTokens)'
+
 async function tvl(api) {
-  const { factory } = config[api.chain]
+  const { factory, deployBlock } = config[api.chain]
   const tokens = await api.fetchList({ lengthAbi: 'uint256:launchCount', itemAbi: 'function allLaunches(uint256) view returns (address)', target: factory })
   if (!tokens.length) return api.getBalances()
   const launches = await api.multiCall({ abi: launchInfoAbi, calls: tokens, target: factory })
@@ -30,9 +33,16 @@ async function tvl(api) {
   // the staked token is the launch token/WETH Uniswap v2 pair; zero address until liquidity is seeded
   const lpTokens = await api.multiCall({ abi: 'address:lpToken', calls: lpStakings })
   const ownerTokens = []
+  const seeded = []
   lpTokens.forEach((lp, i) => {
-    if (lp !== nullAddress) ownerTokens.push([[lp], lpStakings[i]])
+    if (lp === nullAddress) return
+    ownerTokens.push([[lp], lpStakings[i]])
+    seeded.push({ pair: lp, presaleManager: launches[i].presaleManager })
   })
+  // permanently locked liquidity: the LP minted at seeding is burned to the dead
+  // address; count exactly the amount from each presale's LiquiditySeeded event
+  const seedLogs = await Promise.all(seeded.map(i => getLogs2({ api, target: i.presaleManager, eventAbi: liquiditySeededAbi, fromBlock: deployBlock })))
+  seedLogs.forEach((logs, i) => logs.forEach(log => api.add(seeded[i].pair, log.lpTokens)))
   return sumUnknownTokens({ api, ownerTokens, resolveLP: true, useDefaultCoreAssets: true })
 }
 
@@ -40,7 +50,7 @@ module.exports = {
   misrepresentedTokens: true,
   doublecounted: true, // staked LP is canonical Uniswap v2 pair liquidity, also counted in the uniswap listing
   start: '2026-07-18',
-  methodology: 'Counts WETH contributed to active presales (held by each launch\'s PresaleManager) and Uniswap v2 LP tokens from Boardwalk token launches that are staked in each launch\'s LPStaking contract, valued from pair reserves. Staked BWLK on Ethereum is counted under staking.',
+  methodology: 'Counts WETH contributed to active presales (held by each launch\'s PresaleManager), the permanently locked launch liquidity (LP minted at seeding and burned to the dead address, measured from each presale\'s LiquiditySeeded event), and Uniswap v2 LP tokens staked in each launch\'s LPStaking contract, all valued from pair reserves. Staked BWLK on Ethereum is counted under staking.',
 }
 
 Object.keys(config).forEach(chain => {

--- a/projects/boardwalk/index.js
+++ b/projects/boardwalk/index.js
@@ -22,6 +22,10 @@ async function tvl(api) {
   const tokens = await api.fetchList({ lengthAbi: 'uint256:launchCount', itemAbi: 'function allLaunches(uint256) view returns (address)', target: factory })
   if (!tokens.length) return api.getBalances()
   const launches = await api.multiCall({ abi: launchInfoAbi, calls: tokens, target: factory })
+  // WETH contributed to presales sits in each launch's PresaleManager until
+  // liquidity seeding moves it to the pair (or refunds return it)
+  const raiseToken = await api.call({ abi: 'address:RAISE_TOKEN', target: factory })
+  await api.sumTokens({ owners: launches.map(i => i.presaleManager), tokens: [raiseToken] })
   const lpStakings = launches.map(i => i.lpStaking)
   // the staked token is the launch token/WETH Uniswap v2 pair; zero address until liquidity is seeded
   const lpTokens = await api.multiCall({ abi: 'address:lpToken', calls: lpStakings })
@@ -36,7 +40,7 @@ module.exports = {
   misrepresentedTokens: true,
   doublecounted: true, // staked LP is canonical Uniswap v2 pair liquidity, also counted in the uniswap listing
   start: '2026-07-18',
-  methodology: 'Counts Uniswap v2 LP tokens from Boardwalk token launches that are staked in each launch\'s LPStaking contract, valued from pair reserves. Staked BWLK on Ethereum is counted under staking.',
+  methodology: 'Counts WETH contributed to active presales (held by each launch\'s PresaleManager) and Uniswap v2 LP tokens from Boardwalk token launches that are staked in each launch\'s LPStaking contract, valued from pair reserves. Staked BWLK on Ethereum is counted under staking.',
 }
 
 Object.keys(config).forEach(chain => {

--- a/projects/boardwalk/index.js
+++ b/projects/boardwalk/index.js
@@ -1,3 +1,4 @@
+const sdk = require('@defillama/sdk')
 const { staking } = require('../helper/staking')
 const { sumUnknownTokens } = require('../helper/unknownTokens')
 const { nullAddress } = require('../helper/tokenMapping')
@@ -41,7 +42,11 @@ async function tvl(api) {
   })
   // permanently locked liquidity: the LP minted at seeding is burned to the dead
   // address; count exactly the amount from each presale's LiquiditySeeded event
-  const seedLogs = await Promise.all(seeded.map(i => getLogs2({ api, target: i.presaleManager, eventAbi: liquiditySeededAbi, fromBlock: deployBlock })))
+  const seedLogs = await sdk.util.runInPromisePool({
+    items: seeded,
+    concurrency: 10,
+    processor: (launch) => getLogs2({ api, target: launch.presaleManager, eventAbi: liquiditySeededAbi, fromBlock: deployBlock }),
+  })
   seedLogs.forEach((logs, i) => logs.forEach(log => api.add(seeded[i].pair, log.lpTokens)))
   return sumUnknownTokens({ api, ownerTokens, resolveLP: true, useDefaultCoreAssets: true })
 }


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).

---
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama): Boardwalk

##### Twitter Link: https://x.com/useboardwalk

##### List of audit links if any: https://github.com/useboardwalk/boardwalk-contracts/tree/main/audits

##### Website Link: https://www.useboardwalk.com/

##### Logo (High resolution, will be shown with rounded borders): https://www.useboardwalk.com/images/power/logo.svg

##### Current TVL: ~$342k ($300k BWLK staked on Ethereum under staking; ~$41.5k launch TVL on Base from locked and staked launch liquidity)

##### Treasury Addresses (if the protocol has treasury): 0x366624d894920e3abE1F231f67a02a1861Ff1CA3

##### Chain: Ethereum, Base, Arbitrum, Robinhood

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): boardwalk (https://www.coingecko.com/en/coins/boardwalk)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):

##### Short Description (to be shown on DefiLlama): Boardwalk is a permissionless, community-centered fee-protection protocol for launching, discovering, and participating in token economies. Issuers create a launch, define its rules up front, and auction a new token under visible mechanics. If the auction reaches its graduation threshold, the raised asset pairs with the token supply to seed permanently locked liquidity, and the token moves into a live economy. If the threshold isn't met, contributors can claim a full refund.

##### Token address and ticker if any: $BWLK 0xF9a352b7C7B62a852e5C8A64A455246Dd9596461 (Ethereum)

##### Category (full list at https://defillama.com/categories) \*Please choose only one: Launchpad

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.): none

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

##### forkedFrom (Does your project originate from another project): No. Launch liquidity lives in the official Uniswap v2 deployment on each chain.

##### methodology (what is being counted as tvl, how is tvl being calculated): Counts WETH contributed to active presales (held by each PresaleManager), the permanently locked launch liquidity (LP minted at seeding and burned to the dead address, measured from each presale's LiquiditySeeded event), and Uniswap v2 LP tokens staked in each launch's LPStaking contract, all valued from pair reserves. BWLK staked in the Ethereum reward tracker is counted under staking.

##### Github org/user (Optional, if your code is open source, we can track activity):

##### Does this project have a referral program? Standard (advanced) launches may set a referrer who earns a share of the launch token's transfer tax.

---

Notes for review:

- Supersedes https://github.com/DefiLlama/DefiLlama-Adapters/pull/19648 (closed for zero TVL). The v2 deployment now has live launches with staked liquidity.
- Launches are enumerated onchain from the LaunchFactory (`launchCount` / `allLaunches` / `launches`); each launch's staked Uniswap v2 LP is read from its LPStaking contract. Launch tokens are priced from their WETH pair reserves, hence `misrepresentedTokens: true`.
- `doublecounted: true` is set since the locked and staked LP is Uniswap v2 pair liquidity, also counted by the uniswap listing.
- Locked liquidity is measured from each presale's one-time `LiquiditySeeded` event (the exact LP amount the protocol burned to the dead address), not the dead address's balance, so third-party LP burns can never inflate it.
- The legacy BMX adapters (`registries/gmx.js`) are intentionally left untouched; this lists the new Boardwalk deployment as its own project. Please do not merge BMX and Boardwalk together into one page.
- Companion fees/revenue adapter: https://github.com/useboardwalk/defillama-dimension-adapters/pull/1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Boardwalk v2 TVL tracking across supported chains.
  * Tracks presale funds, liquidity provider positions, and permanently locked liquidity.
  * Added an Ethereum staking breakdown for staked BWLK.
  * Added coverage metadata and methodology details for the TVL reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->