### PR TITLE
 Add Base and Solana support to the DGLD (Digital Gold) adapter

### DIFF
--- a/projects/dgld/index.js
+++ b/projects/dgld/index.js
@@ -1,98 +1,48 @@
-// ============================================================================
-// DGLD (Digital Gold) — DefiLlama TVL adapter — V2
-// File location in the repo: projects/dgld/index.js
-// ============================================================================
+// DGLD (Digital Gold) — tokenized physical gold.
+// 1 DGLD = 1 fine troy ounce of allocated, audited gold held in Swiss custody.
 //
-// WHY A V2 / WHAT THIS FIXES
-// ----------------------------------------------------------------------------
-// The adapter currently live on DefiLlama (merged Jan 2026, PR #17739 by
-// GitHub user RohanNero — an independent open-source contributor, not a
-// GTSA/DGLD team member) only tracks Ethereum, and its methodology comment
-// says:
+// TVL is the total supply on each chain, priced in USD.
 //
-//   "All tokens are minted on L1 (Ethereum); L2 tokens represent locked L1
-//    tokens, so L1 total supply accounts for all value."
+// Every chain has its own dedicated, independently backed supply: gold is
+// placed in the vault and minted natively on that chain. Nothing is bridged
+// between chains, so summing the per-chain supplies does not double-count.
+// The original Base contract (0xd02f50E1017F493ffFFa70c8fCf09e349e11d6c9) was a
+// bridged mirror of the Ethereum supply; it has been fully burned down
+// (totalSupply is 0) and replaced by the native-supply contract below.
 //
-// That was accurate under the OLD Base bridging model, where Base DGLD was
-// just a 1:1 bridged mirror of the Ethereum supply (so counting Ethereum
-// alone was enough — counting Base too would have double-counted the same
-// gold).
-//
-// Since GTSA's Base migration (contract redeployed to
-// 0xe908475f8Beb7A138B0dc6eb5A05cb27068ffB9A), Base no longer bridges from
-// Ethereum: it has its OWN dedicated, independently gold-backed supply (a new
-// bar is placed in the vault and minted directly on Base). The old adapter
-// therefore now UNDER-COUNTS total TVL, because it only sees the Ethereum
-// supply and ignores the Base-native supply entirely. It also has no Solana
-// support at all, since DGLD only launched there after this adapter was
-// written.
-//
-// This V2 keeps the original Ethereum logic completely untouched (it was
-// already correct and matches the DefiLlama-native pattern used for other
-// gold-backed tokens such as PAXG — see projects/paxos-gold/index.js), and
-// adds:
-//   1. Base: same on-chain totalSupply pattern, new dedicated-supply contract.
-//   2. Solana: new dedicated-supply mint, read via the repo's real exported
-//      helper `getTokenSupplies` from projects/helper/solana.js (NOT
-//      `getTokenSupply`, singular — that function does not exist and was an
-//      earlier, incorrect assumption, caught by cross-checking the actual
-//      helper file before writing this version).
-//   3. An updated methodology string that reflects the current multi-chain,
-//      dedicated-supply-per-chain reality instead of the outdated bridging
-//      assumption.
-//
-// STILL UNVERIFIED — DO NOT SUBMIT A PR UNTIL THIS IS CONFIRMED:
-// ----------------------------------------------------------------------------
-// Whether DefiLlama's pricing layer already resolves a USD price for the
-// Solana mint below purely from its address (it does for the Ethereum/Base
-// contracts, since those are long-established and already priced). Run:
-//
-//     node test.js projects/dgld
-//
-// If the Solana leg comes back as an "unknown token" / unpriced, this
-// adapter needs a different pricing approach for that chain — re-check with
-// a person or the repo's adapter-author skill first, do not guess a fix.
-// ============================================================================
-
-// One DGLD token corresponds to one fine troy ounce
-// of fully allocated, audited gold held in Swiss custody.
-const DGLD_TOKEN = '0xA9299C296d7830A99414d1E5546F5171fA01E9c8';
-const DGLD_BASE = '0xe908475f8Beb7A138B0dc6eb5A05cb27068ffB9A';
+// NOTE: ethereum:0xA9299C296d7830A99414d1E5546F5171fA01E9c8 is not currently
+// indexed by coins.llama.fi, so the Ethereum leg prices to 0. See the PR
+// description. This comment can be removed once the token is indexed.
 
 const { getTokenSupplies } = require('../helper/solana')
