### PR TITLE
feat(subfrost): track the frUSD collateral vault on ethereum

### DIFF
--- a/projects/subfrost/index.js
+++ b/projects/subfrost/index.js
@@ -1,4 +1,5 @@
 const { sumTokens } = require("../helper/sumTokens");
+const ADDRESSES = require("../helper/coreAssets.json");
 const bitcoinAddressBook = require("../helper/bitcoin-book/index.js");
 
 // SUBFROST is a decentralized signing network on Bitcoin L1. It issues frBTC, a
@@ -7,11 +8,28 @@ const bitcoinAddressBook = require("../helper/bitcoin-book/index.js");
 // custody address.
 const owners = bitcoinAddressBook.subfrost;
 
-async function tvl(api) {
+// SUBFROST also issues frUSD, a dollar asset on Alkanes, against USDC/USDT
+// deposited in this vault on Ethereum.
+//
+// The value is reported on ethereum, where the collateral actually sits, and the
+// frUSD minted against it is not counted again. That follows the same convention
+// as the bitcoin leg above and as WBTC/tBTC, which report against the chain
+// holding the deposits rather than the chain the representation is issued on.
+const FRUSD_VAULT = "0x95779e7e1c943042255b8a78273fe6de4823cf06";
+
+async function bitcoinTvl(api) {
   return sumTokens({ owners, api });
 }
 
+async function ethereumTvl(api) {
+  return api.sumTokens({
+    owner: FRUSD_VAULT,
+    tokens: [ADDRESSES.ethereum.USDC, ADDRESSES.ethereum.USDT],
+  });
+}
+
 module.exports = {
-  bitcoin: { tvl },
-  methodology: `Total value of all BTC held by the transparent and verifiable SUBFROST signing group. Covers both frBTC deployments: Alkanes and BRC2.0. frBTC minted against these deposits is not counted separately, so nothing is double counted.`,
+  bitcoin: { tvl: bitcoinTvl },
+  ethereum: { tvl: ethereumTvl },
+  methodology: `Total value of the collateral held by the transparent and verifiable SUBFROST signing group. On bitcoin, all BTC backing frBTC across both deployments, Alkanes and BRC2.0. On ethereum, the USDC and USDT held in the frUSD vault. The frBTC and frUSD minted against these deposits are not counted separately, so nothing is double counted.`,
 };


### PR DESCRIPTION
Follow-up to #20344, which was closed with:

> since the adapter still only tracks btc we'd prefer not to add "and stablecoins" to the methodology. Once the subfrost adapter tracks frUSD backing we can update it.

That is what this does. No methodology claim is added that the adapter does not actually compute.

## What changed

SUBFROST issues **frUSD**, a dollar asset on Alkanes, against USDC/USDT deposited in a vault on Ethereum (`0x95779e7e1c943042255b8a78273fe6de4823cf06`). The adapter tracked only the BTC backing frBTC, so that collateral was not counted at all.

Adds an `ethereum` leg reading the vault's USDC and USDT balances, and updates the methodology to describe both legs.

## Attribution and double counting

The value is reported on **ethereum**, where the collateral actually sits. The frUSD minted against it on Alkanes is not counted again.

That is deliberately the same convention as the existing bitcoin leg, and matches how WBTC and tBTC are handled here: report against the chain holding the deposits, not the chain the representation is issued on. Nothing in this PR is counted in two places.

## Test

```
node test.js projects/subfrost/index.js

------ TVL ------
bitcoin                   7.00 M
ethereum                  65.00

total                    7.00 M
```

The ethereum leg is genuinely small right now: frUSD launched days ago and its supply is ~61 frUSD. I would rather have the plumbing correct and reviewed while the number is trivial than add it later once it is material. It grows with frUSD supply with no further changes.

Happy to adjust the methodology wording if you would prefer it phrased differently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ethereum collateral tracking for USDC and USDT held in the frUSD vault.
  * Expanded supported chain coverage to include Ethereum alongside Bitcoin.
  * Added separate total value locked (TVL) reporting for Bitcoin and Ethereum assets.

* **Documentation**
  * Updated methodology details to explain collateral tracking across both Bitcoin and Ethereum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->