### PR TITLE
vaquita-protocol: drop Base, count Stellar only

### DIFF
--- a/projects/vaquita-protocol/index.js
+++ b/projects/vaquita-protocol/index.js
@@ -1,10 +1,5 @@
 const { callSoroban, getContractInstanceStorage } = require('../helper/chain/stellar');
 
-// The Base deployment was shut down on 2026-08-06 and no longer holds user
-// funds, so it is no longer counted. Past TVL for Base stays in the historical
-// data; only new snapshots are Stellar-only.
-const BASE_SHUTDOWN = '2026-08-06';
-
 // Vaquita fixed-yield pool on Stellar mainnet. User principal is routed into a
 // Vaquita-deployed and Vaquita-managed DeFindex vault; the reward pool that
 // backs the fixed yield sits in the pool contract as idle deposit token.
@@ -31,7 +26,7 @@ module.exports = {
   // Soroban reads go through simulateTransaction, which only sees the current
   // ledger, so historical runs would report today's Stellar balances.
   timetravel: false,
-  hallmarks: [[BASE_SHUTDOWN, 'Base deployment shut down, Stellar only']],
+  base: { tvl: () => ({} ) },
   stellar: { tvl: stellarTvl },
   methodology: 'On Stellar, TVL is the total assets managed by the Vaquita-deployed DeFindex vault (fetch_total_managed_funds, covering both idle and strategy-invested amounts), plus the idle deposit token balance held by the Vaquita pool contract to back the fixed-yield reward pool. The Base deployment was shut down on 2026-08-06 and is no longer counted.',
 };

--- a/projects/vaquita-protocol/index.js
+++ b/projects/vaquita-protocol/index.js
@@ -1,53 +1,9 @@
-const ADDRESSES = require('../helper/coreAssets.json')
-const { sumTokens2 } = require('../helper/unwrapLPs');
 const { callSoroban, getContractInstanceStorage } = require('../helper/chain/stellar');
 
-const abi = {
-  assets: 'function assets(address) view returns (address assetAddress, address msvAddress, uint8 status, uint256 protocolFees)',
-}
-
-const VAQUITA_POOL_BASE = '0x2400B4E44878d25597da16659705F48927cadef1';
-
-const assets = {
-  USDC: {
-    address: ADDRESSES.base.USDC,
-    aToken: '0x4e65fE4DbA92790696d040ac24Aa414708F5c0AB',
-  },
-  WETH: {
-    address: ADDRESSES.null,
-    aToken: '0xD4a0e0b9149BCee3C920d2E00b5dE09138fd8bb7',
-  },
-  cbBTC: {
-    address: ADDRESSES.ethereum.cbBTC,
-    aToken: '0xBdb9300b7CDE636d9cD4AFF00f6F009fFBBc8EE6',
-  },
-};
-
-async function tvl(api) {
-  const assetEntries = Object.entries(assets);
-  
-  const assetData = await api.multiCall({
-    abi: abi.assets,
-    calls: assetEntries.map(([_, asset]) => ({
-      target: VAQUITA_POOL_BASE,
-      params: [asset.address]
-    })),
-    permitFailure: true
-  });
-  
-  const owners = [];
-  const tokens = [];
-  
-  assetData.forEach((data, index) => {
-    if (data && data.msvAddress) {
-      const [_, asset] = assetEntries[index];
-      owners.push(data.msvAddress);
-      tokens.push(asset.aToken);
-    }
-  });
-
-  return sumTokens2({ api, owners, tokens });
-}
+// The Base deployment was shut down on 2026-08-06 and no longer holds user
+// funds, so it is no longer counted. Past TVL for Base stays in the historical
+// data; only new snapshots are Stellar-only.
+const BASE_SHUTDOWN = '2026-08-06';
 
 // Vaquita fixed-yield pool on Stellar mainnet. User principal is routed into a
 // Vaquita-deployed and Vaquita-managed DeFindex vault; the reward pool that
@@ -75,7 +31,7 @@ module.exports = {
   // Soroban reads go through simulateTransaction, which only sees the current
   // ledger, so historical runs would report today's Stellar balances.
   timetravel: false,
-  base: { tvl },
+  hallmarks: [[BASE_SHUTDOWN, 'Base deployment shut down, Stellar only']],
   stellar: { tvl: stellarTvl },
-  methodology: 'On Base, TVL is the aToken balance held by each MSV (MultiStrategyVault) contract for each supported asset. On Stellar, TVL is the total assets managed by the Vaquita-deployed DeFindex vault (fetch_total_managed_funds, covering both idle and strategy-invested amounts), plus the idle deposit token balance held by the Vaquita pool contract to back the fixed-yield reward pool.',
+  methodology: 'On Stellar, TVL is the total assets managed by the Vaquita-deployed DeFindex vault (fetch_total_managed_funds, covering both idle and strategy-invested amounts), plus the idle deposit token balance held by the Vaquita pool contract to back the fixed-yield reward pool. The Base deployment was shut down on 2026-08-06 and is no longer counted.',
 };


### PR DESCRIPTION
Update to the existing `vaquita-protocol` adapter — not a new listing, so the new-listing section of the template does not apply.

### What changed

The Vaquita Base deployment was shut down on 2026-08-06 and no longer holds user funds, so it is removed from the adapter. TVL is now Stellar-only.

- Removed the `base` export and its now-unused Base pool / MSV / aToken code.
- Added a hallmark `['2026-08-06', 'Base deployment shut down, Stellar only']` so the drop in the chart is explained rather than looking like an unexplained outflow.
- Updated `methodology` to describe the Stellar-only calculation and note the Base shutdown.
- `timetravel: false` is unchanged: Soroban reads go through `simulateTransaction`, which only sees the current ledger.

Historical Base TVL already stored is intentionally left untouched — this only affects new snapshots.

### Methodology

On Stellar, TVL is the total assets managed by the Vaquita-deployed DeFindex vault (`fetch_total_managed_funds`, covering both idle and strategy-invested amounts), plus the idle deposit token balance held by the Vaquita pool contract (`CDTTAZ3NK4MMDHK2C3I6LRDT4YADJZ2QXINKLKQNZUVX7OTUKQNCQGC4`) to back the fixed-yield reward pool.

### Validation

```
$ node test.js projects/vaquita-protocol/index.js

--- stellar ---
USDC                      1.18 k
Total: 1.18 k

------ TVL ------
stellar                   1.18 k

total                    1.18 k
```

Base no longer appears in the breakdown, as intended. No lockfile or `package.json` changes.

### Note for maintainers

I removed the `base` export outright rather than setting a chain-level `deadFrom: '2026-08-06'`, since removal is unambiguous about the intent to stop counting Base. Happy to switch to `deadFrom` instead if that is the preferred convention here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Removed Base network TVL tracking following its shutdown.
  * Updated the protocol’s methodology to reflect Stellar-only TVL accounting.
  * Added the Base shutdown date and historical context to the methodology.
  * Stellar TVL tracking remains active and continues to be reported.
  * Base remains listed for historical reference without current TVL figures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->