### PR TITLE
sodax: fix staking TVL (read xSODA vault totalAssets)

### DIFF
--- a/projects/sodax/index.js
+++ b/projects/sodax/index.js
@@ -62,18 +62,25 @@ async function sonicTvl(api) {
   return sumTokens2({ api, ownerTokens: sonicHubVaults });
 }
 
-// Sonic-only: SODA held by xSODA and stSoda staking contracts.
+// Sonic-only: staked SODA.
+// SODAX staking uses a two-level vault: user deposits SODA -> receives stSoda
+// (1:1 liquid staking token) -> stSoda is auto-deposited into the xSoda ERC-4626
+// vault (`asset() = stSoda`, `totalAssets()` = total stSoda under management,
+// which equals total SODA staked). Neither contract holds SODA directly, so
+// a naive `balanceOf(SODA)` on either address returns 0. Use the vault's
+// `totalAssets()` to get the true staked amount (matches the SDK's
+// `getStakedSodaAmount` -> `totalStaked` field).
 const SODA_SONIC = '0x7c7d53EEcda37a87ce0D5bf8E0b24512A48dC963';
 const XSODA = '0xADC6561Cc8FC31767B4917CCc97F510D411378d9';
-const STSODA = '0x4333B324102d00392038ca92537DfbB8CB0DAc68';
 
 async function sonicStaking(api) {
-  return sumTokens2({ api, owners: [XSODA, STSODA], tokens: [SODA_SONIC] });
+  const totalStaked = await api.call({ target: XSODA, abi: 'uint256:totalAssets' });
+  api.add(SODA_SONIC, totalStaked);
 }
 
 module.exports = {
   methodology:
-    'TVL sums assets custodied by the SODAX AssetManager on each supported spoke chain plus the Sonic-native assets held in the hub-side sodaX vault tokens (sodaUSDC, sodaUSDT, sodaETH, sodaS). Per-chain AssetManager addresses and supported-token sets are pulled live from the SODAX spoke config API. Money-market supplied collateral is not counted separately because it is the same wrapped representation of assets already locked on spoke AssetManagers. Solver inventory is external and excluded. Staked SODA (xSODA + stSoda) is reported under staking rather than TVL. Non-EVM spokes (Solana, Bitcoin, Stellar, Sui, ICON, NEAR, Stacks, Injective) will be added in a follow-up.',
+    'TVL sums assets custodied by the SODAX AssetManager on each supported spoke chain plus the Sonic-native assets held in the hub-side sodaX vault tokens (sodaUSDC, sodaUSDT, sodaETH, sodaS). Per-chain AssetManager addresses and supported-token sets are pulled live from the SODAX spoke config API. Money-market supplied collateral is not counted separately because it is the same wrapped representation of assets already locked on spoke AssetManagers. Solver inventory is external and excluded. Staked SODA is reported under staking as the xSODA vault totalAssets (the SDK-canonical "totalStaked" figure). Non-EVM spokes (Solana, Bitcoin, Stellar, Sui, ICON, NEAR, Stacks, Injective) will be added in a follow-up.',
 };
 
 Object.values(chainIdToName).forEach((chain) => {


### PR DESCRIPTION
Fixes SODAX staking reporting \$0 on https://defillama.com/protocol/sodax.

**Root cause:** SODAX staking is a two-level vault system:

1. User deposits SODA
2. Receives `stSoda` (`0x4333B324102d00392038ca92537DfbB8CB0DAc68`) — a 1:1 liquid staking token
3. `stSoda` is auto-deposited into the `xSODA` ERC-4626 vault (`0xADC6561Cc8FC31767B4917CCc97F510D411378d9`), where `asset() = stSoda`

Neither `xSODA` nor `stSoda` holds SODA directly, so `balanceOf(SODA, xSODA)` and `balanceOf(SODA, stSoda)` both return 0. The old adapter summed both and reported 0 staked.

**Fix:** Read `xSODA.totalAssets()` — this is what the SODAX SDK's `getStakedSodaAmount` returns as `totalStaked` ([docs](https://docs.sodax.com/developers/packages/foundation/sdk/functional-modules/staking.md)):

> `totalStaked: bigint;      // Total SODA staked (totalAssets from xSODA vault)`

**Verified live via `node test.js projects/sodax/index.js`:**

```
--- staking ---
SODA                      647.71 k
Total: 647.71 k
```

36,037,051 SODA @ \$0.018 = \$647.71k, up from \$0.

**Also updates the methodology string** to remove the misleading reference to a separate `stSoda` staking contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Sonic staking balance calculations by using the vault’s reported total assets.
  * Updated staking totals to more accurately reflect SODA deposited through the vault.
* **Documentation**
  * Clarified the vault-based methodology used to calculate total staked amounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->