### PR TITLE
Add HRUSD TVL adapter

### DIFF
--- a/projects/hrusd/index.js
+++ b/projects/hrusd/index.js
@@ -1,0 +1,42 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+const { sumTokens2 } = require('../helper/unwrapLPs')
+
+/**
+ * HRUSD — USD-pegged stablecoin on Base, minted 1:1 against USDC through a Peg
+ * Stability Module, with an incentivised HRUSD/USDC Uniswap V3 LP program.
+ */
+
+const USDC = ADDRESSES.base.USDC
+
+/** PSM: users deposit USDC here and the operator mints HRUSD 1:1 against it. */
+const PSM = '0xe5545fd5e48425663Bf207183a868Eb0A1d2b9ee'
+
+/**
+ * V3LPStakingRewards deployments. Both escrow Uniswap V3 HRUSD/USDC position
+ * NFTs; the first is the legacy contract users are migrating away from, the
+ * second is the current one. Positions exist in both while the migration runs.
+ */
+const STAKING = [
+  '0xb72f376ae7732a76F1C18e0547553A616a33a2bd',
+  '0xA61C08DeC414416E55de7b4510bA8Ef25C89886a',
+]
+
+/**
+ * On-chain USDC reserve of the PSM. The module keeps a liquid buffer
+ * (`bufferBps()`) here; the rest of the backing is custodied off-chain, so this
+ * counts only what is measurable on Base.
+ */
+const tvl = async (api) => api.sumTokens({ owner: PSM, tokens: [USDC] })
+
+/**
+ * HRUSD/USDC Uniswap V3 positions staked in the LP reward contracts, unwrapped
+ * to their underlying token amounts.
+ */
+const pool2 = async (api) => sumTokens2({ api, owners: STAKING, resolveUniV3: true })
+
+module.exports = {
+  methodology:
+    'TVL counts the USDC reserve held on-chain by the HRUSD Peg Stability Module (0xe5545fd5e48425663Bf207183a868Eb0A1d2b9ee). Pool2 counts the Uniswap V3 HRUSD/USDC liquidity positions escrowed in the two V3LPStakingRewards contracts, unwrapped to their underlying USDC and HRUSD amounts. The remainder of the HRUSD backing is custodied on a centralised exchange and is deliberately not counted here.',
+  start: '2026-04-24', // PSM deployed at Base block 45094158
+  base: { tvl, pool2 },
+}


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
HRUSD

##### Twitter Link:
https://x.com/hyperoute

##### List of audit links if any:

##### Website Link:
https://hyperoute.xyz/

##### Logo (High resolution, will be shown with rounded borders):
https://hyperoute.xyz/logo_HR.png

##### Current TVL:
~$642 (USDC held in the PSM) plus ~$9.6k in staked HRUSD/USDC Uniswap V3 liquidity (pool2).
Measured 2026-08-19 at Base block 50,178,814.

##### Treasury Addresses (if the protocol has treasury)
No on-chain treasury. `0xdd8da890e316d7409ca341b0d29a2070807f5a34` is a pass-through wallet:
it receives the PSM's USDC withdrawals and forwards them straight to Bybit (see the
disclosure under *methodology*). It retains no balance.

##### Chain:
Base

##### Coingecko ID:

##### Coinmarketcap ID:

##### Short Description (to be shown on DefiLlama):
HRUSD is a USD-pegged stablecoin on Base, minted 1:1 against USDC through a Peg Stability
Module, with an incentivised HRUSD/USDC Uniswap V3 liquidity program.

##### Token address and ticker if any:
HRUSD — `0x5587AD03F9565F1B86cfA51a3C744Bcc4039dAf0` (Base, 6 decimals)

##### Category:
Basis Trading

(The whitepaper describes a delta-neutral strategy funded by perpetual futures funding rates
— the same shape as Ethena USDe, which DefiLlama categorises as `Basis Trading` today. HRUSD
is not a CDP: no debt position, no overcollateralisation, no liquidation.)

##### Oracle Provider(s):
Uniswap V3 TWAP (in-protocol). The staking contract exposes `twapWindowSeconds()` and the
front-end enforces a max spot-vs-TWAP deviation of 50 ticks over a 900-second window before
building a liquidity range. No external oracle provider (Chainlink/Band/API3) is used.

