### PR TITLE
Count Cookie Chain side of Cookie Bridge in TVL

### DIFF
--- a/projects/cookiechain-bridge/index.js
+++ b/projects/cookiechain-bridge/index.js
@@ -1,12 +1,18 @@
-const { sumTokens2 } = require('../helper/solana')
+const { PublicKey } = require('@solana/web3.js')
+const { getConnection, sumTokens2 } = require('../helper/solana')
 
 // Cookie Bridge moves COOK between Solana and Cookie Chain (a Solana / Agave fork)
-// 1:1 — it is the same asset on both chains. TVL is measured on the canonical
-// Solana side only (counting the mirrored Cookie Chain balance too would
-// double-count the same COOK). This continues the bridge's original methodology
-// ("COOK locked in the Solana bridge"), which counted the Squads multi-sig; with
-// the migration to Hyperlane the bridge now also escrows COOK in a Hyperlane warp
-// PDA on Solana, so that PDA is added alongside the multi-sig.
+// 1:1 via a Hyperlane collateral<->collateral warp route: SPL COOK is locked in a
+// warp escrow on Solana and native COOK is locked in a warp PDA on Cookie Chain,
+// and the relayer releases from the other side's escrow. The two escrows are two
+// halves of one inventory pool, so each side is counted on its own chain — those
+// are distinct token units and no COOK is counted twice. Counting only one side
+// would instead make TVL rise and fall with the direction users happen to bridge.
+//
+// Alongside the escrows the bridge reserve is custodied in a Squads multi-sig on
+// each chain, mirroring the same undistributed COOK. Only the Solana multi-sig is
+// counted (as the bridge's original methodology, "COOK locked in the Solana
+// bridge", always did); adding the Cookie Chain one would double-count that reserve.
 
 // SPL COOK (Token-2022, 6dp).
 const SOLANA_COOK = '36ZrtQoab5MhhySaP1YSTwUahSk6GRVUTtZ6cuVfm9e1'
@@ -15,7 +21,13 @@ const SQUADS_MULTISIG = 'DoYYCtcG2vfrE3HtxBBXiNVieMutvWBXsgbF3SKtYCyx'
 // Hyperlane warp escrow token account (added with the Hyperlane migration).
 const HYPERLANE_PDA = '88q7zoKctwAQRsoTxkMJy95sNE3tntuyEhSrhvR1eZwq'
 
-async function tvl(api) {
+// Cookie Chain side: Hyperlane warp PDA holding native COOK.
+const COOKIECHAIN_HYPERLANE_PDA = 'CL2JoQ5jdTpRNKshWhaTihuooT4qrKdLUiPsqKj3yAKz'
+// Native COOK is priced under the wrapped mint address (Solana fork -> same address
+// as wrapped SOL), 9dp.
+const COOKIECHAIN_COOK = 'So11111111111111111111111111111111111111112'
+
+async function solanaTvl(api) {
   return sumTokens2({
     api,
     tokenAccounts: [HYPERLANE_PDA],                    // Hyperlane warp escrow (is itself the token account)
@@ -23,9 +35,17 @@ async function tvl(api) {
   })
 }
 
+async function cookiechainTvl(api) {
+  // Read the native balance straight off the chain's connection: sumTokens2's
+  // `solOwners` path resolves its connection without a chain and would read Solana.
+  const balance = await getConnection(api.chain).getBalance(new PublicKey(COOKIECHAIN_HYPERLANE_PDA))
+  api.add(COOKIECHAIN_COOK, balance)
+}
+
 module.exports = {
   timetravel: false,
   methodology:
-    'TVL is the COOK locked in the bridge on Solana: SPL COOK held in the Hyperlane warp escrow PDA plus the Squads multi-sig that custodies the bridge reserve. COOK bridges 1:1 and is the same asset on Cookie Chain, so the mirrored Cookie Chain balances are not counted again.',
-  solana: { tvl },
+    'TVL is the COOK locked in the bridge on both sides: the Hyperlane warp escrow and the Squads reserve multi-sig on Solana, plus the Hyperlane warp PDA on Cookie Chain. The mirrored Cookie Chain reserve multi-sig is excluded, so the same reserve is not counted twice.',
+  solana: { tvl: solanaTvl },
+  cookiechain: { tvl: cookiechainTvl },
 }


### PR DESCRIPTION
Hi team, I'd like this bridge to show up on both of its chains and to count the Cookie Chain side too, without inflating anything.

Cookie Bridge is a Hyperlane collateral↔collateral warp route: SPL COOK is locked in a warp escrow on Solana, native COOK in a warp PDA on Cookie Chain, and the relayer releases from the opposite side. The adapter only counted the Solana side, which makes TVL rise and fall with whichever direction users happen to bridge, even though nothing enters or leaves the bridge.

This PR adds a `cookiechain` leg for the warp PDA `CL2JoQ5jdTpRNKshWhaTihuooT4qrKdLUiPsqKj3yAKz`. The Solana leg is unchanged.

**The two escrows are two halves of one inventory pool, so nothing is counted twice.** Measured across 13 days:

| date | Solana `88q7…` | Cookie Chain `CL2Jo…` | sum |
|---|---|---|---|
| 2026-07-20 | 33.94M | 18.09M | **52.03M** |
| 2026-07-24 | 34.72M | 17.31M | **52.03M** |
| 2026-08-02 | 32.712214M | 19.315611M | **52.03M** |

The split tracks flow direction; the total is invariant. The two balances are distinct token units on distinct chains and different token programs — the Solana one is an SPL Token-2022 account, the Cookie Chain one a native lamport balance.

The bridge reserve is custodied in a Squads multi-sig on each chain, mirroring the same undistributed COOK. Only the Solana multi-sig is counted, as the adapter has always done; the Cookie Chain one (`G3mm95M4ns7mk8oseWGJnirvgyMahMz3vZEUhdJn8oGX`) stays excluded so that reserve isn't counted twice.

## Result

| chain | COOK |
|---|---|
| solana | 448,409,433.415005 |
| cookiechain | 19,315,610.730112 |
| **total** | **467,725,044.145117** |

Previously 448,409,433.42 on Solana alone, so +4.3%.

## Verification

Both legs were executed against live RPC (`api.mainnet-beta.solana.com` and `rpc.cookiescan.io`) and produced the figures above. Checks for double counting:

- `88q7…`'s token-account authority is itself, not the multi-sig, so the `tokensAndOwners` sweep for `DoYYC…` cannot pick the escrow up again — that lookup returns exactly one account, `BbAPtGG22Wy8FuxYUr6fRE2yLojU862hsBoMaxGzkBN9`.
- None of these addresses appear in any other adapter or in `registries/`.

`COOKIECHAIN_RPC` already has a default in `projects/helper/env.js`, so the new leg needs no configuration. The native balance is read with `getConnection(api.chain).getBalance()` rather than `sumTokens2({ solOwners })`, because that helper path resolves its connection without a chain and would read Solana instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * TVL reporting for the COOK bridge now separates balances on Solana and Cookie Chain.
  * Solana escrow and reserve balances continue to be included, while Cookie Chain native balances are now tracked independently.
  * Updated methodology clarifies how bridge-side balances are calculated and avoids double-counting mirrored reserves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->