### PR TITLE
feat: add Xona Agent staking adapter (Solana)

### DIFF
--- a/projects/xona-agent/index.js
+++ b/projects/xona-agent/index.js
@@ -1,0 +1,27 @@
+const { sumTokensExport } = require('../helper/solana')
+
+// $XONA staking runs on Streamflow's stake-pool program. Each lock tier is its
+// own stake pool, and every pool holds the staked $XONA in a dedicated vault
+// token account. Summing those four vaults gives the total amount staked.
+//
+// Pool -> vault:
+//   7d   8Decw6QqPQedPk9wc6WDEbbwCJYhVRcW56Ctju7F4pJF -> Ci3CwCoZoSuKAD1h7AcfnnSR32gE5rBw1jgysGpqXZAv
+//   30d  CARFKPj4DbXCcC2LoQP6Q7z8BP4v1yuLPY1oaWRaUCcs -> EJU9GprW3U4DpxzhEKNtSnBK4gsGCg7RD9sdH8Nej8Kh
+//   90d  3fSNKW4L8EocGk3DPvNNYcn3jRHwBoKzFbAnUhzaNbxP -> FatAxEievkavRn7EEuyLkgk6NMEUFpigRxpeyHatYyMD
+//   180d 2V8WTgdNAe8fYGWYe2nBtr9scuAtxqBzUjbaUVAv7vHU -> 9xRfz54N76qfRGcyBk8ZBvKbbD6pYs9dXfUPvM8CgDms
+const stakeVaults = [
+  'Ci3CwCoZoSuKAD1h7AcfnnSR32gE5rBw1jgysGpqXZAv', // 7 day tier
+  'EJU9GprW3U4DpxzhEKNtSnBK4gsGCg7RD9sdH8Nej8Kh', // 30 day tier
+  'FatAxEievkavRn7EEuyLkgk6NMEUFpigRxpeyHatYyMD', // 90 day tier
+  '9xRfz54N76qfRGcyBk8ZBvKbbD6pYs9dXfUPvM8CgDms', // 180 day tier
+]
+
+module.exports = {
+  timetravel: false,
+  methodology:
+    'Counts $XONA locked in the four Xona Agent staking tiers (7, 30, 90 and 180 days). Each tier is a Streamflow stake pool; the amount staked is read on-chain from each pool vault token account. Reported under staking since only the protocol native token is deposited. Reward vaults are not counted, as those tokens are not user deposits.',
+  solana: {
+    tvl: () => ({}),
+    staking: sumTokensExport({ tokenAccounts: stakeVaults }),
+  },
+}


### PR DESCRIPTION
Adds a TVL adapter for **Xona Agent** staking on Solana.

## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
Xona Agent

##### Twitter Link:
https://x.com/xona_agent

##### List of audit links if any:
No independent audit of our own. Staking runs on Streamflow's audited stake-pool program (`STAKEvGqQTtzJZH6BWDcbpzXXn2BBerPAgQ3EGLN2GH`) rather than custom contracts. https://streamflow.finance/

##### Website Link:
https://xona-agent.com (staking app: https://stake.xona-agent.com)

##### Logo (High resolution, will be shown with rounded borders):
https://xona-agent.com/icon-new.png

##### Current TVL:
~303,924,276 $XONA staked (~$90k at time of writing)

##### Treasury Addresses (if the protocol has treasury)
n/a

##### Chain:
Solana

##### Coingecko ID:
xona-agent

##### Coinmarketcap ID:
(not listed)

##### Short Description (to be shown on DefiLlama):
Lock $XONA across four fixed-term tiers and earn a share of every buyback made from protocol revenue, plus bonus reward tokens from partner projects.

##### Token address and ticker if any:
`Ckit5s1Cpc3RdMh1HrhfW2nAy4PnkkgjXgXMeykbpump` — $XONA

##### Category:
Staking Pool

##### Oracle Provider(s):
None. No oracle is used; balances are read directly from on-chain token accounts.

##### Implementation Details:
n/a — no oracle integration.

##### Documentation/Proof:
n/a — no oracle integration.

##### forkedFrom (Does your project originate from another project):
Not a fork of the code, but worth flagging explicitly: staking is deployed on **Streamflow**'s stake-pool program rather than our own contracts. Streamflow is already listed on DefiLlama. If your methodology already counts third-party stake pools inside Streamflow's TVL, please let me know and I'll close this rather than introduce double counting — happy to follow whatever you prefer here.

##### methodology (what is being counted as tvl, how is tvl being calculated):
$XONA is staked into four Streamflow stake pools, one per lock tier (7, 30, 90 and 180 days). Each pool holds deposits in its own vault token account. The adapter sums the balances of those four vaults on-chain.

Reported under the `staking` key rather than `tvl`, because only the protocol's own native token is deposited. Please re-key it if you'd rather it counted as TVL.

Reward vaults are deliberately excluded — those hold undistributed rewards, not user deposits.

Pool → vault:
| Tier | Stake pool | Vault |
|---|---|---|
| 7d | `8Decw6QqPQedPk9wc6WDEbbwCJYhVRcW56Ctju7F4pJF` | `Ci3CwCoZoSuKAD1h7AcfnnSR32gE5rBw1jgysGpqXZAv` |
| 30d | `CARFKPj4DbXCcC2LoQP6Q7z8BP4v1yuLPY1oaWRaUCcs` | `EJU9GprW3U4DpxzhEKNtSnBK4gsGCg7RD9sdH8Nej8Kh` |
| 90d | `3fSNKW4L8EocGk3DPvNNYcn3jRHwBoKzFbAnUhzaNbxP` | `FatAxEievkavRn7EEuyLkgk6NMEUFpigRxpeyHatYyMD` |
| 180d | `2V8WTgdNAe8fYGWYe2nBtr9scuAtxqBzUjbaUVAv7vHU` | `9xRfz54N76qfRGcyBk8ZBvKbbD6pYs9dXfUPvM8CgDms` |

##### Github org/user (Optional):
n/a

##### Does this project have a referral program?
No

---

No new npm dependencies added, and `pnpm-lock.yaml` is untouched. Adapter tested locally and returns `solana:Ckit5s1Cpc3RdMh1HrhfW2nAy4PnkkgjXgXMeykbpump: 303924276939686`, which matches the four vault balances read directly from an RPC.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Solana staking coverage for XONA Agent.
  - Tracks staked assets across four vault terms: 7, 30, 90, and 180 days.
  - Reports aggregate staking totals for improved visibility into locked assets.

- **Documentation**
  - Added methodology details explaining how vault-based staking balances are calculated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->