### PR TITLE
originether: stop counting the plume vault WETH balance twice

### DIFF
--- a/projects/originether/index.js
+++ b/projects/originether/index.js
@@ -88,9 +88,6 @@ async function baseTvl(api) {
 async function plumeTvl(api) {
   const vault = '0xc8c8F8bEA5631A8AF26440AF32a55002138cB76a'
 
-  const vaultBalance = await api.call({ abi: 'erc20:balanceOf', target: ADDRESSES.plume_mainnet.WETH, params: vault })
-  api.add(ADDRESSES.plume_mainnet.WETH, vaultBalance)
-
   return api.sumTokens({ owners: [vault], tokens: [ADDRESSES.plume_mainnet.WETH] })
 }
 


### PR DESCRIPTION
`plumeTvl` reads the vault's WETH balance into `api.add` and then calls `sumTokens` over the same vault and the same token, so the balance is counted twice. That is the entire function:

```js
async function plumeTvl(api) {
  const vault = '0xc8c8F8bEA5631A8AF26440AF32a55002138cB76a'

  const vaultBalance = await api.call({ abi: 'erc20:balanceOf', target: ADDRESSES.plume_mainnet.WETH, params: vault })
  api.add(ADDRESSES.plume_mainnet.WETH, vaultBalance)

  return api.sumTokens({ owners: [vault], tokens: [ADDRESSES.plume_mainnet.WETH] })
}
```

#20312 removed exactly this pattern from `ethTvl`:

```diff
-  // vault balance
-  const vaultBalance = await api.call({ abi: 'erc20:balanceOf', target: ADDRESSES.ethereum.WETH, params: vault })
-  api.add(ADDRESSES.ethereum.WETH, vaultBalance)
```

but left it in `plumeTvl`. This PR applies the same removal.

## Verification

On chain, vault `0xc8c8F8bEA5631A8AF26440AF32a55002138cB76a`:

```
WETH.balanceOf(vault) = 1496494516488662000
                      = 1.496494516488662 WETH   (~$2.79k)
```

where WETH is `0xca59cA09E5602fAe8B629DeE83FfA819741f14be`, matching `ADDRESSES.plume_mainnet.WETH`.

```
node test.js projects/originether/index.js

plume_mainnet before  5.57 k
plume_mainnet after   2.79 k
```

The fixed figure matches the vault's actual holdings; the previous one was exactly double.

`ethereum` and `baseTvl` are not touched by this change. `baseTvl` has a similar-looking `api.add` for the vault buffer, but it never calls `sumTokens` over that vault, so there is no overlap there. The small ethereum/base movement between my two runs is price drift, not a behaviour change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WETH balance reporting for the Plume vault by consolidating balance tracking into a single calculation method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->