### PR TITLE
Lombard Earn vault: unwrap sLBTC (Sentora) and BTCoc vault shares

### DIFF
--- a/projects/lombard-vault/index.js
+++ b/projects/lombard-vault/index.js
@@ -8,8 +8,20 @@ const LBTC = ADDRESSES.etlk.LBTC
 
 // ── Add new BoringVault tokens here ──────────────────────────────────────────
 // Unwrapped to underlying base asset in tvlEthExtras.
+// `asset` optionally overrides the accountant base asset (same price magnitude,
+// used when the vault reports a different-but-equivalent BTC unit of account).
 const BORING_VAULTS_ETH = [
-  '0x75231079973c23e9eb6180fa3d2fc21334565ab5',  // Turtle Club (katanaLBTCv)
+  { token: '0x75231079973c23e9eb6180fa3d2fc21334565ab5' },                                 // Turtle Club (katanaLBTCv) -> accountant base
+  // Sentora Lombard Vault (sLBTC): LBTC deposits are deployed into a SupervisedLoanPositionManager
+  // (0x6cad5fcb29d98c4968a79ea7db286c5986389009) that currently holds the backing as LBTC.
+  // The accountant's base asset is WBTC (pricing unit only), so count the position as LBTC.
+  { token: '0x13cc1b39cb259ba10cd174eae42012e698ed7c51', asset: ADDRESSES.ethereum.LBTC },
+]
+
+// ── Add new pricePerShare vault tokens here ───────────────────────────────────
+// ERC4626-style shares valued as asset() * pricePerShare(); unwrapped in tvlEthExtras.
+const PPS_VAULTS_ETH = [
+  '0xf14f678d9c05798ba61652a950a05d74ad2e0a6c',  // Bitcoin Onchain Credit Strategy (BTCoc) -> BTC.b
 ]
 
 // ── Add new Curve pools here ──────────────────────────────────────────────────
