### PR TITLE
Add Delpho Adapter

### DIFF
--- a/projects/delpho/index.js
+++ b/projects/delpho/index.js
@@ -1,23 +1,29 @@
-const VAULT = '0x79A86A652B6DeC1E7F5727C9aA1C02E1C8Af6E78';
-const COLLATERALS = [
-  '0xb88339CB7199b77E23DB6E890353E22632Ba630f',
-  '0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb',
-  '0x5555555555555555555555555555555555555555',
-  '0xfD739d4e423301CE9385c1fb8850539D657C296D',
-];
+
+const CONFIG_PROVIDER = '0xeC884577055e1f32f2579CAB9f348F4918Cd757f';
 
 async function tvl(api) {
+  const vault = await api.call({
+    abi: 'address:delphoVault',
+    target: CONFIG_PROVIDER,
+  });
+
+  const tokens = await api.call({
+    abi: 'address[]:getAllSupportedTokens',
+    target: CONFIG_PROVIDER,
+  });
+
   const bals = await api.multiCall({
     abi: 'function totalCollateral(address token) view returns (uint256)',
-    calls: COLLATERALS.map(token => ({ target: VAULT, params: [token] })),
+    calls: tokens.map(token => ({ target: vault, params: [token] })),
   });
-  api.addTokens(COLLATERALS, bals);
+
+  api.addTokens(tokens, bals);
 }
 
 module.exports = {
   methodology:
-    'TVL is user collateral (USDC, USDT, WHYPE, kHYPE) deposited into Delpho, read via the vault\'s totalCollateral view which aggregates buffer, allocated, and executor-deployed amounts across HyperLend and Morpho. USDV (minted debt) and sUSDV (staked USDV) are excluded to avoid double-counting.',
-  start: 1783010460, 
+    'TVL is user collateral deposited into Delpho, read via the vault\'s totalCollateral view which aggregates buffer, allocated, and executor-deployed amounts. Supported collateral tokens are enumerated from the Delpho config provider (getAllSupportedTokens). USDV (minted debt) and sUSDV (staked USDV) are excluded to avoid double-counting.',
+  start: 1783010460,
   timetravel: true,
   hyperliquid: { tvl },
 };

