### PR TITLE
stonkbrokers: count Safe Launch locked LP (up. DEX box locker) in TVL

### DIFF
--- a/projects/stonkbrokers/index.js
+++ b/projects/stonkbrokers/index.js
@@ -37,6 +37,7 @@ async function tvl(api) {
 module.exports = {
   methodology:
     'TVL is the liquidity permanently locked in the Safety Deposit Box lockers: Uniswap V3 position NFTs escrowed in the V3 box, plus up. DEX (Slipstream) positions escrowed in the up. box — including every Safe Launch pad graduation pool, whose full raise + LP tax reserve is locked forever at bond. Only the WETH side of each position is counted (meme-token legs stay unpriced). Staking tracks STONKBROKER tokens in the escrow contract.',
+  doublecounted: true,
   robinhood: {
     tvl,
     staking: sumTokensExport({ owner: STONK_ESCROW, tokens: [STONKBROKER] }),

--- a/projects/stonkbrokers/index.js
+++ b/projects/stonkbrokers/index.js
@@ -1,0 +1,44 @@
+const { sumTokens2, unwrapSlipstreamNFT, sumTokensExport } = require('../helper/unwrapLPs')
+const ADDRESSES = require('../helper/coreAssets.json')
+
+// Safety Deposit Box — Uniswap V3 box locker (position NFTs escrowed
+// permanently or on long vests) + the up. DEX (Slipstream) box locker, which
+// also holds every Safe Launch pad graduation pool (100% of each launch's
+// raise + LP tax reserve is locked there forever at bond).
+const V3_BOX_LOCKER = '0xFc96CF67eCC55bE4AdABc3AecBe6Ad6349f11223'
+const UNI_V3_NFPM = '0x73991a25C818Bf1f1128dEAaB1492D45638DE0D3'
+const UP_CL_BOX_LOCKER = '0xc1AfA59e2aBC1C868C51a1F799a7578EaCfEa076'
+const UP_SLIPSTREAM_NFPM = '0x07F44c47743A2f36414A82b9F558ECFCf0EEdCEf'
+
+const STONK_ESCROW = '0x799AE26fA515ceF145e8bC8636F7fFF87B05Cf62'
+const STONKBROKER = '0xe934e36A439C94017B64a3FecE66AF12099aBF50'
+
+async function tvl(api) {
+  // Uniswap V3 box positions (WETH side only — meme pair legs stay unpriced).
+  await sumTokens2({
+    api,
+    owner: V3_BOX_LOCKER,
+    resolveUniV3: true,
+    uniV3WhitelistedTokens: [ADDRESSES.robinhood.WETH],
+    uniV3ExtraConfig: { nftAddress: UNI_V3_NFPM },
+  })
+  // up. DEX (Slipstream) box positions, incl. all Safe Launch locked pools.
+  // Called directly because the slipstream resolver has no Robinhood default
+  // NFPM and the shared sumTokens2 config cannot carry a second one.
+  await unwrapSlipstreamNFT({
+    api,
+    owner: UP_CL_BOX_LOCKER,
+    nftAddress: UP_SLIPSTREAM_NFPM,
+    whitelistedTokens: [ADDRESSES.robinhood.WETH],
+  })
+  return api.getBalances()
+}
+
+module.exports = {
+  methodology:
+    'TVL is the liquidity permanently locked in the Safety Deposit Box lockers: Uniswap V3 position NFTs escrowed in the V3 box, plus up. DEX (Slipstream) positions escrowed in the up. box — including every Safe Launch pad graduation pool, whose full raise + LP tax reserve is locked forever at bond. Only the WETH side of each position is counted (meme-token legs stay unpriced). Staking tracks STONKBROKER tokens in the escrow contract.',
+  robinhood: {
+    tvl,
+    staking: sumTokensExport({ owner: STONK_ESCROW, tokens: [STONKBROKER] }),
+  },
+}

--- a/registries/sumTokens.js
+++ b/registries/sumTokens.js
@@ -26615,23 +26615,6 @@ const configs = {
       ]
     },
   },
-  "stonkbrokers": {
-    "methodology": "TVL is the liquidity locked in the Safety Deposit Box locker (Uniswap V3 position NFTs escrowed permanently or on long vests). Staking tracks STONKBROKER tokens in the escrow contract. The previous TVL owner (StockBooster fee collector) was retired on 2026-08-04 and only holds transient fee dust between sweeps.",
-    "robinhood": {
-      "tvl": {
-        "owner": "0xFc96CF67eCC55bE4AdABc3AecBe6Ad6349f11223",
-        "resolveUniV3": true,
-        "uniV3WhitelistedTokens": [ADDRESSES.robinhood.WETH],
-        "uniV3ExtraConfig": {
-          "nftAddress": "0x73991a25C818Bf1f1128dEAaB1492D45638DE0D3"
-        }
-      },
-      "staking": {
-        "owner": "0x799AE26fA515ceF145e8bC8636F7fFF87B05Cf62",
-        "tokens": ["0xe934e36A439C94017B64a3FecE66AF12099aBF50"]
-      }
-    }
-  },
   "stormtrade": {
     "timetravel": false,
     "methodology": "Total amount of jUSDT locked in the StormTrade vault (EQDynReiCeK8xlKRbYArpp4jyzZuF6-tYfhFM0O5ulOs5H0L)",


### PR DESCRIPTION
## Summary

- The Safety Deposit Box has a second locker on Robinhood Chain: the **up. DEX (Slipstream) box locker** [`0xc1AfA59e2aBC1C868C51a1F799a7578EaCfEa076`](https://robinhoodchain.blockscout.com/address/0xc1AfA59e2aBC1C868C51a1F799a7578EaCfEa076). Every **Safe Launch** pad graduation (pad public since 2026-08-17, [`0xEcA5726dae1e53365c37fFc02369d947A91d71f9`](https://robinhoodchain.blockscout.com/address/0xEcA5726dae1e53365c37fFc02369d947A91d71f9)) locks 100% of the launch raise + LP tax reserve there permanently at bond — this liquidity was invisible to the current adapter.
- The registry spec can only carry one position manager per chain and the slipstream resolver has no Robinhood default NFPM, so the adapter moves from `registries/sumTokens.js` back to `projects/stonkbrokers/index.js`. **Nothing is removed**: the existing Uniswap V3 box leg (owner `0xFc96…1223`, NFPM `0x7399…0D3`, WETH-whitelisted) and the staking bucket are reproduced exactly; the only addition is the Slipstream leg via `unwrapSlipstreamNFT` (owner = up. box locker, NFPM `0x07F44c47743A2f36414A82b9F558ECFCf0EEdCEf`), same WETH-only whitelist so meme pair legs stay unpriced.

## Test

`node test.js projects/stonkbrokers/index.js`:

```
--- tvl ---      WETH  573.92 k
--- staking ---  STONKBROKER  19.45 M
```

Split-leg check: Uniswap V3 box 69.22 WETH + Slipstream box 224.78 WETH — the Safe Launch locked pools more than quadruple the tracked locked liquidity.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Robinhood protocol TVL tracking for qualifying Uniswap V3 and Slipstream liquidity positions.
  * Added coverage for Slipstream Safety Deposit Box lockers, including Safe Launch graduation pools.
  * Added tracking for STONKBROKER staking balances held in the escrow contract.
  * Published methodology details describing the TVL and staking calculations.
  * Improved visibility into Robinhood’s liquidity and staking activity across supported venues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->