### PR TITLE
feat(strata-tranches): add nOPAL (Nest BlackOpal LiquidStone II) vaults

### DIFF
--- a/projects/strata-tranches/index.js
+++ b/projects/strata-tranches/index.js
@@ -10,13 +10,15 @@ const srUSDatVault = "0xFaa9a0e1Db9E22AE3A20B2B58a68DC24D053d066";
 const jrUSDatVault = "0x011e55d2b28306458e37Ca7E997C879BB25A455D";
 const jrtPrimeVault = "0xF4C91F24E20EE8ed5eda905E501A1136334C2F27";
 const srtPrimeVault = "0x35bFF778d3fc53a561486BF28e761428499232Eb";
+const jrNOPALVault = "0x1b2b8cFEF0b7B1Fad216b55fefeEb0c3349Da141";
+const srNOPALVault = "0x8a646Edc4633ADBA5Ec87DedaF3Af958e268FE96";
 
 module.exports = {
     methodology: "Protocol TVL refers to the dollar value of all assets deposited into the protocol smart contracts.",
     ethereum: {
         async tvl (api) {
             return await api.erc4626Sum2({
-                calls: [ srUSDeVault, jrUSDeVault, srNUSDVault, jrNUSDVault, srmHYPERVault, jrmHYPERVault, srmM1USDVault, jrmM1USDVault, srUSDatVault, jrUSDatVault, jrtPrimeVault, srtPrimeVault ],
+                calls: [ srUSDeVault, jrUSDeVault, srNUSDVault, jrNUSDVault, srmHYPERVault, jrmHYPERVault, srmM1USDVault, jrmM1USDVault, srUSDatVault, jrUSDatVault, jrtPrimeVault, srtPrimeVault, jrNOPALVault, srNOPALVault ],
             });
         }
     },


### PR DESCRIPTION
Adds the nOPAL Junior and Senior tranche vaults to the Strata TVL adapter.

nOPAL is a Nest Credit RWA vault (BlackOpal LiquidStone II) deployed on Ethereum with USDC as the base asset. The vaults are standard ERC4626 and work with the existing `erc4626Sum2` pattern.

| Vault | Address | TVL |
|---|---|---|
| Junior (JRT) | `0x1b2b8cFEF0b7B1Fad216b55fefeEb0c3349Da141` | $148,217 |
| Senior (SRT) | `0x8a646Edc4633ADBA5Ec87DedaF3Af958e268FE96` | $78 |

Verified on-chain: `asset()` returns USDC, `totalAssets()` returns correct values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added NOPAL senior and junior vaults to Ethereum TVL tracking.
  * Ethereum ERC-4626 TVL calculations now include these vaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->