### PR TITLE
Add Spiral Stake

### DIFF
--- a/projects/spiral-stake/index.js
+++ b/projects/spiral-stake/index.js
@@ -1,0 +1,96 @@
+const { getLogs2 } = require('../helper/cache/getLogs')
+
+// Spiral Stake opens leveraged positions on Morpho Blue in a single transaction: flash-borrow the
+// loan token, swap to collateral, supply collateral, borrow against it, repay the flash loan.
+// Every position is held by its own UserProxy clone, so the Morpho collateral/debt sits under the
+// proxy rather than the user's address.
+//
+// Discovery: LeveragePositionOpened gives every user that has ever opened a position, and
+// FlashLeverage itself is the registry of their positions (market + proxy).
+const config = {
+  ethereum: {
+    flashLeverage: '0x2B12066ebD67A6A58E70b37051AbED0590E5A721',
+    morpho: '0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb',
+    fromBlock: 25327266,
+  },
+  robinhood: {
+    flashLeverage: '0x27eaF95d39cB07d544026167365689C34B4d3f9A',
+    morpho: '0x9D53d5E3bd5E8d4Cbfa6DB1ca238AEA02E651010',
+    fromBlock: 1244405,
+  },
+}
+
+const abis = {
+  LeveragePositionOpened: 'event LeveragePositionOpened(address indexed user, uint256 indexed positionId, uint256 indexed amountDepositedInLoanToken, uint256 amountCollateral)',
+  getUserLeveragePositions: 'function getUserLeveragePositions(address user) view returns ((bool open, bytes32 marketId, address userProxy, uint256 amountDepositedInLoanToken, uint256 amountReturnedInLoanToken)[])',
+  idToMarketParams: 'function idToMarketParams(bytes32) view returns (address loanToken, address collateralToken, address oracle, address irm, uint256 lltv)',
+  getMorphoPosition: 'function getMorphoPosition(address user, (address loanToken, address collateralToken, address oracle, address irm, uint256 lltv) market) view returns ((uint256 supplyShares, uint128 borrowShares, uint128 collateral))',
+  getSharesValueInLoanToken: 'function getSharesValueInLoanToken((address loanToken, address collateralToken, address oracle, address irm, uint256 lltv) market, uint256 borrowShares) view returns (uint256)',
+}
+
+// Returns one entry per live position: its market params, Morpho collateral and debt in loan-token
+// units. Debt is resolved through the protocol's own share->assets conversion so it matches what a
+// close would actually have to repay.
+async function getPositions(api) {
+  const { flashLeverage, morpho, fromBlock } = config[api.chain]
+
+  const logs = await getLogs2({ api, target: flashLeverage, eventAbi: abis.LeveragePositionOpened, fromBlock })
+  const users = [...new Set(logs.map(i => i.user.toLowerCase()))]
+  if (!users.length) return []
+
+  const positionLists = await api.multiCall({ target: flashLeverage, abi: abis.getUserLeveragePositions, calls: users })
+  const positions = positionLists.flat().filter(i => i.open && i.userProxy !== nullAddress)
+  if (!positions.length) return []
+
+  const marketIds = [...new Set(positions.map(i => i.marketId))]
+  const marketParams = await api.multiCall({ target: morpho, abi: abis.idToMarketParams, calls: marketIds })
+  const marketById = {}
+  marketIds.forEach((id, i) => {
+    const { loanToken, collateralToken, oracle, irm, lltv } = marketParams[i]
+    marketById[id] = [loanToken, collateralToken, oracle, irm, lltv]
+  })
+
+  const morphoPositions = await api.multiCall({
+    target: flashLeverage, abi: abis.getMorphoPosition,
+    calls: positions.map(i => ({ params: [i.userProxy, marketById[i.marketId]] })),
+  })
+  const debts = await api.multiCall({
+    target: flashLeverage, abi: abis.getSharesValueInLoanToken,
+    calls: positions.map((i, idx) => ({ params: [marketById[i.marketId], morphoPositions[idx].borrowShares] })),
+  })
+
+  return positions.map((i, idx) => ({
+    collateralToken: marketById[i.marketId][1],
+    loanToken: marketById[i.marketId][0],
+    collateral: morphoPositions[idx].collateral,
+    debt: debts[idx],
+  }))
+}
+
+const nullAddress = '0x0000000000000000000000000000000000000000'
+
+// Only the user's own margin is new value in the underlying Morpho market — the leveraged portion is
+// flash-borrowed and immediately repaid out of the Morpho borrow — so the debt is netted off here
+// and reported separately under `borrowed`.
+const tvl = async (api) => {
+  const positions = await getPositions(api)
+  positions.forEach(({ collateralToken, loanToken, collateral, debt }) => {
+    api.add(collateralToken, collateral)
+    api.add(loanToken, -debt)
+  })
+}
+
+const borrowed = async (api) => {
+  const positions = await getPositions(api)
+  positions.forEach(({ loanToken, debt }) => api.add(loanToken, debt))
+}
+
+module.exports = {
+  start: '2026-06-16',
+  doublecounted: true,
+  methodology: 'Spiral Stake opens leveraged positions on Morpho Blue markets. Each position is held by a dedicated UserProxy contract that supplies collateral to and borrows from a Morpho market. TVL counts the collateral held across all open Spiral positions minus the debt owed to Morpho, i.e. only the user margin, since the leveraged portion is flash-borrowed and immediately repaid out of the Morpho borrow. Debt is reported separately as borrowed. The collateral is also counted in Morpho Blue TVL, so this listing is flagged as doublecounted.',
+}
+
+Object.keys(config).forEach(chain => {
+  module.exports[chain] = { tvl, borrowed }
+})


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
Spiral Stake

