### PR TITLE
keellabs: add the factories deployed 2026-08-09 and 2026-08-15 (TVL reporting 0)

### DIFF
--- a/projects/keellabs/index.js
+++ b/projects/keellabs/index.js
@@ -12,7 +12,8 @@ const config = {
       '0x3031B1661Bb584bBA566D74Ba0c86Ab6f525AF07',   // VaultNext
       '0xAd7f3B6C7D16e19A3284BE0cE14578296feA471A',   // VaultRecover
       '0xF41AA2bb58952F490E2DFe437d50489Ac3c6A4bC',   // VaultClaim
-      '0x3e682FEC310d297cB109AC0b1Fe53F4EB0C8a5F8',   // Keel v2 — deployed 2026-08-05
+      '0x3e682FEC310d297cB109AC0b1Fe53F4EB0C8a5F8',   // Keellabs v2 — deployed 2026-08-05
+      '0x61C6dEc573505125EBc2b7e569250262b8dF33bC',   // fresh factory — deployed 2026-08-09
     ],
     npm: '0xC36442b4a4522E871399CD717aBDD847Ab11FE88',
   },
@@ -22,7 +23,8 @@ const config = {
       '0xAc17cF95525796F81587c47Bb78d4ce7a187e5C7',   // VaultNext (costBasis1 sincronizado) — desplegada 2026-08-03
       '0x62fC42AA2Aa1F8743d97daBeD925E70E04682a1c',   // VaultRecover
       '0x3031B1661Bb584bBA566D74Ba0c86Ab6f525AF07',   // VaultClaim
-      '0x7c32443061e54681ebc9f8581E4fc2867A2D6384',   // Keel v2 — deployed 2026-08-05
+      '0x7c32443061e54681ebc9f8581E4fc2867A2D6384',   // Keellabs v2 — deployed 2026-08-05
+      '0x2fA41b881d194628160d7f95f10442Dc6BC5e06F',   // fresh factory — deployed 2026-08-09
     ],
     npm: '0x73991a25C818Bf1f1128dEAaB1492D45638DE0D3',
   },
@@ -33,7 +35,8 @@ const config = {
       '0xF4263810321f03C01abA727De0210c4BFB13fdB8',   // VaultNext
       '0x811e2843c2a55b70D9C867988D69E624c35dAF4C',   // VaultRecover
       '0x609B9A1c089cb29a38bf19901a39259493997AB4',   // VaultClaim
-      '0x1E2c70bbEB3A156443B6ECBa23105FedD74a71a8',   // Keel v2 — deployed 2026-08-05
+      '0x1E2c70bbEB3A156443B6ECBa23105FedD74a71a8',   // Keellabs v2 — deployed 2026-08-05
+      '0xb2AA23f1664dB2AC87816ad69a2C19f217F57fc4',   // fresh factory — deployed 2026-08-09
     ],
     // PRJX's position manager, not the chain's default Uniswap deployment.
     npm: '0xeaD19AE861c29bBb2101E834922B2FEee69B9091',

--- a/projects/keellabs/index.js
+++ b/projects/keellabs/index.js
@@ -1,10 +1,10 @@
 const { sumTokens2 } = require('../helper/unwrapLPs')
 
