### PR TITLE
multipli: make the rwaUSDi blacklist actually match, it has never fired

### DIFF
--- a/projects/multipli/index.js
+++ b/projects/multipli/index.js
@@ -13,11 +13,15 @@ const tvl = async (api) => {
   const { data } = await axios.get(API)
   const payload = data.payload?.tvl_data ?? data.payload ?? {}
   const balances = payload[api.chain] ?? {}
+  // The payload is keyed by bare token addresses, so the chain-prefixed key this
+  // used to build ("ethereum:0xa39986f9...") could never match "0xa39986f9..."
+  // and the filter was a no-op. Match the bare address, and keep tolerating a
+  // chain-prefixed key in case the shape changes again.
   const blacklisted = rwaUSDis[api.chain]?.toLowerCase()
   if (blacklisted) {
-    const target = `${api.chain}:${blacklisted}`
     for (const key of Object.keys(balances)) {
-      if (key.toLowerCase() === target) delete balances[key]
+      const address = key.toLowerCase().split(':').pop()
+      if (address === blacklisted) delete balances[key]
     }
   }
   return balances


### PR DESCRIPTION
The rwaUSDi blacklist added in #19421 has never been able to fire.

## The bug

It builds a chain-prefixed key:

```js
const target = `${api.chain}:${blacklisted}`
for (const key of Object.keys(balances)) {
  if (key.toLowerCase() === target) delete balances[key]
}
```

while the API keys balances by bare token addresses. From the live response today, all four chains it serves:

```
ethereum: 0xdAC17F958D2ee523a2206206994597C13D831ec7=3990220655398
          0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48=25897518254385
          0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599=4464092056
avax:     0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E=13205005072  ...
bsc:      0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d=552208884726201949072795  ...
monad:    0x754704Bc059F8C67012fEd69BC8A327a5aafb603=8809358425
```

No chain prefix anywhere, so `"0xa39986f9..."` was being compared against `"ethereum:0xa39986f9..."` and never matched.

Now it compares the bare address, and still tolerates a chain-prefixed key in case the shape changes again.

## Credit

**0xshubhs** found this, on #20236, while looking at something else, and offered to send it separately. Ten days on it was still unsent so I have picked it up rather than leave a dead filter in the tree. Happy to close this in favour of their own PR if they would prefer that.

## Verified by making it fire

Since rwaUSDi is not in the payload today, the only honest way to test the match is to point the blacklist at a token that *is*. Used USDT on ethereum and ran both versions in the same shell:

| | ethereum TVL | |
|---|---|---|
| master + USDT blacklisted | 32.71 M | filter never fires |
| fixed + USDT blacklisted | **28.73 M** | drops 3.98 M |

USDT's payload entry is `3990220655398` at 6 decimals, so $3.99M, which is the drop. That is the match working, measured rather than asserted.

Then restored the real rwaUSDi map, which leaves today's output untouched:

```
ethereum   32.71 M
bsc       725.76 k
base / monad / arbitrum / avax   0.00
total      33.44 M
```

## So this changes nothing today, deliberately

It is preventive, and here is why it is worth having. `projects/afiprotocol` counts **$225.3M** of `afi-rwaUSDi`, which is a 1:1 wrapper of this same rwaUSDi on ethereum, base and monad (verified on chain in #20236: `exchangeRate()` is 1e18, both fee bps are 0, and the oracle has emitted one `ExchangeRateUpdated` ever, at deployment, with `newRate = 1000000`).

Right now **two independent things** are keeping that from double counting: rwaUSDi having dropped out of Multipli's response on its own, and a filter that would not have caught it if it came back. This fixes the second. #20236 is the open question about how the first should be resolved, and it does not need answering for this PR to be correct either way.

## Separate observation, not fixed here

This adapter returns $33.44M locally, but `api.llama.fi/protocol/multipli.fi` reports `currentChainTvls: {}` with a **zero-length series**. So nothing is being published at all, even after #20416 fixed the payload shape. I have not established why and deliberately have not touched it, to keep this PR to one thing. Flagging it because the CI run on this PR executes the adapter from a GitHub runner, so if the API is unreachable from a datacenter IP the check here will say so.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved blacklist matching by supporting both chain-prefixed and unprefixed token addresses.
  * Blacklisted entries are now reliably removed regardless of address format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->