### PR TITLE
Add SwitchX TVL adapter

### DIFF
--- a/projects/switchx/index.js
+++ b/projects/switchx/index.js
@@ -1,198 +1,30 @@
 const sdk = require('@defillama/sdk')
-const BigNumber = require('bignumber.js')
+const { uniV3Export } = require('../helper/uniswapV3')
 const { sumTokens2 } = require('../helper/unwrapLPs')
+const { getLogs2 } = require('../helper/cache/getLogs')
 
 const FACTORY = '0xeF72cbCcF4A807DfA1fbecd61DdB488fF8a05fa3'
 const ALM_VAULT_FACTORY = '0x8d8535C8842Aa541fcB3F6CC436e1b3A816a3a0e'
-const USDC = '0x15D38573d2feeb82e7ad5187aB8c1D52810B1f07'
-const SWITCH = '0x357D80EA5dC53999Da7dA747e7afEBc02fe276Fb'
-const WPLS = '0xA1077a294dDE1B09bB078844df40758a5D0f9a27'
-const SWITCH_USDC_POOL = '0x066589f69c4016C75883612a50aEc76c4887ac38'
-const SWITCH_WPLS_POOL = '0x829f3d4aBAfa6920648188750A8e36220F137B67'
-const USDC_WPLS_POOL = '0xb0753197dcBd873c8E8131f3D691C3135C3D8d66'
-const FACTORY_FROM_BLOCK = 26521466
-// The shared cloud cache can claim complete coverage while omitting PulseChain
-// logs. Use the SDK's local cache and bound every RPC fallback range instead.
-const MAX_LOG_BLOCK_RANGE = 99_979
-const TWAP_WINDOW = 60 * 60
-const MAX_ORACLE_AGE = 6 * 60 * 60
-const MAX_TIMESTAMP_SKEW = 5 * 60
-const MAX_ROUTE_DEVIATION_BPS = 500
-const MIN_ROUTE_USDC_RESERVE = 10_000n * 10n ** 6n
-const MIN_COMBINED_USDC_RESERVE = 50_000n * 10n ** 6n
-const MIN_SWITCH_RESERVE = 1_000_000n * 10n ** 18n
-const Decimal = BigNumber.clone({ DECIMAL_PLACES: 40, POW_PRECISION: 40 })
+const FROM_BLOCK = 26521466
 
-const STANDARD_POOL_CREATED = 'event Pool(address indexed token0, address indexed token1, address pool)'
-const CUSTOM_POOL_CREATED = 'event CustomPool(address indexed deployer, address indexed token0, address indexed token1, address pool)'
-const ALM_VAULT_CREATED =
-  'event ALMVaultCreated(address indexed sender, address almVault, address tokenA, bool allowTokenA, address tokenB, bool allowTokenB, uint256 count)'
-const GET_RESERVES = 'function getReserves() view returns (uint128 reserve0, uint128 reserve1)'
-const GET_TIMEPOINTS =
-  'function getTimepoints(uint32[] secondsAgos) view returns (int56[] tickCumulatives, uint88[] volatilityCumulatives)'
+const ALM_VAULT_CREATED = 'event ALMVaultCreated(address indexed sender, address almVault, address tokenA, bool allowTokenA, address tokenB, bool allowTokenB, uint256 count)'
 
-function lower(address) {
-  return address.toLowerCase()
-}
+const poolsTvl = uniV3Export({
+  pulse: { factory: FACTORY, fromBlock: FROM_BLOCK, isAlgebra: true },
+})
 
