### PR TITLE
track n1 exchange bridge tvl

### DIFF
--- a/registries/sumTokens/data1.js
+++ b/registries/sumTokens/data1.js
@@ -730,4 +730,11 @@ module.exports = {
     "methodology": "TVL is the USDC collateral held in Pascal's vault token account on Solana.",
     "solana": { "tokenAccounts": ["5vRGRcwN4iYaiQdso1vgWbTDFYbS8GQNUDRMMKE2ycZS"] }
   },
+  "n1-exchange-bridge": {
+    "methodology": "Counts the USDC held in the N1 Exchange bridge custody wallet on Solana.",
+    "solana": {
+      "owners": ["2ds4b3zrkgZ9FU8vNBSpT1UzACnmfYtjGsazPRzsbCCz"],
+      "tokens": [ADDRESSES.solana.USDC]
+    }
+  },
 }


### PR DESCRIPTION
https://github.com/DefiLlama/dimension-adapters/pull/8720

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added tracking for USDC held by the N1 Exchange bridge custody wallet on Solana.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->