### PR TITLE
Add Loyal Earn TVL adapter (Solana)

### DIFF
--- a/projects/loyal/index.js
+++ b/projects/loyal/index.js
@@ -1,12 +1,19 @@
 const { PublicKey } = require('@solana/web3.js')
-const { Program } = require('@project-serum/anchor')
 const { getConfig } = require('../helper/cache')
-const { getConnection, getMultipleAccounts } = require('../helper/solana')
+const { getConnection, runInChunks } = require('../helper/solana')
 const ADDRESSES = require('../helper/coreAssets.json')
 
-const VAULTS_API = 'https://stats.askloyal.com/api/earn/vaults'
+// Preview while PR is open; switch to https://stats.askloyal.com/api/earn/vaults after merge
+const VAULTS_API =
+  process.env.VAULTS_API ||
+  'https://loyal-dashboard-git-vercel-preview-pr-614-loyal-team.vercel.app/api/earn/vaults'
 
 const KLEND_PROGRAM_ID = new PublicKey('KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD')
+const TOKEN_PROGRAM_ID = new PublicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA')
+const ASSOCIATED_TOKEN_PROGRAM_ID = new PublicKey(
+  'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL',
+)
+const USDC_MINT = ADDRESSES.solana.USDC
 
 // RiskBasket.Safe — packages/loyal-actions/src/constants.ts
 const SAFE_MARKETS = [
@@ -17,60 +24,34 @@ const SAFE_MARKETS = [
   'BJnbcRHqvppTyGesLzWASGKnmnF1wq9jZu6ExrjT7wvF', // Ethena
 ]
 
-// KAMINO_VANILLA_OBLIGATION_TAG / ID from loyal-actions constants
+// Not in /api/earn/vaults (that query is user_yield_positions only).
+// Loyal treasury autonomous vault — same vanilla klend path as Earn.
+// Source: apps/admin/.../autonomous-vault-data.ts MANIFEST.vault
+const EXTRA_VAULTS = [
+  'F7zuL14omw4JJfS1cvsWXVb3wh48dvsonMJgoc9tYu3e',
+]
+
 const OBLIGATION_TAG = 0
 const OBLIGATION_ID = 0
+const RPC_SLEEP_MS = Number(process.env.LOYAL_RPC_SLEEP_MS || 600)
 
-const SF = 2 ** 60 // Kamino scaled-fraction
+// Obligation layout (matches @loyal-labs/smart-account-vaults)
+const DEPOSITS_OFFSET = 96
+const COLLATERAL_SIZE = 136
+const DEPOSITED_AMOUNT_OFFSET = 32
 
-// Minimal IDL to decode Obligation.deposits[].marketValueSf
-const klendIdl = {
-  version: '0.1.0',
-  name: 'klend',
-  instructions: [],
-  accounts: [
-    {
-      name: 'obligation',
-      type: {
-        kind: 'struct',
-        fields: [
-          { name: 'tag', type: 'u64' },
-          { name: 'lastUpdate', type: { defined: 'LastUpdate' } },
-          { name: 'lendingMarket', type: 'publicKey' },
-          { name: 'owner', type: 'publicKey' },
-          { name: 'deposits', type: { array: [{ defined: 'ObligationCollateral' }, 8] } },
-        ],
-      },
-    },
-  ],
-  types: [
-    {
-      name: 'LastUpdate',
-      type: {
-        kind: 'struct',
-        fields: [
-          { name: 'slot', type: 'u64' },
-          { name: 'stale', type: 'u8' },
-          { name: 'priceStatus', type: 'u8' },
-          { name: 'placeholder', type: { array: ['u8', 6] } },
-        ],
-      },
-    },
-    {
-      name: 'ObligationCollateral',
-      type: {
-        kind: 'struct',
-        fields: [
-          { name: 'depositReserve', type: 'publicKey' },
-          { name: 'depositedAmount', type: 'u64' },
-          { name: 'marketValueSf', type: 'u128' },
-          { name: 'borrowedAmountAgainstThisCollateralInElevationGroup', type: 'u64' },
-          { name: 'padding', type: { array: ['u64', 9] } },
-        ],
-      },
-    },
-  ],
+// Reserve layout offsets
+const RESERVE = {
+  liquidityMint: 8 + 120,
+  liquidityAvailableAmount: 8 + 216,
+  liquidityBorrowedAmountSf: 8 + 224,
+  liquidityAccumulatedProtocolFeesSf: 8 + 336,
+  liquidityAccumulatedReferrerFeesSf: 8 + 352,
+  liquidityPendingReferrerFeesSf: 8 + 368,
+  collateralMintTotalSupply: 8 + 2584,
 }
+const FRACTION_BITS = 60n
+const FRACTION_SCALE = 1n << FRACTION_BITS
 
 function deriveVanillaObligation(owner, market) {
   const [pda] = PublicKey.findProgramAddressSync(
@@ -87,56 +68,220 @@ function deriveVanillaObligation(owner, market) {
   return pda
 }
 
+function getAssociatedTokenAddress(mint, owner) {
+  const mintKey = typeof mint === 'string' ? new PublicKey(mint) : mint
+  const ownerKey = typeof owner === 'string' ? new PublicKey(owner) : owner
+  const [ata] = PublicKey.findProgramAddressSync(
+    [ownerKey.toBuffer(), TOKEN_PROGRAM_ID.toBuffer(), mintKey.toBuffer()],
+    ASSOCIATED_TOKEN_PROGRAM_ID,
+  )
+  return ata
+}
+
+function readU64LE(buf, offset) {
+  return buf.readBigUInt64LE(offset)
+}
+
+function readU128LE(buf, offset) {
+  const lo = buf.readBigUInt64LE(offset)
+  const hi = buf.readBigUInt64LE(offset + 8)
+  return lo + (hi << 64n)
+}
+
+function readPubkey(buf, offset) {
+  return new PublicKey(buf.subarray(offset, offset + 32))
+}
+
+function parseObligationDeposits(data) {
+  if (!data || data.length < DEPOSITS_OFFSET + 8 * COLLATERAL_SIZE) return []
+  const deposits = []
+  for (let i = 0; i < 8; i++) {
+    const base = DEPOSITS_OFFSET + i * COLLATERAL_SIZE
+    const reserveBytes = data.subarray(base, base + 32)
+    if (reserveBytes.every((b) => b === 0)) continue
+    const depositedAmountRaw = readU64LE(data, base + DEPOSITED_AMOUNT_OFFSET)
+    if (depositedAmountRaw <= 0n) continue
+    deposits.push({
+      reserve: new PublicKey(reserveBytes).toBase58(),
+      depositedAmountRaw,
+    })
+  }
+  return deposits
+}
+
+function parseReserveSnapshot(data) {
+  if (!data || data.length < RESERVE.collateralMintTotalSupply + 8) return null
+  const liquidityAvailableAmount = readU64LE(data, RESERVE.liquidityAvailableAmount)
+  const liquidityBorrowedAmountSf = readU128LE(data, RESERVE.liquidityBorrowedAmountSf)
+  const feesSf =
+    readU128LE(data, RESERVE.liquidityAccumulatedProtocolFeesSf) +
+    readU128LE(data, RESERVE.liquidityAccumulatedReferrerFeesSf) +
+    readU128LE(data, RESERVE.liquidityPendingReferrerFeesSf)
+  const collateralSupplyRaw = readU64LE(data, RESERVE.collateralMintTotalSupply)
+  const grossLiquiditySupplyScaled =
+    (liquidityAvailableAmount << FRACTION_BITS) + liquidityBorrowedAmountSf
+  const totalLiquiditySupplyScaled =
+    grossLiquiditySupplyScaled > feesSf ? grossLiquiditySupplyScaled - feesSf : 0n
+
+  return {
+    liquidityMint: readPubkey(data, RESERVE.liquidityMint).toBase58(),
+    collateralSupplyRaw,
+    totalLiquiditySupplyScaled,
+  }
+}
+
+function collateralToRedeemableLiquidity(collateralAmountRaw, snapshot) {
+  if (collateralAmountRaw <= 0n) return 0n
+  if (
+    snapshot.collateralSupplyRaw === 0n ||
+    snapshot.totalLiquiditySupplyScaled === 0n
+  ) {
+    return collateralAmountRaw
+  }
+  return (
+    (collateralAmountRaw * snapshot.totalLiquiditySupplyScaled) /
+    (snapshot.collateralSupplyRaw * FRACTION_SCALE)
+  )
+}
+
+function tokenAccountAmount(data) {
+  if (!data || data.length < 72) return 0n
+  return Buffer.from(data).readBigUInt64LE(64)
+}
+
 async function tvl(api) {
   const connection = getConnection()
-  const data = await getConfig('loyal/vaults', VAULTS_API)
-  const owners = Array.isArray(data) ? data : (data.vaults || [])
+
+  const data = await getConfig('loyal/vaults', undefined, {
+    fetcher: async () => {
+      const res = await fetch(VAULTS_API, {
+        headers: process.env.VERCEL_PREVIEW_COOKIE
+          ? { Cookie: process.env.VERCEL_PREVIEW_COOKIE }
+          : {},
+      })
+      if (!res.ok) throw new Error(`Loyal vaults API HTTP ${res.status}`)
+      return res.json()
+    },
+  })
+
+  const apiOwners = Array.isArray(data) ? data : data.vaults || []
+  const extra = EXTRA_VAULTS.filter((v) => !apiOwners.includes(v))
+  const owners = apiOwners.concat(extra)
+  console.log(
+    `[Loyal] vaults from API: ${apiOwners.length} (count field: ${data.count ?? 'n/a'}; updatedAt: ${data.updatedAt ?? 'n/a'}) + extra ${extra.length}`,
+  )
 
   if (!owners.length) {
-    api.log('[Loyal] empty vault list')
+    console.log('[Loyal] empty vault list — check VERCEL_PREVIEW_COOKIE / VAULTS_API')
     return {}
   }
-  api.log(`[Loyal] ${owners.length} vaults × ${SAFE_MARKETS.length} markets`)
 
+  // --- Kamino vanilla obligations (Safe markets) ---
   const obligationPubkeys = []
   for (const owner of owners) {
     for (const market of SAFE_MARKETS) {
       obligationPubkeys.push(deriveVanillaObligation(owner, market))
     }
   }
+  console.log(
+    `[Loyal] obligation PDAs: ${obligationPubkeys.length} (${owners.length} × ${SAFE_MARKETS.length})`,
+  )
 
-  const accountInfos = await getMultipleAccounts(obligationPubkeys, { api })
-  const program = new Program(klendIdl, KLEND_PROGRAM_ID, {
-    connection,
-    publicKey: PublicKey.unique(),
-  })
+  const accountInfos = await runInChunks(
+    obligationPubkeys,
+    (chunk) => connection.getMultipleAccountsInfo(chunk),
+    { chunkSize: 99, sleepTime: RPC_SLEEP_MS },
+  )
 
-  let active = 0
+  const collateralByReserve = new Map()
+  let accountsWithData = 0
+  let depositSlots = 0
+
   for (const info of accountInfos) {
     if (!info?.data) continue
-    try {
-      const decoded = program.coder.accounts.decode('obligation', info.data)
-      for (const d of decoded.deposits) {
-        if (d.depositReserve.equals(PublicKey.default)) continue
-        const usd = Number(d.marketValueSf.toString()) / SF
-        if (usd > 0) {
-          // Report as USDC (6 decimals) so DefiLlama prices at ~$1
-          api.add(ADDRESSES.solana.USDC, Math.round(usd * 1e6))
-          active++
-        }
-      }
-    } catch {
-      // missing / empty obligation
+    accountsWithData++
+    for (const d of parseObligationDeposits(Buffer.from(info.data))) {
+      depositSlots++
+      collateralByReserve.set(
+        d.reserve,
+        (collateralByReserve.get(d.reserve) || 0n) + d.depositedAmountRaw,
+      )
     }
   }
 
-  api.log(`[Loyal] ${active} non-zero collateral slots`)
+  console.log(`[Loyal] accounts with data: ${accountsWithData}`)
+  console.log(`[Loyal] active collateral slots: ${depositSlots}`)
+  console.log(`[Loyal] unique reserves: ${collateralByReserve.size}`)
+
+  let usdcFromObligations = 0n
+  let skippedNonUsdcReserves = 0
+
+  if (collateralByReserve.size) {
+    const reserveKeys = [...collateralByReserve.keys()].map((r) => new PublicKey(r))
+    const reserveInfos = await runInChunks(
+      reserveKeys,
+      (chunk) => connection.getMultipleAccountsInfo(chunk),
+      { chunkSize: 99, sleepTime: RPC_SLEEP_MS },
+    )
+
+    for (let i = 0; i < reserveKeys.length; i++) {
+      const reserveId = reserveKeys[i].toBase58()
+      const info = reserveInfos[i]
+      if (!info?.data) continue
+      const snapshot = parseReserveSnapshot(Buffer.from(info.data))
+      if (!snapshot) continue
+
+      // Product default is USDC-only (NEXT_PUBLIC_EARN_ENABLED_STABLECOINS defaults to USDC).
+      // Multi-mint rollout is env-gated; ignore non-USDC dust / test deposits for now.
+      if (snapshot.liquidityMint !== USDC_MINT) {
+        skippedNonUsdcReserves++
+        continue
+      }
+
+      const coll = collateralByReserve.get(reserveId) || 0n
+      usdcFromObligations += collateralToRedeemableLiquidity(coll, snapshot)
+    }
+  }
+
+  // --- Idle USDC sitting on vault ATAs (included in Loyal admin AUM) ---
+  const usdcAtas = owners.map((o) => getAssociatedTokenAddress(USDC_MINT, o))
+  const ataInfos = await runInChunks(
+    usdcAtas,
+    (chunk) => connection.getMultipleAccountsInfo(chunk),
+    { chunkSize: 99, sleepTime: RPC_SLEEP_MS },
+  )
+  let usdcIdle = 0n
+  let idleAccounts = 0
+  for (const info of ataInfos) {
+    const amt = tokenAccountAmount(info?.data)
+    if (amt > 0n) {
+      usdcIdle += amt
+      idleAccounts++
+    }
+  }
+
+  const totalUsdc = usdcFromObligations + usdcIdle
+  api.add(USDC_MINT, totalUsdc.toString())
+
+  console.log(
+    `[Loyal] USDC from obligations: $${(Number(usdcFromObligations) / 1e6).toFixed(2)}`,
+  )
+  console.log(
+    `[Loyal] idle USDC on vaults: $${(Number(usdcIdle) / 1e6).toFixed(2)} (${idleAccounts} ATAs)`,
+  )
+  console.log(`[Loyal] total USDC TVL: $${(Number(totalUsdc) / 1e6).toFixed(2)}`)
+  if (skippedNonUsdcReserves) {
+    console.log(
+      `[Loyal] skipped ${skippedNonUsdcReserves} non-USDC reserve(s) (multi-mint not counted yet)`,
+    )
+  }
+
   return api.getBalances()
 }
 
 module.exports = {
   timetravel: false,
   methodology:
-    'TVL is the on-chain USD market value of collateral deposited by Loyal Earn Squads smart accounts into Kamino Lend obligations across the five RiskBasket.Safe markets (Main, Figure, Maple, OnRe, Ethena). Vault addresses are fetched from the public Loyal stats API; obligation values are read on-chain via marketValueSf.',
+    'TVL is on-chain USDC in Loyal Earn Squads vaults plus the Loyal treasury autonomous vault: redeemable USDC from Kamino Lend vanilla obligations across RiskBasket.Safe markets (Main, Figure, Maple, OnRe, Ethena), converting collateral shares with each reserve exchange rate (same method as Loyal earn holdings), plus idle USDC in vault ATAs. User vaults come from /api/earn/vaults; the treasury vault is not in that user-position list and is included explicitly. Non-USDC stables omitted until Earn multi-mint is generally enabled.',
   solana: { tvl },
 }

--- a/projects/loyal/index.js
+++ b/projects/loyal/index.js
@@ -1,15 +1,11 @@
 const { PublicKey } = require('@solana/web3.js')
 const { getConfig } = require('../helper/cache')
-const { getConnection, runInChunks } = require('../helper/solana')
+const { getConnection, runInChunks, sumTokens2 } = require('../helper/solana')
 const ADDRESSES = require('../helper/coreAssets.json')
 
 const VAULTS_API = 'https://stats.askloyal.com/api/earn/vaults'
 
 const KLEND_PROGRAM_ID = new PublicKey('KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD')
-const TOKEN_PROGRAM_ID = new PublicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA')
-const ASSOCIATED_TOKEN_PROGRAM_ID = new PublicKey(
-  'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL',
-)
 const USDC_MINT = ADDRESSES.solana.USDC
 
 // RiskBasket.Safe — packages/loyal-actions/src/constants.ts
@@ -30,18 +26,8 @@ const DEPOSITS_OFFSET = 96
 const COLLATERAL_SIZE = 136
 const DEPOSITED_AMOUNT_OFFSET = 32
 
-// Reserve layout offsets
-const RESERVE = {
-  liquidityMint: 8 + 120,
-  liquidityAvailableAmount: 8 + 216,
-  liquidityBorrowedAmountSf: 8 + 224,
-  liquidityAccumulatedProtocolFeesSf: 8 + 336,
-  liquidityAccumulatedReferrerFeesSf: 8 + 352,
-  liquidityPendingReferrerFeesSf: 8 + 368,
-  collateralMintTotalSupply: 8 + 2584,
-}
-const FRACTION_BITS = 60n
-const FRACTION_SCALE = 1n << FRACTION_BITS
+const RESERVE_LIQUIDITY_MINT = 8 + 120
+const RESERVE_COLLATERAL_MINT = 8 + 2584 - 32 // ReserveCollateral.mintPubkey, 32B before mintTotalSupply
 
 function deriveVanillaObligation(owner, market) {
   const [pda] = PublicKey.findProgramAddressSync(
@@ -58,28 +44,8 @@ function deriveVanillaObligation(owner, market) {
   return pda
 }
 
-function getAssociatedTokenAddress(mint, owner) {
-  const mintKey = typeof mint === 'string' ? new PublicKey(mint) : mint
-  const ownerKey = typeof owner === 'string' ? new PublicKey(owner) : owner
-  const [ata] = PublicKey.findProgramAddressSync(
-    [ownerKey.toBuffer(), TOKEN_PROGRAM_ID.toBuffer(), mintKey.toBuffer()],
-    ASSOCIATED_TOKEN_PROGRAM_ID,
-  )
-  return ata
-}
-
-function readU64LE(buf, offset) {
-  return buf.readBigUInt64LE(offset)
-}
-
-function readU128LE(buf, offset) {
-  const lo = buf.readBigUInt64LE(offset)
-  const hi = buf.readBigUInt64LE(offset + 8)
-  return lo + (hi << 64n)
-}
-
 function readPubkey(buf, offset) {
-  return new PublicKey(buf.subarray(offset, offset + 32))
+  return new PublicKey(buf.subarray(offset, offset + 32)).toBase58()
 }
 
 function parseObligationDeposits(data) {
@@ -89,56 +55,11 @@ function parseObligationDeposits(data) {
     const base = DEPOSITS_OFFSET + i * COLLATERAL_SIZE
     const reserveBytes = data.subarray(base, base + 32)
     if (reserveBytes.every((b) => b === 0)) continue
-    const depositedAmountRaw = readU64LE(data, base + DEPOSITED_AMOUNT_OFFSET)
+    const depositedAmountRaw = data.readBigUInt64LE(base + DEPOSITED_AMOUNT_OFFSET)
     if (depositedAmountRaw <= 0n) continue
-    deposits.push({
-      reserve: new PublicKey(reserveBytes).toBase58(),
-      depositedAmountRaw,
-    })
+    deposits.push({ reserve: new PublicKey(reserveBytes).toBase58(), depositedAmountRaw })
   }
   return deposits
-}
-
-function parseReserveSnapshot(data) {
-  if (!data || data.length < RESERVE.collateralMintTotalSupply + 8) return null
-  const liquidityAvailableAmount = readU64LE(data, RESERVE.liquidityAvailableAmount)
-  const liquidityBorrowedAmountSf = readU128LE(data, RESERVE.liquidityBorrowedAmountSf)
-  const feesSf =
-    readU128LE(data, RESERVE.liquidityAccumulatedProtocolFeesSf) +
-    readU128LE(data, RESERVE.liquidityAccumulatedReferrerFeesSf) +
-    readU128LE(data, RESERVE.liquidityPendingReferrerFeesSf)
-  const collateralSupplyRaw = readU64LE(data, RESERVE.collateralMintTotalSupply)
-  const grossLiquiditySupplyScaled =
-    (liquidityAvailableAmount << FRACTION_BITS) + liquidityBorrowedAmountSf
-  const totalLiquiditySupplyScaled =
-    grossLiquiditySupplyScaled > feesSf ? grossLiquiditySupplyScaled - feesSf : 0n
-
-  return {
-    liquidityMint: readPubkey(data, RESERVE.liquidityMint).toBase58(),
-    collateralSupplyRaw,
-    totalLiquiditySupplyScaled,
-  }
-}
-
-function collateralToRedeemableLiquidity(collateralAmountRaw, snapshot) {
-  if (collateralAmountRaw <= 0n) return 0n
-  if (
-    snapshot.collateralSupplyRaw === 0n ||
-    snapshot.totalLiquiditySupplyScaled === 0n
-  ) {
-    throw new Error(
-      `[Loyal] inconsistent Kamino reserve snapshot: collateralSupply=${snapshot.collateralSupplyRaw}, liquiditySupplyScaled=${snapshot.totalLiquiditySupplyScaled}`,
-    )
-  }
-  return (
-    (collateralAmountRaw * snapshot.totalLiquiditySupplyScaled) /
-    (snapshot.collateralSupplyRaw * FRACTION_SCALE)
-  )
-}
-
-function tokenAccountAmount(data) {
-  if (!data || data.length < 72) return 0n
-  return Buffer.from(data).readBigUInt64LE(64)
 }
 
 function fetchAccounts(connection, pubkeys) {
@@ -154,101 +75,43 @@ async function tvl(api) {
 
   const data = await getConfig('loyal/vaults', VAULTS_API)
   const owners = Array.isArray(data) ? data : data.vaults || []
-  api.log(
-    `[Loyal] vaults from API: ${owners.length} (count field: ${data.count ?? 'n/a'}; updatedAt: ${data.updatedAt ?? 'n/a'})`,
+  if (!owners.length) throw new Error(`[Loyal] empty vault list from ${VAULTS_API}`)
+  api.log(`[Loyal] vaults from API: ${owners.length}`)
+
+  // --- Kamino vanilla obligations (Safe markets): sum collateral shares per reserve ---
+  const obligationPubkeys = owners.flatMap((o) =>
+    SAFE_MARKETS.map((m) => deriveVanillaObligation(o, m)),
   )
-
-  if (!owners.length) {
-    throw new Error(`[Loyal] empty vault list from ${VAULTS_API}`)
-  }
-
-  // --- Kamino vanilla obligations (Safe markets) ---
-  const obligationPubkeys = []
-  for (const owner of owners) {
-    for (const market of SAFE_MARKETS) {
-      obligationPubkeys.push(deriveVanillaObligation(owner, market))
-    }
-  }
-  api.log(
-    `[Loyal] obligation PDAs: ${obligationPubkeys.length} (${owners.length} × ${SAFE_MARKETS.length})`,
-  )
-
-  const accountInfos = await fetchAccounts(connection, obligationPubkeys)
+  const obligationInfos = await fetchAccounts(connection, obligationPubkeys)
 
   const collateralByReserve = new Map()
-  let accountsWithData = 0
-  let depositSlots = 0
-
-  for (const info of accountInfos) {
+  for (const info of obligationInfos) {
     if (!info?.data) continue
-    accountsWithData++
     for (const d of parseObligationDeposits(Buffer.from(info.data))) {
-      depositSlots++
       collateralByReserve.set(
         d.reserve,
         (collateralByReserve.get(d.reserve) || 0n) + d.depositedAmountRaw,
       )
     }
   }
-
-  api.log(`[Loyal] accounts with data: ${accountsWithData}`)
-  api.log(`[Loyal] active collateral slots: ${depositSlots}`)
-  api.log(`[Loyal] unique reserves: ${collateralByReserve.size}`)
-
-  let usdcFromObligations = 0n
-  let skippedNonUsdcReserves = 0
+  api.log(`[Loyal] Kamino reserves with deposits: ${collateralByReserve.size}`)
 
   if (collateralByReserve.size) {
     const reserveKeys = [...collateralByReserve.keys()].map((r) => new PublicKey(r))
     const reserveInfos = await fetchAccounts(connection, reserveKeys)
-
-    for (let i = 0; i < reserveKeys.length; i++) {
-      const reserveId = reserveKeys[i].toBase58()
-      const info = reserveInfos[i]
-      if (!info?.data) continue
-      const snapshot = parseReserveSnapshot(Buffer.from(info.data))
-      if (!snapshot) continue
-
-      // Product default is USDC-only (NEXT_PUBLIC_EARN_ENABLED_STABLECOINS defaults to USDC).
-      // Multi-mint rollout is env-gated; ignore non-USDC dust / test deposits for now.
-      if (snapshot.liquidityMint !== USDC_MINT) {
-        skippedNonUsdcReserves++
-        continue
-      }
-
-      const coll = collateralByReserve.get(reserveId) || 0n
-      usdcFromObligations += collateralToRedeemableLiquidity(coll, snapshot)
-    }
+    reserveInfos.forEach((info, i) => {
+      if (!info?.data) return
+      const buf = Buffer.from(info.data)
+      // USDC-only for now (multi-mint Earn is env-gated).
+      if (readPubkey(buf, RESERVE_LIQUIDITY_MINT) !== USDC_MINT) return
+      const collateralMint = readPubkey(buf, RESERVE_COLLATERAL_MINT)
+      const shares = collateralByReserve.get(reserveKeys[i].toBase58()) || 0n
+      api.add(collateralMint, shares.toString())
+    })
   }
 
   // --- Idle USDC sitting on vault ATAs (included in Loyal admin AUM) ---
-  const usdcAtas = owners.map((o) => getAssociatedTokenAddress(USDC_MINT, o))
-  const ataInfos = await fetchAccounts(connection, usdcAtas)
-  let usdcIdle = 0n
-  let idleAccounts = 0
-  for (const info of ataInfos) {
-    const amt = tokenAccountAmount(info?.data)
-    if (amt > 0n) {
-      usdcIdle += amt
-      idleAccounts++
-    }
-  }
-
-  const totalUsdc = usdcFromObligations + usdcIdle
-  api.add(USDC_MINT, totalUsdc.toString())
-
-  api.log(
-    `[Loyal] USDC from obligations: $${(Number(usdcFromObligations) / 1e6).toFixed(2)}`,
-  )
-  api.log(
-    `[Loyal] idle USDC on vaults: $${(Number(usdcIdle) / 1e6).toFixed(2)} (${idleAccounts} ATAs)`,
-  )
-  api.log(`[Loyal] total USDC TVL: $${(Number(totalUsdc) / 1e6).toFixed(2)}`)
-  if (skippedNonUsdcReserves) {
-    api.log(
-      `[Loyal] skipped ${skippedNonUsdcReserves} non-USDC reserve(s) (multi-mint not counted yet)`,
-    )
-  }
+  await sumTokens2({ api, tokensAndOwners: owners.map((o) => [USDC_MINT, o]) })
 
   return api.getBalances()
 }
@@ -258,6 +121,6 @@ module.exports = {
   doublecounted: true, // deployed into already-listed Kamino Lend
   isHeavyProtocol: true,
   methodology:
-    'TVL is on-chain USDC in Loyal Earn Squads vaults, including the treasury autonomous vault listed by the public stats API (intentional: runway will sit in that vault as the autonomous-treasury product). Counts redeemable USDC from Kamino Lend vanilla obligations across RiskBasket.Safe markets (Main, Figure, Maple, OnRe, Ethena), converting collateral shares with each reserve exchange rate (same method as Loyal earn holdings), plus idle USDC in vault ATAs. Vault addresses come from https://stats.askloyal.com/api/earn/vaults. Overlaps Kamino Lend TVL, so this adapter is marked doublecounted. Non-USDC stables omitted until Earn multi-mint is generally enabled.',
+    'TVL is on-chain USDC in Loyal Earn Squads vaults, including the treasury autonomous vault listed by the public stats API. Counts redeemable USDC from Kamino Lend vanilla obligations across RiskBasket.Safe markets (Main, Figure, Maple, OnRe, Ethena) as the reserve\'s collateral (cToken) balance plus idle USDC in vault ATAs. Vault addresses come from https://stats.askloyal.com/api/earn/vaults. Overlaps Kamino Lend TVL, so this adapter is marked doublecounted. Non-USDC stables omitted until Earn multi-mint is generally enabled.',
   solana: { tvl },
 }

--- a/projects/loyal/index.js
+++ b/projects/loyal/index.js
@@ -126,7 +126,9 @@ function collateralToRedeemableLiquidity(collateralAmountRaw, snapshot) {
     snapshot.collateralSupplyRaw === 0n ||
     snapshot.totalLiquiditySupplyScaled === 0n
   ) {
-    return collateralAmountRaw
+    throw new Error(
+      `[Loyal] inconsistent Kamino reserve snapshot: collateralSupply=${snapshot.collateralSupplyRaw}, liquiditySupplyScaled=${snapshot.totalLiquiditySupplyScaled}`,
+    )
   }
   return (
     (collateralAmountRaw * snapshot.totalLiquiditySupplyScaled) /
@@ -139,6 +141,14 @@ function tokenAccountAmount(data) {
   return Buffer.from(data).readBigUInt64LE(64)
 }
 
+function fetchAccounts(connection, pubkeys) {
+  return runInChunks(
+    pubkeys,
+    (chunk) => connection.getMultipleAccountsInfo(chunk),
+    { chunkSize: 99, sleepTime: RPC_SLEEP_MS },
+  )
+}
+
 async function tvl(api) {
   const connection = getConnection()
 
@@ -149,8 +159,7 @@ async function tvl(api) {
   )
 
   if (!owners.length) {
-    api.log('[Loyal] empty vault list from', VAULTS_API)
-    return {}
+    throw new Error(`[Loyal] empty vault list from ${VAULTS_API}`)
   }
 
   // --- Kamino vanilla obligations (Safe markets) ---
@@ -164,11 +173,7 @@ async function tvl(api) {
     `[Loyal] obligation PDAs: ${obligationPubkeys.length} (${owners.length} × ${SAFE_MARKETS.length})`,
   )
 
-  const accountInfos = await runInChunks(
-    obligationPubkeys,
-    (chunk) => connection.getMultipleAccountsInfo(chunk),
-    { chunkSize: 99, sleepTime: RPC_SLEEP_MS },
-  )
+  const accountInfos = await fetchAccounts(connection, obligationPubkeys)
 
   const collateralByReserve = new Map()
   let accountsWithData = 0
@@ -195,11 +200,7 @@ async function tvl(api) {
 
   if (collateralByReserve.size) {
     const reserveKeys = [...collateralByReserve.keys()].map((r) => new PublicKey(r))
-    const reserveInfos = await runInChunks(
-      reserveKeys,
-      (chunk) => connection.getMultipleAccountsInfo(chunk),
-      { chunkSize: 99, sleepTime: RPC_SLEEP_MS },
-    )
+    const reserveInfos = await fetchAccounts(connection, reserveKeys)
 
     for (let i = 0; i < reserveKeys.length; i++) {
       const reserveId = reserveKeys[i].toBase58()
@@ -222,11 +223,7 @@ async function tvl(api) {
 
   // --- Idle USDC sitting on vault ATAs (included in Loyal admin AUM) ---
   const usdcAtas = owners.map((o) => getAssociatedTokenAddress(USDC_MINT, o))
-  const ataInfos = await runInChunks(
-    usdcAtas,
-    (chunk) => connection.getMultipleAccountsInfo(chunk),
-    { chunkSize: 99, sleepTime: RPC_SLEEP_MS },
-  )
+  const ataInfos = await fetchAccounts(connection, usdcAtas)
   let usdcIdle = 0n
   let idleAccounts = 0
   for (const info of ataInfos) {

--- a/projects/loyal/index.js
+++ b/projects/loyal/index.js
@@ -3,10 +3,7 @@ const { getConfig } = require('../helper/cache')
 const { getConnection, runInChunks } = require('../helper/solana')
 const ADDRESSES = require('../helper/coreAssets.json')
 
-// Preview while PR is open; switch to https://stats.askloyal.com/api/earn/vaults after merge
-const VAULTS_API =
-  process.env.VAULTS_API ||
-  'https://loyal-dashboard-git-vercel-preview-pr-614-loyal-team.vercel.app/api/earn/vaults'
+const VAULTS_API = 'https://stats.askloyal.com/api/earn/vaults'
 
 const KLEND_PROGRAM_ID = new PublicKey('KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD')
 const TOKEN_PROGRAM_ID = new PublicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA')
@@ -24,16 +21,9 @@ const SAFE_MARKETS = [
   'BJnbcRHqvppTyGesLzWASGKnmnF1wq9jZu6ExrjT7wvF', // Ethena
 ]
 
-// Not in /api/earn/vaults (that query is user_yield_positions only).
-// Loyal treasury autonomous vault — same vanilla klend path as Earn.
-// Source: apps/admin/.../autonomous-vault-data.ts MANIFEST.vault
-const EXTRA_VAULTS = [
-  'F7zuL14omw4JJfS1cvsWXVb3wh48dvsonMJgoc9tYu3e',
-]
-
 const OBLIGATION_TAG = 0
 const OBLIGATION_ID = 0
-const RPC_SLEEP_MS = Number(process.env.LOYAL_RPC_SLEEP_MS || 600)
+const RPC_SLEEP_MS = 300
 
 // Obligation layout (matches @loyal-labs/smart-account-vaults)
 const DEPOSITS_OFFSET = 96
@@ -152,27 +142,14 @@ function tokenAccountAmount(data) {
 async function tvl(api) {
   const connection = getConnection()
 
-  const data = await getConfig('loyal/vaults', undefined, {
-    fetcher: async () => {
-      const res = await fetch(VAULTS_API, {
-        headers: process.env.VERCEL_PREVIEW_COOKIE
-          ? { Cookie: process.env.VERCEL_PREVIEW_COOKIE }
-          : {},
-      })
-      if (!res.ok) throw new Error(`Loyal vaults API HTTP ${res.status}`)
-      return res.json()
-    },
-  })
-
-  const apiOwners = Array.isArray(data) ? data : data.vaults || []
-  const extra = EXTRA_VAULTS.filter((v) => !apiOwners.includes(v))
-  const owners = apiOwners.concat(extra)
-  console.log(
-    `[Loyal] vaults from API: ${apiOwners.length} (count field: ${data.count ?? 'n/a'}; updatedAt: ${data.updatedAt ?? 'n/a'}) + extra ${extra.length}`,
+  const data = await getConfig('loyal/vaults', VAULTS_API)
+  const owners = Array.isArray(data) ? data : data.vaults || []
+  api.log(
+    `[Loyal] vaults from API: ${owners.length} (count field: ${data.count ?? 'n/a'}; updatedAt: ${data.updatedAt ?? 'n/a'})`,
   )
 
   if (!owners.length) {
-    console.log('[Loyal] empty vault list — check VERCEL_PREVIEW_COOKIE / VAULTS_API')
+    api.log('[Loyal] empty vault list from', VAULTS_API)
     return {}
   }
 
@@ -183,7 +160,7 @@ async function tvl(api) {
       obligationPubkeys.push(deriveVanillaObligation(owner, market))
     }
   }
-  console.log(
+  api.log(
     `[Loyal] obligation PDAs: ${obligationPubkeys.length} (${owners.length} × ${SAFE_MARKETS.length})`,
   )
 
@@ -209,9 +186,9 @@ async function tvl(api) {
     }
   }
 
-  console.log(`[Loyal] accounts with data: ${accountsWithData}`)
-  console.log(`[Loyal] active collateral slots: ${depositSlots}`)
-  console.log(`[Loyal] unique reserves: ${collateralByReserve.size}`)
+  api.log(`[Loyal] accounts with data: ${accountsWithData}`)
+  api.log(`[Loyal] active collateral slots: ${depositSlots}`)
+  api.log(`[Loyal] unique reserves: ${collateralByReserve.size}`)
 
   let usdcFromObligations = 0n
   let skippedNonUsdcReserves = 0
@@ -263,15 +240,15 @@ async function tvl(api) {
   const totalUsdc = usdcFromObligations + usdcIdle
   api.add(USDC_MINT, totalUsdc.toString())
 
-  console.log(
+  api.log(
     `[Loyal] USDC from obligations: $${(Number(usdcFromObligations) / 1e6).toFixed(2)}`,
   )
-  console.log(
+  api.log(
     `[Loyal] idle USDC on vaults: $${(Number(usdcIdle) / 1e6).toFixed(2)} (${idleAccounts} ATAs)`,
   )
-  console.log(`[Loyal] total USDC TVL: $${(Number(totalUsdc) / 1e6).toFixed(2)}`)
+  api.log(`[Loyal] total USDC TVL: $${(Number(totalUsdc) / 1e6).toFixed(2)}`)
   if (skippedNonUsdcReserves) {
-    console.log(
+    api.log(
       `[Loyal] skipped ${skippedNonUsdcReserves} non-USDC reserve(s) (multi-mint not counted yet)`,
     )
   }
@@ -281,7 +258,9 @@ async function tvl(api) {
 
 module.exports = {
   timetravel: false,
+  doublecounted: true, // deployed into already-listed Kamino Lend
+  isHeavyProtocol: true,
   methodology:
-    'TVL is on-chain USDC in Loyal Earn Squads vaults plus the Loyal treasury autonomous vault: redeemable USDC from Kamino Lend vanilla obligations across RiskBasket.Safe markets (Main, Figure, Maple, OnRe, Ethena), converting collateral shares with each reserve exchange rate (same method as Loyal earn holdings), plus idle USDC in vault ATAs. User vaults come from /api/earn/vaults; the treasury vault is not in that user-position list and is included explicitly. Non-USDC stables omitted until Earn multi-mint is generally enabled.',
+    'TVL is on-chain USDC in Loyal Earn Squads vaults, including the treasury autonomous vault listed by the public stats API (intentional: runway will sit in that vault as the autonomous-treasury product). Counts redeemable USDC from Kamino Lend vanilla obligations across RiskBasket.Safe markets (Main, Figure, Maple, OnRe, Ethena), converting collateral shares with each reserve exchange rate (same method as Loyal earn holdings), plus idle USDC in vault ATAs. Vault addresses come from https://stats.askloyal.com/api/earn/vaults. Overlaps Kamino Lend TVL, so this adapter is marked doublecounted. Non-USDC stables omitted until Earn multi-mint is generally enabled.',
   solana: { tvl },
 }

--- a/projects/loyal/index.js
+++ b/projects/loyal/index.js
@@ -1,0 +1,41 @@
+const { getConfig } = require('../helper/cache')
+const { sumTokens2 } = require('../helper/solana')
+const ADDRESSES = require('../helper/coreAssets.json')
+
+// Public list of active Earn vault pubkeys (Squads smart accounts)
+// Production: https://stats.askloyal.com/api/earn/vaults
+// For local / PR testing you can temporarily point this at your Vercel preview URL
+const VAULTS_API = 'https://stats.askloyal.com/api/earn/vaults'
+
+const TOKENS = [
+  ADDRESSES.solana.USDC,   // EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
+  // add more stables here if Earn supports them later (USDT, PYUSD, etc.)
+]
+
+async function tvl(api) {
+  const data = await getConfig('loyal/vaults', VAULTS_API)
+
+  // Support both the object shape { vaults: [...] } and a plain array
+  const owners = Array.isArray(data) ? data : (data.vaults || [])
+
+  if (!owners.length) {
+    api.log('[Loyal] No active vaults returned from API')
+    return {}
+  }
+
+  api.log(`[Loyal] Fetching balances for ${owners.length} vaults`)
+
+  return sumTokens2({
+    api,
+    owners,
+    tokens: TOKENS,
+    // allowError: true, // uncomment if some ATAs may not exist yet
+  })
+}
+
+module.exports = {
+  timetravel: false, // list of vaults comes from a live API
+  methodology:
+    'TVL is the sum of token balances held by active Loyal Earn vaults (Squads smart accounts). The list of vault addresses is fetched from the public Loyal stats API; balances are read on-chain.',
+  solana: { tvl },
+}

--- a/projects/loyal/index.js
+++ b/projects/loyal/index.js
@@ -1,41 +1,142 @@
+const { PublicKey } = require('@solana/web3.js')
+const { Program } = require('@project-serum/anchor')
 const { getConfig } = require('../helper/cache')
-const { sumTokens2 } = require('../helper/solana')
+const { getConnection, getMultipleAccounts } = require('../helper/solana')
 const ADDRESSES = require('../helper/coreAssets.json')
 
-// Public list of active Earn vault pubkeys (Squads smart accounts)
-// Production: https://stats.askloyal.com/api/earn/vaults
-// For local / PR testing you can temporarily point this at your Vercel preview URL
 const VAULTS_API = 'https://stats.askloyal.com/api/earn/vaults'
 
-const TOKENS = [
-  ADDRESSES.solana.USDC,   // EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
-  // add more stables here if Earn supports them later (USDT, PYUSD, etc.)
+const KLEND_PROGRAM_ID = new PublicKey('KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD')
+
+// RiskBasket.Safe — packages/loyal-actions/src/constants.ts
+const SAFE_MARKETS = [
+  '7u3HeHxYDLhnCoErrtycNokbQYbWGzLs6JSDqGAv5PfF', // Main
+  'CqAoLuqWtavaVE8deBjMKe8ZfSt9ghR6Vb8nfsyabyHA', // Figure
+  '6WEGfej9B9wjxRs6t4BYpb9iCXd8CpTpJ8fVSNzHCC5y', // Maple
+  '47tfyEG9SsdEnUm9cw5kY9BXngQGqu3LBoop9j5uTAv8', // OnRe
+  'BJnbcRHqvppTyGesLzWASGKnmnF1wq9jZu6ExrjT7wvF', // Ethena
 ]
 
-async function tvl(api) {
-  const data = await getConfig('loyal/vaults', VAULTS_API)
+// KAMINO_VANILLA_OBLIGATION_TAG / ID from loyal-actions constants
+const OBLIGATION_TAG = 0
+const OBLIGATION_ID = 0
 
-  // Support both the object shape { vaults: [...] } and a plain array
+const SF = 2 ** 60 // Kamino scaled-fraction
+
+// Minimal IDL to decode Obligation.deposits[].marketValueSf
+const klendIdl = {
+  version: '0.1.0',
+  name: 'klend',
+  instructions: [],
+  accounts: [
+    {
+      name: 'obligation',
+      type: {
+        kind: 'struct',
+        fields: [
+          { name: 'tag', type: 'u64' },
+          { name: 'lastUpdate', type: { defined: 'LastUpdate' } },
+          { name: 'lendingMarket', type: 'publicKey' },
+          { name: 'owner', type: 'publicKey' },
+          { name: 'deposits', type: { array: [{ defined: 'ObligationCollateral' }, 8] } },
+        ],
+      },
+    },
+  ],
+  types: [
+    {
+      name: 'LastUpdate',
+      type: {
+        kind: 'struct',
+        fields: [
+          { name: 'slot', type: 'u64' },
+          { name: 'stale', type: 'u8' },
+          { name: 'priceStatus', type: 'u8' },
+          { name: 'placeholder', type: { array: ['u8', 6] } },
+        ],
+      },
+    },
+    {
+      name: 'ObligationCollateral',
+      type: {
+        kind: 'struct',
+        fields: [
+          { name: 'depositReserve', type: 'publicKey' },
+          { name: 'depositedAmount', type: 'u64' },
+          { name: 'marketValueSf', type: 'u128' },
+          { name: 'borrowedAmountAgainstThisCollateralInElevationGroup', type: 'u64' },
+          { name: 'padding', type: { array: ['u64', 9] } },
+        ],
+      },
+    },
+  ],
+}
+
+function deriveVanillaObligation(owner, market) {
+  const [pda] = PublicKey.findProgramAddressSync(
+    [
+      Buffer.from([OBLIGATION_TAG]),
+      Buffer.from([OBLIGATION_ID]),
+      new PublicKey(owner).toBuffer(),
+      new PublicKey(market).toBuffer(),
+      PublicKey.default.toBuffer(),
+      PublicKey.default.toBuffer(),
+    ],
+    KLEND_PROGRAM_ID,
+  )
+  return pda
+}
+
+async function tvl(api) {
+  const connection = getConnection()
+  const data = await getConfig('loyal/vaults', VAULTS_API)
   const owners = Array.isArray(data) ? data : (data.vaults || [])
 
   if (!owners.length) {
-    api.log('[Loyal] No active vaults returned from API')
+    api.log('[Loyal] empty vault list')
     return {}
   }
+  api.log(`[Loyal] ${owners.length} vaults × ${SAFE_MARKETS.length} markets`)
 
-  api.log(`[Loyal] Fetching balances for ${owners.length} vaults`)
+  const obligationPubkeys = []
+  for (const owner of owners) {
+    for (const market of SAFE_MARKETS) {
+      obligationPubkeys.push(deriveVanillaObligation(owner, market))
+    }
+  }
 
-  return sumTokens2({
-    api,
-    owners,
-    tokens: TOKENS,
-    // allowError: true, // uncomment if some ATAs may not exist yet
+  const accountInfos = await getMultipleAccounts(obligationPubkeys, { api })
+  const program = new Program(klendIdl, KLEND_PROGRAM_ID, {
+    connection,
+    publicKey: PublicKey.unique(),
   })
+
+  let active = 0
+  for (const info of accountInfos) {
+    if (!info?.data) continue
+    try {
+      const decoded = program.coder.accounts.decode('obligation', info.data)
+      for (const d of decoded.deposits) {
+        if (d.depositReserve.equals(PublicKey.default)) continue
+        const usd = Number(d.marketValueSf.toString()) / SF
+        if (usd > 0) {
+          // Report as USDC (6 decimals) so DefiLlama prices at ~$1
+          api.add(ADDRESSES.solana.USDC, Math.round(usd * 1e6))
+          active++
+        }
+      }
+    } catch {
+      // missing / empty obligation
+    }
+  }
+
+  api.log(`[Loyal] ${active} non-zero collateral slots`)
+  return api.getBalances()
 }
 
 module.exports = {
-  timetravel: false, // list of vaults comes from a live API
+  timetravel: false,
   methodology:
-    'TVL is the sum of token balances held by active Loyal Earn vaults (Squads smart accounts). The list of vault addresses is fetched from the public Loyal stats API; balances are read on-chain.',
+    'TVL is the on-chain USD market value of collateral deposited by Loyal Earn Squads smart accounts into Kamino Lend obligations across the five RiskBasket.Safe markets (Main, Figure, Maple, OnRe, Ethena). Vault addresses are fetched from the public Loyal stats API; obligation values are read on-chain via marketValueSf.',
   solana: { tvl },
 }


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).

2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** Please send a mail to metadata@defillama.com
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes

---
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
Loyal Earn

##### Twitter Link:
https://x.com/loyal_hq

##### List of audit links if any:

##### Website Link:
https://askloyal.com

##### Logo (High resolution, will be shown with rounded borders):
<img width="820" height="820" alt="loyallogo" src="https://github.com/user-attachments/assets/4119e444-9a19-49a3-8a7d-7f69a0a3332d" />


##### Current TVL:
~$660k USDC

##### Treasury Addresses (if the protocol has treasury)
F7zuL14omw4JJfS1cvsWXVb3wh48dvsonMJgoc9tYu3e

##### Chain:
Solana

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): 
loyal

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): 
39037

##### Short Description (to be shown on DefiLlama):
Loyal Earn is self-custodial USDC yield on Solana. Each user holds funds in their own Squads smart account; automated policies route idle USDC into Kamino Lend under on-chain constraints, without giving up keys or final authority on material actions. The stack is open source, launched and governed through MetaDAO futarchy, with a DAO multisig treasury and protocol fees returned on-chain.

##### Token address and ticker if any:
LYLikzBQtpa9ZgVrJsqYGQpR3cC1WMJrBHaXGrQmeta 
LOYAL


## Technical notes

- Adapter path: `projects/loyal/index.js`
- Vault list API: https://stats.askloyal.com/api/earn/vaults (includes user Earn vaults and treasury vault `F7zuL14omw4JJfS1cvsWXVb3wh48dvsonMJgoc9tYu3e`)
- TVL is computed on-chain: vanilla Kamino obligations on RiskBasket.Safe markets; collateral shares converted to redeemable USDC via reserve exchange rate; plus idle USDC in vault ATAs
- `timetravel: false` (vault set from live API)
- `doublecounted: true` (capital is in already-listed Kamino Lend)
- `isHeavyProtocol: true`
- USDC-only for now
- Companion API: loyal-labs/loyal-app#614 (merged)

## Test

```bash
node test.js projects/loyal



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added TVL tracking for Solana Loyal vaults.
  - Reports USDC liquidity from idle vault balances and lending positions.
  - Includes collateral balances for supported USDC lending reserves.
- **Bug Fixes**
  - Improved handling of empty vault responses to prevent invalid results.
  - Simplified balance reporting for more consistent TVL calculations.
- **Documentation**
  - Updated methodology details to clarify how lending collateral is represented.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->