### PR TITLE
makina-finance: net out the srRoyUSDC leg already counted by royco-v2

### DIFF
--- a/projects/makina-finance/index.js
+++ b/projects/makina-finance/index.js
@@ -9,14 +9,35 @@ const usdSHFmk_TOKEN = '0xac499adf00a54044b988a59b19016655c3494b06';
 const intMkSrRoyUSDC_TOKEN = '0x1004D230aCA4b781d0049AFD6D0b1ee8ed3A6787';
 const DQAeETH_TOKEN = '0x2b24dFcE3a6AEF36E147C692Fa32d484ec538FC1';
 
+// intMkSrRoyUSDC is minted against deposits routed in from Royco V2's srRoyUSDC vault, and
+// projects/royco-v2 already counts those deposits at the issuing vault (its stated Yearn-style
+// convention: deposits count toward the issuing protocol even when forwarded elsewhere). The
+// strategy-held share is therefore subtracted here so the same dollars are not counted on both
+// protocols. Holders are read from the vault rather than hardcoded, so this follows along if
+// Royco adds or rotates strategies.
+const SR_ROY_USDC_VAULT = '0xcd9f5907f92818bc06c9ad70217f089e190d2a32';
+const getStrategiesAbi = 'function getStrategies() view returns (address[])';
+
+async function roycoHeldIntMkSrRoyUSDC(api) {
+  const strategies = await api.call({ abi: getStrategiesAbi, target: SR_ROY_USDC_VAULT });
+  if (!strategies.length) return 0n;
+
+  const balances = await api.multiCall({
+    abi: 'erc20:balanceOf',
+    calls: strategies.map((strategy) => ({ target: intMkSrRoyUSDC_TOKEN, params: [strategy] })),
+  });
+  return balances.reduce((sum, balance) => sum + BigInt(balance), 0n);
+}
+
 async function tvl(api) {
-  const [dusdSupply, dethSupply, dbitSupply, usdSHFmkSupply, intMkSrRoyUSDCSupply, DQAeETHSupply] = await Promise.all([
+  const [dusdSupply, dethSupply, dbitSupply, usdSHFmkSupply, intMkSrRoyUSDCSupply, DQAeETHSupply, roycoHeld] = await Promise.all([
     api.call({ abi: 'erc20:totalSupply', target: DUSD_TOKEN }),
     api.call({ abi: 'erc20:totalSupply', target: DETH_TOKEN }),
     api.call({ abi: 'erc20:totalSupply', target: DBIT_TOKEN }),
     api.call({ abi: 'erc20:totalSupply', target: usdSHFmk_TOKEN }),
     api.call({ abi: 'erc20:totalSupply', target: intMkSrRoyUSDC_TOKEN }),
     api.call({ abi: 'erc20:totalSupply', target: DQAeETH_TOKEN }),
+    roycoHeldIntMkSrRoyUSDC(api),
   ]);
 
   return {
@@ -24,13 +45,13 @@ async function tvl(api) {
     [DETH_TOKEN]: dethSupply,
     [DBIT_TOKEN]: dbitSupply,
     [usdSHFmk_TOKEN]: usdSHFmkSupply,
-    [intMkSrRoyUSDC_TOKEN]: intMkSrRoyUSDCSupply,
+    [intMkSrRoyUSDC_TOKEN]: (BigInt(intMkSrRoyUSDCSupply) - roycoHeld).toString(),
     [DQAeETH_TOKEN]: DQAeETHSupply,
   };
 }
 
 module.exports = {
-  methodology: "TVL counts the total supply of share tokens of the protocol",
+  methodology: "TVL counts the total supply of share tokens of the protocol. intMkSrRoyUSDC is counted net of the amount held by Royco V2's srRoyUSDC strategies, since projects/royco-v2 already counts those deposits at the issuing vault.",
   misrepresentedTokens: true,
   start: 23428036,
   ethereum: { tvl },


### PR DESCRIPTION
intMkSrRoyUSDC is minted against deposits routed in from Royco V2's srRoyUSDC vault, and projects/royco-v2 already counts those deposits at the issuing vault. Neither adapter accounted for the overlap, so the same dollars landed twice in the Ethereum and global aggregates.

Verified on mainnet:

  srRoyUSDC 0xcd9f5907f92818bc06c9ad70217f089e190d2a32
    getStrategies() -> [0xc5FeF644d59415cec65049e0653CA10eD9Cba778]

  intMkSrRoyUSDC 0x1004D230aCA4b781d0049AFD6D0b1ee8ed3A6787
    totalSupply()                     -> 10,826,887.302243
    balanceOf(0xc5FeF644...Cba778)    -> 10,826,887.302243

100% of supply sits in Royco's single strategy.

Subtracts the strategy-held balance from the intMkSrRoyUSDC leg rather than flagging the adapter doublecounted: this adapter also counts dUSD, dETH, dBIT, usdSHFmk and DQAeETH, none of which overlap with Royco, so a protocol-level flag would wrongly drop those from the aggregates too.

Royco is left untouched. Its adapter documents the Yearn-style convention that deposits count toward the issuing protocol even when forwarded elsewhere, so the venue side is the one that nets out.

Strategy holders are read from the vault rather than hardcoded, so the subtraction follows along if Royco adds or rotates strategies.

Fixes #20323

**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).

2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** Please send a mail to metadata@defillama.com
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes

---
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):

##### Twitter Link:

##### List of audit links if any:

##### Website Link:

##### Logo (High resolution, will be shown with rounded borders):

##### Current TVL:

##### Treasury Addresses (if the protocol has treasury)

##### Chain:

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama):

##### Token address and ticker if any:

##### Category (full list at https://defillama.com/categories) \*Please choose only one:

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

##### forkedFrom (Does your project originate from another project):

##### methodology (what is being counted as tvl, how is tvl being calculated):

##### Github org/user (Optional, if your code is open source, we can track activity):

##### Does this project have a referral program?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dynamic tracking of Royco V2 strategy balances for the configured vault.
  * TVL calculations now account for tokens held by Royco strategies and report net supply.

* **Documentation**
  * Updated methodology information to explain the Royco-held balance deduction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->