### PR TITLE
Add Axis

### DIFF
--- a/projects/axis/index.js
+++ b/projects/axis/index.js
@@ -1,0 +1,16 @@
+// Axis — https://axis.to
+// TVL = circulating USDx on Ethereum V2. Do not add sUSDx or Origin (double count).
+const USDX = '0xa1fA7777974312f7d801A8880714a218F76233f8'
+
+async function tvl(api) {
+  const supply = await api.call({
+    target: USDX,
+    abi: 'uint256:totalSupply',
+  })
+  api.add(USDX, supply)
+}
+
+module.exports = {
+  methodology: 'Supply of USDx on Ethereum. sUSDx is an ERC-4626 vault of USDx and is excluded to avoid double counting. The Upshift Origin Vault is excluded because it is already counted under Upshift.',
+  ethereum: { tvl },
+}


### PR DESCRIPTION
**NOTE**

Allow edits by maintainers: yes

This is a new TVL listing only (not dimension-adapters). No new npm dependencies, no lockfile changes — the diff is a single new file, `projects/axis/index.js`.

##### Name (to be shown on DefiLlama):
Axis

##### Twitter Link:
https://x.com/AxisFDN

##### List of audit links if any:
https://www.openzeppelin.com/news/axis-coordinate-v2-contracts-audit

##### Website Link:
https://axis.to
Docs: https://docs.axis.to
Contracts: https://docs.axis.to/reference/contract-addresses.md

##### Logo (High resolution, will be shown with rounded borders):
https://axis.to/images/webclip.svg (256x256 square SVG, dark background)
Fallback raster: https://axis.to/favicon.ico (256x256)

##### Current TVL:
$67.49M — output of `node test.js projects/axis/index.js`:

```
--- ethereum ---
USDx                      67.49 M
Total: 67.49 M

------ TVL ------
ethereum                  67.49 M
total                     67.49 M
```

##### Treasury Addresses (if the protocol has treasury)
n/a

##### Chain:
Ethereum

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):

##### Short Description (to be shown on DefiLlama):
Quantitative yield protocol that issues USDx, a synthetic dollar backed by a cross-venue arbitrage engine. sUSDx is the staked yield-bearing vault.

##### Token address and ticker if any:
USDx `0xa1fA7777974312f7d801A8880714a218F76233f8` (Ethereum, 18 decimals)

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Basis Trading

##### Oracle Provider(s):
None for protocol TVL. USDx market-price feed is not required for this adapter.

##### Implementation Details:
n/a — TVL is ERC-20 `totalSupply()` of the canonical USDx proxy on Ethereum.

##### Documentation/Proof:
https://docs.axis.to/reference/contract-addresses.md

##### forkedFrom (Does your project originate from another project):
No

##### methodology (what is being counted as tvl, how is tvl being calculated):
Supply of USDx on Ethereum. sUSDx (`0xEB892628D1E58BC475A6dCB7F5dBC4F591632AA4`) is an ERC-4626 vault whose underlying asset is USDx, so it is deliberately excluded to avoid double counting. The Upshift Origin Vault (`0xAD958C4c0c90bf0216e0f5472F074a9AB30f595F`) is also excluded because it holds USDx/sUSDx and is already counted under Upshift.

Same shape as the existing `projects/tori-finance` adapter (`methodology: 'Supply of trUSD'`).

##### Github org/user (Optional, if your code is open source, we can track activity):
(omitted — contracts are not currently in a public repo)

##### Does this project have a referral program?
Yes (Coordinates points / referral codes). Not used in TVL.

---

**Name collision note for reviewers** — several unrelated tokens share the USDX ticker. This listing is *only* the Ethereum token at `0xa1fA7777974312f7d801A8880714a218F76233f8`:
- Not Stables Labs USDX
- Not usdx.money
- Not Kava USDX
- Not Plasma V1 AxisUSD `0xA1FA77779e6866fa3eF48FC0720657E042158387` (deprecating; note it shares the first 8 hex chars with the V2 address above — the V2 token ends `33f8`, Plasma V1 ends `8387`)