### PR TITLE
resolve covalent failures

### DIFF
--- a/registries/treasury.js
+++ b/registries/treasury.js
@@ -1367,12 +1367,14 @@ const configs = {
         nullAddress,
         ADDRESSES.bsc.USDT,
         ADDRESSES.bsc.WBNB,
+        '0xd631d33F2c3f38d9ABDaE08ebC0B69fA636E8ec2',
+        '0x000Ae314E2A2172a039B26378814C252734f556A',
+        '0x3a9e15b28e099708d0812e0843a9ed70c508fb4b'
       ],
       owners: [
         '0x7f01f344b1950a3C5EA3B9dB7017f93aB0c8f88E',
         '0x31EE4A9Ed7eF0CF0dcdF881eDc9c82C661a40b80',
         '0x90084B88c772ED1bA5dafa71430628fC6aE004ff',
-        '0xbc15aaa0B1C37ebb7B506ADe0BFA35F16E67f534',
         '0xf7efE91bB756D7754aE8936e1F6041848f848AD3',
         '0x36E4c71917245746C45bF7A031166489986A75A8',
         '0x02f81Ca4CAb8fB64C82A6F1bC5E3EB32C62AFcA3',
@@ -1384,6 +1386,7 @@ const configs = {
         '0x16F1b9B34F2596c5538E0ad1B10C85D4B2820b82',
       ],
       ownTokens: ['0xBe96fcF736AD906b1821Ef74A0e4e346C74e6221'],
+      fetchCoValentTokens: false
     },
   },
   'treasury/csrfi': {
@@ -4626,7 +4629,6 @@ const configs = {
     arbitrum: {
       tokens: [
         nullAddress,
-        '0x25118290e6a5f4139381d072181157035864099d', // rain token
       ],
       owners: [
         '0x7B72bE69F99c0C9D9832Ed6c88e4397E44673Af8',
@@ -4643,6 +4645,7 @@ const configs = {
         '0xFf027fF0Fcd426DcB8EA648430f1588f9C976bAe',
       ],
       ownTokens: ['0x25118290e6a5f4139381d072181157035864099d'],
+      fetchCoValentTokens: false,
     },
   },
   'treasury/raisehood': {


### PR DESCRIPTION
cryptonopix - added three tokens that had value (aster,love,snap), removed an EOA that was never used, and removed fetchCoValent. It was fetching >2k tokens yet less than 5 had any substantial value (alternatively, we could keep fetchCoValent but remove some of the dead treasury addresses such as `0x6E653a3f76eCE9C3b1849b2159fDdf3bB20f0DF4`

rain - only tracked ETH position, removed fetchCoValent and duplicate RAIN entry

resolves #20603

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Added three BSC token addresses to the Cryptonopix treasury.
  * Removed an owner address from the Cryptonopix treasury.
  * Removed the Rain treasury’s Arbitrum rain-token entry.
  * Disabled CoValent token fetching for both treasuries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->