### PR TITLE
fix(hatom-tao-bridge): switch to mint-side MultiversX supply accounting

### DIFF
--- a/projects/hatom-tao-bridge/index.js
+++ b/projects/hatom-tao-bridge/index.js
@@ -2,8 +2,12 @@ const { getTokenData } = require('../helper/chain/elrond')
 
 async function tvl(api) {
   const data = await getTokenData('WTAO-4f5363')
-  // circulatingSupply is already in human-readable units
-  const supply = Number(data.circulatingSupply || 0)
+  const supply = Number(data.circulatingSupply)
+
+  if (!Number.isFinite(supply) || supply < 0) {
+    throw new Error(`Invalid WTAO-4f5363 circulatingSupply: ${data.circulatingSupply}`)
+  }
+
   api.addCGToken('bittensor', supply)
 }
 

--- a/projects/hatom-tao-bridge/index.js
+++ b/projects/hatom-tao-bridge/index.js
@@ -2,10 +2,21 @@ const { getTokenData } = require('../helper/chain/elrond')
 
 async function tvl(api) {
   const data = await getTokenData('WTAO-4f5363')
-  const supply = Number(data.circulatingSupply)
+  const rawSupply = data?.circulatingSupply
+
+  if (
+    rawSupply === null ||
+    rawSupply === undefined ||
+    (typeof rawSupply !== 'number' && typeof rawSupply !== 'string') ||
+    (typeof rawSupply === 'string' && rawSupply.trim() === '')
+  ) {
+    throw new Error(`Invalid WTAO-4f5363 circulatingSupply: ${rawSupply}`)
+  }
+
+  const supply = Number(rawSupply)
 
   if (!Number.isFinite(supply) || supply < 0) {
-    throw new Error(`Invalid WTAO-4f5363 circulatingSupply: ${data.circulatingSupply}`)
+    throw new Error(`Invalid WTAO-4f5363 circulatingSupply: ${rawSupply}`)
   }
 
   api.addCGToken('bittensor', supply)

--- a/projects/hatom-tao-bridge/index.js
+++ b/projects/hatom-tao-bridge/index.js
@@ -1,6 +1,14 @@
-const { getExports } = require('../helper/heroku-api')
+const { getTokenData } = require('../helper/chain/elrond')
+
+async function tvl(api) {
+  const data = await getTokenData('WTAO-4f5363')
+  // circulatingSupply is already in human-readable units
+  const supply = Number(data.circulatingSupply || 0)
+  api.addCGToken('bittensor', supply)
+}
 
 module.exports = {
-  methodology: 'Value of tao locked in the bridge contract',
-  ...getExports("hatom-tao-bridge", ['bittensor']),
+  timetravel: false,
+  methodology: 'TVL is calculated as the circulating supply of Wrapped TAO (WTAO-4f5363) on MultiversX (minted minus burnt), which represents the exact amount of TAO locked on the Bittensor side of the bridge.',
+  bittensor: { tvl },
 }


### PR DESCRIPTION
Fixes #19016

The previous adapter relied on an outdated Heroku API proxy tracking Bittensor side custody wallets which recently broke, causing TVL to drop to near-zero.

This PR switches the TVL logic to use robust mint side accounting. We now directly query the circulating supply of the Wrapped TAO token (`WTAO-4f5363`) on MultiversX via the existing `elrond.js` helper. This cleanly ensures we only count user bridged value without having to worry about rotating Bittensor multisigs or staked positions.

- Tested locally, returns a healthy & realistic TVL (~$1.13M at current time)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added TVL tracking for the Hatom TAO Bridge using validated WTAO circulating supply from MultiversX.
  - Included circulating supply in Bittensor CG token amounts for more complete reporting.

- **Updates**
  - Updated the integration’s TVL methodology to reflect the new data source.
  - Disabled time-travel support to ensure historical values are not inferred.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->