### PR TITLE
Add HyperHAM (Hyperliquid L1)

### DIFF
--- a/projects/hyperham/index.js
+++ b/projects/hyperham/index.js
@@ -14,8 +14,10 @@ const { sumTokens2 } = require('../helper/unwrapLPs')
              blacklisted out of this bucket — it is protocol inventory, not a reserve.
              Both assets in this bucket are core assets, so tvl does not depend on wHAM
              having a price feed.
-  ownTokens  HAM and wHAM held by the multisig. Protocol inventory, reported separately
-             so it is never counted as backing for itself.
+  ownTokens  HAM and wHAM held by the multisig, plus the wHAM leg of protocol-owned
+             liquidity. Protocol inventory, reported separately so it is never counted as
+             backing for itself. The LP has two legs and both are treasury-owned — counting
+             only the WHYPE one would drop real inventory from the report.
   borrowed   WHYPE lent by the Cooler desk and still outstanding. Those tokens have left
              the multisig and sit with borrowers, so they are reported here instead of in
              tvl — the same treatment Olympus gives Cooler Loans debt.
@@ -32,19 +34,22 @@ const OWN_TOKENS = [HAM, WHAM]
 
 // The protocol-owned Ramses position is a Solidly-style pair whose symbol
 // ("Volatile - WHYPE/wHAM") does not match the repo's isLP heuristic, so `resolveLP` leaves
-// it as an unpriced LP token. It is unwrapped explicitly here. Only the WHYPE side is added:
-// the wHAM side is the protocol's own token and belongs in ownTokens, not in TVL.
-const addProtocolOwnedLiquidity = async (api) => {
+// it as an unpriced LP token. It is unwrapped explicitly here instead. Both legs are
+// returned and each goes to the bucket it belongs in: WHYPE to tvl, wHAM to ownTokens.
+const getProtocolOwnedLiquidity = async (api) => {
   const [balance, supply, reserves, token0] = await Promise.all([
     api.call({ target: RAMSES_WHYPE_WHAM, abi: 'erc20:balanceOf', params: [TREASURY] }),
     api.call({ target: RAMSES_WHYPE_WHAM, abi: 'uint256:totalSupply' }),
     api.call({ target: RAMSES_WHYPE_WHAM, abi: 'function getReserves() view returns (uint256 reserve0, uint256 reserve1, uint256 blockTimestampLast)' }),
     api.call({ target: RAMSES_WHYPE_WHAM, abi: 'address:token0' }),
   ])
-  if (!+supply || !+balance) return
+  if (!+supply || !+balance) return null
   const isToken0 = token0.toLowerCase() === WHYPE.toLowerCase()
-  const whypeReserve = isToken0 ? reserves.reserve0 : reserves.reserve1
-  api.add(WHYPE, (BigInt(whypeReserve) * BigInt(balance)) / BigInt(supply))
+  const share = (reserve) => (BigInt(reserve) * BigInt(balance)) / BigInt(supply)
+  return {
+    whype: share(isToken0 ? reserves.reserve0 : reserves.reserve1),
+    wham: share(isToken0 ? reserves.reserve1 : reserves.reserve0),
+  }
 }
 
 const tvl = async (api) => {
@@ -54,14 +59,21 @@ const tvl = async (api) => {
     tokens: [WHYPE, ADDRESSES.null],
     blacklistedTokens: OWN_TOKENS,
   })
-  await addProtocolOwnedLiquidity(api)
+  const pol = await getProtocolOwnedLiquidity(api)
+  // Lowercase: sumTokens2 writes lowercased keys, and api.add does not normalize — a
+  // checksummed address here would create a second balance entry for the same token.
+  if (pol) api.add(WHYPE.toLowerCase(), pol.whype)
 }
 
