### PR TITLE
Add DiceMoon adapter (Base)

### DIFF
--- a/projects/dicemoon/index.js
+++ b/projects/dicemoon/index.js
@@ -1,0 +1,13 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+
+// DiceMoonTables: the single non-custodial escrow behind dicemoon.com (multiplayer dice + Sit & Go
+// poker on Base). TVL is the USDC it holds: active-game buy-ins and not-yet-claimed winnings.
+const DICEMOON_TABLES = '0x0bc585e3c8c47EE507C873eC994b14fC7883793d'
+
+module.exports = {
+  methodology:
+    'USDC held by the DiceMoonTables escrow contract on Base: buy-ins of games in progress and winnings not yet claimed. The operator never takes custody - stakes go wallet -> escrow -> winners.',
+  base: {
+    tvl: (api) => api.sumTokens({ owner: DICEMOON_TABLES, tokens: [ADDRESSES.base.USDC] }),
+  },
+}


### PR DESCRIPTION
## DiceMoon

- **Name**: DiceMoon
- **Website**: https://dicemoon.com
- **Category**: Gambling (Prediction Market / Betting family)
- **Chain**: Base
- **Description**: Non-custodial provably-fair dice and poker for USDC on Base. Stakes are locked in the DiceMoonTables escrow contract - the operator never takes custody; settlement is an EIP-712 server signature the contract verifies, and every roll/deal is recomputable from published seeds.
- **Contract (verified on Basescan)**: `0x0bc585e3c8c47EE507C873eC994b14fC7883793d`
- **Methodology**: TVL is the USDC held by the escrow contract: buy-ins of games in progress and winnings not yet claimed.
- **Twitter**: none yet
- **Audit**: internal only (contract source verified on Basescan)

Adapter output (Building prices get queries for 1 tokens
--- base ---
USDC                      0.74
Total: 0.74 

--- tvl ---
USDC                      1.00
Total: 0.74 

------ TVL ------
base                      1.00

total                    0.74 ) currently reports ~0.74 USDC - the site is in its early for-friends phase, TVL is genuinely tiny and grows with games played.