### PR TITLE
add kayen finance treasury

### DIFF
--- a/registries/treasury.js
+++ b/registries/treasury.js
@@ -3050,6 +3050,12 @@ const configs = {
       ownTokens: ["0x91fbB2503AC69702061f1AC6885759Fc853e6EaE"]
     },
   },
+  'treasury/kayen-finance': {
+    chz: {
+      tokens: [nullAddress],
+      owners: ['0xCf271d12C2d1a757829F5F216a564017D60886F0']
+    }
+  },
   'treasury/keeperdao': {
     ethereum: {
       tokens: [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kayen Finance treasury tracking for the CHZ chain’s native asset.
  * Included the associated treasury owner address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->