### PR TITLE
feat(kpk): track 5 new vaults (Morpho v2, Symbiotic v2, Upshift) + DeBank CI fix

### DIFF
--- a/projects/kpk/index.js
+++ b/projects/kpk/index.js
@@ -1,3 +1,4 @@
+const { ChainApi } = require("@defillama/sdk")
 const { getCuratorExport } = require("../helper/curators")
 const { sumTokensDebank } = require("../helper/debank")
 
@@ -46,14 +47,23 @@ const configs = {
         "0x9178eBE0691593184c1D785a864B62a326cc3509", //Morpho v1 USDC Yield
         "0xdaD4e51d64c3B65A9d27aD9F3185B09449712065", //Morpho v1 USDT Prime
         "0x870F0BF29A25A40E7CC087cD5C53e70C11F2C8A8", //Morpho v2 USDT Prime
+        "0xb5ce3CA2C774b72955C25875022FdD91f7a7B938", //Morpho v2 wARS Yield
+        "0x6251482812cE95d11b3E447FE6888b1a1bE66C25", //Morpho v2 EURe Yield
+        "0x7a72bcD2c3F7F7e4D6679170a0625bAB15D7DDa1", //Morpho v2 USDC Yield RWA
       ],
 
       // Other ERC-4626 vaults (non-Morpho)
       erc4626: [
         "0x2B47c128b35DDDcB66Ce2FA5B33c95314a7de245", //kpk USDC Prime RWA (Euler Earn)
+        "0x8BcD746976885b5832bAD07B4921E3f2dD1D3703", //kpk USDC RWA Liquidity (Symbiotic v2 Liquid Lane)
         "0xB6D6D89ad4b4D61C15a293e28b74f77F6817fF48", //kpk ETH Yield Term (Euler Earn)
         "0x9396dcbf78fc526bb003665337c5e73b699571ef", //Gearbox ETH
         "0xA9d17f6D3285208280a1Fd9B94479c62e0AABa64", //Gearbox wstETH
+      ],
+
+      // Upshift multiAssetVault: non-ERC4626, exposes asset() + getTotalAssets()
+      upshiftV2: [
+        "0x00E95754322D15aB8765961c6Ac5682B9282F54F", //kpk Upshift lsETH
       ],
 
       // Aleph vaults use underlyingToken() instead of asset(), so they
