### PR TITLE
chore(subfrost): refresh TVL methodology wording

### DIFF
--- a/projects/subfrost/index.js
+++ b/projects/subfrost/index.js
@@ -1,9 +1,10 @@
 const { sumTokens } = require("../helper/sumTokens");
 const bitcoinAddressBook = require("../helper/bitcoin-book/index.js");
 
-// SUBFROST is a decentralized custodian on Bitcoin L1. It issues frBTC, a synthetic
-// bitcoin pegged 1:1 to BTC, against BTC held by a FROST signer set. frBTC is issued
-// on two Bitcoin metaprotocols, Alkanes and BRC2.0, each with its own custody address.
+// SUBFROST is a decentralized signing network on Bitcoin L1. It issues frBTC, a
+// synthetic bitcoin pegged 1:1 to BTC, against BTC held by a FROST signer set. frBTC
+// is issued on two Bitcoin metaprotocols, Alkanes and BRC2.0, each with its own
+// custody address.
 const owners = bitcoinAddressBook.subfrost;
 
 async function tvl(api) {
@@ -12,5 +13,5 @@ async function tvl(api) {
 
 module.exports = {
   bitcoin: { tvl },
-  methodology: `TVL is the BTC held in the SUBFROST signer custody addresses that back frBTC, read directly from the Bitcoin chain. Covers both frBTC deployments: Alkanes and BRC2.0. frBTC minted against these deposits is not counted separately, so nothing is double counted.`,
+  methodology: `Total value of all BTC held by the transparent and verifiable SUBFROST signing group. Covers both frBTC deployments: Alkanes and BRC2.0. frBTC minted against these deposits is not counted separately, so nothing is double counted.`,
 };


### PR DESCRIPTION
Wording-only change to the SUBFROST adapter (protocol id 8317). No change to what is counted, no change to the addresses, no new dependency.

**Methodology**

before:
> TVL is the BTC held in the SUBFROST signer custody addresses that back frBTC, read directly from the Bitcoin chain. Covers both frBTC deployments: Alkanes and BRC2.0. frBTC minted against these deposits is not counted separately, so nothing is double counted.

after:
> Total value of all BTC held by the transparent and verifiable SUBFROST signing group. Covers both frBTC deployments: Alkanes and BRC2.0. frBTC minted against these deposits is not counted separately, so nothing is double counted.

The sentence stating that minted frBTC is not counted separately is kept as-is, since that is the part that explains why there is no double counting.

The header comment is updated to match how the protocol now describes itself ("decentralized signing network" rather than "decentralized custodian"). Same signer set, same 6-of-9 FROST threshold, same two custody addresses.

`tvl` still sums only the two Bitcoin addresses in `helper/bitcoin-book` (`subfrost`), so the methodology describes exactly what the adapter computes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated SUBFROST documentation to describe its decentralized signing network and custody model.
  * Clarified that BTC held by the transparent, verifiable signing group backs both frBTC deployments.
  * Revised the total value locked methodology for greater clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->