-const ownTokens = async (api) => sumTokens2({
-  api,
-  owners: [TREASURY],
-  tokens: OWN_TOKENS,
-})
+const ownTokens = async (api) => {
+  await sumTokens2({
+    api,
+    owners: [TREASURY],
+    tokens: OWN_TOKENS,
+  })
+  const pol = await getProtocolOwnedLiquidity(api)
+  if (pol) api.add(WHAM.toLowerCase(), pol.wham)
+}
 
 const borrowed = async (api) => {
   const receivables = await api.call({ target: COOLER_VAULT, abi: 'uint256:reserveReceivables' })

--- a/projects/hyperham/index.js
+++ b/projects/hyperham/index.js
@@ -1,0 +1,84 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+const { sumTokens2 } = require('../helper/unwrapLPs')
+
+/*
+  HyperHAM (HAM Protocol) — HyperEVM (chain key `hyperliquid`)
+
+  HAM is a rebasing ERC-20 backed by a HYPE-denominated reserve held in the protocol
+  multisig. The protocol's measurable value is that reserve, so TVL is measured the way
+  Olympus's is (projects/olympus): assets held by the treasury, excluding the protocol's
+  own token and the own-token side of protocol-owned liquidity.
+
+  tvl        Reserve assets the multisig holds: WHYPE, native HYPE, and the WHYPE side of
+             protocol-owned Ramses liquidity. The LP is unwrapped and its wHAM side is
+             blacklisted out of this bucket — it is protocol inventory, not a reserve.
+             Both assets in this bucket are core assets, so tvl does not depend on wHAM
+             having a price feed.
+  ownTokens  HAM and wHAM held by the multisig. Protocol inventory, reported separately
+             so it is never counted as backing for itself.
+  borrowed   WHYPE lent by the Cooler desk and still outstanding. Those tokens have left
+             the multisig and sit with borrowers, so they are reported here instead of in
+             tvl — the same treatment Olympus gives Cooler Loans debt.
+*/
+
+const TREASURY = '0xF61D218b1429243d7F5937bCB85A4B8b41301CCa'
+const HAM = '0xd62DcC1E28D646Db54E2204A40980F9db28e0363'
+const WHAM = '0xD48ad2f34Ce9071ac130F55237c030643C5eeDe6'
+const RAMSES_WHYPE_WHAM = '0x6cCA1C5a88A391f4e55f69E7BBA13e42A813BaD5'
+const COOLER_VAULT = '0x4B184A9f7DE61A3254B35Bb2F0295D68B0C3221e'
+
+const WHYPE = ADDRESSES.hyperliquid.WHYPE
+const OWN_TOKENS = [HAM, WHAM]
+
+// The protocol-owned Ramses position is a Solidly-style pair whose symbol
+// ("Volatile - WHYPE/wHAM") does not match the repo's isLP heuristic, so `resolveLP` leaves
+// it as an unpriced LP token. It is unwrapped explicitly here. Only the WHYPE side is added:
+// the wHAM side is the protocol's own token and belongs in ownTokens, not in TVL.
+const addProtocolOwnedLiquidity = async (api) => {
+  const [balance, supply, reserves, token0] = await Promise.all([
+    api.call({ target: RAMSES_WHYPE_WHAM, abi: 'erc20:balanceOf', params: [TREASURY] }),
+    api.call({ target: RAMSES_WHYPE_WHAM, abi: 'uint256:totalSupply' }),
+    api.call({ target: RAMSES_WHYPE_WHAM, abi: 'function getReserves() view returns (uint256 reserve0, uint256 reserve1, uint256 blockTimestampLast)' }),
+    api.call({ target: RAMSES_WHYPE_WHAM, abi: 'address:token0' }),
+  ])
+  if (!+supply || !+balance) return
+  const isToken0 = token0.toLowerCase() === WHYPE.toLowerCase()
+  const whypeReserve = isToken0 ? reserves.reserve0 : reserves.reserve1
+  api.add(WHYPE, (BigInt(whypeReserve) * BigInt(balance)) / BigInt(supply))
+}
+
+const tvl = async (api) => {
+  await sumTokens2({
+    api,
+    owners: [TREASURY],
+    tokens: [WHYPE, ADDRESSES.null],
+    blacklistedTokens: OWN_TOKENS,
+  })
+  await addProtocolOwnedLiquidity(api)
+}
+
+const ownTokens = async (api) => sumTokens2({
+  api,
+  owners: [TREASURY],
+  tokens: OWN_TOKENS,
+})
+
+const borrowed = async (api) => {
+  const receivables = await api.call({ target: COOLER_VAULT, abi: 'uint256:reserveReceivables' })
+  api.add(WHYPE, receivables)
+}
+
+module.exports = {
+  start: '2026-06-13',
+  methodology:
+    'TVL is the reserve held by the HAM treasury multisig: WHYPE, native HYPE, and the WHYPE side of protocol-owned Ramses liquidity. HAM and wHAM held by the multisig are protocol inventory and are reported under ownTokens rather than TVL, so the token is never counted as its own backing. WHYPE lent out by the Cooler desk and still outstanding is reported under borrowed.',
+  hallmarks: [
+    ['2026-06-13', 'Mainnet launch'],
+    ['2026-08-10', 'Liquidity migrated to Ramses (wHAM/WHYPE)'],
+  ],
+  hyperliquid: {
+    tvl,
+    ownTokens,
+    borrowed,
+  },
+}


### PR DESCRIPTION
Adds a TVL adapter for **HyperHAM**, a reserve-backed rebasing token on HyperEVM.

Validated locally: `node test.js projects/hyperham/index.js` → **$34.71k** total (tvl $34.71k, borrowed $3.38k). No dependencies added, no lockfile touched, one new file.

##### Name (to be shown on DefiLlama):
HyperHAM

##### Twitter Link:
https://x.com/HyperHAM

##### List of audit links if any:
None — the contracts have not had a third-party audit.

##### Website Link:
https://hyperham.finance

##### Logo (High resolution, will be shown with rounded borders):
https://hyperham.finance/favicon.svg (vector, 1024×1024 viewBox). PNG raster also available at https://hyperham.finance/apple-touch-icon.png — happy to attach a larger PNG if the SVG is inconvenient.

##### Current TVL:
~$34.7k (582.35 WHYPE + 5.27 native HYPE). Denominated in HYPE, so it moves with the HYPE price.

##### Treasury Addresses (if the protocol has treasury)
`0xF61D218b1429243d7F5937bCB85A4B8b41301CCa` — the protocol multisig on HyperEVM. This address *is* the TVL for this listing; see methodology below.

##### Chain:
Hyperliquid L1 (adapter chain key `hyperliquid`; HyperEVM, chain id 999)

##### Coingecko ID:
(not listed)

##### Coinmarketcap ID:
(not listed)

##### Short Description (to be shown on DefiLlama):
HyperHAM is a rebasing token on HyperEVM backed by a HYPE-denominated reserve held in the protocol multisig. The reserve is grown through liquidity bonds and rebase seigniorage, and backs a fixed-rate, no-liquidation borrowing desk against wrapped HAM collateral.

##### Token address and ticker if any:
- HAM (rebasing, 18 decimals): `0xd62DcC1E28D646Db54E2204A40980F9db28e0363`
- wHAM (non-rebasing wrapper, **24 decimals**): `0xD48ad2f34Ce9071ac130F55237c030643C5eeDe6`

Neither currently resolves in `coins.llama.fi`. The adapter is built so that this does not matter — TVL contains only WHYPE and native HYPE, both core assets, so the listing does not depend on either token having a price feed. Flagging the 24 decimals explicitly because registering wHAM at the default 18 would overstate the `ownTokens` bucket by 10^6.

##### Category:
Reserve Currency

##### Oracle Provider(s):
HyperCore precompiles, read through the protocol's own oracle adapter — perp feed as primary with the spot feed as a divergence bracket.

##### Implementation Details:
The oracle prices HYPE for the rebase policy and for the borrowing desk's solvency mark. **It is not used by this TVL adapter** — TVL here is raw token balances, priced by DefiLlama.

##### Documentation/Proof:
On-chain: the live rebaser `0x08E5cEf25c7fe9dbcf584d1Bd95de5cDD55962F5` returns `reserveUsdOracle() = 0xb582949a6A7350F6678487C0a6eD28f8072111f5`. https://docs.hyperham.finance describes the pricing mechanism but does not name the underlying feed, so the contract read is the better proof.

##### forkedFrom:
YAM Finance — the codebase began as a fork of the early YAM contracts, since rewritten (Solidity 0.8.30, UUPS, OpenZeppelin v5).

##### methodology:
TVL is the reserve held by the HAM treasury multisig: WHYPE, native HYPE, and the WHYPE side of protocol-owned Ramses liquidity. HAM and wHAM held by the multisig are protocol inventory and are reported under `ownTokens` rather than TVL, so the token is never counted as its own backing. WHYPE lent out by the Cooler-style desk and still outstanding is reported under `borrowed`.

This follows `projects/olympus/index.js`, the closest listed analogue — a treasury-backed token whose TVL is its reserve, with own tokens split into a separate bucket and Cooler debt kept out of TVL.

**One note for reviewers:** the protocol-owned Ramses position is unwrapped explicitly rather than via `resolveLP`. Ramses legacy pairs are named `"Volatile - WHYPE/wHAM"`, which matches none of the patterns in `isLP()` (`projects/helper/utils.js`), so `resolveLP` leaves the pair as an unpriced LP token contributing zero:

```js
isLP('Volatile - WHYPE/wHAM', '0x6cca…bad5', 'hyperliquid') === false
```

The adapter therefore reads `balanceOf` / `totalSupply` / `getReserves` / `token0` on the pair directly. Adding a `hyperliquid` branch to `isLP` would have been the smaller diff, but it changes behavior for every adapter on this chain, so it seemed wrong for a first PR. Happy to switch to that if you'd prefer it handled in the shared helper.

##### Github org/user:
(none — the contract repository is not public)

##### Does this project have a referral program?
No.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HyperHAM accounting support on HyperEVM.
  * TVL now includes treasury-held WHYPE, native HYPE, and the protocol-owned WHYPE share of Ramses liquidity.
  * HAM and wHAM are reported separately as owned tokens.
  * Outstanding Cooler WHYPE receivables are tracked as borrowed assets.
  * Added protocol metadata, launch and liquidity milestones, and Hyperliquid chain support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->