### PR TITLE
Add Bonker (Base launchpad)

### DIFF
--- a/projects/bonker/index.js
+++ b/projects/bonker/index.js
@@ -1,22 +1,61 @@
-const { uniV4HookExport } = require('../helper/uniswapV4')
+const { getLogs2 } = require('../helper/cache/getLogs')
+const { sumTokens2 } = require('../helper/unwrapLPs')
 
-const BONKER_HOOKS = [
-  '0x963E91A45148b39737b9DF10c5b897B55cA9e8cC',
-  '0xC9156C1868E122eF5b3e6ed946e1E88ff7da68Cc',
-]
+const LP_LOCKER = '0xBf05b1d5E356f3219D0086A4e09c969ADbe2e7d0'
+const POSITION_MANAGER = '0x7C5f5A4bBd8fD63184577525326123B519429bDc'
+const WETH = '0x4200000000000000000000000000000000000006'
+const START_BLOCK = 43_000_832
+
+const TOKEN_REWARD_ADDED_EVENT =
+  'event TokenRewardAdded(address token, (address currency0, address currency1, uint24 fee, int24 tickSpacing, address hooks) poolKey, uint256 poolSupply, uint256 positionId, uint256 numPositions, uint16[] rewardBps, address[] rewardAdmins, address[] rewardRecipients, int24[] tickLower, int24[] tickUpper, uint16[] positionBps)'
+
+const OWNER_OF_ABI = 'function ownerOf(uint256 tokenId) view returns (address)'
 
 const tvl = async (api) => {
-  for (const hook of BONKER_HOOKS) {
-    await uniV4HookExport({ hook })(api)
-  }
+  const launches = await getLogs2({
+    api,
+    target: LP_LOCKER,
+    eventAbi: TOKEN_REWARD_ADDED_EVENT,
+    fromBlock: START_BLOCK,
+  })
+
+  const positionIds = [
+    ...new Set(
+      launches.flatMap(({ positionId, numPositions }) =>
+        Array.from({ length: Number(numPositions) }, (_, i) =>
+          (BigInt(positionId) + BigInt(i)).toString(),
+        ),
+      ),
+    ),
+  ]
+  if (!positionIds.length) return {}
+
+  const owners = await api.multiCall({
+    target: POSITION_MANAGER,
+    abi: OWNER_OF_ABI,
+    calls: positionIds,
+    permitFailure: true,
+  })
+  const lockedPositionIds = positionIds.filter(
+    (_, i) => owners[i]?.toLowerCase() === LP_LOCKER.toLowerCase(),
+  )
+  if (!lockedPositionIds.length) return {}
+
+  return sumTokens2({
+    api,
+    resolveUniV4: true,
+    uniV4ExtraConfig: {
+      positionIds: lockedPositionIds,
+      whitelistedTokens: [WETH],
+    },
+  })
 }
 
 module.exports = {
   methodology:
-    'Counts the value of tokens in Uniswap V4 pools created by Bonker dynamic and static hooks. Bonker LP positions are permanently locked in the Bonker LP locker.',
+    'Counts the WETH side of Uniswap V4 liquidity positions created by the Bonker factory and permanently held by the Bonker LP locker. Positions are enumerated on-chain from TokenRewardAdded events, and launchpad-minted tokens are excluded to avoid circular pricing.',
   start: 1772755200,
   doublecounted: true,
-  timetravel: false,
   base: {
     tvl,
   },

--- a/projects/bonker/index.js
+++ b/projects/bonker/index.js
@@ -1,9 +1,9 @@
 const { getLogs2 } = require('../helper/cache/getLogs')
 const { sumTokens2 } = require('../helper/unwrapLPs')
+const ADDRESSES = require('../helper/coreAssets.json')
 
 const LP_LOCKER = '0xBf05b1d5E356f3219D0086A4e09c969ADbe2e7d0'
 const POSITION_MANAGER = '0x7C5f5A4bBd8fD63184577525326123B519429bDc'
-const WETH = '0x4200000000000000000000000000000000000006'
 const START_BLOCK = 43_000_832
 
 const TOKEN_REWARD_ADDED_EVENT =
@@ -46,7 +46,7 @@ const tvl = async (api) => {
     resolveUniV4: true,
     uniV4ExtraConfig: {
       positionIds: lockedPositionIds,
-      whitelistedTokens: [WETH],
+      whitelistedTokens: [ADDRESSES.base.WETH],
     },
   })
 }
