### PR TITLE
originether: include compounding staking strategies in ethereum TVL

### DIFF
--- a/projects/originether/index.js
+++ b/projects/originether/index.js
@@ -14,10 +14,6 @@ const ethTvl = async (api) => {
   const isCompoundingStrategy = (await api.multiCall({  abi: 'address:BEACON_PROOFS', calls: strategies, permitFailure: true})).map(i => !!i)
   const nativeStrategies = strategies.filter((_, i) => isNativeStrategy[i] || isCompoundingStrategy[i])
 
-  // vault balance
-  const vaultBalance = await api.call({ abi: 'erc20:balanceOf', target: ADDRESSES.ethereum.WETH, params: vault })
-  api.add(ADDRESSES.ethereum.WETH, vaultBalance)
-
   // add native & compounding staking strategies
   for(const nativeStrategy of nativeStrategies) {
     const stakingBalance = await api.call({ abi: abi.checkBalance, target: nativeStrategy, params: ADDRESSES.ethereum.WETH })

--- a/projects/originether/index.js
+++ b/projects/originether/index.js
@@ -10,13 +10,15 @@ const ethTvl = async (api) => {
   const vault = "0x39254033945aa2e4809cc2977e7087bee48bd7ab";
   const strategies = await api.call({ abi: 'function getAllStrategies() view returns (address[])', target: vault })
   const isNativeStrategy = (await api.multiCall({  abi: 'uint256:activeDepositedValidators', calls: strategies, permitFailure: true})).map(i => !!i)
-  const nativeStrategies = strategies.filter((_, i) => isNativeStrategy[i])
+  // compounding staking strategies don't have activeDepositedValidators(), detect them via their BEACON_PROOFS getter
+  const isCompoundingStrategy = (await api.multiCall({  abi: 'address:BEACON_PROOFS', calls: strategies, permitFailure: true})).map(i => !!i)
+  const nativeStrategies = strategies.filter((_, i) => isNativeStrategy[i] || isCompoundingStrategy[i])
 
   // vault balance
   const vaultBalance = await api.call({ abi: 'erc20:balanceOf', target: ADDRESSES.ethereum.WETH, params: vault })
   api.add(ADDRESSES.ethereum.WETH, vaultBalance)
 
-  // add native strategies
+  // add native & compounding staking strategies
   for(const nativeStrategy of nativeStrategies) {
     const stakingBalance = await api.call({ abi: abi.checkBalance, target: nativeStrategy, params: ADDRESSES.ethereum.WETH })
     api.add(ADDRESSES.ethereum.WETH, stakingBalance)


### PR DESCRIPTION
The ethereum TVL detects staking strategies by probing activeDepositedValidators(), which Origin's newer compounding staking strategies do not implement, so their WETH balances were silently excluded (~18.8M USD at time of fix). Detect them with a second permitFailure probe on BEACON_PROOFS(), a getter unique to the compounding strategy contracts, so future deployments are picked up automatically.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved total value locked calculations to include eligible compounding staking strategies alongside native staking strategies.
  * Ensured supported strategies are recognized based on either active deposited validators or beacon proof data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->