### PR TITLE
Add MINER (miner.tools): locked $MINER TVL on Solana

### DIFF
--- a/projects/miner-gold/index.js
+++ b/projects/miner-gold/index.js
@@ -1,50 +1,29 @@
-const ADDRESSES = require('../helper/coreAssets.json')
-const { getConnection } = require('../helper/solana')
+const { getConnection, sumTokens2 } = require('../helper/solana')
 const { PublicKey } = require('@solana/web3.js')
 
-// MINER (miner.tools): proof-of-work mining token on Solana. Miners can
-// lock $MINER in program-owned lock vaults (lock-to-boost) for a mining
-// weight multiplier; the locked tokens are the protocol TVL.
 const MINER_PROGRAM = 'FyTBuifdJ1u3rF2bsK2NmjzogkCbNK3KtFfZyM3CUfv1'
-// Lock PDA: discriminator u64 (=6) + authority [u8;32] + amount u64 +
-// unlock_ts i64 + multiplier_bps u64 + bump u64 = 72 bytes. The amount
-// field mirrors the lock vault balance exactly.
+const MINER_MINT = 'GNuooA9WSTDazufDHksrdkspCieoxBERuWNUewkMbyzG'
+// Lock PDA: discriminator u64 (=6) + authority [u8;32] + amount u64 + unlock_ts i64 +
+// multiplier_bps u64 + bump u64 = 72 bytes. Each lock PDA is the authority of a vault
+// token account that custodies the locked $MINER.
 const LOCK_SIZE = 72
 const LOCK_DISCRIMINATOR_B58 = '21D35quxec7' // u64 LE 6
-const LOCK_AMOUNT_OFFSET = 40
 