@@ -54,9 +54,7 @@ const tvl = async (api) => {
 module.exports = {
   methodology:
     'Counts the WETH side of Uniswap V4 liquidity positions created by the Bonker factory and permanently held by the Bonker LP locker. Positions are enumerated on-chain from TokenRewardAdded events, and launchpad-minted tokens are excluded to avoid circular pricing.',
-  start: 1772755200,
+  start: '2026-03-06',
   doublecounted: true,
-  base: {
-    tvl,
-  },
+  base: { tvl },
 }

--- a/projects/bonker/index.js
+++ b/projects/bonker/index.js
@@ -1,0 +1,23 @@
+const { uniV4HookExport } = require('../helper/uniswapV4')
+
+const BONKER_HOOKS = [
+  '0x963E91A45148b39737b9DF10c5b897B55cA9e8cC',
+  '0xC9156C1868E122eF5b3e6ed946e1E88ff7da68Cc',
+]
+
+const tvl = async (api) => {
+  for (const hook of BONKER_HOOKS) {
+    await uniV4HookExport({ hook })(api)
+  }
+}
+
+module.exports = {
+  methodology:
+    'Counts the value of tokens in Uniswap V4 pools created by Bonker dynamic and static hooks. Bonker LP positions are permanently locked in the Bonker LP locker.',
+  start: 1772755200,
+  doublecounted: true,
+  timetravel: false,
+  base: {
+    tvl,
+  },
+}


### PR DESCRIPTION
## Bonker

Bonker is a permissionless token launchpad and token factory on Base. Creators can launch through the web app, social bots, public scripts, or the Bonker MCP server. Each token receives a Uniswap v4 pool with permanently locked initial liquidity, configurable creator/reward-recipient fee splits, and optional MEV-protection and supply extensions.

This PR adds Bonker as a new DefiLlama project and tracks the external-value side of the permanently locked Uniswap v4 positions created by the production Bonker factory.

## Current protocol snapshot

Snapshot from the public Bonker index on 2026-08-18:

- **51 tokens launched**
- **~$669.6k market-reported pool liquidity** across 36 currently priced pools
- **~$715.7k aggregate market cap**
- **$288.04 trailing 24h volume**
- **4,752 indexed transfers**

The market-reported liquidity figure values both sides of each pool, including Bonker-launched tokens at their pool-derived prices. It is included here as a protocol activity snapshot, not as the DefiLlama TVL value.

Fees and revenue tracking has already been merged in [DefiLlama/dimension-adapters#8840](https://github.com/DefiLlama/dimension-adapters/pull/8840).

## TVL methodology

The adapter is fully on-chain and has no subgraph or project-API dependency:

1. Enumerate `TokenRewardAdded` events emitted by the production Bonker LP Locker.
2. Expand each event's first position ID and position count into the complete set of Uniswap v4 NFT position IDs.
3. Verify that each position remains owned by the immutable LP Locker.
4. Resolve each position through the canonical Base Uniswap v4 Position Manager and State View.
5. Count only the WETH side of the locked positions. Bonker-launched tokens are excluded to avoid circularly valuing pool inventory from the same pool's price.

At local verification on 2026-08-18, the adapter returned `0.07623855892569382 WETH` (approximately `$145`). The adapter is marked `doublecounted` because the same locked positions are also included in Uniswap v4 TVL. Launch count, market-reported liquidity, fees, and trading volume are not added to TVL.

## Production contracts

| Contract | Base address |
|---|---|
| Factory | `0xD850DACe6c3E3B3cf09ABb92342Fab681013c8cB` |
| Fee Locker | `0x473e52D89bE6ea78f94d1b5c62Bd1f01b1E32e21` |
| LP Locker | `0xBf05b1d5E356f3219D0086A4e09c969ADbe2e7d0` |
| Dynamic-fee hook | `0x963E91A45148b39737b9DF10c5b897B55cA9e8cC` |
| Static-fee hook | `0xC9156C1868E122eF5b3e6ed946e1E88ff7da68Cc` |

## Verification

- `node test.js projects/bonker/index.js` — current TVL passed
- `node test.js projects/bonker/index.js 2026-08-01` — historical TVL passed
- ESLint passed for `projects/bonker/index.js`

---

## New listing information

##### Name (to be shown on DefiLlama):
Bonker

##### Twitter Link:
https://x.com/bonker_wtf

##### List of audit links if any:
No independent audit published. Production contracts are source-verified on BaseScan.

##### Website Link:
https://bonker.wtf

##### Logo (High resolution, will be shown with rounded borders):
https://bonker.wtf/favicon-512x512.png

##### Current TVL:
Approximately `0.0762 WETH` (`~$145`) at local verification on 2026-08-18. This counts only the externally valued WETH side of the permanently locked positions; the separate market-reported two-sided pool-liquidity snapshot is approximately `$669.6k`.

##### Treasury Addresses (if the protocol has treasury):
Base: `0x6097DD26871b0c7811D52B674e7407a38F7E84e5`

##### Chain:
Base

##### Coingecko ID:
N/A — Bonker currently has no protocol token.

##### Coinmarketcap ID:
N/A — Bonker currently has no protocol token.

##### Short Description (to be shown on DefiLlama):
Bonker is a permissionless token launchpad on Base with permanently locked Uniswap v4 liquidity, configurable creator rewards, MEV protection, presales, and agent/social launch integrations.

##### Token address and ticker if any:
None — Bonker currently has no protocol token.

##### Category:
Launchpad

##### Oracle Provider(s):
None. Bonker pools use on-chain Uniswap v4 pricing and do not depend on an external oracle.

##### Implementation Details:
N/A — no external oracle integration.

##### Documentation/Proof:
- https://bonker.wtf/docs
- https://basescan.org/address/0xD850DACe6c3E3B3cf09ABb92342Fab681013c8cB#code
- https://basescan.org/address/0xBf05b1d5E356f3219D0086A4e09c969ADbe2e7d0#code
- https://basescan.org/address/0x963E91A45148b39737b9DF10c5b897B55cA9e8cC#code
- https://basescan.org/address/0xC9156C1868E122eF5b3e6ed946e1E88ff7da68Cc#code

##### forkedFrom (Does your project originate from another project):
Bonker's contracts originate from [Clanker v4](https://github.com/clanker-devco/v4-contracts). Bonker operates its own factory and production deployment, with protocol fees routed to the Bonker factory.

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL is the WETH reserve attributable to Uniswap v4 position NFTs minted by the Bonker factory and permanently held by the Bonker LP Locker. Positions are enumerated from on-chain `TokenRewardAdded` events and resolved against canonical Uniswap v4 contracts. Bonker-launched token balances are excluded to avoid circular pricing. The result is marked double-counted because the same positions are also represented in Uniswap v4 TVL.

##### Github org/user:
https://github.com/3h4x/bonker

##### Does this project have a referral program?
Yes. A wallet-address referrer can receive 5% of LP-fee rewards generated by tokens launched through its referral link.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for Bonker on Base.
  * Accurately includes eligible liquidity positions and verifies they are held by the designated liquidity locker.
  * Calculates TVL using WETH-denominated liquidity while preventing duplicate counting.
  * Added methodology, launch date, and double-counting classification metadata for clearer reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->