### PR TITLE
Add Gauntlet Morph vault tracking

### DIFF
--- a/projects/aera-v3/index.js
+++ b/projects/aera-v3/index.js
@@ -51,7 +51,6 @@ const contracts = {
     },
   };
 const { getLogs } = require('../helper/cache/getLogs')
-const { getFixBalances } = require('../helper/portedTokens')
 
 async function getMultiDepositorVaults(api) {
     const vaults = [];
@@ -107,8 +106,6 @@ async function tvl(api) {
 
         api.add(numeraireToken, numeraireBalance);
     }));
-
-    return getFixBalances(api.chain)(api.getBalances());
 }
 
 module.exports = {

--- a/projects/aera-v3/index.js
+++ b/projects/aera-v3/index.js
@@ -39,8 +39,19 @@ const contracts = {
         topics: [topics.SingleDepositorVault_VaultCreated]
       },
     },
+    morph: {
+      // factory deployed at a different address than ethereum/base
+      fromBlock: 24054994,
+      multiDepositorVaultFactory: {
+        address: '0xA735FaF51AE8BD0637b8468828dC83E2C24A8E60',
+        fromBlock: 24054994,
+        eventAbi: eventAbis.MultiDepositorVault_VaultCreated,
+        topics: [topics.MultiDepositorVault_VaultCreated]
+      },
+    },
   };
 const { getLogs } = require('../helper/cache/getLogs')
+const { getFixBalances } = require('../helper/portedTokens')
 
 async function getMultiDepositorVaults(api) {
     const vaults = [];
@@ -96,6 +107,8 @@ async function tvl(api) {
 
         api.add(numeraireToken, numeraireBalance);
     }));
+
+    return getFixBalances(api.chain)(api.getBalances());
 }
 
 module.exports = {
@@ -103,4 +116,5 @@ module.exports = {
   start: 1748414859,
   base: { tvl },
   ethereum: { tvl },
+  morph: { tvl },
 };

--- a/projects/gauntlet/index.js
+++ b/projects/gauntlet/index.js
@@ -1,6 +1,8 @@
 const { getCuratorExport, kaminoLendVaultTvl } = require("../helper/curators");
 const axios = require('axios');
-// const aeraV3 = require('../aera-v3')  // excluded till we find a way to exclude deposits from aera-v3 into other gauntlet curated vaults
+// aeraV3.ethereum/base excluded till we find a way to exclude deposits from aera-v3 into other gauntlet curated vaults
+// aeraV3.morph is safe to include directly: Gauntlet is the only curator on that factory (prod + staging vaults)
+const aeraV3 = require('../aera-v3')
 const coreAssets = require('../helper/coreAssets.json')
 
 const configs = {
@@ -157,6 +159,11 @@ const configs = {
         '0x6d6783c146f2b0b2774c1725297f1845dc502525', // Lista USDT Vault
       ],
     },
+    morph: {
+      morpho: [
+        '0x9131eb40bd0bdce73c72755f1bb2cf39a9453341', // Gauntlet USDC Morpho vault
+      ],
+    },
   }
 }
 
