### PR TITLE
durianfun: index the V5 launchpad factory (TVL)

### DIFF
--- a/projects/durianfun/index.js
+++ b/projects/durianfun/index.js
@@ -2,20 +2,25 @@ const ADDRESSES = require('../helper/coreAssets.json')
 /**
  * Durianfun — meme-token launchpad on KUB Chain (chainId 96).
  *
- * Tracks native KUB locked across FOUR generations of the launchpad:
+ * Tracks native KUB locked across FIVE generations of the launchpad:
  *   - V4.2 (legacy main, frozen)
  *   - V4.5 (current sacred main, frozen — no new tokens, residual liquidity)
  *   - V4.6.6 Deluxe (deployed 2026-05-03)
- *   - V4.6.7 (current production, deployed 2026-05-31 — dual graduation:
- *     in-contract DurianAMM (native KUB) OR external KUBLERX V3 pool (KKUB))
+ *   - V4.6.7 (deployed 2026-05-31 — dual graduation: in-contract DurianAMM
+ *     (native KUB) OR external KUBLERX V3 pool (KKUB))
+ *   - V5 (current production, deployed 2026-08-12 — dual graduation into a
+ *     BOUNDED-RANGE Uniswap-V3 position on either the external KUBLERX V3
+ *     factory (default target) or Durianfun's own DurianV3FactoryV5 as the
+ *     fallback venue. Both V5 venues are V3 pools and hold KKUB.)
  *
  * ── TVL formula ────────────────────────────────────────────────────
  *
  *   TVL = Σ(native KUB held by every BondingCurveMarket that has
- *           NOT yet graduated, across all four factories)
+ *           NOT yet graduated, across all five factories)
  *       + Σ(native KUB held by every DurianAMM pool produced by
  *           graduations from those factories)
- *       + Σ(KKUB held by every V4.6.7 KUBLERX-graduated V3 pool)
+ *       + Σ(KKUB held by every V4.6.7 / V5 graduated V3 pool —
+ *           KUBLERX-seeded or Durian-V3-seeded)
  *
  * Each launchpad token gets:
  *   1. A `BondingCurveMarket` (BCM) that holds native KUB during the
@@ -23,7 +28,9 @@ const ADDRESSES = require('../helper/coreAssets.json')
  *   2. An optional `DurianAMM` Uniswap-V2-style pool that gets seeded
  *      with the BCM's full KUB balance once the migration cap is hit
  *      (4400 KUB on V4.6.6). Post-graduation, all liquidity lives in
- *      the AMM.
+ *      the AMM. On V4.6.7 and V5 the graduation venue may instead be a
+ *      Uniswap-V3 pool holding KKUB — the `ammPool()` getter returns
+ *      that pool either way, so discovery is unchanged.
  *
  * The split between (ungraduated BCM) ∪ (graduated AMM) prevents
  * double-counting: a graduated BCM has already moved its KUB into the
@@ -37,6 +44,8 @@ const ADDRESSES = require('../helper/coreAssets.json')
  *   not "external" liquidity.
  * - Factory-D test environment (V2.5 + V2.4.2): denominated in dKUB,
  *   which is mintable by the project — not real protocol TVL.
+ * - The V5 test stack (separate cap-5 factory) and the unwired V4.7
+ *   factory: no public tokens, excluded for the same reason.
  *
  * ── Discovery strategy ─────────────────────────────────────────────
  *
@@ -45,7 +54,7 @@ const ADDRESSES = require('../helper/coreAssets.json')
  * address. We scan from each factory's deploy block and feed all BCMs
  * into a single `multiCall` of `ammPool()` to detect graduation. Then
  * we `sumTokens({ owners, tokens: [nullAddress, KKUB] })` to fetch
- * native KUB + (for KUBLERX-graduated V4.6.7 pools) KKUB balances in
+ * native KUB + (for V3-graduated V4.6.7 / V5 pools) KKUB balances in
  * one batched RPC pass. Each owner holds native KUB or KKUB, never
  * both, so summing both sentinels never double-counts.
  *
@@ -71,14 +80,23 @@ const FACTORY_V42 = "0xeadEc9dA89F97Ae6215362EBA4B33F3F1d1775b2";
 // V4.6.6 Deluxe — deployed 2026-05-03. Native KUB only.
 const FACTORY_V466 = "0x89b6b73BD18dbEA0e2218c25c1963fd5FBaB3c87";
 
-// V4.6.7 — current production launchpad, deployed 2026-05-31. Dual
-// graduation: in-contract DurianAMM (native KUB) OR external KUBLERX
-// V3 pool (KUB wrapped as KKUB). Its TokenCreated appends a trailing
-// `uint8 graduationTarget`, changing the event hash — so it needs its
-// own 8-arg ABI (below); the 7-arg ABI matches zero V4.6.7 events.
+// V4.6.7 — deployed 2026-05-31. Dual graduation: in-contract DurianAMM
+// (native KUB) OR external KUBLERX V3 pool (KUB wrapped as KKUB). Its
+// TokenCreated appends a trailing `uint8 graduationTarget`, changing the
+// event hash — so it needs its own 8-arg ABI (below); the 7-arg ABI
+// matches zero V4.6.7 events.
 const FACTORY_V467 = "0x0480017E51dC813a0fad8aA73EAb2f8476ac0e8F";
 
-// KKUB (wrapped native KUB) — the V4.6.7 KUBLERX-graduated side holds
+// V5 — current production launchpad, deployed 2026-08-12. Same dual
+// graduation, but BOTH venues are bounded-range Uniswap-V3 pools:
+// the external KUBLERX V3 factory (default) or Durianfun's own
+// DurianV3FactoryV5 (fallback when the KUBLERX seed reverts). Either
+// way the pool holds KKUB and `market.ammPool()` returns its address,
+// so no new discovery path is needed. Its `TokenCreated` is the same
+// 8-arg event as V4.6.7 (identical topic0), so it reuses that ABI.
+const FACTORY_V5 = "0xE3861e300043d8c20A927340cbA6379D0BECb793";
+
+// KKUB (wrapped native KUB) — the V4.6.7 / V5 V3-graduated side holds
 // KUB wrapped as KKUB. Summed alongside native KUB (see header).
 const KKUB = ADDRESSES.bitkub.KKUB;
 
@@ -86,18 +104,20 @@ const FACTORY_V45_BLOCK = 30_999_992;
 const FACTORY_V42_BLOCK = 30_990_140;
 const FACTORY_V466_BLOCK = 31_393_573;
 const FACTORY_V467_BLOCK = 32_196_516;
+const FACTORY_V5_BLOCK = 34_014_875;
 
 // Identical signature across V4.2 / V4.5 / V4.6.6.
 const TOKEN_CREATED_ABI =
   "event TokenCreated(address indexed token, address indexed market, address indexed creator, string name, string symbol, uint256 totalSupply, uint256 timestamp)";
 
 // V4.6.7 appends a trailing `uint8 graduationTarget` → distinct event hash.
+// V5 emits the byte-identical event, so both factories share this ABI.
 const TOKEN_CREATED_ABI_V467 =
   "event TokenCreated(address indexed token, address indexed market, address indexed creator, string name, string symbol, uint256 totalSupply, uint256 timestamp, uint8 graduationTarget)";
 
 async function tvl(api) {
-  // 1. Pull every TokenCreated event from all four factories in parallel.
-  const [logsV45, logsV42, logsV466, logsV467] = await Promise.all([
+  // 1. Pull every TokenCreated event from all five factories in parallel.
+  const [logsV45, logsV42, logsV466, logsV467, logsV5] = await Promise.all([
     getLogs({
       api,
       target: FACTORY_V45,
@@ -126,17 +146,25 @@ async function tvl(api) {
       fromBlock: FACTORY_V467_BLOCK,
       onlyArgs: true,
     }),
+    getLogs({
+      api,
+      target: FACTORY_V5,
+      eventAbi: TOKEN_CREATED_ABI_V467,
+      fromBlock: FACTORY_V5_BLOCK,
+      onlyArgs: true,
+    }),
   ]);
 
   // 2. Each `market` is a bonding-curve contract that holds KUB until graduation.
-  const markets = [...logsV45, ...logsV42, ...logsV466, ...logsV467].map((l) => l.market);
+  const markets = [...logsV45, ...logsV42, ...logsV466, ...logsV467, ...logsV5].map((l) => l.market);
   if (markets.length === 0) return {};
 
-  // 3. After graduation `market.ammPool()` returns the DurianAMM pool address;
-  //    pre-graduation it returns the zero address. We split markets into two
-  //    sets so the curve side counts ONLY ungraduated markets (matches the
-  //    methodology) — graduated markets have transferred their KUB to the
-  //    AMM pool, so counting both would double-count any residual dust.
+  // 3. After graduation `market.ammPool()` returns the graduation pool address
+  //    (a DurianAMM V2 pool on V4.2–V4.6.7, a KUBLERX or Durian Uniswap-V3 pool
+  //    on V4.6.7 / V5); pre-graduation it returns the zero address. We split
+  //    markets into two sets so the curve side counts ONLY ungraduated markets
+  //    (matches the methodology) — graduated markets have transferred their KUB
+  //    to the pool, so counting both would double-count any residual dust.
   const ammPools = await api.multiCall({
     abi: "function ammPool() view returns (address)",
     calls: markets,
@@ -159,7 +187,7 @@ async function tvl(api) {
 
 module.exports = {
   methodology:
-    "TVL counts native KUB locked in (a) Durianfun bonding-curve markets that have not yet graduated (V4.2 + V4.5 + V4.6.6 Deluxe + V4.6.7), and (b) post-graduation liquidity pools. V4.6.7 tokens that graduate to a KUBLERX V3 pool hold wrapped KKUB, which is summed alongside native KUB. Meme-token reserves are intentionally excluded to avoid circular pricing, and the separately-deployed Factory-D test environment is excluded.",
+    "TVL counts native KUB locked in (a) Durianfun bonding-curve markets that have not yet graduated (V4.2 + V4.5 + V4.6.6 Deluxe + V4.6.7 + V5), and (b) post-graduation liquidity pools. V4.6.7 and V5 tokens graduate into a Uniswap-V3 pool — on the external KUBLERX V3 factory, or (V5 fallback only) on Durianfun's own DurianV3FactoryV5 — and those pools hold wrapped KKUB, which is summed alongside native KUB. Meme-token reserves are intentionally excluded to avoid circular pricing, and the separately-deployed Factory-D / V5-test environments are excluded.",
   start: FACTORY_V42_BLOCK,
   bitkub: { tvl },
 };


### PR DESCRIPTION
## Durianfun — add the V5 launchpad factory

`projects/durianfun/index.js` covers V4.2 / V4.5 / V4.6.6 / V4.6.7. **V5** went live on 2026-08-12 (block 34,014,875) and is now where every new coin launches, so its markets and its graduated pool are currently unindexed.

### Change (additive — the four existing factories are untouched)
- `FACTORY_V5 = 0xE3861e300043d8c20A927340cbA6379D0BECb793`, `FACTORY_V5_BLOCK = 34_014_875`
- one more `getLogs` in the existing `Promise.all`, and `logsV5` in the `markets` concat

V5's `TokenCreated` is **byte-identical to V4.6.7's** 8-arg event (topic0 `0xfade53e2bb55ccda5abac7024cd4a210349c26b2d26f9b45f901942066860b10` for both), so it reuses `TOKEN_CREATED_ABI_V467` — no new ABI. The `ammPool()` multiCall and `sumTokens({ owners, tokens: [nullAddress, KKUB] })` already handle V5 as-is: V5 graduates into a bounded-range Uniswap-V3 position on either the external KUBLERX V3 factory (default) or Durianfun's own `DurianV3FactoryV5` (fallback), and `ammPool()` returns that pool in both cases. Both venues hold **KKUB**, which the existing sentinel list already sums.

### On-chain verification (KUB mainnet, block 34,316,959)
4 V5 markets discovered with the shared 8-arg ABI:

| market | state | native KUB | KKUB |
|---|---|---|---|
| COLD | curve | 0.007171 | — |
| DEVIL | curve | 1.384600 | — |
| SAMMONK | curve | 0.836714 | — |
| QQK | graduated → `0x2594D4c84Dd8A6FC69F34b072DbE70427cEa388C` | — | 4,323.955787 |

**V5 TVL delta = 2.228485 KUB native + 4,323.955787 KKUB = 4,326.18 KUB.** The graduated market is correctly excluded from the native side (its balance is accrued fees, not liquidity), exactly as the existing methodology prescribes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking Durianfun V5 token markets and pools.
  * Included V5 liquidity from external or fallback Uniswap V3 pools.
  * Combined native KUB and KKUB balances in total value tracking.

* **Documentation**
  * Updated methodology to cover all five factories and explain V5 exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->