### PR TITLE
origindollar: exclude AMO-minted OUSD from ethereum TVL

### DIFF
--- a/projects/origindollar/index.js
+++ b/projects/origindollar/index.js
@@ -6,11 +6,51 @@ const abi = {
 const { staking } = require("../helper/staking");
 
 const vault = "0xE75D77B1865Ae93c7eaa3040B038D7aA7BC02F70";
+const OUSD = "0x2A8e1E676Ec238d8A992307B495b45B3fEAa5e86";
+
+// Curve AMO strategies mint OUSD to pair against the vault's stablecoin inside the pool, and their
+// checkBalance() reports the strategy's whole LP position -- both sides. That leaves the vault
+// total counting protocol-minted OUSD as if it were external backing, which is circular: redeeming
+// the LP returns the stablecoin and burns the OUSD. Subtract each AMO's share of the pool's OUSD.
+// (originether does the equivalent by only counting the ETH side of its Curve/Convex positions.)
+//
+// The AMO currently holds ~95.6% of the OUSD/USDC pool, so ~$634k of the reported ~$5.78M was its
+// own minted OUSD.
+const removeAmoMintedOusd = async (api) => {
+  const strategies = await api.call({ abi: 'address[]:getAllStrategies', target: vault })
+  // Only AMO strategies answer lpToken(); a null marks a strategy that holds no Curve position.
+  const lpTokens = await api.multiCall({ abi: 'address:lpToken', calls: strategies, permitFailure: true })
+  const gauges = await api.multiCall({ abi: 'address:gauge', calls: strategies, permitFailure: true })
+
+  for (const [i, lpToken] of lpTokens.entries()) {
+    if (!lpToken) continue
+
+    // The strategy's pool share, read straight off its LP position: held directly plus staked in
+    // the gauge. Taken from the LP rather than checkBalance() so a strategy that does not support
+    // one of the vault's assets cannot silently contribute a partial value here.
+    const [held, staked, lpSupply, poolOusd] = await Promise.all([
+      api.call({ abi: 'erc20:balanceOf', target: lpToken, params: strategies[i] }),
+      gauges[i]
+        ? api.call({ abi: 'erc20:balanceOf', target: gauges[i], params: strategies[i] })
+        : 0,
+      api.call({ abi: 'erc20:totalSupply', target: lpToken }),
+      api.call({ abi: 'erc20:balanceOf', target: OUSD, params: lpToken }),
+    ])
+
+    if (!Number(lpSupply)) continue
+
+    // The pool's OUSD is protocol-minted in proportion to the share the AMO owns.
+    const share = (Number(held) + Number(staked)) / Number(lpSupply)
+    api.add(OUSD, -share * Number(poolOusd))
+  }
+}
 
 const ethTvl = async (api) => {
   const tokens = await api.call({  abi: abi.getAllAssets, target: vault})
   const bals = await api.multiCall({  abi: abi.checkBalance, calls: tokens, target: vault})
   api.add(tokens, bals)
+
+  await removeAmoMintedOusd(api)
 };
 
 module.exports = {

--- a/projects/origindollar/index.js
+++ b/projects/origindollar/index.js
@@ -7,6 +7,7 @@ const { staking } = require("../helper/staking");
 
 const vault = "0xE75D77B1865Ae93c7eaa3040B038D7aA7BC02F70";
 const OUSD = "0x2A8e1E676Ec238d8A992307B495b45B3fEAa5e86";
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
 // Curve AMO strategies mint OUSD to pair against the vault's stablecoin inside the pool, and their
 // checkBalance() reports the strategy's whole LP position -- both sides. That leaves the vault
@@ -20,19 +21,24 @@ const removeAmoMintedOusd = async (api) => {
   const strategies = await api.call({ abi: 'address[]:getAllStrategies', target: vault })
   // Only AMO strategies answer lpToken(); a null marks a strategy that holds no Curve position.
   const lpTokens = await api.multiCall({ abi: 'address:lpToken', calls: strategies, permitFailure: true })
-  const gauges = await api.multiCall({ abi: 'address:gauge', calls: strategies, permitFailure: true })
 
   for (const [i, lpToken] of lpTokens.entries()) {
     if (!lpToken) continue
+
+    // Read without permitFailure, and only for strategies already identified as AMOs: an AMO whose
+    // gauge could not be read would otherwise fall back to zero staked LP and silently skip its
+    // deduction, which is the whole point of this function. A gauge-less AMO returns the zero
+    // address, which is a real answer and handled below.
+    const gauge = await api.call({ abi: 'address:gauge', target: strategies[i] })
 
     // The strategy's pool share, read straight off its LP position: held directly plus staked in
     // the gauge. Taken from the LP rather than checkBalance() so a strategy that does not support
     // one of the vault's assets cannot silently contribute a partial value here.
     const [held, staked, lpSupply, poolOusd] = await Promise.all([
       api.call({ abi: 'erc20:balanceOf', target: lpToken, params: strategies[i] }),
-      gauges[i]
-        ? api.call({ abi: 'erc20:balanceOf', target: gauges[i], params: strategies[i] })
-        : 0,
+      gauge.toLowerCase() === ZERO_ADDRESS
+        ? 0
+        : api.call({ abi: 'erc20:balanceOf', target: gauge, params: strategies[i] }),
       api.call({ abi: 'erc20:totalSupply', target: lpToken }),
       api.call({ abi: 'erc20:balanceOf', target: OUSD, params: lpToken }),
     ])


### PR DESCRIPTION
Remove the new OUSD AMO TVL from (protocol owned liquidity) from its TVL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved total value locked (TVL) reporting by excluding OUSD associated with Curve AMO strategies.
  * TVL calculations now more accurately reflect assets held by the vault rather than OUSD already accounted for in related liquidity pools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->