-// KeelLabs deploys one non-custodial vault per user per pool (EIP-1167 clones of a shared
-// implementation) from a VaultFactory, and each vault keeps a single Uniswap V3 concentrated
-// liquidity position that a restricted keeper re-centers. A user may own several vaults, and each
-// chain may have more than one factory (a new implementation always ships with a new factory,
-// because VaultFactory.implementation is immutable — older factories stay live and are kept here).
+// KeelLabs deploys a non-custodial vault per position (EIP-1167 clones of a shared implementation)
+// from a VaultFactory, and each vault keeps a single Uniswap V3 concentrated liquidity position
+// that a restricted keeper re-centers. A user may own several vaults — since the 2026-08-15
+// factories, several in the same pool — and each chain may have more than one factory. Older
+// factories stay live and are kept here.
 const config = {
   arbitrum: {
     factories: [
@@ -14,6 +14,7 @@ const config = {
       '0xF41AA2bb58952F490E2DFe437d50489Ac3c6A4bC',   // VaultClaim
       '0x3e682FEC310d297cB109AC0b1Fe53F4EB0C8a5F8',   // Keellabs v2 — deployed 2026-08-05
       '0x61C6dEc573505125EBc2b7e569250262b8dF33bC',   // fresh factory — deployed 2026-08-09
+      '0xDa877e3A5896dba00309684A5B40441f6A37e6e5',   // multi-vault factory — deployed 2026-08-15
     ],
     npm: '0xC36442b4a4522E871399CD717aBDD847Ab11FE88',
   },
@@ -25,6 +26,7 @@ const config = {
       '0x3031B1661Bb584bBA566D74Ba0c86Ab6f525AF07',   // VaultClaim
       '0x7c32443061e54681ebc9f8581E4fc2867A2D6384',   // Keellabs v2 — deployed 2026-08-05
       '0x2fA41b881d194628160d7f95f10442Dc6BC5e06F',   // fresh factory — deployed 2026-08-09
+      '0xc92bf423d730f1CA42F852d5Fc85467A10bCa572',   // multi-vault factory — deployed 2026-08-15
     ],
     npm: '0x73991a25C818Bf1f1128dEAaB1492D45638DE0D3',
   },
@@ -37,6 +39,7 @@ const config = {
       '0x609B9A1c089cb29a38bf19901a39259493997AB4',   // VaultClaim
       '0x1E2c70bbEB3A156443B6ECBa23105FedD74a71a8',   // Keellabs v2 — deployed 2026-08-05
       '0xb2AA23f1664dB2AC87816ad69a2C19f217F57fc4',   // fresh factory — deployed 2026-08-09
+      '0x309b918A4EBf5aB960B7787FE154d10229ED928b',   // multi-vault factory — deployed 2026-08-15
     ],
     // PRJX's position manager, not the chain's default Uniswap deployment.
     npm: '0xeaD19AE861c29bBb2101E834922B2FEee69B9091',


### PR DESCRIPTION
### What

Adds the KeelLabs `VaultFactory` contracts deployed on **2026-08-09** and **2026-08-15** to each of the three chains.

| chain | 2026-08-09 | 2026-08-15 (multi-vault) |
|---|---|---|
| arbitrum | `0x61C6dEc573505125EBc2b7e569250262b8dF33bC` | `0xDa877e3A5896dba00309684A5B40441f6A37e6e5` |
| robinhood | `0x2fA41b881d194628160d7f95f10442Dc6BC5e06F` | `0xc92bf423d730f1CA42F852d5Fc85467A10bCa572` |
| hyperliquid | `0xb2AA23f1664dB2AC87816ad69a2C19f217F57fc4` | `0x309b918A4EBf5aB960B7787FE154d10229ED928b` |

### Why

The merged adapter lists factories up to 2026-08-05 only (#20408). Those are empty — every vault created from them was closed and withdrawn. All live vaults were created by the 2026-08-09 factories, which are not in the list, so the adapter enumerates nothing with a balance and TVL reports **$0**.

The 2026-08-15 factories drop the one-vault-per-(owner, pool) restriction, so a user can now hold several positions in the same pool. Every vault is created from those from now on, and leaving them out would repeat the same problem the moment anyone opens a position.

### Verified

Ran the adapter against the current chain state:

```
------ TVL ------
robinhood                 1.99 k
hyperliquid               0.00
arbitrum                  0.00

total                     1.99 k
```

Both open positions are on Robinhood Chain:

- `0x63544768119b7A04c5aBEE6317afBb66D98dc62b` — GME/USDG
- `0xC8984a3C7F4c6A548076874fC51A59d44F4358BD` — NVDA/USDG

`npx eslint -c eslint.config.js projects/keellabs/index.js` passes.

### Notes

- Older factories are kept in the list, as before: `VaultFactory.implementation` is immutable, so a new implementation always ships with a new factory and the old ones stay live with withdrawable user funds.
- No change to the methodology or to `tvl()` — only addresses appended, plus the header comment and three project-name comments updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fresh and multi-vault factory deployments for Arbitrum, Robinhood, and Hyperliquid.
  * Added support for one vault per position and multiple vaults per pool.

* **Documentation**
  * Updated VaultFactory documentation and clarified “Keellabs v2” deployment labeling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->