### PR TITLE
Add SwingHook TVL adapter

### DIFF
--- a/projects/swinghook/index.js
+++ b/projects/swinghook/index.js
@@ -1,0 +1,24 @@
+const { staking } = require('../helper/staking')
+const { nullAddress } = require('../helper/tokenMapping')
+
+const SWING = '0x89Cf5C1b3bc04ea54795B37A85258F1dfC9c31dF'
+const HOLDER_VAULT = '0x2e6970112417dd28341976Cb5E1Fc479dd5d2F58'
+
+const ETH_OWNERS = [
+  '0xa22aB327373EF932239FF0AEC7E0BB746eD00Da2', // ETHSettlementVault
+  HOLDER_VAULT,
+  '0x538177Ab16B34Ff5ce95BebFdeA5f0A2A16313D3', // FeeKeep
+]
+
+async function tvl(api) {
+  return api.sumTokens({ owners: ETH_OWNERS, tokens: [nullAddress] })
+}
+
+module.exports = {
+  methodology:
+    'TVL counts ETH held by the ETH Settlement Vault, Holder Vault, and FeeKeep. Staked Swing is reported separately. The protocol-native Swing settlement reserve and the official Uniswap v4 pool are excluded.',
+  ethereum: {
+    tvl,
+    staking: staking(HOLDER_VAULT, SWING),
+  },
+}


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).

2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.

3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating the adapter, please hop onto our discord, we are happy to assist you.

4. **For updating listing info** Please send a mail to metadata@defillama.com

5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes.

---

## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):

SwingHook

##### Twitter Link:

https://x.com/Hooknomics

##### List of audit links if any:

None.

##### Website Link:

https://swinghook.eth.limo

##### Logo (High resolution, will be shown with rounded borders):

https://swinghook.eth.limo/favicon.png

##### Current TVL:

Approximately $72,030 in base TVL at the time of submission. Staked SWING is tracked separately and is currently unpriced by DefiLlama.

##### Treasury Addresses (if the protocol has treasury):

None.

##### Chain:

Ethereum

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):

##### Short Description (to be shown on DefiLlama):

SwingHook is a trading-centered onchain protocol built around Uniswap v4 Hooks. It supports standard swaps and optional SwingBuy and SwingSell modes, connecting trading activity with settlement reserves, staking, Echo rewards, and protocol state transitions.

##### Token address and ticker if any:

SWING token (onchain symbol: Swing): 0x89Cf5C1b3bc04ea54795B37A85258F1dfC9c31dF

##### Category (full list at https://defillama.com/categories) \*Please choose only one:

Dexs

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

Chainlink VRF (randomness only; no external price oracle)

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

Chainlink VRF v2.5 is used only by the optional SwingBuy and SwingSell modes. RandomnessManager prepays the native VRF fee, requests a random word through the immutable VRF wrapper, and forwards fulfillment to SwingHook for settlement. Standard swaps do not use VRF. Market pricing comes directly from the Uniswap v4 pool rather than an external price oracle.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

- https://swinghook.eth.limo/whitepaper
- https://github.com/Hooknomics/swinghook-smartcontract
- https://github.com/Hooknomics/swinghook-smartcontract/blob/main/src/RandomnessManager.sol

##### forkedFrom (Does your project originate from another project):

No. SwingHook is a custom protocol built around Uniswap v4 Hook interfaces.

##### methodology (what is being counted as tvl, how is tvl being calculated):

Base TVL is calculated from the native ETH balances held by the ETH Settlement Vault, Holder Vault, and FeeKeep contracts. Staking is reported separately using the SWING balance held by the Holder Vault. The protocol-native SWING settlement reserve and the official Uniswap v4 pool are excluded.

##### Github org/user (Optional, if your code is open source, we can track activity):

https://github.com/Hooknomics

##### Does this project have a referral program?

No.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SwingHook TVL tracking on Ethereum.
  * Reports ETH held across the ETH settlement, holder, and fee vaults.
  * Added separate reporting for staked Swing through the holder vault.
  * Excludes protocol-native Swing reserves and the official Uniswap v4 pool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->