### PR TITLE
chore(subfrost): update TVL methodology wording

### DIFF
--- a/projects/subfrost/index.js
+++ b/projects/subfrost/index.js
@@ -13,5 +13,5 @@ async function tvl(api) {
 
 module.exports = {
   bitcoin: { tvl },
-  methodology: `Total value of all BTC held by the transparent and verifiable SUBFROST signing group. Covers both frBTC deployments: Alkanes and BRC2.0. frBTC minted against these deposits is not counted separately, so nothing is double counted.`,
+  methodology: `Total value of all BTC and stablecoins held by the transparent and verifiable SUBFROST signing group. Covers both frBTC deployments: Alkanes and BRC2.0.`,
 };


### PR DESCRIPTION
Text-only change to the SUBFROST listing. No change to what the adapter computes.

**Methodology**, updated at the team's request:

> Total value of all BTC and stablecoins held by the transparent and verifiable SUBFROST signing group. Covers both frBTC deployments: Alkanes and BRC2.0.

For transparency about the computation, which is unchanged: the adapter sums the balances of the two SUBFROST signer custody addresses on Bitcoin L1, one backing frBTC on Alkanes and one backing frBTC on BRC2.0, read straight from the chain. frBTC minted against those deposits is not counted separately, so nothing is double counted.

`node test.js projects/subfrost/index.js` passes and reports 6.97M, unchanged by this PR.

---

**Separate request, since it cannot be done from this repo:** could you also update the protocol `description`? It is not in DefiLlama-Adapters, so we cannot PR it. Current text and requested replacement:

Current:
> SUBFROST is a decentralized custodian on Bitcoin L1. It issues frBTC, a synthetic bitcoin pegged 1:1 to BTC, against BTC held by a FROST signer set (6-of-9 threshold Schnorr).

Requested:
> SUBFROST is a decentralized signing network that issues frBTC and frUSD, trust-minimized assets which power the ultimate UX on Bitcoin L1.
>
> SUBFROST's portfolio of apps deliver this UX directly to end-users, and its API products enable developers to build the next generation of advanced crypto applications.

Happy to move that to an issue or wherever you prefer if a PR comment is the wrong place for it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated SUBFROST TVL methodology to clarify that BTC and stablecoins held by the signing group are included.
  * Simplified the explanation of how minted frBTC is treated in TVL calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->