### PR TITLE
add aave v4 avax

### DIFF
--- a/projects/aave-v4/index.js
+++ b/projects/aave-v4/index.js
@@ -8,7 +8,12 @@ const config = {
       "0x06002e9c4412CB7814a791eA3666D905871E536A", // Plus Hub
       "0x943827DCA022D0F354a8a8c332dA1e5Eb9f9F931", // Prime Hub
     ],
-  }
+  },
+  avax: {
+    HUBS: [
+      "0xd07369fAE4A5BB13c9Ce446B052c7867B1AbDf6e", // Core Hub
+    ],
+  },
 }
 
 const abis = {


### PR DESCRIPTION
hub address from https://github.com/aave-dao/aave-address-book/blob/main/src/ts/AaveV4Avalanche.ts#L20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Avalanche network support, including TVL and borrowed amount calculations alongside Ethereum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->