##### Implementation Details:
The HRUSD/USDC Uniswap V3 pool (`0xAE2E818A18e95212FAE482e2180bC89546393DC9`, fee tier 500)
is observed directly. The V3LPStakingRewards contract reads the pool TWAP to value staked
positions when accruing rewards; the mint flow rejects a range whose spot price diverges
from the TWAP by more than 50 ticks.

##### Documentation/Proof:
Whitepaper: https://hyperoute.xyz/docs/HRUSD-Protocol.pdf — section 2 states the protocol
"checks the pool price against a Uniswap V3 TWAP before building the range, and refuses to
mint if the spot price has diverged too far from it", and section 3 that "staked positions
are valued on a 30-minute TWAP rather than the spot price".

Protocol overview: https://hyperoute.xyz/docs/HRUSD-How-it-Works.jpg

On-chain confirmation: `twapWindowSeconds()` on the V3LPStakingRewards contract
(`0xA61C08DeC414416E55de7b4510bA8Ef25C89886a`) returns `1800`, i.e. the 30-minute window the
whitepaper describes.

Live reserves page: https://hyperoute.xyz/reserves — publishes circulating HRUSD against the
USDC held on-chain by the PSM and the reserve deployed off-chain, refreshed every 60 seconds.
Its on-chain half is independently verifiable and matches Base state to the cent at the block
above. Its off-chain figure is self-reported by the protocol: it is **not** a third-party
attestation, and no auditor or custodian confirms it.

##### forkedFrom:
Not a fork.

##### methodology (what is being counted as tvl, how is tvl being calculated):
- **tvl** — USDC held by the Peg Stability Module
  (`0xe5545fd5e48425663Bf207183a868Eb0A1d2b9ee`), read with `erc20:balanceOf`. This is the
  on-chain collateral reserve backing circulating HRUSD.
- **pool2** — Uniswap V3 HRUSD/USDC position NFTs escrowed in the two V3LPStakingRewards
  contracts (`0xb72f376ae7732a76F1C18e0547553A616a33a2bd` legacy and
  `0xA61C08DeC414416E55de7b4510bA8Ef25C89886a` current), unwrapped to their underlying token
  amounts via the repo's `sumTokens2({ resolveUniV3: true })` helper.

Everything is read from Base state; no protocol API is involved.

**Disclosure for reviewers — where the rest of the backing sits.** The PSM keeps only a 2%
liquid buffer on-chain (`bufferBps() = 200`, `availableUSDC() = 642.38`) against
`psmDebt() = 32,119.15` USDC of obligations. The remainder is custodied on Bybit, in a
unified trading account the protocol reads through Bybit's private V5 API.

That flow is fully traceable on Base. Scanning every USDC transfer over the PSM's lifetime
up to block 49,655,676 (the pattern has continued since; supply has roughly doubled):

```
PSM 0xe5545fd5…  --19,081.37 USDC-->  0xdd8da890e316d7409ca341b0d29a2070807f5a34
0xdd8da890…      --19,081.37 USDC-->  0xbaed383ede0e5d9d72430661f3285daa77e9439f
```

`0xbaed383e…` is a **Bybit deposit address already listed in this repo**, in
`cex/bybit.js` under both `ethereum.owners` and `base.owners`. Those USDC therefore already
count toward Bybit's TVL on DefiLlama; counting them again under HRUSD would double-count
your own numbers.

So this adapter counts only what is measurable on-chain and makes no attempt to represent
the exchange-held backing. The circulating supply that backing supports is reported through
the companion stablecoin listing in `peggedassets-server`.

##### Github org/user (Optional):

##### Does this project have a referral program?
Yes — the front-end includes a referral/affiliate program.

---

## Validation

```
$ node test.js projects/hrusd/index.js

--- base ---
USDC                      642.20
Total: 642.20

--- base-pool2 ---
USDC                      9.59 k
Total: 9.59 k

------ TVL ------
base-pool2                9.59 k
pool2                     9.59 k
base                      642.00

total                    642.20
```

`npx eslint -c eslint.config.js projects/hrusd/index.js` — clean.
No npm dependencies added; `pnpm-lock.yaml` and `pnpm-workspace.yaml` untouched.

The HRUSD leg of the staked LP positions contributes no dollar value because HRUSD has no
price feed on DefiLlama yet — it is not listed on CoinGecko or CoinMarketCap. Only the USDC
leg is priced. This resolves itself once the stablecoin listing lands.
