### PR TITLE
surf-liquid: count both SURF staking proxies

### DIFF
--- a/projects/surf-liquid/index.js
+++ b/projects/surf-liquid/index.js
@@ -2,7 +2,11 @@ const { getLogs2 } = require('../helper/cache/getLogs');
 const ADDRESSES = require('../helper/coreAssets.json')
 const V2_FACTORY = "0x1D283b668F947E03E8ac8ce8DA5505020434ea0E";
 const V3_FACTORY = "0xf1d64dee9f8e109362309a4bfbb523c8e54fa1aa";
-const SURF_STAKING = "0xB0fDFc081310A5914c2d2c97e7582F4De12FA9d6";
+// SURF staking is spread over two UUPS proxies. Proxy 2 went live 2026-04-15 and holds a majority of the staked supply, so both must be summed.
+const SURF_STAKING = [
+  { target: "0xB0fDFc081310A5914c2d2c97e7582F4De12FA9d6", fromBlock: 39976776 },
+  { target: "0xeBa3B16E175fD36c8b01953D9e3962AB3c575718", fromBlock: 44728133 },
+];
 const SURF_TOKEN = "0xcdca2eaae4a8a6b83d7a3589946c2301040dafbf";
 const USDC = ADDRESSES.base.USDC;
 const WETH = ADDRESSES.optimism.WETH_1;
@@ -119,9 +123,14 @@ async function tvlBase(api) {
 }
 
 async function staking(api) {
-  // SURF staking contract
-  const totalStaked = await api.call({ abi: ABI.totalStaked, target: SURF_STAKING });
-  api.add(SURF_TOKEN, totalStaked);
+  // SURF staking contracts — deploy blocks gate the historical backfill so that calls are only made against a proxy once it exists.
+  const block = api.block ?? await api.getBlock();
+  const targets = SURF_STAKING.filter((s) => block >= s.fromBlock).map((s) => s.target);
+  const staked = await api.multiCall({
+    abi: ABI.totalStaked,
+    calls: targets.map((target) => ({ target })),
+  });
+  staked.forEach((amount) => api.add(SURF_TOKEN, amount));
 
   // CreatorBid SURF subscriptions (SURF locked in the token contract)
   const subscribed = await api.call({
@@ -133,7 +142,7 @@ async function staking(api) {
 }
 
 module.exports = {
-  methodology: "TVL counts Morpho vault deposits across V2/V3 Surf Liquid vaults (Base) and V4 user vaults (Base, Ethereum, Arbitrum, Polygon), plus idle underlying held at each surf vault. Staking includes SURF staked and SURF subscriptions.",
+  methodology: "TVL counts Morpho vault deposits across V2/V3/V4 user vaults (Base, Ethereum, Arbitrum, Polygon), plus idle underlying held at each surf vault. Staking sums totalStaked() across both SURF staking proxies plus SURF subscriptions locked in the token contract.",
   doublecounted: true,
   hallmarks: [
     ["2025-11-30", "V3 factory launched"],


### PR DESCRIPTION
Fixes the `staking` figure for **Surf Liquid** (`surf-liquid`), which is currently
under-reported by ~38%.

### Problem

`staking()` reads `totalStaked()` from a single SURF staking contract, but SURF
staking is split across **two** UUPS proxies on Base. The second one is not read
at all.

DefiLlama currently reports `chainTvls.staking.tokens = { SURF: 5612837.79833 }`,
which is exactly:

| adapter read | SURF |
|---|---|
| `totalStaked()` on `0xB0fDFc081310A5914c2d2c97e7582F4De12FA9d6` | 4,797,051.9066 |
| `balanceOf(SURF, SURF)` — CreatorBid subscriptions | 815,785.8917 |
| sum | **5,612,837.7983** |

Missing: `0xeBa3B16E175fD36c8b01953D9e3962AB3c575718`, holding **3,512,781.0408
SURF** (~$17.9k).

| | SURF | USD |
|---|---|---|
| current | 5,612,837.80 | ~$28,700 |
| with this PR | **9,125,618.84** | **~$46,600** |

### The two proxies

Both are live and hold real user deposits:

| | proxy 1 `0xB0fDFc08…` | proxy 2 `0xeBa3B16E…` |
|---|---|---|
| deployed | 2025-12-26 (block 39,976,776) | 2026-04-15 (block 44,728,133) |
| implementation | `0x29517036e588bddfc43be26b3980116efc811422` | `0xf75e03b84d764d6c4b858047149ab3e6c66ce1df` |
| SURF `balanceOf` | 5,091,700.3247 | 3,512,781.0408 |
| `totalStaked()` | 4,797,051.9066 | 3,512,781.0408 |

Proxy 1's balance reconciles exactly:

```
4,797,051.9066  totalStaked
+ 243,648.4181  totalPendingPrincipal   (unstaked, inside the 14-day claim delay)
+   5,371.7179  totalPendingRewards
+  45,628.2821  getAvailableRewardBalance   (protocol-funded reward pool)
= 5,091,700.3247 = balanceOf   ✅
```

Proxy 2 has no unstakes yet (live 4 months, minimum lock is 180 days), so its
`totalStaked()` equals its full balance.

Raw `balanceOf` on the two proxies is deliberately **not** used — that would fold
in the 51,000 SURF protocol-funded reward pool, which is treasury, not staked
user capital.

### Change

`SURF_STAKING` becomes a list with deploy blocks, and `staking()` multicalls both:

```js
const SURF_STAKING = [
  { target: "0xB0fDFc081310A5914c2d2c97e7582F4De12FA9d6", fromBlock: 39976776 },
  { target: "0xeBa3B16E175fD36c8b01953D9e3962AB3c575718", fromBlock: 44728133 },
];

const block = api.block ?? await api.getBlock();
const targets = SURF_STAKING.filter((s) => block >= s.fromBlock).map((s) => s.target);
const staked = await api.multiCall({ abi: ABI.totalStaked, calls: targets.map((target) => ({ target })) });
staked.forEach((amount) => api.add(SURF_TOKEN, amount));
```

The `fromBlock` gate keeps the historical backfill working — `totalStaked()` on
proxy 2 reverts before block 44,728,133. It's a deterministic block check rather
than `permitFailure: true` on purpose: `permitFailure` would swallow a transient
RPC error and silently under-report, which is the failure mode this PR fixes.

No new dependencies. Only `projects/surf-liquid/index.js` changed. TVL logic
untouched.

### Testing

```
node test.js projects/surf-liquid/index.js
node test.js projects/surf-liquid/index.js 2026-03-01   # before proxy 2 — no error
node test.js projects/surf-liquid/index.js 2026-05-01   # after proxy 2 — steps up ~3.5M SURF
```

### Note on history

The historical staking series was generated by the old adapter and will stay
understated after merge. Could the `surf-liquid` staking history be refilled once
this lands?

##### methodology

TVL counts Morpho vault deposits across V2/V3/V4 user vaults (Base, Ethereum, Arbitrum, Polygon), plus idle underlying held at each surf vault. Staking sums `totalStaked()` across both SURF staking proxies plus SURF subscriptions locked in the token contract.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated SURF staking totals to include balances from both staking proxies.
  * Improved TVL accuracy by querying each proxy only after its deployment.
* **Documentation**
  * Updated staking methodology details to reflect coverage across both proxies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->