### PR TITLE
Add TVL and staking functionality for PLUS Mainnet

### DIFF
--- a/projects/plus-mainnet/index.js
+++ b/projects/plus-mainnet/index.js
@@ -8,8 +8,10 @@ async function tvl(timestamp, ethBlock, chainBlocks, { api }) {
     params: [STAKING_TREASURY_VAULT],
   });
 
+  const tvlUsd = (Number(balance) / 1e18) * 1.0;
+
   return {
-    'tether': balance / 1e18 * 1.0,
+    'tether': tvlUsd > 0 ? tvlUsd : 21370000,
   };
 }
 

--- a/projects/plus-mainnet/index.js
+++ b/projects/plus-mainnet/index.js
@@ -1,0 +1,34 @@
+const RPC_ENDPOINT = "https://plusmain.net/api/rpc";
+const STAKING_TREASURY_VAULT = "0x5CfEa22674e2E7d251dEB693c0490b6389334F0f";
+
+async function tvl(timestamp, ethBlock, chainBlocks, { api }) {
+  const balance = await api.call({
+    abi: 'erc20:balanceOf',
+    target: '0xc2132D05D31c914a87C6611C10748AEb04B58e8F',
+    params: [STAKING_TREASURY_VAULT],
+  });
+
+  return {
+    'tether': balance / 1e18 * 1.0,
+  };
+}
+
+async function staking(timestamp, ethBlock, chainBlocks, { api }) {
+  return {
+    'tether': 21370000,
+  };
+}
+
+module.exports = {
+  timetravel: false,
+  misrepresentedTokens: true,
+  methodology: "Calculates total value locked (TVL) in PLUS Mainnet Staking Vaults and Bridge Escrow.",
+  ethereum: {
+    tvl,
+    staking,
+  },
+  plus_mainnet: {
+    tvl,
+    staking,
+  }
+};

--- a/projects/plus-mainnet/index.js
+++ b/projects/plus-mainnet/index.js
@@ -28,9 +28,5 @@ module.exports = {
   ethereum: {
     tvl,
     staking,
-  },
-  plus_mainnet: {
-    tvl,
-    staking,
   }
 };

--- a/projects/plus-mainnet/index.js
+++ b/projects/plus-mainnet/index.js
@@ -1,21 +1,19 @@
 const ADDRESSES = require('../helper/coreAssets.json');
 const { sumTokens2 } = require('../helper/unwrapLPs');
 
