### PR TITLE
Add xSLP TVL to the Cabal protocol

### DIFF
--- a/projects/cabal/index.js
+++ b/projects/cabal/index.js
@@ -1,4 +1,4 @@
-const { post } = require('../helper/http')
+const { post, get } = require('../helper/http')
 
 const REST_URL = 'https://rest.initia.xyz/initia/move/v1/view/json'
 const CABAL_MODULE_ADDRESS = '0x53c3f5d8e11844ba3747ebaec1b2d25051574ffbeedc69d72068395991e3ea28'
@@ -9,14 +9,22 @@ const CABAL_VAULTS = [
   '0x69fdf919612Ef40e89e56282C6891aca41640204', // Delta Neutral vault
 ]
 
+// strat-1: separate MiniMove rollup hosting the xSLP vault
+const STRAT_VIEW_URL = 'https://rest-strat-1.anvil.asia-northeast.initia.xyz/initia/move/v1/view/json'
+const STRAT_SUPPLY_URL = 'https://rest-strat-1.anvil.asia-northeast.initia.xyz/cosmos/bank/v1beta1/supply/by_denom'
+const STRAT_ADDRESS = '0x9a838c8d805e885481f594efee110d6f5b407d530866f4973955afae88941733'
+const STRAT_VAULT_ADDRESS = '0xd49da8a8c29c1294b98fcb119ae3bdc1cf697ac2b42d63caed608b07941ce111'
+const STRAT_X_SLP_METADATA = '0x4e11c0a219f362e4d0e1f131699aa83bee40ebc8701b424373a8517d0c9e85fb'
+const STRAT_I_USD_METADATA = '0x13bab7c0ed9dd9f4609f7dee7a5f69c99e14eca507f77e088d9b429f77e47b81'
+
 function toNum(str) {
   const clean = String(str).replace(/[^\d.]/g, '');
   return parseFloat(clean);
 }
 
