### PR TITLE
Add TVL calculation for dyield wrappers

### DIFF
--- a/dyield/index.js
+++ b/dyield/index.js
@@ -1,7 +1,7 @@
 const WRAPPERS = [
-  '0x98F6529DF7BF5088DB795CA1590c51d81b2175CA',
-  '0xfa2c898Aa1a41DE6EE334C187983DD3875354fc4',
-  '0x9AEE2D78Eb7F6781Aeb7247bB764784C1048C881',
+  '0x6fc2670a0e3ecFfAc27c66009530f16BC07cd2Cc', // dyield Prime — d$P
+  '0x80729552cb813d95d54474c0E7e9E5ed8F5A8D89', // dyield High  — d$H
+  '0xB7E50801E30cB5eF02b95D1bbc8363bc260197FF', // dyield Ultra — d$U
 ]
 async function tvl(api) {
   const assets = await api.multiCall({ abi: 'address:asset', calls: WRAPPERS })
@@ -13,5 +13,5 @@ module.exports = {
   start: 1785811569,
   base: { tvl },
   doublecounted: true,
-  hallmarks: [[1785811569, 'Wrappers deployed on Base']],
+  hallmarks: [['2026-08-05', 'Wrappers deployed on Base']],
 }

--- a/dyield/index.js
+++ b/dyield/index.js
@@ -1,0 +1,17 @@
+const WRAPPERS = [
+  '0x98F6529DF7BF5088DB795CA1590c51d81b2175CA',
+  '0xfa2c898Aa1a41DE6EE334C187983DD3875354fc4',
+  '0x9AEE2D78Eb7F6781Aeb7247bB764784C1048C881',
+]
+async function tvl(api) {
+  const assets = await api.multiCall({ abi: 'address:asset', calls: WRAPPERS })
+  const balances = await api.multiCall({ abi: 'uint256:totalAssets', calls: WRAPPERS })
+  api.addTokens(assets, balances)
+}
+module.exports = {
+  methodology: 'Sum of totalAssets() across the three dyield wrapper vaults on Base. Double counted with Morpho.',
+  start: 1785811569,
+  base: { tvl },
+  doublecounted: true,
+  hallmarks: [[1785811569, 'Wrappers deployed on Base']],
+}


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).

2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** Please send a mail to metadata@defillama.com
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes

---
## (Needs to be filled only for new listings)
##### Name (to be shown on DefiLlama):
dyield

##### Twitter Link:
https://twitter.com/dyieldio

##### List of audit links if any:
None — dyield deploys Morpho Vault V2 unmodified. Morpho's contracts are independently audited.

##### Website Link:
https://dyield.io

##### Logo (High resolution, will be shown with rounded borders):
[Attached]

##### Current TVL:
~$81

##### Treasury Addresses (if the protocol has treasury)
0xEa6047FE1c320F5462C094BD9b6771b879386F51

##### Chain:
Base

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):

##### Short Description (to be shown on DefiLlama):
Non-custodial USDC yield infrastructure on Base. Three ERC-4626 vault receipt tokens — d$P, d$H, d$U — each wrapping a Morpho Vault V2 curated by Steakhouse Financial, Gauntlet, and Clearstar Labs respectively. Issued by LightVessel DAO, a Wyoming LLC.

##### Token address and ticker if any:
None — no governance token

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Yield

##### Oracle Provider(s):
None

##### Implementation Details:
TVL is the sum of totalAssets() across three wrapper vaults. Share price derived from on-chain vault accounting via convertToAssets(). No external oracle used.

##### Documentation/Proof:
https://dyield.io

##### forkedFrom (Does your project originate from another project):
Morpho Vault V2

##### methodology (what is being counted as tvl, how is tvl being calculated):
Sum of totalAssets() across three dyield ERC-4626 wrapper vaults on Base (d$P, d$H, d$U). Double counted with Morpho — the same USDC sits in underlying Morpho vaults tracked by the Morpho adapter.

##### Github org/user:
lightvessel-dao

##### Does this project have a referral program?
No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for three dYield wrapper vaults on Base.
  * Included underlying asset balances and total asset values in reported metrics.
  * Added methodology, deployment start date, double-counting metadata, and deployment milestone information for improved transparency and reporting context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->