### PR TITLE
Add TayDex TVL adapter

### DIFF
--- a/projects/taydex/index.js
+++ b/projects/taydex/index.js
@@ -1,10 +1,11 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+
 const TAYDEX_MARKET = '0x3ade22Fa1EF5ac75437A3734D91bA588E54875dd'
-const BASE_USDC = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'
 
 async function tvl(api) {
   return api.sumTokens({
     owner: TAYDEX_MARKET,
-    tokens: [BASE_USDC],
+    tokens: [ADDRESSES.base.USDC],
   })
 }
 

--- a/projects/taydex/index.js
+++ b/projects/taydex/index.js
@@ -1,0 +1,16 @@
+const TAYDEX_MARKET = '0x3ade22Fa1EF5ac75437A3734D91bA588E54875dd'
+const BASE_USDC = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'
+
+async function tvl(api) {
+  return api.sumTokens({
+    owner: TAYDEX_MARKET,
+    tokens: [BASE_USDC],
+  })
+}
+
+module.exports = {
+  methodology:
+    'Counts native Base USDC held by the verified TayDex market contract as liquidity locked across TayDex prediction markets. Trading volume, wallet balances, and fees already transferred out of the contract are not included.',
+  start: 1777393441,
+  base: { tvl },
+}


### PR DESCRIPTION
## New listing: TayDex

##### Name (to be shown on DefiLlama):

TayDex

##### Twitter Link:

https://x.com/taydexfun

##### List of audit links if any:

None. The core smart contract source is verified on Base Blockscout:
https://base.blockscout.com/address/0x3ade22Fa1EF5ac75437A3734D91bA588E54875dd

##### Website Link:

https://taydex.fun

##### Logo (High resolution, will be shown with rounded borders):

https://taydex.fun/brand/icon-512.png

##### Current TVL:

0.00 native Base USDC in the 2026-08-09 adapter test. The adapter reads the live on-chain balance, so this value will change only when USDC is actually held by the contract.

##### Treasury Addresses (if the protocol has treasury):

Fee recipient: `0xc0b085c1a5514d8541adcb105aa7e6e8e5bc74ed`

##### Chain:

Base

##### Coingecko ID:

None

##### Coinmarketcap ID:

None

##### Short Description:

TayDex is a prediction exchange on Base for creating and trading binary event markets in native USDC.

##### Token address and ticker if any:

None — TayDex has no native token.

##### Category:

Prediction Market

##### Oracle Provider(s):

None. Markets are resolved administratively from the public reference source specified for each market.

##### Implementation Details:

The verified contract does not call an on-chain oracle for settlement. The owner-only `resolveSingleBinary` and `resolveMarket` functions record the outcome after checking the market's stated public reference source.

##### Documentation/Proof:

Verified contract source and ABI:
https://base.blockscout.com/address/0x3ade22Fa1EF5ac75437A3734D91bA588E54875dd?tab=contract

##### forkedFrom:

None

##### methodology:

TVL is the native Base USDC balance held by the verified TayDex market contract as liquidity across TayDex prediction markets. Trading volume, wallet balances, and fees already transferred out of the contract are excluded.

##### Github org/user:

Not provided. The verified contract source should not be presented as proof that the whole product is open source.

##### Does this project have a referral program?

No public referral program.

## Validation

- One adapter file only: `projects/taydex/index.js`
- No dependencies or lockfiles changed
- `node test.js projects/taydex/index.js` completed successfully
- Current test output: Base TVL `0.00`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for TayDex on the Base network.
  * Includes native USDC held by the TayDex market contract in TVL calculations.
  * Added methodology details and tracking start information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->