### PR TITLE
Monetrix: add mxHYPE child TVL adapter

### DIFF
--- a/projects/monetrix-mxhype/index.js
+++ b/projects/monetrix-mxhype/index.js
@@ -1,0 +1,35 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+
+const HYPE_ACCOUNTANT = '0xAcE53c4ef6619E7850E7d5fa45b8410C725D266D'
+const WHYPE = ADDRESSES.hyperliquid.WHYPE
+
+// First production mxHYPE deposit: 2026-08-17 08:54:56 UTC (block 43,412,473).
+const START_TIMESTAMP = 1786956896
+
+async function tvl(api) {
+  if (api.timestamp && api.timestamp < START_TIMESTAMP) return
+
+  // Native HYPE backing mxHYPE: HYPE held by the HypeVault and RedeemEscrow,
+  // plus the HypeVault's HyperCore account equity, denominated in HYPE.
+  const totalBackingSigned = await api.call({
+    target: HYPE_ACCOUNTANT,
+    abi: 'function totalBackingSigned() view returns (int256)',
+  })
+
+  // Book native HYPE as WHYPE so DefiLlama can price the backing.
+  if (BigInt(totalBackingSigned) > 0n) api.add(WHYPE, totalBackingSigned)
+}
+
+module.exports = {
+  misrepresentedTokens: true,
+  methodology:
+    'TVL is the native HYPE collateral backing mxHYPE: HYPE held by the HypeVault ' +
+    'and RedeemEscrow on HyperEVM plus the HypeVault\'s Hyperliquid Core account equity, ' +
+    'read on-chain from the HypeAccountant (totalBackingSigned) and denominated in HYPE. ' +
+    'Staked mxHYPE (smxHYPE) is a receipt token and is not counted separately. ' +
+    'The protocol-owned insurance fund is excluded.',
+  start: START_TIMESTAMP,
+  hyperliquid: {
+    tvl,
+  },
+}

--- a/projects/monetrix/index.js
+++ b/projects/monetrix/index.js
@@ -2,8 +2,13 @@ const ADDRESSES = require('../helper/coreAssets.json')
 
 const MONETRIX_GENESIS_VAULT = '0xc50A1dd2866A822c81bd0aA00B638c4BdDc9cd63'
 const MONETRIX_ACCOUNTANT = '0x8950A5136f3994f82b998e37e1183b8A37c12705'
+const HYPE_ACCOUNTANT = '0xAcE53c4ef6619E7850E7d5fa45b8410C725D266D'
+
+// First production mxHYPE deposit: 2026-08-17 08:54:56 UTC (block 43,412,473).
+const MXHYPE_START_TIMESTAMP = 1786956896
 
 const USDC = ADDRESSES.hyperliquid.USDC
