### PR TITLE
Add KasDex TVL adapter (Igra)

### DIFF
--- a/projects/kasdex/index.js
+++ b/projects/kasdex/index.js
@@ -1,0 +1,30 @@
+// KasDex is a single-contract, multi-pool constant-product AMM: every pool's
+// reserves are held as plain ERC20 balances of the KasDex contract itself
+// (no factory / per-pair contracts), so TVL = the contract's token balances.
+const KASDEX = '0xEA4c25D1e8111e74F7c1d3C92dA840e78D5e67E7'
+
+// token address -> [coingecko id, decimals]; WKAS is 1:1 wrapped bridged KAS
+const TOKENS = {
+  '0xCfEa894a9a6745719D72C5dE2002AbC1e6626551': ['kaspa', 18], // WKAS
+  '0xA5b8BF902b2844dA17d4506cc827F7F1681735E7': ['usd-coin', 6], // USDC
+  '0x46346F49b4fe8c640c5FCdbed2d6741056FEB959': ['tether', 6], // USDT
+  '0x69790024D44504F05973E127197E6df17e283859': ['weth', 18], // WETH
+}
+
+async function tvl(api) {
+  const tokens = Object.keys(TOKENS)
+  const bals = await api.multiCall({
+    abi: 'erc20:balanceOf',
+    calls: tokens.map((t) => ({ target: t, params: KASDEX })),
+  })
+  tokens.forEach((t, i) => {
+    const [cgId, decimals] = TOKENS[t]
+    api.addCGToken(cgId, bals[i] / 10 ** decimals)
+  })
+}
+
+module.exports = {
+  methodology:
+    'TVL is the sum of pool reserves (WKAS, USDC, USDT, WETH) held by the KasDex AMM contract on Igra. KasDex is a single-contract multi-pool constant-product DEX, so all reserves live as ERC20 balances of one address.',
+  igra: { tvl },
+}


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).

2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** Please send a mail to metadata@defillama.com
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes

---
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama): KasDex

##### Twitter Link: https://x.com/KASDEXAPP

##### List of audit links if any: None yet (early beta)

##### Website Link: https://kasdex.app

##### Logo (High resolution, will be shown with rounded borders):

##### Current TVL: ~$281

##### Treasury Addresses (if the protocol has treasury)

##### Chain: Igra (Kaspa EVM L2, chainId 38833)

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama): Constant-product AMM on Igra (Kaspa's EVM L2) with a keyless agent API, MCP server, and Python/TypeScript SDKs — the first DEX on Kaspa built for autonomous trading agents.

##### Token address and ticker if any: No protocol token

##### Category (full list at https://defillama.com/categories) \*Please choose only one: Dexes

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.): None — uses on-chain AMM spot price (x*y=k)

##### Implementation Details: Briefly describe how the oracle is integrated into your project: No oracle integration. Price discovery is entirely from pool reserves via the constant-product formula.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage: https://kasdex.app/developers

##### forkedFrom (Does your project originate from another project): Original (not forked)

##### methodology (what is being counted as tvl, how is tvl being calculated): TVL is the sum of ERC20 token balances (WKAS, USDC, USDT, WETH) held by the single KasDex AMM contract on Igra mainnet. All pool reserves are held by one contract address rather than separate per-pair contracts.

##### Github org/user (Optional, if your code is open source, we can track activity): https://github.com/kasdex-app

##### Does this project have a referral program? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added KasDex TVL tracking on Igra.
  * Added support for tracking WKAS, USDC, USDT, and WETH balances.
  * Added token balance reporting with decimal conversion and methodology details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->