### PR TITLE
keellabs: add factories for two new vault implementations

### DIFF
--- a/projects/keellabs/index.js
+++ b/projects/keellabs/index.js
@@ -10,6 +10,8 @@ const config = {
     factories: [
       '0xBfdDA6efE302fC8743Deb9cD7DB4A24Ffcb9E836',
       '0x3031B1661Bb584bBA566D74Ba0c86Ab6f525AF07',   // VaultNext
+      '0xAd7f3B6C7D16e19A3284BE0cE14578296feA471A',   // VaultRecover
+      '0xF41AA2bb58952F490E2DFe437d50489Ac3c6A4bC',   // VaultClaim
     ],
     npm: '0xC36442b4a4522E871399CD717aBDD847Ab11FE88',
   },
@@ -17,6 +19,8 @@ const config = {
     factories: [
       '0x7CfCEd5dFeF1884b057553B2b60F5d387005Cd3d',
       '0xAc17cF95525796F81587c47Bb78d4ce7a187e5C7',   // VaultNext (costBasis1 sincronizado) — desplegada 2026-08-03
+      '0x62fC42AA2Aa1F8743d97daBeD925E70E04682a1c',   // VaultRecover
+      '0x3031B1661Bb584bBA566D74Ba0c86Ab6f525AF07',   // VaultClaim
     ],
     npm: '0x73991a25C818Bf1f1128dEAaB1492D45638DE0D3',
   },
@@ -25,6 +29,8 @@ const config = {
       '0x9d1B8796FB080e07aa26F26765f12e2012DD0d26',
       '0x52dc92C7e3FdbD4fff7892dFc9DC7bc1d7a01ecf',
       '0xF4263810321f03C01abA727De0210c4BFB13fdB8',   // VaultNext
+      '0x811e2843c2a55b70D9C867988D69E624c35dAF4C',   // VaultRecover
+      '0x609B9A1c089cb29a38bf19901a39259493997AB4',   // VaultClaim
     ],
     // PRJX's position manager, not the chain's default Uniswap deployment.
     npm: '0xeaD19AE861c29bBb2101E834922B2FEee69B9091',


### PR DESCRIPTION
Follow-up to #20338, which added the KeelLabs adapter.

Two new vault implementations have been deployed since then. `VaultFactory.implementation` is
`immutable`, so every implementation ships with its own factory — this adds the six new ones and
keeps the previous factories, because the vaults they already created are still live and must keep
counting.

| chain | factory | implementation |
|---|---|---|
| arbitrum | `0xAd7f3B6C7D16e19A3284BE0cE14578296feA471A` | VaultRecover |
| arbitrum | `0xF41AA2bb58952F490E2DFe437d50489Ac3c6A4bC` | VaultClaim |
| robinhood | `0x62fC42AA2Aa1F8743d97daBeD925E70E04682a1c` | VaultRecover |
| robinhood | `0x3031B1661Bb584bBA566D74Ba0c86Ab6f525AF07` | VaultClaim |
| hyperliquid | `0x811e2843c2a55b70D9C867988D69E624c35dAF4C` | VaultRecover |
| hyperliquid | `0x609B9A1c089cb29a38bf19901a39259493997AB4` | VaultClaim |

The deployer reuses the same nonce sequence across chains, so a few of these addresses collide with
factories that belong to a *different* chain in this same config. Each one was checked on its own
chain: all thirteen have code, answer `vaultsCount()` and return the expected `implementation()`.

No logic changed — only the `factories` arrays. TVL is still read entirely on-chain through
`api.fetchList` + the `uniV3` helper.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added VaultRecover and VaultClaim factory addresses for Arbitrum, Robinhood, and Hyperliquid configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->