### PR TITLE
Add tracking for ROAR

### DIFF
--- a/projects/roar/index.js
+++ b/projects/roar/index.js
@@ -30,6 +30,6 @@ async function staking(api) {
 
 module.exports = {
   methodology: 'TVL counts only user-owned WETH liabilities: active-round escrow and unclaimed settlement rewards in the Game, plus prepaid automated-mining escrow in the canonical AutoMiner. Pending admin settlement, Treasury assets, and Giga LP liquidity are excluded. Staking counts the Game reward liability (unclaimed round rewards and the Motherlode) plus all ROAR held by the Staking contract as staked principal, earned rewards, and unvested rewards.',
-  start: '2026-07-30',
+  start: 1785423000, // after the canonical AutoMiner deployment
   robinhood: { tvl, staking },
 }

--- a/projects/roar/index.js
+++ b/projects/roar/index.js
@@ -1,0 +1,35 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+
+const GAME = '0xB9E308C0de769aB61089Ef47231f0ff92AE8BF69'
+const AUTO_MINER = '0x451e9b91447bE0abeebD3110b8c372988383f72C'
+const STAKING = '0xAB9E06E60AafE34257315c12717e0b9E5bFa7631'
+const ROAR = '0xf1d3e39cc61Aedd53dc40d8AFFf6aA1dD51875D0'
+const WETH = ADDRESSES.robinhood.WETH
+
+async function tvl(api) {
+  const [roundEscrow, outstandingSettlement, autoMinerEscrow] = await Promise.all([
+    api.call({ target: GAME, abi: 'uint256:roundEscrowSettlement' }),
+    api.call({ target: GAME, abi: 'uint256:totalRoundSettlementOutstanding' }),
+    api.call({ target: AUTO_MINER, abi: 'uint256:totalEscrowLiability' }),
+  ])
+
+  api.add(WETH, BigInt(roundEscrow) + BigInt(outstandingSettlement) + BigInt(autoMinerEscrow))
+}
+
+async function staking(api) {
+  const [liabilities, stakingBalance] = await Promise.all([
+    api.call({
+      target: GAME,
+      abi: 'function liabilities() view returns (uint256 settlementLiability, uint256 rewardLiability)',
+    }),
+    api.call({ target: ROAR, abi: 'erc20:balanceOf', params: STAKING }),
+  ])
+
+  api.add(ROAR, BigInt(liabilities[1]) + BigInt(stakingBalance))
+}
+
+module.exports = {
+  methodology: 'TVL counts only user-owned WETH liabilities: active-round escrow and unclaimed settlement rewards in the Game, plus prepaid automated-mining escrow in the canonical AutoMiner. Pending admin settlement, Treasury assets, and Giga LP liquidity are excluded. Staking counts the Game reward liability (unclaimed round rewards and the Motherlode) plus all ROAR held by the Staking contract as staked principal, earned rewards, and unvested rewards.',
+  start: '2026-07-30',
+  robinhood: { tvl, staking },
+}

--- a/projects/treasury/roar.js
+++ b/projects/treasury/roar.js
@@ -1,0 +1,44 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+const sdk = require('@defillama/sdk')
+const { sumTokensExport } = require('../helper/unwrapLPs')
+
+const TREASURY = '0x809e60F2C2556b5B70A372BCE6F7300f8F216f24'
+const LIQUIDITY_LOCKER = '0xC34b8225e740B1c6982A07884D135524f6DbDFf7'
+const GIGA_POSITION_MANAGER = '0xA79F5775b0B49E51202c48DDF03F380FaA96f641'
+const ROAR = '0xf1d3e39cc61Aedd53dc40d8AFFf6aA1dD51875D0'
+const WETH = ADDRESSES.robinhood.WETH
+
+const treasuryTvl = sumTokensExport({
+  owner: TREASURY,
+  tokens: [WETH],
+})
+
+const lockedLiquidityTvl = sumTokensExport({
+  owner: LIQUIDITY_LOCKER,
+  resolveUniV3: true,
+  uniV3ExtraConfig: { nftAddress: GIGA_POSITION_MANAGER },
+  uniV3WhitelistedTokens: [WETH],
+  blacklistedTokens: [ROAR],
+})
+
+const treasuryOwnTokens = sumTokensExport({
+  owner: TREASURY,
+  tokens: [ROAR],
+})
+
+const lockedLiquidityOwnTokens = sumTokensExport({
+  owner: LIQUIDITY_LOCKER,
+  resolveUniV3: true,
+  uniV3ExtraConfig: { nftAddress: GIGA_POSITION_MANAGER },
+  uniV3WhitelistedTokens: [ROAR],
+  blacklistedTokens: [WETH],
+})
+
+module.exports = {
+  methodology: 'Treasury TVL counts WETH held by the Roar Treasury and the WETH side of Giga concentrated-liquidity positions held by the protocol liquidity locker. Own tokens count ROAR held by the Treasury and the ROAR side of those locked positions. The locked liquidity is also counted by Giga DEX CL.',
+  doublecounted: true,
+  robinhood: {
+    tvl: sdk.util.sumChainTvls([treasuryTvl, lockedLiquidityTvl]),
+    ownTokens: sdk.util.sumChainTvls([treasuryOwnTokens, lockedLiquidityOwnTokens]),
+  },
+}

--- a/registries/sumTokens.js
+++ b/registries/sumTokens.js
@@ -18124,6 +18124,26 @@ const configs = {
       },
     }
   },
