### PR TITLE
earngrid: update vault address to v2.0.0

### DIFF
--- a/registries/erc4626.js
+++ b/registries/erc4626.js
@@ -93,7 +93,7 @@ const configs = {
   'earngrid': {
     methodology: 'Automated USDC yield vault on Base — aggregates MetaMorpho strategies. TVL via totalAssets().',
     doublecounted: true,
-    base: ['0x8694D7D44309665D51Cb5002fceC0454f1c233dE'],
+    base: ['0xbDacA8B7782C66cc0ee32Cf70F835EBe86cb20D3'],
   },
   'eva': {
     ethereum: [

--- a/registries/erc4626.js
+++ b/registries/erc4626.js
@@ -93,7 +93,7 @@ const configs = {
   'earngrid': {
     methodology: 'Automated USDC yield vault on Base — aggregates MetaMorpho strategies. TVL via totalAssets().',
     doublecounted: true,
-    base: ['0xbDacA8B7782C66cc0ee32Cf70F835EBe86cb20D3'],
+    base: ['0x8694D7D44309665D51Cb5002fceC0454f1c233dE', '0xbDacA8B7782C66cc0ee32Cf70F835EBe86cb20D3'],
   },
   'eva': {
     ethereum: [


### PR DESCRIPTION
BlendedVault v2.0.0 redeployed on Base (2026-08-14): slim core, sole admin, in-vault referral system, 4% performance fee. Both contracts Sourcify exact_match. Old v1.0.4 vault is drained (migration complete).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a second Earngrid vault on Base while retaining the existing vault.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->