### PR TITLE
add concrete tvl check

### DIFF
--- a/projects/concrete-xyz/index.js
+++ b/projects/concrete-xyz/index.js
@@ -19,17 +19,24 @@ const tvl = async (api) => {
   const chainId = api.chainId
   const data = await getConfig('concrete-xyz/vaults', URL)
   // exclude test vaults and vaults with no tvl (onchain totalAssets() may be stale)
-  const vaults = Object.values(data[chainId])
-    .filter(v => v.address && Number(v.tvl) > 0 && !excludeVaults.includes(v.address.toLowerCase()))
-    .map(v => v.address)
+  const vaults = Object.values(data[chainId]).filter(v => v.address && Number(v.tvl) > 0 && !excludeVaults.includes(v.address.toLowerCase()))
 
-  const assets = await api.multiCall({ calls: vaults, abi: abis.asset })
+  const addresses = vaults.map(v => v.address)
+  const assets = await api.multiCall({ calls: addresses, abi: abis.asset })
   // there is a weird bug when totalAssets return 0, we get an error, maybe because total shares is 0?
-  const totalAssets = await api.multiCall({ calls: vaults, abi: abis.totalAssets, permitFailure: true })
+  const totalAssets = await api.multiCall({ calls: addresses, abi: abis.totalAssets, permitFailure: true })
 
+  let apiTvl = 0
   for (let i = 0; i < vaults.length; i++) {
     if (!totalAssets[i]) continue;
     api.add(assets[i], totalAssets[i])
+    apiTvl += Number(vaults[i].tvl)
+  }
+
+  // throws if onchain tvl is >10% above API tvl (not thrown on historic runs since api tvl is always current)
+  if (!api.timestamp || api.timestamp > Date.now() / 1e3 - 3600) {
+    const onchainTvl = await api.getUSDValue()
+    if (onchainTvl > apiTvl * 1.1) throw new Error(`concrete-xyz ${api.chain}: onchain TVL $${onchainTvl.toFixed(0)} is >10% above API TVL $${apiTvl.toFixed(0)}`)
   }
 }
 


### PR DESCRIPTION
if onchain tvl is 10% higher than the API tvl we throw an error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Vault data is now preserved correctly after filtering.
  - Total value locked (TVL) calculations now include all successful asset results.
  - Recent data runs now detect and report significant discrepancies between on-chain TVL and API-provided TVL, improving data accuracy and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->