### PR TITLE
Add Avocado Fund TVL adapter (Arbitrum)

### DIFF
--- a/projects/avocado-fund/index.js
+++ b/projects/avocado-fund/index.js
@@ -1,0 +1,30 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+const { sumTokens2 } = require('../helper/unwrapLPs')
+
+// Avocado Fund — uncollateralised USDC lending on Arbitrum One
+// https://avocado.fund | https://github.com/0x-Naomi/avocado-fund
+const USDC = ADDRESSES.arbitrum.USDC_CIRCLE
+const VAULT = '0xa3185e9AD376BC95600b65648bac02aF23653741' // AvocadoVault (ERC-4626, avUSDC shares)
+const LENDING = '0xFF27bAeE76495a33CAed3c7cad31E404034b8911' // AvocadoLending (credit lines, borrow/repay)
+
+// TVL = USDC actually held by the protocol: idle USDC in the ERC-4626 vault plus
+// USDC deployed to the lending contract but not yet drawn by borrowers.
+// USDC out with borrowers is excluded here and reported under `borrowed`.
+const tvl = async (api) => sumTokens2({ api, owners: [VAULT, LENDING], tokens: [USDC] })
+
+// Outstanding borrower debt (principal + accrued interest), read from the lending contract.
+const borrowed = async (api) => {
+  const debt = await api.call({ abi: 'uint256:totalOutstandingDebt', target: LENDING })
+  api.add(USDC, debt)
+}
+
+module.exports = {
+  methodology:
+    'TVL counts the USDC balance held by the AvocadoVault (ERC-4626, avUSDC) and by the AvocadoLending contract on Arbitrum One. Borrowed counts totalOutstandingDebt() on the AvocadoLending contract, which is uncollateralised borrower principal plus accrued interest. Uncollateralised debt is excluded from TVL so lender deposits are not double counted with funds drawn by borrowers.',
+  // AvocadoVault deployed 2026-05-01 (Arbitrum block 458279525, tx 0x67ea3ee8...bda6e0)
+  start: '2026-05-01',
+  arbitrum: {
+    tvl,
+    borrowed,
+  },
+}


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
Avocado Fund

##### Twitter Link:
https://x.com/_avocadofund

##### List of audit links if any:
https://avocado.fund/audit (Omniscia)

##### Website Link:
https://avocado.fund

##### Logo (High resolution, will be shown with rounded borders):
https://avocado.fund/logos/avocado-fund-logo.svg
NEEDS INPUT: DefiLlama wants a high-resolution logo. Ask the client for a 1000x1000
PNG on a transparent background and link that instead.

##### Current TVL:
~$5,400 USDC on Arbitrum One

##### Treasury Addresses (if the protocol has treasury)
NEEDS INPUT: the vault's feeRecipient address. Ask the client for it, and confirm
they are happy for it to be published.

##### Chain:
Arbitrum

##### Coingecko ID:
(leave empty — AVO is not deployed)

##### Coinmarketcap ID:
(leave empty — AVO is not deployed)

##### Short Description (to be shown on DefiLlama):
Uncollateralised USDC lending on Arbitrum. Borrowers pass identity verification and
build an on-chain credit score to draw an unsecured credit line; lenders supply USDC
to an ERC-4626 vault and earn borrower interest.

##### Token address and ticker if any:
None. The AVO token is not deployed.

##### Category:
Lending

##### Oracle Provider(s):
None. TVL and debt are read directly from protocol contracts. USDC is priced by
DefiLlama, not by an in-protocol oracle.

##### Implementation Details:
Not applicable — the protocol uses no price oracle. The vault holds a single asset
(USDC) and the borrow rate is a fixed 12% APR set on-chain, not oracle-derived.

##### Documentation/Proof:
https://github.com/0x-Naomi/avocado-fund
https://avocado.fund/transparency

##### forkedFrom:
Not a fork. AvocadoVault extends OpenZeppelin's ERC4626 implementation.

##### methodology:
TVL counts the USDC balance held by the AvocadoVault (ERC-4626, avUSDC shares,
0xa3185e9AD376BC95600b65648bac02aF23653741) and by the AvocadoLending contract
(0xFF27bAeE76495a33CAed3c7cad31E404034b8911) on Arbitrum One. Borrowed counts
totalOutstandingDebt() on AvocadoLending, which is uncollateralised borrower
principal plus accrued interest. Uncollateralised debt is excluded from TVL so
lender deposits are not double counted against funds drawn by borrowers.

##### Github org/user:
https://github.com/0x-Naomi/avocado-fund

##### Does this project have a referral program?
NEEDS INPUT: ask the client.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for tracking Avocado Fund on Arbitrum One.
  - Reports USDC assets held in vault and lending contracts as total value locked (TVL).
  - Separately displays outstanding lending debt for clearer financial reporting.
  - Includes methodology and deployment start-date information for improved transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->