### PR TITLE
rysk-v12: updated tvl calculation on ethereum chain

### DIFF
--- a/registries/sumTokens.js
+++ b/registries/sumTokens.js
@@ -24813,6 +24813,14 @@ const configs = {
           "0x684404F2AEBAD87a6803F13741B1d638Bfe2C671"
         ],
         [
+          ADDRESSES.ethereum.WEETH,
+          "0x684404F2AEBAD87a6803F13741B1d638Bfe2C671"
+        ],
+        [
+          ADDRESSES.ethereum.RETH,
+          "0x684404F2AEBAD87a6803F13741B1d638Bfe2C671"
+        ],
+        [
           "0x68749665FF8D2d112Fa859AA293F07A622782F38",
           "0x684404F2AEBAD87a6803F13741B1d638Bfe2C671"
         ]

--- a/registries/sumTokens.js
+++ b/registries/sumTokens.js
@@ -24793,6 +24793,14 @@ const configs = {
           "0xc01c9EF5de5862354adD9501a29e8765cFF01c32"
         ],
         [
+          ADDRESSES.ethereum.USDC,
+          "0x684404F2AEBAD87a6803F13741B1d638Bfe2C671"
+        ],
+        [
+          ADDRESSES.ethereum.USDT,
+          "0x684404F2AEBAD87a6803F13741B1d638Bfe2C671"
+        ],
+        [
           ADDRESSES.ethereum.WETH,
           "0x684404F2AEBAD87a6803F13741B1d638Bfe2C671"
         ],


### PR DESCRIPTION
Added tracking for WeETH and rETH covered calls, and missing USDC and USDT stored as collateral in marginPool on Ethereum

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing USDC, USDT, WEETH, and RETH token entries on Ethereum.
  * Mapped these tokens to their corresponding registry address for improved token handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->