### PR TITLE
feat(subfrost): count the frUSD collateral deployed into Curve 3pool

### DIFF
--- a/registries/sumTokens/data2.js
+++ b/registries/sumTokens/data2.js
@@ -1048,8 +1048,12 @@ module.exports = {
     },
   },
   "subfrost": {
-    "methodology": "Total value of the collateral held by the transparent and verifiable SUBFROST signing group. On bitcoin, all BTC backing frBTC across both deployments, Alkanes and BRC2.0. On ethereum, the USDC and USDT held in the frUSD vault. The frBTC and frUSD minted against these deposits are not counted separately, so nothing is double counted.",
+    "methodology": "Total value of the collateral held by the transparent and verifiable SUBFROST signing group. On bitcoin, all BTC backing frBTC across both deployments, Alkanes and BRC2.0. On ethereum, the collateral backing frUSD: the USDC and USDT held in the frUSD vault, plus the Curve 3pool (3CRV) position the vault deploys its stablecoins into. The frBTC and frUSD minted against these deposits are not counted separately, so nothing is double counted.",
     "bitcoin": { "tvl": { "__btcBook": "subfrost" } },
-    "ethereum": { "owner": "0x95779e7e1c943042255b8a78273fe6de4823cf06", "tokens": [ADDRESSES.ethereum.USDC, ADDRESSES.ethereum.USDT]}
+    "ethereum": { "tokensAndOwners": [
+      [ADDRESSES.ethereum.USDC, "0x95779e7e1c943042255b8a78273fe6de4823cf06"],
+      [ADDRESSES.ethereum.USDT, "0x95779e7e1c943042255b8a78273fe6de4823cf06"],
+      ["0x6c3f90f043a72fa612cbac8115ee7e52bde6e490", "0x5c5d66c82e2c634074661c3e7427668737c70100"],
+    ]}
   }
 }

--- a/registries/sumTokens/data2.js
+++ b/registries/sumTokens/data2.js
@@ -1048,11 +1048,13 @@ module.exports = {
     },
   },
   "subfrost": {
-    "methodology": "Total value of the collateral held by the transparent and verifiable SUBFROST signing group. On bitcoin, all BTC backing frBTC across both deployments, Alkanes and BRC2.0. On ethereum, the collateral backing frUSD: the USDC and USDT held in the frUSD vault, plus the Curve 3pool (3CRV) position the vault deploys its stablecoins into. The frBTC and frUSD minted against these deposits are not counted separately, so nothing is double counted.",
+    "methodology": "Total value of the collateral held by the transparent and verifiable SUBFROST signing group. On bitcoin, all BTC backing frBTC across both deployments, Alkanes and BRC2.0. On ethereum, the collateral backing frUSD: the USDC and USDT held in the frUSD vault, plus the Curve 3pool position the vault deploys its stablecoins into. The frBTC and frUSD minted against these deposits are not counted separately. Note that the 3CRV portion is also part of Curve's own TVL.",
     "bitcoin": { "tvl": { "__btcBook": "subfrost" } },
     "ethereum": { "tokensAndOwners": [
+      // frUSD vault
       [ADDRESSES.ethereum.USDC, "0x95779e7e1c943042255b8a78273fe6de4823cf06"],
       [ADDRESSES.ethereum.USDT, "0x95779e7e1c943042255b8a78273fe6de4823cf06"],
+      // 3CRV held by the vault's 3pool strategy (pool() -> 0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7)
       ["0x6c3f90f043a72fa612cbac8115ee7e52bde6e490", "0x5c5d66c82e2c634074661c3e7427668737c70100"],
     ]}
   }


### PR DESCRIPTION
The `subfrost` ethereum leg only reads the frUSD vault address itself. Since 2026-08-14 the vault deploys its stablecoins into the Curve 3pool, so the adapter has been reporting **$58** against **$24.4k** of actual collateral. This adds the 3CRV holder alongside the vault.

### Measured on-chain

```
vault    0x95779e7e1c943042255b8a78273fe6de4823cf06   0 USDC + 58.67 USDT
strategy 0x5c5d66c82e2c634074661c3e7427668737c70100   23,410.4630 3CRV
         3pool get_virtual_price() = 1.039824       = $24,342.76
total                                                 $24,401.43
```

The strategy contract's `pool()` returns the 3pool (`0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7`), and it was funded exclusively by the vault: USDT out on Aug 14 (18,859.5861 + 1,005.4844) and Aug 15 (5,492.5120), with 1,004.9646 returned, for **24,352.6179 USDT net**.

Two independent cross-checks, so this does not rest on the transfer trail alone:

- frUSD total supply on Alkanes is **24,352.617871** — equal to the net USDT to the 4th decimal.
- Collateral / supply = **1.0020**. The 0.04% shortfall against the 3CRV that 24,352.62 USDT should have minted at the current virtual price is 9.48 3CRV (~$9.86), consistent with 3pool deposit fees.

### Test

```
node test.js subfrost

before:  ethereum 58.62      bitcoin 7.22 M
after:   ethereum 24.40 k    bitcoin 7.22 M
         (3Crv 24.34 k + USDT 58.62)
```

The bitcoin leg is untouched. 3CRV is already priced by `coins.llama.fi` (1.0398237, confidence 0.99), so no LP unwrap is needed — and `unwrapLPsAuto` is uni-v2-only anyway, so it would not classify 3CRV as an LP.

### On double counting — please tell me which you prefer

The 3CRV portion's underlying is inside Curve's own TVL, so at the aggregate level this $24.3k does overlap. I did **not** set `doublecounted`, because the flag is per-protocol and would drag the $7.22M bitcoin leg — clean, non-overlapping collateral — along with it for the sake of 0.33% of protocol TVL. I've stated the overlap in the methodology instead. There is precedent for counting raw 3CRV in `projects/fraxfinance`, which does set the flag.

Happy to go whichever way you'd rather: keep it as is, drop the 3CRV leg, or set the flag.

### One caveat worth recording

This is a hardcoded address, so if the collateral is redeployed again the leg goes quiet rather than erroring. Two concrete cases: the strategy staking its 3CRV into the 3pool gauge (`0xbFcF63294aD7105dEa65aA58F8AE5BE2D9d0952A`, currently holding 0 from this address), or the vault moving to a different venue. I checked whether adding the gauge token pre-emptively would help, but `coins.llama.fi` has no price for it, so it would count as zero either way. We'll open a PR if it moves.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated Ethereum TVL tracking for the frUSD vault to include USDC, USDT, and 3CRV holdings.
  - Clarified that minted frBTC and frUSD are excluded from TVL calculations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->