### PR TITLE
Add Alandale TVL adapters (Robinhood Chain ve(3,3) DEX)

### DIFF
--- a/registries/uniswapV2.js
+++ b/registries/uniswapV2.js
@@ -3095,6 +3095,13 @@ const uniV2Configs = {
   'kolswap': {
     robinhood: '0xdB2Ec80E55527b5D858b54173083139679f5DE6f',
     bsc: '0x6af79510599dE74E5922A2771b29160dA8b7b4c1'
+  },
+  'alandale-v2': {
+    start: '2026-08-04',
+    _options: {
+      hasStablePools: true,
+    },
+    robinhood: '0xe0799417eff30A12249b8c30941BC2d7c52A0339',
   }
 }
 

--- a/registries/uniswapV3.js
+++ b/registries/uniswapV3.js
@@ -1773,6 +1773,15 @@ const uniV3Configs = {
   },
   'giga-dex-cl': {
     robinhood: { factory: '0xEce6eCd61177336ea6Fb9b17937AC439D85EE20B', fromBlock: 10357399 }
+  },
+  'alandale': {
+    start: '2026-08-04',
+    methodology: 'Value of the tokens locked in the concentrated liquidity pools.',
+    robinhood: {
+      factory: '0x16494A80E08Bcb9285D87b67149d7b01774D82F8',
+      fromBlock: 27941500,
+      isAlgebra: true,
+    },
   }
 }
 


### PR DESCRIPTION
---

"Allow edits by maintainers" is enabled.

##### Name (to be shown on DefiLlama):
Alandale

##### Twitter Link:
https://x.com/alandalexyz

##### List of audit links if any:
None.

##### Website Link:
https://alandale.xyz (app: https://app.alandale.xyz)

##### Logo (High resolution, will be shown with rounded borders):
https://app.alandale.xyz/icon.svg

##### Current TVL:
~$347,000 total — ~$327k in the concentrated-liquidity pools (`alandale`) and ~$20k in the
v2 pair (`alandale-v2`)

##### Treasury Addresses (if the protocol has treasury)
None.

##### Chain:
Robinhood Chain

##### Coingecko ID (leave empty if not listed):

##### Coinmarketcap ID (leave empty if not listed):


##### Short Description (to be shown on DefiLlama):
Alandale is a ve(3,3) DEX on Robinhood Chain. LPs earn LUTE emissions, veLUTE lockers vote weekly
on emissions and receive all trading fees and bribes.

##### Token address and ticker if any:
LUTE — `0xD1e861CC5Eee7eA88649206b74504D78CCD7AEeA`

##### Category:
Dexes

##### Oracle Provider(s):
None. Alandale does not consume an external price oracle — `priceProvider` is the zero address on
mainnet, and the frontend derives prices from its own pool graph anchored on USDG. The adapter does
not rely on any Alandale oracle; it uses DefiLlama pricing.

##### Implementation Details:
n/a — no oracle integration.

##### Documentation/Proof:
n/a

##### forkedFrom:

##### methodology:
Two registry entries, one per AMM engine:

- `alandale` — Algebra Integral concentrated-liquidity pools (`isAlgebra: true`).
- `alandale-v2` — Solidly v2 volatile and stable pairs (`hasStablePools: true`). One pair exists so
  far (`vAMM-WETH/LUTE`, `0x426e33194aA6dc8Ef2bAC618954266Aba9E12B2F`); further pairs are picked up
  automatically from the factory.

##### Github org/user:

##### Does this project have a referral program?
No

---

### Notes for reviewers

One thing worth flagging up front.

**Historical backfill needs an archive RPC.** The Robinhood endpoint in `@defillama/sdk`
`providers.json` serves only a few thousand blocks of state, so balance reads at a historical block
fail there. `timetravel` is left unset, matching every other entry in this file. Against an archive
node backfill does work correctly, including returning zero before the first pool was created on
2026-08-07 15:27 UTC.

**No token substitution is used**, so `misrepresentedTokens` is left at its default. Every pool
token is priced by DefiLlama directly, including LUTE. veLUTE lock NFTs are not counted.

**Validation:** `node test.js alandale` → $327.43k across 7 tokens (USDG, WETH, LUTE, NVDA, GME,
SNDK, SPCX). `node test.js alandale-v2` → $19.94k. Independently reconciled to the dollar against
the protocol's own subgraph priced through the DefiLlama coins API — a completely separate route
from the on-chain balances this adapter reads.

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking Robinhood’s new Uniswap V2 and V3 liquidity pools.
  * Enabled stable-pool support for the V2 deployment.
  * Added deployment timing and TVL tracking configuration for the V3 deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->