### PR TITLE
fix vishwa

### DIFF
--- a/projects/helper/bitcoin-book/fetchers.js
+++ b/projects/helper/bitcoin-book/fetchers.js
@@ -248,6 +248,7 @@ module.exports = {
   vishwa: async () => {
     const staticAddresses = await getConfig('vishwa', undefined, {
       fetcher: async () => {
+        throw new Error("temp break until api is fixed (falls back to cache)")
         const { data } = await axios.get('https://vault.vishwalab.com/vapi/btc/address')
         return data.data
       }


### PR DESCRIPTION
api is returning empty owner array, throwing inside getConfig falls back to cache

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Temporarily disabled the unavailable Bitcoin data service to prevent failed requests.
  * The app now falls back to cached data when live data cannot be retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->