### PR TITLE
accountable: exclude vaults not yet publicly listed

### DIFF
--- a/projects/accountable/index.js
+++ b/projects/accountable/index.js
@@ -37,6 +37,27 @@ const EXTRA_VAULTS = {
     ],
 }
 
+// Deployed on-chain but not yet publicly listed on the Accountable platform —
+// excluded from TVL until they are.
+const EXCLUDED_STRATEGIES = {
+    ethereum: [
+        '0x6378767e76ab068b6b1a01bd6e200beca339d21c',
+        '0x93f0b21693bf992417317b4074af4ee10d4e7d3a',
+        '0x8a5afc1d1efccf72cbb6daa885112f36da2682b4',
+        '0xc3edd8b28c41749eed38c2a33a78e3e046dfb876',
+        '0xb072cb45e87bb8704c38297b9f6ad02f8acc82a7',
+    ],
+    monad: [
+        '0xb66adea8a43d5c1d2f962a8c69f67a859425c293',
+        '0xb52fb6b4fda374859a21988ed48bf0ddc8d95e30',
+        '0x78f9486c71371bb5af50cbcdf4bacdc298ec8a97',
+        '0x0d58d3a21adc8f60c81c00c13e7363cc56c6e061',
+        '0xa783b87047dcdaf5d84f4843fae85a6c9e3343af',
+        '0x945dc31b38c811a0188b5b30cf1ea7721666cf7c',
+        '0x33ca98cfca7f25735d8719e67f616fcc44d7771e',
+    ],
+}
+
 const abis = {
     strategyProxies: 'function strategyProxies(uint256) view returns (address)',
     strategyVaults: 'function strategyVaults(address) view returns (address)',
@@ -50,6 +71,9 @@ async function getVaults(api) {
     const vaults = new Set()
     const batchSize = 20
     const factories = FACTORIES[api.chain]
+    const excludedStrategies = new Set(
+        (EXCLUDED_STRATEGIES[api.chain] || []).map((s) => s.toLowerCase())
+    )
 
     for (const factory of factories) {
         for (let start = 0; ; start += batchSize) {
@@ -61,8 +85,12 @@ async function getVaults(api) {
                 calls: indexes.map((i) => ({ params: [i] })),
                 permitFailure: true,
             })
-            const validStrategies = strategies.filter((s) => s && s !== NULL_ADDRESS)
-            if (!validStrategies.length) break
+            const allStrategies = strategies.filter((s) => s && s !== NULL_ADDRESS)
+            if (!allStrategies.length) break
+            const validStrategies = allStrategies.filter(
+                (s) => !excludedStrategies.has(s.toLowerCase())
+            )
+            if (!validStrategies.length) continue
 
             const factoryVaults = await api.multiCall({
                 target: factory,


### PR DESCRIPTION
These strategy addresses are deployed on-chain but not yet publicly listed on our platform, so they should not be counted in TVL until they are.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Excluded unpublished strategies from vault listings.
  * Improved vault loading so batches containing only excluded strategies no longer stop the listing process prematurely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->