### PR TITLE
bedrock: count Merlin M-BTC as BTC, its own quote is missing half the days

### DIFF
--- a/projects/bedrock/index.js
+++ b/projects/bedrock/index.js
@@ -1,3 +1,4 @@
+const ADDRESSES = require('../helper/coreAssets.json')
 const { sumTokens } = require('../helper/chain/bitcoin')
 const bitcoinAddressBook = require('../helper/bitcoin-book/index.js')
 const { getConfig } = require('../helper/cache.js')
@@ -15,6 +16,14 @@ module.exports = {
   }
 }
 
+// Merlin's M-BTC, which coreAssets already registers as merlin WBTC_1. Its own
+// price feed is unusable: only 7 of the last 14 days carry a quote at all, and on
+// the days that do the value wanders far off BTC (exact parity on 08-12 and 08-17,
+// 19% below on 08-07). A day with no quote drops the whole position, which is what
+// makes the published series flap - M-BTC is 57.7M of a 316M protocol.
+// Counted as BTC instead, which is quoted every day.
+const MBTC = ADDRESSES.merlin.WBTC_1.toLowerCase()
+
 async function tvlEvm(api) {
   // const API_URL = 'https://raw.githubusercontent.com/Bedrock-Technology/uniBTC/refs/heads/main/data/tvl/reserve_address.json'
   const API_URL = 'https://bedrock-datacenter.rockx.com/uniBTC/reserve/address'
@@ -24,7 +33,16 @@ async function tvlEvm(api) {
   const chain = chainAlias[api.chain] ? chainAlias[api.chain] : api.chain
   const { vault, tokens } = evm?.[chain] ?? {}
   if (!vault) return;
-  return api.sumTokens({ api, owner: vault, tokens })
+
+  const isMBTC = (token) => api.chain === 'merlin' && token.toLowerCase() === MBTC
+  await api.sumTokens({ api, owner: vault, tokens: tokens.filter(i => !isMBTC(i)) })
+
+  if (tokens.some(isMBTC)) {
+    const balance = await api.call({ target: MBTC, abi: 'erc20:balanceOf', params: [vault] })
+    api.addCGToken('bitcoin', balance / 1e18)   // M-BTC is 18 decimals
+  }
+
+  return api.getBalances()
 }
 
 ['base', 'hemi', 'rsk', 'tac', 'taiko', 'btr', 'ethereum', 'bsc', 'arbitrum', 'mantle', 'merlin', 'optimism', 'bob', 'bsquared', 'zeta', 'mode', 'berachain'].forEach(chain => {


### PR DESCRIPTION
Bedrock uniBTC's published TVL flaps. M-BTC is **57.7M of a 316M protocol** and it is the only token that leaves, on 2 of the last 14 days:

```
token   seq (last 14 days, 1 = present)
M-BTC   11111111011011
```

## The quote is unusable in both directions

Only 7 of the last 14 days carry a quote at all, and on the days that do the value wanders far off BTC:

| day | M-BTC | BTC | ratio |
| --- | --- | --- | --- |
| 08-07 | 51,882.50 | 64,140.66 | 0.809 |
| 08-08 | 53,628.90 | 64,977.39 | 0.825 |
| 08-09 | 59,706.87 | 64,746.36 | 0.922 |
| 08-12 | 63,776.02 | 63,762.83 | **1.0002** |
| 08-14 | 61,704.31 | 63,329.53 | 0.974 |
| 08-17 | 63,452.61 | 63,507.65 | **0.999** |
| 08-20 | 61,676.28 | 69,388.04 | 0.889 |

A day with no quote drops the whole position rather than erroring, so the series flaps instead of showing a gap.

## Change

Count it as BTC, which is quoted every day. Position read on-chain:

```
M-BTC            18 decimals, totalSupply 5,699.412
vault 0xF977..   holds 990.8838 M-BTC
```

Test: `merlin 61.13 M -> 68.97 M`, total `315.24 M -> 323.34 M`. Other chains move less than 0.2% between the two runs, which is BTC drifting, not this change.

## What is assumed, and what is not

Treating M-BTC as 1 BTC is the assumption. What supports it:

- `coreAssets` already registers this exact address as merlin `WBTC_1`, so the repo classifies it as a wrapped-BTC core asset.
- The quote prints exact BTC parity on 08-12 (+0.02%) and 08-17 (−0.09%) and then wanders to −19%. A real sustained depeg does not return to exact parity twice.
- uniBTC trades at 68,907.84 against BTC 69,512.67, 0.87% below, while M-BTC is about 22% of the collateral behind it. An 11% M-BTC depeg would not leave uniBTC that close to parity.

What I could **not** do: find an M-BTC pool on Merlin to price it directly. DefiLlama tracks no Merlin pools, so there is no liquidity read to settle it. If M-BTC really is trading at a discount then this overstates Merlin by about 7.8M, and the honest alternative is to leave it on its own feed and accept the flap. Your call.

Kept in the adapter rather than in `fixBalancesTokens` because this adapter uses `api.sumTokens`, which does not run the balance-fixing layer.