### PR TITLE
lido: count previously excluded v3 stvault collateral

### DIFF
--- a/projects/lido/index.js
+++ b/projects/lido/index.js
@@ -38,14 +38,14 @@ const VAULT_HUB_START_BLOCK = 23933041;
 async function stVaultEther(api) {
   if (api.block < VAULT_HUB_START_BLOCK) return 0n
 
-  const vaultsCount = await api.call({ target: VAULT_HUB, abi: "uint256:vaultsCount" })
-  if (!Number(vaultsCount)) return 0n
-
-  const vaults = await api.multiCall({
+  const vaults = await api.fetchList({
+    lengthAbi: "uint256:vaultsCount",
+    itemAbi: "function vaultByIndex(uint256) view returns (address)",
     target: VAULT_HUB,
-    abi: "function vaultByIndex(uint256) view returns (address)",
-    calls: [...Array(Number(vaultsCount))].map((_, i) => ({ params: [i + 1] })),
+    startFromOne: true,
   })
+  if (!vaults.length) return 0n
+  
   const totalValues = await api.multiCall({
     target: VAULT_HUB,
     abi: "function totalValue(address) view returns (uint256)",

--- a/projects/lido/index.js
+++ b/projects/lido/index.js
@@ -54,7 +54,8 @@ async function stVaultEther(api) {
   const externalEther = await api.call({ target: ethContract, abi: "uint256:getExternalEther" })
 
   // subtracting externalEther is required, it is already inside getTotalPooledEther()
-  return totalValues.reduce((sum, value) => sum + BigInt(value), 0n) - BigInt(externalEther)
+  const uncounted = totalValues.reduce((sum, value) => sum + BigInt(value), 0n) - BigInt(externalEther)
+  return uncounted > 0n ? uncounted : 0n
 }
 
 async function eth(api) {
@@ -129,6 +130,9 @@ module.exports = {
   },
   ethereum: {
     tvl: eth
+  },
+  terra: {
+    tvl: () => ({}),
   },
   moonriver:{
     tvl: ksm

--- a/projects/lido/index.js
+++ b/projects/lido/index.js
@@ -29,8 +29,32 @@ const { getConnection } = require('../helper/solana');
 
 const ethContract = ADDRESSES.ethereum.STETH;
 
-async function terra() {
-  return {}
+const VAULT_HUB = "0x1d201BE093d847f6446530Efb0E8Fb426d176709";
+const VAULT_HUB_START_BLOCK = 23933041;
+
+// Lido V3: ETH held in stVaults is outside getTotalPooledEther() except for the part
+// minted as stETH against vault collateral, which shows up as getExternalEther().
+// So the uncounted remainder is sum(totalValue) - getExternalEther().
+async function stVaultEther(api) {
+  if (api.block < VAULT_HUB_START_BLOCK) return 0n
+
+  const vaultsCount = await api.call({ target: VAULT_HUB, abi: "uint256:vaultsCount" })
+  if (!Number(vaultsCount)) return 0n
+
+  const vaults = await api.multiCall({
+    target: VAULT_HUB,
+    abi: "function vaultByIndex(uint256) view returns (address)",
+    calls: [...Array(Number(vaultsCount))].map((_, i) => ({ params: [i + 1] })),
+  })
+  const totalValues = await api.multiCall({
+    target: VAULT_HUB,
+    abi: "function totalValue(address) view returns (uint256)",
+    calls: vaults.map(vault => ({ params: [vault] })),
+  })
+  const externalEther = await api.call({ target: ethContract, abi: "uint256:getExternalEther" })
+
+  // subtracting externalEther is required, it is already inside getTotalPooledEther()
+  return totalValues.reduce((sum, value) => sum + BigInt(value), 0n) - BigInt(externalEther)
 }
 
 async function eth(api) {
@@ -44,8 +68,10 @@ async function eth(api) {
     abi: "uint256:getTotalPooledMatic",
   })
 
+  const vaultETH = await stVaultEther(api)
+
   return {
-    [ADDRESSES.null]: pooledETH,
+    [ADDRESSES.null]: (BigInt(pooledETH) + vaultETH).toString(),
     [ADDRESSES.ethereum.MATIC]: pooledMatic,
   }
 }
@@ -95,7 +121,7 @@ module.exports = {
     ['2022-11-08', "FTX collapse"],
     ['2023-05-15', "ETH Withdrawal Activation"]
   ],
-  methodology: 'Staked tokens are counted as TVL based on the chain that they are staked on and where the liquidity tokens are issued, stMATIC is counted as Ethereum TVL since MATIC is staked in Ethereum and the liquidity token is also issued on Ethereum',
+  methodology: 'Staked tokens are counted as TVL based on the chain that they are staked on and where the liquidity tokens are issued, stMATIC is counted as Ethereum TVL since MATIC is staked in Ethereum and the liquidity token is also issued on Ethereum.',
   timetravel: false, // solana
   doublecounted: true,
   solana: {
@@ -103,9 +129,6 @@ module.exports = {
   },
   ethereum: {
     tvl: eth
-  },
-  terra: {
-    tvl: terra
   },
   moonriver:{
     tvl: ksm


### PR DESCRIPTION
The existing adapter undercounted Ethereum TVL by **6,737.97 ETH (~$12.75M)** because V3 vault collateral beyond minted stETH is excluded from Lido core's pooled-ether accounting.

## Changes

* Added VaultHub stVault collateral: `Σ totalValue() - getExternalEther()`.
* Removed the unused `terra` chain bucket.

## Validation

* Ethereum: **+6,737.97 ETH / +$12.75M**.
* Total TVL: **$18.01B**.
* Confirmed VaultHub liability shares match Lido external shares, avoiding double counting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Lido V3 stVault accounting on Ethereum.
  - Ethereum TVL now includes eligible vault value while avoiding duplicate external ether counts.

- **Bug Fixes**
  - Improved Ethereum TVL accuracy by preventing negative uncounted values from reducing totals.
  - Updated Terra TVL handling to avoid reporting unsupported values.

- **Documentation**
  - Refined methodology text for improved clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->