### PR TITLE
Adding Delta (Robinhood Chain)

### DIFF
--- a/projects/delta-liquidity/index.js
+++ b/projects/delta-liquidity/index.js
@@ -1,6 +1,6 @@
 const { sumTokens2 } = require('../helper/unwrapLPs')
-const { nullAddress } = require('../helper/tokenMapping')
-const { getLogs } = require('../helper/cache/getLogs')
+const { getLogs2 } = require('../helper/cache/getLogs')
+const ADDRESSES = require('../helper/coreAssets.json')
 
 // Delta v3 (live stack)
 const VAULT_FACTORY = '0x68EDc4948F60D21c4a7Dcbb8Ed4500cE6D0b153c'
@@ -15,75 +15,100 @@ const FARM_FACTORY_V2 = '0xc6F0E707574Fce5Da8B125edD9529DbAF985e62A'
 const NPM = '0x73991a25C818Bf1f1128dEAaB1492D45638DE0D3' // UniswapV3 NonfungiblePositionManager
 const V4_POSM = '0x58daec3116aae6D93017bAAea7749052E8a04fA7' // UniswapV4 PositionManager
 const V4_STATE_VIEW = '0xF3334192D15450CdD385c8B70e03f9A6bD9E673b'
-const WETH = '0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73'
 const DELTA = '0xe8ffd7e24187F72afB08d75B1bb13088A989a791'
 const LADDER_DEPLOY_BLOCK = 29958000
 
+async function getOwnersAndTokens(api) {
+    // Delta vaults (each vault custodies one Uniswap v3 position NFT)
+    const vaults = await api.fetchList({
+        lengthAbi: 'uint256:vaultCount',
+        itemAbi: 'function allVaults(uint256) view returns (address)',
+        target: VAULT_FACTORY,
+    })
+
+    // Legacy v2 farms custody Uniswap v2 LP tokens
+    const farmsV2 = await api.fetchList({
+        lengthAbi: 'uint256:farmCount',
+        itemAbi: 'function allFarms(uint256) view returns (address)',
+        target: FARM_FACTORY_V2,
+    })
+
+    const lpTokens = farmsV2.length ? await api.multiCall({ abi: 'address:stakingToken', calls: farmsV2 }) : []
+    const owners = [LADDER_MANAGER, ROUTER_V3, ROUTER_V2, ...vaults, ...farmsV2]
+
+    // Uniswap v4 positions managed by the ladder manager.
+    // No v4 subgraph on this chain, so position ids are enumerated from the
+    // manager's own events, minus closed positions.
+    const openedV4 = await getLogs2({
+        api,
+        target: LADDER_MANAGER,
+        eventAbi: 'event ManagedOpenV4(address indexed owner, bytes32 indexed poolId, uint256[] tokenIds)',
+        fromBlock: LADDER_DEPLOY_BLOCK,
+        extraKey: 'managed-open-v4',
+    })
+    const closed = await getLogs2({
+        api,
+        target: LADDER_MANAGER,
+        eventAbi: 'event PositionClosed(address indexed owner, uint8 version, uint256 tokenId, uint256 principal0, uint256 principal1)',
+        fromBlock: LADDER_DEPLOY_BLOCK,
+        extraKey: 'position-closed',
+    })
+    const closedV4 = new Set(closed.filter(i => Number(i.version) === 4).map(i => i.tokenId.toString()))
+    const positionIds = openedV4.flatMap(i => i.tokenIds.map(j => j.toString())).filter(id => !closedV4.has(id))
+
+    return { owners, lpTokens, positionIds }
+}
+
 async function tvl(api) {
-  // Delta vaults (each vault custodies one Uniswap v3 position NFT)
-  const vaults = await api.fetchList({
-    lengthAbi: 'uint256:vaultCount',
-    itemAbi: 'function allVaults(uint256) view returns (address)',
-    target: VAULT_FACTORY,
-  })
-
-  // Legacy v2 farms custody Uniswap v2 LP tokens
-  const farmsV2 = await api.fetchList({
-    lengthAbi: 'uint256:farmCount',
-    itemAbi: 'function allFarms(uint256) view returns (address)',
-    target: FARM_FACTORY_V2,
-  })
-  const lpTokens = farmsV2.length
-    ? await api.multiCall({ abi: 'address:stakingToken', calls: farmsV2 })
-    : []
-
-  const owners = [LADDER_MANAGER, ROUTER_V3, ROUTER_V2, ...vaults, ...farmsV2]
+  const { owners, lpTokens, positionIds } = await getOwnersAndTokens(api)
 
   // Uniswap v3 positions + ERC20/native balances + legacy LP
   await sumTokens2({
     api,
     owners,
-    tokens: [nullAddress, WETH, DELTA, ...lpTokens],
+    tokens: [ADDRESSES.null, ADDRESSES.robinhood.WETH, ...lpTokens],
     resolveUniV3: true,
     resolveLP: true,
+    blacklistedTokens: [DELTA],
     uniV3ExtraConfig: { nftAddress: NPM },
   })
 
-  // Uniswap v4 positions managed by the ladder manager.
-  // No v4 subgraph on this chain, so position ids are enumerated from the
-  // manager's own events, minus closed positions.
-  const openedV4 = await getLogs({
-    api,
-    target: LADDER_MANAGER,
-    eventAbi: 'event ManagedOpenV4(address indexed owner, bytes32 indexed poolId, uint256[] tokenIds)',
-    onlyArgs: true,
-    fromBlock: LADDER_DEPLOY_BLOCK,
-  })
-  const closed = await getLogs({
-    api,
-    target: LADDER_MANAGER,
-    eventAbi: 'event PositionClosed(address indexed owner, uint8 version, uint256 tokenId, uint256 principal0, uint256 principal1)',
-    onlyArgs: true,
-    fromBlock: LADDER_DEPLOY_BLOCK,
-  })
-  const closedV4 = new Set(closed.filter(i => Number(i.version) === 4).map(i => i.tokenId.toString()))
-  const positionIds = openedV4
-    .flatMap(i => i.tokenIds.map(j => j.toString()))
-    .filter(id => !closedV4.has(id))
+  // v4 positions
+  if (positionIds.length)
+    await sumTokens2({
+      api,
+      blacklistedTokens: [DELTA],
+      resolveUniV4: true,
+      uniV4ExtraConfig: { nftAddress: V4_POSM, stateViewer: V4_STATE_VIEW, positionIds },
+    })
+}
 