-async function fetchView(functionName, moduleName, args) {
-  const response = await post(REST_URL, {
-    address: CABAL_MODULE_ADDRESS,
+async function fetchView(endpoint, address, moduleName, functionName, args) {
+  const response = await post(endpoint, {
+    address,
     module_name: moduleName,
     function_name: functionName,
     args: args,
@@ -27,16 +35,29 @@ async function fetchView(functionName, moduleName, args) {
 
 async function tvl(api) {
   const [initStakes, lpStakes] = await Promise.all([
-    fetchView('get_real_total_stakes', 'pool_router', [`"${INIT_METADATA_ADDRESS}"`]),
-    fetchView('get_real_total_stakes', 'pool_router', [`"${USDC_INIT_LP_METADATA_ADDRESS}"`])
+    fetchView(REST_URL, CABAL_MODULE_ADDRESS, 'pool_router', 'get_real_total_stakes', [`"${INIT_METADATA_ADDRESS}"`]),
+    fetchView(REST_URL, CABAL_MODULE_ADDRESS, 'pool_router', 'get_real_total_stakes', [`"${USDC_INIT_LP_METADATA_ADDRESS}"`])
   ])
   api.add(INIT_METADATA_ADDRESS, toNum(initStakes))
   api.add(USDC_INIT_LP_METADATA_ADDRESS, toNum(lpStakes))
 }
 
+async function xslpTvl(api) {
+  const iusdArg = `"${STRAT_I_USD_METADATA}"`
+  const xslpDenom = `move/${STRAT_X_SLP_METADATA.slice(2).toLowerCase()}`
+  const [stratShareRatio, sharePrice, supply] = await Promise.all([
+    fetchView(STRAT_VIEW_URL, STRAT_ADDRESS, 'lp', 'get_strat_share_to_xslp_ratio', [iusdArg]),
+    fetchView(STRAT_VIEW_URL, STRAT_VAULT_ADDRESS, 'vault', 'get_share_price', [iusdArg]),
+    get(`${STRAT_SUPPLY_URL}?denom=${xslpDenom}`),
+  ])
+  const rawIusdAmount = toNum(supply?.amount?.amount) * toNum(stratShareRatio) * toNum(sharePrice)
+  api.add(STRAT_I_USD_METADATA, rawIusdAmount)
+}
+
 module.exports = {
   timetravel: false,
-  methodology: 'TVL is calculated as the sum of: INIT token stakes (sxINIT vault), USDC-INIT LP token stakes (cbl LP vault) on Initia, and iUSD holdings across the Cabal iUSD and Delta Neutral INIT EVM vaults on the cabal-1 L2.',
+  methodology: 'TVL is calculated as the sum of: INIT token stakes (sxINIT vault), USDC-INIT LP token stakes (cbl LP vault) on Initia, iUSD holdings across the Cabal iUSD and Delta Neutral INIT EVM vaults on the cabal-1 L2, and the xSLP predeposit vault on the strat-1 L2, converted to its underlying iUSD value (xSLP supply x strat-share ratio x share price).',
   initia: { tvl },
   cabal: { tvl: async (api) => api.erc4626Sum2({ calls: CABAL_VAULTS }) },
+  strat: { tvl: xslpTvl },
 }

--- a/projects/cabal/index.js
+++ b/projects/cabal/index.js
@@ -57,6 +57,11 @@ async function xslpTvl(api) {
 module.exports = {
   timetravel: false,
   methodology: 'TVL is calculated as the sum of: INIT token stakes (sxINIT vault), USDC-INIT LP token stakes (cbl LP vault) on Initia, iUSD holdings across the Cabal iUSD and Delta Neutral INIT EVM vaults on the cabal-1 L2, and the xSLP predeposit vault on the strat-1 L2, converted to its underlying iUSD value (xSLP supply x strat-share ratio x share price).',
+  hallmarks: [
+    ['2026-03-15', 'iUSD vault launch'],
+    ['2026-04-01', 'xSLP vault launch'],
+    ['2026-04-02', 'Delta Neutral INIT (dnINIT) vault launch'],
+  ],
   initia: { tvl },
   cabal: { tvl: async (api) => api.erc4626Sum2({ calls: CABAL_VAULTS }) },
   strat: { tvl: xslpTvl },

--- a/projects/cabal/index.js
+++ b/projects/cabal/index.js
@@ -50,8 +50,13 @@ async function xslpTvl(api) {
     fetchView(STRAT_VIEW_URL, STRAT_VAULT_ADDRESS, 'vault', 'get_share_price', [iusdArg]),
     get(`${STRAT_SUPPLY_URL}?denom=${xslpDenom}`),
   ])
-  const rawIusdAmount = toNum(supply?.amount?.amount) * toNum(stratShareRatio) * toNum(sharePrice)
-  api.add(STRAT_I_USD_METADATA, rawIusdAmount)
+  const supplyAmount = toNum(supply?.amount?.amount)
+  const shareRatio = toNum(stratShareRatio)
+  const sharePriceAmount = toNum(sharePrice)
+  if (![supplyAmount, shareRatio, sharePriceAmount].every(Number.isFinite)) {
+    throw new Error('Invalid Strat xSLP TVL response')
+  }
+  api.add(STRAT_I_USD_METADATA, supplyAmount * shareRatio * sharePriceAmount)
 }
 
 module.exports = {

--- a/projects/helper/chains.json
+++ b/projects/helper/chains.json
@@ -443,6 +443,7 @@
   "starcoin",
   "stargaze",
   "starknet",
+  "strat",
   "strato",
   "stellar",
   "step",


### PR DESCRIPTION
**Update Cabal adapter: add xSLP predeposit vault TVL (strat-1)**

This is an update to an existing adapter (not a new listing), so the template fields don't apply.

Extends the existing Cabal adapter to include TVL from the xSLP vault, which lives on strat-1 — a separate MiniMove rollup from the initia and cabal chains this adapter already tracks.

**What changed**:
- Added TVL for the xSLP vault on strat-1 (new strat chain entry in the adapter)
- Added "strat" to projects/helper/chains.json

**Implementation notes**:
- TVL is computed entirely from on-chain reads against strat-1, mirroring fetchXSLPTVL() in Cabal's own backend (cabal-stats/src/services/vaults.ts):
  - lp::get_strat_share_to_xslp_ratio and vault::get_share_price — Move view calls
  - xSLP total supply — Cosmos bank module supply/by_denom query
- stratShareRatio and sharePrice are dimensionless conversion factors, so multiplying them into the raw (base-unit) xSLP supply gives the raw iUSD amount directly. That's priced via api.add(STRAT_I_USD_METADATA, rawIusdAmount) — the same address-priced pattern this adapter already uses for INIT/USDC-INIT LP on the initia chain — rather than assuming a $1 peg.
- Generalized the existing fetchView helper to take an explicit endpoint + module address (previously hardcoded to Initia's REST URL/module address), so it could be reused for strat-1's different REST host and module addresses without duplicating code.

Verified via:
node test.js projects/cabal/index.js

Results:
```
--- initia ---
USDC-INIT                 483.83 k
INIT                      377.41 k
Total: 861.24 k

--- strat ---
iUSD                      506.43 k
Total: 506.43 k

--- cabal ---
iUSD                      1.11 M
Total: 1.11 M

--- tvl ---
iUSD                      1.61 M
USDC-INIT                 483.83 k
INIT                      377.41 k
Total: 2.47 M

------ TVL ------
cabal                     1.11 M
initia                    861.24 k
strat                     506.43 k

total                     2.47 M
```
---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for Strat’s xSLP predeposit vault.
  * Added conversion of xSLP deposits into their underlying iUSD value.
  * Added Strat network support and vault launch milestones.
  * Added metadata for Strat’s xSLP and iUSD vault configuration.

* **Documentation**
  * Updated methodology details covering xSLP valuation and iUSD conversion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->