### PR TITLE
Add SatRush tvl adapter

### DIFF
--- a/projects/satrush/index.js
+++ b/projects/satrush/index.js
@@ -1,0 +1,17 @@
+const { sumTokens2 } = require('../helper/solana')
+
+const SATS_VAULT_BTC_ATA = "2zpcctvd7sCdtWe4bAYcNmfVFzaiFVtH81tfMAWCtMh9";
+
+async function tvl(api) {
+  const tokenAccounts = [SATS_VAULT_BTC_ATA];
+  return sumTokens2({ tokenAccounts, api });
+}
+
+module.exports = {
+  timetravel: false,
+  methodology: 'BTC (cbBTC) received from mining held in the Sats Vault.',
+  solana: {
+    tvl
+  },
+  start: "2026-08-02",
+}


### PR DESCRIPTION
### methodology (what is being counted as tvl, how is tvl being calculated):
The Sats Vault on SatRush holds the unclaimed BTC (cbBTC) funds earned by mining.
Each claim pays 10% exit tax, which results in passive yield earned by holders, thus the balance of the Sats Vault can be counted as the protocol's TVL.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for the Sats Vault on Solana.
  * Includes BTC balance reporting with methodology details and historical data starting from the configured launch date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->