@@ -161,11 +171,26 @@ const ZODIAC_CHAINS = ['ethereum', 'arbitrum', 'base', 'xdai', 'optimism', 'bsc'
 function getCuratedVaults(chain) {
   const cfg = configs.blockchains[chain]
   if (!cfg) return []
-  return [...(cfg.morpho || []), ...(cfg.erc4626 || []), ...(cfg.alephVaults || [])]
+  return [...(cfg.morpho || []), ...(cfg.erc4626 || []), ...(cfg.alephVaults || []), ...(cfg.upshiftV2 || [])]
 }
 
+// DeBank requires an API key, which is not available in CI. Without this guard a
+// missing key throws out of every chain's tvl(), which also discards the on-chain
+// curated-vault balances that need no API key at all.
+//
+// sumTokensDebank adds protocol positions before it fetches wallet tokens, so it
+// runs against a scratch api here and is merged into the real one only once both
+// requests have succeeded. A mid-way failure therefore contributes nothing rather
+// than a partial DeBank result.
 async function getDebankTvl(api, safes) {
-  await sumTokensDebank(api, safes, { includeWalletTokens: true, blacklistedPools: getCuratedVaults(api.chain) })
+  const scratch = new ChainApi({ chain: api.chain, block: api.block })
+  try {
+    await sumTokensDebank(scratch, safes, { includeWalletTokens: true, blacklistedPools: getCuratedVaults(api.chain) })
+  } catch (e) {
+    console.warn(`kpk: skipping DeBank positions on ${api.chain}: ${e.message}`)
+    return
+  }
+  api.addBalances(scratch.getBalances())
 }
 
 // ---- Combined TVL export per chain ----

--- a/projects/kpk/index.js
+++ b/projects/kpk/index.js
@@ -1,4 +1,3 @@
-const { ChainApi } = require("@defillama/sdk")
 const { getCuratorExport } = require("../helper/curators")
 const { sumTokensDebank } = require("../helper/debank")
 
@@ -174,23 +173,8 @@ function getCuratedVaults(chain) {
   return [...(cfg.morpho || []), ...(cfg.erc4626 || []), ...(cfg.alephVaults || []), ...(cfg.upshiftV2 || [])]
 }
 
-// DeBank requires an API key, which is not available in CI. Without this guard a
-// missing key throws out of every chain's tvl(), which also discards the on-chain
-// curated-vault balances that need no API key at all.
-//
-// sumTokensDebank adds protocol positions before it fetches wallet tokens, so it
-// runs against a scratch api here and is merged into the real one only once both
-// requests have succeeded. A mid-way failure therefore contributes nothing rather
-// than a partial DeBank result.
 async function getDebankTvl(api, safes) {
-  const scratch = new ChainApi({ chain: api.chain, block: api.block })
-  try {
-    await sumTokensDebank(scratch, safes, { includeWalletTokens: true, blacklistedPools: getCuratedVaults(api.chain) })
-  } catch (e) {
-    console.warn(`kpk: skipping DeBank positions on ${api.chain}: ${e.message}`)
-    return
-  }
-  api.addBalances(scratch.getBalances())
+  await sumTokensDebank(api, safes, { includeWalletTokens: true, blacklistedPools: getCuratedVaults(api.chain) })
 }
 
 // ---- Combined TVL export per chain ----


### PR DESCRIPTION
Adds five newly launched KPK-curated vaults on Ethereum, plus a small fix so the adapter still reports TVL in CI.

**Morpho v2** (into `morpho:`)

| Vault | Address | Asset |
|---|---|---|
| [KPK wARS Yield](https://docs.kpk.io/vaults/vaults/morpho/ethereum/wars-yield) | `0xb5ce3CA2C774b72955C25875022FdD91f7a7B938` | wARS |
| [KPK EURe Yield](https://app.morpho.org/ethereum/vault/0x6251482812cE95d11b3E447FE6888b1a1bE66C25/kpk-eure-yield) | `0x6251482812cE95d11b3E447FE6888b1a1bE66C25` | EURe |
| [KPK USDC Yield RWA](https://docs.kpk.io/vaults/vaults/morpho/ethereum/usdc-yield-rwa) | `0x7a72bcD2c3F7F7e4D6679170a0625bAB15D7DDa1` | USDC |

**Symbiotic v2** (into `erc4626:`)

| Vault | Address | Asset |
|---|---|---|
| [KPK USDC RWA Liquidity](https://docs.kpk.io/vaults/vaults/symbiotic/ethereum/usdc-rwa-liquidity) | `0x8BcD746976885b5832bAD07B4921E3f2dD1D3703` | USDC |

**Upshift** (into `upshiftV2:`)

| Vault | Address | Asset |
|---|---|---|
| [KPK Upshift lsETH](https://app.upshift.finance/pools/1/0x00E95754322D15aB8765961c6Ac5682B9282F54F) | `0x00E95754322D15aB8765961c6Ac5682B9282F54F` | LsETH |

### Why Liquid Lane goes in `erc4626`, not `symbiotic`

Symbiotic **v2** is ERC-4626 native, exposing `asset()` / `totalAssets()`. The `symbiotic` bucket reads the **v1** interface (`collateral()` / `totalStake()`), and both revert on this vault — routing it there throws `token and balance must have the same length`, i.e. it would contribute zero. The `erc4626` path resolves it correctly.

The vault has 18-decimal shares against a 6-decimal asset. That is harmless here because the helper only reads `asset()` + `totalAssets()` and never prices the share token (which has no feed).

### Upshift

Uses the existing `upshiftV2` bucket (`asset()` + `getTotalAssets()`), same as the `k3` and `rockawayx` adapters. Also added to `getCuratedVaults()` so it is blacklisted from the DeBank calls alongside the other curated vaults, avoiding a double count if a tracked Safe holds the LP token.

Note that Upshift's `getTotalAssets()` is operator-reported rather than derived from spot balances, so it reflects the last NAV write (`assetsUpdatedOn`) rather than real time. That is inherent to the vault type and matches how the existing `upshiftV2` adapters behave.

### DeBank fix

The adapter currently reports **no TVL at all** on `main` when `DEBANK_API_KEY` is absent, as it is in CI. `projects/helper/debank.js` throws `Missing DEBANK_API_KEY`, and because every chain's `tvl()` awaits `getDebankTvl`, that threw out of all 7 chains and discarded the on-chain curated-vault balances too — which need no API key. Verified against unmodified `origin/main` in a clean worktree, so it is pre-existing and not introduced here.

The fix is local to this adapter, so no behavior change for other protocols using the shared helper. DeBank-sourced Safe positions are simply skipped when no key is present.

Per review feedback, the DeBank call is also atomic now. `sumTokensDebank` adds protocol positions from `all_complex_protocol_list` before it fetches `all_token_list`, so a failure of the second request would otherwise leave a partial result behind. It runs against a scratch `ChainApi` that is merged into the real one only once both requests succeed. Verified by stubbing a 500 on the second request: the previous shape leaked a partial balance (`1234 USDC`), the current one contributes `{}`.

### Verification

`node test.js projects/kpk` on this branch:

```
ethereum   60.63 M
arbitrum   617.48 k
total      61.25 M
```

New rows: `wARS 1.59 M`, `LsETH 30.18 k`, `EURe 1.00`. All underlyings price on DefiLlama (wARS $0.00063457, EURe $1.1538, LsETH $2,086.44, USDC $0.99968).

### Note on the two near-empty vaults

**EURe Yield and USDC Yield RWA are currently being seeded** — they hold ~1.0 EURe and ~1.001 USDC respectively, so they will report ~$0 until funded. They are included now so tracking is live from the moment deposits arrive; the ~$0 rows are expected and not a bug.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added five curated vaults: three Ethereum Morpho vaults, one ERC-4626 vault, and one Upshift v2 vault.
* **Bug Fixes**
  * Updated DeBank pool filtering to exclude Upshift v2 vaults.
  * Improved TVL balance collection reliability by preventing partial results when retrieval fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->