### PR TITLE
Delist Shade Protocol adapters backed by decommissioned APIs

### DIFF
--- a/projects/shadeprotocol-lend/index.js
+++ b/projects/shadeprotocol-lend/index.js
@@ -18,6 +18,7 @@ async function borrowed(api) {
 
 
 module.exports = {
+  deadFrom: '2026-08-08',
   misrepresentedTokens: true,
   secret: {
     tvl,

--- a/projects/shadeprotocol-moneymarket/index.js
+++ b/projects/shadeprotocol-moneymarket/index.js
@@ -16,6 +16,7 @@ async function borrowed(api) {
 }
 
 module.exports = {
+  deadFrom: '2026-08-08',
   misrepresentedTokens: true,
   secret: {
     tvl,

--- a/projects/shadeprotocol-silk/index.js
+++ b/projects/shadeprotocol-silk/index.js
@@ -8,6 +8,7 @@ async function tvl(api) {
 }
 
 module.exports = {
+  deadFrom: '2026-08-08',
   misrepresentedTokens: true,
   secret: {
     tvl

--- a/projects/shadeswap/index.js
+++ b/projects/shadeswap/index.js
@@ -7,6 +7,7 @@ async function tvl(api) {
 
 
 module.exports = {
+  deadFrom: '2026-08-08',
   misrepresentedTokens: true,
   secret: {
     tvl


### PR DESCRIPTION
Shade Protocol is decommissioning the backend endpoints that these adapters depend on, so they can no longer report accurate TVL. Marking them `deadFrom: '2026-08-08'`.

| Adapter | Endpoint | Current status |
|---|---|---|
| `shadeswap` | `prodv1.securesecrets.org/graphql` | being retired |
| `shadeprotocol-lend` | `prodv1.securesecrets.org/graphql` | being retired |
| `shadeprotocol-moneymarket` | `prodv1.securesecrets.org/defillama/moneymarket/` | already returning 400 |
| `shadeprotocol-silk` | `ruvzuawwz7.execute-api.us-east-1.amazonaws.com/prod-analytics-v1/silk` | already returning 500 |

`shadeprotocol-derivatives` (stkd-SCRT) is intentionally **not** included — it queries Secret Network contracts directly, doesn't touch the retired backend, and still runs clean:

```
--- tvl ---
SCRT                      188.35 k
```

I'm on the Shade Protocol team (the owner of these endpoints), so this is a self-requested delisting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an end-of-coverage date of August 8, 2026, for Shade Protocol Lend, Shade Protocol Money Market, Shade Protocol Silk, and ShadeSwap.
  * These integrations will be recognized as inactive after the specified date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->