### PR TITLE
lombard-vault: convert the ethereum BTC positions that have no price feed

### DIFF
--- a/projects/lombard-vault/index.js
+++ b/projects/lombard-vault/index.js
@@ -12,6 +12,12 @@ const BORING_VAULTS_ETH = [
   '0x75231079973c23e9eb6180fa3d2fc21334565ab5',  // Turtle Club (katanaLBTCv)
 ]
 
+// ── Unpriced BTC-denominated tokens held on Ethereum ─────────────────────────
+// Neither has a price feed on ethereum, so their balances are dropped from TVL.
+// Both are 8-decimal BTC wrappers and are converted to cbBTC in tvlEthExtras.
+const BTCOC_ETH = '0xf14f678d9c05798ba61652a950a05d74ad2e0a6c'  // Bitcoin Onchain Credit Strategy (vault share)
+const BTC_B_ETH = '0xB0F70C0bD6FD87dbEb7C10dC692a2a6106817072'  // BTC.b
+
 // ── Add new Curve pools here ──────────────────────────────────────────────────
 const CURVE_POOLS_ETH = [
   { pool: '0x2f3bc4c27a4437aeca13de0e37cdf1028f3706f0', coinCount: 2 },
@@ -91,6 +97,37 @@ async function unwrapBoringVault(api, vaultToken, holder) {
   api.add(baseAsset, amount)
 }
 
+// Converts the Ethereum BTC positions that have no price feed into cbBTC.
+// BTCoc is a vault share, so it is converted at its on-chain pricePerShare;
+// BTC.b is a plain BTC wrapper and converts one to one. All three tokens use
+// 8 decimals.
+async function convertUnpricedBtcEth(api) {
+  const cbBTC = ADDRESSES.ethereum.cbBTC
+  const balances = api.getBalances()
+
+  // balance keys keep whatever casing the source used, so one token can be held
+  // under both its checksummed and its lowercase address
+  const totalBalance = (token) => {
+    const suffix = `:${token.toLowerCase()}`
+    return Object.keys(balances)
+      .filter((key) => key.toLowerCase().endsWith(suffix))
+      .reduce((sum, key) => sum + Number(balances[key]), 0)
+  }
+
+  const btcocBalance = totalBalance(BTCOC_ETH)
+  if (btcocBalance > 0) {
+    const pricePerShare = await api.call({ target: BTCOC_ETH, abi: 'uint256:pricePerShare' })
+    api.removeTokenBalance(BTCOC_ETH)
+    api.add(cbBTC, btcocBalance * (Number(pricePerShare) / 1e8))
+  }
+
+  const btcbBalance = totalBalance(BTC_B_ETH)
+  if (btcbBalance > 0) {
+    api.removeTokenBalance(BTC_B_ETH)
+    api.add(cbBTC, btcbBalance)
+  }
+}
+
 // ─── Per-chain extra TVL hooks ────────────────────────────────────────────────
 
 async function tvlEthExtras(api) {
@@ -105,6 +142,9 @@ async function tvlEthExtras(api) {
   }
 
   await sumTokens2({ api, owner: LBTCV, resolveUniV4: true, })
+
+  // 3. Convert BTC positions that have no ethereum price feed
+  await convertUnpricedBtcEth(api)
 }
 
 async function tvlCornExtras(api) {


### PR DESCRIPTION
## What

The Lombard Earn vault holds two BTC positions on ethereum that have no price feed there, so their balances are dropped from the total rather than raising an error. The published TVL flaps between roughly half and full value depending on whether a quote happens to exist that day.

| date | published total | BTCoc | BTC.b |
|---|---|---|---|
| 2026-08-11 | 25.24M | absent | 4.96M |
| 2026-08-12 | 62.03M | 27.38M | 4.62M |
| 2026-08-14 | 59.40M | 27.43M | absent |
| 2026-08-15 | 31.77M | absent | absent |
| 2026-08-21 | 34.54M | absent | absent |

## BTCoc

`0xf14f678d9c05798ba61652a950a05d74ad2e0a6c`, Bitcoin Onchain Credit Strategy.

`coins.llama.fi/chart/ethereum:0xf14f...?span=45&period=1d` returns **one point**, 2026-08-12 at 64,026.55, and `prices/current` returns an empty `coins` object. 2026-08-12 is the day the token was added to the adapter in #20467.

The vault holds 430.32892115 of the 430.41147067 total supply, 99.98%, and dexscreener lists no pairs. There is no float and no market to price it from, so this is not a case of a liquid token being mapped away.

It is a share token with `asset()` = BTC.b, `pricePerShare()` = 1.00505224 and `totalAssets()` = 432.58601271. The rate reconciles: 430.41147067 * 1.00505224 = 432.586.

## BTC.b

`0xB0F70C0bD6FD87dbEb7C10dC692a2a6106817072`, 25.0006 held after the Curve unwrap.

Also unpriced on ethereum, but the **same address is priced on megaeth** at 77,703.51695080652, byte-identical to `avax:0x152b9d0FdC40C096757F570A51E494bd4b943E50`, so the avalanche BTC.b mapping already exists elsewhere and only the ethereum deployment is missing it.

Its one ethereum market is a uniswap BTC.b/cbBTC pool with 7.74M liquidity and 458k of 24h volume, quoted at **1.00009466 cbBTC**.

## How

Both are 8 decimal BTC wrappers, so express them as cbBTC in `tvlEthExtras`, after the scan so the Curve and BoringVault unwraps are already in. BTCoc converts at its on-chain `pricePerShare`, BTC.b one to one.

The lookup sums case-insensitively: balance keys keep whatever casing the source used, and the same token can be present under both its checksummed and its lowercase address (LBTC and cbBTC both are here). `removeTokenBalance` is already case-insensitive, so a lowercase-only lookup removes the balance but reads it as zero.

## Verification

Local `node test.js projects/lombard-vault/index.js`, same shell, before and after:

| | before | after |
|---|---|---|
| ethereum | 30.16M | 65.55M |
| total | 34.30M | 69.68M |

The 457.5866 cbBTC added lands at an implied 77,362 per unit against 77,371 quoted for the pool, agreeing to 0.01%.

Balance keys checked directly before and after: BTCoc and BTC.b are both gone and cbBTC rises by exactly 2,500,062,494 for the BTC.b leg. `doublecounted: true` is already set on this adapter, so the aggregate is unaffected either way.

## On the history here

#20386 proposed unwrapping these on-chain and was closed on 2026-08-12 by @RohanNero with "both tokens are now priced on the server". That held for sLBTC, which is priced at 78,508.20 today and is left untouched by this PR. It did not hold for BTCoc, which produced one quote and stopped. @VaitaR reported this on the closed PR on 2026-08-18.

Credit for both the original unwrap and the regression report goes to @VaitaR, and I am happy to close this in favour of them resubmitting theirs.

The root cause for BTCoc is server side. If that price is restored durably the BTCoc half can be reverted. The BTC.b half stands either way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Ethereum vault valuation by supporting BTCoc and BTC.b balances.
  * BTCoc balances are valued using their current share price, while BTC.b balances are converted at a one-to-one rate.
  * Equivalent cbBTC values are now included in reported TVL, providing a more complete and accurate view of vault assets.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->