##### Twitter Link:
https://x.com/0xspiralstake

##### List of audit links if any:
Phage (2026-01-20): https://github.com/spiral-stake/v2-core/blob/main/audits/2026-01-20-phage-spiral-stake-v2.pdf
Cyfrin (2026-03-12): https://github.com/spiral-stake/v2-core/blob/main/audits/2026-03-12-cyfrin-spiral-stake-v2.pdf
Sherlock (2026-04-27): https://github.com/spiral-stake/v2-core/blob/main/audits/2026-04-27-sherlock-spiral-stake-v2.pdf

##### Website Link:
https://spiralstake.xyz

##### Logo (High resolution, will be shown with rounded borders):
https://app.spiralstake.xyz/logo.svg

##### Current TVL:
~$7.3k net equity (Ethereum + Robinhood Chain), computed live by the adapter. Gross looped collateral (~$194k lifetime) is intentionally not counted — see methodology.

##### Treasury Addresses (if the protocol has treasury):
0x9ced716f16651b69D5167C82003690621e8F90b9

##### Chain:
Ethereum, Robinhood Chain

##### Coingecko ID:
(none — no token)

##### Coinmarketcap ID:
(none — no token)

##### Short Description (to be shown on DefiLlama):
Spiral Stake opens one-transaction leveraged ("looping") positions on Morpho Blue markets — flash-borrow the loan asset, swap to collateral, supply, and borrow against it — with each position held in its own proxy.

##### Token address and ticker if any:
None.

##### Category (choose one):
Leveraged Farming

##### Oracle Provider(s):
Per-market Morpho Blue oracles (inherited). Spiral runs no oracle of its own; each position is valued and liquidated by the oracle its Morpho Blue market is configured with (varies by market — e.g. Chainlink/RedStone-style feeds, Pendle PT oracles).

##### Implementation Details:
Spiral does not integrate a price oracle directly. Positions live in Morpho Blue markets; each market's own oracle governs collateral valuation and liquidation. The TVL adapter reads raw on-chain collateral and debt amounts from Morpho (no price feed of its own); DefiLlama prices the tokens.

##### Documentation/Proof:
https://docs.spiralstake.xyz — per-market oracle addresses are on-chain via Morpho idToMarketParams.

##### forkedFrom:
None.

##### methodology (what is counted as TVL, how it is calculated):
TVL = collateral − debt across all open Spiral positions (only the user's own margin), since the leveraged portion is flash-borrowed and immediately repaid out of the Morpho borrow. Debt is reported separately as borrowed. Collateral is already inside Morpho Blue's TVL, so the module is flagged doublecounted: true. Same shape as Contango/Origami.

##### Github org/user (Optional):
https://github.com/spiral-stake

##### Does this project have a referral program?
Yes.