### PR TITLE
feat: add Covenant and Open Vecta staking adapters (Solana)

### DIFF
--- a/registries/sumTokens.js
+++ b/registries/sumTokens.js
@@ -12073,6 +12073,23 @@ const configs = {
       }
     },
   },
+  "covenant": {
+    "methodology": "Tracks CVNT tokens in the Streamflow staking contracts.",
+    "doublecounted": true,
+    "solana": {
+      "staking": {
+        "tokenAccounts": [
+          '5Fg449W8E7EnLfC7Sgn4zCwSmFXP1YbpVEnVQ3WKEwuC',
+          '12zg2Eu2HM2X39ZCoVbQRA6t6xP3Fmz21WskfzbCCsK6',
+          '9fEQ4ow9WM4XkSZiNrEPDgy1rt73WgUJvnKsLWQR1Qus',
+          '4TtDoALukroBBRbibXknqsDkpo3ak1pN5i52LtjgmDyk',
+        ]
+      },
+      "tvl": {
+        "__empty": true
+      }
+    }
+  },
   "crackandstack": {
     "methodology": "Crack & Stack TVL is the backed value of the Lanterns NFT.",
     "taiko": {
@@ -20966,6 +20983,23 @@ const configs = {
         ADDRESSES.bsc.USDT
       ]
     },
+  },
+  "open-vecta": {
+    "methodology": "Tracks VECTA tokens in the Streamflow staking contracts.",
+    "doublecounted": true,
+    "solana": {
+      "staking": {
+        "tokenAccounts": [
+          'HB3TJsPBcSn8LJ7h3SeR2cKsZNRpZftZ1bGAto83JXsd',
+          'DWhcx3Q6fmeEFufdSyBxws9S4yk9h737x2WhkG1iLpK1',
+          '9noqjg9tLXhZd5Gvxc2MFFtoyxiNHuR1DyHog3teXsAT',
+          'EVyKtMBBdzuxcRm7z6xDncKvgRnawtbaqMjPpSpX4cVy',
+        ]
+      },
+      "tvl": {
+        "__empty": true
+      }
+    }
   },
   "optinyan": {
     "optimism": {

--- a/registries/sumTokens.js
+++ b/registries/sumTokens.js
@@ -12073,7 +12073,7 @@ const configs = {
       }
     },
   },
-  "covenant": {
+  "covenant-protocol": {
     "methodology": "Tracks CVNT tokens in the Streamflow staking contracts.",
     "doublecounted": true,
     "solana": {


### PR DESCRIPTION
Adds two more Solana staking protocols, same team and same setup as [`xona-agent`](https://github.com/DefiLlama/DefiLlama-Adapters/pull/20547) which @RohanNero kindly merged in #20573. Following that exact pattern, straight into `registries/sumTokens.js`.

Both are deployed on **Streamflow**'s stake-pool program rather than custom contracts, so both are marked `doublecounted: true` to match how xona-agent was handled.

## Covenant

##### Name: Covenant
##### Twitter: https://x.com/opencovenant
##### Website: https://opencovenant.org (staking: https://stake.opencovenant.org)
##### Chain: Solana
##### Token: `2mNVZ6aEjrGwiUVCfz7XGWpiXuWzgBDoznwE579upump` — $CVNT
##### Current: ~123,821,367 CVNT staked (~$6.7k)
##### Category: Staking Pool
##### forkedFrom: not a code fork; deployed on Streamflow's stake-pool program
##### Audits: none of our own; runs on Streamflow's audited program
##### Oracle: none, balances read directly from on-chain token accounts
##### Referral program: no

## Open Vecta

##### Name: Open Vecta
##### Twitter: https://x.com/openvecta
##### Website: https://openvecta.com (staking: https://stake.openvecta.com)
##### Chain: Solana
##### Token: `4VBvCEMrPEU6yYF43pdahJafdHGaRxtMtKENqYpnpump` — $VECTA
##### Current: ~225,057,110 VECTA staked (~$6.6k)
##### Category: Staking Pool
##### forkedFrom: not a code fork; deployed on Streamflow's stake-pool program
##### Audits: none of our own; runs on Streamflow's audited program
##### Oracle: none, balances read directly from on-chain token accounts
##### Referral program: no

## methodology

Each project stakes its own token across four fixed lock tiers (7, 30, 90, 180 days). Every tier is a separate Streamflow stake pool holding deposits in its own vault token account. The adapter sums those four vaults on-chain.

Reported under `staking` with `tvl: __empty`, since only the protocol's native token is deposited — same call as xona-agent. Reward vaults are excluded, as those hold undistributed rewards rather than user deposits.

Verified locally against mainnet:

```
covenant       123,821,367  solana:2mNVZ6aEjrGwiUVCfz7XGWpiXuWzgBDoznwE579upump
open-vecta     225,057,110  solana:4VBvCEMrPEU6yYF43pdahJafdHGaRxtMtKENqYpnpump
```

## One question, on a third protocol

We have a fourth staking program, **Agent Ranking** (`92eXvBFGBAXwgmPf6t6CUCNJH2xChsCJuWzaGPjyPUmP`, $AR), with ~445.5M staked. It is deliberately **not** in this PR: the token is not in your price database, so an adapter would return a balance you cannot value.

It trades on PumpSwap (~$13k liquidity, ~$0.0000283), which would put it around $12.6k. Is there anything we should do to get it into the price feed, or is that liquidity simply too thin? Happy to submit the adapter separately once it can be priced.

---
No new npm dependencies, and `pnpm-lock.yaml` is untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tracking configurations for the covenant-protocol and open-vecta tokens.
  * Enabled Streamflow Solana staking contract tracking and double-counting support for both tokens.
  * Added token account configuration for improved tracking accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->