### PR TITLE
Add wambo.fun (parimutuel memecoin races on Robinhood Chain)

### DIFF
--- a/projects/wambo-fun/index.js
+++ b/projects/wambo-fun/index.js
@@ -1,0 +1,16 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+const { sumTokensExport } = require('../helper/unwrapLPs')
+
+// wambo.fun — parimutuel memecoin races on Robinhood Chain. RaceBook holds
+// every wei the venue owes anyone: live race stakes, unclaimed winnings and
+// refunds, accrued rake and the rollover pot, all in native ETH.
+const RACEBOOK = '0x6a8196b02d94e96366ace6f494fc46eae3c35e31'
+
+module.exports = {
+  methodology:
+    'TVL is the native ETH held by the RaceBook contract: live race stakes, unclaimed winnings and refunds, accrued rake and the pot rolling into the next race.',
+  start: '2026-08-11',
+  robinhood: {
+    tvl: sumTokensExport({ owner: RACEBOOK, tokens: [ADDRESSES.null] }),
+  },
+}


### PR DESCRIPTION
**Name**: wambo.fun
**Website**: https://wambo.fun
**Twitter**: https://x.com/Wambofun
**Category**: Prediction Market
**Chain**: Robinhood Chain

wambo.fun is a live parimutuel betting venue on Robinhood Chain: five memecoins race for ten minutes, scored by Uniswap v3 TWAP, and backers of the winner split everyone else's stake. Settlement is fully on-chain via the RaceBook contract.

**Methodology**: TVL is the native ETH held by RaceBook (`0x6a8196b02d94e96366ace6f494fc46eae3c35e31`): live race stakes, unclaimed winnings and refunds, accrued rake, and the pot rolling into the next race.

The venue launched on mainnet 2026-08-12 and races run every ~12 minutes, so TVL is currently near zero between stakes — the adapter reads the true book balance.

Explorer: https://robinhoodchain.blockscout.com/address/0x6a8196b02d94e96366ace6f494fc46eae3c35e31

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Wambo.fun coverage for tracking native ETH held by its RaceBook contract on Robinhood Chain.
  * TVL now includes race stakes, winnings, refunds, rake, and rollover funds.
  * Added methodology details and historical tracking beginning August 11, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->