### PR TITLE
multipli: their api moved balances under payload.tvl_data, tvl has been reading zero

### DIFF
--- a/projects/multipli/index.js
+++ b/projects/multipli/index.js
@@ -11,7 +11,8 @@ const rwaUSDis = {
 
 const tvl = async (api) => {
   const { data } = await axios.get(API)
-  const balances = data.payload[api.chain] ?? {}
+  const payload = data.payload?.tvl_data ?? data.payload ?? {}
+  const balances = payload[api.chain] ?? {}
   const blacklisted = rwaUSDis[api.chain]?.toLowerCase()
   if (blacklisted) {
     const target = `${api.chain}:${blacklisted}`


### PR DESCRIPTION
Multipli TVL is reading $0 right now. `api.llama.fi/protocol/multipli.fi` returns `chainTvls` with a single `Ethereum` key holding an empty `tokens` array, and no tvl series at all.

Their API changed shape, balances moved one level down, under `payload.tvl_data`:

```
$ curl https://api.multipli.fi/multipli/v1/external-aggregator/defillama/tvl/
{"status":"success","payload":{"tvl_data":{"ethereum":{...},"avax":{...},"bsc":{...},"monad":{...}}}}
```

`payload` now contains only `tvl_data`, so `data.payload[api.chain]` is `undefined` for every chain and `?? {}` turns that into an empty balance set rather than an error:

```
payload[ethereum] = undefined
payload[bsc]      = undefined
payload[avax]     = undefined
payload[base]     = undefined
payload[monad]    = undefined
payload[arbitrum] = undefined
```

Reading `payload.tvl_data` when it's there, falling back to the old shape otherwise, so it keeps working if they revert.

Before: every chain $0. After:

```
--- ethereum ---   USDC 19.42 M | WBTC 2.89 M | USDT 1.26 M   Total: 23.57 M
--- bsc ---                                                    Total: 746.82 k
------ TVL ------  total 24.32 M
```

Same on a second run. The ethereum leg matches the raw API by hand: USDT 1,262,268.97 + USDC 19,426,656.09 + 44.50 WBTC.

avax and monad still come out at 0, avax is ~$13.2k of USDC.e plus 0.0034 BTC.b, and the monad entry is a token that doesn't price, so they're dust either way, not something this changes.

I kept the API path rather than going on-chain, since #19233 / #19225 / #20247 were all closed with "we have decided to continue allowing them to use their API for now since tracking their on-chain idle vault balances would undercount". This is just realigning the read with their current response.

One thing I noticed but did not touch: the rwaUSDi blacklist from #19421 builds its key as `` `${api.chain}:${blacklisted}` `` while the payload keys are bare addresses (`0xdAC17F95...`), so it would no longer match if rwaUSDi came back. It's a no-op today, rwaUSDi isn't in the response at all, and it's your fix, so I left it alone. Happy to send that separately if you want it.

Knock-on: `fees/multipli-fi` in dimension-adapters currently dies with `TypeError: Cannot read properties of undefined (reading 'tokens')` because it reads `chainTvls[chain].tokens` off this same endpoint and finds it empty; its fees chart has been stopped since 08-03. That should clear once TVL is populated again.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TVL data handling for responses with nested payloads.
  * Preserved compatibility with existing TVL response formats.
  * Prevented errors when chain balance data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->