### PR TITLE
accountable: add Arbitrum

### DIFF
--- a/projects/accountable/index.js
+++ b/projects/accountable/index.js
@@ -14,6 +14,11 @@ const FACTORIES = {
         '0xB4082B8126AF8B5345CfB159AC5d4b4F05F54bC5',
         '0xC0f778b51bF9751BBccBF4e78A107026aDaDbe43', // yield factory
     ],
+    arbitrum: [
+        '0x2A7F22f81A3d301b8f0EAf4f09a78558c91Fc69a',
+        '0xB4082B8126AF8B5345CfB159AC5d4b4F05F54bC5',
+        '0xC0f778b51bF9751BBccBF4e78A107026aDaDbe43', // yield factory
+    ],
     citrea: [
         '0x4927Ce3402035b801A1bEdDC498b7fb2fe9eA181',
         '0x2f5CAc28cf80D465d7C8D67a49c8e36710a4B83B',
@@ -112,6 +117,10 @@ module.exports = {
         borrowed: tvl(true)
     },
     ethereum: {
+        tvl: tvl(false),
+        borrowed: tvl(true)
+    },
+    arbitrum: {
         tvl: tvl(false),
         borrowed: tvl(true)
     },


### PR DESCRIPTION
Adds Arbitrum One (chain id 42161) to the Accountable adapter.

Accountable's strategy factories are deployed on Arbitrum and the first vault there (Noon Symphony Yield Vault, `0x9fe29A3feC55414F70454E2dBe6522f48cEd3E85`, USDC) is live. Without this entry its ~$2.3M is missing from Accountable's TVL entirely.

The three factories listed are the ones registered for Arbitrum (FixedTerm, OpenTerm, Yield). They share addresses with the `ethereum` entry because the deploys are deterministic across chains.

No methodology change: the vault is discovered through the existing `strategyProxies` / `strategyVaults` factory enumeration and valued via `convertToAssets`, same as every other chain.

Verified with `node test.js projects/accountable`:

```
--- arbitrum ---            USDC 78.16 k
--- arbitrum-borrowed ---   USDC 2.24 M
```

This matches the vault read directly on-chain (`totalAssets` 2,319,181.83 USDC = liquid 78,186.37 + borrowed 2,240,995.46). No other chain's numbers changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded Arbitrum support for vault discovery.
  * Added Arbitrum exports for total value locked and borrowed balances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->