+async function staking(api) {
+  const { owners, positionIds } = await getOwnersAndTokens(api)
+
+  // Direct DELTA balances + the DELTA side of v3 positions
+  await sumTokens2({
+    api,
+    owners,
+    tokens: [DELTA],
+    resolveUniV3: true,
+    uniV3WhitelistedTokens: [DELTA],
+    uniV3ExtraConfig: { nftAddress: NPM },
+  })
+
+  // DELTA side of v4 positions
   if (positionIds.length)
     await sumTokens2({
       api,
       resolveUniV4: true,
+      uniV3WhitelistedTokens: [DELTA],
       uniV4ExtraConfig: { nftAddress: V4_POSM, stateViewer: V4_STATE_VIEW, positionIds },
     })
-
-  return api.getBalances()
 }
 
 module.exports = {
   methodology:
     'TVL counts assets custodied by Delta contracts on Robinhood Chain: Uniswap v3 and v4 position NFTs held by Delta vaults and the ladder manager (unwrapped to underlying token amounts; v4 positions enumerated from the manager\'s open/close events since the chain has no v4 subgraph), liquidity-depth budgets (WETH and paired tokens) held by the liquidity routers, and Uniswap v2 LP tokens staked in legacy Delta farms (unwrapped to underlying reserves). Vault share tokens and farm receipt tokens are excluded to avoid double counting. User-custodied positions are not counted.',
   doublecounted: true, // liquidity sits inside Uniswap pools, which DefiLlama counts under Uniswap
-  robinhood: { tvl },
+  robinhood: { tvl, staking },
 }