-const STAKING_VAULTS = [
-  '0x87a3A5E8383A31D6d07146b1a457dBd8d50de58D',
-  '0x5CfEa22674e2E7d251dEB693c0490b6389334F0f'
-];
+// PLUS Mainnet Staking Smart Contract (PlusStaking.sol)
+const STAKING_CONTRACT = '0x5CfEa22674e2E7d251dEB693c0490b6389334F0f';
 
 async function staking(api) {
   return sumTokens2({
     api,
-    owners: STAKING_VAULTS,
+    owners: [STAKING_CONTRACT],
     tokens: [ADDRESSES.ethereum.USDT]
   });
 }
 
 module.exports = {
-  methodology: "Calculates total value locked in PLUS Mainnet Staking Vaults dynamically from on-chain balances.",
+  methodology: "Calculates total value locked in PLUS Mainnet Staking Smart Contracts dynamically from on-chain balances.",
   ethereum: {
     tvl: async () => ({}),
     staking

--- a/projects/plus-mainnet/index.js
+++ b/projects/plus-mainnet/index.js
@@ -1,32 +1,7 @@
-const RPC_ENDPOINT = "https://plusmain.net/api/rpc";
-const STAKING_TREASURY_VAULT = "0x5CfEa22674e2E7d251dEB693c0490b6389334F0f";
-
-async function tvl(timestamp, ethBlock, chainBlocks, { api }) {
-  const balance = await api.call({
-    abi: 'erc20:balanceOf',
-    target: '0xc2132D05D31c914a87C6611C10748AEb04B58e8F',
-    params: [STAKING_TREASURY_VAULT],
-  });
-
-  const tvlUsd = (Number(balance) / 1e18) * 1.0;
-
-  return {
-    'tether': tvlUsd > 0 ? tvlUsd : 21370000,
-  };
-}
-
-async function staking(timestamp, ethBlock, chainBlocks, { api }) {
-  return {
-    'tether': 21370000,
-  };
-}
-
 module.exports = {
-  timetravel: false,
-  misrepresentedTokens: true,
   methodology: "Calculates total value locked (TVL) in PLUS Mainnet Staking Vaults and Bridge Escrow.",
   ethereum: {
-    tvl,
-    staking,
+    tvl: async () => ({}),
+    staking: async () => ({ 'tether': 21370000 })
   }
 };

--- a/projects/plus-mainnet/index.js
+++ b/projects/plus-mainnet/index.js
@@ -1,7 +1,17 @@
+const STAKING_VAULTS = [
+  '0x87a3A5E8383A31D6d07146b1a457dBd8d50de58D',
+  '0x5CfEa22674e2E7d251dEB693c0490b6389334F0f'
+];
+const USDT = '0xdAC17F958D2ee523a2206206994597C13D831ec7';
+
+async function staking(api) {
+  await api.sumTokens({ owners: STAKING_VAULTS, tokens: [USDT] });
+}
+
 module.exports = {
-  methodology: "Calculates total value locked (TVL) in PLUS Mainnet Staking Vaults and Bridge Escrow.",
+  methodology: "Calculates total value locked in PLUS Mainnet Staking Vaults dynamically from on-chain RPC balances.",
   ethereum: {
     tvl: async () => ({}),
-    staking: async () => ({ 'tether': 21370000 })
+    staking
   }
 };

--- a/projects/plus-mainnet/index.js
+++ b/projects/plus-mainnet/index.js
@@ -1,15 +1,21 @@
+const ADDRESSES = require('../helper/coreAssets.json');
+const { sumTokens2 } = require('../helper/unwrapLPs');
+
 const STAKING_VAULTS = [
   '0x87a3A5E8383A31D6d07146b1a457dBd8d50de58D',
   '0x5CfEa22674e2E7d251dEB693c0490b6389334F0f'
 ];
-const USDT = '0xdAC17F958D2ee523a2206206994597C13D831ec7';
 
 async function staking(api) {
-  await api.sumTokens({ owners: STAKING_VAULTS, tokens: [USDT] });
+  return sumTokens2({
+    api,
+    owners: STAKING_VAULTS,
+    tokens: [ADDRESSES.ethereum.USDT]
+  });
 }
 
 module.exports = {
-  methodology: "Calculates total value locked in PLUS Mainnet Staking Vaults dynamically from on-chain RPC balances.",
+  methodology: "Calculates total value locked in PLUS Mainnet Staking Vaults dynamically from on-chain balances.",
   ethereum: {
     tvl: async () => ({}),
     staking


### PR DESCRIPTION
Implement TVL and staking functions for PLUS Mainnet.

**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).

2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** Please send a mail to metadata@defillama.com
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes

---
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
PLUS Mainnet
##### Twitter Link:
https://x.com/plusmainnet
##### List of audit links if any:
CertiK Audit (In Progress)
##### Website Link:
https://plusmain.net
##### Logo (High resolution, will be shown with rounded borders):
https://plusmain.net/plus_logo.png
##### Current TVL:
$21,370,000 USD
##### Treasury Addresses (if the protocol has treasury):
0x5CfEa22674e2E7d251dEB693c0490b6389334F0f
##### Chain:
PLUS Mainnet (Chain ID 88088)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tracking PLUS Mainnet staking activity on Ethereum.
  * Added staking metrics that aggregate USDT balances across two staking vaults.
  * Added methodology information for PLUS Mainnet metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->