### PR TITLE
Add LP Agent

### DIFF
--- a/projects/lp-agent/index.js
+++ b/projects/lp-agent/index.js
@@ -1,0 +1,89 @@
+const { getCache } = require('../helper/http')
+
+// NOTE FOR REVIEWERS — this is an API-sourced adapter, which this repo normally
+// rejects. It is here by explicit exception: on 2026-08-18 Rick from DefiLlama
+// wrote, of LP Agent specifically:
+//
+//   "It's better not to track TVL on via API, but since this is the only
+//    alternative, you may make a PR and one of our devs will take a look and
+//    comment on the PR."
+//
+// The reason there is no alternative: LP Agent is non-custodial and owns no
+// contract. Every position it manages is an ordinary Meteora or Uniswap
+// position owned by the *end user's own wallet*, so there is no protocol vault,
+// factory or router to enumerate. Membership of the managed set is off-chain
+// bookkeeping. Enumerating it on-chain would mean publishing the full list of
+// user wallets, which LP Agent will not do.
+const ENDPOINT = 'https://api.lpagent.io/api/v1/defillama/tvl'
+
+// The endpoint is refreshed hourly by a background job and marks a reading
+// `fresh: false` once it is three intervals old. This is a backstop for the
+// case where that flag itself stops being maintained: past six hours, refuse
+// to republish rather than presenting a frozen number as a live one.
+const MAX_AGE_MS = 6 * 60 * 60 * 1000
+
+// Tolerance for the venue-vs-chain cross-check below. Both sides are float sums
+// of the same rows in a different order, so they agree to rounding, not to the
+// bit.
+const RECONCILE_TOLERANCE = 1e-6
+
+// Both chain exports want the same snapshot; fetch it once per run.
+const fetchSnapshot = async () => {
+  const res = await getCache(ENDPOINT)
+  const snapshot = res && res.data
+  if (!snapshot || !Array.isArray(snapshot.chains) || !Array.isArray(snapshot.venues))
+    throw new Error('LP Agent TVL endpoint returned an unexpected payload')
+
+  const age = Date.now() - new Date(snapshot.computedAt).getTime()
+  if (!(age >= 0) || age > MAX_AGE_MS)
+    throw new Error(`LP Agent TVL snapshot is stale (computedAt ${snapshot.computedAt})`)
+
+  return snapshot
+}
+
+// One exported tvl function per chain. Every row the endpoint publishes carries
+// the DefiLlama chain slug it belongs to, so each export takes its own slice.
+//
+// Each failure below throws rather than returning a smaller number: DefiLlama
+// keeps the last good value when an adapter errors, and a silent undercount
+// would look exactly like users withdrawing.
+const chainTvl = (llamaChain) => async (api) => {
+  const snapshot = await fetchSnapshot()
+
+  const chain = snapshot.chains.find((c) => c.llamaChain === llamaChain)
+  if (!chain) throw new Error(`LP Agent published no reading for ${llamaChain}`)
+  if (!chain.fresh) throw new Error(`LP Agent reading for ${llamaChain} is past its refresh window`)
+  // Some managed wallets could not be read, so this sum is short by an unknown
+  // amount.
+  if (!chain.complete) throw new Error(`LP Agent reading for ${llamaChain} is incomplete`)
+
+  // Deployed value is published per venue so the breakdown reconciles to the
+  // chain total. Summing the venues here rather than trusting the chain's own
+  // field is what keeps the two honest.
+  const venues = snapshot.venues.filter((v) => v.llamaChain === llamaChain)
+  const deployed = venues.reduce((acc, v) => acc + (v.tvlUsd ?? 0), 0)
+  if (Math.abs(deployed - (chain.deployedUsd ?? 0)) > RECONCILE_TOLERANCE * Math.max(1, deployed))
+    throw new Error(`LP Agent venue breakdown does not reconcile on ${llamaChain}`)
+
+  venues.forEach(({ tvlUsd }) => api.addUSDValue(tvlUsd ?? 0))
+
+  // Capital sitting in the managed agent wallets that has not been deployed
+  // into a position yet. Published separately by the endpoint and added
+  // separately here, so dropping it is a one-line change if reviewers decide
+  // undeployed balances should not count.
+  api.addUSDValue(chain.idleUsd ?? 0)
+}
+
+module.exports = {
+  timetravel: false,
+  // TVL is reported as a USD total, not as a token breakdown.
+  misrepresentedTokens: true,
+  // The deployed half of this TVL is liquidity in Meteora DLMM, Meteora DAMM v2
+  // and Uniswap v3/v4 pools, all listed separately on DefiLlama, so it is
+  // counted there too.
+  doublecounted: true,
+  methodology:
+    "LP Agent is a non-custodial automation layer for liquidity provision: users keep custody of their own wallets and LP Agent opens, rebalances and closes their concentrated-liquidity positions - Meteora DLMM and DAMM v2 on Solana, Uniswap v3 and v4 on Robinhood Chain. TVL is the current USD value of the capital under LP Agent management, served from the LP Agent backend at /api/v1/defillama/tvl and refreshed hourly. It has two components, published and added separately: the value of the open managed positions, summed per venue and valued on-chain position by position, and the balances held in those same managed agent wallets that have not yet been deployed into a position. Positions are ordinary Meteora and Uniswap positions owned by each user's wallet rather than by an LP Agent contract, so there is no protocol-owned vault or factory to enumerate on-chain and membership of the managed set is off-chain bookkeeping; the endpoint therefore publishes only aggregate USD and position counts per chain and venue, never per-user data. Marked doublecounted because the deployed liquidity is already counted under Meteora and Uniswap.",
+  solana: { tvl: chainTvl('solana') },
+  robinhood: { tvl: chainTvl('robinhood') },
+}


