### PR TITLE
Add RaiseHood (launchpad on Robinhood Chain)

### DIFF
--- a/projects/raisehood/index.js
+++ b/projects/raisehood/index.js
@@ -9,6 +9,44 @@ const NFT_MANAGERS = [
 ]
 
 const saleDataAbi = 'function getSaleData() view returns (tuple(address saleToken, address quoteToken, uint256 tokensPerQuoteUnit, uint256 softCap, uint256 hardCap, uint256 minBuy, uint256 maxBuy, uint64 startsAt, uint64 endsAt, bytes32 merkleRoot, uint16 tgeBps, uint64 cliffDuration, uint64 vestingDuration, address lpAdapter, uint16 lpBps, uint8 state, uint256 totalRaised, uint256 totalTokensSold, uint256 saleAllocation, uint64 finalizedAt, uint64 claimsOpenAt, bool deposited, bool cancelled, bool lpCreated, address projectOwner, uint256 quoteDecimalScale, uint256 platformFeeBps, bool escaped, bool closedEarly, uint8 pricingMode, address priceFeed, uint256 tokenPriceUsd, uint256 totalRaisedUsd, uint64 lpLockDuration, uint256 lpTokensAmount, bool burnUnsold))'
+const positionsAbi = 'function positions(uint256) view returns (uint96 nonce, address operator, address token0, address token1, uint24 fee, int24 tickLower, int24 tickUpper, uint128 liquidity, uint256 feeGrowthInside0LastX128, uint256 feeGrowthInside1LastX128, uint128 tokensOwed0, uint128 tokensOwed1)'
+const ticksAbi = 'function ticks(int24) view returns (uint128 liquidityGross, int128 liquidityNet, uint256 feeGrowthOutside0X128, uint256 feeGrowthOutside1X128, int56 tickCumulativeOutside, uint160 secondsPerLiquidityOutsideX128, uint32 secondsOutside, bool initialized)'
+const slot0Abi = 'function slot0() view returns (uint160 sqrtPriceX96, int24 tick, uint16 observationIndex, uint16 observationCardinality, uint16 observationCardinalityNext, uint8 feeProtocol, bool unlocked)'
+
+const Q128 = 2n ** 128n
+const U256 = 2n ** 256n
+const subMod = (a, b) => ((a - b) % U256 + U256) % U256
+
+// uncollected fees = checkpointed tokensOwed + liquidity * feeGrowthInside delta since last checkpoint
+async function addUncollectedFees(api, npm, owner) {
+  const count = await api.call({ abi: 'erc20:balanceOf', target: npm, params: owner })
+  if (+count === 0) return
+  const ids = await api.multiCall({ abi: 'function tokenOfOwnerByIndex(address, uint256) view returns (uint256)', target: npm, calls: Array.from({ length: +count }, (_, i) => ({ params: [owner, i] })) })
+  const positions = await api.multiCall({ abi: positionsAbi, target: npm, calls: ids })
+  const factory = await api.call({ abi: 'address:factory', target: npm })
+  const pools = await api.multiCall({ abi: 'function getPool(address, address, uint24) view returns (address)', target: factory, calls: positions.map(p => ({ params: [p.token0, p.token1, p.fee] })) })
+  const [slot0s, global0s, global1s, lowerTicks, upperTicks] = await Promise.all([
+    api.multiCall({ abi: slot0Abi, calls: pools }),
+    api.multiCall({ abi: 'uint256:feeGrowthGlobal0X128', calls: pools }),
+    api.multiCall({ abi: 'uint256:feeGrowthGlobal1X128', calls: pools }),
+    api.multiCall({ abi: ticksAbi, calls: pools.map((pool, i) => ({ target: pool, params: [positions[i].tickLower] })) }),
+    api.multiCall({ abi: ticksAbi, calls: pools.map((pool, i) => ({ target: pool, params: [positions[i].tickUpper] })) }),
+  ])
+  positions.forEach((p, i) => {
+    const tick = +slot0s[i].tick
+    for (const side of [0, 1]) {
+      const global = BigInt(side === 0 ? global0s[i] : global1s[i])
+      const outsideLower = BigInt(lowerTicks[i][`feeGrowthOutside${side}X128`])
+      const outsideUpper = BigInt(upperTicks[i][`feeGrowthOutside${side}X128`])
+      const below = tick >= +p.tickLower ? outsideLower : subMod(global, outsideLower)
+      const above = tick < +p.tickUpper ? outsideUpper : subMod(global, outsideUpper)
+      const inside = subMod(subMod(global, below), above)
+      const delta = subMod(inside, BigInt(p[`feeGrowthInside${side}LastX128`]))
+      const owed = BigInt(p[`tokensOwed${side}`]) + BigInt(p.liquidity) * delta / Q128
+      api.add(side === 0 ? p.token0 : p.token1, owed.toString())
+    }
+  })
+}
 
 async function tvl(api) {
   const sales = await api.fetchList({ lengthAbi: 'uint256:allSalesLength', itemAbi: 'function allSales(uint256) view returns (address)', target: FACTORY })
@@ -17,8 +55,11 @@ async function tvl(api) {
 
   // quote assets (native ETH, USDG, tokenized stocks) escrowed in each sale during the raise
   const ownerTokens = saleData.map((d, i) => [[d.quoteToken], sales[i]])
-  // the locker also accrues LP trading fees in the same quote assets
-  ownerTokens.push([saleData.map(d => d.quoteToken), lpLocker])
+  // the locker also holds LP trading fees already collected from locked positions (both quote and sale-token side)
+  ownerTokens.push([saleData.flatMap(d => [d.quoteToken, d.saleToken]), lpLocker])
+
+  // fees earned by the locked positions but not yet collected to the locker
+  for (const npm of NFT_MANAGERS) await addUncollectedFees(api, npm, lpLocker)
 
   return sumTokens2({
     api,
@@ -28,7 +69,7 @@ async function tvl(api) {
 }
 
 module.exports = {
-  methodology: 'TVL counts the quote assets (ETH, USDG, Robinhood tokenized stocks) escrowed in RaiseHood sale contracts during active raises, plus the V3 LP positions (Uniswap V3 / RobinSwap) that are auto-seeded at settlement and time-locked in the RaiseHood LP fee vault, plus LP trading fees accrued to that vault.',
+  methodology: 'TVL counts the quote assets (ETH, USDG, Robinhood tokenized stocks) escrowed in RaiseHood sale contracts during active raises, plus the V3 LP positions (Uniswap V3 / RobinSwap) that are auto-seeded at settlement and time-locked in the RaiseHood LP fee vault, plus accrued LP trading fees.',
   doublecounted: true, // locked LP positions sit in Uniswap V3 / RobinSwap pools, which are tracked separately
   robinhood: { tvl },
 }

--- a/projects/raisehood/index.js
+++ b/projects/raisehood/index.js
@@ -1,75 +1,32 @@
 const { sumTokens2 } = require('../helper/unwrapLPs')
+const ADDRESSES = require('../helper/coreAssets.json')
 
 const FACTORY = '0xde540a7d140e27e50305fae78e736fe00f4a917f'
-
-// V3 position managers RaiseHood seeds locked liquidity on
 const NFT_MANAGERS = [
   '0x73991a25C818Bf1f1128dEAaB1492D45638DE0D3', // Uniswap V3 NPM (Robinhood Chain)
   '0xd359160448B011dC1AAAF9C166e2e13bb414e6b3', // RobinSwap V3 NPM
 ]
 
 const saleDataAbi = 'function getSaleData() view returns (tuple(address saleToken, address quoteToken, uint256 tokensPerQuoteUnit, uint256 softCap, uint256 hardCap, uint256 minBuy, uint256 maxBuy, uint64 startsAt, uint64 endsAt, bytes32 merkleRoot, uint16 tgeBps, uint64 cliffDuration, uint64 vestingDuration, address lpAdapter, uint16 lpBps, uint8 state, uint256 totalRaised, uint256 totalTokensSold, uint256 saleAllocation, uint64 finalizedAt, uint64 claimsOpenAt, bool deposited, bool cancelled, bool lpCreated, address projectOwner, uint256 quoteDecimalScale, uint256 platformFeeBps, bool escaped, bool closedEarly, uint8 pricingMode, address priceFeed, uint256 tokenPriceUsd, uint256 totalRaisedUsd, uint64 lpLockDuration, uint256 lpTokensAmount, bool burnUnsold))'
-const positionsAbi = 'function positions(uint256) view returns (uint96 nonce, address operator, address token0, address token1, uint24 fee, int24 tickLower, int24 tickUpper, uint128 liquidity, uint256 feeGrowthInside0LastX128, uint256 feeGrowthInside1LastX128, uint128 tokensOwed0, uint128 tokensOwed1)'
-const ticksAbi = 'function ticks(int24) view returns (uint128 liquidityGross, int128 liquidityNet, uint256 feeGrowthOutside0X128, uint256 feeGrowthOutside1X128, int56 tickCumulativeOutside, uint160 secondsPerLiquidityOutsideX128, uint32 secondsOutside, bool initialized)'
-const slot0Abi = 'function slot0() view returns (uint160 sqrtPriceX96, int24 tick, uint16 observationIndex, uint16 observationCardinality, uint16 observationCardinalityNext, uint8 feeProtocol, bool unlocked)'
-
-const Q128 = 2n ** 128n
-const U256 = 2n ** 256n
-const subMod = (a, b) => ((a - b) % U256 + U256) % U256
-
-// uncollected fees = checkpointed tokensOwed + liquidity * feeGrowthInside delta since last checkpoint
-async function addUncollectedFees(api, npm, owner) {
-  const count = await api.call({ abi: 'erc20:balanceOf', target: npm, params: owner })
-  if (+count === 0) return
-  const ids = await api.multiCall({ abi: 'function tokenOfOwnerByIndex(address, uint256) view returns (uint256)', target: npm, calls: Array.from({ length: +count }, (_, i) => ({ params: [owner, i] })) })
-  const positions = await api.multiCall({ abi: positionsAbi, target: npm, calls: ids })
-  const factory = await api.call({ abi: 'address:factory', target: npm })
-  const pools = await api.multiCall({ abi: 'function getPool(address, address, uint24) view returns (address)', target: factory, calls: positions.map(p => ({ params: [p.token0, p.token1, p.fee] })) })
-  const [slot0s, global0s, global1s, lowerTicks, upperTicks] = await Promise.all([
-    api.multiCall({ abi: slot0Abi, calls: pools }),
-    api.multiCall({ abi: 'uint256:feeGrowthGlobal0X128', calls: pools }),
-    api.multiCall({ abi: 'uint256:feeGrowthGlobal1X128', calls: pools }),
-    api.multiCall({ abi: ticksAbi, calls: pools.map((pool, i) => ({ target: pool, params: [positions[i].tickLower] })) }),
-    api.multiCall({ abi: ticksAbi, calls: pools.map((pool, i) => ({ target: pool, params: [positions[i].tickUpper] })) }),
-  ])
-  positions.forEach((p, i) => {
-    const tick = +slot0s[i].tick
-    for (const side of [0, 1]) {
-      const global = BigInt(side === 0 ? global0s[i] : global1s[i])
-      const outsideLower = BigInt(lowerTicks[i][`feeGrowthOutside${side}X128`])
-      const outsideUpper = BigInt(upperTicks[i][`feeGrowthOutside${side}X128`])
-      const below = tick >= +p.tickLower ? outsideLower : subMod(global, outsideLower)
-      const above = tick < +p.tickUpper ? outsideUpper : subMod(global, outsideUpper)
-      const inside = subMod(subMod(global, below), above)
-      const delta = subMod(inside, BigInt(p[`feeGrowthInside${side}LastX128`]))
-      const owed = BigInt(p[`tokensOwed${side}`]) + BigInt(p.liquidity) * delta / Q128
-      api.add(side === 0 ? p.token0 : p.token1, owed.toString())
-    }
-  })
-}
 
 async function tvl(api) {
   const sales = await api.fetchList({ lengthAbi: 'uint256:allSalesLength', itemAbi: 'function allSales(uint256) view returns (address)', target: FACTORY })
   const lpLocker = await api.call({ abi: 'address:lpLocker', target: FACTORY })
   const saleData = await api.multiCall({ abi: saleDataAbi, calls: sales })
 
-  // quote assets (native ETH, USDG, tokenized stocks) escrowed in each sale during the raise
   const ownerTokens = saleData.map((d, i) => [[d.quoteToken], sales[i]])
-  // the locker also holds LP trading fees already collected from locked positions (both quote and sale-token side)
-  ownerTokens.push([saleData.flatMap(d => [d.quoteToken, d.saleToken]), lpLocker])
-
-  // fees earned by the locked positions but not yet collected to the locker
-  for (const npm of NFT_MANAGERS) await addUncollectedFees(api, npm, lpLocker)
+  const quoteWhitelist = [...new Set(saleData.map(d => d.quoteToken === ADDRESSES.null ? ADDRESSES.robinhood.WETH : d.quoteToken))]
 
   return sumTokens2({
     api,
     ownerTokens,
     uniV3nftsAndOwners: NFT_MANAGERS.map(npm => [npm, lpLocker]),
+    uniV3WhitelistedTokens: quoteWhitelist,
   })
 }
 
 module.exports = {
-  methodology: 'TVL counts the quote assets (ETH, USDG, Robinhood tokenized stocks) escrowed in RaiseHood sale contracts during active raises, plus the V3 LP positions (Uniswap V3 / RobinSwap) that are auto-seeded at settlement and time-locked in the RaiseHood LP fee vault, plus accrued LP trading fees.',
-  doublecounted: true, // locked LP positions sit in Uniswap V3 / RobinSwap pools, which are tracked separately
+  methodology: 'Quote assets (ETH, USDG, tokenized stocks) escrowed in RaiseHood sale contracts during active raises, plus the locked V3 LP positions auto-seeded at settlement. Locked LP sits in Uniswap V3 / RobinSwap pools tracked separately, so doublecounted.',
+  doublecounted: true,
   robinhood: { tvl },
 }

--- a/projects/raisehood/index.js
+++ b/projects/raisehood/index.js
@@ -1,0 +1,34 @@
+const { sumTokens2 } = require('../helper/unwrapLPs')
+
+const FACTORY = '0xde540a7d140e27e50305fae78e736fe00f4a917f'
+
+// V3 position managers RaiseHood seeds locked liquidity on
+const NFT_MANAGERS = [
+  '0x73991a25C818Bf1f1128dEAaB1492D45638DE0D3', // Uniswap V3 NPM (Robinhood Chain)
+  '0xd359160448B011dC1AAAF9C166e2e13bb414e6b3', // RobinSwap V3 NPM
+]
+
+const saleDataAbi = 'function getSaleData() view returns (tuple(address saleToken, address quoteToken, uint256 tokensPerQuoteUnit, uint256 softCap, uint256 hardCap, uint256 minBuy, uint256 maxBuy, uint64 startsAt, uint64 endsAt, bytes32 merkleRoot, uint16 tgeBps, uint64 cliffDuration, uint64 vestingDuration, address lpAdapter, uint16 lpBps, uint8 state, uint256 totalRaised, uint256 totalTokensSold, uint256 saleAllocation, uint64 finalizedAt, uint64 claimsOpenAt, bool deposited, bool cancelled, bool lpCreated, address projectOwner, uint256 quoteDecimalScale, uint256 platformFeeBps, bool escaped, bool closedEarly, uint8 pricingMode, address priceFeed, uint256 tokenPriceUsd, uint256 totalRaisedUsd, uint64 lpLockDuration, uint256 lpTokensAmount, bool burnUnsold))'
+
+async function tvl(api) {
+  const sales = await api.fetchList({ lengthAbi: 'uint256:allSalesLength', itemAbi: 'function allSales(uint256) view returns (address)', target: FACTORY })
+  const lpLocker = await api.call({ abi: 'address:lpLocker', target: FACTORY })
+  const saleData = await api.multiCall({ abi: saleDataAbi, calls: sales })
+
+  // quote assets (native ETH, USDG, tokenized stocks) escrowed in each sale during the raise
+  const ownerTokens = saleData.map((d, i) => [[d.quoteToken], sales[i]])
+  // the locker also accrues LP trading fees in the same quote assets
+  ownerTokens.push([saleData.map(d => d.quoteToken), lpLocker])
+
+  return sumTokens2({
+    api,
+    ownerTokens,
+    uniV3nftsAndOwners: NFT_MANAGERS.map(npm => [npm, lpLocker]),
+  })
+}
+
+module.exports = {
+  methodology: 'TVL counts the quote assets (ETH, USDG, Robinhood tokenized stocks) escrowed in RaiseHood sale contracts during active raises, plus the V3 LP positions (Uniswap V3 / RobinSwap) that are auto-seeded at settlement and time-locked in the RaiseHood LP fee vault, plus LP trading fees accrued to that vault.',
+  doublecounted: true, // locked LP positions sit in Uniswap V3 / RobinSwap pools, which are tracked separately
+  robinhood: { tvl },
+}


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
RaiseHood

##### Twitter Link:
https://x.com/RaiseHood

##### List of audit links if any:
None

##### Website Link:
https://www.raisehood.xyz

##### Logo (High resolution, will be shown with rounded borders):
https://www.raisehood.xyz/favicon.svg (vector) — PNG fallback: https://www.raisehood.xyz/apple-touch-icon.png

##### Current TVL:
~$2.5k (one graduated genesis launch; TVL is its locked LP)

##### Treasury Addresses (if the protocol has treasury)
robinhood:0x0a39701e5D5BB5A6146aEEba66638297D0947f04

##### Chain:
Robinhood Chain

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):


##### Short Description (to be shown on DefiLlama):
Fair-raise token launchpad on Robinhood Chain: fixed-price presales paired with ETH, USDG, or Robinhood stock tokens. Settlement auto-seeds V3 liquidity that is time-locked in the protocol's fee vault, and buyers get mutually exclusive claim-or-refund outcomes.

##### Token address and ticker if any:
None

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Launchpad

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
None (live config uses fixed-price sales only)

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
n/a

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
n/a

##### forkedFrom (Does your project originate from another project):
None

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL counts the quote assets (ETH, USDG, Robinhood tokenized stocks) escrowed in RaiseHood sale contracts during active raises, plus the V3 LP positions (Uniswap V3 / RobinSwap) that are auto-seeded at settlement and time-locked in the RaiseHood LP fee vault, plus LP trading fees accrued to that vault. The locked LP sits in Uniswap V3 / RobinSwap pools tracked separately on DefiLlama, so the adapter sets doublecounted: true.

##### Github org/user (Optional, if your code is open source, we can track activity):


##### Does this project have a referral program?
No (the factory supports an optional referral fee; it is currently set to 0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added RaiseHood total value locked (TVL) tracking.
  - Automatically discovers sale contracts and the liquidity-provider locker.
  - Tracks escrowed quote assets across sale contracts.
  - Includes whitelisted assets held in locked Uniswap V3 and RobinSwap V3 positions.
  - Accounts for collected and uncollected liquidity-provider trading fees.
  - Added methodology details and double-counting disclosures for greater transparency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->