### PR TITLE
fix: update VFT Manager address of Vara ⇌ Ethereum Bridge

### DIFF
--- a/projects/vara-ethereum-bridge/index.js
+++ b/projects/vara-ethereum-bridge/index.js
@@ -6,7 +6,7 @@ const ERC20_MANAGER = '0x16fCff97822fcf3345Fa76D29c229b11C49EaE12';
 
 const VARA_RPC = 'https://rpc.vara.network'
 const WVARA_VFT = '0x29c42c668012b1ce20720e4615229215023281ef4676fdc77bf047d7fbcb9d17'
-const VFT_MANAGER = '0xe01ddc667f80cf57704352b557668b710c345395abcac0752c01402d16e3e81b'
+const VFT_MANAGER = '0xc97d76b9aa85ca7738ac2b9eb30756edb985abd93a65834438e751bd0a5237af'
 const GAS_LIMIT = 750000000000
 
 // SCALE-encode a string: https://github.com/paritytech/parity-scale-codec


### PR DESCRIPTION
@RohanNero Hey, we found critical issue with double mint at [gear-tech/gear-bridges](https://github.com/gear-tech/gear-bridges) using Claude at Rust part of contracts and migrated it to new `VFTManager` [here](https://vara.subsquare.io/fellowship/referenda/67). Imbalance was [only `$69` on `ERC20Manager`](https://etherscan.io/tx/0x3e72f11539258342d7626acdcfc29d5762c2893acfd0a151dfadfac4d1d3c9f5). One of [exploiters withdrew `$800` and then deposited it back into bridge](https://etherscan.io/address/0x89a20dd0196f48e61a4a1fe1a8923e3f373461e9#tokentxns). We stopped bridge relay shortly afterward because we noticed this early this morning. `$10,000` in assets are safe! :rocket:

PR fixes this:
<img width="555" height="235" alt="image" src="https://github.com/user-attachments/assets/8f511666-75c9-4a96-a1ae-7939292e1ba1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the bridge configuration to ensure Vara TVL balance queries use the correct VFT manager address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->