### PR TITLE
Add Waddle Club adapter

### DIFF
--- a/projects/waddle-club/index.js
+++ b/projects/waddle-club/index.js
@@ -76,6 +76,6 @@ module.exports = {
   doublecounted: true,
   // First staker deployment (Kumbaya on MegaETH, block 3520323).
   start: "2025-12-21",
-  megaeth: { tvl, staking },
+  megaeth: { tvl },
   robinhood: { tvl, staking },
 };

--- a/projects/waddle-club/index.js
+++ b/projects/waddle-club/index.js
@@ -1,0 +1,92 @@
+const { unwrapUniswapV3NFT } = require("../helper/unwrapLPs");
+const { getLogs2 } = require("../helper/cache/getLogs");
+
+/**
+ * Waddle Club Staking - liquidity mining for Uniswap V3 style positions.
+ *
+ * TVL is what the staker contracts custody, which is two things:
+ *
+ *   1. LP NFTs. Staking transfers the position NFT to the staker, so the
+ *      protocol holds it. The underlying pair sits in the pool contract, not
+ *      the staker, so a token balance read returns zero: the positions have to
+ *      be unwrapped from liquidity and tick bounds against the pool's current
+ *      tick. Positions parked outside the live range are single sided and a
+ *      50/50 assumption would misprice them.
+ *   2. Reward tokens. Incentives are funded up front and the unclaimed balance
+ *      sits in the staker until stakers claim or the refundee pulls it back.
+ *
+ * Reward tokens are discovered from IncentiveCreated rather than hardcoded, so
+ * a new program with a new reward token needs no adapter change. Note refundee
+ * is NOT indexed on this event, verified against the deployed logs.
+ *
+ * Expect this to be flagged doublecounted, as Convex and Aura are: the same LP
+ * value is already counted under the DEX.
+ */
+
+const INCENTIVE_CREATED =
+  "event IncentiveCreated(address indexed rewardToken, address indexed pool, uint256 startTime, uint256 endTime, address refundee, uint256 reward)";
+
+/**
+ * One entry per venue, where a venue is one DEX deployment on one chain.
+ * Every staker here was deployed by the Waddle Club team; the Kumbaya venue
+ * uses a staker deployed for Waddle Club and is not counted in Kumbaya's TVL.
+ * The testnet venue is deliberately absent.
+ */
+const config = {
+  megaeth: [
+    {
+      // Kumbaya V3 on MegaETH
+      staker: "0x9F393A399321110Fb7D85aCc812b8e48A7c569aC",
+      nft: "0x2b781C57e6358f64864Ff8EC464a03Fdaf9974bA",
+      fromBlock: 3520323,
+    },
+    {
+      // Uniswap V3 on MegaETH
+      staker: "0xc52bb87d29b539F7A2d249aBa117Afaa41515D77",
+      nft: "0xCDc86e98184e96436F733a8Bf31BD4F0214E6D7d",
+      fromBlock: 23391267,
+    },
+  ],
+  robinhood: [
+    {
+      // Uniswap V3 on Robinhood Chain
+      staker: "0x6729488a69c70Fb1fD91aF240960a71C1E21be43",
+      nft: "0x73991a25C818Bf1f1128dEAaB1492D45638DE0D3",
+      fromBlock: 31259721,
+    },
+  ],
+};
+
+async function tvl(api) {
+  for (const venue of config[api.chain]) {
+    const logs = await getLogs2({
+      api,
+      target: venue.staker,
+      eventAbi: INCENTIVE_CREATED,
+      fromBlock: venue.fromBlock,
+    });
+
+    // Unclaimed reward tokens sitting in the staker.
+    const rewardTokens = [...new Set(logs.map((log) => log.rewardToken))];
+    if (rewardTokens.length) {
+      await api.sumTokens({ owner: venue.staker, tokens: rewardTokens });
+    }
+
+    // Staked positions. Unwrapped, not balance-read - see the note above.
+    await unwrapUniswapV3NFT({
+      api,
+      owner: venue.staker,
+      nftAddress: venue.nft,
+    });
+  }
+}
+
+module.exports = {
+  methodology:
+    "Counts assets custodied by the Waddle Club staker contracts: the Uniswap V3 style LP NFTs staked into incentive programs, unwrapped to their underlying tokens at the pool's current tick, plus reward tokens funded into incentives and not yet claimed or refunded. Reward tokens are discovered from IncentiveCreated events. LP value is also counted by the underlying DEX, so this is double counted at the chain level.",
+  doublecounted: true,
+  // First staker deployment (Kumbaya on MegaETH, block 3520323).
+  start: "2025-12-21",
+  megaeth: { tvl },
+  robinhood: { tvl },
+};

