### PR TITLE
vaquita-protocol: add Stellar TVL

### DIFF
--- a/projects/vaquita-protocol/index.js
+++ b/projects/vaquita-protocol/index.js
@@ -72,6 +72,9 @@ async function stellarTvl(api) {
 }
 
 module.exports = {
+  // Soroban reads go through simulateTransaction, which only sees the current
+  // ledger, so historical runs would report today's Stellar balances.
+  timetravel: false,
   base: { tvl },
   stellar: { tvl: stellarTvl },
   methodology: 'On Base, TVL is the aToken balance held by each MSV (MultiStrategyVault) contract for each supported asset. On Stellar, TVL is the total assets managed by the Vaquita-deployed DeFindex vault (fetch_total_managed_funds, covering both idle and strategy-invested amounts), plus the idle deposit token balance held by the Vaquita pool contract to back the fixed-yield reward pool.',

--- a/projects/vaquita-protocol/index.js
+++ b/projects/vaquita-protocol/index.js
@@ -1,11 +1,12 @@
 const ADDRESSES = require('../helper/coreAssets.json')
 const { sumTokens2 } = require('../helper/unwrapLPs');
+const { callSoroban, getContractInstanceStorage } = require('../helper/chain/stellar');
 
 const abi = {
   assets: 'function assets(address) view returns (address assetAddress, address msvAddress, uint8 status, uint256 protocolFees)',
 }
 
-const VAQUITA_CONTRACT = '0x2400B4E44878d25597da16659705F48927cadef1';
+const VAQUITA_POOL_BASE = '0x2400B4E44878d25597da16659705F48927cadef1';
 
 const assets = {
   USDC: {
@@ -28,7 +29,7 @@ async function tvl(api) {
   const assetData = await api.multiCall({
     abi: abi.assets,
     calls: assetEntries.map(([_, asset]) => ({
-      target: VAQUITA_CONTRACT,
+      target: VAQUITA_POOL_BASE,
       params: [asset.address]
     })),
     permitFailure: true
@@ -48,7 +49,30 @@ async function tvl(api) {
   return sumTokens2({ api, owners, tokens });
 }
 
+// Vaquita fixed-yield pool on Stellar mainnet. User principal is routed into a
+// Vaquita-deployed and Vaquita-managed DeFindex vault; the reward pool that
+// backs the fixed yield sits in the pool contract as idle deposit token.
+const VAQUITA_POOL_STELLAR = 'CDTTAZ3NK4MMDHK2C3I6LRDT4YADJZ2QXINKLKQNZUVX7OTUKQNCQGC4';
+
+async function stellarTvl(api) {
+  // Read live config from instance storage so admin updates to the deposit
+  // token / vault are picked up without an adapter change.
+  const { BlendToken: token, DeFindexVaultAddress: vault } = await getContractInstanceStorage(VAQUITA_POOL_STELLAR);
+
+  // Reward pool held directly by the pool contract, outside the vault.
+  const idle = await callSoroban(token, 'balance', [VAQUITA_POOL_STELLAR]);
+  api.add(token, idle);
+
+  // The vault is a Vaquita product, so all of its deposits count, not just the
+  // share of it held by the pool. total_amount covers idle + strategy-invested.
+  const funds = await callSoroban(vault, 'fetch_total_managed_funds');
+  for (const { asset, total_amount } of funds) {
+    if (asset && total_amount != null) api.add(asset, total_amount.toString());
+  }
+}
+
 module.exports = {
-  base: { tvl }, 
-  methodology: 'TVL is calculated by checking the aToken balance held by each MSV (MultiStrategyVault) contract for each supported asset in Vaquita Protocol',
+  base: { tvl },
+  stellar: { tvl: stellarTvl },
+  methodology: 'On Base, TVL is the aToken balance held by each MSV (MultiStrategyVault) contract for each supported asset. On Stellar, TVL is the total assets managed by the Vaquita-deployed DeFindex vault (fetch_total_managed_funds, covering both idle and strategy-invested amounts), plus the idle deposit token balance held by the Vaquita pool contract to back the fixed-yield reward pool.',
 };


### PR DESCRIPTION
Adds the **Stellar** chain to the existing `vaquita-protocol` adapter (previously Base-only). This is not a new listing, so the metadata section of the template does not apply.

##### methodology (what is being counted as tvl, how is tvl being calculated):

All values are read on-chain via Soroban RPC simulation using the repo's existing `helper/chain/stellar.js` helpers. No new dependencies, no API-sourced TVL.

Stellar TVL is the sum of two non-overlapping buckets:

1. **Vaquita DeFindex vault** `CB2U6PWS225PXWOAYGFIAWXYJBQHBWBQHEPC6NU2M257DKBRLBGMUPUZ` — `fetch_total_managed_funds()`, which covers both idle and strategy-invested amounts. This vault was deployed and is managed by Vaquita; it is **not** in DeFindex's vault discovery list (`api.defindex.io/vault/discover?network=mainnet`, 14 vaults), so it is not counted by the `defindex` adapter.
2. **Vaquita pool contract** `CDTTAZ3NK4MMDHK2C3I6LRDT4YADJZ2QXINKLKQNZUVX7OTUKQNCQGC4` — idle deposit-token balance held directly by the pool, which backs the fixed-yield reward pool. This sits outside the vault, so there is no overlap with bucket 1.

The deposit token and vault address are resolved at runtime from the pool's instance storage rather than hardcoded, so admin updates via `set_blend_token` / `set_defindex_vault` don't require an adapter change.

##### Double-counting disclosure

Vaquita routes deposits into Blend. The vault's strategy `CDB2WMKQQNVZMEBY7Q7GZ5C7E7IAFSNMZ7GGVD6WKTCEWK7XOIAVZSAP` deposits into Blend pool `CAJJZSGMMM3PD7N33TAPHGBUGTB43OC73HVIK2L2G6BNGGGYOSSYBXBD`, which is in the Blend V2 backstop reward zone and therefore also counted by `blend-pools-v2`.

`vaquita-protocol` is already categorized as **Yield Aggregator** (same as `defindex`, which occupies the equivalent position in the stack), so this should already be handled. Flagging it explicitly rather than leaving it for review.

##### Validation

```
$ node test.js projects/vaquita-protocol/index.js

--- stellar ---
USDC                      97.15
Total: 97.15

--- base ---
aBasUSDC                 250.75
aBasWETH                   1.51
Total: 252.27

------ TVL ------
base                     252.00
stellar                   97.00
total                    349.43
```

Stellar figure reconciles against on-chain state: 67.16 USDC (vault `total_amount`) + 30.00 USDC (pool reward pool) = 97.16 USDC. Both tokens price correctly; no unknown-token warnings. `npx eslint -c eslint.config.js projects/vaquita-protocol/index.js` passes.

Base behaviour is unchanged by this PR and still matches the live listing (~$252).

##### Notes

- No npm dependencies added; `package.json` and lockfiles untouched.
- Existing Base logic is untouched apart from renaming its pool address constant (`VAQUITA_CONTRACT` → `VAQUITA_POOL_BASE`) for symmetry with the new `VAQUITA_POOL_STELLAR`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for the Vaquita pool on the Stellar network.
  * Expanded Stellar TVL coverage to include idle deposit-token balances and assets managed through its DeFindex vault.
  * Added network-specific methodology details for Base and Stellar calculations.

* **Bug Fixes**
  * Updated Base TVL tracking to use the correct pool configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->