### PR TITLE
fix(winr-protocol): point TVL at live bankroll and escrow contracts

### DIFF
--- a/projects/winr-protocol/index.js
+++ b/projects/winr-protocol/index.js
@@ -10,7 +10,7 @@ const WINR_ESCROW = '0xD75a51364440dAF83B78B9888D2b8F28eaC0D280'
 
 module.exports = {
   methodology:
-    'TVL is the total value of WINR held in the protocol bankroll vault and escrow contract on Arbitrum. The bankroll holds liquidity provider funds backing all JustBet gameplay; the escrow holds user balances, settled on-chain via merkle roots. Game logic and accounting run off-chain, so these contracts hold the entirety of on-chain protocol value.',
+    'TVL is the tracked Arbitrum value of WINR held in the protocol bankroll vault and escrow contract. The bankroll holds liquidity provider funds backing all JustBet gameplay; the escrow holds user balances, settled on-chain via merkle roots. Prior-generation USDC contracts and the separate staking contract are excluded from this export.',
   arbitrum: {
     tvl: sumTokensExport({
       owners: [WINR_BANKROLL, WINR_ESCROW],

--- a/projects/winr-protocol/index.js
+++ b/projects/winr-protocol/index.js
@@ -12,7 +12,8 @@ module.exports = {
   methodology:
     'TVL is the tracked Arbitrum value of WINR held in the protocol bankroll vault and escrow contract. The bankroll holds liquidity provider funds backing all JustBet gameplay; the escrow holds user balances, settled on-chain via merkle roots. Prior-generation USDC contracts and the separate staking contract are excluded from this export.',
   arbitrum: {
-    tvl: sumTokensExport({
+    tvl: () => ({}),
+    staking: sumTokensExport({
       owners: [WINR_BANKROLL, WINR_ESCROW],
       tokens: [WINR],
     }),

--- a/projects/winr-protocol/index.js
+++ b/projects/winr-protocol/index.js
@@ -1,8 +1,20 @@
-const { gmxExports } = require('../helper/gmx')
-const WINR_VAULT_CONTRACT = "0x8c50528F4624551Aad1e7A265d6242C3b06c9Fca";
+const { sumTokensExport } = require('../helper/unwrapLPs')
+
+const WINR = '0xD77B108d4f6cefaa0Cae9506A934e825BEccA46E'
+
+// Bankroll vault - liquidity provider funds backing gameplay
+const WINR_BANKROLL = '0x5eD22F7693fea5A0B45dB31771aa94E941b6df8a'
+
+// Escrow - user balances, settled on-chain via merkle roots
+const WINR_ESCROW = '0xD75a51364440dAF83B78B9888D2b8F28eaC0D280'
 
 module.exports = {
+  methodology:
+    'TVL is the total value of WINR held in the protocol bankroll vault and escrow contract on Arbitrum. The bankroll holds liquidity provider funds backing all JustBet gameplay; the escrow holds user balances, settled on-chain via merkle roots. Game logic and accounting run off-chain, so these contracts hold the entirety of on-chain protocol value.',
   arbitrum: {
-    tvl: gmxExports({ vault: WINR_VAULT_CONTRACT }),
+    tvl: sumTokensExport({
+      owners: [WINR_BANKROLL, WINR_ESCROW],
+      tokens: [WINR],
+    }),
   },
-};
+}


### PR DESCRIPTION
**Allow edits by maintainers is enabled.**

This is an update to an existing listing (`winr-protocol`), not a new listing, so the new-listing section below is left blank. No new npm dependencies; `pnpm-lock.yaml` is untouched.

---

## Summary

The `winr-protocol` adapter currently reports **$0**. It points at a decommissioned GMX-fork vault (`0x8c50528F4624551Aad1e7A265d6242C3b06c9Fca`) via `gmxExports`. This PR repoints it at the contracts that actually hold protocol funds today.

## Why it broke: architecture change

JustBet (the product built on WINR Protocol) migrated from a fully on-chain casino to a **hybrid off-chain model**. Game logic, RNG, rake, affiliate and VIP accounting all moved off-chain. Only two things remain on-chain:

1. the **bankroll vault** — liquidity provider funds backing player payouts, and
2. the **escrow** — user balances, committed as merkle roots roughly every 5 minutes, which players withdraw trustlessly against.

Separately, **WINR Chain was shut down on 2025-11-01**, so every WINR-Chain-scoped reference is dead. This adapter is now **Arbitrum-only**. (DefiLlama retains historical TVL for removed chains, so nothing is erased.)

## Why the helper changed

`gmxExports` only ever worked because the old vault was a GMX fork — it enumerates `allWhitelistedTokens(i)` and reads `poolAmounts(token)`, methods that only exist on GMX-shaped contracts. The current `WINRBankroll` is a plain verified vault that simply holds WINR. It is **not** ERC4626 and has **no ERC20 share token** (shares are internal `shares[user]` accounting). So `sumTokensExport` is both correct and simpler here.

## What is counted

Single token — WINR, [`0xD77B108d4f6cefaa0Cae9506A934e825BEccA46E`](https://arbiscan.io/token/0xD77B108d4f6cefaa0Cae9506A934e825BEccA46E), 18 decimals — held by two contracts on Arbitrum One (42161):

| Contract | Address | Purpose |
|---|---|---|
| WINRBankroll | [`0x5eD22F7693fea5A0B45dB31771aa94E941b6df8a`](https://arbiscan.io/address/0x5eD22F7693fea5A0B45dB31771aa94E941b6df8a) | Primary LP vault backing gameplay |
| WINR Escrow | [`0xD75a51364440dAF83B78B9888D2b8F28eaC0D280`](https://arbiscan.io/address/0xD75a51364440dAF83B78B9888D2b8F28eaC0D280) | User credit balances, merkle-settled |

Prior-generation USDC bankroll and escrow contracts are deliberately excluded: they are withdraw-only, being wound down, and hold a residual balance of roughly a thousand dollars, which is not material against the total.

Bankroll and escrow are **disjoint pools** — the bankroll holds LP liquidity, the escrow holds user credits — so including both is not double counting. Settlement moves value between them; total on-chain WINR is conserved across that transfer (verified below).

## Pre-empting the "own token" question

WINR held in the bankroll is a large share of float, so the natural question is whether it belongs under `staking:` rather than `tvl:`.

It is not governance staking, and it earns no staking rewards. The WINR in the bankroll is **the bankroll asset backing player payouts** — working capital genuinely at risk against gameplay outcomes. It is paid out to winning players and topped up by losing ones; over the last 24h it absorbed a net loss. This is exactly the function a stablecoin bankroll serves in a conventional on-chain casino; the asset happens to be the protocol's own token, but its role in the system is that of collateral at risk, not of staked supply.

The protocol's actual *staking* system (WINRStakingV2) is a separate contract and is deliberately **not** included in this adapter.

## Note on a number discrepancy

Our own LP-facing app displays `principalPool()` — the WINR backing *active* shares. This adapter reports the raw token balance, per DefiLlama's "total value of all coins held in the smart contracts" methodology.

The gap is the epoch-deferred pending-deposit queue (`totalPendingDepositWinr()`). Deposits and withdrawals are queued and claimed after the next settlement so a settlement cannot be flash-arbitraged. That queued WINR is locked in the contract, so it counts as TVL. The contract's own invariant:

```
principalPool()              500,004,014.380 WINR
+ totalPendingDepositWinr()      550,150.167 WINR
= vaultBalance()             500,554,164.547 WINR   == WINR.balanceOf(bankroll)
```

So a reviewer comparing our app to DefiLlama should expect this adapter to read slightly higher.

## Verification

Per-owner on-chain reads (`balanceOf`, Arbitrum One):

| Owner | Balance |
|---|---|
| WINRBankroll | 500,544,942.086 WINR |
| WINR Escrow | 7,152,065.204 WINR |

Sampled twice a few minutes apart: the bankroll fell by 9,222.46 WINR and the escrow rose by exactly 9,222.46 WINR (a settlement transfer), with the combined total unchanged at 507,697,007.291 WINR — confirming the two owners are disjoint and jointly complete.

Price feed confirmed live: `coins.llama.fi` prices `arbitrum:0xD77B108d4f6cefaa0Cae9506A934e825BEccA46E` as WINR, 18 decimals, confidence 0.99.

```
$ node test.js projects/winr-protocol/index.js
Building prices get queries for 1 tokens
--- arbitrum ---
WINR                      2.10 M
Total: 2.10 M

--- tvl ---
WINR                      2.10 M
Total: 2.10 M

------ TVL ------
arbitrum                  2.10 M

total                    2.10 M
```

Historical backfill also resolves correctly:

```
$ node test.js projects/winr-protocol/index.js 2026-06-01
Building prices get queries for 1 tokens
--- arbitrum ---
WINR                      502.47 k
Total: 502.47 k

--- tvl ---
WINR                      502.47 k
Total: 502.47 k

------ TVL ------
arbitrum                  502.47 k

total                    502.47 k
```

## Follow-ups (separate)

- The `dexs/justbet` and `fees/justbet` adapters in `dimension-adapters` are still scoped to the dead WINR Chain and read V1 contracts that no longer exist. A separate PR will address those.
- Listing metadata (category, the deprecated flag on the JustBet entry) will be sent to metadata@defillama.com separately.

---
## (Needs to be filled only for new listings)

Not a new listing — existing `winr-protocol` adapter.

##### methodology (what is being counted as tvl, how is tvl being calculated):

TVL is the total value of WINR held in the protocol bankroll vault and escrow contract on Arbitrum. The bankroll holds liquidity provider funds backing all JustBet gameplay; the escrow holds user balances, settled on-chain via merkle roots. Game logic and accounting run off-chain, so these contracts hold the entirety of on-chain protocol value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added staking balance tracking for WINR on Arbitrum, covering bankroll and escrow contracts.
  * Added methodology details describing tracked balances and excluded contracts.
* **Updates**
  * Removed GMX-based TVL tracking for the WINR protocol on Arbitrum.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->