-const SOLANA_MINT = 'dg1dmo6NZNagkwB6EAfUeaco6CFXFLRhb1KCrsqXTVz'
+
+const DGLD_ETHEREUM = '0xA9299C296d7830A99414d1E5546F5171fA01E9c8'
+const DGLD_BASE = '0xe908475f8Beb7A138B0dc6eb5A05cb27068ffB9A'
+const DGLD_SOLANA = 'dg1dmo6NZNagkwB6EAfUeaco6CFXFLRhb1KCrsqXTVz'
 
 async function ethereumTvl(api) {
-    const totalSupply = await api.call({
-        abi: 'erc20:totalSupply',
-        target: DGLD_TOKEN,
-    });
-
-    api.add(DGLD_TOKEN, totalSupply);
+  const totalSupply = await api.call({ abi: 'erc20:totalSupply', target: DGLD_ETHEREUM })
+  api.add(DGLD_ETHEREUM, totalSupply)
 }
 
 async function baseTvl(api) {
-    const totalSupply = await api.call({
-        abi: 'erc20:totalSupply',
-        target: DGLD_BASE,
-    });
-
-    api.add(DGLD_BASE, totalSupply);
+  const totalSupply = await api.call({ abi: 'erc20:totalSupply', target: DGLD_BASE })
+  api.add(DGLD_BASE, totalSupply)
 }
 
 async function solanaTvl(api) {
-    await getTokenSupplies([SOLANA_MINT], { api })
+  await getTokenSupplies([DGLD_SOLANA], { api })
 }
 
 module.exports = {
-    methodology: 'Calculates TVL by multiplying the total DGLD supply on each chain by the token price. Each DGLD token represents 1 troy ounce of allocated, audited gold held in Swiss custody. Following the Base migration, each chain now has its own dedicated, independently-backed supply (no longer bridged from Ethereum), so TVL is the sum of the supply on every chain.',
-    ethereum: {
-        tvl: ethereumTvl,
-    },
-    base: {
-        tvl: baseTvl,
-    },
-    solana: {
-        tvl: solanaTvl,
-    },
-};
+  methodology: 'TVL is the total DGLD supply on each chain, priced in USD. Each DGLD token represents 1 fine troy ounce of allocated, audited gold held in Swiss custody. Every chain has its own dedicated, independently backed supply minted natively on that chain rather than bridged from Ethereum, so TVL is the sum of the supply on every chain.',
+  ethereum: {
+    tvl: ethereumTvl,
+  },
+  base: {
+    tvl: baseTvl,
+  },
+  solana: {
+    tvl: solanaTvl,
+  },
+}

--- a/projects/dgld/index.js
+++ b/projects/dgld/index.js
@@ -10,32 +10,48 @@
 // bridged mirror of the Ethereum supply; it has been fully burned down
 // (totalSupply is 0) and replaced by the native-supply contract below.
 //
-// NOTE: ethereum:0xA9299C296d7830A99414d1E5546F5171fA01E9c8 is not currently
-// indexed by coins.llama.fi, so the Ethereum leg prices to 0. See the PR
-// description. This comment can be removed once the token is indexed.
+// Pricing: the DGLD token addresses are not indexed by coins.llama.fi, so
+// address-based pricing resolves to 0. Instead we price the decimal-normalized
+// supply directly against the CoinGecko id `gold-token-sa-dgld-tokenized-gold`
+// via api.addCGToken. DGLD is one-to-one (1 token = 1 fine oz) on every chain,
+// so the same CoinGecko id prices all three legs.
 
 const { getTokenSupplies } = require('../helper/solana')
 
+const CG_ID = 'gold-token-sa-dgld-tokenized-gold'
 const DGLD_ETHEREUM = '0xA9299C296d7830A99414d1E5546F5171fA01E9c8'
 const DGLD_BASE = '0xe908475f8Beb7A138B0dc6eb5A05cb27068ffB9A'
 const DGLD_SOLANA = 'dg1dmo6NZNagkwB6EAfUeaco6CFXFLRhb1KCrsqXTVz'
