### PR TITLE
morpho-blue: blacklist two RSS/USDC markets on base

### DIFF
--- a/projects/morpho-blue/config.js
+++ b/projects/morpho-blue/config.js
@@ -36,6 +36,8 @@ const config = {
     blacklistedMarketIds: [
       '0xff0f2bd52ca786a4f8149f96622885e880222d8bed12bbbf5950296be8d03f89', // bad debt due to resolv hack
       '0xe1986e80099257c65dd18091ec7e34752ae2336870a5649f20c450c9c4931fb8', // HERMES market
+      '0xa4ec527128b425ee3fcb7f60eca37677b63b3d003345ec2a72ef6a2e72da53fc', // RSS/USDC (77% LLTV) market, single supplier looping against self-issued RSS collateral
+      '0x41c08085ddcfd1dc1c5eb82d7dc031593d1a1a831958380e8b60469c45bf7d88', // RSS/USDC (77% LLTV) market, single supplier looping against self-issued RSS collateral
     ]
   },
   arbitrum: {


### PR DESCRIPTION
Adds two Base markets to `blacklistedMarketIds` for the `morpho-blue` adapter, following the same pattern as #19290.

Both are RSS/USDC markets at 77% LLTV with a single supplier and a single borrower, 100% utilised, collateralised by a self-issued RSS token that has no price feed:

| market id | collateral | supply = borrow |
|---|---|---|
| `0xa4ec527128b425ee3fcb7f60eca37677b63b3d003345ec2a72ef6a2e72da53fc` | [`0x50639C42E2FFDEC4F68FB468968a55b3Af944583`](https://basescan.org/address/0x50639C42E2FFDEC4F68FB468968a55b3Af944583) (RSS, 8d) | ~16.5M USDC |
| `0x41c08085ddcfd1dc1c5eb82d7dc031593d1a1a831958380e8b60469c45bf7d88` | [`0x7a305D07B537359cf468eAea9bb176E5308bC337`](https://basescan.org/address/0x7a305D07B537359cf468eAea9bb176E5308bC337) (RSS, 18d) | ~200.8M USDC |

Neither RSS token is priced by DefiLlama today, so `borrowed` already skips both markets via the unpriced-collateral guard and current numbers are unchanged. Blacklisting them explicitly makes the exclusion durable: if either RSS token later gets a price feed, ~$217M of circular borrows would otherwise show up in Morpho's Base metrics.

Ran `node test.js projects/morpho-blue/index.js` — passes, only pre-existing `ink` RPC failures unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added two Base Morpho RSS/USDC markets with self-issued RSS collateral looping to the blacklist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->