### PR TITLE
near: convert LiNEAR at its on-chain rate, its price feed is too sparse to depend on

### DIFF
--- a/projects/burrow.cash/index.js
+++ b/projects/burrow.cash/index.js
@@ -1,4 +1,4 @@
-const { call, sumSingleBalance, sumTokens } = require('../helper/chain/near')
+const { call, sumSingleBalance, sumTokens, convertThinFeeds } = require('../helper/chain/near')
 const { default: BigNumber } = require("bignumber.js")
 const BURROW_CONTRACT = 'contract.main.burrow.near'
 
@@ -18,7 +18,7 @@ function tvl(borrowed = false) {
       sumSingleBalance(balances, token, adjustedAmount);
     });
 
-    return balances;
+    return convertThinFeeds(balances);
   }
 }
 

--- a/projects/helper/chain/near.js
+++ b/projects/helper/chain/near.js
@@ -66,6 +66,45 @@ const tokenMapping = {
   'xrp.omft.near': { name: 'ripple', decimals: 6 },
 }
 
+// Tokens whose own price feed is too sparse to depend on. LiNEAR is quoted on only
+// 12 of the last 20 days, and on a day with no quote the entire balance silently
+// disappears from TVL instead of erroring, so the published series flaps. Each entry
+// is converted to a base asset at the issuing contract's own on-chain exchange rate,
+// and the base asset is quoted every day.
+//
+// Keyed by the balance key sumSingleBalance produces (the tokenMapping name), so the
+// conversion works whether the balance arrived through sumTokens/addTokenBalances or
+// through a direct sumSingleBalance call.
+const thinFeedTokens = {
+  'linear-protocol': {
+    contract: ADDRESSES.near.LINA,
+    base: 'coingecko:near',
+    method: 'ft_price',      // value of 1 LiNEAR in yoctoNEAR
+    rateDecimals: 24,
+  },
+}
+
+const rateCache = {}
+
+async function getConversionRate({ contract, method, rateDecimals }) {
+  if (!rateCache[contract])
+    rateCache[contract] = call(contract, method, {}).then(i => Number(i) / 10 ** rateDecimals)
+  return rateCache[contract]
+}
+
+// Re-denominate any thin-feed token already accumulated in `balances`. Idempotent:
+// the key is removed once converted, so calling it twice is a no-op.
+async function convertThinFeeds(balances = {}) {
+  for (const [key, config] of Object.entries(thinFeedTokens)) {
+    const amount = balances[key]
+    if (!amount) continue
+    const rate = await getConversionRate(config)
+    delete balances[key]
+    sdk.util.sumSingleBalance(balances, config.base, Number(amount) * rate)
+  }
+  return balances
+}
+
 function shouldRetry(error) {
   if (!error.response) return true;
   const retriable = [400, 429, 500, 504];
@@ -141,7 +180,7 @@ async function addTokenBalances(tokens, account, balances = {}) {
     items: tokens,
     processor: token => addAsset(token, account, balances),
   })
-  return balances
+  return convertThinFeeds(balances)
 }
 
 async function addAsset(token, account, balances = {}) {
@@ -179,11 +218,12 @@ async function sumTokens({ balances = {}, owners = [], tokens = []}) {
   })
   const nearBalance = bals.reduce((a,i) => a + (i.amount/1e24), 0)
   sdk.util.sumSingleBalance(balances,'coingecko:near',nearBalance)
