### PR TITLE
small fixes

### DIFF
--- a/projects/aries-markets/index.js
+++ b/projects/aries-markets/index.js
@@ -13,8 +13,7 @@ const faWrapperFilter = (i) => i.type.includes("0x9770fa9c725cbd97eb50b2be5f7416
 
 module.exports = {
   timetravel: false,
-  methodology:
-    "Counts the lamports in each coin container in the Aries contract account.",
+  methodology: "Counts the lamports in each coin container in the Aries contract account.",
   aptos: {
     tvl: async (api) => {
       const data = await _getResources()
@@ -37,45 +36,6 @@ module.exports = {
         api.add(faAddress, lamports);
       });
     },
-    borrowed: async (api) => {
-      const data = await _getResources()
-      const reserveTableHandle = data.filter(i => i.type === "0x9770fa9c725cbd97eb50b2be5f7416efdfd1f1554beb0750d4dae4c64e860da3::reserve::Reserves")[0].data.stats.handle
-
-      const coinContainers = await Promise.all(
-        data.filter(reserveContrainerFilter)
-        .map(async (i) => {
-          const coin_type = extractCoinAddress(i.type)
-
-          const [address, module, struct] = coin_type.split("::");
-
-          const reserveStatus = await getTableData({ 
-            table: reserveTableHandle, 
-            data: { 
-              key_type: "0x1::type_info::TypeInfo",
-              value_type: "0x9770fa9c725cbd97eb50b2be5f7416efdfd1f1554beb0750d4dae4c64e860da3::reserve_details::ReserveDetails",
-              key: {
-                account_address: address,
-                module_name: toHex(module),
-                struct_name: toHex(struct)
-              }
-            } 
-          });
-
-          const total_borrowed = BigInt(reserveStatus.total_borrowed.val) / BigInt(10 ** 18);
-
-          const faInfo = data.filter(faWrapperFilter).filter((i) => i.type.includes(coin_type));
-          const normalizedAddress = faInfo.length == 0 ? coin_type : faInfo[0].data.metadata.inner;
-  
-          return {
-            lamports: total_borrowed.toString(),
-            tokenAddress: normalizedAddress,
-          };
-        })
-      );
-
-      coinContainers.forEach(({ lamports, tokenAddress }) => {
-        api.add(tokenAddress, lamports);
-      });
-    },
+    borrowed: () => ({}) // markets wound down in July 2026 and liquidity was removed
   },
 };

--- a/projects/boardwalk/index.js
+++ b/projects/boardwalk/index.js
@@ -5,12 +5,13 @@ const { sumUnknownTokens, nullAddress } = require('../helper/unknownTokens')
 // Staked BWLK is held by the staked-BWLK tracker (sBWLK).
 const BWLK = '0xF9a352b7C7B62a852e5C8A64A455246Dd9596461'
 const STAKED_BWLK_TRACKER = '0x3961F92c26724C9d61CED679540F35794d90c576'
+const DEAD = '0x000000000000000000000000000000000000dEaD'
 
 const config = {
-    ethereum: '0xfAEdbA0E97D5DCD7A29fB6778D7e17b1be35c0b8',
-    base: '0x4F7af6f968C30be6FC196Cd5eed68032022AB067',
-    arbitrum: '0xe64A71A60D552B56579D8edeB13E86bD6222F882',
-    robinhood: '0x177dbEDd02cEe010b80a0A3F284c9FD9F67D8a9e',
+  ethereum: '0xfAEdbA0E97D5DCD7A29fB6778D7e17b1be35c0b8',
+  base: '0x4F7af6f968C30be6FC196Cd5eed68032022AB067',
+  arbitrum: '0xe64A71A60D552B56579D8edeB13E86bD6222F882',
+  robinhood: '0x177dbEDd02cEe010b80a0A3F284c9FD9F67D8a9e',
 }
 
 const launchInfoAbi = 'function launches(address) view returns (address token, address feeDistributor, address presaleManager, address vestingStream, address lpStaking, address issuer, uint8 path, uint32 createdAt)'
@@ -31,15 +32,18 @@ async function tvl(api) {
   lpTokens.forEach((lp, i) => {
     if (lp === nullAddress) return
     ownerTokens.push([[lp], lpStakings[i]])
+    ownerTokens.push([[lp], DEAD])
   })
-  return sumUnknownTokens({ api, ownerTokens, resolveLP: true, useDefaultCoreAssets: true })
+
+  const memeTokens = launches.map(l => l.token).filter(Boolean)
+  return sumUnknownTokens({ api, ownerTokens, resolveLP: true, useDefaultCoreAssets: true, blacklist: memeTokens })
 }
 
 module.exports = {
   misrepresentedTokens: true,
-  doublecounted: true, // staked LP is canonical Uniswap v2 pair liquidity, also counted in the uniswap listing
+  doublecounted: true, // LP is canonical Uniswap v2 pair liquidity, also counted in the uniswap listing
   start: '2026-07-18',
-  methodology: 'Counts WETH contributed to active presales (held by each launch\'s PresaleManager) and Uniswap v2 LP tokens staked in each launch\'s LPStaking contract, valued from pair reserves. Staked BWLK on Ethereum is counted under staking.',
+  methodology: 'Counts WETH contributed to active presales (held by each launch\'s PresaleManager), plus the WETH side of the Uniswap v2 LP staked in each launch\'s LPStaking contract and the permanently-locked seed LP burned to the dead address at graduation. Only the WETH side of each pair is counted; the launch-token side is self-priced and excluded. Staked BWLK on Ethereum is counted under staking.',
 }
 
 Object.keys(config).forEach(chain => {


### PR DESCRIPTION
- removes aries borrowed export as it is no longer accurate since the markets are wound down - to be marked deadFrom shortly after remaining liquidity is removed
- fixes boardwalk by including burned LP and tracking only quote side of pairs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated Aries Markets reporting to reflect that wound-down markets no longer have active borrowed balances.
  - Improved Boardwalk liquidity reporting by excluding burned or inaccessible launch tokens from balance calculations.
  - Refined staked liquidity accounting and WETH-only valuation for more accurate market metrics.

- **Documentation**
  - Updated methodology details to clarify burned seed liquidity and valuation treatment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->