### PR TITLE
Add Qom X DEX

### DIFF
--- a/projects/qomx/index.js
+++ b/projects/qomx/index.js
@@ -1,6 +1,11 @@
+const { getUniTVL } = require('../helper/unknownTokens')
+
 module.exports = {
-  methodology: 'QomX DEX pools and farms on BSC',
+  methodology: 'TVL is the value of tokens locked in Qom X DEX liquidity pools on BSC (calculated from the factory).',
   bsc: {
-    tvl: async () => ({})
+    tvl: getUniTVL({
+      factory: '0x356037CbC77B3A2B36E0484d96DF0De247e66785',
+      useDefaultCoreAssets: true,
+    })
   }
 }

--- a/projects/qomx/index.js
+++ b/projects/qomx/index.js
@@ -10,18 +10,20 @@ async function farms(api) {
     abi: 'function getAllFarms() view returns (address[])'
   })
 
+  if (!farms.length) return {}
+
   const lpTokens = await api.multiCall({
     abi: 'address:lpToken',
     calls: farms
   })
 
-  const balances = await api.multiCall({
-    abi: 'uint256:totalStaked',
-    calls: farms
-  })
-
   const tokensAndOwners = lpTokens.map((lp, i) => [lp, farms[i]])
-  return sumTokens2({ api, tokensAndOwners })
+
+  return sumTokens2({
+    api,
+    tokensAndOwners,
+    resolveLP: true
+  })
 }
 
 module.exports = {
@@ -31,6 +33,6 @@ module.exports = {
       factory: DEX_FACTORY,
       useDefaultCoreAssets: true,
     }),
-    staking: farms,   // this will show as "Staking" TVL on DefiLlama
+    staking: farms,
   }
 }

--- a/projects/qomx/index.js
+++ b/projects/qomx/index.js
@@ -1,11 +1,36 @@
 const { getUniTVL } = require('../helper/unknownTokens')
+const { sumTokens2 } = require('../helper/unwrapLPs')
+
+const FARM_FACTORY = '0x951AFf794ffD122e4EA90B8BcFeE722c05f7133D'
+const DEX_FACTORY = '0x356037CbC77B3A2B36E0484d96DF0De247e66785'
+
+async function farms(api) {
+  const farms = await api.call({
+    target: FARM_FACTORY,
+    abi: 'function getAllFarms() view returns (address[])'
+  })
+
+  const lpTokens = await api.multiCall({
+    abi: 'address:lpToken',
+    calls: farms
+  })
+
+  const balances = await api.multiCall({
+    abi: 'uint256:totalStaked',
+    calls: farms
+  })
+
+  const tokensAndOwners = lpTokens.map((lp, i) => [lp, farms[i]])
+  return sumTokens2({ api, tokensAndOwners })
+}
 
 module.exports = {
-  methodology: 'TVL is the value of tokens locked in Qom X DEX liquidity pools on BSC (calculated from the factory).',
+  methodology: 'TVL includes tokens locked in Qom X DEX liquidity pools + tokens staked in Qom X farms on BSC.',
   bsc: {
     tvl: getUniTVL({
-      factory: '0x356037CbC77B3A2B36E0484d96DF0De247e66785',
+      factory: DEX_FACTORY,
       useDefaultCoreAssets: true,
-    })
+    }),
+    staking: farms,   // this will show as "Staking" TVL on DefiLlama
   }
 }

--- a/projects/qomx/index.js
+++ b/projects/qomx/index.js
@@ -1,0 +1,6 @@
+module.exports = {
+  methodology: 'QomX DEX pools and farms on BSC',
+  bsc: {
+    tvl: async () => ({})
+  }
+}


### PR DESCRIPTION


Name (to be shown on DefiLlama):
Qom X

Twitter Link:
https://x.com/QomX_io

List of audit links if any:
None yet

Website Link:
https://qomx.io/

Logo (High resolution, will be shown with rounded borders):
https://i.ibb.co/5WK6zG51/qomx.jpg

Current TVL:
Low (new protocol) estimated $45,000 if you include the Q/QOMX pool. 

Treasury Addresses (if the protocol has treasury):
team address used in the dex factory as treasury is 0xCd72c926CBcDc4c1e173023105589C9e42EC4EDe

Chain:
BSC

Coingecko ID: NA
Coinmarketcap ID: NA
Short Description (to be shown on DefiLlama):
Qom X is a hybrid exchange on Binance Smart Chain with a fully working CEX with 100% referral system, Alpha Dex with permissionless farms, four-meme launchpad with 3333 contracts and dual qomx/bnb quote system, and Q stablecoin bridge using hyperlane tech. 

Token address and ticker if any:
QOMX - 0xC9e127bFcA0b16c276444FdC9600EE876281a831

Category:
Dex, Cex, Farm, Launchpad, Bridge

Oracle Provider(s):
None

Implementation Details:
Documentation/Proof:
forked
From:
methodology:
TVL is the value of tokens locked in Qom X DEX liquidity pools on BSC, calculated from the factory using getUniTVL helper.

Github org/user (Optional):

Does this project have a referral program?
Yes (on the CEX side)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Qom X TVL tracking on BSC.
  * Added farm staking TVL tracking, including discovered farms, LP tokens, and staked balances.
  * Included methodology details for liquidity pools and farms.
  * Added configuration for supported factory addresses and default core assets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->