### PR TITLE
add frontier

### DIFF
--- a/projects/frontier-fun/index.js
+++ b/projects/frontier-fun/index.js
@@ -1,0 +1,25 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+const { getLogs2 } = require('../helper/cache/getLogs')
+
+// Frontier (frontier.fun) — bonding-curve token launchpad on Robinhood Chain (4663).
+// Each launched token custodies the native ETH its own curve raises, so TVL is the
+// ETH sitting in un-graduated token contracts. When a curve fills, the token pays
+// the creator fee and seeds a Uniswap V4 pool in the same transaction, leaving its
+// own balance at zero — graduated markets therefore drop out on their own, and
+// their liquidity is already counted by the uniswap-v4 adapter on this chain.
+const FACTORY = '0x3cbC9395046607C083B383DC3588A3e8308dFf54'
+const FROM_BLOCK = 23650298 // block of the first CoinDeployed event
+
+const COIN_DEPLOYED_EVENT = 'event CoinDeployed(address indexed creator, address indexed token, address factory, address lp, string name, string symbol, string description, string image, uint256 initialSupply, uint256 maxSupply, uint256 initialETHReserves, uint256 initialPrice, uint256 initialMarketCap, uint256 targetETH)'
+
+async function tvl(api) {
+  const logs = await getLogs2({ api, factory: FACTORY, eventAbi: COIN_DEPLOYED_EVENT, fromBlock: FROM_BLOCK })
+  return api.sumTokens({ tokensAndOwners: logs.map(log => [ADDRESSES.null, log.token]) })
+}
+
+module.exports = {
+  methodology:
+    'Counts the native ETH held by Frontier bonding-curve token contracts on Robinhood Chain, enumerated from the factory\'s CoinDeployed events. Each token custodies the ETH its own curve raises until the curve fills, at which point the token pays out the creator fee and seeds a Uniswap V4 pool in the same transaction and its balance goes to zero — so graduated markets are excluded here and their liquidity is counted by the Uniswap V4 adapter instead. The launched tokens themselves are not counted.',
+  start: '2026-07-30',
+  robinhood: { tvl },
+}


### PR DESCRIPTION
Adds a TVL adapter for **Frontier**, a bonding-curve token launchpad on Robinhood Chain (4663).

##### Name (to be shown on DefiLlama):
Frontier

##### Twitter Link:
https://x.com/frontierhood

##### List of audit links if any:
None — the protocol has not been audited.

##### Website Link:
https://frontier.fun

##### Logo (High resolution, will be shown with rounded borders):
https://frontier.fun/favicon.svg

##### Current TVL:
~$3.4k

##### Treasury Addresses (if the protocol has treasury)
`0x97FcE327df892E77A0B1E64c2e59902505a842bB` (Safe, Robinhood Chain)

##### Chain:
Robinhood

##### Coingecko ID:
n/a — no protocol token

##### Coinmarketcap ID:
n/a — no protocol token

##### Short Description (to be shown on DefiLlama):
Bonding-curve token launchpad on Robinhood Chain. Tokens trade on a shared bonding curve until it fills, then graduate to a Uniswap V4 pool.

##### Token address and ticker if any:
None — Frontier has no protocol token.

##### Category:
Launchpad

##### Oracle Provider(s):
None — the adapter uses no oracle. Balances are read on-chain and priced by DefiLlama.

##### Implementation Details:
n/a

##### Documentation/Proof:
https://docs.frontier.fun

##### forkedFrom:
n/a — original.

##### methodology (what is being counted as tvl, how is tvl being calculated):
Counts the native ETH held by Frontier bonding-curve token contracts, enumerated from the factory's `CoinDeployed` events (`getLogs2`, factory `0x3cbC9395046607C083B383DC3588A3e8308dFf54`, from block 23650298).

Each launched token custodies the ETH its own curve raises. When the curve fills, the token pays out the creator fee and seeds a Uniswap V4 pool in the same transaction, leaving its own balance at zero — so graduated markets fall out of the total on their own, and their liquidity is counted by the existing `uniswap-v4` adapter on this chain rather than double counted here. The launched tokens themselves are not counted.

##### Github org/user:
n/a

##### Does this project have a referral program?
Yes — an off-chain points/referral rewards program. It is not a trade-time fee split and does not affect TVL.

---

Volume, fees and revenue for this protocol will be submitted separately to `DefiLlama/dimension-adapters`.

**Test output** (`node test.js projects/frontier-fun/index.js`):

```
--- robinhood ---
ETH                       3.45 k
Total: 3.45 k

------ TVL ------
robinhood                 3.45 k

total                     3.45 k
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Frontier TVL tracking on Robinhood Chain.
  * TVL now includes native ETH balances held by tokens deployed through Frontier’s factory.
  * Historical tracking begins from block 23,650,298 and includes the adapter’s methodology and start date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->