### PR TITLE
Add Kayen Finance LST (Chiliz)

### DIFF
--- a/projects/kayen-finance-lst/index.js
+++ b/projects/kayen-finance-lst/index.js
@@ -1,0 +1,21 @@
+// Kayen Finance LST: liquid staking of native CHZ on Chiliz.
+//
+// stCHZ is an exchange-rate token rather than a rebasing one, so balances are fixed
+// shares and the rate rises as validator rewards compound. The CHZ backing those
+// shares is held by the depositor, which delegates it to the Chiliz validator set,
+// so totalDeposits() is the single source of truth for TVL: staked principal,
+// accrued rewards net of the protocol fee, amounts still undelegating and the idle
+// balance, less the CHZ already reserved for pending withdrawals.
+//
+// https://chiliscan.com/address/0xc3cbf2c6b3ea81f1A8a9fd24D8179B6F39860DB7
+const CHILIZ_DEPOSITOR = '0xc3cbf2c6b3ea81f1A8a9fd24D8179B6F39860DB7'
+
+async function tvl(api) {
+  const totalDeposits = await api.call({ target: CHILIZ_DEPOSITOR, abi: 'uint256:totalDeposits' })
+  api.addGasToken(totalDeposits)
+}
+
+module.exports = {
+  methodology: 'Counts the CHZ staked through Kayen Finance LST, read from ChilizDepositor.totalDeposits(): the pooled CHZ backing stCHZ, covering staked principal, accrued rewards, amounts still undelegating and the idle balance, excluding CHZ reserved for pending withdrawals.',
+  chz: { tvl },
+}


### PR DESCRIPTION
Adds a TVL adapter for Kayen Finance LST, liquid staking of native CHZ on Chiliz.

stCHZ is an exchange-rate token rather than a rebasing one, so balances are fixed shares and the CHZ redeemable per share rises as validator rewards compound. The pooled CHZ sits in `ChilizDepositor`, which delegates it to the Chiliz validator set, and `totalDeposits()` returns exactly what backs stCHZ: staked principal, accrued rewards net of the protocol fee, amounts still undelegating and the idle balance, less the CHZ already reserved for pending withdrawals. The adapter is a single call, no subgraph or off-chain source involved.

Verified against the protocol's own subgraph at matching blocks: `totalDeposits()` 9,479,487 CHZ and `stCHZ.totalSupply()` 9,313,194 agree to the wei, and `node test.js projects/kayen-finance-lst` reports 124.09k.

Chiliz is already a supported chain here (`chz`), so nothing new is needed on that side.

##### Name (to be shown on DefiLlama):
Kayen Finance LST

##### Twitter Link:
https://x.com/KayenFinance

##### List of audit links if any:
Audited by Halborn (Feb 2026) and Nemesis AI (Mar 2026). Happy to add report links on request.

##### Website Link:
https://app.kayen.finance/lst/stake

##### Logo (High resolution, will be shown with rounded borders):
Attached below
<img width="640" height="640" alt="kayenfi-logo" src="https://github.com/user-attachments/assets/456c2bc2-556e-4c71-a1fa-86712af56eee" />
.

##### Current TVL:
~$124k (9,479,487 CHZ)

##### Treasury Addresses (if the protocol has treasury)
Protocol fee vault: 0xCf271d12C2d1a757829F5F216a564017D60886F0

##### Chain:
Chiliz

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):

##### Short Description (to be shown on DefiLlama):
Liquid staking for native CHZ on Chiliz. Staking CHZ mints stCHZ, a transferable token whose redemption value rises as the delegated CHZ earns validator rewards.

##### Token address and ticker if any:
stCHZ, 0xBF4ca6F798b2e342E36dc2eC80667B58CF480787

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Liquid Staking

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
None. The CHZ per stCHZ rate is computed on-chain from the depositor's validator delegations rather than read from a price feed.

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
Not applicable, no oracle is used.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
Not applicable, no oracle is used.

##### forkedFrom (Does your project originate from another project):
No

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL is the CHZ staked through the protocol, read from `ChilizDepositor.totalDeposits()`. That covers staked principal, accrued rewards, amounts still undelegating and the idle balance, and excludes CHZ reserved for pending withdrawals.

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/kayenfinance

##### Does this project have a referral program?
No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for Kayen Finance’s liquid staking token on Chiliz.
  * Reports deposited CHZ backing and documents the treatment of pooled assets and pending withdrawals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->