### PR TITLE
switch to dynamic on chain MetaMorpho vault discovery on HyperEVM

### DIFF
--- a/projects/felix-vanilla/index.js
+++ b/projects/felix-vanilla/index.js
@@ -1,20 +1,23 @@
 const morphoBlueAdapter = require("../morpho-blue/index.js");
+const { getLogs2 } = require("../helper/cache/getLogs");
+
+const morphoFactory = "0xec051b19d654c48c357dc974376deb6272f24e53";
+const governor = "0x4A827418D632C415E19825fd011283A4ba020B3A";
+const startBlock = 1988677;
 
 const tvl = async (api) => {
   await morphoBlueAdapter.hyperliquid.tvl(api);
 
-  const felixVaultAddresses = [
-    "0x835febf893c6dddee5cf762b0f8e31c5b06938ab",
-    "0xfc5126377f0efc0041c0969ef9ba903ce67d151e",
-    "0x9c59a9389d8f72de2cdaf1126f36ea4790e2275e",
-    "0x2900ABd73631b2f60747e687095537B673c06A76",
-    "0x9896a8605763106e57A51aa0a97Fe8099E806bb3",
-    "0x66c71204B70aE27BE6dC3eb41F9aF5868E68fDb6",
-    "0x8A862fD6c12f9ad34C9c2ff45AB2b6712e8CEa27",
-    "0x207ccaE51Ad2E1C240C4Ab4c94b670D438d2201C",
-    "0x808F72b6Ff632fba005C88b49C2a76AB01CAB545", // Felix USDC (Frontier)
-    "0x274f854b2042DB1aA4d6C6E45af73588BEd4Fc9D", // Felix USDH (Frontier)
-  ];
+  const logs = await getLogs2({
+    api,
+    factory: morphoFactory,
+    eventAbi:
+      "event CreateMetaMorpho(address indexed metaMorpho, address indexed caller, address initialOwner, uint256 initialTimelock, address indexed asset, string name, string symbol, bytes32 salt)",
+    fromBlock: startBlock,
+  });
+  const allVaults = logs.map((log) => log.metaMorpho);
+  const owners = await api.multiCall({ abi: "address:owner", calls: allVaults });
+  const felixVaultAddresses = allVaults.filter((_, i) => owners[i] && owners[i].toLowerCase() === governor.toLowerCase());
 
   const assets = await api.multiCall({
     abi: "function asset() view returns (address)",

--- a/projects/felix-vaults/index.js
+++ b/projects/felix-vaults/index.js
@@ -1,23 +1,12 @@
 const { getMorphoVaultTvl } = require("../helper/morpoho");
 
 const hyperliquidConfig = {
-  governor: "0x2157f54f7a745c772e686AA691Fa590B49171eC9",
+  governor: "0x4A827418D632C415E19825fd011283A4ba020B3A",
 }
 
 module.exports = {
   doublecounted: true,
-  hyperliquid: { tvl: getMorphoVaultTvl(hyperliquidConfig.governor, {
-    vaults: [
-      '0x835febf893c6dddee5cf762b0f8e31c5b06938ab', 
-      '0xfc5126377f0efc0041c0969ef9ba903ce67d151e', 
-      '0x9c59a9389d8f72de2cdaf1126f36ea4790e2275e', 
-      '0x2900ABd73631b2f60747e687095537B673c06A76',
-      '0x9896a8605763106e57A51aa0a97Fe8099E806bb3',
-      '0x66c71204B70aE27BE6dC3eb41F9aF5868E68fDb6',
-      '0x8A862fD6c12f9ad34C9c2ff45AB2b6712e8CEa27',
-      '0x207ccaE51Ad2E1C240C4Ab4c94b670D438d2201C',
-      '0x808F72b6Ff632fba005C88b49C2a76AB01CAB545', // Felix USDC (Frontier)
-      '0x274f854b2042DB1aA4d6C6E45af73588BEd4Fc9D', // Felix USDH (Frontier)
-    ]
-  }) },
+  hyperliquid: {
+    tvl: getMorphoVaultTvl(hyperliquidConfig.governor)
+  },
 }


### PR DESCRIPTION
### Summary
- Corrected the Felix governor address to `0x4A827418D632C415E19825fd011283A4ba020B3A` (the verified on-chain `owner()` of Felix's MetaMorpho vaults on HyperEVM).
- Removed hardcoded static vault address arrays from `projects/felix-vaults/index.js` and `projects/felix-vanilla/index.js` in favor of dynamic on-chain discovery via MetaMorpho Factory (`0xec051b19d654c48c357dc974376deb6272f24e53`).

### Testing
- `felix-vaults`: Tested via `node test.js projects/felix-vaults/index.js` -> **$72.52M** TVL dynamically fetched across all active Felix vaults.
- `felix-vanilla`: Tested via `node test.js projects/felix-vanilla/index.js` -> **$182.60M** TVL (Morpho Blue direct lending total minus dynamically deducted Felix vault TVL).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vault TVL tracking now automatically discovers eligible vaults from the configured factory.
  * Vaults are filtered by the configured governor before their assets are included.

* **Bug Fixes**
  * Updated the Hyperliquid governor address.
  * Removed reliance on a manually maintained vault allowlist for TVL retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->