### PR TITLE
Add Kestrel Finance TVL adapter

### DIFF
--- a/projects/kestrel/index.js
+++ b/projects/kestrel/index.js
@@ -1,9 +1,10 @@
 const { Program } = require("@coral-xyz/anchor");
 const { PublicKey } = require("@solana/web3.js");
-const { getProvider } = require("../helper/solana");
+const { getProvider, sumTokens2 } = require("../helper/solana");
 
 const PROGRAM_ID = new PublicKey("LYC8YiiSzQfPpxUW2tpxfuPKGZwywAJhXKUfDP2B66f");
-const TVL_USD_DECIMALS = 8;
+const USD_DECIMALS = 8;
+const ZERO = "11111111111111111111111111111111";
 
 async function tvl(api) {
   const provider = getProvider("solana");
@@ -12,19 +13,35 @@ async function tvl(api) {
 
   const program = new Program(idl, provider);
   const tokens = await program.account.token.all();
-  const totalTvlUsd = tokens.reduce(
-    (sum, { account }) => sum + BigInt(account.accounting.tvlUsd.toString()),
-    0n,
-  );
 
-  api.addUSDValue(Number(totalTvlUsd) / 10 ** TVL_USD_DECIMALS);
+  // idle collateral
+  await sumTokens2({
+    api,
+    owners: tokens.map((t) => t.publicKey.toString()),
+    tokens: [...new Set(tokens.map((t) => t.account.collateral.mint.toString()))],
+  });
+
+  for (const { account } of tokens) {
+    const collateralMint = account.collateral.mint.toString();
+
+    for (const lp of account.lendingPositions) {
+      const collateral = lp.accounting.collateral.toString();
+      if (collateral !== "0") api.add(collateralMint, collateral);
+      const debt = lp.accounting.debt;
+      if (debt.mint.toString() !== ZERO && debt.amount.toString() !== "0")
+        api.add(debt.mint.toString(), "-" + debt.amount.toString());
+    }
+
+    for (const dc of account.debtCarry)
+      if (dc.tvlUsd.toString() !== "0")
+        api.addUSDValue(Number(dc.tvlUsd.toString()) / 10 ** USD_DECIMALS);
+  }
 }
 
 module.exports = {
   timetravel: false,
   doublecounted: true,
   misrepresentedTokens: true,
-  methodology:
-    "TVL is the sum of the USD-denominated on-chain accounting value for every Token account owned by Kestrel's Long Yield Carry program.",
+  methodology: "TVL is the net value of every Long Yield Carry vault: collateral held idle and deposited in lending platforms (Kamino/Marginfi) minus the stable debt borrowed against it plus the redeployed yield position.",
   solana: { tvl },
 };

--- a/projects/kestrel/index.js
+++ b/projects/kestrel/index.js
@@ -1,0 +1,30 @@
+const { Program } = require("@coral-xyz/anchor");
+const { PublicKey } = require("@solana/web3.js");
+const { getProvider } = require("../helper/solana");
+
+const PROGRAM_ID = new PublicKey("LYC8YiiSzQfPpxUW2tpxfuPKGZwywAJhXKUfDP2B66f");
+const TVL_USD_DECIMALS = 8;
+
+async function tvl(api) {
+  const provider = getProvider("solana");
+  const idl = await Program.fetchIdl(PROGRAM_ID, provider);
+  if (!idl) throw new Error("Unable to fetch the Long Yield Carry program IDL");
+
+  const program = new Program(idl, provider);
+  const tokens = await program.account.token.all();
+  const totalTvlUsd = tokens.reduce(
+    (sum, { account }) => sum + BigInt(account.accounting.tvlUsd.toString()),
+    0n,
+  );
+
+  api.addUSDValue(Number(totalTvlUsd) / 10 ** TVL_USD_DECIMALS);
+}
+
+module.exports = {
+  timetravel: false,
+  doublecounted: true,
+  misrepresentedTokens: true,
+  methodology:
+    "TVL is the sum of the USD-denominated on-chain accounting value for every Token account owned by Kestrel's Long Yield Carry program.",
+  solana: { tvl },
+};


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
Kestrel

##### Twitter Link:
https://x.com/kestrel_fi

##### List of audit links if any:
None at this time.

##### Website Link:
https://kestrel.finance

##### Logo (High resolution, will be shown with rounded borders):

<img width="503" height="503" alt="logo-X-black and orange" src="https://github.com/user-attachments/assets/c6ffe649-96ba-4785-8e91-0b31c672b8b4" />

##### Current TVL:
~$3,026 USD (Solana mainnet, read on 2026-08-09 from the program's on-chain
accounting: 2 Token accounts, one at $0 and one at $3,025.95).

##### Treasury Addresses (if the protocol has treasury)
None.

##### Chain:
Solana

##### Coingecko ID:
(empty — not listed)

##### Coinmarketcap ID:
(empty — not listed)

##### Short Description (to be shown on DefiLlama):
Kestrel turns DeFi strategies into tokens on Solana. Users deposit an asset,
receive a yield-bearing token, and redeem it later at the on-chain redemption
price.

##### Token address and ticker if any:
Kestrel has no governance token.

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Onchain Capital Allocator

##### Oracle Provider(s):
Pyth Network (all live tokens). The program also supports Switchboard
On-Demand, SPL stake-pool rates, and Perena bank/tranche NAV feeds.

##### Implementation Details:
Each token stores its oracle account address and oracle type on chain. The
values are set when the token is created. An operational key cannot replace
them. On every price-sensitive instruction the program verifies that the
supplied oracle account is in the token's registered oracle list, reads the
price, and rejects the price if it is older than the configured maximum age.
The program uses these prices to value collateral and debt, to calculate the
token redemption price, and to enforce deposit and leverage limits.

##### Documentation/Proof:
https://kestrel.finance/docs/security
https://kestrel.finance/docs/risks

##### forkedFrom (Does your project originate from another project):
None. The code is original.

##### methodology (what is being counted as tvl, how is tvl being calculated):
Counts the collateral backing Kestrel's tokens on Solana, net of the debt the
strategy has borrowed against it. The adapter reads every Token account owned
by the program (LYC8YiiSzQfPpxUW2tpxfuPKGZwywAJhXKUfDP2B66f) and sums the
on-chain USD value each one reports. Marked `doublecounted` because the
collateral is supplied to third-party lending markets that DefiLlama also
counts.

TVL includes unlent collateral held in the token's reserves and collateral
supplied to external lending markets, less nothing. The adapter is marked
`doublecounted` because part of the collateral sits in third-party lending
markets that DefiLlama also counts.

##### Github org/user (Optional, if your code is open source, we can track activity):
(empty — the repository is private)

##### Does this project have a referral program?
No.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for Kestrel’s Long Yield Carry program on Solana.
  * Calculates total value using collateral, deposits, debt, and USD valuations.
  * Added Solana network configuration and tracking metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->