### PR TITLE
Add STOCKMON (Robinhood Chain)

### DIFF
--- a/projects/stockmon/index.js
+++ b/projects/stockmon/index.js
@@ -1,0 +1,43 @@
+// STOCKMON — stock-DNA creature NFTs whose token IDs own exact onchain Vault
+// subledgers of Robinhood Chain stock tokens plus WETH pending fills.
+// TVL is the exact token balances held by STOCKMON vaults; nothing is
+// self-reported. Site: https://stockmon.app
+
+// Vaults by collection — Aetheryn joins this list when its vault deploys.
+const VAULTS = [
+  "0xb78edcb4de39355747c62e6d55209c01a2294ad8", // Genesis Vault
+];
+
+const WETH = "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73";
+
+// Canonical Robinhood Chain stock-token deployments (Robinhood registry).
+const STOCK_TOKENS = [
+  "0xd0601CE157Db5bdC3162BbaC2a2C8aF5320D9EEC", // NVDA
+  "0x322F0929c4625eD5bAd873c95208D54E1c003b2d", // TSLA
+  "0x2e0847E8910a9732eB3fb1bb4b70a580ADAD4FE3", // GOOGL
+  "0xaF3D76f1834A1d425780943C99Ea8A608f8a93f9", // AAPL
+  "0xe93237C50D904957Cf27E7B1133b510C669c2e74", // MSFT
+  "0x12f190a9F9d7D37a250758b26824B97CE941bF54", // AMZN
+  "0xc0D6457C16Cc70d6790Dd43521C899C87ce02f35", // META
+  "0x894E1EC2D74FFE5AEF8Dc8A9e84686acCB964F2A", // PLTR
+  "0x117cc2133c37B721F49dE2A7a74833232B3B4C0C", // SPY
+  "0xD5f3879160bc7c32ebb4dC785F8a4F505888de68", // QQQ
+  "0x4a0E65A3EcceC6dBe60AE065F2e7bb85Fae35eEa", // SPCX (SpaceX)
+  "0x4D21483a44Bf67a86b77E3dA301411880797D452", // BA
+  "0xB1BF26c1D20ff267A4f93550d1E0d06ac40a114B", // RIVN
+  "0xF0AB0c93bE6F41369d302e55db1A96b3c430212D", // IREN
+  "0x284358abc07F9359f19f4b5b4aC91901Be2597Ba", // RGTI
+  "0xC583c60aeF9Dc401Da72cEC1B404743a93cea1Cc", // QBTS
+];
+
+module.exports = {
+  methodology:
+    "TVL is the exact onchain balances held by STOCKMON vaults on Robinhood Chain: the 16 Robinhood stock tokens backing each creature's permanent stock DNA, plus WETH pending settlement into stock fills. Balances are read directly from the vault contracts; no value is self-reported.",
+  robinhood: {
+    tvl: (api) =>
+      api.sumTokens({
+        owners: VAULTS,
+        tokens: [WETH, ...STOCK_TOKENS],
+      }),
+  },
+};

--- a/projects/stockmon/index.js
+++ b/projects/stockmon/index.js
@@ -1,43 +1,20 @@
-// STOCKMON — stock-DNA creature NFTs whose token IDs own exact onchain Vault
-// subledgers of Robinhood Chain stock tokens plus WETH pending fills.
-// TVL is the exact token balances held by STOCKMON vaults; nothing is
-// self-reported. Site: https://stockmon.app
+const ADDRESSES = require('../helper/coreAssets.json')
 
 // Vaults by collection — Aetheryn joins this list when its vault deploys.
 const VAULTS = [
   "0xb78edcb4de39355747c62e6d55209c01a2294ad8", // Genesis Vault
 ];
 
-const WETH = "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73";
-
-// Canonical Robinhood Chain stock-token deployments (Robinhood registry).
-const STOCK_TOKENS = [
-  "0xd0601CE157Db5bdC3162BbaC2a2C8aF5320D9EEC", // NVDA
-  "0x322F0929c4625eD5bAd873c95208D54E1c003b2d", // TSLA
-  "0x2e0847E8910a9732eB3fb1bb4b70a580ADAD4FE3", // GOOGL
-  "0xaF3D76f1834A1d425780943C99Ea8A608f8a93f9", // AAPL
-  "0xe93237C50D904957Cf27E7B1133b510C669c2e74", // MSFT
-  "0x12f190a9F9d7D37a250758b26824B97CE941bF54", // AMZN
-  "0xc0D6457C16Cc70d6790Dd43521C899C87ce02f35", // META
-  "0x894E1EC2D74FFE5AEF8Dc8A9e84686acCB964F2A", // PLTR
-  "0x117cc2133c37B721F49dE2A7a74833232B3B4C0C", // SPY
-  "0xD5f3879160bc7c32ebb4dC785F8a4F505888de68", // QQQ
-  "0x4a0E65A3EcceC6dBe60AE065F2e7bb85Fae35eEa", // SPCX (SpaceX)
-  "0x4D21483a44Bf67a86b77E3dA301411880797D452", // BA
-  "0xB1BF26c1D20ff267A4f93550d1E0d06ac40a114B", // RIVN
-  "0xF0AB0c93bE6F41369d302e55db1A96b3c430212D", // IREN
-  "0x284358abc07F9359f19f4b5b4aC91901Be2597Ba", // RGTI
-  "0xC583c60aeF9Dc401Da72cEC1B404743a93cea1Cc", // QBTS
-];
+async function tvl(api) {
+  const assetRegistry = await api.call({ abi: 'address:assetRegistry', target:'0xb78edcb4de39355747c62e6d55209c01a2294ad8' });
+  const stocks = await api.fetchList({  lengthAbi: 'ASSET_COUNT', itemAbi: 'function assetAt(uint8) view returns (address)', target: assetRegistry})
+  const tokens = stocks.concat([ADDRESSES.robinhood.WETH])
+  return api.sumTokens({ tokens, owners: VAULTS })
+}
 
 module.exports = {
-  methodology:
-    "TVL is the exact onchain balances held by STOCKMON vaults on Robinhood Chain: the 16 Robinhood stock tokens backing each creature's permanent stock DNA, plus WETH pending settlement into stock fills. Balances are read directly from the vault contracts; no value is self-reported.",
+  methodology: "Value of stocks and WETH held in STOCKMON vaults",
   robinhood: {
-    tvl: (api) =>
-      api.sumTokens({
-        owners: VAULTS,
-        tokens: [WETH, ...STOCK_TOKENS],
-      }),
+    tvl
   },
 };


### PR DESCRIPTION
Adds STOCKMON — stock-DNA creature NFTs whose token IDs own exact onchain Vault subledgers on Robinhood Chain (chainId 4663). TVL is the exact stock-token and WETH balances held by STOCKMON vaults, read from the vault contract; nothing is self-reported.

Site: [https://stockmon.app](https://stockmon.app)
Vault: 0xb78edcb4de39355747c62e6d55209c01a2294ad8
Tokens: canonical Robinhood Chain stock-token deployments + WETH
Category suggestion: RWA (tokenized equities backing NFT vaults)

A second collection (Aetheryn) launches later; its vault will be added to the VAULTS list in a follow-up PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for the Stockmon Genesis Vault on Robinhood Chain.
  * Automatically monitors WETH and stock-token assets held across configured vaults.
  * Includes methodology details explaining how total value is calculated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->