### PR TITLE
feat(wise-token): track staked WISE via token globals(), reword TVL methodology

### DIFF
--- a/projects/wise-token/index.js
+++ b/projects/wise-token/index.js
@@ -34,6 +34,6 @@ async function staking(api) {
 module.exports = {
   misrepresentedTokens: true,
   doublecounted: true,
-  methodology: 'TVL = ownerless (unclaimed) share of ETH in the WISE/ETH Uniswap LP',
+  methodology: 'TVL = ownerless (burned LP) share of ETH in the WISE/ETH Uniswap LP',
   ethereum: { tvl, staking }
 };

--- a/projects/wise-token/index.js
+++ b/projects/wise-token/index.js
@@ -1,6 +1,7 @@
 const WISE_ETH_PAIR_ADDR = '0x21b8065d10f73EE2e260e5B47D3344d3Ced7596E';
 const ZERO_ADDR = '0x0000000000000000000000000000000000000000';
 const WETH_ADDR = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+const WISE_TOKEN_ADDR = '0x66a0f676479Cee1d7373f3DC2e2952778BfF5bd6';
 
 async function tvl(api) {
   const [unownedUniLP, totalUniLP, reserves] = await Promise.all([
@@ -18,9 +19,21 @@ async function tvl(api) {
   api.add(WETH_ADDR, uniswapOwnerlessEth);
 }
 
+// WISE staking is HEX-style: staked tokens are burned from circulating supply and
+// tracked internally, not held in a separate vault contract. globals().totalStaked
+// on the token contract itself is the only source for this figure.
+async function staking(api) {
+  const globals = await api.call({
+    target: WISE_TOKEN_ADDR,
+    abi: 'function globals() view returns (uint256 totalStaked, uint256 totalShares, uint256 sharePrice, uint256 currentWiseDay, uint256 referralShares, uint256 liquidityShares)'
+  });
+
+  api.add(WISE_TOKEN_ADDR, globals.totalStaked);
+}
+
 module.exports = {
   misrepresentedTokens: true,
   doublecounted: true,
   methodology: 'TVL = ownerless (unclaimed) share of ETH in the WISE/ETH Uniswap LP',
-  ethereum: { tvl }
+  ethereum: { tvl, staking }
 };


### PR DESCRIPTION
Adds staking TVL to the wise-token adapter, on top of the existing ownerless-ETH Uniswap LP tracking.

- Tracks totalStaked from the WISE token contract's globals() function (0x66a0f676479Cee1d7373f3DC2e2952778BfF5bd6). WISE staking is HEX-style: staked tokens are burned from circulating supply and tracked internally via globals(), not held in a separate vault contract, so this is the only on-chain source for the figure.
- Rewords the TVL methodology string from "ownerless (unclaimed) share" to "ownerless (burned LP) share" for clarity on how the ETH-backing figure is derived (LP tokens sent to the zero address are permanently unclaimable, and their share of pool reserves is what's counted).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tracking for WISE token staking holdings and total value locked.
  * Added the WISE token address to the Ethereum integration.

* **Documentation**
  * Clarified that the liquidity provider share is ownerless or burned rather than unclaimed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->