### PR TITLE
steer: paginate the vault query so active vaults past the first 1000 are counted

### DIFF
--- a/projects/steer/index.js
+++ b/projects/steer/index.js
@@ -307,21 +307,23 @@ const supportedChains = [
 ]
 
 const query = `
-  query getVaults {
+  query getVaults($lastId: ID) {
     vaults(
       first: 1000
       orderBy: id
       orderDirection: asc
+      where: { id_gt: $lastId }
     ) { id beaconName token0 token1 token0Balance token1Balance }
   }
 `
 
 const OFFLINE_SUBGRAPH_QUERY = `
-  query getVaults {
+  query getVaults($lastId: ID) {
     vaults(
       first: 1000
       orderBy: id
       orderDirection: asc
+      where: { id_gt: $lastId }
     ) { id beaconName token0 token1 token0Balance token1Balance }
   }
 `
@@ -412,8 +414,9 @@ supportedChains.forEach(chain => {
       const usesOfflineSubgraph = chain.subgraphEndpoint.startsWith(OFFLINE_SUBGRAPH_URL_PREFIX)
       const data = await cachedGraphQuery(`steer-v4/${chain.identifier}`, chain.subgraphEndpoint, usesOfflineSubgraph ? OFFLINE_SUBGRAPH_QUERY : query, {
         headers: chain.headers,
+        fetchById: true,
       })
-      // The array fallback supports a cache entry produced by the previous paginated query.
+      // The object fallback supports a cache entry produced by the previous unpaginated query.
       const vaultData = Array.isArray(data) ? data : data.vaults
       if (!Array.isArray(vaultData)) throw new Error(`Could not fetch vaults for ${api.chain}`)
       const v4Vaults = vaultData.filter(({ beaconName }) => UNISWAP_V4_BEACON_NAMES.has(beaconName))


### PR DESCRIPTION
#20182 rewrote the Steer subgraph query and dropped both the `where` filter and pagination. What is on main now is:

```graphql
query getVaults {
  vaults(first: 1000, orderBy: id, orderDirection: asc) {
    id beaconName token0 token1 token0Balance token1Balance
  }
}
```

`cachedGraphQuery` is called without `fetchById`, so there is no second page. Anything sorting past the first 1000 ids is invisible.

## Measured on the live Polygon subgraph

- 1114 vaults total
- 171 active (`totalLPTokensIssued_not: "0"`, `lastSnapshot_not: "0"`)
- **14 of those active vaults sort past the first-1000 boundary** and were being dropped

```
0xe6a5b583b5f835f46033661505eb8146f1b4ffc3
0xea102e191687b47d23f1239c6bca03389fd98a32
0xeaf074040369f1a5e49fc47410e895fd79be5da0
0xed8a2bc8b47eade8f9eb0594689256e3bc9fbc30
0xee4ea289d12973558982ec1a7933f5e838ec2a71
0xf39bfc10ab9655a7c06d11d90ed40f4d2920b57f
0xf626514a3b5b7670e5d3cb2b6533e5eb4b3a9e9c
0xf757fb28069415677ab3e206ef94f125cfbc24ff
0xfa57c7e0bb748aacd147e087dbda4d369a548e49
0xfaba2d9d74d2645ad83fbd70cdf5db759958d121
0xfdbe9f4abbeefb4382d4be2d074e806fb8bb539d
0xfdfe89ed927b976f9003893065cbd9c65b24e7d1
0xfea9faf87e39651e3691b121c6bb017202692135
0xfed2f9a4a48a884dffb37fb719a13b27d08adfe9
```

All 14 have live `token0`/`token1` balances. Every other chain is under 1000 vaults today and loses nothing, but they hit the same wall as they grow.

## Result

```
node test.js projects/steer/index.js

polygon before  225.38 k
polygon after   231.45 k
```

Other chains unchanged.

## Notes on the approach

Restoring pagination rather than re-adding the `where` filter keeps the change purely additive: no vault counted today stops being counted. The filter would have removed the ~940 inactive Polygon vaults the current query picks up, which is a separate semantic question.

The consuming code already handles the flat array `graphFetchById` returns (`const vaultData = Array.isArray(data) ? data : data.vaults`), and the object branch still covers a cache entry written by the unpaginated query, so a cached fallback keeps working across the change.

`$lastId` is typed `ID` rather than `String` because the archive subgraphs at `subgraph-archive.steer.finance` type `id_gt` as `ID` and reject a `String` variable. `ID` is accepted by both endpoint families, verified against the Ormi Polygon endpoint and the archive metis and fantom endpoints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vault data retrieval by supporting paginated results.
  * Enhanced cached graph query handling, including compatibility with previously stored data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->