### PR TITLE
fix(hypersurface): include USDC-collateral pool in HyperEVM TVL

### DIFF
--- a/registries/sumTokens.js
+++ b/registries/sumTokens.js
@@ -16182,15 +16182,19 @@ const configs = {
     },
   },
   "hypersurface": {
-    "methodology": "TVL includes tokens in MarginPool, HedgedPool, and Hedger contracts. LP positions held by the Hedger are unwrapped to their underlying tokens.",
+    "methodology": "TVL includes tokens in MarginPool, HedgedPool, and Hedger contracts of every collateral pool (USDT0-collateral and USDC-collateral on HyperEVM, USDC-collateral on Base). LP positions held by the Hedger are unwrapped to their underlying tokens.",
     "hyperliquid": {
       "owners": [
         "0x7D2e4b4d7ba55C423F5CCe194ae8194eFD1C6e35",
         "0x0095aCDD705Cfcc11eAfFb6c19A28C0153ad196F",
-        "0xa8c9403BDf554C047Ad91a448DDb24208Ab5313c"
+        "0xa8c9403BDf554C047Ad91a448DDb24208Ab5313c",
+        "0x7FfD5706C916499676D707f3ec3F0c9b928E7A95",
+        "0xe0F9cA7FD12E31F5d720A93d04722d6DFbAD59e7",
+        "0x220f86b641ec63f4832CC30a663Bb26b15259Ee2"
       ],
       "tokens": [
-        ADDRESSES.corn.USDT0,
+        ADDRESSES.hyperliquid.USDT0,
+        ADDRESSES.hyperliquid.USDC,
         "0xbe6727b535545c67d5caa73dea54865b92cf7907",
         "0x9fdbda0a5e284c32744d2f17ee5c74b284993463",
         ADDRESSES.hyperliquid.WHYPE,


### PR DESCRIPTION
Hypersurface deploys one set of MarginPool / HedgedPool / Hedger contracts per collateral. The registry entry only listed the USDT0-collateral pool, so the USDC-collateral pool on HyperEVM was missing from TVL entirely.

This adds the three USDC pool contracts as owners and USDC to the token list. The already-listed Hedger also holds USDC, so that balance was being dropped too. USDT0 is switched to the `hyperliquid` namespace — same address, correct chain.

Verified on-chain (latest block) that the newly added owners hold 3,121,728 USDC and 25,333 WHYPE.

`node test.js projects/hypersurface`:

before
```
hyperliquid   314.38 k
base           11.66 k
total         326.03 k
```

after
```
hyperliquid     5.31 M
base           11.66 k
total           5.32 M
```

No change to the Base section — that pool is USDC-collateral and already covered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded Hyperliquid TVL coverage to include MarginPool, HedgedPool, and Hedger contracts across supported collateral pools and networks.
  * Added support for Hyperliquid USDT0 and USDC token references.
  * Included additional owner addresses for improved coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->