### PR TITLE
Add Magpie Capital (Solana lending)

### DIFF
--- a/projects/magpie-capital/index.js
+++ b/projects/magpie-capital/index.js
@@ -1,0 +1,26 @@
+const { sumTokens2 } = require("../helper/solana");
+
+// Magpie Capital — permissionless collateral lending on Solana
+// (memecoins, tokenized stocks/RWAs, collectibles). https://magpie.capital
+//
+// TVL = SOL lending liquidity held in the protocol's pool vaults (wSOL
+// token accounts owned by each lending pool PDA):
+//   V1 pool vault (program 4FEFPeMH68BbkrrZW2ak9wWXUS7JCkvXqBkGf5Bg6wmh)
+//   V3 pool vault (program B8AwYzFmc3ZB5EWWVtJcJhJtEmKL78W5i3kZrL1uMCmP)
+//   V4 pool vault (program HA1hgvskN1goEsb33rNHFBcDXBaYyLyyqfGwGMgTUwNo)
+const POOL_VAULTS = [
+  "5CYVDEqnLknmtyKkFEvpr5XnEJRzieXm1G5hSvYFG2Ko", // V1
+  "s2M7st6DEepiuKhX3ouJM7mUsr8aDMJNm8UQh82KrVb", // V3
+  "7vfpVHc2ndPYw9dToiag2ARoUZ75BjLLuzsEfSjMtD1w", // V4
+];
+
+async function tvl() {
+  return sumTokens2({ tokenAccounts: POOL_VAULTS });
+}
+
+module.exports = {
+  timetravel: false,
+  methodology:
+    "TVL is the SOL lending liquidity held in Magpie's on-chain pool vaults (wSOL token accounts owned by the V1, V3 and V4 lending-pool PDAs). Collateral locked against active loans is not counted.",
+  solana: { tvl },
+};


### PR DESCRIPTION
**Name:** Magpie Capital
**Website:** https://magpie.capital
**Twitter:** https://x.com/MagpieLoans
**Category:** Lending
**Chain:** Solana

Magpie Capital is a permissionless collateral-lending protocol on Solana: users borrow SOL against memecoins, tokenized stocks/RWAs, and (upcoming) tokenized collectibles, on fixed terms with in-vault exit orders (take-profit / stop-loss / laddered auto-sells on the collateral while the loan stays active).

**Methodology:** TVL = SOL lending liquidity in the protocol's three on-chain pool vaults (wSOL token accounts owned by the V1/V3/V4 lending-pool PDAs, addresses in the adapter). Collateral locked against active loans is intentionally not counted.

Live protocol stats (on-chain): https://magpie.capital/stats

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Solana TVL tracking for Magpie Capital.
  * Includes lending liquidity held across V1, V3, and V4 pool vaults.
  * Added methodology details clarifying included liquidity and excluded collateral.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->