+const DGLD_SOLANA_DECIMALS = 9 // fixed at mint creation; Token-2022 mint decimals are immutable
+
+// Price the ERC-20 total supply via CoinGecko, normalized by the token's decimals.
+async function erc20Tvl(api, target) {
+  const [totalSupply, decimals] = await Promise.all([
+    api.call({ abi: 'erc20:totalSupply', target }),
+    api.call({ abi: 'erc20:decimals', target }),
+  ])
+  api.addCGToken(CG_ID, totalSupply / 10 ** decimals)
+}
 
 async function ethereumTvl(api) {
-  const totalSupply = await api.call({ abi: 'erc20:totalSupply', target: DGLD_ETHEREUM })
-  api.add(DGLD_ETHEREUM, totalSupply)
+  await erc20Tvl(api, DGLD_ETHEREUM)
 }
 
 async function baseTvl(api) {
-  const totalSupply = await api.call({ abi: 'erc20:totalSupply', target: DGLD_BASE })
-  api.add(DGLD_BASE, totalSupply)
+  await erc20Tvl(api, DGLD_BASE)
 }
 
 async function solanaTvl(api) {
-  await getTokenSupplies([DGLD_SOLANA], { api })
+  // Fetch the raw SPL supply WITHOUT passing `api` — doing so would add it keyed
+  // by the mint address (which coins.llama.fi does not price, i.e. 0). Instead we
+  // price the decimal-normalized amount against the same CoinGecko id.
+  const supplies = await getTokenSupplies([DGLD_SOLANA])
+  const supply = Number(supplies[DGLD_SOLANA] || 0) / 10 ** DGLD_SOLANA_DECIMALS
+  api.addCGToken(CG_ID, supply)
 }
 
 module.exports = {
-  methodology: 'TVL is the total DGLD supply on each chain, priced in USD. Each DGLD token represents 1 fine troy ounce of allocated, audited gold held in Swiss custody. Every chain has its own dedicated, independently backed supply minted natively on that chain rather than bridged from Ethereum, so TVL is the sum of the supply on every chain.',
+  methodology: 'TVL is the total DGLD supply on each chain, priced in USD. Each DGLD token represents 1 fine troy ounce of allocated, audited gold held in Swiss custody. Every chain has its own dedicated, independently backed supply minted natively on that chain rather than bridged from Ethereum, so TVL is the sum of the supply on every chain. Supplies are priced against the CoinGecko id gold-token-sa-dgld-tokenized-gold because the token addresses are not indexed by coins.llama.fi.',
   ethereum: {
     tvl: ethereumTvl,
   },

--- a/projects/dgld/index.js
+++ b/projects/dgld/index.js
@@ -1,6 +1,66 @@
-// One DGLD token corresponds to one fine troy ounce 
+// ============================================================================
+// DGLD (Digital Gold) — DefiLlama TVL adapter — V2
+// File location in the repo: projects/dgld/index.js
+// ============================================================================
+//
+// WHY A V2 / WHAT THIS FIXES
+// ----------------------------------------------------------------------------
+// The adapter currently live on DefiLlama (merged Jan 2026, PR #17739 by
+// GitHub user RohanNero — an independent open-source contributor, not a
+// GTSA/DGLD team member) only tracks Ethereum, and its methodology comment
+// says:
+//
+//   "All tokens are minted on L1 (Ethereum); L2 tokens represent locked L1
+//    tokens, so L1 total supply accounts for all value."
+//
+// That was accurate under the OLD Base bridging model, where Base DGLD was
+// just a 1:1 bridged mirror of the Ethereum supply (so counting Ethereum
+// alone was enough — counting Base too would have double-counted the same
+// gold).
+//
+// Since GTSA's Base migration (contract redeployed to
+// 0xe908475f8Beb7A138B0dc6eb5A05cb27068ffB9A), Base no longer bridges from
+// Ethereum: it has its OWN dedicated, independently gold-backed supply (a new
+// bar is placed in the vault and minted directly on Base). The old adapter
+// therefore now UNDER-COUNTS total TVL, because it only sees the Ethereum
+// supply and ignores the Base-native supply entirely. It also has no Solana
+// support at all, since DGLD only launched there after this adapter was
+// written.
+//
+// This V2 keeps the original Ethereum logic completely untouched (it was
+// already correct and matches the DefiLlama-native pattern used for other
+// gold-backed tokens such as PAXG — see projects/paxos-gold/index.js), and
+// adds:
+//   1. Base: same on-chain totalSupply pattern, new dedicated-supply contract.
+//   2. Solana: new dedicated-supply mint, read via the repo's real exported
+//      helper `getTokenSupplies` from projects/helper/solana.js (NOT
+//      `getTokenSupply`, singular — that function does not exist and was an
+//      earlier, incorrect assumption, caught by cross-checking the actual
+//      helper file before writing this version).
+//   3. An updated methodology string that reflects the current multi-chain,
+//      dedicated-supply-per-chain reality instead of the outdated bridging
+//      assumption.
+//
+// STILL UNVERIFIED — DO NOT SUBMIT A PR UNTIL THIS IS CONFIRMED:
+// ----------------------------------------------------------------------------
+// Whether DefiLlama's pricing layer already resolves a USD price for the
+// Solana mint below purely from its address (it does for the Ethereum/Base
+// contracts, since those are long-established and already priced). Run:
+//
+//     node test.js projects/dgld
+//
+// If the Solana leg comes back as an "unknown token" / unpriced, this
+// adapter needs a different pricing approach for that chain — re-check with
+// a person or the repo's adapter-author skill first, do not guess a fix.
+// ============================================================================
+
+// One DGLD token corresponds to one fine troy ounce
 // of fully allocated, audited gold held in Swiss custody.
 const DGLD_TOKEN = '0xA9299C296d7830A99414d1E5546F5171fA01E9c8';
+const DGLD_BASE = '0xe908475f8Beb7A138B0dc6eb5A05cb27068ffB9A';
+
+const { getTokenSupplies } = require('../helper/solana')
+const SOLANA_MINT = 'dg1dmo6NZNagkwB6EAfUeaco6CFXFLRhb1KCrsqXTVz'
 
 async function ethereumTvl(api) {
     const totalSupply = await api.call({
@@ -11,9 +71,28 @@ async function ethereumTvl(api) {
     api.add(DGLD_TOKEN, totalSupply);
 }
 
+async function baseTvl(api) {
+    const totalSupply = await api.call({
+        abi: 'erc20:totalSupply',
+        target: DGLD_BASE,
+    });
+
+    api.add(DGLD_BASE, totalSupply);
+}
+
+async function solanaTvl(api) {
+    await getTokenSupplies([SOLANA_MINT], { api })
+}
+
 module.exports = {
-    methodology: 'Calculates TVL by multiplying the DGLD total supply by the token price. Each DGLD token represents 1 troy ounce of gold. All tokens are minted on L1 (Ethereum); L2 tokens represent locked L1 tokens, so L1 total supply accounts for all value.',
+    methodology: 'Calculates TVL by multiplying the total DGLD supply on each chain by the token price. Each DGLD token represents 1 troy ounce of allocated, audited gold held in Swiss custody. Following the Base migration, each chain now has its own dedicated, independently-backed supply (no longer bridged from Ethereum), so TVL is the sum of the supply on every chain.',
     ethereum: {
         tvl: ethereumTvl,
+    },
+    base: {
+        tvl: baseTvl,
+    },
+    solana: {
+        tvl: solanaTvl,
     },
 };


### PR DESCRIPTION
Adds Base and Solana support to the DGLD (Digital Gold) adapter, and updates the methodology to reflect that each chain now has its own dedicated supply.

## Pricing request on Ethereum

`ethereum:0xA9299C296d7830A99414d1E5546F5171fA01E9c8` has no entry in coins.llama.fi, despite CoinGecko mapping it to `gold-token-sa-dgld-tokenized-gold` , the same coin that prices the already-indexed Base (`0xe908475f8Beb7A138B0dc6eb5A05cb27068ffB9A`) and Solana (`dg1dmo6NZNagkwB6EAfUeaco6CFXFLRhb1KCrsqXTVz`) contracts. CoinGecko's reverse lookup `coins/ethereum/contract/0xa9299c...` resolves to that coin, and `prices/first` returns empty for the Ethereum key, so it appears never to have been indexed rather than stale.

This is why the `digital-gold` protocol page currently shows $0 TVL. Until the address is indexed the Ethereum leg prices to 0, visible as `ethereum 0.00` in the CI comment below, against a real on-chain supply of 1,603.687 DGLD (~$7.0M at the current DGLD price).

**Would DefiLlama be able to index it?** Happy to use `addCGToken` with the CoinGecko id as a workaround instead if you'd prefer the adapter not depend on that.

Also noting that DGLD seems accessible from 2 URLs ("protocol" & "token" paths; and on the token path the TVL is currently accurate):
- https://defillama.com/protocol/digital-gold
- https://defillama.com/token/DGLD

## What changed

- **Base:** `totalSupply` of the native-supply contract `0xe908475f8Beb7A138B0dc6eb5A05cb27068ffB9A`.
- **Solana:** `totalSupply` of mint `dg1dmo6NZNagkwB6EAfUeaco6CFXFLRhb1KCrsqXTVz`, via `getTokenSupplies`.
- **Methodology updated:** the previous version assumed L2 tokens represented locked L1 tokens, so counting Ethereum alone sufficed. That is no longer the case: each chain's supply is minted natively against gold placed in the vault for that chain. The original bridged Base contract `0xd02f50E1017F493ffFFa70c8fCf09e349e11d6c9` has been fully deprecated (`totalSupply` is 0), so summing the per-chain supplies does not double-count.

Each DGLD token represents 1 fine troy ounce of allocated, audited gold held in Swiss custody.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DGLD TVL tracking now includes native supplies on Ethereum, Base, and Solana.
  * Added chain-specific supply calculations for ERC-20 and Solana token balances.
  * Normalized supplies are priced using the DGLD market identifier.

* **Documentation**
  * Updated the methodology to describe independently backed, natively minted supply across each chain.
  * Added the relevant contract addresses and removed the previous Ethereum-only accounting assumption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->