@@ -308,10 +315,16 @@ async function combinedBaseTvl(api) {
 
 async function combinedBscTvl(api) {
   const LISTA_START = 1777303000 // 2026-04-27, listing date for BSC Lista (Moolah) vaults
-  
+
   if (api.timestamp < LISTA_START) return;
   const curatorExport = getCuratorExport(configs);
   if (curatorExport.bsc?.tvl) await curatorExport.bsc.tvl(api);
+}
+
+async function combinedMorphTvl(api) {
+  const curatorExport = getCuratorExport(configs);
+  if (curatorExport.morph?.tvl) await curatorExport.morph.tvl(api);
+  await aeraV3.morph.tvl(api);
 }
 
 module.exports = {
@@ -320,6 +333,7 @@ module.exports = {
   ethereum: { tvl: combinedEthereumTvl },
   base: { tvl: combinedBaseTvl },
   bsc: { tvl: combinedBscTvl },
+  morph: { tvl: combinedMorphTvl },
   timetravel: false,
   hallmarks: [
     ["2026-03-22", "Resolve USR hack"],

--- a/projects/gauntlet/index.js
+++ b/projects/gauntlet/index.js
@@ -1,8 +1,6 @@
 const { getCuratorExport, kaminoLendVaultTvl } = require("../helper/curators");
 const axios = require('axios');
-// aeraV3.ethereum/base excluded till we find a way to exclude deposits from aera-v3 into other gauntlet curated vaults
-// aeraV3.morph is safe to include directly: Gauntlet is the only curator on that factory (prod + staging vaults)
-const aeraV3 = require('../aera-v3')
+// const aeraV3 = require('../aera-v3')  // excluded till we find a way to exclude deposits from aera-v3 into other gauntlet curated vaults
 const coreAssets = require('../helper/coreAssets.json')
 
 const configs = {
@@ -324,7 +322,7 @@ async function combinedBscTvl(api) {
 async function combinedMorphTvl(api) {
   const curatorExport = getCuratorExport(configs);
   if (curatorExport.morph?.tvl) await curatorExport.morph.tvl(api);
-  await aeraV3.morph.tvl(api);
+  // await aeraV3.morph.tvl(api);
 }
 
 module.exports = {

--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -46,12 +46,6 @@ const fixBalancesTokens = {
       decimals: 6,
     },
   },
-  morph: {
-    '0x31011317764e097b28d159a8145b92bfa453f606': {
-      coingeckoId: 'bitget-wrapped-btc',
-      decimals: 8,
-    },
-  },
   ozone: {
     // '0x83048f0bf34feed8ced419455a4320a735a92e9d': { coingeckoId: "ozonechain", decimals: 18 }, // was mapped to wrong chain
   },

--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -46,6 +46,12 @@ const fixBalancesTokens = {
       decimals: 6,
     },
   },
+  morph: {
+    '0x31011317764e097b28d159a8145b92bfa453f606': {
+      coingeckoId: 'bitget-wrapped-btc',
+      decimals: 8,
+    },
+  },
   ozone: {
     // '0x83048f0bf34feed8ced419455a4320a735a92e9d': { coingeckoId: "ozonechain", decimals: 18 }, // was mapped to wrong chain
   },


### PR DESCRIPTION
## Summary
- Adds two Gauntlet-curated vaults on Morph to the `gauntlet` TVL adapter:
  - Gauntlet USDC Morpho vault (`0x9131eb40bd0bdce73c72755f1bb2cf39a9453341`)
  - Aera V3 vaults, discovered via Morph's `MultiDepositorVaultFactory` (`0xA735FaF51AE8BD0637b8468828dC83E2C24A8E60` — a different address than the ethereum/base factory)
- Extends `projects/aera-v3/index.js` with the Morph factory config/export, following the same event-log discovery pattern already used for ethereum/base.
- Wires Morph's combined TVL in `projects/gauntlet/index.js` to include both the curator-tracked Morpho vault and `aera-v3`'s Morph output directly (safe here since Gauntlet is the only curator on that factory, unlike ethereum/base where `aera-v3` stays excluded to avoid double-counting other curators' vaults).
- Adds a `fixBalancesTokens` mapping for BGBTC (Bitget Wrapped BTC) on Morph to `projects/helper/tokenMapping.js`, since it's the numeraire token for the Aera vaults and isn't yet priced by DefiLlama's coins service for this chain.

## Test plan
- [x] Ran `node test.js projects/gauntlet/index.js` — Morph shows the Morpho vault's TVL; adapter runs without errors
- [x] Ran `node test.js projects/aera-v3/index.js` — both Morph vaults (`gtOVBG`, `stgOVBG`) are discovered via the factory and their balances compute correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Morph network support for Aera V3 vault tracking.
  * Enabled Gauntlet TVL reporting on Morph by aggregating configured vault data.
  * Added Morph vault configuration for accurate TVL reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->