-// $MINER is not covered by the llama price feed yet, so the locked
-// amount is converted to SOL through the canonical MINER/WSOL pool
-// (Meteora DAMM v2 aka cp-amm; the same pool the program itself reads
-// as its price oracle). Both mints have 9 decimals, so the spot price
-// in lamports per native unit is simply (sqrt_price / 2^64)^2.
-const POOL = 'CvLcJ8ypG6iikSjFdtkA8LXrbhN8SSyUdUvhbEBhmyGR'
-const SQRT_PRICE_OFFSET = 456
-
-async function tvl(api) {
+async function staking(api) {
   const connection = getConnection()
-  const accounts = await connection.getProgramAccounts(new PublicKey(MINER_PROGRAM), {
+  const locks = await connection.getProgramAccounts(new PublicKey(MINER_PROGRAM), {
     filters: [
       { dataSize: LOCK_SIZE },
       { memcmp: { offset: 0, bytes: LOCK_DISCRIMINATOR_B58 } },
     ],
-    dataSlice: { offset: LOCK_AMOUNT_OFFSET, length: 8 },
+    dataSlice: { offset: 0, length: 0 },
   })
-  let lockedNative = 0n
-  accounts.forEach(({ account }) => { lockedNative += account.data.readBigUInt64LE(0) })
-
-  const pool = await connection.getAccountInfo(new PublicKey(POOL))
-  const sqrtPrice = pool.data.readBigUInt64LE(SQRT_PRICE_OFFSET)
-    + (pool.data.readBigUInt64LE(SQRT_PRICE_OFFSET + 8) << 64n)
-  const solPerMiner = Number(sqrtPrice) / 2 ** 64
-  const lamports = Number(lockedNative) * solPerMiner * solPerMiner
-
-  api.add(ADDRESSES.solana.SOL, Math.round(lamports))
+  const owners = locks.map(l => l.pubkey.toString())
+  return sumTokens2({ api, owners, tokens: [MINER_MINT] })
 }
 
 module.exports = {
   timetravel: false,
-  methodology:
-    'TVL is the $MINER locked in program-owned lock vaults (lock-to-boost): miners lock tokens for 7/30/90 days for a mining weight multiplier. Each lock account mirrors its vault balance on-chain; the amount is valued in SOL through the canonical MINER/WSOL pool spot price.',
-  solana: { tvl },
+  methodology: 'Staking is the $MINER locked in program-owned lock vaults (lock-to-boost): miners lock tokens for 7/30/90 days for a mining weight multiplier. Lock vaults are discovered from the MINER program and their $MINER balances are summed on-chain.',
+  solana: { tvl: () => ({}), staking },
 }

--- a/projects/miner-gold/index.js
+++ b/projects/miner-gold/index.js
@@ -1,0 +1,50 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+const { getConnection } = require('../helper/solana')
+const { PublicKey } = require('@solana/web3.js')
+
+// MINER (miner.tools): proof-of-work mining token on Solana. Miners can
+// lock $MINER in program-owned lock vaults (lock-to-boost) for a mining
+// weight multiplier; the locked tokens are the protocol TVL.
+const MINER_PROGRAM = 'FyTBuifdJ1u3rF2bsK2NmjzogkCbNK3KtFfZyM3CUfv1'
+// Lock PDA: discriminator u64 (=6) + authority [u8;32] + amount u64 +
+// unlock_ts i64 + multiplier_bps u64 + bump u64 = 72 bytes. The amount
+// field mirrors the lock vault balance exactly.
+const LOCK_SIZE = 72
+const LOCK_DISCRIMINATOR_B58 = '21D35quxec7' // u64 LE 6
+const LOCK_AMOUNT_OFFSET = 40
+
+// $MINER is not covered by the llama price feed yet, so the locked
+// amount is converted to SOL through the canonical MINER/WSOL pool
+// (Meteora DAMM v2 aka cp-amm; the same pool the program itself reads
+// as its price oracle). Both mints have 9 decimals, so the spot price
+// in lamports per native unit is simply (sqrt_price / 2^64)^2.
+const POOL = 'CvLcJ8ypG6iikSjFdtkA8LXrbhN8SSyUdUvhbEBhmyGR'
+const SQRT_PRICE_OFFSET = 456
+
+async function tvl(api) {
+  const connection = getConnection()
+  const accounts = await connection.getProgramAccounts(new PublicKey(MINER_PROGRAM), {
+    filters: [
+      { dataSize: LOCK_SIZE },
+      { memcmp: { offset: 0, bytes: LOCK_DISCRIMINATOR_B58 } },
+    ],
+    dataSlice: { offset: LOCK_AMOUNT_OFFSET, length: 8 },
+  })
+  let lockedNative = 0n
+  accounts.forEach(({ account }) => { lockedNative += account.data.readBigUInt64LE(0) })
+
+  const pool = await connection.getAccountInfo(new PublicKey(POOL))
+  const sqrtPrice = pool.data.readBigUInt64LE(SQRT_PRICE_OFFSET)
+    + (pool.data.readBigUInt64LE(SQRT_PRICE_OFFSET + 8) << 64n)
+  const solPerMiner = Number(sqrtPrice) / 2 ** 64
+  const lamports = Number(lockedNative) * solPerMiner * solPerMiner
+
+  api.add(ADDRESSES.solana.SOL, Math.round(lamports))
+}
+
+module.exports = {
+  timetravel: false,
+  methodology:
+    'TVL is the $MINER locked in program-owned lock vaults (lock-to-boost): miners lock tokens for 7/30/90 days for a mining weight multiplier. Each lock account mirrors its vault balance on-chain; the amount is valued in SOL through the canonical MINER/WSOL pool spot price.',
+  solana: { tvl },
+}


### PR DESCRIPTION
## New protocol listing: MINER

- **Name**: MINER
- **Symbol**: MINER
- **Chain**: Solana
- **Token**: `solana:GNuooA9WSTDazufDHksrdkspCieoxBERuWNUewkMbyzG`
- **Category**: Staking
- **Website**: https://miner.tools
- **Twitter**: https://x.com/MrMinerSolana
- **Program (verified on-chain, OtterSec)**: `FyTBuifdJ1u3rF2bsK2NmjzogkCbNK3KtFfZyM3CUfv1`
- **GitHub**: https://github.com/MrMinerSolana/Miner

MINER is a proof-of-work mining token on Solana (browser CPU mining, ORE-style)
with a PvP staking game (Caves). Miners can lock $MINER in program-owned lock
vaults for 7/30/90 days to get a mining weight multiplier (lock-to-boost).

**TVL**: sum of all `Lock` program accounts (dataSize 72, discriminator 6);
each account's `amount` field mirrors its vault balance exactly. $MINER is not
covered by the llama price feed yet, so the adapter values the locked amount
in SOL through the canonical MINER/WSOL Meteora DAMM v2 pool spot price
(`CvLcJ8ypG6iikSjFdtkA8LXrbhN8SSyUdUvhbEBhmyGR`) - the same pool the program
itself uses as its on-chain price oracle. Happy to switch to `api.add(mint, ...)`
once the token is priced upstream.

Tested with `node test.js projects/miner-gold/index.js` -> ~$14.3k
(333k $MINER locked, matches DexScreener).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Solana staking tracking for MINER.
  - Reports MINER balances held in eligible lock accounts as staked assets.
  - Includes methodology details explaining how locked MINER balances are identified and counted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->