### PR TITLE
symbiosis adds stable chain support

### DIFF
--- a/projects/symbiosis-finance/config.js
+++ b/projects/symbiosis-finance/config.js
@@ -532,6 +532,15 @@ module.exports = {
       holders: [
         '0x292fC50e4eB66C3f6514b9E402dBc25961824D62' // portal
       ]
+    },
+    {
+      name: 'stable',
+      tokens: [
+        '0x779Ded0c9e1022225f8E0630b35a9b54bE713736', // USDT0
+      ],
+      holders: [
+        '0x292fC50e4eB66C3f6514b9E402dBc25961824D62' // portal
+      ]
     }
   ]
 }


### PR DESCRIPTION
Adds the Stable chain (chainId 988) portal to the Symbiosis TVL adapter.

**Addresses** — taken from [`symbiosis-finance/sdk-types`](https://github.com/symbiosis-finance/sdk-types), `ChainId.STABLE_MAINNET` in `src/crosschain/config/mainnet.ts`:

- portal `0x292fC50e4eB66C3f6514b9E402dBc25961824D62`
- USDT0 `0x779Ded0c9e1022225f8E0630b35a9b54bE713736` (6 decimals)

**Why only the ERC20 entry, no null address.** On Stable, USDT0 is both the native gas token and an ERC20, and the two interfaces expose *the same underlying balance* at different scales — 18 decimals via `address.balance`, 6 decimals via `balanceOf()` ([docs](https://docs.stable.xyz/en/explanation/usdt-as-gas-token/)). Verified on live holders, e.g. `0xd5719ab2ef9ca621df5633cf00ef1c08800ad84b` reports `32.961669` under both views. Listing `ADDRESSES.null` alongside the token address would therefore count the same deposits twice. `balanceOf(portal)` alone already captures native deposits.

For reference, `gUSDT` (the chain's original gas token, still the symbol returned by `coins.llama.fi` for `stable:0x0`) was retired in the v1.2.0 upgrade on 2026-02-04, with balances auto-converted to USDT0 — so the legacy `wgUSDT` wrappers are not tracked either.

**Draft on purpose:** the portal currently holds no deposits (both balance views read 0), so this contributes $0 today. Opening it now so the adapter change is reviewable; will mark ready for review once the portal holds a balance.

Verified with `node test.js projects/symbiosis-finance` — passes, `stable` appears in the chain breakdown.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the stable chain.
  * Added USDT0 token configuration and portal holder details for the new chain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->