### PR TITLE
mt-gox entity points at Silk Road's addresses, double counting 69,370 BTC ($4.41B)

### DIFF
--- a/projects/entities/mt-gox.js
+++ b/projects/entities/mt-gox.js
@@ -1,5 +1,0 @@
-const { treasuryExports } = require("../helper/treasury")
-const bitcoinAddressBook = require('../helper/bitcoin-book/index.js')
-
-const config = { bitcoin: { owners: bitcoinAddressBook.mtGox } }
-module.exports = treasuryExports(config)

--- a/projects/entities/mt-gox.js
+++ b/projects/entities/mt-gox.js
@@ -1,5 +1,5 @@
 const { treasuryExports } = require("../helper/treasury")
 const bitcoinAddressBook = require('../helper/bitcoin-book/index.js')
 
-const config = { bitcoin: { owners: bitcoinAddressBook.mtGoxEntities } }
+const config = { bitcoin: { owners: bitcoinAddressBook.mtGox } }
 module.exports = treasuryExports(config)

--- a/projects/helper/bitcoin-book/index.js
+++ b/projects/helper/bitcoin-book/index.js
@@ -618,13 +618,6 @@ module.exports = {
     "3NbdrezMzAVVfXv5MTQJn4hWqKhYCTCJoB",
     "34VXKa5upLWVYMXmgid6bFM4BaQXHxSUoL",
   ],
-  mtGoxEntities: [
-    // https://www.reddit.com/r/CryptoCurrency/comments/li1fw7/btc_silkroad_stash_seized_nov_2020_by_the_feds/
-    "bc1qa5wkgaew2dkv56kfvj49j0av5nml45x9ek9hz6",
-    "bc1qmxjefnuy06v345v6vhwpwt05dztztmx4g3y7wp",
-    "bc1qf2yvj48mzkj7uf8lc2a9sa7w983qe256l5c8fs",
-    "bc1qe7nk2nlnjewghgw4sgm0r89zkjzsurda7z4rdg",
-  ],
   silkroadFBIEntities: [
     // https://www.reddit.com/r/CryptoCurrency/comments/li1fw7/btc_silkroad_stash_seized_nov_2020_by_the_feds/
     "bc1qa5wkgaew2dkv56kfvj49j0av5nml45x9ek9hz6",


### PR DESCRIPTION
`projects/entities/mt-gox.js` reads `bitcoinAddressBook.mtGoxEntities`, and that key is a **byte-identical copy of `silkroadFBIEntities`** — same four addresses, same order, and the same source comment, which links a reddit post titled *"BTC silkroad stash seized Nov 2020 by the feds"*:

```js
  mtGoxEntities: [
    // https://www.reddit.com/r/CryptoCurrency/comments/li1fw7/btc_silkroad_stash_seized_nov_2020_by_the_feds/
    "bc1qa5wkgaew2dkv56kfvj49j0av5nml45x9ek9hz6",
    ...
  ],
  silkroadFBIEntities: [
    // https://www.reddit.com/r/CryptoCurrency/comments/li1fw7/btc_silkroad_stash_seized_nov_2020_by_the_feds/
    "bc1qa5wkgaew2dkv56kfvj49j0av5nml45x9ek9hz6",
    ...
  ],
```

No Mt. Gox address appears in it at all.

## Both entities report the same coins

Run against master, identical output:

```
entities/mt-gox             bitcoin   4.41 B
entities/silkroad-fbifunds  bitcoin   4.41 B
```

That is one address, `bc1qa5wkgaew2dkv56kfvj49j0av5nml45x9ek9hz6`, holding `6,937,018,458,660` sats = **69,370.18 BTC**, which at $63,596.64 is **$4.41B counted twice**.

69,370 BTC is also the documented "Individual X" seizure of November 2020, which is Silk Road, not Mt. Gox. So the attribution is wrong on the facts, not merely duplicated.

## The real addresses were never lost

They are already in the book under the `mtGox` key — 79 of them — and **nothing consumes that key**. They arrived in aab9b2698 (#6105) as `projects/mt-gox/index.js` via `cexExports`, and survived the bitcoin-book migration; only the entity adapter ended up wired to the wrong key.

So this is a one-word fix plus a dead-data removal, not a research project.

## After

```
entities/mt-gox             bitcoin   561.44
entities/silkroad-fbifunds  bitcoin   4.41 B    unchanged
```

$561.44 is what those 79 addresses actually hold today, which is what you would expect after the 2024-2025 creditor distributions. Low, but real and correctly attributed, rather than $4.41B of someone else's coins.

`mtGoxEntities` is dropped since it was a pure duplicate of `silkroadFBIEntities` and now has no consumer.

## Verified with the repo's own checker

`npm run check-bitcoin-duplicates`, same rows before and after:

```
before   'mtGoxEntities, silkroadFBIEntities, silkroad'
after    'silkroadFBIEntities, silkroad'
```

The remaining `silkroadFBIEntities` / `silkroad` pair is harmless: `silkroad` has no consumer either, so nothing counts those addresses twice. I also confirmed `mtGox`'s 79 addresses introduce no new duplicate rows of their own.

## How I got here

Came out of #12913, which asks how to clear the duplicates that checker reports. Worth recording what that turned up, since it changes the shape of that issue:

- the FBTC duplicates named there (`fbtc`/`lombard` 7 addresses, `pumpBTC`/`fbtc` 3) **all hold exactly 0 sats**, so there is no double count to fix in any of them
- `projects/fbtc/index.js` does not exist upstream at all; the issue links a fork
- more broadly, most of the checker's rows pair a consumed book key against an unconsumed one (`binance` vs `binanceFetcher`, `esbtc` vs `exsatCreditStaking`, `merlin` vs `exsatCreditStaking`), so they are duplicates in the address book rather than in anyone's TVL. Only one `getBTCExport` call site exists in the repo, and the consumed keys are the ones reached as properties.

`mtGoxEntities` / `silkroadFBIEntities` was the one pair where **both sides are live**, which is why it is the only one worth a code change. I will write the rest up on #12913 separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Mt. Gox treasury configuration to use the correct Bitcoin address source.
  * Removed the obsolete Mt. Gox address list to prevent outdated address references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->