### PR TITLE
Add Niza.io CEX PoR adapte

### DIFF
--- a/projects/niza-cex/index.js
+++ b/projects/niza-cex/index.js
@@ -1,0 +1,16 @@
+const { cexExports } = require('../helper/cex')
+
+const config = {
+  bitcoin: {
+    owners: [
+      'bc1qx2p4hx3s60cg69rt3j78l2vskelgcjj95s5ty3'
+    ]
+  },
+  ethereum: {
+    owners: [
+      '0x8374F37B298420ae13ccD3cbE7dC07895290676d'
+    ]
+  }
+}
+
+module.exports = cexExports(config)


### PR DESCRIPTION
## Niza.io CEX Adapter

Adding Proof of Reserves tracking for Niza.io.

- Website: https://niza.io/
- Twitter: https://x.com/nizacoin

### Addresses
- Bitcoin: `bc1qx2p4hx3s60cg69rt3j78l2vskelgcjj95s5ty3`
- Ethereum: `0x8374F37B298420ae13ccD3cbE7dC07895290676d`

Methodology: Sum of balances held in publicly disclosed Proof of Reserves wallet addresses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized exchange configuration for Bitcoin and Ethereum ownership addresses.
  * Enabled the exchange configuration to be exported for use by the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->