### PR TITLE
feat: add feather polygon vaults

### DIFF
--- a/registries/curators.js
+++ b/registries/curators.js
@@ -436,6 +436,12 @@ const configs = {
             '0x85fCb4604f25e17Ae4e1EAc202adba4F999d7FF5', // Feather MegaETH vault
           ],
         },
+        polygon: {
+          morpho: [
+            '0x902Af532d51D4983DBf9B8E29d1f01E430B24435', // Feather BRZ vault
+            '0x922c843349e3Bd9e4C3572171DfCa5e08836151F', // Feather frxUSD vault
+          ],
+        },
       }
     },
     _meta: {


### PR DESCRIPTION
Adds Feather's Polygon vaults to the curators registry, following the same pattern as the previously added MegaETH and Ethereum entries.

Vaults (Morpho V2, Polygon):
- `0x902Af532d51D4983DBf9B8E29d1f01E430B24435` — Feather BRZ
- `0x922c843349e3Bd9e4C3572171DfCa5e08836151F` — Feather frxUSD

Both are owned by `0x81c76F62f7E05DEC75800150bA5A23f62e2f091F` and curated by `0x66d702C8f95A2E5A2A018e1Cb0edc4aea4E58A27` (Feather).

Tested with `npx tsx test.js projects/feather/index.js`:

```
--- polygon ---
frxUSD                    1.00
brz                       0.19
Total: 1.19
```

The vaults were recently deployed and currently hold seed amounts only; balances resolve and price correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Polygon support to the Feather curator configuration.
  * Added tracking for Morpho vaults featuring BRZ and frxUSD assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->