### PR TITLE
Add EarnGrid ERC-4626 vault on Base

### DIFF
--- a/registries/erc4626.js
+++ b/registries/erc4626.js
@@ -90,6 +90,11 @@ const configs = {
       '0x36213ca1483869c5616be738Bf8da7C9B34Ace8d',
     ],
   },
+  'earngrid': {
+    methodology: 'Automated USDC yield vault on Base — aggregates MetaMorpho strategies. TVL via totalAssets().',
+    doublecounted: true,
+    base: ['0x6eca76891504fc2362ac0e6fd5998dfff44e8fe1'],
+  },
   'eva': {
     ethereum: [
       '0x741bD193B6b40f8703d2e116FD1965421f290F58', // USDC vault


### PR DESCRIPTION
## EarnGrid — Automated USDC Yield Vault on Base

- **Website:** https://earngrid.site
- **Chain:** Base (8453)
- **Vault:** `0x6eca76891504fc2362ac0e6fd5998dfff44e8fe1`
- **Type:** ERC-4626 vault aggregating MetaMorpho strategies
- **TVL method:** `totalAssets()`
- **`doublecounted: true`** — funds deployed into MetaMorpho vaults which DeFiLlama already tracks

### Test output
```
node test.js earngrid
--- base ---
USDC                      18.98
Total: 18.98
```

### About
EarnGrid is an automated USDC yield vault that rebalances across Morpho Blue MetaMorpho strategies to maximize APY. Built with Foundry + viem + Next.js. Source-verified on Sourcify.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking the Earngrid ERC4626 vault on the Base network.
  * Included vault methodology and double-counting metadata for accurate reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->