### PR TITLE
removed morph market from LayerBank adapter (#14580)

### DIFF
--- a/projects/lineabank/index.js
+++ b/projects/lineabank/index.js
@@ -16,7 +16,6 @@ const v2Config = {
   mint: '0x0f225d10dd29D4703D42C5E93440F828bf04D150',
   taiko: '0x803a61d82BaD2743bE35Be5dC6DEA0CccE82C056',
   bsc: '0x8eFdD7396b83Cd53ae7555224A30c41b1A100ffA',
-  morph: '0xD48c646CF9B011D97E31770873985ADD8ed7371c',
   rsk: '0xc30991623fb2a63E6e1B59A29987E1EEE57447bF',
   hemi: '0x16B3A05f1adaCa8F028AAd7C5B0475cC512a0619',
 }
@@ -25,7 +24,6 @@ const insolvantChains = {
   mode: true,
   scroll: true,
   bsquared: true,
-  morph: true,
   linea: true,
   manta: true,
   zklink: true,


### PR DESCRIPTION
Fixes #14580

## Summary
Removes the `morph` entry from `v2Config` and `insolvantChains` in
`projects/lineabank/index.js`

## Description
LayerBank's Morph market (mphBTC) intermittently reports $0 TVL despite
no actual change in balances (#14580). A prior PR (#19196) attempted to
fix this by remapping mphBTC's price to `coingecko:bitcoin` to work
around a pricing-path failure on the token's low liquidity. The
maintainer previously mentioned LayerBank has
deprecated the Morph market, so it shouldn't be tracked at all rather
than patched.

Checking the live app directly at
https://app.layerbank.finance/bank?chain=morph shows Total Supplied
and Total Borrowed both at $0, indicating the market is no longer
active on the protocol's own front end. 

## Testing
Ran `node test.js projects/lineabank/index.js` before and after the
change. Before removal, Morph TVL was ~$1k. After removal, the adapter runs
clean with `morph`/`morph-borrowed` no longer present, and all other
chains report unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the obsolete LayerBank V2 chain configuration.
  * Removed the associated insolvency status from the available configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->