### PR TITLE
Add Aumo (X Layer)

### DIFF
--- a/projects/aumo/index.js
+++ b/projects/aumo/index.js
@@ -1,0 +1,22 @@
+// DefiLlama TVL adapter for Aumo.
+// Submit as projects/aumo/index.js in https://github.com/DefiLlama/DefiLlama-Adapters
+//
+// Aumo is an autonomous treasury agent for stablecoins on X Layer. Deposits sit in an ERC-4626
+// vault (AumoPool) whose totalAssets() is the full USDT0 under management: the idle buffer plus
+// principal deployed across allowlisted venues (Aave v3, USDG, Pendle PT). Counting totalAssets in
+// USDT0 avoids double-counting the venue positions, since the vault already values them.
+
+const POOL = "0x8a98A4A868e5FBAc05B9d1dC0742BD008354114F"; // AumoPool (ERC-4626), X Layer
+const USDT0 = "0x779Ded0c9e1022225f8E0630b35a9b54bE713736"; // base asset, pegs to $1
+
+async function tvl(api) {
+  const assets = await api.call({ target: POOL, abi: "uint256:totalAssets" });
+  api.add(USDT0, assets);
+  return api.getBalances();
+}
+
+module.exports = {
+  methodology:
+    "TVL is the total USDT0 under management in the AumoPool ERC-4626 vault on X Layer, read from totalAssets() (idle buffer plus principal deployed across allowlisted venues).",
+  xlayer: { tvl },
+};


### PR DESCRIPTION
TVL adapter for Aumo, an autonomous stablecoin treasury agent on X Layer. Chain: xlayer. Category: Yield. Site: https://aumo.finance. Vault (ERC-4626): 0x8a98A4A868e5FBAc05B9d1dC0742BD008354114F. Asset: USDT0. Methodology: totalAssets() of the AumoPool vault (idle + principal across Aave v3 / USDG / Pendle PT); avoids double-counting since the vault already values venue positions.

github: https://github.com/cryptoduke01/aumo
twitter: https://x.com/aumofinance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added TVL tracking for Aumo on X Layer.
  - Reports assets held in the AumoPool vault as USDT0.
  - Added TVL methodology and X Layer adapter configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->