### PR TITLE
Add Polygon TVL for QuickSwap V4 (Algebra Integral)

### DIFF
--- a/projects/quickswap-v4/index.js
+++ b/projects/quickswap-v4/index.js
@@ -23,6 +23,11 @@ module.exports = uniV3Export({
     isAlgebra: true,
     fromBlock: 40341077,
   },
+  polygon: {
+    factory: '0x134c1dBE4860A9cAaf89002574fFe814772D9904',
+    isAlgebra: true,
+    fromBlock: 85606804,
+  },
 /*   mantra: {
     factory: '0x10253594A832f967994b44f33411940533302ACb',
     isAlgebra: true,


### PR DESCRIPTION
**NOTE**

Adds Polygon to the existing QuickSwap V4 adapter.

- **Factory:** `0x134c1dBE4860A9cAaf89002574fFe814772D9904`
- **Chain:** polygon
- **fromBlock:** 85606804 (factory deployment)
- **Protocol type:** Algebra Integral, same as the other chains already in this adapter

Volume and fees for this deployment are already tracked in dimension-adapters (DefiLlama/dimension-adapters#8556), this adds the matching TVL so the chain is complete on the dashboard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Polygon network support to the QuickSwap V4 integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->