### PR TITLE
byzanlink: Add byzanlink vaults

### DIFF
--- a/projects/byzanlink/byzanlink-vault-idl.json
+++ b/projects/byzanlink/byzanlink-vault-idl.json
@@ -1,0 +1,328 @@
+{
+  "version": "0.1.0",
+  "name": "byzanlink_vault",
+  "instructions": [],
+  "accounts": [
+    {
+      "name": "VaultState",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vaultAdminAuthority",
+            "type": "publicKey"
+          },
+          {
+            "name": "baseVaultAuthority",
+            "type": "publicKey"
+          },
+          {
+            "name": "baseVaultAuthorityBump",
+            "type": "u64"
+          },
+          {
+            "name": "tokenMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "tokenMintDecimals",
+            "type": "u64"
+          },
+          {
+            "name": "tokenVault",
+            "type": "publicKey"
+          },
+          {
+            "name": "tokenProgram",
+            "type": "publicKey"
+          },
+          {
+            "name": "sharesMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "sharesMintDecimals",
+            "type": "u64"
+          },
+          {
+            "name": "tokenAvailable",
+            "type": "u64"
+          },
+          {
+            "name": "sharesIssued",
+            "type": "u64"
+          },
+          {
+            "name": "reservedCrankFunds",
+            "docs": [
+              "Reserved (formerly `available_crank_funds`, dead since the first",
+              "PayFi-only pass; no longer dead now that permissionless `invest()`",
+              "exists again, but repurposing this specific field isn't necessary —",
+              "left as reserved padding)."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "performanceFeeBps",
+            "type": "u64"
+          },
+          {
+            "name": "managementFeeBps",
+            "type": "u64"
+          },
+          {
+            "name": "lastFeeChargeTimestamp",
+            "type": "u64"
+          },
+          {
+            "name": "prevAumSf",
+            "type": {
+              "array": ["u64", 2]
+            }
+          },
+          {
+            "name": "pendingFeesSf",
+            "type": {
+              "array": ["u64", 2]
+            }
+          },
+          {
+            "name": "minDepositAmount",
+            "type": "u64"
+          },
+          {
+            "name": "minWithdrawAmount",
+            "type": "u64"
+          },
+          {
+            "name": "pendingAdmin",
+            "type": "publicKey"
+          },
+          {
+            "name": "feeAuthority",
+            "docs": [
+              "Recipient of `withdraw_pending_fees` transfers. Distinct from",
+              "`vault_admin_authority`, which continues to sign the withdrawal but no",
+              "longer receives the funds. Set/rotated via `update_vault_config`."
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "cumulativeEarnedInterestSf",
+            "type": {
+              "array": ["u64", 2]
+            }
+          },
+          {
+            "name": "cumulativeMgmtFeesSf",
+            "type": {
+              "array": ["u64", 2]
+            }
+          },
+          {
+            "name": "cumulativePerfFeesSf",
+            "type": {
+              "array": ["u64", 2]
+            }
+          },
+          {
+            "name": "name",
+            "type": {
+              "array": ["u8", 40]
+            }
+          },
+          {
+            "name": "creationTimestamp",
+            "type": "u64"
+          },
+          {
+            "name": "withdrawalPenaltyLamports",
+            "type": "u64"
+          },
+          {
+            "name": "withdrawalPenaltyBps",
+            "type": "u64"
+          },
+          {
+            "name": "depositCap",
+            "type": "u64"
+          },
+          {
+            "name": "perUserDepositCap",
+            "docs": [
+              "Max net-deposited principal (see `UserPosition::net_deposited`) any single",
+              "depositor may hold. 0 = uncapped."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "unallocatedWeight",
+            "docs": [
+              "Weight for the \"keep unallocated/idle\" bucket in target-allocation math."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "unallocatedTokensCap",
+            "docs": ["Cap on how much can sit unallocated. 0 = uncapped."],
+            "type": "u64"
+          },
+          {
+            "name": "allocationAdmin",
+            "docs": [
+              "Secondary admin allowed to update the weight/caps of *existing*",
+              "allocation slots (creating a new slot still requires",
+              "`vault_admin_authority`)."
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "allowAllocationsInWhitelistedPoolsOnly",
+            "docs": [
+              "When non-zero, allocation slots can only be created/increased",
+              "targeting a whitelisted pool."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "allowInvestInWhitelistedPoolsOnly",
+            "docs": [
+              "When non-zero, `invest()` can only deposit into a whitelisted pool."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "allocationFlagsPadding",
+            "type": {
+              "array": ["u8", 6]
+            }
+          },
+          {
+            "name": "vaultAllocationStrategy",
+            "docs": [
+              "Up to `MAX_ALLOCATIONS` `payfi-vault` pools this vault can spread",
+              "liquidity across. Empty slots have `pool == Pubkey::default()`."
+            ],
+            "type": {
+              "array": [
+                {
+                  "defined": "VaultAllocation"
+                },
+                1
+              ]
+            }
+          },
+          {
+            "name": "allocator",
+            "docs": [
+              "The only role (besides `vault_admin_authority`, which always retains",
+              "an override) allowed to call `invest()`/`deallocate()` — i.e. actually",
+              "move funds into or out of the payfi-vault pool. Distinct from",
+              "`allocation_admin`, which only configures weight/caps. Carved from",
+              "the tail end of what was `padding_end` — placed *after*",
+              "`vault_allocation_strategy` deliberately, so this field's offset",
+              "doesn't shift any already-live account's existing data on upgrade."
+            ],
+            "type": "publicKey"
+          },
+          {
+            "name": "paddingEnd",
+            "type": {
+              "array": ["u64", 28]
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "types": [
+    {
+      "name": "VaultAllocation",
+      "docs": [
+        "One allocation slot targeting a `payfi-vault` `Pool` (this program's",
+        "generic stand-in for what used to be a klend `Reserve`). `shares_vault`",
+        "holds the shares this vault's `invest()` calls have accumulated from that",
+        "pool — the receipt-token analogue of klend's cTokens."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "publicKey"
+          },
+          {
+            "name": "sharesVault",
+            "type": "publicKey"
+          },
+          {
+            "name": "targetAllocationWeight",
+            "type": "u64"
+          },
+          {
+            "name": "tokenAllocationCap",
+            "docs": [
+              "Max underlying-token amount this pool may hold on this vault's behalf."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "sharesVaultBump",
+            "type": "u64"
+          },
+          {
+            "name": "sharesAllocationCap",
+            "docs": [
+              "Raw `SharesCap` value — 0 or `u64::MAX` both mean uncapped."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "configPadding",
+            "type": {
+              "array": ["u64", 126]
+            }
+          },
+          {
+            "name": "sharesAllocation",
+            "docs": ["Current shares balance this vault holds against `pool`."],
+            "type": "u64"
+          },
+          {
+            "name": "lastInvestSlot",
+            "type": "u64"
+          },
+          {
+            "name": "tokenTargetAllocationSf",
+            "docs": [
+              "Scaled-fraction (`Fraction`) target token amount, recomputed each",
+              "`refresh_target_allocations` call — see the 128-bit-field comment at",
+              "the top of `vault_state.rs` for why this is `[u64; 2]`, not `u128`."
+            ],
+            "type": {
+              "array": ["u64", 2]
+            }
+          },
+          {
+            "name": "cachedRealValue",
+            "docs": [
+              "Last-known underlying-token value of `shares_allocation`, refreshed",
+              "only when `invest()` reads the pool live. `compute_aum()` sums this",
+              "across slots rather than reading every allocated pool's account on",
+              "every deposit/withdraw/fee-charge — same caching philosophy as the",
+              "old operator-reported PayFi NAV: fresh as of the last time something",
+              "actually touched this pool, not live on every call."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "statePadding",
+            "type": {
+              "array": ["u64", 127]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/projects/byzanlink/index.js
+++ b/projects/byzanlink/index.js
@@ -1,0 +1,35 @@
+const { Program } = require('@project-serum/anchor')
+const { PublicKey } = require('@solana/web3.js')
+const { getProvider, getTokenAccountBalances } = require('../helper/solana')
+const { sumERC4626VaultsExport2 } = require('../helper/erc4626')
+
+const big = (v) => BigInt(v.toString())
+const prog = (idl, id) => new Program(idl, new PublicKey(id), getProvider())
+const erc4626 = (...vaults) => ({ tvl: sumERC4626VaultsExport2({ vaults }) })
+
+module.exports = {
+  methodology: 'Total value of assets deposited in the Byzanlink vaults, read on-chain and valued in USD.',
+  hedera: erc4626('0x6b8dfA6aa5f803a886Beb2492eF3307EC0Ee16FB'), // Credible PayFi Vault
+  ethereum: erc4626('0xA5cDEE01aA7A5E0620df5f27F26E552fdf7f5F20'), // bSyrupUSDC
+  solana: {
+    tvl: async (api) => {
+      const vaultProgram = prog(require('./byzanlink-vault-idl.json'), 'HyuZ17H9ScJ6GsMnJMYTCUZrw6Jz4AS4RGD9h3Pt4Se') // Byzanlink vault program
+      const vault = await vaultProgram.account.vaultState.fetch('96k5AKfdHMW6URrn3Qwn4wp3gN4S2GupK27dPxtt3vfw') // Credible PayFi Vault
+
+      const [{ pool: poolKey, sharesAllocation }] = vault.vaultAllocationStrategy
+      const payfiProgram = prog(require('./payfi-vault-idl.json'), 'B9wHQVTeCkZ8KM8nZTBfHQyfQhJvuihhHa9SdWo4x77U') // PayFi pool program
+      const pool = await payfiProgram.account.pool.fetch(poolKey)
+
+      const [liq] = await getTokenAccountBalances([pool.poolLiquidityVault], { individual: true })
+
+      const backing = big(pool.reportedNav)
+        + big(pool.inflowSinceLastNavUpdate)
+        - big(pool.outflowSinceLastNavUpdate)
+        + big(liq.amount)
+
+      const allocated = big(sharesAllocation) * backing / big(pool.totalSharesIssued)
+
+      api.add(vault.tokenMint.toString(), (big(vault.tokenAvailable) + allocated).toString())
+    },
+  },
+}

--- a/projects/byzanlink/index.js
+++ b/projects/byzanlink/index.js
@@ -17,10 +17,14 @@ module.exports = {
       const vault = await vaultProgram.account.vaultState.fetch('96k5AKfdHMW6URrn3Qwn4wp3gN4S2GupK27dPxtt3vfw') // Credible PayFi Vault
 
       const [{ pool: poolKey, sharesAllocation }] = vault.vaultAllocationStrategy
-      const payfiProgram = prog(require('./payfi-vault-idl.json'), 'B9wHQVTeCkZ8KM8nZTBfHQyfQhJvuihhHa9SdWo4x77U') // PayFi pool program
-      const pool = await payfiProgram.account.pool.fetch(poolKey)
+      const shares = big(sharesAllocation)
+      let allocated = 0n
 
-      const [liq] = await getTokenAccountBalances([pool.poolLiquidityVault], { individual: true })
+      // an unallocated slot leaves the pool unset, so there is nothing to fetch or value
+      if (shares > 0n) {
+        const payfiProgram = prog(require('./payfi-vault-idl.json'), 'B9wHQVTeCkZ8KM8nZTBfHQyfQhJvuihhHa9SdWo4x77U') // PayFi pool program
+        const pool = await payfiProgram.account.pool.fetch(poolKey)
+        const [liq] = await getTokenAccountBalances([pool.poolLiquidityVault], { individual: true })
 
         // Pool::exchange_rate backing: real_assets() plus repaid liquidity awaiting redemption
         const backing = big(pool.reportedNav)
@@ -28,7 +32,8 @@ module.exports = {
           - big(pool.outflowSinceLastNavUpdate)
           + big(liq.amount)
 
-      const allocated = big(sharesAllocation) * backing / big(pool.totalSharesIssued)
+        allocated = shares * backing / big(pool.totalSharesIssued)
+      }
 
       api.add(vault.tokenMint.toString(), (big(vault.tokenAvailable) + allocated).toString())
     },

--- a/projects/byzanlink/index.js
+++ b/projects/byzanlink/index.js
@@ -22,10 +22,11 @@ module.exports = {
 
       const [liq] = await getTokenAccountBalances([pool.poolLiquidityVault], { individual: true })
 
-      const backing = big(pool.reportedNav)
-        + big(pool.inflowSinceLastNavUpdate)
-        - big(pool.outflowSinceLastNavUpdate)
-        + big(liq.amount)
+        // Pool::exchange_rate backing: real_assets() plus repaid liquidity awaiting redemption
+        const backing = big(pool.reportedNav)
+          + big(pool.inflowSinceLastNavUpdate)
+          - big(pool.outflowSinceLastNavUpdate)
+          + big(liq.amount)
 
       const allocated = big(sharesAllocation) * backing / big(pool.totalSharesIssued)
 

--- a/projects/byzanlink/payfi-vault-idl.json
+++ b/projects/byzanlink/payfi-vault-idl.json
@@ -1,0 +1,154 @@
+{
+  "version": "0.1.0",
+  "name": "payfi_vault",
+  "instructions": [],
+  "accounts": [
+    {
+      "name": "Pool",
+      "docs": [
+        "A single investment target kvault (or any depositor program) can CPI into:",
+        "deposit -> lands in `pool_liquidity_vault`, receive `share_mint` shares",
+        "back priced off `real_assets()`. A separate, operator-signed `allocate`",
+        "call then pushes liquidity onward to `borrower_wallet` as needed. Mirrors",
+        "the old in-process `PayfiAllocatorState` almost field-for-field — this is",
+        "that same logic, extracted into its own program so kvault can treat it as",
+        "one of (potentially several) generic allocation targets instead of",
+        "hardcoding it."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "poolAdmin",
+            "type": "publicKey"
+          },
+          {
+            "name": "pendingAdmin",
+            "type": "publicKey"
+          },
+          {
+            "name": "operator",
+            "type": "publicKey"
+          },
+          {
+            "name": "borrowerWallet",
+            "type": "publicKey"
+          },
+          {
+            "name": "underlyingMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "shareMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "poolLiquidityVault",
+            "type": "publicKey"
+          },
+          {
+            "name": "poolAuthorityBump",
+            "type": "u64"
+          },
+          {
+            "name": "shareMintBump",
+            "type": "u64"
+          },
+          {
+            "name": "poolLiquidityVaultBump",
+            "type": "u64"
+          },
+          {
+            "name": "reportedNav",
+            "docs": [
+              "Last operator-reported NAV of capital allocated to `borrower_wallet`."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "totalSharesIssued",
+            "type": "u64"
+          },
+          {
+            "name": "inflowSinceLastNavUpdate",
+            "docs": [
+              "Combined with `reported_nav`, gives `real_assets()` between NAV updates."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "outflowSinceLastNavUpdate",
+            "type": "u64"
+          },
+          {
+            "name": "pendingDeallocationAmount",
+            "type": "u64"
+          },
+          {
+            "name": "pendingDeallocationRequestedAt",
+            "type": "u64"
+          },
+          {
+            "name": "allowedNavChangeUpper",
+            "type": "u64"
+          },
+          {
+            "name": "allowedNavChangeLower",
+            "type": "u64"
+          },
+          {
+            "name": "lastNavUpdateTimestamp",
+            "type": "u64"
+          },
+          {
+            "name": "minimumUpdateDelaySeconds",
+            "type": "u64"
+          },
+          {
+            "name": "isPaused",
+            "type": "u8"
+          },
+          {
+            "name": "skipBoundsCheck",
+            "type": "u8"
+          },
+          {
+            "name": "isInitialized",
+            "type": "u8"
+          },
+          {
+            "name": "paddingFlags",
+            "type": {
+              "array": ["u8", 5]
+            }
+          },
+          {
+            "name": "absoluteCap",
+            "docs": [
+              "Max total assets allocatable to the borrower wallet. 0 = uncapped."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "relativeCapBps",
+            "docs": [
+              "Max assets allocatable, as bps of the pool's current NAV. 0 = uncapped."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "creationTimestamp",
+            "type": "u64"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": ["u64", 16]
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "types": []
+}

--- a/registries/erc4626.js
+++ b/registries/erc4626.js
@@ -290,11 +290,6 @@ const configs = {
     base: ['0x00325d9da832b38179ed2f0dabd4062d93e325a7'],
     methodology: 'TVL is calculated as the total USDC held in the ArcisVault contract, including both reserve and deployed capital across yield strategies.'
   },
-  'byzanlink': {
-    hedera: ['0x6b8dfA6aa5f803a886Beb2492eF3307EC0Ee16FB'],
-    ethereum: ['0xA5cDEE01aA7A5E0620df5f27F26E552fdf7f5F20'],
-    methodology: 'Total value of assets deposited in the Byzanlink vaults, read on-chain and valued in USD.'
-  },
   'crystalclear': {
     methodology: "TVL is the sum of totalAssets() across all live CrystalClear ERC-4626 vaults on HyperEVM. Each vault holds USDC and trades perpetuals on Hyperliquid via a delegated agent.",
     hyperliquid: [


### PR DESCRIPTION
The new Solana vault is not ERC4626, so it needs a custom tvl function that the registry cannot express. Hedera and Ethereum vaults are carried over unchanged.

Solana TVL is the vault's idle USDC plus the underlying value of the PayFi pool shares held in its allocation, valued at the pool's live backing and denominated in USDC.

Byzanlink is already listed (#19946), so this is a chain addition rather than a new listing. The metadata below is included for reference — `Chain` now covers Hedera, Ethereum and Solana.

**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).

2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** Please send a mail to metadata@defillama.com
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes

---
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
Byzanlink RWA Markets

##### Twitter Link:
https://x.com/byzanlink

##### List of audit links if any:
1. https://sherlock-files.ams3.digitaloceanspaces.com/reports/2026.01.19%20-%20Final%20-%20Byzanlink%20Collaborative%20Audit%20Report%201768840093.pdf
2. https://sherlock-files.ams3.digitaloceanspaces.com/reports/2026.01.19%20-%20Final%20-%20Byzanlink%20Collaborative%20Audit%20Report%201768839590.pdf

##### Website Link:
https://markets.byzanlink.com

##### Logo (High resolution, will be shown with rounded borders):
https://markets.byzanlink.com/byzanlink-logo-without-text.svg

##### Current TVL:
~$1.26M (Hedera ~$1.16M, Solana ~$90k, Ethereum ~$2.1k)

##### Treasury Addresses (if the protocol has treasury)
NA

##### Chain:
Hedera, Ethereum, Solana

##### Coingecko ID:
byzanlink

##### Coinmarketcap ID:
NA

##### Short Description (to be shown on DefiLlama):
Byzanlink RWA Markets is a decentralised, non-custodial RWA yield platform where users access curated tokenised real-world yield strategies through standardised onchain vaults.

##### Token address and ticker if any:
BYZAN

##### Category (full list at https://defillama.com/categories) \*Please choose only one:
Private Credit

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
NA

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
NA

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
NA

##### forkedFrom (Does your project originate from another project):
Morpho (https://github.com/morpho-org/vault-v2) - EVM Vaults
kvault (https://github.com/Kamino-Finance/kvault) - Solana Vaults

##### methodology (what is being counted as tvl, how is tvl being calculated):
**EVM (Hedera, Ethereum):** TVL is the `totalAssets()` of each ERC-4626 vault. The fund manager updates the underlying asset values every two days based on the latest private credit returns. These NAV updates are performed through the adapter. The vault's TVL is calculated using the real-time asset value reported by the adapter, reflecting the latest NAV. The vault has a `MAX_RATE` of 20% configured for `accrueInterest`, which serves as the upper bound on the interest accrual rate between NAV updates. Additionally, a 10% performance fee is applied during the `accrueInterest` process, ensuring that the fund manager receives their share of generated returns before the updated asset value is reflected in the vault.

```math
\text{totalAssets} =
\min\left(
\text{vaultBalance} + \sum \text{adapter.realAssets()},
\;
\text{lastTotalAssets} \times \left(1 + \text{maxRate} \times \Delta t\right)
\right)
```

**Solana:** the vault is not ERC-4626, so TVL is read directly from program state rather than from token balances. The adapter decodes the vault state account `96k5AKfdHMW6URrn3Qwn4wp3gN4S2GupK27dPxtt3vfw` and takes its idle underlying balance (`token_available`), then values the PayFi pool shares held in its allocation slot. The pool address `74PNQHRwEtyVaWjNuR2byghmwvrrJBMnEUZKX17hnXW6` is read from that allocation rather than hardcoded, so the adapter follows any reallocation.

Pool shares are valued at the pool's live backing, which is the last operator-reported NAV adjusted for flows since that report, plus any repaid liquidity sitting in the pool awaiting redemption:

```math
\text{backing} = \text{reported\_nav} + \text{inflow\_since\_last\_nav\_update} - \text{outflow\_since\_last\_nav\_update} + \text{pool\_liquidity\_vault}
```

```math
\text{totalAssets} = \text{token\_available} + \frac{\text{shares\_allocation} \times \text{backing}}{\text{total\_shares\_issued}}
```

This mirrors the pool program's own `Pool::exchange_rate()` and `shares_to_assets_floor()`, so the adapter reports the same value the program itself would pay out. TVL is denominated in the vault's underlying USDC mint, so the pool share token does not need to be priced. Trimmed Anchor IDLs for the vault and pool programs are included in the adapter folder.

##### Github org/user (Optional, if your code is open source, we can track activity):
NA

##### Does this project have a referral program?
NA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added TVL tracking for Byzanlink vaults across Hedera, Ethereum, and Solana.
  - Added valuation support for vault assets, liquidity positions, allocations, and available balances.
  - Added vault and pool state definitions for more complete accounting and allocation data.

- **Refactor**
  - Consolidated Byzanlink coverage within its dedicated integration.
  - Removed the previous standalone Byzanlink ERC-4626 configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->