### PR TITLE
Add Openlaunch (Stable)

### DIFF
--- a/projects/openlaunch/index.js
+++ b/projects/openlaunch/index.js
@@ -1,0 +1,53 @@
+const { sumTokens2 } = require('../helper/unwrapLPs')
+const { uniV3Export } = require('../helper/uniswapV3')
+
+const STABLE_MAINNET_UNISWAP_V3_FACTORY = '0xC837ab0f8919Fb47f17b7cD302d88895032e5908'
+const STABLE_MAINNET_POOL_FACTORY_V2 = '0x701F02d3133E14a9dfd94C399586aC22A05bCa25'
+
+// Both Openlaunch's own permissionless pool creation (PoolFactoryV3, the
+// general "create a pool" flow) and every token launch's automatic
+// single-sided locked position (LaunchFactory -> the real
+// NonfungiblePositionManager -> the real UniswapV3Factory directly, bypassing
+// PoolFactoryV3 entirely) ultimately create pools through this same real,
+// unmodified UniswapV3Factory -- so pointing uniV3Export at it alone captures
+// every V3 pool's locked value regardless of which path created it or who
+// holds the position (a plain LP or a launch's permanent-lock vault), since
+// in Uniswap v3 the underlying tokens sit in the pool contract itself, not
+// with whoever holds the position NFT.
+const v3 = uniV3Export({
+  stable: {
+    factory: STABLE_MAINNET_UNISWAP_V3_FACTORY,
+    fromBlock: 34196085,
+  },
+})
+
+// Openlaunch's own V2 factory (PoolFactoryV2) is functionally a Uniswap v2
+// fork but with a non-standard enumeration interface (a parameterless
+// getAllPools() returning the whole pool array at once, not the classic
+// allPairsLength()/allPairs(uint256) indexed-getter pair this repo's
+// standard getUniTVL helper expects) -- summed manually here instead, using
+// the same sumTokens2 primitive uniV3Export itself relies on.
+async function v2Tvl(api) {
+  const pools = await api.call({
+    abi: 'function getAllPools() view returns (address[])',
+    target: STABLE_MAINNET_POOL_FACTORY_V2,
+  })
+  if (!pools.length) return
+  const token0s = await api.multiCall({ abi: 'address:token0', calls: pools })
+  const token1s = await api.multiCall({ abi: 'address:token1', calls: pools })
+  const ownerTokens = pools.map((pool, i) => [[token0s[i], token1s[i]], pool])
+  return sumTokens2({ api, ownerTokens })
+}
+
+module.exports = {
+  methodology: "Sums token balances held by every pool under Openlaunch's real UniswapV3Factory on Stable "
+    + '(covers both permissionlessly-created pools and every token launch\'s permanently-locked single-sided '
+    + 'position, since in Uniswap v3 the underlying tokens live in the pool contract itself) plus every pair '
+    + "held by Openlaunch's own V2 factory.",
+  stable: {
+    tvl: async (api) => {
+      await v3.stable.tvl(api)
+      await v2Tvl(api)
+    },
+  },
+}


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

- [x] Allow edits by maintainers is enabled.

---

Adds a TVL adapter for Openlaunch, a permissionless DEX (real forked Uniswap v2 + v3) and safety-first token launchpad, live on Stable Network mainnet (chain id 988).

Sums balances held by every pool under Openlaunch's real `UniswapV3Factory` (`0xC837ab0f8919Fb47f17b7cD302d88895032e5908`, via `uniV3Export` scanning `PoolCreated` logs from deploy block `34196085`) plus every pair held by Openlaunch's own V2 factory (`0x701F02d3133E14a9dfd94C399586aC22A05bCa25`, summed manually since it has a non-standard `getAllPools()` enumeration interface rather than the classic `allPairsLength`/`allPairs(uint256)` shape). Every token launch's permanently-locked liquidity position is created directly against the same real `UniswapV3Factory` (bypassing our own pool-creation wrapper), so it's automatically covered without any special-casing.

Tested locally via `node test.js projects/openlaunch/index.js` — passes, correctly reports the real (currently small, ~$1) TVL from the one live pool.

## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
Openlaunch

##### Twitter Link:
https://x.com/OpenLaunchFI

##### List of audit links if any:
None — not audited. Disclosed openly, not gated on an audit happening later.

##### Website Link:
https://openlaunchfi.xyz

##### Logo (High resolution, will be shown with rounded borders):
https://www.openlaunchfi.xyz/icon.svg

##### Current TVL:
~$1 (brand new deployment, deployed 2026-08-03)

##### Treasury Addresses (if the protocol has treasury)
Stable mainnet: `0x1870F0B2521773c3621BCa5244E950900c38cc2C` (real Safe multisig, 2-of-3)

##### Chain:
Stable

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description (to be shown on DefiLlama):
Permissionless DEX + safety-first launchpad. No hidden mints, no admin backdoors — liquidity locked forever, verifiably, not by promise.

##### Token address and ticker if any:
None — Openlaunch itself has no token.

##### Category (full list at https://defillama.com/categories) \*Please choose only one:
Dexs

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
None used.

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
N/A

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
N/A

##### forkedFrom (Does your project originate from another project):
Uniswap v2 and v3 (vendored source for the DEX/AMM engine; the launchpad and safety model are original).

##### methodology (what is being counted as tvl, how is tvl being calculated):
Token balances held directly by every AMM pool (V2 pairs and V3 pools) created through Openlaunch's contracts on Stable mainnet — this includes both permissionlessly-created general pools and every token launch's permanently-locked liquidity position, since in both the V2 and V3 model the underlying tokens sit in the pool contract itself, not with whoever holds the LP/position.

##### Github org/user (Optional, if your code is open source, we can track activity):
Source is currently in a private repository; happy to open it up on request.

##### Does this project have a referral program?
No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Openlaunch TVL tracking on Stable.
  * Coverage now includes liquidity from both Uniswap V3 and Openlaunch V2 pools.
  * Added methodology details describing the tracked pool coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->