--- a/projects/delta-liquidity/index.js
+++ b/projects/delta-liquidity/index.js
@@ -1,0 +1,53 @@
+const { sumTokens2 } = require('../helper/unwrapLPs')
+const { nullAddress } = require('../helper/tokenMapping')
+
+// Delta v3 (live stack)
+const VAULT_FACTORY = '0x68EDc4948F60D21c4a7Dcbb8Ed4500cE6D0b153c'
+const LADDER_MANAGER = '0x64680254BF644BBdDe394b95129895c13317FeD4'
+const ROUTER_V3 = '0x46dFEa430d1F069C129E26445319562e29f39C47'
+
+// Delta v2 (legacy stack, still active)
+const ROUTER_V2 = '0x75A361513Ccad1b1E9AAe33458764Df06001DC43'
+const FARM_FACTORY_V2 = '0xc6F0E707574Fce5Da8B125edD9529DbAF985e62A'
+
+// Chain infra
+const NPM = '0x73991a25C818Bf1f1128dEAaB1492D45638DE0D3' // UniswapV3 NonfungiblePositionManager
+const WETH = '0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73'
+const DELTA = '0xe8ffd7e24187F72afB08d75B1bb13088A989a791'
+
+async function tvl(api) {
+  // Delta vaults (each vault custodies one Uniswap v3 position NFT)
+  const vaults = await api.fetchList({
+    lengthAbi: 'uint256:vaultCount',
+    itemAbi: 'function allVaults(uint256) view returns (address)',
+    target: VAULT_FACTORY,
+  })
+
+  // Legacy v2 farms custody Uniswap v2 LP tokens
+  const farmsV2 = await api.fetchList({
+    lengthAbi: 'uint256:farmCount',
+    itemAbi: 'function allFarms(uint256) view returns (address)',
+    target: FARM_FACTORY_V2,
+  })
+  const lpTokens = farmsV2.length
+    ? await api.multiCall({ abi: 'address:stakingToken', calls: farmsV2 })
+    : []
+
+  const owners = [LADDER_MANAGER, ROUTER_V3, ROUTER_V2, ...vaults, ...farmsV2]
+
+  return sumTokens2({
+    api,
+    owners,
+    tokens: [nullAddress, WETH, DELTA, ...lpTokens],
+    resolveUniV3: true,
+    resolveLP: true,
+    uniV3ExtraConfig: { nftAddress: NPM },
+  })
+}
+
+module.exports = {
+  methodology:
+    'TVL counts assets custodied by Delta contracts on Robinhood Chain: Uniswap v3 position NFTs held by Delta vaults and by the ladder manager (unwrapped to underlying token amounts via the position manager), liquidity-depth budgets (WETH and paired tokens) held by the liquidity routers, and Uniswap v2 LP tokens staked in legacy Delta farms (unwrapped to underlying reserves). Vault share tokens and farm receipt tokens are excluded to avoid double counting. User-custodied ladder positions (where the user retains the NFT) are not counted.',
+  doublecounted: true, // liquidity sits inside Uniswap pools, which DefiLlama counts under Uniswap
+  robinhood: { tvl },
+}

--- a/projects/delta-liquidity/index.js
+++ b/projects/delta-liquidity/index.js
@@ -1,5 +1,6 @@
 const { sumTokens2 } = require('../helper/unwrapLPs')
 const { nullAddress } = require('../helper/tokenMapping')
+const { getLogs } = require('../helper/cache/getLogs')
 
 // Delta v3 (live stack)
 const VAULT_FACTORY = '0x68EDc4948F60D21c4a7Dcbb8Ed4500cE6D0b153c'
@@ -12,8 +13,11 @@ const FARM_FACTORY_V2 = '0xc6F0E707574Fce5Da8B125edD9529DbAF985e62A'
 
 // Chain infra
 const NPM = '0x73991a25C818Bf1f1128dEAaB1492D45638DE0D3' // UniswapV3 NonfungiblePositionManager
+const V4_POSM = '0x58daec3116aae6D93017bAAea7749052E8a04fA7' // UniswapV4 PositionManager
+const V4_STATE_VIEW = '0xF3334192D15450CdD385c8B70e03f9A6bD9E673b'
 const WETH = '0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73'
 const DELTA = '0xe8ffd7e24187F72afB08d75B1bb13088A989a791'
