### PR TITLE
Add FairyLaunch TVL adapter for BSC

### DIFF
--- a/projects/fairylaunch/index.js
+++ b/projects/fairylaunch/index.js
@@ -1,0 +1,68 @@
+const FACTORY = '0x28163d7943AA6715a9559D468B29c0343412E236';
+
+const LAUNCH_INFO_ABI = {
+  components: [
+    { name: 'launchId', type: 'uint256' },
+    { name: 'creator', type: 'address' },
+    { name: 'treasury', type: 'address' },
+    { name: 'token', type: 'address' },
+    { name: 'bondingCurve', type: 'address' },
+    { name: 'graduated', type: 'bool' },
+    { name: 'createdAt', type: 'uint256' },
+    { name: 'graduatedAt', type: 'uint256' },
+    { name: 'name', type: 'string' },
+    { name: 'symbol', type: 'string' },
+    { name: 'metadataUri', type: 'string' },
+  ],
+  name: 'LaunchInfo',
+  type: 'tuple',
+};
+
+async function tvl(api) {
+  const totalLaunches = await api.call({
+    target: FACTORY,
+    abi: 'uint256:totalLaunches',
+  });
+
+  const bondingCurves = [];
+
+  for (let i = 1; i <= Number(totalLaunches); i++) {
+    try {
+      const launch = await api.call({
+        target: FACTORY,
+        abi: {
+          inputs: [{ name: 'launchId', type: 'uint256' }],
+          name: 'getLaunch',
+          outputs: [LAUNCH_INFO_ABI],
+          stateMutability: 'view',
+          type: 'function',
+        },
+        params: [i],
+      });
+
+      if (!launch.graduated && launch.bondingCurve !== '0x0000000000000000000000000000000000000000') {
+        bondingCurves.push(launch.bondingCurve);
+      }
+    } catch (e) {
+      // Ignorar errores individuales
+    }
+  }
+
+  const ethReserves = await api.multiCall({
+    calls: bondingCurves.map(target => ({ target })),
+    abi: 'uint256:ethReserve',
+    permitFailure: true,
+  });
+
+  ethReserves.forEach((reserve) => {
+    if (reserve && reserve > 0) {
+      api.addGasToken(reserve);
+    }
+  });
+}
+
+module.exports = {
+  bsc: {
+    tvl,
+  },
+};


### PR DESCRIPTION
## FairyLaunch TVL Adapter

### Protocol Description
FairyLaunch is a Pump.fun style launchpad on BSC using bonding curves. Each launch creates a dedicated BondingCurve where users trade tokens with native BNB.

### Chain
BSC Mainnet

### TVL Methodology
Sum of ethReserve from all non-graduated BondingCurves discovered via LaunchFactory.getLaunch().

### Contracts
- LaunchFactory: 0x28163d7943AA6715a9559D468B29c0343412E236
- Example BondingCurve: 0x3014646079673048abaa2d84c9a197eefcde7b9b

---

## New Listing Information

##### Name (to be shown on DefiLlama):
FairyLaunch

##### Twitter Link:
https://x.com/FairyLaunch

##### List of audit links if any:
N/A

##### Website Link:
https://fairylaunch.xyz

##### Logoth rounded borders):
https://fairylaunch.xyz/logo.png
##### Current TVL:
$1.97 USD

##### Treasury Addresses (if the protocol has treasury):
N/A

##### Chain:
BSC

##### Coingecko ID:
(leave empty if not listed)

##### Coinmarketcap ID:
(leave empty if not listed)

##### Short Description (to be shown on DefiLlama):
FairyLaunch is a Pump.fun style launchpad on BSC enabling instant token launches using bonding curves with native BNB trading.


##### Category:
Launchpad

##### Oracle Provider(s):
No external oracle. Uses on-chain bonding curve pricing (quoteBuy/quoteSell).

##### Implementation Details:
N/A - No external oracle used.

##### Documentation/Proof:
https://bscscan.com/address/0x28163d7943AA6715a9559D468B29c0343412E236#code

##### forkedFrom:
N/A

##### methodology:
TVL = sum of ethReserve from all non-graduated BondingCurves. Each BondingCurve is discovered via LaunchFactory.getLaunch(launchId). Graduated curves are excluded.

##### Github org/user:
https://github.com/FairyLaunch

##### Does this project have a referral program?
No