--- a/projects/waddle-club/index.js
+++ b/projects/waddle-club/index.js
@@ -1,30 +1,11 @@
-const { unwrapUniswapV3NFT } = require("../helper/unwrapLPs");
+const { sumTokens2 } = require("../helper/unwrapLPs");
 const { getLogs2 } = require("../helper/cache/getLogs");
 
-/**
- * Waddle Club Staking - liquidity mining for Uniswap V3 style positions.
- *
- * TVL is what the staker contracts custody, which is two things:
- *
- *   1. LP NFTs. Staking transfers the position NFT to the staker, so the
- *      protocol holds it. The underlying pair sits in the pool contract, not
- *      the staker, so a token balance read returns zero: the positions have to
- *      be unwrapped from liquidity and tick bounds against the pool's current
- *      tick. Positions parked outside the live range are single sided and a
- *      50/50 assumption would misprice them.
- *   2. Reward tokens. Incentives are funded up front and the unclaimed balance
- *      sits in the staker until stakers claim or the refundee pulls it back.
- *
- * Reward tokens are discovered from IncentiveCreated rather than hardcoded, so
- * a new program with a new reward token needs no adapter change. Note refundee
- * is NOT indexed on this event, verified against the deployed logs.
- *
- * Expect this to be flagged doublecounted, as Convex and Aura are: the same LP
- * value is already counted under the DEX.
- */
+const INCENTIVE_CREATED = "event IncentiveCreated(address indexed rewardToken, address indexed pool, uint256 startTime, uint256 endTime, address refundee, uint256 reward)";
 
