### PR TITLE
fix(coinbase-btc): discover custody addresses from PoR and add cbMEGA

### DIFF
--- a/projects/coinbase-ada/index.js
+++ b/projects/coinbase-ada/index.js
@@ -1,17 +1,8 @@
-const sdk = require('@defillama/sdk');
-const { sumTokensExport } = require('../helper/sumTokens');
-
-const ADA_ADDRESSES = [
-  "addr1qyn4lcv64v40a4667j7x3gjmc4wt32dejakwnwxx2geyemp8tlse42e2lmt44a9udz39h32uhz5mn9mvaxuvv53jfnkqc00vz5",
-  "addr1vx6h5wyagdu70ecth9xmcnlnq9jct42nj4mm4ej3fmrcmvgaycmzh",
-  "addr1vxwzm0hd3vpsxg9p7mm386ahul8l08jvq2v6cm7v5gg9p3cx8al02"
-];
+const { reservesTvl } = require('../coinbase-btc/reserves');
 
 module.exports = {
   methodology: "ADA collateral backing CBADA https://www.coinbase.com/cbada/proof-of-reserves",
   cardano: {
-    tvl: sdk.util.sumChainTvls([
-      sumTokensExport({ owners: ADA_ADDRESSES }),
-    ]),
+    tvl: reservesTvl('cbada'),
   },
 };

--- a/projects/coinbase-btc/index.js
+++ b/projects/coinbase-btc/index.js
@@ -1,59 +1,33 @@
 const sdk = require('@defillama/sdk');
-const { sumTokensExport } = require('../helper/sumTokens');
-const { getConfig } = require('../helper/cache');
-const bitcoinAddressBook = require('../helper/bitcoin-book/index.js')
-
-
-const ADA_ADDRESSES = [
-  "addr1qyn4lcv64v40a4667j7x3gjmc4wt32dejakwnwxx2geyemp8tlse42e2lmt44a9udz39h32uhz5mn9mvaxuvv53jfnkqc00vz5",
-  "addr1vx6h5wyagdu70ecth9xmcnlnq9jct42nj4mm4ej3fmrcmvgaycmzh",
-  "addr1vxwzm0hd3vpsxg9p7mm386ahul8l08jvq2v6cm7v5gg9p3cx8al02"
-];
-
-const XRP_ADDRESSES = [
-    "rKopBmtBSMmUD6NCFNwGTG3b9ZxNzf7Tt4",
-    "rU1DGbMWhrFSJLPcrtKuV5iPyD1wrVgeaU",
-    "rMbVVXFHaBpSpJhdR1xvy7dkQL1gtnkopg",
-    "rGsMk4nK4M8MtcjVbjUeaJBppjjKpXyJ7F"
-];
-
-const DOGE_ADDRESSES = [
-  "DLuceb7v8vHknepvYRTzz5bSMUAqax8vTN",
-  "DCqkF26vcqG1FGJiB7L73jyTDeFkjeEPvJ",
-  "DNhLqkURqaQDW4f4J9wxtVzRw1XxhkjZ6m"
-  ];
+const ADDRESSES = require('../helper/coreAssets.json');
+const { getReserves, reservesTvl } = require('./reserves');
 
 async function btcTvl(api) {
-  const config = await getConfig('coinbase-cbbtc-proof-of-reserves', 'https://www.coinbase.com/cbbtc/proof-of-reserves.json')
+  const config = await getReserves('cbbtc')
   const balances = {}
   const totalBtc = config.reserveAddresses.reduce((sum, item) => sum + parseFloat(item.balance.amount), 0)
   sdk.util.sumSingleBalance(balances, 'bitcoin', totalBtc)
   return balances
 }
 
-
-
 module.exports = {
-    methodology: "TVL tracks wrapped tokens backed 1:1 by assets held by Coinbase",
-    cardano: {
-      tvl: sdk.util.sumChainTvls([
-        sumTokensExport({ owners: ADA_ADDRESSES }),
-      ]),
-    },
-    ripple: {
-      tvl: sdk.util.sumChainTvls([
-        sumTokensExport({ owners: XRP_ADDRESSES }),
-      ]),
-    },
-    bitcoin: {
-        tvl: btcTvl,
-    },
-    litecoin: {
-        tvl: sdk.util.sumChainTvls([
-          sumTokensExport({ owners: bitcoinAddressBook.coinbaseltc }),
-        ]),
-    },
-    doge: {
-      tvl: sumTokensExport({ owners: DOGE_ADDRESSES }),
-    },
-  };
+  methodology: "TVL tracks wrapped tokens backed 1:1 by assets held by Coinbase.",
+  cardano: {
+    tvl: reservesTvl('cbada'),
+  },
+  ripple: {
+    tvl: reservesTvl('cbxrp'),
+  },
+  bitcoin: {
+    tvl: btcTvl,
+  },
+  litecoin: {
+    tvl: reservesTvl('cbltc'),
+  },
+  doge: {
+    tvl: reservesTvl('cbdoge'),
+  },
+  megaeth: {
+    tvl: reservesTvl('cbmega', [ADDRESSES.megaeth.MEGA]),
+  },
+};