+  "roar": {
+    "start": "2026-07-30",
+    "methodology": "TVL is WETH held by the active Game and canonical AutoMiner, covering player deployments, unclaimed settlement rewards, and prepaid automated-mining balances. Staking counts ROAR held by the Game as unclaimed round rewards and the Motherlode, plus ROAR held by the Staking contract as staked principal and vesting rewards. Treasury assets and Giga LP liquidity are excluded.",
+    "robinhood": {
+      "tvl": {
+        "owners": [
+          "0xB9E308C0de769aB61089Ef47231f0ff92AE8BF69",
+          "0x451e9b91447bE0abeebD3110b8c372988383f72C"
+        ],
+        "tokens": [ADDRESSES.robinhood.WETH]
+      },
+      "staking": {
+        "owners": [
+          "0xB9E308C0de769aB61089Ef47231f0ff92AE8BF69",
+          "0xAB9E06E60AafE34257315c12717e0b9E5bFa7631"
+        ],
+        "tokens": ["0xf1d3e39cc61Aedd53dc40d8AFFf6aA1dD51875D0"]
+      },
+    }
+  },
   "mining-tycoon": {
     "timetravel": false,
     "methodology": "TVL counts SOL locked in the mining vault. Staking counts the protocol's own GPU tokens locked in the GPU vault. Mining Tycoon is a dual-currency mining pool where users buy mining power with SOL or GPU tokens and earn proportional rewards from both vaults.",

--- a/registries/sumTokens.js
+++ b/registries/sumTokens.js
@@ -18124,26 +18124,6 @@ const configs = {
       },
     }
   },
-  "roar": {
-    "start": "2026-07-30",
-    "methodology": "TVL is WETH held by the active Game and canonical AutoMiner, covering player deployments, unclaimed settlement rewards, and prepaid automated-mining balances. Staking counts ROAR held by the Game as unclaimed round rewards and the Motherlode, plus ROAR held by the Staking contract as staked principal and vesting rewards. Treasury assets and Giga LP liquidity are excluded.",
-    "robinhood": {
-      "tvl": {
-        "owners": [
-          "0xB9E308C0de769aB61089Ef47231f0ff92AE8BF69",
-          "0x451e9b91447bE0abeebD3110b8c372988383f72C"
-        ],
-        "tokens": [ADDRESSES.robinhood.WETH]
-      },
-      "staking": {
-        "owners": [
-          "0xB9E308C0de769aB61089Ef47231f0ff92AE8BF69",
-          "0xAB9E06E60AafE34257315c12717e0b9E5bFa7631"
-        ],
-        "tokens": ["0xf1d3e39cc61Aedd53dc40d8AFFf6aA1dD51875D0"]
-      },
-    }
-  },
   "mining-tycoon": {
     "timetravel": false,
     "methodology": "TVL counts SOL locked in the mining vault. Staking counts the protocol's own GPU tokens locked in the GPU vault. Mining Tycoon is a dual-currency mining pool where users buy mining power with SOL or GPU tokens and earn proportional rewards from both vaults.",


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).

2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** Please send a mail to metadata@defillama.com
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes

---
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama): ROAR

##### Twitter Link: https://x.com/roar_supply

##### List of audit links if any: N/A

##### Website Link: https://roar.supply

##### Logo (High resolution, will be shown with rounded borders): https://roar.supply/apple-touch-icon.png

##### Current TVL: 

Approximately $3.4K of core user TVL, consisting of 1.8132 WETH at the current snapshot. An additional 634.34 ROAR is reported separately under staking, but it currently has no USD value in DefiLlama because ROAR pricing is not yet supported. Protocol-owned Treasury assets and locked GigaDEX CL liquidity are excluded from core protocol TVL and reported separately.

##### Treasury Addresses (if the protocol has treasury): `robinhood:0x809e60F2C2556b5B70A372BCE6F7300f8F216f24`

##### Chain: Robinhood

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list) N/A

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000) N/A

##### Short Description (to be shown on DefiLlama): ROAR is the internet’s magic roaring money. Fair-launched on the Robinhood Chain.

##### Token address and ticker if any: 0xf1d3e39cc61Aedd53dc40d8AFFf6aA1dD51875D0

##### Category (full list at https://defillama.com/categories) \*Please choose only one: Gamified Mining

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.): N/A

##### Implementation Details: Briefly describe how the oracle is integrated into your project: N/A

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage: N/A

##### forkedFrom (Does your project originate from another project): original codebase, mechanisms inspired by ORE on Solana

##### methodology (what is being counted as tvl, how is tvl being calculated): 

Core TVL counts only user-owned WETH liabilities: WETH escrowed in the active mining round, unclaimed WETH winnings and refunds from completed rounds, and refundable prepaid WETH held by the canonical AutoMiner. Pending admin fees, protocol Treasury assets, and protocol-owned Giga concentrated liquidity are excluded.

Staking is reported separately and consists of the Game contract’s ROAR reward liabilities - including unclaimed mining rewards and the Bounty (aka. Motherlode) - plus all ROAR held by the Staking contract as staked principal, earned rewards, and unvested rewards.

##### Github org/user (Optional, if your code is open source, we can track activity): N/A

##### Does this project have a referral program? N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Roar protocol TVL tracking for WETH-backed liabilities, ROAR liabilities, and staking balances.
  - Added Roar treasury tracking for WETH held in treasury, liquidity lockers, and concentrated-liquidity positions.
  - Added separate reporting for ROAR holdings and own-token metrics.
  - Included methodology, deployment timing, and double-counting metadata for clearer, more accurate reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->