### PR TITLE
protocol update: add EarnJPYC Super Vault to SuperEarn TVL on Kaia

### DIFF
--- a/projects/kaia-superEarn/index.js
+++ b/projects/kaia-superEarn/index.js
@@ -2,16 +2,58 @@ const { sumERC4626VaultsExport2 } = require('../helper/erc4626')
 
 const config = {
   klaytn: {
+    // Super Vaults whose token() (the CooldownVault share) DefiLlama already
+    // prices, so totalAssets() can be reported in that share directly.
     vaults: [
-      '0x2e4e573D86c70688cD97D76bc5DDc1Bb265bF5D6', // Super Vault (EarnUSDT)
+      '0x2e4e573D86c70688cD97D76bc5DDc1Bb265bF5D6', // Super Vault (EarnUSDT) -> seCDV
+    ],
+    // Super Vaults whose CooldownVault share is NOT priced by DefiLlama. Reporting
+    // totalAssets() in that share would silently contribute zero, so the share is
+    // unwrapped one more hop into the CooldownVault's own asset(), which is priced.
+    // Same two-layer structure as EarnUSDT: SuperVault -> CooldownVault share -> asset.
+    unwrappedVaults: [
+      {
+        vault: '0x1dc3De9fA858B4F9c6bA9EBEA9B5150b09280dd9',        // Super Vault JPYC (EarnJPYC)
+        cooldownVault: '0x632e099A74ed961f3C284c6E5E16641B75c1A09D', // seCDV-JPYC
+        asset: '0xe7c3D8C9a439FeDE00d2600032D5db0be71C3c29',        // JPYC (JPY Coin), 18 decimals
+      },
     ],
   },
 }
 
+// EarnJPYC holds seCDV-JPYC, which DefiLlama has no price for. Convert the Super
+// Vault's totalAssets() from CooldownVault shares into the underlying asset via the
+// CooldownVault's own ERC-4626 convertToAssets(), then report the asset. The rate is
+// READ, never assumed: it is 1:1 while the CooldownVault has accrued nothing, but a
+// hardcoded 1 would silently understate TVL the moment it accrues.
+function unwrappedVaultsTvl(vaults) {
+  return async (api) => {
+    const shares = await api.multiCall({
+      abi: 'uint256:totalAssets',
+      calls: vaults.map((v) => v.vault),
+    })
+    const assets = await api.multiCall({
+      abi: 'function convertToAssets(uint256) view returns (uint256)',
+      calls: vaults.map((v, i) => ({ target: v.cooldownVault, params: [shares[i]] })),
+    })
+    vaults.forEach((v, i) => api.add(v.asset, assets[i]))
+  }
+}
+
 module.exports = {
-  methodology: 'TVL is the sum of totalAssets() across SuperEarn Super Vaults on Kaia. Each Super Vault holds seCDV (CooldownVault share) as its underlying.'
+  methodology:
+    'TVL is the sum of totalAssets() across SuperEarn Super Vaults on Kaia. Each Super Vault holds a CooldownVault share (seCDV) as its underlying. EarnUSDT is reported in seCDV directly; EarnJPYC is reported in JPYC, converted from seCDV-JPYC through the CooldownVault own convertToAssets() because seCDV-JPYC has no price feed.',
 }
 
 for (const chain of Object.keys(config)) {
-  module.exports[chain] = { tvl: sumERC4626VaultsExport2({vaults: config[chain].vaults, tokenAbi: 'address:token', balanceAbi: 'uint256:totalAssets'}) }
+  const { vaults = [], unwrappedVaults = [] } = config[chain]
+  const priced = sumERC4626VaultsExport2({ vaults, tokenAbi: 'address:token', balanceAbi: 'uint256:totalAssets' })
+  const unwrapped = unwrappedVaultsTvl(unwrappedVaults)
+  module.exports[chain] = {
+    tvl: async (api) => {
+      await priced(api)
+      await unwrapped(api)
+      return api.getBalances()
+    },
+  }
 }


### PR DESCRIPTION
Adds the EarnJPYC Super Vault (`0x1dc3De9fA858B4F9c6bA9EBEA9B5150b09280dd9`, "Super Vault JPYC") to the existing `kaia-superEarn` adapter. It was missing, so SuperEarn's reported TVL understated holdings by ~$5.58M.

Follows #19322, which added this adapter for EarnUSDT.

### Why it is not just another entry in `vaults`

`sumERC4626VaultsExport2` reports a Super Vault's `totalAssets()` denominated in its `token()` — the CooldownVault share. In #19322 that worked because DefiLlama in effect prices `seCDV` (which corresponds 1:1 to USDT).

DefiLlama has **no price for `seCDV-JPYC`** (`0x632e099A74ed961f3C284c6E5E16641B75c1A09D`). Adding EarnJPYC to the same list would have contributed **$0** while looking correct. So the JPYC leg unwraps one hop further — `totalAssets()` → the CooldownVault's own ERC-4626 `convertToAssets()` → JPYC (`0xe7c3D8C9a439FeDE00d2600032D5db0be71C3c29`), which DefiLlama does price. The EarnUSDT path is unchanged.

### Assumptions, and how they differ from #19322

#19322 assumed: *"the vault underlying is seCDV (CooldownVault share) which is pegged 1:1 to USDT, so totalAssets is priced directly as USDT."*

The structure here is identical — `SuperVault → CooldownVault share → asset` — but two things differ:

1. **The peg is read, not assumed.** `seCDV-JPYC` is 1:1 with JPYC today (`convertToAssets(1e18) = 1e18`; the CooldownVault's `totalAssets() == totalSupply()`), the same relationship #19322 asserted for seCDV/USDT. Rather than rely on it, the adapter calls `convertToAssets()` each run. A hardcoded `1` would silently understate TVL the moment the CooldownVault accrues.

2. **The underlying is not a USD stablecoin.** seCDV/USDT could be priced at par; **JPYC is JPY-denominated,** so a real FX rate is required. This adapter does not supply one — it reports a JPYC balance and lets DefiLlama price it (currently $0.00627310705, confidence 0.99, implied ¥159.41/USD), which is why no external oracle appears in the code.

### Not added to `registries/erc4626.js`

That registry exports `tvl` via `buildProtocolExports`, so an entry there would publish a second protocol TVL and double-count the same $5.58M. (#19322 removed the old `kaia-superEarn` registry entry for the analogous reason.)

### Verification

On-chain reads, 2026-08-11:

| read | value |
|---|---|
| `EarnJPYC.totalAssets()` | 889,264,809.556019 seCDV-JPYC |
| `seCDV-JPYC.convertToAssets(1e18)` | `1e18` (exactly 1:1) |
| `seCDV-JPYC.totalAssets()` / `totalSupply()` | identical |
| `JPYC.balanceOf(seCDV-JPYC)` | 889,264,809.556019 (fully idle) |
| **⇒ EarnJPYC** | **$5,578,453** |

`node test.js projects/kaia-superEarn/index.js`:

```
--- klaytn ---
seCDV                     10.23 M
JPYC                      5.58 M
Total: 15.81 M
```

##### Github org/user (Optional, if your code is open source, we can track activity): superearn-io org; the contract is not fully open, though

##### Does this project have a referral program? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Super Vault value reporting by distinguishing directly priced vaults from unpriced vaults.
  * Added support for converting EarnJPYC shares into their underlying JPYC value for more accurate balances.
* **Documentation**
  * Updated valuation methodology to explain the Super Vault conversion process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->