### PR TITLE
Add several Earn staking addresses and one BTC reserve address

### DIFF
--- a/projects/gate-io/index.js
+++ b/projects/gate-io/index.js
@@ -1821,9 +1821,9 @@ unsupportedChains.forEach(chain => delete config[chain]);
 const earnStakers = {
   celestia: ['celestia10v2gu0vvdeuv8pexnl98lmyva4cq8jkavlk9w4'],
   cosmos: ['cosmos10v2gu0vvdeuv8pexnl98lmyva4cq8jkaa4845c'],
-  injective: ['inj10v2gu0vvdeuv8pexnl98lmyva4cq8jkahus3xq'],
+  injective: ['inj10v2gu0vvdeuv8pexnl98lmyva4cq8jkahus3xq', 'inj18njk2lz5q7juryvzgyly2qxetuwqadxzpvmuhj'],
   dydx: ['dydx10v2gu0vvdeuv8pexnl98lmyva4cq8jka5vf350'],
-  sui: ['0x6edd3be944aeaa90f86f95008b852308e5ab48dc6d2df756e92e11c1ec73b8c0'],
+  sui: ['0x6edd3be944aeaa90f86f95008b852308e5ab48dc6d2df756e92e11c1ec73b8c0', '0xf15b7dbce9f19b0efb66d08aeb9bf840e0bb96d75021c941b9b417b5034560aa'],
 }
 
 /**
@@ -1844,7 +1844,7 @@ const earnOnlyOwners = {
     'addr1q9lqxlvk2dk8sffhr56gc4c4lckpv56l4r7wwh474caywurve9ssnt966vmezsfsppfm5sxgu5sqxacp8t7kpjzp9yxqn24ckj',
     'addr1qyxuqrcjfyyz99yx4s307x33tu45944j607cywzvh3ykxw8c0cqknc77ed7uu7v465ufhkuu73ve6x7r9emq8vfkhxts23pyk4',
   ],
-  algorand: ['4EHCQSBDXQDSR4MFASDP2TGNKVDCJEKA5FUCHLAJ7FVTANR42JISNPV6UU'],
+  algorand: ['4EHCQSBDXQDSR4MFASDP2TGNKVDCJEKA5FUCHLAJ7FVTANR42JISNPV6UU', 'XQBOKHK7JQBWCHXSRWH5XW5ADMRX6WUHB6WXM4GQUF5BUFETJOLX7AMJRI'],
   solana: ['DevD35PrcsJfg9CwpypmrD7GsYMRQpZQx6rfeSbkVtFp'],
 }
 
@@ -1858,15 +1858,27 @@ Object.entries(earnOnlyOwners).forEach(([chain, owners]) => {
 
 // delegation pools have to be named explicitly - a delegator's stake is stored
 // per-pool, there is no "list my pools" view on chain
-const aptosDelegators = [{
-  owner: '0x664208180d23956463ab9bf0a8f2a8f095bca2e27ac9c60623a4e22e78456d3f',
-  pools: ['0xdb5247f859ce63dbe8940cf8773be722a60dcc594a8be9aca4b76abceb251b8e'],
-}]
+const aptosDelegators = [
+  {
+    owner: '0x664208180d23956463ab9bf0a8f2a8f095bca2e27ac9c60623a4e22e78456d3f',
+    pools: ['0xdb5247f859ce63dbe8940cf8773be722a60dcc594a8be9aca4b76abceb251b8e'],
+  },
+  {
+    owner: '0x4c3badbfdfe003ab15c753efd24f32866c13451d468983c17cbb0d77e880b792',
+    pools: ['0xdb5247f859ce63dbe8940cf8773be722a60dcc594a8be9aca4b76abceb251b8e'],
+  },
+]
 
-const nearDelegators = [{
-  owner: 'e10e284823bc0728f1850486fd4ccd5546249140e96823ac09f96b30363cd251',
-  pools: ['gtnode-0.poolv1.near'],
-}]
+const nearDelegators = [
+  {
+    owner: 'e10e284823bc0728f1850486fd4ccd5546249140e96823ac09f96b30363cd251',
+    pools: ['gtnode-0.poolv1.near'],
+  },
+  {
+    owner: 'bc02e51d5f4c03611ef28d8fdbdba01b237f5a870fad7670d0a17a1a14934b97',
+    pools: ['gtnode-0.poolv1.near'],
+  },
+]
 
 // bittensor coldkey as a 32-byte pubkey (SS58 5H9nqVMLfYWN6MiiCLrWjR1ADjR7V7FcBEenBY66NiHeKucE)
 const bittensorColdkeys = ['e10e284823bc0728f1850486fd4ccd5546249140e96823ac09f96b30363cd251']

--- a/projects/gate-io/index.js
+++ b/projects/gate-io/index.js
@@ -54,7 +54,6 @@ const config = {
       "0xcf6f5ec73942314c3ec864202b40dcbb1f9477a0",
       "0x76bbb8D5dbedde9cB34882c9588DFa9dEF00B8bc",
       "0xccc5eeebe15291620be733997af60735618548d7",
-      "0xba622437b70d86EADd6F2f5fB7A5124270c35705",
     ]
   },
   "avax": {
@@ -1904,14 +1903,18 @@ const earnReceiptTokens = {
       '0x444c55075086f531a1c02730f41c46b9bbb00a39',
       '0x356b9e62b20f4666e914fb99a9f651e5574f2bf7',
       '0x8cd6437feaeb1a3a0cd65a16de2ad26bff1f5e43',
+      '0xC453E33Ae2d465d36fEA462BfE810cD6ab408916',
+      "0xba622437b70d86EADd6F2f5fB7A5124270c35705",
     ],
     tokens: [
       '0x23878914efe38d27c4d67ab83ed1b93a74d4086a', // aEthUSDT (Aave v3)
       '0x4da27a545c0c5b758a6ba100e3a049001de870f5', // stkAAVE
+      '0xBc65ad17c5C0a2A4D159fa5a503f4992c7B545FE', // sUSDC 
       '0xe2e7a17dFf93280dec073C995595155283e3C372', // spUSDT  (Spark savings USDT)
       '0x23f5E9c35820f4baB695Ac1F19c203cC3f8e1e11', // skyMoneyUsdtSavings
       '0xE1753F2e00940cC31213dd92013cF019DFE4ca1d', // sGHO   (Aave savings GHO)
       '0xC02aB1A5eaA8d1B114EF786D9bde108cD4364359', // spUSDS (Spark savings USDS)
+      '0xe7df13b8e3d6740fe17cbe928c7334243d86c92f', // spUSDT
     ],
   },
   arbitrum: {

--- a/projects/helper/bitcoin-book/index.js
+++ b/projects/helper/bitcoin-book/index.js
@@ -654,6 +654,7 @@ module.exports = {
     "1FhncfokiSDagazXbuVqKQ6ew4oyDmAzhG",
     "1FLKsCiEsABS7LysfDA8R181TQ6eLjoxPv",
     "1L1SN3BxXaXEAzzGcWqjF9svxmN6F2mBoR",
+    "16G1xYBbiNG78LSuZdMqp6tux5xvVp9Wxh"
   ],
   hashkey: [
     "bc1qyvppkaa74d9jvtz664a6uxmj09hf0eyg3uhx4h",


### PR DESCRIPTION

Add several Earn staking addresses and one BTC reserve address

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).

2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** Please send a mail to metadata@defillama.com
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated Gate Earn address configurations for Ethereum, Injective, Sui, Algorand, Aptos, and NEAR staking pools.
  * Added support for Ethereum receipt-token addresses.
  * Added a Bitcoin address to the Gate.io wallet list.
  * Refined supported staking and earn-only address coverage across the updated networks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->