### PR TITLE
zilliqa: price WZIL as ZIL, its own feed is quoted on half the days

### DIFF
--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -42,6 +42,12 @@ const ibcMappings = {
 }
 
 const fixBalancesTokens = {
+  // WZIL is wrapped native ZIL, 1:1. Its own feed is quoted on 11 of the last 20
+  // days and a missing day drops the whole balance out of TVL rather than erroring,
+  // which makes every zilliqa DEX flap. ZIL is quoted every day.
+  zilliqa: {
+    [ADDRESSES.zilliqa.WZIL]: { coingeckoId: 'zilliqa', decimals: 18 },
+  },
   provenance: {
     'ueurc.figure.se': { coingeckoId: 'euro-coin', decimals: 6 },
     'pm.pool.asset.3hjz8rcr3pejdc3msntlvy': { coingeckoId: 'usd-coin', decimals: 0 },


### PR DESCRIPTION
PlunderSwap V2, PlunderSwap V3 and the other zilliqa DEXes flap. V2 drops from ~92k to **3 dollars** and back, V3 from ~104k to ~43k and back, on 08-13, 08-17 and 08-19.

## What leaves

Only WZIL. Everything else is present every day:

| plunderswap-v3 | 08-14 | 08-15 | 08-16 | 08-17 | 08-18 | 08-19 | 08-20 |
| --- | --- | --- | --- | --- | --- | --- | --- |
| WZIL | 57,198 | 56,088 | 56,817 | – | 54,593 | – | 57,598 |
| zUSDT | 43,372 | 43,373 | 43,375 | 43,376 | 43,378 | 43,384 | 43,387 |
| SEED | 3,818 | 3,750 | 3,783 | – | 3,659 | – | 3,886 |

On V2 that leaves only a 4 dollar zUSDT position, which is why it reads 3 dollars on a bad day rather than a partial figure.

## Why

WZIL's feed is thin, and its last quote is stale:

```
zilliqa:0x94e18ae7dd5ee57b55f30c4b63e2760c09efb192   11 of the last 20 days
coingecko:zilliqa                                    20 of the last 20 days

WZIL  0.0023673677  timestamp 1787171200
ZIL   0.0024371898  timestamp 1787199710
```

With no quote the whole balance is dropped from the total rather than erroring, so the series flaps instead of showing a gap.

## The fix

WZIL is wrapped native ZIL at 1:1, so map it onto ZIL through `fixBalancesTokens`, which already exists for exactly this case on memecore, allora and mantra. It applies per chain, so it covers V2 (which resolves through the uniswapV2 registry after #18076), V3, and anything else on zilliqa holding WZIL.

## Test

```
plunderswap-v3   before  WZIL 57.60k + zUSDT 43.38k + SEED 3.89k = 104.86k
                 after   ZIL  59.30k + zUSDT 43.38k + SEED 3.89k = 106.56k
```

The 1.6% move is the stale WZIL quote being replaced by the live ZIL one.

No regression on the other zilliqa adapters: `zilswap` is 142.11k before and after, `avely-finance-swap` runs clean. `pillar` fails identically on master and on this branch, unrelated.

SEED also drops on those days and has no denser feed to map to, so it is left alone; it is 3.7% of V3 and absent from V2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for displaying WZIL balances as native ZIL.
  * Uses the Zilliqa market data feed and standard 18-decimal formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->