-  return balances
+  return convertThinFeeds(balances)
 }
 
 module.exports = {
   view_account,
+  convertThinFeeds,
   call,
   addTokenBalances,
   getTokenBalance,

--- a/projects/helper/chain/near.js
+++ b/projects/helper/chain/near.js
@@ -87,8 +87,12 @@ const thinFeedTokens = {
 const rateCache = {}
 
 async function getConversionRate({ contract, method, rateDecimals }) {
+  // A rejected lookup must not be cached, or the first failure blocks every retry
+  // for the life of the process.
   if (!rateCache[contract])
-    rateCache[contract] = call(contract, method, {}).then(i => Number(i) / 10 ** rateDecimals)
+    rateCache[contract] = call(contract, method, {})
+      .then(i => Number(i) / 10 ** rateDecimals)
+      .catch(e => { delete rateCache[contract]; throw e })
   return rateCache[contract]
 }
 
@@ -98,8 +102,12 @@ async function convertThinFeeds(balances = {}) {
   for (const [key, config] of Object.entries(thinFeedTokens)) {
     const amount = balances[key]
     if (!amount) continue
-    const rate = await getConversionRate(config)
+    // Claim the balance before the first await. sumTokens aggregates several owners
+    // concurrently into one balances object, so reading the amount and only deleting
+    // the key after awaiting the rate would let two callers convert the same balance
+    // and book it twice.
     delete balances[key]
+    const rate = await getConversionRate(config)
     sdk.util.sumSingleBalance(balances, config.base, Number(amount) * rate)
   }
   return balances

--- a/projects/reffinance.js
+++ b/projects/reffinance.js
@@ -1,5 +1,5 @@
 const { default: BigNumber } = require('bignumber.js')
-const { call, sumSingleBalance, } = require('./helper/chain/near')
+const { call, sumSingleBalance, convertThinFeeds, } = require('./helper/chain/near')
 
 const PROJECT_CONTRACT = 'v2.ref-finance.near'
 const PROJECT_DCL_CONTRACT = 'dclv2.ref-labs.near'
@@ -32,7 +32,7 @@ async function tvl() {
     poolIndex += 500
   } while (poolIndex < numberOfPools)
 
-  return balances
+  return convertThinFeeds(balances)
 }
 
 


### PR DESCRIPTION
Rhea Lend's published TVL flaps between ~67M and ~31M, and Allstake's between ~655k and ~108k, on the same days: 08-04, 08-15, 08-16, 08-18, 08-19.

## What is actually missing

The per-token breakdown names it. On Rhea Lend every token is present every day except `LINEAR`, which is 37.4M, more than half the total:

| token | 08-14 | 08-15 | 08-16 | 08-17 | 08-18 | 08-19 | 08-20 |
| --- | --- | --- | --- | --- | --- | --- | --- |
| LINEAR | 37,377,772 | – | – | 36,587,596 | – | – | 39,301,943 |
| STNEAR | 13,247,275 | 13,317,518 | 13,217,348 | 13,023,392 | 13,372,181 | 12,777,037 | 14,227,748 |
| NEAR | 2,443,521 | 2,441,260 | 2,407,305 | 2,364,280 | 2,432,308 | 2,302,454 | 2,632,965 |

Allstake shows the same token missing on the same days.

## Why

It is the price feed, not the balance read. Over the last 20 days:

```
coingecko:linear-protocol   12 points
near:linear-protocol.near   12 points   (same feed)
coingecko:near              20 points
coingecko:staked-near       20 points
```

Missing quote days: 08-03, 08-04, 08-13, 08-14, 08-15, 08-17, 08-18, 08-19. With no quote the whole balance is dropped from the total rather than erroring, so the series flaps instead of showing a gap.

## The fix

LiNEAR is a NEAR liquid-staking token, so stop asking for its own quote and convert it to NEAR at the issuing contract's own exchange rate. NEAR is quoted every day.

Verified against the live feed on a day where both exist:

```
linear-protocol.near ft_price   1414847317392289540775760  -> 1.41485 NEAR
coingecko:near                  1.71977
implied                         1.41485 * 1.71977 = 2.4334
coins.llama.fi LINEAR           2.42884
```

0.19% apart.

## Test

Same shell, before and after:

```
burrow.cash (Rhea Lend)   72.63 M -> 72.75 M    (+0.17%)
allstake near             691.97 k               matches the 695k good-day figure
```

The number is unchanged on a day the feed works, and no longer collapses on a day it does not.

Applied through a `rateMapping` table so the same treatment can be given to any other NEAR token with a thin feed. The `borrowed` leg goes through `sumSingleBalance` directly and is untouched; it does not flap.

Allstake's Solana leg fails locally on the public RPC (`Failed to post https://api.mainnet-beta.solana.com`), same on master, unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for converting LiNEAR balances into their equivalent NEAR value.
  * NEAR-denominated balances now include converted LiNEAR amounts for more accurate portfolio reporting across supported integrations.
  * Borrowed LiNEAR balances are also converted before display.
  * Conversion rates are reused to improve consistency and efficiency when reporting balances.

* **Bug Fixes**
  * Improved retry handling for failed conversion-rate lookups.
  * Prevented duplicate conversions during concurrent balance aggregation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->