### PR TITLE
add fake wallstreet tvl

### DIFF
--- a/registries/sumTokens/data2.js
+++ b/registries/sumTokens/data2.js
@@ -1057,5 +1057,11 @@ module.exports = {
       // 3CRV held by the vault's 3pool strategy (pool() -> 0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7)
       ["0x6c3f90f043a72fa612cbac8115ee7e52bde6e490", "0x5c5d66c82e2c634074661c3e7427668737c70100"],
     ]}
+  },
+  "fake-wallstreet": {
+    methodology: "Value of the Tokenized Stocks on the Pool",
+    "robinhood": {
+      "tvl": { owner: '0xf2B967494BbdD37cDfbE585E3b84B85461C7Da37', fetchBlockscoutTokens: true, blacklistedTokens: [ADDRESSES.null] }
+    }
   }
 }


### PR DESCRIPTION
##### Name (to be shown on DefiLlama): Fake Wall Street

##### Twitter Link: https://x.com/fwsfun

##### Website Link: https://fws.fun

##### Logo (High resolution, will be shown with rounded borders): https://pbs.twimg.com/profile_images/2085007216348635136/MqE-oTMz_400x400.jpg

##### Chain: Robinhood

##### Short Description (to be shown on DefiLlama):  Fake Wall Street is a lootbox style game on Robinhood chain where users open packs to win a random tokenised stock from the pool.

##### Category (full list at https://defillama.com/categories) \*Please choose only one: Gamified Mining


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Fake Wallstreet registry on Robinhood.
  * Added TVL tracking for tokenized stocks while excluding native assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->