+const LADDER_DEPLOY_BLOCK = 29958000
 
 async function tvl(api) {
   // Delta vaults (each vault custodies one Uniswap v3 position NFT)
@@ -35,7 +39,8 @@ async function tvl(api) {
 
   const owners = [LADDER_MANAGER, ROUTER_V3, ROUTER_V2, ...vaults, ...farmsV2]
 
-  return sumTokens2({
+  // Uniswap v3 positions + ERC20/native balances + legacy LP
+  await sumTokens2({
     api,
     owners,
     tokens: [nullAddress, WETH, DELTA, ...lpTokens],
@@ -43,11 +48,42 @@ async function tvl(api) {
     resolveLP: true,
     uniV3ExtraConfig: { nftAddress: NPM },
   })
+
+  // Uniswap v4 positions managed by the ladder manager.
+  // No v4 subgraph on this chain, so position ids are enumerated from the
+  // manager's own events, minus closed positions.
+  const openedV4 = await getLogs({
+    api,
+    target: LADDER_MANAGER,
+    eventAbi: 'event ManagedOpenV4(address indexed owner, bytes32 indexed poolId, uint256[] tokenIds)',
+    onlyArgs: true,
+    fromBlock: LADDER_DEPLOY_BLOCK,
+  })
+  const closed = await getLogs({
+    api,
+    target: LADDER_MANAGER,
+    eventAbi: 'event PositionClosed(address indexed owner, uint8 version, uint256 tokenId, uint256 principal0, uint256 principal1)',
+    onlyArgs: true,
+    fromBlock: LADDER_DEPLOY_BLOCK,
+  })
+  const closedV4 = new Set(closed.filter(i => Number(i.version) === 4).map(i => i.tokenId.toString()))
+  const positionIds = openedV4
+    .flatMap(i => i.tokenIds.map(j => j.toString()))
+    .filter(id => !closedV4.has(id))
+
+  if (positionIds.length)
+    await sumTokens2({
+      api,
+      resolveUniV4: true,
+      uniV4ExtraConfig: { nftAddress: V4_POSM, stateViewer: V4_STATE_VIEW, positionIds },
+    })
+
+  return api.getBalances()
 }
 
 module.exports = {
   methodology:
-    'TVL counts assets custodied by Delta contracts on Robinhood Chain: Uniswap v3 position NFTs held by Delta vaults and by the ladder manager (unwrapped to underlying token amounts via the position manager), liquidity-depth budgets (WETH and paired tokens) held by the liquidity routers, and Uniswap v2 LP tokens staked in legacy Delta farms (unwrapped to underlying reserves). Vault share tokens and farm receipt tokens are excluded to avoid double counting. User-custodied ladder positions (where the user retains the NFT) are not counted.',
+    'TVL counts assets custodied by Delta contracts on Robinhood Chain: Uniswap v3 and v4 position NFTs held by Delta vaults and the ladder manager (unwrapped to underlying token amounts; v4 positions enumerated from the manager\'s open/close events since the chain has no v4 subgraph), liquidity-depth budgets (WETH and paired tokens) held by the liquidity routers, and Uniswap v2 LP tokens staked in legacy Delta farms (unwrapped to underlying reserves). Vault share tokens and farm receipt tokens are excluded to avoid double counting. User-custodied positions are not counted.',
   doublecounted: true, // liquidity sits inside Uniswap pools, which DefiLlama counts under Uniswap
   robinhood: { tvl },
 }


### PR DESCRIPTION
Delta is a liquidity infrastructure protocol on Robinhood Chain enabling users to create concentrated-liquidity ladders on Uniswap v3 and v4, staking vaults, and fee routing.

Name: Delta
Category: Liquidity manager
Chain: Robinhood Chain
Website: https://deltaliquidity.app/
Twitter: https://x.com/deltaliquidity
Token: $DELTA, 0xe8ffd7e24187F72afB08d75B1bb13088A989a791 (Robinhood Chain)
Public analytics: https://dune.com/omenxbt1573/delta-analytics

Methodology: TVL counts assets custodied by Delta contracts: Uniswap v3 and v4 position NFTs held by Delta vaults and the ladder manager (unwrapped to underlying amounts; v4 position ids are enumerated from the manager's ManagedOpenV4/PositionClosed events since there is no v4 subgraph on this chain), WETH depth budgets held by the liquidity routers, and Uniswap v2 LP staked in legacy farms. Receipt tokens excluded. doublecounted: true since positions sit inside Uniswap pools.

Vault list is enumerated live from the VaultFactory (0x68ED...153c). All addresses verifiable on-chain; the ladder manager (0x6468...FeD4) currently holds ~567 v3 and ~263 v4 position NFTs, visible on Blockscout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added staking balance tracking for Delta Liquidity on Robinhood Chain.
  * Staking metrics include direct DELTA holdings and DELTA exposure through supported v3 and v4 positions.
  * Expanded TVL tracking across Delta v3 vaults, legacy v2 farms, LP tokens, and Uniswap v2, v3, and v4 positions.
  * Improved asset accounting to avoid double-counting DELTA and accurately include active positions.
  * Includes methodology and double-counting metadata for transparent reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->