-const INCENTIVE_CREATED =
-  "event IncentiveCreated(address indexed rewardToken, address indexed pool, uint256 startTime, uint256 endTime, address refundee, uint256 reward)";
+const OWN_TOKENS = {
+  robinhood: ['0xd3af6612119362d31d7a6c93ad5e6d01443c855d'], // HONK
+};
 
 /**
  * One entry per venue, where a venue is one DEX deployment on one chain.
@@ -58,35 +39,43 @@ const config = {
 };
 
 async function tvl(api) {
-  for (const venue of config[api.chain]) {
+  const venues = config[api.chain];
+
+  // reward tokens in each staker
+  const ownerTokens = [];
+  for (const venue of venues) {
     const logs = await getLogs2({
       api,
       target: venue.staker,
       eventAbi: INCENTIVE_CREATED,
       fromBlock: venue.fromBlock,
     });
-
-    // Unclaimed reward tokens sitting in the staker.
     const rewardTokens = [...new Set(logs.map((log) => log.rewardToken))];
-    if (rewardTokens.length) {
-      await api.sumTokens({ owner: venue.staker, tokens: rewardTokens });
-    }
+    if (rewardTokens.length) ownerTokens.push([rewardTokens, venue.staker]);
+  }
 
-    // Staked positions. Unwrapped, not balance-read - see the note above.
-    await unwrapUniswapV3NFT({
-      api,
-      owner: venue.staker,
-      nftAddress: venue.nft,
-    });
+  return sumTokens2({
+    api,
+    ownerTokens,
+    uniV3nftsAndOwners: venues.map((venue) => [venue.nft, venue.staker]),
+    blacklistedTokens: OWN_TOKENS[api.chain] ?? [],
+  });
+}
+
+async function staking(api) {
+  const ownTokens = OWN_TOKENS[api.chain];
+  if (!ownTokens?.length) return;
+  for (const venue of config[api.chain]) {
+    await api.sumTokens({ owner: venue.staker, tokens: ownTokens });
   }
 }
 
 module.exports = {
   methodology:
-    "Counts assets custodied by the Waddle Club staker contracts: the Uniswap V3 style LP NFTs staked into incentive programs, unwrapped to their underlying tokens at the pool's current tick, plus reward tokens funded into incentives and not yet claimed or refunded. Reward tokens are discovered from IncentiveCreated events. LP value is also counted by the underlying DEX, so this is double counted at the chain level.",
+    "tvl is the assets the Waddle Club stakers custody: the staked Uniswap V3 style LP NFTs unwrapped to their underlying tokens at the pool's current tick, plus reward tokens funded into incentives and not yet claimed or refunded (discovered from IncentiveCreated events). LP value is also counted by the underlying DEX, so tvl is double counted at the chain level.",
   doublecounted: true,
   // First staker deployment (Kumbaya on MegaETH, block 3520323).
   start: "2025-12-21",
-  megaeth: { tvl },
-  robinhood: { tvl },
+  megaeth: { tvl, staking },
+  robinhood: { tvl, staking },
 };


### PR DESCRIPTION
Adds a TVL adapter for Waddle Club, a liquidity mining protocol for Uniswap V3 style positions on MegaETH and Robinhood Chain.

`node test.js projects/waddle-club/index.js` passes with no warnings:

```
--- megaeth ---
MEGA                      1.79
USDm                      1.69
Total: 3.48

--- robinhood ---
WETH                    245.10
Total: 245.10

------ TVL ------
robinhood               245.00
megaeth                   3.00
total                   248.86
```

Note: $HONK is not currently priced by DefiLlama (`coins.llama.fi` returns empty for `robinhood:0xd3AF6612119362D31d7A6C93Ad5E6d01443c855D`), so the HONK side of the LP positions and ~19.85M HONK of unclaimed rewards are excluded from the total above. A CoinGecko listing is pending; TVL will rise once the token is priced, with no adapter change.

---

##### Name (to be shown on DefiLlama):
Waddle Club

##### Twitter Link:
https://x.com/waddle_club

##### List of audit links if any:
None - our Hub is unaudited. It holds no privileged role over any other contract and cannot touch staked positions or funded incentives; the creation fee is hard-capped at 5% on-chain. The staker is a fork of Uniswap v3-staker v1.0.2.

##### Website Link:
https://staking.waddleclub.xyz

##### Logo (High resolution, will be shown with rounded borders):
https://www.waddleclub.xyz/waddle-club-logo.png

##### Current TVL:
~$249

##### Treasury Addresses (if the protocol has treasury)
0xfE88793e8332F5CD3C5Cc370d6dAa680167C6453

##### Chain:
MegaETH, Robinhood Chain

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):
(submitted, awaiting review)

##### Coinmarketcap ID:
(not listed)

##### Short Description (to be shown on DefiLlama):
Waddle Club lets any project fund liquidity mining rewards for its own Uniswap V3 pool. Pick the reward token, amount and window, fund it in one transaction, and LPs stake their position NFT to earn.

##### Token address and ticker if any:
(none linked yet)

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Farm

##### Oracle Provider(s):
None. TVL is read directly from contracts.

##### Implementation Details:
Not applicable, no oracle is used.

##### Documentation/Proof:
Not applicable, no oracle is used.

##### forkedFrom (Does your project originate from another project):
Uniswap V3 Staker

##### methodology (what is being counted as tvl, how is tvl being calculated):
Assets custodied by the Waddle Club staker contracts:

1. **Staked LP NFTs.** Staking transfers the Uniswap V3 style position NFT to the staker, so the protocol holds it. Unwrapped with `unwrapUniswapV3NFT` at the pool's current tick. A token balance read on the staker returns zero for the pair, because the underlying sits in the pool contract, so positions must be unwrapped rather than balance-read. Some positions are outside the live range and single sided.
2. **Unclaimed reward tokens.** Incentives are funded up front and the balance sits in the staker until claimed or refunded. Reward tokens are discovered from `IncentiveCreated` logs rather than hardcoded.

Marked `doublecounted`: the LP value is also counted under Uniswap V3 on the same chains, so it should not inflate chain totals. Same treatment as Convex and Aura.

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/waddleclub/

##### Does this project have a referral program?
No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for Waddle Club across MegaETH and Robinhood venues.
  * Included unclaimed staking rewards and underlying assets from staked Uniswap V3 positions in TVL calculations.
  * Added automatic reward-token discovery for more complete value reporting.
  * Added chain-specific TVL reporting with methodology and double-counting details.
  * Improved coverage and accuracy for reported Waddle Club asset values across supported venues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->