### PR TITLE
Revert "fix vishwa"

### DIFF
--- a/projects/helper/bitcoin-book/fetchers.js
+++ b/projects/helper/bitcoin-book/fetchers.js
@@ -248,7 +248,6 @@ module.exports = {
   vishwa: async () => {
     const staticAddresses = await getConfig('vishwa', undefined, {
       fetcher: async () => {
-        throw new Error("temp break until api is fixed (falls back to cache)")
         const { data } = await axios.get('https://vault.vishwalab.com/vapi/btc/address')
         return data.data
       }


### PR DESCRIPTION
Reverts DefiLlama/DefiLlama-Adapters#20479

The API is now fixed: https://vault.vishwalab.com/vapi/btc/address

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored live address retrieval from the Vishwa API.
  * Prevented unnecessary fallback to cached data during successful requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->