### PR TITLE
feat: add pupcup hammer staking tvl adapter on ethereum and base

### DIFF
--- a/projects/pupcup-hammer/index.js
+++ b/projects/pupcup-hammer/index.js
@@ -1,0 +1,24 @@
+const config = {
+  ethereum: {
+    token: '0x884649f1fE3Bf3Ae0Bd720Eaf660cB561dcE39ef',
+    stakingVault: '0x8da35B1BBC0209D5140B64ff256dAe2Db703165d',
+  },
+  base: {
+    token: '0x42BAb297f90e6285546F05abdF4C42D8415E9794',
+    stakingVault: '0x63E311CF0cBfb1C0984EEad4C416B6b830b046Ab',
+  },
+}
+
+async function staking(api) {
+  const { token, stakingVault } = config[api.chain]
+  const totalStaked = await api.call({ target: stakingVault, abi: 'uint256:totalStaked' })
+  api.add(token, totalStaked)
+}
+
+const tvl = async () => ({})
+
+module.exports = {
+  methodology: 'Staking TVL is the PUPCUP principal deposited in the Ethereum and Base staking vaults, as reported by each vault\'s totalStaked value. LayerZero bridge escrow balances and staking reward reserves are excluded.',
+  ethereum: { tvl, staking },
+  base: { tvl, staking },
+}


### PR DESCRIPTION
## Description

Fixes #19347

Adds a PupCup Hammer adapter that tracks PUPCUP deposited in the protocol’s staking vaults on Ethereum and Base.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added TVL tracking for PUPCUP staking vaults on Ethereum and Base.
  - Reports staked balances for the corresponding tokens on each supported chain.
  - Includes methodology details clarifying excluded bridge escrow and staking reward balances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->