### PR TITLE
term-structure: track TermMax Alpha factories on Robinhood chain

### DIFF
--- a/projects/term-structure/index.js
+++ b/projects/term-structure/index.js
@@ -358,12 +358,24 @@ const ADDRESSES = {
         address: "0x03c4FCF963E5FBC0dC5851d2340624E70492acb9",
         fromBlock: 21550658,
       },
+      // Start of TermMax Alpha
+      {
+        address: "0xF8F8D8E6f139841a30C8C3d6A2F656f195755Ceb",
+        fromBlock: 25939853,
+      },
+      // End of TermMax Alpha
     ],
     VaultFactoryV2: [
       {
         address: "0x276C0E52508d94ff2D4106b1559c8c4Bc3a75dec",
         fromBlock: 21550718,
       },
+      // Start of TermMax Alpha
+      {
+        address: "0x1C2a752db503b7E447114ff0C61802F19D8f765B",
+        fromBlock: 25939844,
+      },
+      // End of TermMax Alpha
     ],
     TermMax4626Factory: [
       { address: "0xa50929A67daF9Ff3567e2Bb3411204A134f72546", fromBlock: 21550753 },


### PR DESCRIPTION
Registers two newly deployed TermMax Alpha factories on Robinhood chain under the existing `robinhood` entry in `projects/term-structure/index.js`.

| Contract | Address | Verified name | Deploy block |
|---|---|---|---|
| Alpha market factory | `0xF8F8D8E6f139841a30C8C3d6A2F656f195755Ceb` | `TermMaxFactoryV2` | 25939853 |
| Alpha vault factory | `0x1C2a752db503b7E447114ff0C61802F19D8f765B` | `TermMaxVaultFactoryV2` | 25939844 |

Both contracts emit `MarketCreated` / `VaultCreated` with signatures that match the existing `EVENTS.V2` definitions field-for-field, so they slot straight into the `FactoryV2` / `VaultFactoryV2` arrays with no new event ABIs. They are marked with the same `// Start of TermMax Alpha` / `// End of TermMax Alpha` comments already used for BSC and Base.

The market factory's ABI also contains `StableERC4626*Created` events, but that is the same shared ABI as the existing `0x03c4FCF9...` factory — 4626 vaults on this chain are still tracked through the separate `TermMax4626Factory` (`0xa50929A6...`), which is unchanged.

Deploy blocks and contract names were read from the Robinhood chain Blockscout explorer.

### Testing

`LLAMA_DEBUG_MODE=true node test.js projects/term-structure/index.js`

```
robinhood                 0.00
robinhood-borrowed        0.00
total                    31.54 M
```

Robinhood reports 0 because these factories have not created any markets or vaults yet (`has_logs: false` on both addresses); this registers them ahead of the first deployment. Other chains are unaffected. `base` failed in the local run due to public RPC rate limiting and head-block lag, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Robinhood TermMax Alpha factory addresses for `FactoryV2` and `VaultFactoryV2`.
  * Enabled indexing from the specified starting block.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->