### PR TITLE
sodax: correct positioning language + request metadata update

### DIFF
--- a/projects/sodax/index.js
+++ b/projects/sodax/index.js
@@ -80,7 +80,7 @@ async function sonicStaking(api) {
 
 module.exports = {
   methodology:
-    'TVL sums assets custodied by the SODAX AssetManager on each supported spoke chain plus the Sonic-native assets held in the hub-side sodaX vault tokens (sodaUSDC, sodaUSDT, sodaETH, sodaS). Per-chain AssetManager addresses and supported-token sets are pulled live from the SODAX spoke config API. Money-market supplied collateral is not counted separately because it is the same wrapped representation of assets already locked on spoke AssetManagers. Solver inventory is external and excluded. Staked SODA is reported under staking as the xSODA vault totalAssets (the SDK-canonical "totalStaked" figure). Non-EVM spokes (Solana, Bitcoin, Stellar, Sui, ICON, NEAR, Stacks, Injective) will be added in a follow-up.',
+    'TVL sums assets custodied by the SODAX AssetManager on each supported blockchain network plus the Sonic-native assets held in the hub-side sodaVariants (sodaUSDC, sodaUSDT, sodaETH, sodaS). Per-network AssetManager addresses and supported-token sets are pulled live from the SODAX spoke config API. Money-market supplied collateral is not counted separately because it is the same wrapped representation of assets already locked on the AssetManagers. Independent solver inventory is external and excluded. Staked SODA is reported under staking as the xSODA vault totalAssets (the SDK-canonical "totalStaked" figure). SODAX is live on 21 blockchain networks total; this adapter currently covers the 12 EVM networks. Non-EVM networks (Solana, Bitcoin, Stellar, Sui, ICON, NEAR, Stacks, Injective) and Redbelly will be added in follow-up PRs.',
 };
 
 Object.values(chainIdToName).forEach((chain) => {


### PR DESCRIPTION
Two things — one code change, one metadata request for a DefiLlama admin.

## Code change (this PR)

Updates the SODAX adapter methodology string to use accurate positioning language:

- Removes "bridge" framing. SODAX is a **cross-network execution system**, not a bridge. Per the [SODAX voice guardrails](https://marketing.sodax.com/mcp), "bridge" is a prohibited term. The rebrand-away-from-bridge is intentional: SODAX coordinates intent-based routing and settlement via independent solvers, not passive asset transfers.
- Updates chain-count framing: SODAX is live on **21 blockchain networks total**. This adapter currently covers 12 EVM networks; non-EVM (Solana, Bitcoin, Stellar, Sui, ICON, NEAR, Stacks, Injective) + Redbelly will follow in separate PRs.

Adapter behavior is unchanged. `node test.js projects/sodax/index.js` still returns the same $1.86M TVL.

## Metadata update request (for a DefiLlama maintainer)

The current DefiLlama listing at https://defillama.com/protocol/sodax has metadata that carried over from the initial PR (my fault — I used the wrong framing there). Requesting corrections:

**Category:** `Bridge` → `Cross Chain`

Reasoning: SODAX is not a bridge protocol. It is a cross-network execution layer that lets users declare intents (swap X on chain A for Y on chain B, borrow against multi-network collateral, etc.), and independent solvers quote and fill against a shared liquidity layer. `Cross Chain` is the closest fit in the DefiLlama taxonomy that doesn't misrepresent the product.

**Description:**

Old (incorrect): _"SODAX, a cross-chain bridge and money market built around a Sonic-hosted hub with spoke AssetManagers."_

New (proposed): _"SODAX is a cross-network execution system that lets users move, exchange, lend, and settle assets across 21 blockchain networks through intent-based routing. Independent solvers quote and fill user intents, coordinated by a Sonic-hosted hub. Includes an on-chain money market and a shared liquidity layer."_

Happy to iterate on the wording if a maintainer prefers a different phrasing — the essentials are (a) no "bridge", (b) 21 networks not 12, (c) "execution system" / "cross-network" / "intent-based" framing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that SODAX supports 21 networks overall, with the current adapter covering 12 EVM networks.
  * Identified Redbelly as planned for future support.
  * Updated terminology to consistently refer to “blockchain networks” and “sodaVariants.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->