### PR TITLE
yo: add yoUSD Edge vault

### DIFF
--- a/projects/yo/index.js
+++ b/projects/yo/index.js
@@ -10,19 +10,25 @@ const ORACLE_VAULT_DATA_SEED = Buffer.from('yo_oracle_OracleVaultData')
 const VAULT_DATA_SEED = Buffer.from('yo_vault_VaultData')
 const ORACLE_PRICE_DENOMINATOR = 10n ** 9n
 
+const YOUSD_EDGE = '0x5DD8BFa6C5C68D05d25EF6143E05C11E26c4cDB7'
+
 const vaults = {
     base: [
         '0x3a43aec53490cb9fa922847385d82fe25d0e9de7',
         '0xbCbc8cb4D1e8ED048a6276a5E94A3e952660BcbC',
-        '0x50c749aE210D3977ADC824AE11F3c7fd10c871e9'
+        '0x50c749aE210D3977ADC824AE11F3c7fd10c871e9',
+        YOUSD_EDGE
     ],
     ethereum: [
         '0x3a43aec53490cb9fa922847385d82fe25d0e9de7',
         '0xbCbc8cb4D1e8ED048a6276a5E94A3e952660BcbC',
         '0x50c749aE210D3977ADC824AE11F3c7fd10c871e9',
-        '0x586675A3a46B008d8408933cf42d8ff6c9CC61a1'
+        '0x586675A3a46B008d8408933cf42d8ff6c9CC61a1',
+        YOUSD_EDGE
     ],
-    arbitrum: []
+    arbitrum: [
+        YOUSD_EDGE
+    ]
 }
 
 async function tvl(api) {


### PR DESCRIPTION
Adds the yoUSD Edge vault (`0x5DD8BFa6C5C68D05d25EF6143E05C11E26c4cDB7`, ERC-4626) to the YO Protocol TVL adapter on Base, Ethereum and Arbitrum.

yoUSD Edge is a separate vault from yoUSD (different contract, different strategy set) and does not deposit into yoUSD, so there is no double counting. It launched in June 2026 and is already tracked on the yields side (pools labeled `yoUSD Edge`), but its ~$1M TVL is currently missing from the protocol TVL.

`node test.js projects/yo/index.js` output after the change:

```
--- tvl ---
USDC                      13.34 M
WETH                      10.72 M
cbBTC                     7.68 M
xaut                      2.20 M
EURC                      703.74 k
SOL                       511.21 k
Total: 35.16 M
```

USDC goes from 12.35M to 13.34M (+$998k), matching the sum of the three yoUSD Edge pools on the yields dashboard.

I'm a developer at YO Protocol.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the YOUSD Edge vault to the Base, Ethereum, and Arbitrum vault listings.
  * Updated Arbitrum to display the YOUSD Edge vault.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->