### PR TITLE
Price stCHZ and bridged USDC on Chiliz

### DIFF
--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -64,6 +64,16 @@ const fixBalancesTokens = {
   ozone: {
     // '0x83048f0bf34feed8ced419455a4320a735a92e9d': { coingeckoId: "ozonechain", decimals: 18 }, // was mapped to wrong chain
   },
+  chz: {
+    // Bridged USDC (ChainPort), the stablecoin every Chiliz DEX quotes against.
+    // The coins service has no price for it, so pools holding it read as zero.
+    '0xa37936f56249965d407e39347528a1a91eb1cbef': { coingeckoId: 'usd-coin', decimals: 6 },
+    // stCHZ, the liquid staking token for native CHZ. It is not listed on
+    // CoinGecko, so it is valued as the CHZ backing it. That is conservative by
+    // the staking exchange rate (1.021 CHZ per stCHZ at the time of writing)
+    // rather than counting the position as worthless, which is what happens today.
+    '0xbf4ca6f798b2e342e36dc2ec80667b58cf480787': { coingeckoId: 'chiliz', decimals: 18 },
+  },
   provenance: {
     'ueurc.figure.se': { coingeckoId: 'euro-coin', decimals: 6 },
     'pm.pool.asset.3hjz8rcr3pejdc3msntlvy': { coingeckoId: 'usd-coin', decimals: 0 },


### PR DESCRIPTION
Two tokens that Chiliz DEX pools are largely made of have no price in the coins service, so any pool holding them reads as worthless. This adds both to `fixBalancesTokens`.

- `0xa37936f5…cbef` is Bridged USDC (ChainPort), 6 decimals, the stablecoin Chiliz DEXs quote against. Mapped to `usd-coin`.
- `0xbf4ca6f7…0787` is stCHZ, the liquid staking token for native CHZ. It is not listed on CoinGecko, so it is valued as the CHZ backing it. That is conservative by the staking exchange rate, currently 1.0208 CHZ per stCHZ, rather than counting the position as worthless.

### Why it matters

Kayen Finance V3 (`kayen-v3`) holds 95% of its liquidity in a single wCHZ/stCHZ pool, so the listing has been reporting roughly half of what is actually in the pools.

`node test.js kayen-v3`

| | before | after |
|---|---|---|
| WCHZ | 25.82 k | 25.82 k |
| CHZ (from stCHZ) | not priced | 24.52 k |
| USDC | not priced | 984.60 |
| PEPPER | 203.77 | 203.77 |
| **total** | **26.02 k** | **51.53 k** |

The protocol's own subgraph reports 50,981 USD of TVL for the same pools, so the corrected figure lands within about 1%.

Spot check against chain state: the wCHZ/stCHZ pool `0x80cdad61…ab8b` holds 1,917,414.69 stCHZ, which at the CHZ price used in that run comes to 24,517.18 USD, matching the CHZ line above.

### Effect on other Chiliz adapters

`kayen` (v2, listed as FanX Protocol) is the only other adapter meaningfully touched, and its total does not move:

| | before | after |
|---|---|---|
| WCHZ | 1.84 M | 1.79 M |
| USDC | folded into WCHZ | 50.56 k |
| **total** | **1.84 M** | **1.84 M** |

It reaches the same number either way because `getUniTVL` with `useDefaultCoreAssets` was already valuing those pairs through their WCHZ side. The only change is that USDC now shows up as USDC in the breakdown. `chiliz-peppercoin` and `kewl` were also run and are unchanged.

### One thing that would be better fixed on your side

Valuing stCHZ one-for-one with CHZ is off by the staking exchange rate, which is 2.1% today and grows as rewards compound. If the coins service can price `chz:0xbf4ca6f798b2e342e36dc2ec80667b58cf480787` off `ChilizDepositor.totalDeposits() / stCHZ.totalSupply()` (depositor `0xc3cbf2c6b3ea81f1a8a9fd24d8179b6f39860db7`), this mapping can be dropped. Happy to help with whatever shape is useful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added token price support for bridged USDC and stCHZ on the Chiliz chain.
  * Token balances for these assets can now be normalized and displayed with the correct decimal precision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Metadata update request (for a DefiLlama maintainer)

Separate from the code change above. We maintain both Kayen Finance listings and would like four corrections, three of which are our own fault from the original submissions. They are independent, so please take any subset.

**1. Rename id 8379 from "Kayen Finance" to "Kayen Finance LST"**

The liquid staking entry holds the plain brand name while sitting next to "Kayen Finance V3" (id 8026), so the two are easy to confuse. Its adapter module is already `kayen-finance-lst`.

**2. Set the url on id 8026**

It is currently a single space, so the V3 listing has had no website link since it went up. It should be `https://app.kayen.finance`

**3. Clear the token on id 8026**

`address: chz:0x60f397acbcfb8f4e3234c659a3e10867e6fa6b67` and `symbol: PEPPER` came from our original submission and should not be there. PEPPER is not the DEX's token.

**4. Group both entries under a parent, PancakeSwap-style**

A lending protocol is coming and would join the same parent later.

```ts
{
  id: "parent#kayen-finance",
  name: "Kayen Finance",
  url: "https://app.kayen.finance",
  description: "DeFi suite on Chiliz: a concentrated liquidity DEX and a liquid staking protocol for native CHZ.",
  logo: `${baseIconsUrl}/kayen-finance.jpg`,
  chains: [],
  twitter: "KayenFinance",
  github: ["kayenfinance"],
},
```

with `parentProtocol: "parent#kayen-finance"` on 8026 and 8379. Request 1 frees the name the parent needs, so those two go together. Either existing entry logo works for the parent.

One thing to be careful of so it does not get swept in: **"FanX Protocol" (id 4821) belongs to a different team and should stay exactly where it is**, even though its module is still named `kayen/index.js` from before that project was renamed.
