### PR TITLE
Add LuckyLaunch

### DIFF
--- a/projects/luckylaunch/index.js
+++ b/projects/luckylaunch/index.js
@@ -5,15 +5,9 @@
  *   Phase A — a bonding-curve presale pool that holds the AVLO raised so far.
  *   Phase B — after graduation, a native x*y=k AMM ("AvaLove DEX") whose AVLO
  *             reserve is the pool's liquidity. LP is permanently locked.
- *
- * TVL = all AVLO locked across every pool + AMM on each chain. The launchpad's
- * own freshly-minted tokens are intentionally excluded (DefiLlama convention for
- * launchpad-created assets), so we only count the external quote asset (AVLO).
- *
- * Pools are enumerated purely from public on-chain state via each chain's
- * LuckyFactory (launchesLength + getLaunches paging). No private data, no
- * external price calls — DefiLlama's coins service prices AVLO.
  */
+
+const { nullAddress } = require("../helper/tokenMapping");
 
 const AVLO = {
   avax: "0x54eEeB249E3AE445f21eb006DEbB33eFa2B4b3Bb",
@@ -27,33 +21,21 @@ const FACTORY = {
 
 const abi = {
   launchesLength: "function launchesLength() view returns (uint256)",
-  getLaunches:
-    "function getLaunches(uint256 offset, uint256 limit) view returns (tuple(address pool, address amm, address token, address creator, string name, string symbol, uint256 createdAt)[])",
+  launches: "function launches(uint256) view returns (address pool, address amm, address token, address creator, string name, string symbol, uint256 createdAt)",
 };
 
-const PAGE = 100;
-
-// Collect every pool + amm address from the factory registry (paged).
 async function poolAddresses(api) {
-  const factory = FACTORY[api.chain];
-  const length = Number(await api.call({ target: factory, abi: abi.launchesLength }));
-  const owners = [];
-  for (let offset = 0; offset < length; offset += PAGE) {
-    const rows = await api.call({
-      target: factory,
-      abi: abi.getLaunches,
-      params: [offset, Math.min(PAGE, length - offset)],
-    });
-    for (const r of rows) {
-      if (r.pool) owners.push(r.pool);
-      if (r.amm) owners.push(r.amm);
-    }
-  }
-  return owners;
+  const launches = await api.fetchList({
+    target: FACTORY[api.chain],
+    lengthAbi: abi.launchesLength,
+    itemAbi: abi.launches,
+  });
+  return launches
+    .flatMap((l) => [l.pool, l.amm])
+    .filter((a) => a && a !== nullAddress);
 }
 
-// Sum balanceOf(AVLO) over every pool + amm → the AVLO locked in the protocol.
-async function tvl(api) {
+async function staking(api) {
   const owners = await poolAddresses(api);
   if (owners.length === 0) return {};
   return api.sumTokens({ owners, tokens: [AVLO[api.chain]] });
@@ -61,7 +43,7 @@ async function tvl(api) {
 
 module.exports = {
   methodology:
-    "TVL is the AVLO locked across every LuckyLaunch pool: the AVLO raised on each Phase-A bonding-curve presale plus the AVLO reserve of each graduated Phase-B AvaLove DEX pool (x*y=k, LP permanently locked). Launchpad-minted tokens are excluded per DefiLlama convention. Pools are enumerated on-chain from each chain's LuckyFactory (launchesLength + getLaunches).",
-  avax: { tvl },
-  robinhood: { tvl },
+    "TVL is the AVLO locked across every LuckyLaunch pool: the AVLO raised on each Phase-A bonding-curve presale plus the AVLO reserve of each graduated Phase-B AvaLove DEX pool (x*y=k, LP permanently locked). Launchpad-minted tokens are excluded per DefiLlama convention. Pools are enumerated on-chain from each chain's LuckyFactory (launchesLength + launches).",
+  avax: { tvl: () => ({}), staking },
+  robinhood: { tvl: () => ({}), staking },
 };

--- a/projects/luckylaunch/index.js
+++ b/projects/luckylaunch/index.js
@@ -1,0 +1,67 @@
+/**
+ * LuckyLaunch — dual-chain (Avalanche + Robinhood) launchpad + native AMM DEX.
+ *
+ * Every launch runs two phases, both custodying AVLO (the quote asset):
+ *   Phase A — a bonding-curve presale pool that holds the AVLO raised so far.
+ *   Phase B — after graduation, a native x*y=k AMM ("AvaLove DEX") whose AVLO
+ *             reserve is the pool's liquidity. LP is permanently locked.
+ *
+ * TVL = all AVLO locked across every pool + AMM on each chain. The launchpad's
+ * own freshly-minted tokens are intentionally excluded (DefiLlama convention for
+ * launchpad-created assets), so we only count the external quote asset (AVLO).
+ *
+ * Pools are enumerated purely from public on-chain state via each chain's
+ * LuckyFactory (launchesLength + getLaunches paging). No private data, no
+ * external price calls — DefiLlama's coins service prices AVLO.
+ */
+
+const AVLO = {
+  avax: "0x54eEeB249E3AE445f21eb006DEbB33eFa2B4b3Bb",
+  robinhood: "0x7e37298e240c1E644F6F9F96b6A3AA6C5aea9885",
+};
+
+const FACTORY = {
+  avax: "0x77B5D9Fbc8A39A832a2293D8987f12d9e24ae362",
+  robinhood: "0x853203C0f6C7EC1f446B5D0dB3dF00F0c9aA0138",
+};
+
+const abi = {
+  launchesLength: "function launchesLength() view returns (uint256)",
+  getLaunches:
+    "function getLaunches(uint256 offset, uint256 limit) view returns (tuple(address pool, address amm, address token, address creator, string name, string symbol, uint256 createdAt)[])",
+};
+
+const PAGE = 100;
+
+// Collect every pool + amm address from the factory registry (paged).
+async function poolAddresses(api) {
+  const factory = FACTORY[api.chain];
+  const length = Number(await api.call({ target: factory, abi: abi.launchesLength }));
+  const owners = [];
+  for (let offset = 0; offset < length; offset += PAGE) {
+    const rows = await api.call({
+      target: factory,
+      abi: abi.getLaunches,
+      params: [offset, Math.min(PAGE, length - offset)],
+    });
+    for (const r of rows) {
+      if (r.pool) owners.push(r.pool);
+      if (r.amm) owners.push(r.amm);
+    }
+  }
+  return owners;
+}
+
+// Sum balanceOf(AVLO) over every pool + amm → the AVLO locked in the protocol.
+async function tvl(api) {
+  const owners = await poolAddresses(api);
+  if (owners.length === 0) return {};
+  return api.sumTokens({ owners, tokens: [AVLO[api.chain]] });
+}
+
+module.exports = {
+  methodology:
+    "TVL is the AVLO locked across every LuckyLaunch pool: the AVLO raised on each Phase-A bonding-curve presale plus the AVLO reserve of each graduated Phase-B AvaLove DEX pool (x*y=k, LP permanently locked). Launchpad-minted tokens are excluded per DefiLlama convention. Pools are enumerated on-chain from each chain's LuckyFactory (launchesLength + getLaunches).",
+  avax: { tvl },
+  robinhood: { tvl },
+};


### PR DESCRIPTION
LuckyLaunch — a dual-chain (Avalanche + Robinhood) token launchpad with its own native x*y=k AMM DEX ("AvaLove DEX").

TVL = AVLO (the quote asset) locked across every launch on each chain: the AVLO raised on each Phase-A bonding-curve presale pool plus the AVLO reserve of each graduated Phase-B AMM pool (LP permanently locked). Launchpad-minted tokens are excluded per DefiLlama convention. Pools are enumerated purely on-chain from each chain's LuckyFactory via launchesLength + getLaunches. No external price calls.

Chains: avax, robinhood.
Factories: avax 0x77B5D9Fbc8A39A832a2293D8987f12d9e24ae362, robinhood 0x853203C0f6C7EC1f446B5D0dB3dF00F0c9aA0138.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for LuckyLaunch across Avalanche and Robinhood.
  * Includes eligible presale and AMM AVLO reserves in reported totals.
  * Supports paginated discovery of launches and associated pools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->