### PR TITLE
stonkbrokers: fix TVL — track Safety Deposit Box locked LP

### DIFF
--- a/registries/sumTokens.js
+++ b/registries/sumTokens.js
@@ -26584,17 +26584,14 @@ const configs = {
     },
   },
   "stonkbrokers": {
-    "methodology": "TVL is the sum of tokens held by the StockBooster contract. Staking tracks STONKBROKER tokens in the escrow contract.",
+    "methodology": "TVL is the liquidity locked in the Safety Deposit Box locker (Uniswap V3 position NFTs escrowed permanently or on long vests). Staking tracks STONKBROKER tokens in the escrow contract. The previous TVL owner (StockBooster fee collector) was retired on 2026-08-04 and only holds transient fee dust between sweeps.",
     "robinhood": {
       "tvl": {
-        "owner": "0x038a7F4E4E89448ad74e044337C9aC25C11e726B",
-        "tokens": [
-          ADDRESSES.null,
-          ADDRESSES.robinhood.WETH,
-          "0xaF3D76f1834A1d425780943C99Ea8A608f8a93f9",
-          "0x12f190a9F9d7D37a250758b26824B97CE941bF54",
-          "0xd0601CE157Db5bdC3162BbaC2a2C8aF5320D9EEC",
-        ]
+        "owner": "0xFc96CF67eCC55bE4AdABc3AecBe6Ad6349f11223",
+        "resolveUniV3": true,
+        "uniV3ExtraConfig": {
+          "nftAddress": "0x73991a25C818Bf1f1128dEAaB1492D45638DE0D3"
+        }
       },
       "staking": {
         "owner": "0x799AE26fA515ceF145e8bC8636F7fFF87B05Cf62",

--- a/registries/sumTokens.js
+++ b/registries/sumTokens.js
@@ -26589,6 +26589,7 @@ const configs = {
       "tvl": {
         "owner": "0xFc96CF67eCC55bE4AdABc3AecBe6Ad6349f11223",
         "resolveUniV3": true,
+        "uniV3WhitelistedTokens": [ADDRESSES.robinhood.WETH],
         "uniV3ExtraConfig": {
           "nftAddress": "0x73991a25C818Bf1f1128dEAaB1492D45638DE0D3"
         }


### PR DESCRIPTION
Reworked per review — nothing is removed anymore, the inaccurate TVL is fixed instead.

**What was wrong:** the TVL entry summed tokens held by the StockBooster fee collector (`0x038a…726B`). That contract was retired on 2026-08-04 (fee flow moved to a new distribution engine and is swept continuously), so the balance is transient dust between sweeps — it was reading ~$3 while real locked value lives elsewhere.

**Fix:** TVL now resolves the Uniswap V3 position NFTs escrowed in the Safety Deposit Box liquidity locker (`0xFc96…1223`, 25 positions currently, most locked permanently) via `resolveUniV3` with the Robinhood Chain position manager (`0x7399…E0D3` — same config already used by another robinhood entry in this registry). Methodology string updated to match.

The `staking` entry and the `treasury/stonkbrokers` entry are unchanged/restored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated the Stonkbrokers TVL tracking methodology to account for permanently escrowed or long-vested Uniswap V3 position NFTs.
  * Revised the tracked configuration to use the appropriate TVL owner, Uniswap V3 resolution, and NFT address.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->