### PR TITLE
gate-io: drop the duplicate proton key, it was silently deleting the cold wallet

### DIFF
--- a/projects/gate-io/index.js
+++ b/projects/gate-io/index.js
@@ -1817,11 +1817,6 @@ const config = {
       "xpla1n5ukn9q2r5vrgt6su0e6cvm5lyxe2cn9lmfyu7"
     ]
   },
-  "proton": {
-    "owners": [
-      "gatedeposit"
-    ]
-  },
   "zeta": {
     "owners": [
       "0x0d0707963952f2fba59dd06f2b425ace40b492fe",


### PR DESCRIPTION
`config` defines `"proton"` twice:

```
line 1472   "proton": { "owners": ["gatedeposit", "gateiocold"] }
line 1820   "proton": { "owners": ["gatedeposit"] }
```

Both are properties of the same object literal, so the later one wins and `gateiocold` never reaches the adapter:

```js
> const o = { monad: { a: ["A"] }, monad: { a: ["Z"] } }
> JSON.stringify(o)
'{"monad":{"a":["Z"]}}'
```

The second entry also sits between `"xpla"` and `"zeta"` rather than in alphabetical order with the first, which is what an accidental append looks like.

This removes the later entry and keeps the one that lists both owners.

## Size, stated honestly

**This is worth nothing today.** `gateiocold` currently holds:

```
1.5 XPR            (eosio.token)
100,000 SNIPS      (snipcoins)
```

so the published number does not move. What the change buys is that the cold wallet stops being silently excluded, which matters the moment Gate moves funds into it. `gateiocold` appears nowhere else in the repo, so this entry was its only reference.

## How it was found

Parsed every file under `projects/` with acorn and looked for repeated keys inside a single `ObjectExpression`. This is the **only** occurrence in the repo, and the count is 0 after the change. (An indentation-based grep gives hundreds of false positives, because separate config objects at the same indent are not duplicates — worth knowing if anyone wants to re-run this.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed the unsupported Proton chain configuration from Gate.io integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->