### PR TITLE
Add Sapien Vault TVL adapter on Base

### DIFF
--- a/projects/sapien-vault/index.js
+++ b/projects/sapien-vault/index.js
@@ -7,6 +7,7 @@ module.exports = {
     'TVL is SAPIEN held by the Base ERC-4626 Sapien PoQ Vault, measured on-chain via totalAssets(). Protocol-owned SAPIEN in RewardsController is excluded.',
   start: '2026-04-07',
   base: {
-    tvl: sumERC4626VaultsExport2({ vaults: [VAULT] }),
+    tvl: () => ({}),
+    staking: sumERC4626VaultsExport2({ vaults: [VAULT] }),
   },
 }

--- a/projects/sapien-vault/index.js
+++ b/projects/sapien-vault/index.js
@@ -1,0 +1,12 @@
+const { sumERC4626VaultsExport2 } = require('../helper/erc4626')
+
+const VAULT = '0x60Bf63729f688287a450299962b36Cef0aFfaa42'
+
+module.exports = {
+  methodology:
+    'TVL is SAPIEN held by the Base ERC-4626 Sapien PoQ Vault, measured on-chain via totalAssets(). Protocol-owned SAPIEN in RewardsController is excluded.',
+  start: '2026-04-07',
+  base: {
+    tvl: sumERC4626VaultsExport2({ vaults: [VAULT] }),
+  },
+}


### PR DESCRIPTION
## Summary
- Add a Base ERC-4626 TVL adapter for the live Sapien PoQ Vault (`0x60Bf63729f688287a450299962b36Cef0aFfaa42`).
- TVL is on-chain `totalAssets()` (SAPIEN). Protocol-owned SAPIEN in RewardsController is excluded.

**NOTE**

Allow edits by maintainers is enabled.

---

## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
Sapien Vault

##### Twitter Link:
https://x.com/BuildOnSapien

##### List of audit links if any:
https://github.com/Sapien-io/sapien-contracts/blob/main/audits/QS_SapienVault_Final_Report_June_2026.pdf

##### Website Link:
https://vault.sapien.io

##### Logo (High resolution, will be shown with rounded borders):
https://vault.sapien.io/sapien-logo-white.svg

##### Current TVL:
~$29.5k (local `node test.js projects/sapien-vault/index.js`, ~373.5k SAPIEN)

##### Treasury Addresses (if the protocol has treasury)
Top-10 Base SAPIEN holders except Binance: https://holderbrief.com/t/base/0xc729777d0470f30612b1564fd96e8dd26f5814e3
Mint / constructor treasury: `0x454149F78630A82fDcf5559384042A3BBD358FB2`

##### Chain:
Base

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)
sapien-2

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
sapien-io

##### Short Description (to be shown on DefiLlama):
ERC-4626 vault for SAPIEN deposits on Base. Depositors receive vSAPIEN shares; optional lock is PoQ validator collateral. Yield is dripped into the vault as SAPIEN.

##### Token address and ticker if any:
`0xC729777d0470F30612B1564Fd96E8Dd26f5814E3` / SAPIEN (Base)

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Yield

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
None. Vault share price is ERC-4626 `convertToAssets` / `totalAssets`. SAPIEN is priced via CoinGecko.

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
Not applicable. No oracle is used by the vault.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
https://docs.sapien.io/collateral/sapien-vault
https://github.com/Sapien-io/sapien-contracts/blob/main/docs/SapienVault.md

##### forkedFrom (Does your project originate from another project):
No

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL is SAPIEN held by the Base ERC-4626 Sapien PoQ Vault, measured on-chain via `totalAssets()`. Protocol-owned SAPIEN in RewardsController is excluded.

##### Github org/user (Optional, if your code is open source, we can track activity):
Sapien-io/sapien-contracts

##### Does this project have a referral program?
No

## Test plan
- [x] `node test.js projects/sapien-vault/index.js` — Base TVL ~$29.5k, SAPIEN priced, no unknown tokens
- [ ] CI on this PR
- [ ] Reviewers: own-token deposits are submitted as base `tvl`; reclassify to `staking` if that is preferred

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added staking asset tracking for the Sapien Vault on Base.
  * Included vault methodology details, tracking start date, and vault address configuration.
* **Updates**
  * Removed TVL tracking for the Sapien Vault on Base.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->