### PR TITLE
earngrid: update vault address to v1.0.4 (0x8694D7...)

### DIFF
--- a/registries/erc4626.js
+++ b/registries/erc4626.js
@@ -90,6 +90,11 @@ const configs = {
       '0x36213ca1483869c5616be738Bf8da7C9B34Ace8d',
     ],
   },
+  'earngrid': {
+    methodology: 'Automated USDC yield vault on Base — aggregates MetaMorpho strategies. TVL via totalAssets().',
+    doublecounted: true,
+    base: ['0x6eca76891504fc2362ac0e6fd5998dfff44e8fe1'],
+  },
   'eva': {
     ethereum: [
       '0x741bD193B6b40f8703d2e116FD1965421f290F58', // USDC vault

--- a/registries/erc4626.js
+++ b/registries/erc4626.js
@@ -93,7 +93,7 @@ const configs = {
   'earngrid': {
     methodology: 'Automated USDC yield vault on Base — aggregates MetaMorpho strategies. TVL via totalAssets().',
     doublecounted: true,
-    base: ['0x6eca76891504fc2362ac0e6fd5998dfff44e8fe1'],
+    base: ['0x8694D7D44309665D51Cb5002fceC0454f1c233dE'],
   },
   'eva': {
     ethereum: [


### PR DESCRIPTION
Update EarnGrid vault address from v1.0.3 to v1.0.4.

**New vault:** `0x8694D7D44309665D51Cb5002fceC0454f1c233dE` (Base mainnet)
**Old vault:** `0x6eca76891504fc2362ac0e6fd5998dfff44e8fe1` (retired, drained)

- ERC-4626 vault, USDC asset
- Sourcify exact_match verified
- doublecounted: true (deposits into MetaMorpho strategies already tracked)
- Tested: `node test.js earngrid` passes

No other changes — same methodology, same chain, same asset. Just the vault address updated after redeploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Earngrid vault to the ERC-4626 registry on Base.
  * Included vault metadata, methodology, and double-counting classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->