+const WHYPE = ADDRESSES.hyperliquid.WHYPE
 
 async function tvl(api) {
   // Pre-launch Genesis Vault USDC; migrates into the main MonetrixVault when users mint USDM
@@ -16,19 +21,29 @@ async function tvl(api) {
   const totalBackingSigned = await api.call({ target: MONETRIX_ACCOUNTANT, abi: 'function totalBackingSigned() view returns (int256)' })
   // negative backing (mark-to-market drawdown) clamps to zero
   if (BigInt(totalBackingSigned) > 0n) api.add(USDC, totalBackingSigned)
+
+  if (!api.timestamp || api.timestamp >= MXHYPE_START_TIMESTAMP) {
+    // Native HYPE backing mxHYPE: native HYPE in the Vault and RedeemEscrow plus
+    // HyperCore account equity, converted from USD value back to HYPE.
+    const hypeBackingSigned = await api.call({ target: HYPE_ACCOUNTANT, abi: 'function totalBackingSigned() view returns (int256)' })
+    // Add as WHYPE so DefiLlama can price the native HYPE-denominated backing.
+    if (BigInt(hypeBackingSigned) > 0n) api.add(WHYPE, hypeBackingSigned)
+  }
 }
 
 module.exports = {
   misrepresentedTokens: true,
   methodology:
-    'TVL is the USDC collateral backing USDM: USDC held by the MonetrixVault and ' +
+    'TVL is the combined collateral backing USDM and mxHYPE. The USDM leg is USDC held by the MonetrixVault and ' +
     'RedeemEscrow on HyperEVM plus the protocol\'s Hyperliquid Core account equity ' +
     '(delta-neutral spot + short-perp positions, HLP and borrow-lend balances), read ' +
-    'on-chain from the MonetrixAccountant (totalBacking), which marks Core positions ' +
+    'on-chain from the MonetrixAccountant (totalBackingSigned), which marks Core positions ' +
     'to market via Hyperliquid precompiles. USDC still in the pre-launch Genesis Vault ' +
-    'is also counted and migrates into the main vault as users mint USDM. Staked USDM ' +
-    '(sUSDM), the insurance fund (funded from skimmed yield) and undistributed yield ' +
-    'are excluded.',
+    'is also counted and migrates into the main vault as users mint USDM. The mxHYPE leg ' +
+    'is native HYPE held by the HypeVault and RedeemEscrow plus the HypeVault\'s HyperCore ' +
+    'account equity, read on-chain from the HypeAccountant (totalBackingSigned) and denominated ' +
+    'in HYPE. sUSDM and smxHYPE are receipt tokens and are not counted separately. ' +
+    'Protocol-owned insurance funds are excluded.',
   hyperliquid: {
     tvl,
   },

--- a/projects/monetrix/index.js
+++ b/projects/monetrix/index.js
@@ -2,13 +2,8 @@ const ADDRESSES = require('../helper/coreAssets.json')
 
 const MONETRIX_GENESIS_VAULT = '0xc50A1dd2866A822c81bd0aA00B638c4BdDc9cd63'
 const MONETRIX_ACCOUNTANT = '0x8950A5136f3994f82b998e37e1183b8A37c12705'
-const HYPE_ACCOUNTANT = '0xAcE53c4ef6619E7850E7d5fa45b8410C725D266D'
-
-// First production mxHYPE deposit: 2026-08-17 08:54:56 UTC (block 43,412,473).
-const MXHYPE_START_TIMESTAMP = 1786956896
 
 const USDC = ADDRESSES.hyperliquid.USDC
-const WHYPE = ADDRESSES.hyperliquid.WHYPE
 
 async function tvl(api) {
   // Pre-launch Genesis Vault USDC; migrates into the main MonetrixVault when users mint USDM
@@ -21,29 +16,19 @@ async function tvl(api) {
   const totalBackingSigned = await api.call({ target: MONETRIX_ACCOUNTANT, abi: 'function totalBackingSigned() view returns (int256)' })
   // negative backing (mark-to-market drawdown) clamps to zero
   if (BigInt(totalBackingSigned) > 0n) api.add(USDC, totalBackingSigned)
-
-  if (!api.timestamp || api.timestamp >= MXHYPE_START_TIMESTAMP) {
-    // Native HYPE backing mxHYPE: native HYPE in the Vault and RedeemEscrow plus
-    // HyperCore account equity, converted from USD value back to HYPE.
-    const hypeBackingSigned = await api.call({ target: HYPE_ACCOUNTANT, abi: 'function totalBackingSigned() view returns (int256)' })
-    // Add as WHYPE so DefiLlama can price the native HYPE-denominated backing.
-    if (BigInt(hypeBackingSigned) > 0n) api.add(WHYPE, hypeBackingSigned)
-  }
 }
 
 module.exports = {
   misrepresentedTokens: true,
   methodology:
-    'TVL is the combined collateral backing USDM and mxHYPE. The USDM leg is USDC held by the MonetrixVault and ' +
+    'TVL is the USDC collateral backing USDM: USDC held by the MonetrixVault and ' +
     'RedeemEscrow on HyperEVM plus the protocol\'s Hyperliquid Core account equity ' +
     '(delta-neutral spot + short-perp positions, HLP and borrow-lend balances), read ' +
-    'on-chain from the MonetrixAccountant (totalBackingSigned), which marks Core positions ' +
+    'on-chain from the MonetrixAccountant (totalBacking), which marks Core positions ' +
     'to market via Hyperliquid precompiles. USDC still in the pre-launch Genesis Vault ' +
-    'is also counted and migrates into the main vault as users mint USDM. The mxHYPE leg ' +
-    'is native HYPE held by the HypeVault and RedeemEscrow plus the HypeVault\'s HyperCore ' +
-    'account equity, read on-chain from the HypeAccountant (totalBackingSigned) and denominated ' +
-    'in HYPE. sUSDM and smxHYPE are receipt tokens and are not counted separately. ' +
-    'Protocol-owned insurance funds are excluded.',
+    'is also counted and migrates into the main vault as users mint USDM. Staked USDM ' +
+    '(sUSDM), the insurance fund (funded from skimmed yield) and undistributed yield ' +
+    'are excluded.',
   hyperliquid: {
     tvl,
   },


### PR DESCRIPTION
**NOTE**



## Metadata request

- Keep the existing protocol ID `8019` and module `monetrix/index.js` as **Monetrix USDM**, preserving its history.
- Add this new module, `monetrix-mxhype/index.js`, as **Monetrix mxHYPE**.
- Group both children under `parent#monetrix`, displayed as **Monetrix (Combined)**.

This follows the same parent/child structure used for Hybra and its versioned child adapters.

## New listing details

##### Name (to be shown on DefiLlama):
Monetrix mxHYPE

##### Twitter Link:
https://x.com/monetrix_xyz

##### List of audit links if any:
Existing Monetrix audit (USDM architecture): https://code4rena.com/reports/2026-04-monetrix

##### Website Link:
https://www.monetrix.xyz/app/earn?product=mxhype

##### Logo (High resolution, will be shown with rounded borders):
<img width="400" height="400" alt="Monetrix logo" src="https://github.com/user-attachments/assets/429618a0-f775-416b-b286-447e8b8872b2" />

##### Current TVL:
Approximately $266.5K as of 2026-08-21, based on the adapter test.

##### Treasury Addresses (if the protocol has treasury):
N/A

##### Chain:
Hyperliquid L1 / HyperEVM (chain ID 999)

##### Coingecko ID:
N/A

##### Coinmarketcap ID:
N/A

##### Short Description (to be shown on DefiLlama):
Monetrix mxHYPE is a native-HYPE yield product on Hyperliquid. Deposited HYPE mints mxHYPE, while users can stake mxHYPE as smxHYPE to receive yield generated by the protocol's delta-neutral borrowed-USDC overlay.

##### Token address and ticker if any:
- mxHYPE: `0x0fAfAD2825aa646fDf343A0786D0dC1A842543b6`
- smxHYPE: `0xf6B61A1d49B67aC907d825F26e2877F1Ec4f0aE8`

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Basis Trading

##### Oracle Provider(s):
Hyperliquid native read precompiles, including the native HYPE oracle price and HyperCore account-state precompiles.

##### Implementation Details:
The HypeAccountant contract (`0xAcE53c4ef6619E7850E7d5fa45b8410C725D266D`) reads native HYPE balances and the HypeVault's HyperCore account state through Hyperliquid precompiles. Its `totalBackingSigned()` view returns the complete backing in native HYPE units, including HYPE held by the HypeVault and RedeemEscrow plus HyperCore HYPE and USD-denominated account equity converted to HYPE using Hyperliquid's native oracle price. The adapter books this amount as WHYPE solely so DefiLlama can apply its existing HYPE price.

##### Documentation/Proof:
- https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/hyperevm/interacting-with-hypercore
- Adapter implementation: `projects/monetrix-mxhype/index.js`

##### forkedFrom (Does your project originate from another project):
No

##### methodology (what is being counted as TVL, how is TVL being calculated):
TVL is the native HYPE collateral backing mxHYPE: HYPE held by the HypeVault and RedeemEscrow on HyperEVM plus the HypeVault's Hyperliquid Core account equity, read on-chain from `HypeAccountant.totalBackingSigned()` and denominated in HYPE. Native HYPE is represented as WHYPE in the adapter only for pricing. Staked mxHYPE (smxHYPE) is a receipt token and is not counted separately. The protocol-owned insurance fund is excluded.

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/MonetrixLab

##### Does this project have a referral program?
Yes, Monetrix has a referral program integrated into its user onboarding and points system.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for mxHYPE, beginning with its first production deposit.
  * Reports positive HYPE backing as WHYPE while excluding negative values.
  * Includes collateral coverage details and identifies misrepresented tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->