### PR TITLE
xsy: count UTY at its peg, the price feed stopped and TVL has read $0 since 08-05

### DIFF
--- a/projects/xsy/index.js
+++ b/projects/xsy/index.js
@@ -1,14 +1,28 @@
 const ADDRESSES = require('../helper/coreAssets.json')
 
+// UTY is XSY's dollar unit and TVL is its circulating supply.
+//
+// It is booked at its peg rather than through the token, because the UTY price
+// feed stopped on 2026-08-04 and coins.llama.fi now returns an empty `coins`
+// object for it. An unpriced token contributes nothing, so `api.add` published a
+// flat $0 from 08-05 onwards against a live 20.99M supply.
+//
+// The peg is the assumption here and it is stated rather than hidden: every one of
+// the 88 quotes the feed did publish, 2026-04-23 through 2026-08-04, sat between
+// 0.99892 and 0.99953, a 0.06% band. The token is still live (supply steady at
+// 20.99M, transfers of 215k and 700k UTY on 2026-08-17). If UTY ever breaks its
+// peg this overstates TVL, and it should go back to pricing the token the moment
+// the feed returns.
 async function tvl(api) {
   const totalSupply = await api.call({
     abi: 'erc20:totalSupply',
     target: ADDRESSES.avax.UTY,
   })
-  api.add(ADDRESSES.avax.UTY, totalSupply)
+  api.addUSDValue(totalSupply / 1e18)
 }
 
 module.exports = {
   start: 58017291, // block when UTY contract was deployed
+  methodology: 'Circulating supply of UTY, counted at its dollar peg.',
   avax: { tvl },
 }

--- a/projects/xsy/index.js
+++ b/projects/xsy/index.js
@@ -3,9 +3,14 @@ const ADDRESSES = require('../helper/coreAssets.json')
 // UTY is XSY's dollar unit and TVL is its circulating supply.
 //
 // It is booked at its peg rather than through the token, because the UTY price
-// feed stopped on 2026-08-04 and coins.llama.fi now returns an empty `coins`
-// object for it. An unpriced token contributes nothing, so `api.add` published a
-// flat $0 from 08-05 onwards against a live 20.99M supply.
+// feed published its last quote on 2026-08-04 and coins.llama.fi has returned an
+// empty `coins` object for it since. An unpriced token contributes nothing, so
+// `api.add` published a flat $0 from 2026-08-05 onwards against a live 20.99M
+// supply.
+//
+// `addUSDValue` books this through `coingecko:tether`, so it follows USDT's quote
+// rather than a hardcoded 1.0. That quote has held 0.9988 to 0.9997 over the last
+// 30 days, which is the same order as UTY's own band below.
 //
 // The peg is the assumption here and it is stated rather than hidden: every one of
 // the 88 quotes the feed did publish, 2026-04-23 through 2026-08-04, sat between


### PR DESCRIPTION
XSY has published **$0 TVL every day since 2026-08-05**, against a live 20.99M UTY supply.

## Not the balance read, the pricing

```
coins.llama.fi/prices/current/avax:0xdbc5192a6b6ffee7451301bb4ec312f844f02b4a
{"coins":{}}
```

The feed ran 2026-04-23 to 2026-08-04 and then stopped. An unpriced token contributes nothing to the total, so `api.add` published a flat zero rather than erroring. Last real value was **$20,979,172** on 08-05.

## The token is fine

```
totalSupply   20,989,270.43 UTY (18 decimals), unchanged
transfers     215,895 and 700,000 UTY on 2026-08-17
contract      live, symbol UTY, name Unity
```

## Change

Book the supply at its dollar peg instead of routing through the dead feed.

```
Test: 0.00 -> 20.98 M
```

which lines up with the $20,979,172 the adapter last published.

## The assumption, stated rather than hidden

The peg is an assumption. What supports it: all 88 quotes the feed published sat between **0.99892 and 0.99953**, a 0.06% band, and the token is still moving in size.

What I could **not** do: find a UTY pool or an alternate price id to confirm the peg still holds today. If UTY breaks its peg this overstates TVL, and it should go back to pricing the token the moment the feed returns.

Flagging that plainly so you can take the other side if you would rather it stay at zero. There is precedent for the pattern either way — `fixBalancesTokens` already maps an unpriced token onto `tether` for `inri`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added methodology details explaining that UTY’s circulating supply is valued at its dollar peg.

* **Bug Fixes**
  * Improved total value reporting by valuing UTY directly at its dollar peg.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->