### PR TITLE
fix(textile): price Celo/Base cNGN so maker inventory counts toward TVL

### DIFF
--- a/projects/textile/index.js
+++ b/projects/textile/index.js
@@ -15,6 +15,33 @@ const CHAINS = {
   celo: 42220,
 };
 
+// cNGN is one asset the issuer deploys across many chains, but DefiLlama only
+// prices some of them. CoinGecko's `compliant-naira` has no Celo platform (cNGN
+// shipped there in Aug 2026 and the listing hasn't caught up) and points at a Base
+// contract that isn't the issuer's. Both addresses below are the official ones from
+// https://docs.cngn.co/guides/contract-addresses, so without this the maker
+// inventory held in them silently drops out of USD TVL. Balances are still read
+// on-chain; this only fixes how they are valued.
+const UNPRICED_CNGN = {
+  celo: "0xf6829d7393dae24509eb1e52ee8e572e2e271a4f",
+  base: "0x46c85152bfe9f96829aa94755d9f915f9b10ef5f",
+};
+const CNGN_ID = "coingecko:compliant-naira";
+const CNGN_DECIMALS = 6;
+
+function priceCngn(api) {
+  const token = UNPRICED_CNGN[api.chain];
+  if (!token) return;
+
+  const balances = api.getBalances();
+  const key = `${api.chain}:${token}`;
+  const balance = balances[key];
+  if (!balance) return;
+
+  delete balances[key];
+  api.add(CNGN_ID, Number(balance) / 10 ** CNGN_DECIMALS, { skipChain: true });
+}
+
 async function tvl(api) {
   const chainId = CHAINS[api.chain];
 
@@ -32,7 +59,10 @@ async function tvl(api) {
     ...new Set(settlementV3Pools.flatMap((p) => [p.collateralAsset, p.debtAsset])),
   ];
 
-  return api.sumTokens({ owners, tokens });
+  await api.sumTokens({ owners, tokens });
+  priceCngn(api);
+
+  return api.getBalances();
 }
 
 module.exports = {


### PR DESCRIPTION
Not a new listing — this is a fix to an existing adapter (`projects/textile`, Textile FX), so the template form below is replaced with details.

## Summary

Textile FX TVL under-reports because cNGN has no DefiLlama price on Celo or Base, so `api.sumTokens` reads those maker balances on-chain and then silently drops them from USD TVL. Remap them onto `coingecko:compliant-naira`, the id that already prices the BSC cNGN contract.

Balances are still read on-chain. Only the valuation changes.

## Both addresses are the issuer's official contracts

cNGN's issuer publishes its canonical per-chain contracts at [docs.cngn.co/guides/contract-addresses](https://docs.cngn.co/guides/contract-addresses). The two addresses this PR maps are on that list verbatim:

| Chain | Issuer's official contract | Adapter maps it |
|---|---|---|
| Celo | `0xF6829D7393dAe24509eb1E52eE8e572e2E271a4f` | yes |
| Base | `0x46C85152bFe9f96829aA94755D9f915F9B10EF5F` | yes |
| BSC | `0xa8AEA66B361a8d53e8865c62D142167Af28Af058` | no — already priced |

Celo also lists it in [its own docs](https://github.com/celo-org/docs/blob/main/scripts/data/stablecoins.json) as `cNGN / Compliant Naira`, issuer Africa Stablecoin Consortium, at the same address.

## Why these two aren't priced today

**Celo:** CoinGecko's `compliant-naira` has no Celo platform. cNGN only shipped on Celo on 2026-08-06 ([issuer changelog](https://docs.cngn.co/changelog)), so the listing hasn't caught up yet.

**Base:** CoinGecko lists `0xc930784d6e14e2fc2a1f49be1068dc40f24762d3` for Base. That address is **not** on the issuer's official contract list, and GeckoTerminal shows it with no price, no reserves and no volume. The issuer's actual Base contract (`0x46C85152…`, the one this adapter reads) trades at `$0.00072364` with ~$94.7k reserves and ~$3.8k 24h volume, but has `coingecko_coin_id: null`.

All three contracts report `symbol=cNGN, decimals=6` on-chain, and the Base one trades within ~0.9% of `compliant-naira`.

The durable fix is upstream — CoinGecko adding a Celo platform and correcting the Base contract. Happy to drop this in favour of that if you'd rather not carry the remap, but the Celo gap is live now.

## Result

`node test.js projects/textile/index.js`, before → after:

| Chain | Before | After |
|---|---|---|
| ethereum | $110.39k | $110.39k |
| bsc | $99.56k | $99.56k |
| celo | $17.75k | **$103.81k** |
| base | $630 | $630 |
| **total** | **$228.34k** | **$314.38k** |

The +$86.05k on Celo is exactly the makers' cNGN balance there (119,970,138.54 cNGN × $0.00071729), and $314.38k matches Textile's own dashboard. Token breakdown still lists cNGN as its own line rather than an opaque USD blob.

Base is unchanged because makers hold no cNGN there today; the mapping is in place for when they do, and the guard makes it a no-op until then.

## Test plan

- [x] `node test.js projects/textile/index.js` passes
- [x] Celo TVL rises by the current Celo cNGN inventory (~$86k)
- [x] Protocol TVL moves from ~$228k to ~$314k, matching the Textile dashboard
- [x] cNGN still shows as a distinct token in the breakdown
- [x] `npx eslint -c eslint.config.js projects/textile/index.js` clean

No changes to `package.json` / lockfiles.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TVL valuation for unpriced Celo and Base contracts.
  * Added support for valuing eligible on-chain balances using the appropriate cNGN market price.
  * Adjusted balance reporting to reflect corrected valuations.
  * Ensured affected balances are consistently included in overall TVL calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->