-function averageTick(tickCumulativeDelta) {
-  const window = BigInt(TWAP_WINDOW)
-  let tick = tickCumulativeDelta / window
-  // Match the oracle-consumer convention: negative, non-exact averages round
-  // toward negative infinity rather than Solidity's toward-zero division.
-  if (tickCumulativeDelta < 0n && tickCumulativeDelta % window !== 0n) tick -= 1n
-  return Number(tick)
-}
-
-async function readTwapPool(api, pool, expectedToken0, expectedToken1) {
-  const [token0, token1, plugin, reserves] = await Promise.all([
-    api.call({ target: pool, abi: 'address:token0' }),
-    api.call({ target: pool, abi: 'address:token1' }),
-    api.call({ target: pool, abi: 'address:plugin' }),
-    api.call({ target: pool, abi: GET_RESERVES }),
-  ])
-
-  if (lower(token0) !== lower(expectedToken0) || lower(token1) !== lower(expectedToken1)) {
-    throw new Error(`unexpected token order for ${pool}`)
-  }
-
-  const [initialized, lastTimestamp, timepoints] = await Promise.all([
-    api.call({ target: plugin, abi: 'bool:isInitialized' }),
-    api.call({ target: plugin, abi: 'uint32:lastTimepointTimestamp' }),
-    api.call({ target: plugin, abi: GET_TIMEPOINTS, params: [[TWAP_WINDOW, 0]] }),
-  ])
-  if (!initialized) throw new Error(`uninitialized oracle for ${pool}`)
-
-  const now = Number(api.timestamp || Math.floor(Date.now() / 1000))
-  const oracleAge = now - Number(lastTimestamp)
-  // Historical timestamp-to-block resolution can select the first block a few
-  // seconds after midnight. Allow only that bounded mapping skew.
-  if (oracleAge < -MAX_TIMESTAMP_SKEW || oracleAge > MAX_ORACLE_AGE) {
-    throw new Error(`stale oracle for ${pool}`)
-  }
-
-  const tickCumulatives = timepoints.tickCumulatives ?? timepoints[0]
-  if (!Array.isArray(tickCumulatives) || tickCumulatives.length !== 2) {
-    throw new Error(`invalid oracle response for ${pool}`)
-  }
-  const tick = averageTick(BigInt(tickCumulatives[1]) - BigInt(tickCumulatives[0]))
-
-  return {
-    ratio1Per0: new Decimal('1.0001').pow(tick),
-    reserve0: BigInt(reserves.reserve0 ?? reserves[0]),
-    reserve1: BigInt(reserves.reserve1 ?? reserves[1]),
-  }
-}
-
-async function getSwitchUsdcRatio(api) {
-  const [direct, switchWpls, usdcWpls] = await Promise.all([
-    readTwapPool(api, SWITCH_USDC_POOL, USDC, SWITCH),
-    readTwapPool(api, SWITCH_WPLS_POOL, SWITCH, WPLS),
-    readTwapPool(api, USDC_WPLS_POOL, USDC, WPLS),
-  ])
-
-  if (
-    direct.reserve0 < MIN_ROUTE_USDC_RESERVE ||
-    usdcWpls.reserve0 < MIN_ROUTE_USDC_RESERVE ||
-    direct.reserve0 + usdcWpls.reserve0 < MIN_COMBINED_USDC_RESERVE
-  ) {
-    throw new Error('insufficient USDC-side oracle liquidity')
-  }
-  if (direct.reserve1 < MIN_SWITCH_RESERVE || switchWpls.reserve0 < MIN_SWITCH_RESERVE) {
-    throw new Error('insufficient SWITCH-side oracle liquidity')
-  }
-
-  // Pool ticks quote raw token1 units per raw token0 unit. The direct pool
-  // therefore needs inversion, while the two-hop quote divides the two WPLS
-  // legs to produce raw USDC units per raw SWITCH unit.
-  const directRatio = new Decimal(1).div(direct.ratio1Per0)
-  const crossRatio = switchWpls.ratio1Per0.div(usdcWpls.ratio1Per0)
-  const lowerRatio = Decimal.minimum(directRatio, crossRatio)
-  const divergenceBps = directRatio.minus(crossRatio).abs().div(lowerRatio).times(10_000)
-  if (divergenceBps.gt(MAX_ROUTE_DEVIATION_BPS)) throw new Error('SWITCH oracle routes diverged')
-
-  // Use the lower agreeing quote so the custom valuation is conservative.
-  return lowerRatio
-}
-
-async function tvl(api) {
-  const toBlock = await api.getBlock()
-  const getFactoryLogs = (target, eventAbi) =>
-    sdk.getEventLogs({
-      chain: api.chain,
-      target,
-      fromBlock: FACTORY_FROM_BLOCK,
-      toBlock,
-      eventAbi,
-      onlyArgs: true,
-      maxBlockRange: MAX_LOG_BLOCK_RANGE,
-    })
-
-  const [standardPools, customPools, almVaults] = await Promise.all([
-    getFactoryLogs(FACTORY, STANDARD_POOL_CREATED),
-    getFactoryLogs(FACTORY, CUSTOM_POOL_CREATED),
-    getFactoryLogs(ALM_VAULT_FACTORY, ALM_VAULT_CREATED),
-  ])
-
-  const owners = new Map()
-  for (const { token0, token1, pool } of [...standardPools, ...customPools]) {
-    owners.set(pool.toLowerCase(), { token0, token1, owner: pool })
-  }
-  // ALM liquidity positions are already included in pool balances. Only the
-  // vaults' idle underlying balances are additional TVL, so count their
-  // token0/token1 balances without valuing vault shares or NFT positions.
-  for (const { almVault, tokenA, tokenB } of almVaults) {
-    owners.set(almVault.toLowerCase(), { token0: tokenA, token1: tokenB, owner: almVault })
-  }
-
-  const ownerEntries = [...owners.values()]
-  const switchOwners = ownerEntries
-    .filter(({ token0, token1 }) => lower(token0) === lower(SWITCH) || lower(token1) === lower(SWITCH))
-    .map(({ owner }) => ({ target: SWITCH, params: owner }))
-  const [switchBalances] = await Promise.all([
-    switchOwners.length
-      ? api.multiCall({
-          abi: 'erc20:balanceOf',
-          calls: switchOwners,
-          permitFailure: true,
-        })
-      : Promise.resolve([]),
-    sumTokens2({
-      api,
-      ownerTokens: ownerEntries.map(({ token0, token1, owner }) => [[token0, token1], owner]),
-      // SWITCH has no DefiLlama coin price yet. It is handled once below so it
-      // cannot be double counted if the shared price service later adds it.
-      blacklistedTokens: [SWITCH],
-      // Standard pool creation is permissionless. Isolate non-compliant or
-      // reverting ERC-20 balanceOf calls so one hostile pool cannot break TVL.
-      permitFailure: true,
-    }),
-  ])
-  const totalSwitch = switchBalances.reduce((total, balance) => total + BigInt(balance || 0), 0n)
-
-  if (totalSwitch !== 0n) {
-    try {
-      const switchUsdcRatio = await getSwitchUsdcRatio(api)
-      const usdcEquivalent = switchUsdcRatio
-        .times(totalSwitch.toString())
-        .integerValue(Decimal.ROUND_FLOOR)
-        .toFixed(0)
-      api.add(USDC, usdcEquivalent)
-    } catch {
-      // Preserve raw SWITCH on early historical blocks or during a guarded
-      // oracle outage. This keeps the rest of TVL live and allows DefiLlama's
-      // shared price service to value the token if support becomes available.
-      api.add(SWITCH, totalSwitch.toString())
-    }
-  }
-
-  return api.getBalances()
+async function almVaultTvl(api) {
+  const vaults = await getLogs2({ api, target: ALM_VAULT_FACTORY, eventAbi: ALM_VAULT_CREATED, fromBlock: FROM_BLOCK })
+  return sumTokens2({
+    api,
+    ownerTokens: vaults.map(({ almVault, tokenA, tokenB }) => [[tokenA, tokenB], almVault]),
+    permitFailure: true,
+  })
 }
 
 module.exports = {
   start: '2026-05-13',
-  misrepresentedTokens: true,
   methodology:
-    'TVL is the value of token0 and token1 balances held by every standard and custom concentrated-liquidity pool created by the canonical SwitchX factory on PulseChain, plus idle underlying token balances held directly by canonical SwitchX ALM vaults. SWITCH balances are represented as USDC using the lower of an on-chain one-hour SWITCH/USDC TWAP and an independently derived SWITCH/WPLS/USDC TWAP, only while both routes have initialized, fresh oracles, minimum SWITCH and USDC liquidity, and no more than 5% divergence. ALM position liquidity is already custodied by the pools, so vault receipt tokens, farming positions, ve-locked SWITCH, rewards, treasury balances, and other protocol-owned assets are excluded to avoid double counting.',
-  pulse: { tvl },
+    'TVL is the token0/token1 balances held by every pool created by the SwitchX factory on PulseChain, plus the idle underlying token balances held by SwitchX ALM vaults. ALM position liquidity is already custodied by the pools, so vault receipt tokens, farming positions, ve-locked SWITCH, rewards and treasury balances are excluded to avoid double counting.',
+  pulse: { tvl: sdk.util.sumChainTvls([poolsTvl.pulse.tvl, almVaultTvl]) },
 }

--- a/projects/switchx/index.js
+++ b/projects/switchx/index.js
@@ -1,17 +1,119 @@
 const sdk = require('@defillama/sdk')
+const BigNumber = require('bignumber.js')
 const { sumTokens2 } = require('../helper/unwrapLPs')
 
 const FACTORY = '0xeF72cbCcF4A807DfA1fbecd61DdB488fF8a05fa3'
 const ALM_VAULT_FACTORY = '0x8d8535C8842Aa541fcB3F6CC436e1b3A816a3a0e'
+const USDC = '0x15D38573d2feeb82e7ad5187aB8c1D52810B1f07'
+const SWITCH = '0x357D80EA5dC53999Da7dA747e7afEBc02fe276Fb'
+const WPLS = '0xA1077a294dDE1B09bB078844df40758a5D0f9a27'
+const SWITCH_USDC_POOL = '0x066589f69c4016C75883612a50aEc76c4887ac38'
+const SWITCH_WPLS_POOL = '0x829f3d4aBAfa6920648188750A8e36220F137B67'
+const USDC_WPLS_POOL = '0xb0753197dcBd873c8E8131f3D691C3135C3D8d66'
 const FACTORY_FROM_BLOCK = 26521466
 // PulseChain RPC providers can silently truncate wide eth_getLogs ranges.
 // The SDK still uses its cache/indexer first and applies this only on fallback.
 const MAX_LOG_BLOCK_RANGE = 100_000
+const TWAP_WINDOW = 60 * 60
+const MAX_ORACLE_AGE = 6 * 60 * 60
+const MAX_TIMESTAMP_SKEW = 5 * 60
+const MAX_ROUTE_DEVIATION_BPS = 500
+const MIN_ROUTE_USDC_RESERVE = 10_000n * 10n ** 6n
+const MIN_COMBINED_USDC_RESERVE = 50_000n * 10n ** 6n
+const MIN_SWITCH_RESERVE = 1_000_000n * 10n ** 18n
+const Decimal = BigNumber.clone({ DECIMAL_PLACES: 40, POW_PRECISION: 40 })
 
 const STANDARD_POOL_CREATED = 'event Pool(address indexed token0, address indexed token1, address pool)'
 const CUSTOM_POOL_CREATED = 'event CustomPool(address indexed deployer, address indexed token0, address indexed token1, address pool)'
 const ALM_VAULT_CREATED =
   'event ALMVaultCreated(address indexed sender, address almVault, address tokenA, bool allowTokenA, address tokenB, bool allowTokenB, uint256 count)'
+const GET_RESERVES = 'function getReserves() view returns (uint128 reserve0, uint128 reserve1)'
+const GET_TIMEPOINTS =
+  'function getTimepoints(uint32[] secondsAgos) view returns (int56[] tickCumulatives, uint88[] volatilityCumulatives)'
+
+function lower(address) {
+  return address.toLowerCase()
+}
+
+function averageTick(tickCumulativeDelta) {
+  const window = BigInt(TWAP_WINDOW)
+  let tick = tickCumulativeDelta / window
+  // Match the oracle-consumer convention: negative, non-exact averages round
+  // toward negative infinity rather than Solidity's toward-zero division.
+  if (tickCumulativeDelta < 0n && tickCumulativeDelta % window !== 0n) tick -= 1n
+  return Number(tick)
+}
+
+async function readTwapPool(api, pool, expectedToken0, expectedToken1) {
+  const [token0, token1, plugin, reserves] = await Promise.all([
+    api.call({ target: pool, abi: 'address:token0' }),
+    api.call({ target: pool, abi: 'address:token1' }),
+    api.call({ target: pool, abi: 'address:plugin' }),
+    api.call({ target: pool, abi: GET_RESERVES }),
+  ])
+
+  if (lower(token0) !== lower(expectedToken0) || lower(token1) !== lower(expectedToken1)) {
+    throw new Error(`unexpected token order for ${pool}`)
+  }
+
+  const [initialized, lastTimestamp, timepoints] = await Promise.all([
+    api.call({ target: plugin, abi: 'bool:isInitialized' }),
+    api.call({ target: plugin, abi: 'uint32:lastTimepointTimestamp' }),
+    api.call({ target: plugin, abi: GET_TIMEPOINTS, params: [[TWAP_WINDOW, 0]] }),
+  ])
+  if (!initialized) throw new Error(`uninitialized oracle for ${pool}`)
+
+  const now = Number(api.timestamp || Math.floor(Date.now() / 1000))
+  const oracleAge = now - Number(lastTimestamp)
+  // Historical timestamp-to-block resolution can select the first block a few
+  // seconds after midnight. Allow only that bounded mapping skew.
+  if (oracleAge < -MAX_TIMESTAMP_SKEW || oracleAge > MAX_ORACLE_AGE) {
+    throw new Error(`stale oracle for ${pool}`)
+  }
+
+  const tickCumulatives = timepoints.tickCumulatives ?? timepoints[0]
+  if (!Array.isArray(tickCumulatives) || tickCumulatives.length !== 2) {
+    throw new Error(`invalid oracle response for ${pool}`)
+  }
+  const tick = averageTick(BigInt(tickCumulatives[1]) - BigInt(tickCumulatives[0]))
+
+  return {
+    ratio1Per0: new Decimal('1.0001').pow(tick),
+    reserve0: BigInt(reserves.reserve0 ?? reserves[0]),
+    reserve1: BigInt(reserves.reserve1 ?? reserves[1]),
+  }
+}
+
+async function getSwitchUsdcRatio(api) {
+  const [direct, switchWpls, usdcWpls] = await Promise.all([
+    readTwapPool(api, SWITCH_USDC_POOL, USDC, SWITCH),
+    readTwapPool(api, SWITCH_WPLS_POOL, SWITCH, WPLS),
+    readTwapPool(api, USDC_WPLS_POOL, USDC, WPLS),
+  ])
+
+  if (
+    direct.reserve0 < MIN_ROUTE_USDC_RESERVE ||
+    usdcWpls.reserve0 < MIN_ROUTE_USDC_RESERVE ||
+    direct.reserve0 + usdcWpls.reserve0 < MIN_COMBINED_USDC_RESERVE
+  ) {
+    throw new Error('insufficient USDC-side oracle liquidity')
+  }
+  if (direct.reserve1 < MIN_SWITCH_RESERVE || switchWpls.reserve0 < MIN_SWITCH_RESERVE) {
+    throw new Error('insufficient SWITCH-side oracle liquidity')
+  }
+
+  // Algebra ticks quote raw token1 units per raw token0 unit. The direct pool
+  // therefore needs inversion, while the two-hop quote divides the two WPLS
+  // legs to produce raw USDC units per raw SWITCH unit.
+  const directRatio = new Decimal(1).div(direct.ratio1Per0)
+  const crossRatio = switchWpls.ratio1Per0.div(usdcWpls.ratio1Per0)
+  const lowerRatio = Decimal.minimum(directRatio, crossRatio)
+  const divergenceBps = directRatio.minus(crossRatio).abs().div(lowerRatio).times(10_000)
+  if (divergenceBps.gt(MAX_ROUTE_DEVIATION_BPS)) throw new Error('SWITCH oracle routes diverged')
+
+  // Use the lower agreeing quote so the custom valuation is conservative.
+  return lowerRatio
+}
 
 async function tvl(api) {
   const toBlock = await api.getBlock()
@@ -44,18 +146,53 @@ async function tvl(api) {
     owners.set(almVault.toLowerCase(), { token0: tokenA, token1: tokenB, owner: almVault })
   }
 
-  return sumTokens2({
+  const ownerEntries = [...owners.values()]
+  const switchOwners = ownerEntries
+    .filter(({ token0, token1 }) => lower(token0) === lower(SWITCH) || lower(token1) === lower(SWITCH))
+    .map(({ owner }) => ({ target: SWITCH, params: owner }))
+  const switchBalances = switchOwners.length
+    ? await api.multiCall({
+        abi: 'erc20:balanceOf',
+        calls: switchOwners,
+        permitFailure: true,
+      })
+    : []
+  const totalSwitch = switchBalances.reduce((total, balance) => total + BigInt(balance || 0), 0n)
+
+  await sumTokens2({
     api,
-    ownerTokens: [...owners.values()].map(({ token0, token1, owner }) => [[token0, token1], owner]),
+    ownerTokens: ownerEntries.map(({ token0, token1, owner }) => [[token0, token1], owner]),
+    // SWITCH has no DefiLlama coin price yet. It is handled once below so it
+    // cannot be double counted if the shared price service later adds it.
+    blacklistedTokens: [SWITCH],
     // Standard pool creation is permissionless. Isolate non-compliant or
     // reverting ERC-20 balanceOf calls so one hostile pool cannot break TVL.
     permitFailure: true,
   })
+
+  if (totalSwitch !== 0n) {
+    try {
+      const switchUsdcRatio = await getSwitchUsdcRatio(api)
+      const usdcEquivalent = switchUsdcRatio
+        .times(totalSwitch.toString())
+        .integerValue(Decimal.ROUND_FLOOR)
+        .toFixed(0)
+      api.add(USDC, usdcEquivalent)
+    } catch {
+      // Preserve raw SWITCH on early historical blocks or during a guarded
+      // oracle outage. This keeps the rest of TVL live and allows DefiLlama's
+      // shared price service to value the token if support becomes available.
+      api.add(SWITCH, totalSwitch.toString())
+    }
+  }
+
+  return api.getBalances()
 }
 
 module.exports = {
   start: '2026-05-13',
+  misrepresentedTokens: true,
   methodology:
-    'TVL is the value of token0 and token1 balances held by every standard and custom concentrated-liquidity pool created by the canonical SwitchX factory on PulseChain, plus idle underlying token balances held directly by canonical SwitchX ALM vaults. ALM position liquidity is already custodied by the pools, so vault receipt tokens, farming positions, ve-locked SWITCH, rewards, treasury balances, and other protocol-owned assets are excluded to avoid double counting.',
+    'TVL is the value of token0 and token1 balances held by every standard and custom concentrated-liquidity pool created by the canonical SwitchX factory on PulseChain, plus idle underlying token balances held directly by canonical SwitchX ALM vaults. SWITCH balances are represented as USDC using the lower of an on-chain one-hour SWITCH/USDC TWAP and an independently derived SWITCH/WPLS/USDC TWAP, only while both routes have initialized, fresh oracles, minimum SWITCH and USDC liquidity, and no more than 5% divergence. ALM position liquidity is already custodied by the pools, so vault receipt tokens, farming positions, ve-locked SWITCH, rewards, treasury balances, and other protocol-owned assets are excluded to avoid double counting.',
   pulse: { tvl },
 }

--- a/projects/switchx/index.js
+++ b/projects/switchx/index.js
@@ -18,7 +18,6 @@ async function almVaultTvl(api) {
   return sumTokens2({
     api,
     ownerTokens: vaults.map(({ almVault, tokenA, tokenB }) => [[tokenA, tokenB], almVault]),
-    permitFailure: true,
   })
 }
 

--- a/projects/switchx/index.js
+++ b/projects/switchx/index.js
@@ -11,8 +11,8 @@ const SWITCH_USDC_POOL = '0x066589f69c4016C75883612a50aEc76c4887ac38'
 const SWITCH_WPLS_POOL = '0x829f3d4aBAfa6920648188750A8e36220F137B67'
 const USDC_WPLS_POOL = '0xb0753197dcBd873c8E8131f3D691C3135C3D8d66'
 const FACTORY_FROM_BLOCK = 26521466
-// PulseChain RPC providers can silently truncate wide eth_getLogs ranges.
-// The SDK still uses its cache/indexer first and applies this only on fallback.
+// The shared cloud cache can claim complete coverage while omitting PulseChain
+// logs. Use the SDK's local cache and bound every RPC fallback range instead.
 const MAX_LOG_BLOCK_RANGE = 100_000
 const TWAP_WINDOW = 60 * 60
 const MAX_ORACLE_AGE = 6 * 60 * 60
@@ -102,7 +102,7 @@ async function getSwitchUsdcRatio(api) {
     throw new Error('insufficient SWITCH-side oracle liquidity')
   }
 
-  // Algebra ticks quote raw token1 units per raw token0 unit. The direct pool
+  // Pool ticks quote raw token1 units per raw token0 unit. The direct pool
   // therefore needs inversion, while the two-hop quote divides the two WPLS
   // legs to produce raw USDC units per raw SWITCH unit.
   const directRatio = new Decimal(1).div(direct.ratio1Per0)
@@ -125,7 +125,6 @@ async function tvl(api) {
       toBlock,
       eventAbi,
       onlyArgs: true,
-      cacheInCloud: true,
       maxBlockRange: MAX_LOG_BLOCK_RANGE,
     })
 
@@ -150,25 +149,26 @@ async function tvl(api) {
   const switchOwners = ownerEntries
     .filter(({ token0, token1 }) => lower(token0) === lower(SWITCH) || lower(token1) === lower(SWITCH))
     .map(({ owner }) => ({ target: SWITCH, params: owner }))
-  const switchBalances = switchOwners.length
-    ? await api.multiCall({
-        abi: 'erc20:balanceOf',
-        calls: switchOwners,
-        permitFailure: true,
-      })
-    : []
+  const [switchBalances] = await Promise.all([
+    switchOwners.length
+      ? api.multiCall({
+          abi: 'erc20:balanceOf',
+          calls: switchOwners,
+          permitFailure: true,
+        })
+      : Promise.resolve([]),
+    sumTokens2({
+      api,
+      ownerTokens: ownerEntries.map(({ token0, token1, owner }) => [[token0, token1], owner]),
+      // SWITCH has no DefiLlama coin price yet. It is handled once below so it
+      // cannot be double counted if the shared price service later adds it.
+      blacklistedTokens: [SWITCH],
+      // Standard pool creation is permissionless. Isolate non-compliant or
+      // reverting ERC-20 balanceOf calls so one hostile pool cannot break TVL.
+      permitFailure: true,
+    }),
+  ])
   const totalSwitch = switchBalances.reduce((total, balance) => total + BigInt(balance || 0), 0n)
-
-  await sumTokens2({
-    api,
-    ownerTokens: ownerEntries.map(({ token0, token1, owner }) => [[token0, token1], owner]),
-    // SWITCH has no DefiLlama coin price yet. It is handled once below so it
-    // cannot be double counted if the shared price service later adds it.
-    blacklistedTokens: [SWITCH],
-    // Standard pool creation is permissionless. Isolate non-compliant or
-    // reverting ERC-20 balanceOf calls so one hostile pool cannot break TVL.
-    permitFailure: true,
-  })
 
   if (totalSwitch !== 0n) {
     try {

--- a/projects/switchx/index.js
+++ b/projects/switchx/index.js
@@ -1,5 +1,3 @@
-const sdk = require('@defillama/sdk')
-const { uniV3Export } = require('../helper/uniswapV3')
 const { sumTokens2 } = require('../helper/unwrapLPs')
 const { getLogs2 } = require('../helper/cache/getLogs')
 
@@ -7,23 +5,31 @@ const FACTORY = '0xeF72cbCcF4A807DfA1fbecd61DdB488fF8a05fa3'
 const ALM_VAULT_FACTORY = '0x8d8535C8842Aa541fcB3F6CC436e1b3A816a3a0e'
 const FROM_BLOCK = 26521466
 
-const ALM_VAULT_CREATED = 'event ALMVaultCreated(address indexed sender, address almVault, address tokenA, bool allowTokenA, address tokenB, bool allowTokenB, uint256 count)'
+const STANDARD_POOL_CREATED = 'event Pool(address indexed token0, address indexed token1, address pool)'
+const CUSTOM_POOL_CREATED = 'event CustomPool(address indexed deployer, address indexed token0, address indexed token1, address pool)'
+const ALM_VAULT_CREATED =
+  'event ALMVaultCreated(address indexed sender, address almVault, address tokenA, bool allowTokenA, address tokenB, bool allowTokenB, uint256 count)'
 
-const poolsTvl = uniV3Export({
-  pulse: { factory: FACTORY, fromBlock: FROM_BLOCK, isAlgebra: true },
-})
+async function tvl(api) {
+  const [standardPools, customPools, almVaults] = await Promise.all([
+    getLogs2({ api, target: FACTORY, eventAbi: STANDARD_POOL_CREATED, fromBlock: FROM_BLOCK, extraKey: 'pool' }),
+    getLogs2({ api, target: FACTORY, eventAbi: CUSTOM_POOL_CREATED, fromBlock: FROM_BLOCK, extraKey: 'custom-pool' }),
+    getLogs2({ api, target: ALM_VAULT_FACTORY, eventAbi: ALM_VAULT_CREATED, fromBlock: FROM_BLOCK }),
+  ])
 
-async function almVaultTvl(api) {
-  const vaults = await getLogs2({ api, target: ALM_VAULT_FACTORY, eventAbi: ALM_VAULT_CREATED, fromBlock: FROM_BLOCK })
-  return sumTokens2({
-    api,
-    ownerTokens: vaults.map(({ almVault, tokenA, tokenB }) => [[tokenA, tokenB], almVault]),
-  })
+  const owners = new Map()
+  for (const { token0, token1, pool } of [...standardPools, ...customPools])
+    owners.set(pool.toLowerCase(), [[token0, token1], pool])
+  
+  for (const { almVault, tokenA, tokenB } of almVaults)
+    owners.set(almVault.toLowerCase(), [[tokenA, tokenB], almVault])
+
+  return sumTokens2({ api, ownerTokens: [...owners.values()] })
 }
 
 module.exports = {
   start: '2026-05-13',
   methodology:
-    'TVL is the token0/token1 balances held by every pool created by the SwitchX factory on PulseChain, plus the idle underlying token balances held by SwitchX ALM vaults. ALM position liquidity is already custodied by the pools, so vault receipt tokens, farming positions, ve-locked SWITCH, rewards and treasury balances are excluded to avoid double counting.',
-  pulse: { tvl: sdk.util.sumChainTvls([poolsTvl.pulse.tvl, almVaultTvl]) },
-}
+    'TVL is the token0/token1 balances held by every standard and custom pool created by the SwitchX factory on PulseChain, plus the idle underlying token balances held by SwitchX ALM vaults. Pools and vaults are discovered from the factory creation events. ALM position liquidity is already custodied by the pools, so vault receipt tokens, farming positions, ve-locked SWITCH, rewards and treasury balances are excluded to avoid double counting.',
+  pulse: { tvl },
+   }

--- a/projects/switchx/index.js
+++ b/projects/switchx/index.js
@@ -13,7 +13,7 @@ const USDC_WPLS_POOL = '0xb0753197dcBd873c8E8131f3D691C3135C3D8d66'
 const FACTORY_FROM_BLOCK = 26521466
 // The shared cloud cache can claim complete coverage while omitting PulseChain
 // logs. Use the SDK's local cache and bound every RPC fallback range instead.
-const MAX_LOG_BLOCK_RANGE = 100_000
+const MAX_LOG_BLOCK_RANGE = 99_979
 const TWAP_WINDOW = 60 * 60
 const MAX_ORACLE_AGE = 6 * 60 * 60
 const MAX_TIMESTAMP_SKEW = 5 * 60

--- a/projects/switchx/index.js
+++ b/projects/switchx/index.js
@@ -1,9 +1,12 @@
-const { getLogs2 } = require('../helper/cache/getLogs')
+const sdk = require('@defillama/sdk')
 const { sumTokens2 } = require('../helper/unwrapLPs')
 
 const FACTORY = '0xeF72cbCcF4A807DfA1fbecd61DdB488fF8a05fa3'
 const ALM_VAULT_FACTORY = '0x8d8535C8842Aa541fcB3F6CC436e1b3A816a3a0e'
 const FACTORY_FROM_BLOCK = 26521466
+// PulseChain RPC providers can silently truncate wide eth_getLogs ranges.
+// The SDK still uses its cache/indexer first and applies this only on fallback.
+const MAX_LOG_BLOCK_RANGE = 100_000
 
 const STANDARD_POOL_CREATED = 'event Pool(address indexed token0, address indexed token1, address pool)'
 const CUSTOM_POOL_CREATED = 'event CustomPool(address indexed deployer, address indexed token0, address indexed token1, address pool)'
@@ -11,38 +14,23 @@ const ALM_VAULT_CREATED =
   'event ALMVaultCreated(address indexed sender, address almVault, address tokenA, bool allowTokenA, address tokenB, bool allowTokenB, uint256 count)'
 
 async function tvl(api) {
+  const toBlock = await api.getBlock()
+  const getFactoryLogs = (target, eventAbi) =>
+    sdk.getEventLogs({
+      chain: api.chain,
+      target,
+      fromBlock: FACTORY_FROM_BLOCK,
+      toBlock,
+      eventAbi,
+      onlyArgs: true,
+      cacheInCloud: true,
+      maxBlockRange: MAX_LOG_BLOCK_RANGE,
+    })
+
   const [standardPools, customPools, almVaults] = await Promise.all([
-    getLogs2({
-      api,
-      target: FACTORY,
-      fromBlock: FACTORY_FROM_BLOCK,
-      eventAbi: STANDARD_POOL_CREATED,
-      onlyArgs: true,
-      // PulseChain RPC log providers can return incomplete wide-range results.
-      // Prefer DefiLlama's indexed path, while retaining the canonical cache.
-      useIndexer: true,
-      // Both event types come from the same factory, so they need distinct
-      // cache keys to prevent one decoded event set from shadowing the other.
-      extraKey: 'standard-pools',
-    }),
-    getLogs2({
-      api,
-      target: FACTORY,
-      fromBlock: FACTORY_FROM_BLOCK,
-      eventAbi: CUSTOM_POOL_CREATED,
-      onlyArgs: true,
-      useIndexer: true,
-      extraKey: 'custom-pools',
-    }),
-    getLogs2({
-      api,
-      target: ALM_VAULT_FACTORY,
-      fromBlock: FACTORY_FROM_BLOCK,
-      eventAbi: ALM_VAULT_CREATED,
-      onlyArgs: true,
-      useIndexer: true,
-      extraKey: 'alm-vaults',
-    }),
+    getFactoryLogs(FACTORY, STANDARD_POOL_CREATED),
+    getFactoryLogs(FACTORY, CUSTOM_POOL_CREATED),
+    getFactoryLogs(ALM_VAULT_FACTORY, ALM_VAULT_CREATED),
   ])
 
   const owners = new Map()

--- a/projects/switchx/index.js
+++ b/projects/switchx/index.js
@@ -1,0 +1,67 @@
+const { getLogs } = require('../helper/cache/getLogs')
+const { sumTokens2 } = require('../helper/unwrapLPs')
+
+const FACTORY = '0xeF72cbCcF4A807DfA1fbecd61DdB488fF8a05fa3'
+const ALM_VAULT_FACTORY = '0x8d8535C8842Aa541fcB3F6CC436e1b3A816a3a0e'
+const FACTORY_FROM_BLOCK = 26521466
+
+const STANDARD_POOL_CREATED = 'event Pool(address indexed token0, address indexed token1, address pool)'
+const CUSTOM_POOL_CREATED = 'event CustomPool(address indexed deployer, address indexed token0, address indexed token1, address pool)'
+const ALM_VAULT_CREATED =
+  'event ALMVaultCreated(address indexed sender, address almVault, address tokenA, bool allowTokenA, address tokenB, bool allowTokenB, uint256 count)'
+
+async function tvl(api) {
+  const [standardPools, customPools, almVaults] = await Promise.all([
+    getLogs({
+      api,
+      target: FACTORY,
+      fromBlock: FACTORY_FROM_BLOCK,
+      eventAbi: STANDARD_POOL_CREATED,
+      onlyArgs: true,
+      // Both event types come from the same factory, so they need distinct
+      // cache keys to prevent one decoded event set from shadowing the other.
+      extraKey: 'standard-pools',
+    }),
+    getLogs({
+      api,
+      target: FACTORY,
+      fromBlock: FACTORY_FROM_BLOCK,
+      eventAbi: CUSTOM_POOL_CREATED,
+      onlyArgs: true,
+      extraKey: 'custom-pools',
+    }),
+    getLogs({
+      api,
+      target: ALM_VAULT_FACTORY,
+      fromBlock: FACTORY_FROM_BLOCK,
+      eventAbi: ALM_VAULT_CREATED,
+      onlyArgs: true,
+    }),
+  ])
+
+  const owners = new Map()
+  for (const { token0, token1, pool } of [...standardPools, ...customPools]) {
+    owners.set(pool.toLowerCase(), { token0, token1, owner: pool })
+  }
+  // ALM liquidity positions are already included in pool balances. Only the
+  // vaults' idle underlying balances are additional TVL, so count their
+  // token0/token1 balances without valuing vault shares or NFT positions.
+  for (const { almVault, tokenA, tokenB } of almVaults) {
+    owners.set(almVault.toLowerCase(), { token0: tokenA, token1: tokenB, owner: almVault })
+  }
+
+  return sumTokens2({
+    api,
+    ownerTokens: [...owners.values()].map(({ token0, token1, owner }) => [[token0, token1], owner]),
+    // Standard pool creation is permissionless. Isolate non-compliant or
+    // reverting ERC-20 balanceOf calls so one hostile pool cannot break TVL.
+    permitFailure: true,
+  })
+}
+
+module.exports = {
+  start: '2026-05-13',
+  methodology:
+    'TVL is the value of token0 and token1 balances held by every standard and custom concentrated-liquidity pool created by the canonical SwitchX factory on PulseChain, plus idle underlying token balances held directly by canonical SwitchX ALM vaults. ALM position liquidity is already custodied by the pools, so vault receipt tokens, farming positions, ve-locked SWITCH, rewards, treasury balances, and other protocol-owned assets are excluded to avoid double counting.',
+  pulse: { tvl },
+}

--- a/projects/switchx/index.js
+++ b/projects/switchx/index.js
@@ -1,4 +1,4 @@
-const { getLogs } = require('../helper/cache/getLogs')
+const { getLogs2 } = require('../helper/cache/getLogs')
 const { sumTokens2 } = require('../helper/unwrapLPs')
 
 const FACTORY = '0xeF72cbCcF4A807DfA1fbecd61DdB488fF8a05fa3'
@@ -12,30 +12,36 @@ const ALM_VAULT_CREATED =
 
 async function tvl(api) {
   const [standardPools, customPools, almVaults] = await Promise.all([
-    getLogs({
+    getLogs2({
       api,
       target: FACTORY,
       fromBlock: FACTORY_FROM_BLOCK,
       eventAbi: STANDARD_POOL_CREATED,
       onlyArgs: true,
+      // PulseChain RPC log providers can return incomplete wide-range results.
+      // Prefer DefiLlama's indexed path, while retaining the canonical cache.
+      useIndexer: true,
       // Both event types come from the same factory, so they need distinct
       // cache keys to prevent one decoded event set from shadowing the other.
       extraKey: 'standard-pools',
     }),
-    getLogs({
+    getLogs2({
       api,
       target: FACTORY,
       fromBlock: FACTORY_FROM_BLOCK,
       eventAbi: CUSTOM_POOL_CREATED,
       onlyArgs: true,
+      useIndexer: true,
       extraKey: 'custom-pools',
     }),
-    getLogs({
+    getLogs2({
       api,
       target: ALM_VAULT_FACTORY,
       fromBlock: FACTORY_FROM_BLOCK,
       eventAbi: ALM_VAULT_CREATED,
       onlyArgs: true,
+      useIndexer: true,
+      extraKey: 'alm-vaults',
     }),
   ])
 


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):

SwitchX

##### Twitter Link:

https://x.com/BrandonR2R

##### List of audit links if any:

- https://www.switchx.fi/SwitchX-audit-report.pdf
- https://www.switchx.fi/SwitchX%28ALMVault%29_Audit_Final.pdf

##### Website Link:

https://www.switchx.fi/

##### Logo (High resolution, will be shown with rounded borders):

https://cdn.dexscreener.com/cms/images/_naIv_xPDJHZgKMM

##### Current TVL:

Approximately $418.39k returned by the adapter on 2026-08-24. SWITCH balances are valued through the guarded on-chain TWAP methodology described below. PRVX currently has no `coins.llama.fi` price response and does not have sufficiently deep, independently cross-checked on-chain liquidity for a safe custom price, so its raw balances remain omitted from the displayed USD total.

##### Treasury Addresses (if the protocol has treasury)

`0x901A62175aD67A270F48FEa9F54a7dD61dADB459`

##### Chain:

PulseChain

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):

Not listed

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):

Not listed

##### Short Description (to be shown on DefiLlama):

SwitchX is a concentrated-liquidity ve(3,3) DEX on PulseChain with finite emissions, adaptive fees, MEV recapture, fee buybacks, and automated liquidity vaults.

##### Token address and ticker if any:

SWITCH — `0x357D80EA5dC53999Da7dA747e7afEBc02fe276Fb`

##### Category (full list at https://defillama.com/categories) *Please choose only one:

Dexs

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

V4 pool timepoint/TWAP oracles, direct PulseX V1/V2 AMM reserve references, and PulseX StableSwap references for configured stable routes.

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

Pool/plugin timepoints supply volatility observations and the fast/slow TWAPs used by adaptive fees and ALM rebalancing. Toxicity Fee V2 reads bounded external PulseX reserve sources with source-age and spread guards, using configured canonical/median fallbacks. Stablecoin reference and routing paths use configured PulseX StableSwap pools where applicable.

For DefiLlama TVL valuation, the adapter derives a one-hour SWITCH/USDC TWAP directly and an independent one-hour SWITCH/WPLS/USDC cross-route TWAP from canonical pool plugins. It uses the lower quote only when all three oracles are initialized and fresh, both routes meet minimum SWITCH and USDC reserve thresholds, and the two quotes differ by no more than 5%.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

https://github.com/BuildTheTech/SwitchX-Whitepaper/blob/main/WHITEPAPER.md

Relevant sections: 5.1 Adaptive Fee System, 5.3 Toxicity Fee V2, 10.5 PulseX Integration, and 11.2 HybridRebalanceManager.

##### forkedFrom (Does your project originate from another project):

##### methodology (what is being counted as tvl, how is tvl being calculated):

TVL is the value of token0 and token1 balances held by every standard and custom concentrated-liquidity pool created by the canonical SwitchX factory on PulseChain, plus idle underlying token balances held directly by canonical SwitchX ALM vaults. SWITCH balances are represented as USDC using the lower of an on-chain one-hour SWITCH/USDC TWAP and an independently derived SWITCH/WPLS/USDC TWAP, only while both routes have initialized, fresh oracles, minimum SWITCH and USDC liquidity, and no more than 5% divergence. ALM position liquidity is already custodied by the pools, so vault receipt tokens, farming positions, ve-locked SWITCH, rewards, treasury balances, and other protocol-owned assets are excluded to avoid double counting.

##### Github org/user (Optional, if your code is open source, we can track activity):

https://github.com/BuildTheTech

##### Does this project have a referral program?

No

### Implementation notes

- Discovers both `Pool` and `CustomPool` deployments from the canonical factory.
- Discovers ALM vaults from the canonical ALM vault factory and counts only their idle underlying balances.
- Uses DefiLlama's event cache/indexer when available and a bounded 99,979-block RPC fallback so incomplete wide-range PulseChain responses cannot silently omit pools or vaults.
- Uses failure-isolated ERC-20 balance reads so a permissionless pool with a non-compliant or reverting token cannot break the full TVL calculation.
- Separately aggregates SWITCH balances and represents them as USDC using the lower of independently checked direct and cross-route one-hour TWAPs. The guard requires initialized oracles, a maximum six-hour oracle age, at least $10k USDC liquidity per route, at least $50k combined USDC liquidity, at least 1 million SWITCH on each SWITCH leg, and at most 5% quote divergence.
- Falls back to returning raw SWITCH instead of failing the adapter when the custom price guard is unavailable.
- Uses only on-chain logs, balances, reserves, and oracle timepoints; no protocol API or subgraph is used.
- Excludes ALM share tokens, position NFTs, farming positions, ve locks, rewards, and treasury holdings.

### Validation

- `node test.js projects/switchx/index.js` — passed on 2026-08-24; current priced TVL approximately $418.39k.
- `node test.js projects/switchx/index.js 2026-05-14` — passed; approximately $56.39k.
- `node test.js projects/switchx/index.js 2026-06-01` — passed; approximately $298.54k.
- `node test.js projects/switchx/index.js 2026-07-31` — passed; approximately $420.98k.
- `node test.js projects/switchx/index.js 2026-08-01` — passed; approximately $366.94k.
- `node --check projects/switchx/index.js`, targeted ESLint, and whitespace/scope checks passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for SwitchX on PulseChain, including pool liquidity and ALM vault holdings.
  * Improved SWITCH valuation with validated one-hour market pricing routes.
  * Uses the more conservative valid valuation when multiple routes are available.
  * Rejects stale, insufficient, or significantly divergent pricing data.
  * Falls back to reporting raw SWITCH balances when reliable pricing is unavailable.
  * Prevents duplicate counting and expands TVL methodology and token representation disclosures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

