### PR TITLE
grvt: track bridged GRVT token in TVL

### DIFF
--- a/registries/txBridge.js
+++ b/registries/txBridge.js
@@ -78,7 +78,7 @@ const configs = {
   'abstract': { ethereum: { chainId: 2741 } },
   'cronos-zk': { ethereum: { chainId: 388 } },
   'zkcandy': { ethereum: { chainId: 320 } },
-  'grvt-io': { ethereum: { chainId: 325, extraTvl: grvtVaultTvl } },
+  'grvt-io': { ethereum: { chainId: 325, extraTokens: ['0xAD29F2723fcdBcF665F210F25E06f97477e417cF'], extraTvl: grvtVaultTvl } },
   'lens': { ethereum: { chainId: 232 } },
   'openzk': { ethereum: { chainId: 1345 } },
   'treasure': { ethereum: { chainId: 61166 } },

--- a/registries/txBridge.js
+++ b/registries/txBridge.js
@@ -78,7 +78,7 @@ const configs = {
   'abstract': { ethereum: { chainId: 2741 } },
   'cronos-zk': { ethereum: { chainId: 388 } },
   'zkcandy': { ethereum: { chainId: 320 } },
-  'grvt-io': { ethereum: { chainId: 325, extraTokens: ['0xAD29F2723fcdBcF665F210F25E06f97477e417cF'], extraTvl: grvtVaultTvl } },
+  'grvt-io': { ethereum: { chainId: 325, blacklistedTokens: ['0xAD29F2723fcdBcF665F210F25E06f97477e417cF'], extraTvl: grvtVaultTvl } },
   'lens': { ethereum: { chainId: 232 } },
   'openzk': { ethereum: { chainId: 1345 } },
   'treasure': { ethereum: { chainId: 61166 } },


### PR DESCRIPTION
## Summary

The GRVT token (`0xAD29F2723fcdBcF665F210F25E06f97477e417cF`, [CoinGecko](https://www.coingecko.com/en/coins/grvt)) held by the txBridge shared bridge `0xbeD1EB542f9a5aA6419Ff3deb921A372681111f6` was missing from the `grvt-io` TVL — about **57M GRVT (~$13M)**.

## Root cause

`txBridgeTvlV2` discovers which tokens the bridge holds via `sumTokens2({ fetchCoValentTokens: true })`. On Ethereum that discovery routes through Ankr's `ankr_getAccountBalance` with `onlyWhitelisted: true`, and GRVT is not on Ankr's whitelist yet. Because the token is never discovered, its `assetId` / `chainBalance(325, assetId)` is never queried, even though on-chain the bridge accounts for the full balance.

## Fix

Add GRVT to the config's existing `extraTokens`, which injects it into the candidate list regardless of the whitelist discovery.

## Verification

Running the `grvt-io` export locally:

- `balanceOf(bridge)` on GRVT ≈ 57,042,248.9
- `assetId(GRVT)` → `0xde6d…4fed` (valid)
- `chainBalance(325, assetId)` returns the full balance
- DefiLlama has a price for `ethereum:0xAD29…417cF` (~$0.234, confidence 0.99)
- Before: GRVT absent from resolved balances. After: `ethereum:0xad29…417cf` ≈ 56.99M GRVT is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Updated the GRVT Ethereum configuration to blacklist a specified token.
  * Preserved the existing chain and vault TVL integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->