### PR TITLE
fix: nested ERC-4626 curator vault TVL conversion

### DIFF
--- a/projects/helper/curators/index.js
+++ b/projects/helper/curators/index.js
@@ -512,10 +512,15 @@ async function getNested4626Vaults(api, vaults) {
   const vaultAsset = await api.multiCall({ abi: ABI.ERC4626.asset, calls: vaults, permitFailure: true })
   const nestedVaultAsset = await api.multiCall({ abi: ABI.ERC4626.asset, calls: vaultAsset, permitFailure: true })
   const totalAssets = await api.multiCall({ abi: ABI.ERC4626.totalAssets, calls: vaults, permitFailure: true })
+  const convertedAssets = await api.multiCall({
+    abi: ABI.ERC4626.convertToAssets,
+    calls: vaultAsset.map((target, i) => ({ target, params: [totalAssets[i]] })),
+    permitFailure: true,
+  })
   for (let i = 0; i < vaults.length; i++) {
-    const resolvedAsset = nestedVaultAsset[i] || vaultAsset[i]
-    if (!resolvedAsset) continue
-    api.add(resolvedAsset, totalAssets[i])
+    const asset = nestedVaultAsset[i] || vaultAsset[i]
+    const amount = nestedVaultAsset[i] ? convertedAssets[i] : totalAssets[i]
+    if (asset && amount) api.add(asset, amount)
   }
 }
 


### PR DESCRIPTION
## Summary

- Fix `getNested4626Vaults` so nested ERC-4626 vaults convert the outer `totalAssets()` from inner-vault shares into underlying token units via `convertToAssets`.
- Use batched RPC calls for the conversion step.

## Problem

For nested vaults, the outer vault’s `totalAssets()` is denominated in inner-vault shares, not the final underlying asset. The helper was adding that share amount directly to the underlying token, which undercounted TVL when the inner share price was above 1.

Example: Blend’s Scroll nested vault was off by about 5.6% in the current on-chain state.

## Fix

In `projects/helper/curators/index.js`, when an inner `asset()` exists:
- resolve the underlying token from the nested vault
- convert outer `totalAssets()` with `convertToAssets`
- add the converted amount to TVL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reporting of assets held through nested vaults by converting vault shares into their underlying asset amounts.
  * Continued using direct asset totals where applicable.
  * Excluded entries when asset or amount information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->