### PR TITLE
fix(peridot): count Stellar underlying held in DeFindex boosted vaults

### DIFF
--- a/projects/peridot/index.js
+++ b/projects/peridot/index.js
@@ -11,10 +11,16 @@ const stellarMarkets = [
   { vault: 'CD3WN3PLW63HFZXE56OTRLMBV46WG54TFPGRL4RDQ43HQTTWVB4RPO3G', underlying: ADDRESSES.stellar.EURC },
 ]
 
-// Underlying sitting in the vault, i.e. the Soroban equivalent of Compound's getCash().
+// Unborrowed underlying owned by the vault, i.e. the Soroban equivalent of Compound's getCash().
+//
+// This must be read from the vault's own ledger rather than from the SAC balance of the vault
+// address: each ReceiptVault forwards idle underlying into a DeFindex "boosted" vault for extra
+// yield, so the underlying it owns is (SAC balance held directly) + (value of the DeFindex shares
+// it holds). get_available_liquidity() returns that sum. Reading balance(underlying, vault) sees
+// only the un-swept remainder and understates every market by roughly an order of magnitude.
 async function stellarTvl(api) {
   await Promise.all(stellarMarkets.map(async ({ vault, underlying }) => {
-    const cash = await callSoroban(underlying, 'balance', [vault])
+    const cash = await callSoroban(vault, 'get_available_liquidity')
     api.add(underlying, cash.toString())
   }))
 }
@@ -27,7 +33,7 @@ async function stellarBorrowed(api) {
 }
 
 module.exports = {
-  methodology: 'TVL is the underlying held by the protocol: on BSC and Monad the cash of every Peridot market listed on the comptroller, on Stellar the underlying balance custodied by each Soroban ReceiptVault. Outstanding debt is reported separately as borrowed.',
+  methodology: 'TVL is the underlying held by the protocol: on BSC and Monad the cash of every Peridot market listed on the comptroller, on Stellar the available liquidity of each Soroban ReceiptVault (underlying held directly plus underlying the vault has forwarded into its DeFindex boosted vault). Outstanding debt is reported separately as borrowed.',
   bsc: compoundExports2({ comptroller: '0x6fC0c15531CB5901ac72aB3CFCd9dF6E99552e14' }),
   monad: compoundExports2({ comptroller: '0x6D208789f0a978aF789A3C8Ba515749598940716', blacklistedMarkets: ['0xf8255935e62aa000c89de46a97d2f00bfff147e7'], cether: '0x2FB2861402A22244464435773dd1C6951735CdF7' }),
   stellar: { tvl: stellarTvl, borrowed: stellarBorrowed },


### PR DESCRIPTION
This is a fix to the existing `peridot` adapter (not a new listing), so the new-listing template fields are not applicable. No new dependencies, no lockfile changes.

### Problem

Peridot's Stellar markets are Soroban `ReceiptVault` contracts. Each vault forwards idle underlying into a DeFindex vault to earn additional yield, so the underlying a vault owns lives in two places:

1. the SAC balance held directly at the vault address, and
2. the underlying value of the DeFindex shares the vault holds.

The adapter added in #20153 computed TVL as `balance(underlying, vault)`, which only sees (1). Because the sweep into DeFindex is automatic, (1) is just the un-swept remainder — so roughly 90–99% of each market went untracked, and the gap widened with every new deposit.

### Fix

Read `get_available_liquidity()` from the vault, which is the vault's own accounting of unborrowed underlying it owns, i.e. (1) + (2). This is the Soroban equivalent of Compound's `getCash()` and is the same value Peridot's own frontend reports. BSC and Monad are untouched.

### Verification against mainnet

Underlying units, read live:

| asset | `balance(underlying, vault)` (before) | `get_available_liquidity()` (after) | tracked before |
|---|---|---|---|
| XLM  | 1,486.76 | 14,867.57 | 10.0% |
| USDC | 9.96     | 989.65    | 1.0%  |
| EURC | 102.23   | 1,022.35  | 10.0% |

The new figures reconcile against each vault's independent `get_total_underlying()` accessor, and against the DeFindex vaults directly — e.g. for XLM the ReceiptVault holds 133,781,200,653 shares of `CCB2AR5X3KP4WQKE7HNSUSDS7SHFMC2WPVSZ2ZXJ6DHXOKHFFKOZE6GK`, whose `fetch_total_managed_funds()` reports 133,818,187,700 underlying fully allocated to its Blend strategy.

`node test.js projects/peridot/index.js`:

```
before:  stellar  383.00      total  1.43 k
after:   stellar  4.72 k      total  5.77 k
```

### On double-counting

The DeFindex-deployed portion is Peridot users' deposits — Peridot retains the shares and the withdrawal claim, and DeFindex/Blend is the yield venue rather than the depositor. Excluding it would leave the majority of Peridot's Stellar deposits unrepresented on DefiLlama entirely. Happy to adjust if you'd prefer this split out differently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stellar TVL calculations now include liquidity forwarded to DeFindex boosted vaults.
  * TVL reflects each ReceiptVault’s available liquidity for more accurate reporting.

* **Documentation**
  * Updated methodology details to explain the available-liquidity calculation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->