### PR TITLE
include Keep Idea Mode TVL on Solana

### DIFF
--- a/projects/keep-protocol/index.js
+++ b/projects/keep-protocol/index.js
@@ -2,7 +2,10 @@ const { PublicKey } = require("@solana/web3.js");
 const { getConnection, sumTokens2 } = require("../helper/solana");
 const ADDRESSES = require("../helper/coreAssets.json");
 
-const PROGRAM_ID = new PublicKey("ETVtC29T7ExxYyWSkpzKPxzrL3SRyrGPRhZe3FwXmFAo");
+const PROGRAM_IDS = [
+  new PublicKey("ETVtC29T7ExxYyWSkpzKPxzrL3SRyrGPRhZe3FwXmFAo"), // Full Launch
+  new PublicKey("2ww3589FBTgwbCd9sbpBjosiDszsigoqArh5xuc7F2Ve"), // Idea Mode
+];
 
 // Robinhood Chain production deployment (2026-07-15). Each project is an
 // independent Launchpad clone that directly holds refundable Paxos USDG.
@@ -17,24 +20,28 @@ const OFF_USDC_VAULT = 80;
 async function tvl(api) {
   const connection = getConnection();
 
-  const accounts = await connection.getProgramAccounts(PROGRAM_ID, {
-    filters: [{ memcmp: { offset: 0, bytes: LAUNCHPAD_DISC } }],
-    dataSlice: { offset: OFF_USDC_VAULT, length: 32 },
-  });
+  // Full Launch and Idea Mode use separate mainnet programs but the same
+  // LaunchpadState layout and refundable USDC-vault accounting model.
+  const accountGroups = await Promise.all(PROGRAM_IDS.map((programId) =>
+    connection.getProgramAccounts(programId, {
+      filters: [{ memcmp: { offset: 0, bytes: LAUNCHPAD_DISC } }],
+      dataSlice: { offset: OFF_USDC_VAULT, length: 32 },
+    })
+  ));
 
   // Fundraising/Cancelled hold the full raise, HoldPeriod holds the ~10k refund reserve, Failed holds the
   // refund pool, and Success has ~0 here (its reserve was paid out) — so no per-state filtering is needed
   // and the Raydium pool is never double-counted.
-  const usdcVaults = [];
-  for (const { account } of accounts) {
+  const usdcVaults = new Set();
+  for (const { account } of accountGroups.flat()) {
     const data = account.data;
     if (data.length < 32) continue;
     const vault = new PublicKey(data);
     if (vault.equals(PublicKey.default)) continue; // vault not initialized yet
-    usdcVaults.push(vault.toString());
+    usdcVaults.add(vault.toString());
   }
 
-  await sumTokens2({ api, tokenAccounts: usdcVaults });
+  await sumTokens2({ api, tokenAccounts: [...usdcVaults] });
 }
 
 async function robinhoodTvl(api) {
@@ -50,7 +57,8 @@ async function robinhoodTvl(api) {
 module.exports = {
   methodology:
     "TVL is the refundable stablecoin held in keep.coffee's own per-launch vaults/contracts: " +
-    "USDC vault PDAs on Solana and Paxos USDG held directly by Launchpad clones on Robinhood " +
+    "USDC vault PDAs for both Full Launch and Idea Mode on Solana, and Paxos USDG held " +
+    "directly by Launchpad clones on Robinhood " +
     "Chain. It covers active raises, post-bootstrap refund reserves, cancelled-raise balances " +
     "and failed-raise refund pools. Liquidity seeded into Raydium or Uniswap V4 is excluded " +
     "because it is counted by those protocols and is permanently locked after success.",


### PR DESCRIPTION
## Summary

- query both keep.coffee Solana mainnet programs: Full Launch and Idea Mode
- de-duplicate discovered USDC vaults before the batched balance read
- clarify that the Solana methodology covers both launch profiles

## Why

Idea Mode is live on Solana mainnet under its own program (`2ww3589FBTgwbCd9sbpBjosiDszsigoqArh5xuc7F2Ve`). The existing adapter only queried the Full Launch program, so refundable USDC deposited into future Idea Mode launch vaults would be omitted.

Both programs use the same `LaunchpadState` discriminator and `usdc_vault` offset. The TVL definition is unchanged: only refundable USDC in Keep-owned per-launch vaults is counted; Raydium liquidity remains excluded.

## Validation

- `node --check projects/keep-protocol/index.js`
- `pnpm exec eslint projects/keep-protocol/index.js`
- `node test.js projects/keep-protocol/index.js`
  - Solana: approximately 816.47 USDC
  - Robinhood Chain: 0.00 USDG
  - total: approximately 816.47 USD
- direct current-state enumeration:
  - Full Launch program: 10 launch accounts / 10 unique vaults
  - Idea Mode program: 0 launch accounts / 0 vaults (ready to count the first Idea launch without changing current TVL)

No dependency or lockfile changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Solana TVL tracking by including both Full Launch and Idea Mode programs.
  * Prevented duplicate vaults from being counted more than once.
  * Improved balance aggregation across unique USDC vaults.

* **Documentation**
  * Clarified that TVL calculations cover both Solana program variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->