### PR TITLE
add orvex (Robinhood Chain DEX)

### DIFF
--- a/projects/orvex/index.js
+++ b/projects/orvex/index.js
@@ -38,7 +38,6 @@ async function v4Tvl(api) {
 
 module.exports = {
   methodology: 'TVL is the value of tokens locked in Orvex v2 liquidity pairs (Solidly-fork PairFactoryUpgradeable) plus tokens held in the Orvex v4 concentrated liquidity Vault.',
-  timetravel: false,
   robinhood: {
     tvl: sdk.util.sumChainTvls([v2Tvl, v4Tvl]),
   },

--- a/projects/orvex/index.js
+++ b/projects/orvex/index.js
@@ -1,0 +1,45 @@
+const sdk = require('@defillama/sdk')
+const { getUniTVL } = require('../helper/unknownTokens')
+const { getLogs2 } = require('../helper/cache/getLogs')
+const { sumTokens2 } = require('../helper/unwrapLPs')
+
+// Orvex is deployed on Robinhood Chain (Arbitrum Orbit L2, chainId 4663).
+// Contracts source: https://docs.orvex.fi
+const V2_FACTORY = '0x5c98b2d892b37c9a1D3b69472bdDc172A64CdC09' // PairFactoryUpgradeable (Solidly v2)
+const V4_CL_POOL_MANAGER = '0xd01C774d4A66408326Bc65728Ac5Ae5aAf004032'
+const V4_VAULT = '0xFe7E25dE55e5cBbEcCcb661F3679F873f72B9b0D'
+const V4_FROM_BLOCK = 3074079
+
+// v2 pairs (Solidly-fork, stable + volatile curves)
+const v2Tvl = getUniTVL({
+  factory: V2_FACTORY,
+  useDefaultCoreAssets: true,
+  hasStablePools: true,
+})
+
+// v4 CL pools: pool token pairs are enumerated from CLPoolManager Initialize
+// events; all funds are held in the singleton Vault contract.
+async function v4Tvl(api) {
+  const logs = await getLogs2({
+    api,
+    target: V4_CL_POOL_MANAGER,
+    fromBlock: V4_FROM_BLOCK,
+    eventAbi: 'event Initialize(bytes32 indexed id, address indexed currency0, address indexed currency1, address hooks, uint24 fee, bytes32 parameters, uint160 sqrtPriceX96, int24 tick)',
+  })
+
+  const tokens = new Set()
+  logs.forEach(log => {
+    tokens.add(String(log.currency0).toLowerCase())
+    tokens.add(String(log.currency1).toLowerCase())
+  })
+
+  return sumTokens2({ api, tokens: Array.from(tokens), owner: V4_VAULT, permitFailure: true })
+}
+
+module.exports = {
+  methodology: 'TVL is the value of tokens locked in Orvex v2 liquidity pairs (Solidly-fork PairFactoryUpgradeable) plus tokens held in the Orvex v4 concentrated liquidity Vault.',
+  timetravel: false,
+  robinhood: {
+    tvl: sdk.util.sumChainTvls([v2Tvl, v4Tvl]),
+  },
+}

--- a/projects/orvex/index.js
+++ b/projects/orvex/index.js
@@ -33,7 +33,7 @@ async function v4Tvl(api) {
     tokens.add(String(log.currency1).toLowerCase())
   })
 
-  return sumTokens2({ api, tokens: Array.from(tokens), owner: V4_VAULT, permitFailure: true })
+  return sumTokens2({ api, tokens: Array.from(tokens), owner: V4_VAULT })
 }
 
 module.exports = {


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
Orvex

##### Twitter Link:
https://x.com/OrvexFi

##### List of audit links if any:
https://docs.orvex.fi/security-information/audits

##### Website Link:
https://orvex.fi/

##### Logo (High resolution, will be shown with rounded borders):
https://raw.githubusercontent.com/Lynexfi/lynex-lists/main/tokens/assets/orvex-logo-512.png

##### Current TVL:
~$132k (Robinhood Chain)

##### Treasury Addresses (if the protocol has treasury):
0xDb73ba19F072D0Fbc865781Ba468A9F8B77aD2C4

##### Chain:
Robinhood Chain

##### Coingecko ID (leave empty if not listed):

##### Coinmarketcap ID (leave empty if not listed):

##### Short Description (to be shown on DefiLlama):
Orvex is the liquidity coordination layer for Robinhood Chain's RWA economy an RWA-native MetaDEX with curated markets spanning USDG, stablecoins, tokenized equities, ETFs, and other real-world assets.

##### Token address and ticker if any: TGE is soon. No token yet.

##### Category:
Dexes

##### Oracle Provider(s):
None (AMM-only; no oracle dependency for TVL)

##### Implementation Details:
N/A

##### Documentation/Proof:
https://docs.orvex.fi/

##### forkedFrom:
Lynex (v2 Solidly fork) + PancakeSwap v4 CL architecture

##### methodology:
TVL is the value of tokens locked in Orvex v2 liquidity pairs (Solidly-fork PairFactoryUpgradeable at 0x5c98b2d8...CdC09) plus tokens held in the Orvex v4 concentrated liquidity Vault singleton (0xFe7E25dE...9b0D). V4 pool token pairs are enumerated from CLPoolManager (0xd01C774d...4032) Initialize events; all v4 funds sit in the Vault.

##### Github org/user:
https://github.com/Lynexfi

##### Does this project have a referral program?
No


<img width="512" height="512" alt="orvex-logo-512" src="https://github.com/user-attachments/assets/0751fb01-c043-4e35-b7f4-07957998c158" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added total value locked (TVL) tracking for Orvex on Robinhood Chain.
  * TVL includes liquidity from Solidly v2 pairs and v4 concentrated-liquidity funds held in the Vault.
  * Improved pool discovery and token balance aggregation for more complete TVL reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->