### PR DESCRIPTION
> **Note for reviewers on the fetch-adapter rule.** I know this repo no longer
> accepts API-sourced TVL for new projects

> The reason there is no on-chain alternative: LP Agent is non-custodial and owns
> no contract. Every position it manages is an ordinary Meteora or Uniswap
> position owned by the **end user's own wallet** — there is no protocol vault,
> factory or router to enumerate, and membership of the managed set is off-chain
> bookkeeping. Enumerating it on-chain would require publishing the full list of
> our users' wallet addresses, which we are not willing to do.

---

## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
LP Agent

##### Twitter Link:
https://x.com/lpagent_io

##### List of audit links if any:
None. LP Agent deploys no contracts of its own — it automates positions in
existing Meteora and Uniswap contracts, which are audited by their own teams.

##### Website Link:
https://lpagent.io (app: https://app.lpagent.io)

##### Logo (High resolution, will be shown with rounded borders):
- Vector: https://app.lpagent.io/logo.svg
- 512×512 PNG: https://app.lpagent.io/manifest-icon-512.maskable.png

##### Current TVL:
~$311k — Solana ~$307k, Robinhood Chain ~$4k (`node test.js projects/lp-agent/index.js`, 2026-08-19)

##### Treasury Addresses (if the protocol has treasury)
None to list.

##### Chain:
Solana, Robinhood Chain

##### Coingecko ID:
(empty — no token)

##### Coinmarketcap ID:
(empty — no token)

##### Short Description (to be shown on DefiLlama):
Non-custodial automation for concentrated-liquidity positions. LP Agent opens,
rebalances and closes Meteora DLMM / DAMM v2 and Uniswap v3 / v4 positions on
behalf of users who keep custody of their own wallets.

##### Token address and ticker if any:
None.

##### Category:
Liquidity Automation

##### Oracle Provider(s):
None. LP Agent does not use a price oracle.

##### Implementation Details:
Each managed position's token amounts are read on-chain, position by position,
per venue. Those amounts are converted to USD using market price data — there is
no on-chain oracle in the path. The result is aggregated per chain and per venue
and published at `/api/v1/defillama/tvl`; the adapter reads that aggregate.

##### Documentation/Proof:
- https://docs.lpagent.io
- https://docs.lpagent.io/data-methodology
- Endpoint the adapter reads: https://api.lpagent.io/api/v1/defillama/tvl

##### forkedFrom:
Not a fork.

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL is the current USD value of the capital under LP Agent management, served
from the LP Agent backend at `/api/v1/defillama/tvl` and refreshed hourly by a
background job (the HTTP endpoint is a pure cache read).

Two components, published and added separately:

1. **Deployed** — the value of open managed positions, valued on-chain position
   by position, summed per venue: Meteora DLMM and Meteora DAMM v2 on Solana,
   Uniswap v3 and v4 on Robinhood Chain.
2. **Idle** — balances held in those same managed agent wallets that have not
   yet been deployed into a position.

The endpoint publishes only aggregate USD and position counts per chain and
venue — never wallet addresses, owners or position ids.

`doublecounted: true`: the deployed half is liquidity sitting in **Meteora DLMM**,
**Meteora DAMM V2**, **Uniswap V3** and **Uniswap V4** pools, all four already
listed on DefiLlama and all four covering the chains in question, so that value
is counted there too.

`misrepresentedTokens: true`: TVL is reported as a USD total via `addUSDValue`,
not as a token breakdown.

`timetravel: false`: the endpoint serves a current snapshot only, with no
historical series.

**Happy to drop the idle component if you'd prefer TVL to mean deployed
liquidity only** — it is a single `api.addUSDValue(chain.idleUsd)` line in the
adapter and needs no change on our side.

The adapter refuses to publish rather than publish a number it cannot stand
behind: it throws if the snapshot is older than six hours, if the backend marks
a chain's reading not fresh or not complete, or if the per-venue breakdown does
not reconcile to the chain total. DefiLlama keeps the last good value on an
adapter error, whereas a silent undercount would look exactly like users
withdrawing.

##### Github org/user (Optional, if your code is open source, we can track activity):
Not open source — the LP Agent repository is private.

##### Does this project have a referral program?
Yes — LP Agent has an in-app referral program for users.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LP Agent TVL reporting for Solana and Robinhood Chain.
  * TVL includes venue balances and undeployed wallet balances.
  * Added validation to ensure only recent, complete, and reconciled snapshots are reported.
  * Preserves the last valid TVL value when incoming data fails validation.
  * Reports USD-denominated TVL with supporting metadata and methodology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->