### PR TITLE
fix(treasury/stockworks): follow the treasury migration and value the v4 position

### DIFF
--- a/projects/treasury/stockworks.js
+++ b/projects/treasury/stockworks.js
@@ -1,0 +1,61 @@
+const { nullAddress, treasuryExports } = require("../helper/treasury");
+
+// StockWorks (SPCXSTR) — Robinhood Chain.
+//
+// A 10% pool-level swap tax on SPCXSTR funds a treasury that market-makes SPCX
+// (Robinhood tokenized SpaceX stock) against USDG, and converts the harvested
+// LP fees into SPCXSTR buy-and-burn.
+//
+// This cannot be a plain registry entry: almost the entire treasury sits inside
+// a CONCENTRATED Uniswap v4 liquidity position, which is custodied by the v4
+// PoolManager singleton and therefore invisible to ERC20 balanceOf. Summing
+// balances alone reports ~$100 against ~$30k actually held. So we read the
+// controller's own position getters and convert liquidity to token amounts.
+const CONTROLLER = "0x37bBFeD61d9A8C3743D3E7318e635c37c9abdf8e"; // SpcxQuoteController
+const SPCX = "0x4a0E65A3EcceC6dBe60AE065F2e7bb85Fae35eEa";
+const USDG = "0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168";
+
+// SPCXSTR itself is the protocol's own token and is deliberately NOT counted.
+
+module.exports = {
+  methodology:
+    "Treasury of the SpcxQuoteController: the concentrated Uniswap v4 SPCX/USDG liquidity position it market-makes with (valued by converting position liquidity into its underlying SPCX and USDG at the pool's current price), plus any idle SPCX, USDG and native ETH held by the controller. The protocol's own token, SPCXSTR, is excluded.",
+  robinhood: {
+    tvl: async (api) => {
+      // idle balances held directly by the controller
+      const base = treasuryExports({
+        robinhood: {
+          owners: [CONTROLLER],
+          tokens: [nullAddress, SPCX, USDG],
+        },
+      });
+      await base.robinhood.tvl(api);
+
+      // the concentrated v4 position
+      const [liquidity, tickLower, tickUpper, sqrtPriceX96] = await Promise.all([
+        api.call({ target: CONTROLLER, abi: "function positionLiquidity() view returns (uint128)" }),
+        api.call({ target: CONTROLLER, abi: "function tickLower() view returns (int24)" }),
+        api.call({ target: CONTROLLER, abi: "function tickUpper() view returns (int24)" }),
+        api.call({ target: CONTROLLER, abi: "function venueSqrtPrice() view returns (uint160)" }),
+      ]);
+
+      const L = Number(liquidity);
+      if (L > 0) {
+        // sqrt(price) ratios; ticks are log-price so sqrt(1.0001^tick) = 1.0001^(tick/2)
+        const sqrtP = Number(sqrtPriceX96) / 2 ** 96;
+        const sqrtLower = Math.pow(1.0001, Number(tickLower) / 2);
+        const sqrtUpper = Math.pow(1.0001, Number(tickUpper) / 2);
+        // clamp to the range: below it the position is all token0, above all token1
+        const sqrtC = Math.min(Math.max(sqrtP, sqrtLower), sqrtUpper);
+
+        const amount0 = L * (1 / sqrtC - 1 / sqrtUpper); // SPCX, 18 decimals
+        const amount1 = L * (sqrtC - sqrtLower); // USDG, 6 decimals
+
+        api.add(SPCX, amount0);
+        api.add(USDG, amount1);
+      }
+
+      return api.getBalances();
+    },
+  },
+};

--- a/registries/treasury.js
+++ b/registries/treasury.js
@@ -5412,12 +5412,6 @@ const configs = {
       ],
     },
   },
-  'treasury/stockworks': {
-    robinhood: {
-      owners: ['0x57024Aae99f709Bd399252767DDC6487Aa3881De'],
-      tokens: [nullAddress, '0x4a0E65A3EcceC6dBe60AE065F2e7bb85Fae35eEa'],
-    }
-  },
   'treasury/stonkbrokers': {
     robinhood: {
       owners: ['0x16027b596e210c63f750E0bdD156f00bb2749868'],


### PR DESCRIPTION
**Protocol:** StockWorks (`treasury/stockworks`) — Robinhood Chain
**Issue:** the listing has reported **\$0 every day since 2026-08-02** (`api.llama.fi/treasury/stockworks` → `currentChainTvls {"Robinhood Chain": 0}`).

### Why it broke

**1. The address is stale.** The registry entry points at `0x57024Aae99f709Bd399252767DDC6487Aa3881De`, the original controller, which was drained on 2026-08-02. The treasury migrated to a successor and then again to the current contract, `SpcxQuoteController` at `0x37bBFeD61d9A8C3743D3E7318e635c37c9abdf8e` (verified on Blockscout).

**2. Updating the address alone would not fix it.** Almost the entire treasury now sits inside a **concentrated Uniswap v4 liquidity position**. v4 custodies liquidity in the PoolManager singleton, so the position is invisible to ERC20 `balanceOf` — summing plain balances returns roughly **\$100** against roughly **\$30k** actually held.

### What this PR does

Valuing the position needs logic beyond a single `treasuryExports()` call, so per the note at the top of `registries/treasury.js` this moves the entry out of the registry and into `projects/treasury/stockworks.js`.

The adapter still uses `treasuryExports` for idle balances, then reads the controller's own position getters (`positionLiquidity`, `tickLower`, `tickUpper`, `venueSqrtPrice`) and converts liquidity into its underlying SPCX and USDG at the pool's current price.

Also: **USDG was missing from the token list** and is now a material share of the book. SPCXSTR, the protocol's own token, remains excluded.

### Test

```
$ node test.js projects/treasury/stockworks.js

--- robinhood ---
SPCX                      25.37 k
USDG                      4.71 k
ETH                       1.23
Total: 30.08 k
```

Matches the treasury read directly on-chain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added treasury valuation support for StockWorks on Robinhood Chain.
  * Valuation now includes native ETH, SPCX, USDG, and eligible concentrated liquidity positions.
  * SPCXSTR holdings are excluded from valuation.

* **Bug Fixes**
  * Removed the outdated StockWorks treasury registry configuration for Robinhood.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->