@@ -63,7 +75,8 @@ async function unwrapCurvePoolShare({ api, pool, holder, coinCount }) {
 
 // Unwraps a BoringVault share token to its underlying base asset via the
 // Vault → Hook → Accountant → (base, rate) architecture.
-async function unwrapBoringVault(api, vaultToken, holder) {
+// `assetOverride` replaces the accountant base asset when set (equivalent BTC unit).
+async function unwrapBoringVault(api, vaultToken, holder, assetOverride) {
   const shareBalance = await api.call({
     target: vaultToken, abi: 'erc20:balanceOf', params: [holder], permitFailure: true,
   })
@@ -88,7 +101,30 @@ async function unwrapBoringVault(api, vaultToken, holder) {
 
   const amount = BigInt(shareBalance) * BigInt(rate) / scale
   if (amount <= 0n) return
-  api.add(baseAsset, amount)
+  api.add(assetOverride || baseAsset, amount)
+}
+
+// Unwraps an ERC4626-style share token via asset() * pricePerShare().
+async function unwrapPpsVault(api, vaultToken, holder) {
+  const shareBalance = await api.call({
+    target: vaultToken, abi: 'erc20:balanceOf', params: [holder], permitFailure: true,
+  })
+  if (!shareBalance || shareBalance === '0') return
+
+  const [asset, pricePerShare, decimals] = await Promise.all([
+    api.call({ target: vaultToken, abi: 'address:asset', permitFailure: true }),
+    api.call({ target: vaultToken, abi: 'function pricePerShare() view returns (uint256)', permitFailure: true }),
+    api.call({ target: vaultToken, abi: 'erc20:decimals', permitFailure: true }),
+  ])
+  if (!asset || !pricePerShare || decimals === undefined || decimals === null) return
+
+  const scale = 10n ** BigInt(decimals)
+  if (scale === 0n) return
+
+  // pricePerShare is asset units per one whole share (10^decimals shares)
+  const amount = BigInt(shareBalance) * BigInt(pricePerShare) / scale
+  if (amount <= 0n) return
+  api.add(asset, amount)
 }
 
 // ─── Per-chain extra TVL hooks ────────────────────────────────────────────────
@@ -100,8 +136,13 @@ async function tvlEthExtras(api) {
   }
 
   // 2. Unwrap BoringVault shares (add new vaults to BORING_VAULTS_ETH above)
-  for (const vault of BORING_VAULTS_ETH) {
-    await unwrapBoringVault(api, vault, LBTCV)
+  for (const { token, asset } of BORING_VAULTS_ETH) {
+    await unwrapBoringVault(api, token, LBTCV, asset)
+  }
+
+  // 3. Unwrap pricePerShare vault shares (add new vaults to PPS_VAULTS_ETH above)
+  for (const vault of PPS_VAULTS_ETH) {
+    await unwrapPpsVault(api, vault, LBTCV)
   }
 
   await sumTokens2({ api, owner: LBTCV, resolveUniV4: true, })

--- a/projects/lombard-vault/index.js
+++ b/projects/lombard-vault/index.js
@@ -106,17 +106,19 @@ async function unwrapBoringVault(api, vaultToken, holder, assetOverride) {
 
 // Unwraps an ERC4626-style share token via asset() * pricePerShare().
 async function unwrapPpsVault(api, vaultToken, holder) {
+  // No permitFailure: these are hardcoded vaults, so a failing read means the
+  // config broke. Failing loudly keeps the last known-good TVL instead of
+  // silently dropping the whole position.
   const shareBalance = await api.call({
-    target: vaultToken, abi: 'erc20:balanceOf', params: [holder], permitFailure: true,
+    target: vaultToken, abi: 'erc20:balanceOf', params: [holder],
   })
   if (!shareBalance || shareBalance === '0') return
 
   const [asset, pricePerShare, decimals] = await Promise.all([
-    api.call({ target: vaultToken, abi: 'address:asset', permitFailure: true }),
-    api.call({ target: vaultToken, abi: 'function pricePerShare() view returns (uint256)', permitFailure: true }),
-    api.call({ target: vaultToken, abi: 'erc20:decimals', permitFailure: true }),
+    api.call({ target: vaultToken, abi: 'address:asset' }),
+    api.call({ target: vaultToken, abi: 'function pricePerShare() view returns (uint256)' }),
+    api.call({ target: vaultToken, abi: 'erc20:decimals' }),
   ])
-  if (!asset || !pricePerShare || decimals === undefined || decimals === null) return
 
   const scale = 10n ** BigInt(decimals)
   if (scale === 0n) return

--- a/projects/lombard-vault/index.js
+++ b/projects/lombard-vault/index.js
@@ -7,19 +7,15 @@ const SONIC_VAULT = '0x309f25d839a2fe225e80210e110C99150Db98AAF'  // vault (Soni
 const LBTC = ADDRESSES.etlk.LBTC
 
 // ── Add new BoringVault tokens here ──────────────────────────────────────────
-// Unwrapped to underlying base asset in tvlEthExtras.
-// `asset` optionally overrides the accountant base asset (same price magnitude,
-// used when the vault reports a different-but-equivalent BTC unit of account).
+// `asset` overrides the accountant base asset (equivalent BTC unit).
 const BORING_VAULTS_ETH = [
-  { token: '0x75231079973c23e9eb6180fa3d2fc21334565ab5' },                                 // Turtle Club (katanaLBTCv) -> accountant base
-  // Sentora Lombard Vault (sLBTC): LBTC deposits are deployed into a SupervisedLoanPositionManager
-  // (0x6cad5fcb29d98c4968a79ea7db286c5986389009) that currently holds the backing as LBTC.
-  // The accountant's base asset is WBTC (pricing unit only), so count the position as LBTC.
+  { token: '0x75231079973c23e9eb6180fa3d2fc21334565ab5' },  // Turtle Club (katanaLBTCv) -> accountant base
+  // Sentora (sLBTC): backing sits as LBTC in SupervisedLoanPositionManager
+  // 0x6cad5fcb29d98c4968a79ea7db286c5986389009; accountant base WBTC is pricing unit only.
   { token: '0x13cc1b39cb259ba10cd174eae42012e698ed7c51', asset: ADDRESSES.ethereum.LBTC },
 ]
 
 // ── Add new pricePerShare vault tokens here ───────────────────────────────────
-// ERC4626-style shares valued as asset() * pricePerShare(); unwrapped in tvlEthExtras.
 const PPS_VAULTS_ETH = [
   '0xf14f678d9c05798ba61652a950a05d74ad2e0a6c',  // Bitcoin Onchain Credit Strategy (BTCoc) -> BTC.b
 ]
@@ -34,20 +30,15 @@ const CURVE_POOLS_CORN = [
 ]
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
+// No `permitFailure` anywhere: pools/vaults are hardcoded, so a failed read must
+// throw (keeps last known-good TVL) rather than silently omit the position.
 
-// Unwraps a single Curve StableSwap-NG pool LP share held by `holder`.
-// Works for both eth (where base scanner already discovered the LP token) and
-// chains without auto-discovery (Corn): removeTokenBalance is a no-op when the
-// token isn't in balances yet.
+// Curve StableSwap-NG LP share held by `holder` -> underlying coins.
 async function unwrapCurvePoolShare({ api, pool, holder, coinCount }) {
-  const lpBalance = await api.call({
-    target: pool, abi: 'erc20:balanceOf', params: [holder], permitFailure: true,
-  })
+  const lpBalance = await api.call({ target: pool, abi: 'erc20:balanceOf', params: [holder] })
   if (!lpBalance || lpBalance === '0') return
 
-  const totalSupply = await api.call({
-    target: pool, abi: 'erc20:totalSupply', permitFailure: true,
-  })
+  const totalSupply = await api.call({ target: pool, abi: 'erc20:totalSupply' })
   if (!totalSupply || totalSupply === '0') return
 
   api.removeTokenBalance(pool)  // no-op if not present
@@ -57,43 +48,32 @@ async function unwrapCurvePoolShare({ api, pool, holder, coinCount }) {
 
   for (let i = 0; i < coinCount; i++) {
     const token = await api.call({
-      target: pool, abi: 'function coins(uint256) view returns (address)',
-      params: [i], permitFailure: true,
+      target: pool, abi: 'function coins(uint256) view returns (address)', params: [i],
     })
     if (!token || token.toLowerCase() === ADDRESSES.null.toLowerCase()) break
 
     const poolBal = await api.call({
-      target: pool, abi: 'function balances(uint256) view returns (uint256)',
-      params: [i], permitFailure: true,
+      target: pool, abi: 'function balances(uint256) view returns (uint256)', params: [i],
     })
-    if (!poolBal) continue
 
     const amount = BigInt(poolBal) * lpBI / supplyBI
     if (amount > 0n) api.add(token, amount)
   }
 }
 
-// Unwraps a BoringVault share token to its underlying base asset via the
-// Vault → Hook → Accountant → (base, rate) architecture.
-// `assetOverride` replaces the accountant base asset when set (equivalent BTC unit).
+// BoringVault shares -> base asset, via Vault -> Hook -> Accountant -> (base, rate).
 async function unwrapBoringVault(api, vaultToken, holder, assetOverride) {
-  const shareBalance = await api.call({
-    target: vaultToken, abi: 'erc20:balanceOf', params: [holder], permitFailure: true,
-  })
+  const shareBalance = await api.call({ target: vaultToken, abi: 'erc20:balanceOf', params: [holder] })
   if (!shareBalance || shareBalance === '0') return
 
-  const hook = await api.call({ target: vaultToken, abi: 'address:hook', permitFailure: true })
-  if (!hook) return
-
-  const accountant = await api.call({ target: hook, abi: 'address:accountant', permitFailure: true })
-  if (!accountant) return
+  const hook = await api.call({ target: vaultToken, abi: 'address:hook' })
+  const accountant = await api.call({ target: hook, abi: 'address:accountant' })
 
   const [baseAsset, rate, decimals] = await Promise.all([
-    api.call({ target: accountant, abi: 'address:base', permitFailure: true }),
-    api.call({ target: accountant, abi: 'uint256:getRate', permitFailure: true }),
-    api.call({ target: accountant, abi: 'uint8:decimals', permitFailure: true }),
+    api.call({ target: accountant, abi: 'address:base' }),
+    api.call({ target: accountant, abi: 'uint256:getRate' }),
+    api.call({ target: accountant, abi: 'uint8:decimals' }),
   ])
-  if (!baseAsset || !rate || decimals === undefined || decimals === null) return
 
   const decimalsBI = BigInt(decimals)
   const scale = 10n ** decimalsBI
@@ -104,14 +84,9 @@ async function unwrapBoringVault(api, vaultToken, holder, assetOverride) {
   api.add(assetOverride || baseAsset, amount)
 }
 
-// Unwraps an ERC4626-style share token via asset() * pricePerShare().
+// ERC4626-style shares -> asset() * pricePerShare().
 async function unwrapPpsVault(api, vaultToken, holder) {
-  // No permitFailure: these are hardcoded vaults, so a failing read means the
-  // config broke. Failing loudly keeps the last known-good TVL instead of
-  // silently dropping the whole position.
-  const shareBalance = await api.call({
-    target: vaultToken, abi: 'erc20:balanceOf', params: [holder],
-  })
+  const shareBalance = await api.call({ target: vaultToken, abi: 'erc20:balanceOf', params: [holder] })
   if (!shareBalance || shareBalance === '0') return
 
   const [asset, pricePerShare, decimals] = await Promise.all([
@@ -123,7 +98,7 @@ async function unwrapPpsVault(api, vaultToken, holder) {
   const scale = 10n ** BigInt(decimals)
   if (scale === 0n) return
 
-  // pricePerShare is asset units per one whole share (10^decimals shares)
+  // pricePerShare = asset units per 10^decimals shares
   const amount = BigInt(shareBalance) * BigInt(pricePerShare) / scale
   if (amount <= 0n) return
   api.add(asset, amount)
@@ -132,17 +107,17 @@ async function unwrapPpsVault(api, vaultToken, holder) {
 // ─── Per-chain extra TVL hooks ────────────────────────────────────────────────
 
 async function tvlEthExtras(api) {
-  // 1. Unwrap Curve LP pools (add new pools to CURVE_POOLS_ETH above)
+  // Curve LP pools
   for (const { pool, coinCount } of CURVE_POOLS_ETH) {
     await unwrapCurvePoolShare({ api, pool, holder: LBTCV, coinCount })
   }
 
-  // 2. Unwrap BoringVault shares (add new vaults to BORING_VAULTS_ETH above)
+  // BoringVault shares
   for (const { token, asset } of BORING_VAULTS_ETH) {
     await unwrapBoringVault(api, token, LBTCV, asset)
   }
 
-  // 3. Unwrap pricePerShare vault shares (add new vaults to PPS_VAULTS_ETH above)
+  // pricePerShare vault shares
   for (const vault of PPS_VAULTS_ETH) {
     await unwrapPpsVault(api, vault, LBTCV)
   }
@@ -151,7 +126,6 @@ async function tvlEthExtras(api) {
 }
 
 async function tvlCornExtras(api) {
-  // Curve pools on Corn (add new pools to CURVE_POOLS_CORN above)
   for (const { pool, coinCount } of CURVE_POOLS_CORN) {
     await unwrapCurvePoolShare({ api, pool, holder: LBTCV, coinCount })
   }

--- a/projects/lombard-vault/index.js
+++ b/projects/lombard-vault/index.js
@@ -75,10 +75,7 @@ async function unwrapBoringVault(api, vaultToken, holder, assetOverride) {
     api.call({ target: accountant, abi: 'uint8:decimals' }),
   ])
 
-  const decimalsBI = BigInt(decimals)
-  const scale = 10n ** decimalsBI
-  if (scale === 0n) return
-
+  const scale = 10n ** BigInt(decimals)
   const amount = BigInt(shareBalance) * BigInt(rate) / scale
   if (amount <= 0n) return
   api.add(assetOverride || baseAsset, amount)
@@ -95,10 +92,8 @@ async function unwrapPpsVault(api, vaultToken, holder) {
     api.call({ target: vaultToken, abi: 'erc20:decimals' }),
   ])
 
-  const scale = 10n ** BigInt(decimals)
-  if (scale === 0n) return
-
   // pricePerShare = asset units per 10^decimals shares
+  const scale = 10n ** BigInt(decimals)
   const amount = BigInt(shareBalance) * BigInt(pricePerShare) / scale
   if (amount <= 0n) return
   api.add(asset, amount)


### PR DESCRIPTION
## What

The Lombard **Earn** vault (`0x5401b8620E5FB570064CA9114fd1e135fd77D57c`) holds two vault **share tokens** on Ethereum that are not priced, so they were counted as **\$0** (TVL undercount):

- **sLBTC** — Sentora Lombard Vault (`0x13cc1b39cb259ba10cd174eae42012e698ed7c51`), a **BoringVault**
- **BTCoc** — Bitcoin Onchain Credit Strategy (`0xf14f678d9c05798ba61652a950a05d74ad2e0a6c`), an ERC4626-style `pricePerShare` vault

## How

- **sLBTC**: unwrapped via the existing BoringVault path (`hook -> accountant -> getRate`), counted as **LBTC** via a new optional `assetOverride` on `unwrapBoringVault`.
- **BTCoc**: new `unwrapPpsVault` helper + `PPS_VAULTS_ETH` list — valued as `asset() * pricePerShare()` -> **BTC.b**.
- No blacklist needed: the ethereum base scanner uses an explicit `tokens` allowlist, so raw share tokens are never picked up.

## Why sLBTC is counted as LBTC (not the accountant's WBTC base)

The sLBTC BoringVault contract itself holds only dust. The ~399 LBTC deposited by the Earn vault is forwarded to a `SupervisedLoanPositionManager` (`0x6cad5fcb29d98c4968a79ea7db286c5986389009`, verified contract) which **currently holds the backing as 402.32 LBTC** on-chain. The accountant's base asset is WBTC, but that is only the pricing unit of account — the real collateral is LBTC. `getRate` (~1.0132) reflects LBTC principal + accrued strategy yield.

## Verification (ethereum, before/after delta on the real @defillama/sdk path)

| token | before | after | delta |
|---|---|---|---|
| WBTC | 79.573643 | 79.573643 | 0 |
| **LBTC** | 38.364244 | 442.614568 | **+404.250324** |
| cbBTC | 24.519924 | 24.519924 | 0 |
| **BTC.b** | 21.759431 | 202.738022 | **+180.978591** |

- sLBTC -> +404.25 LBTC (WBTC delta 0), BTCoc -> +180.98 BTC.b. Nothing else changes; raw sLBTC/BTCoc absent from balances.
- `node test.js projects/lombard-vault/index.js` passes all chains, total TVL ~\$52.4M.
- `eslint -c eslint.config.js` clean.

Adapter already carries `doublecounted: true`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for additional Ethereum vault configurations, including LBTC-backed vaults.
  * Added ERC4626-style vault valuation using underlying assets, price per share, and share decimals.
  * Added optional overrides for the base asset used during vault valuation.

* **Bug Fixes**
  * Improved Ethereum TVL processing for configured BoringVaults and price-per-share vaults.
  * Improved reliability and valuation accuracy when processing vault data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->