--- a/projects/delpho/index.js
+++ b/projects/delpho/index.js
@@ -23,7 +23,7 @@ async function tvl(api) {
 module.exports = {
   methodology:
     'TVL is user collateral deposited into Delpho, read via the vault\'s totalCollateral view which aggregates buffer, allocated, and executor-deployed amounts. Supported collateral tokens are enumerated from the Delpho config provider (getAllSupportedTokens). USDV (minted debt) and sUSDV (staked USDV) are excluded to avoid double-counting.',
-  start: 1783010460,
+  start: 1783364520,
   timetravel: true,
   hyperliquid: { tvl },
 };

--- a/projects/delpho/index.js
+++ b/projects/delpho/index.js
@@ -1,5 +1,3 @@
-const { timetravel } = require("../deliswap");
-
 const VAULT = '0x79A86A652B6DeC1E7F5727C9aA1C02E1C8Af6E78';
 const COLLATERALS = [
   '0xb88339CB7199b77E23DB6E890353E22632Ba630f',
@@ -19,7 +17,7 @@ async function tvl(api) {
 module.exports = {
   methodology:
     'TVL is user collateral (USDC, USDT, WHYPE, kHYPE) deposited into Delpho, read via the vault\'s totalCollateral view which aggregates buffer, allocated, and executor-deployed amounts across HyperLend and Morpho. USDV (minted debt) and sUSDV (staked USDV) are excluded to avoid double-counting.',
-  start: 1783010460,
+  start: 1783010460, 
   timetravel: true,
   hyperliquid: { tvl },
 };

--- a/projects/delpho/index.js
+++ b/projects/delpho/index.js
@@ -1,3 +1,5 @@
+const { timetravel } = require("../deliswap");
+
 const VAULT = '0x79A86A652B6DeC1E7F5727C9aA1C02E1C8Af6E78';
 const COLLATERALS = [
   '0xb88339CB7199b77E23DB6E890353E22632Ba630f',
@@ -18,5 +20,6 @@ module.exports = {
   methodology:
     'TVL is user collateral (USDC, USDT, WHYPE, kHYPE) deposited into Delpho, read via the vault\'s totalCollateral view which aggregates buffer, allocated, and executor-deployed amounts across HyperLend and Morpho. USDV (minted debt) and sUSDV (staked USDV) are excluded to avoid double-counting.',
   start: 1783010460,
+  timetravel: true,
   hyperliquid: { tvl },
 };

--- a/projects/delpho/index.js
+++ b/projects/delpho/index.js
@@ -1,0 +1,22 @@
+const VAULT = '0x79A86A652B6DeC1E7F5727C9aA1C02E1C8Af6E78';
+const COLLATERALS = [
+  '0xb88339CB7199b77E23DB6E890353E22632Ba630f',
+  '0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb',
+  '0x5555555555555555555555555555555555555555',
+  '0xfD739d4e423301CE9385c1fb8850539D657C296D',
+];
+
+async function tvl(api) {
+  const bals = await api.multiCall({
+    abi: 'function totalCollateral(address token) view returns (uint256)',
+    calls: COLLATERALS.map(token => ({ target: VAULT, params: [token] })),
+  });
+  api.addTokens(COLLATERALS, bals);
+}
+
+module.exports = {
+  methodology:
+    'TVL is user collateral (USDC, USDT, WHYPE, kHYPE) deposited into Delpho, read via the vault\'s totalCollateral view which aggregates buffer, allocated, and executor-deployed amounts across HyperLend and Morpho. USDV (minted debt) and sUSDV (staked USDV) are excluded to avoid double-counting.',
+  start: 1783010460,
+  hyperliquid: { tvl },
+};


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).

2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** Please send a mail to metadata@defillama.com
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes

---
## (Needs to be filled only for new listings)

1. Name (to be shown on DefiLlama): Delpho

2. Twitter Link: https://x.com/delpho_labs

3. List of audit links if any: https://sherlock-files.ams3.digitaloceanspaces.com/reports/2026.07.01%20-%20Final%20-%20Delpho%20Collaborative%20Audit%20Report%201782919020.pdf

4. Website Link: https://www.delpho.xyz

5. Logo (High resolution, will be shown with rounded borders): https://app.delpho.xyz/brand-internal/Logomark-Light.svg

6. Current TVL: 213.85k USD

7. Treasury Addresses (if the protocol has treasury): 0x277CD2bfa7a865859d34EE44E0aBAaC72168b1C3

8. Chain: Hyperliquid

9. Coingecko ID: Still applying
10. Coinmarketcap ID: Still applying

11. Short Description (to be shown on DefiLlama): Delpho is a CDP protocol on HyperEVM. Users deposit collateral to mint USDV, an overcollateralized stablecoin, at 0% interest. The protocol runs delta-neutral positions on Hyperliquid's perpetual markets and streams the resulting funding yield to sUSDV stakers.

12. Token address and ticker if any: 0x8c6EB3C8d1FdDC752684274Fb4A3EB98DBE9cd26

13. Category: CDP

14. Oracle Provider(s): Chainlink

15. Implementation Details (oracle integration): https://delpho.gitbook.io/delpho-docs/how-delpho-works/oracles
16. Documentation/Proof (oracle usage): https://delpho.gitbook.io/delpho-docs/how-delpho-works/oracles

17. forkedFrom:

18. methodology: TVL is user collateral deposited into Delpho, read via the vault's totalCollateral view which aggregates buffer, allocated, and executor-deployed amounts. Supported collateral tokens are enumerated from the Delpho config provider (getAllSupportedTokens). USDV (minted debt) and sUSDV (staked USDV) are excluded to avoid double-counting.

19. Github org/user (optional):
20. Does this project have a referral program?: YES

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for Delpho.
  * Added support for reporting collateral balances across supported vault tokens.
  * Included methodology, start date, and historical data availability details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->