--- a/projects/coinbase-btc/reserves.js
+++ b/projects/coinbase-btc/reserves.js
@@ -1,0 +1,16 @@
+const { sumTokens } = require('../helper/sumTokens');
+const { getConfig } = require('../helper/cache');
+
+// Coinbase publishes one proof-of-reserves feed per wrapped asset, all in the same schema:
+// { reservesTotal, wrappedAssetsTotal, reserveAddresses: [{ address, balance: { amount } }] }
+const getReserves = (asset) => getConfig(`coinbase-${asset}-proof-of-reserves`, `https://www.coinbase.com/${asset}/proof-of-reserves.json`)
+
+const reservesTvl = (asset, tokens) => async (api) => {
+  const { reserveAddresses } = await getReserves(asset)
+  return sumTokens({ api, owners: reserveAddresses.map(i => i.address), tokens })
+}
+
+module.exports = {
+  getReserves,
+  reservesTvl,
+}

--- a/projects/coinbase-ltc/index.js
+++ b/projects/coinbase-ltc/index.js
@@ -1,12 +1,8 @@
-const sdk = require('@defillama/sdk');
-const { sumTokensExport } = require('../helper/sumTokens');
-const bitcoinAddressBook = require('../helper/bitcoin-book/index.js')
+const { reservesTvl } = require('../coinbase-btc/reserves');
 
 module.exports = {
   methodology: "LTC collateral backing CBLTC. https://www.coinbase.com/en-sg/cbltc/proof-of-reserves",
   litecoin: {
-    tvl: sdk.util.sumChainTvls([
-      sumTokensExport({ owners: bitcoinAddressBook.coinbaseltc }),
-    ]),
+    tvl: reservesTvl('cbltc'),
   },
 };

--- a/projects/coinbase-xrp/index.js
+++ b/projects/coinbase-xrp/index.js
@@ -1,18 +1,8 @@
-const sdk = require('@defillama/sdk');
-const { sumTokensExport } = require('../helper/sumTokens');
-
-const XRP_ADDRESSES = [
-"rKopBmtBSMmUD6NCFNwGTG3b9ZxNzf7Tt4",
-"rU1DGbMWhrFSJLPcrtKuV5iPyD1wrVgeaU",
-"rMbVVXFHaBpSpJhdR1xvy7dkQL1gtnkopg",
-"rGsMk4nK4M8MtcjVbjUeaJBppjjKpXyJ7F"
-];
+const { reservesTvl } = require('../coinbase-btc/reserves');
 
 module.exports = {
   methodology: "XRP collateral backing CBXRP https://www.coinbase.com/en-in/cbxrp/proof-of-reserves",
   ripple: {
-    tvl: sdk.util.sumChainTvls([
-      sumTokensExport({ owners: XRP_ADDRESSES }),
-    ]),
+    tvl: reservesTvl('cbxrp'),
   },
 };

--- a/projects/helper/bitcoin-book/index.js
+++ b/projects/helper/bitcoin-book/index.js
@@ -1037,12 +1037,6 @@ module.exports = {
     "bc1q0gw7fexuwthyf9wwzrjn4h0flj5veflwgzdxx0727gt9upfk0cfqfjv42k",
     "bc1qfpk3fj2u9kaw8qq96snm72dws5hyxxym5tf8tn",
   ],
-  coinbaseltc: [
-    "LTbMyvoyfSuQNqG5cGihin6BCbiZay11rU",
-    "LVeXnSCw2ci7qq2EGcNwjZqhQ73KrJHNJE",
-    "ltc1qhac8t52gdh8fzeft4ygzxn05nluwwecjrzel99",
-    "LP3k3DmN21xmCay3b5yReLKQKvViCnDPhi",
-  ],
   prosper: [
     "bc1qcrdvx3dvq35kawsp02033pwla244rr6hptg982", //https://app.prosper-fi.com/stats#dao-treasury
   ],


### PR DESCRIPTION
Discover Coinbase Bridge custody addresses from Coinbase's Proof-of-Reserves feed instead of stale hardcoded lists, and add the missing cbMEGA leg.

## Changes

* Added shared PoR-based custody discovery and `reservesTvl()` helper.
* Replaced stale XRP/DOGE/ADA/LTC address lists.
* Added the missing `megaeth` / cbMEGA leg.
* Removed the unused `coinbaseltc` address-book entry.

## Validation

* PoR reserves verified against native-chain balances.
* Wrapped supply matches the corresponding PoR totals.

| Leg       |        TVL |
| --------- | ---------: |
| Bitcoin   |     $6.20B |
| XRP       |   $114.04M |
| Cardano   |     $9.49M |
| Doge      |     $8.18M |
| Litecoin  |     $3.59M |
| MegaETH   |   $803.91K |
| **Total** | **$6.33B** |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for Coinbase’s MegaETH reserves.
  * Improved Coinbase reserve data retrieval across supported assets.

* **Improvements**
  * Updated Cardano, Bitcoin, XRP, Litecoin, and Dogecoin TVL calculations to use shared reserve data.
  * Improved consistency and accuracy of Coinbase proof-of-reserves reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->