### PR TITLE
Add STONX TVL adapter

### DIFF
--- a/projects/stonx/index.js
+++ b/projects/stonx/index.js
@@ -3,6 +3,7 @@ const { getLogs } = require('../helper/cache/getLogs')
 const CORE = '0x00000000000014aa86c5d3c41765bb24e11bd701'
 const VE33 = '0xD18685A514E59b06d59824e16Db07e73345d9953'
 const VE33_POSITIONS = '0xda38ac72ce7220c4dd7719d114ef94edadb8f068'
+const STONX = '0x570c5aa79c798e7a418412cc8399ae5bcce570c5'
 
 // Ve33 was deployed at block 18,269,246. The first position managed by
 // Ve33Positions was updated at block 23,649,680.
@@ -13,13 +14,16 @@ const POOL_INITIALIZED_EVENT =
   'event PoolInitialized(bytes32 poolId, (address token0, address token1, bytes32 config) poolKey, int32 tick, uint96 sqrtRatio)'
 const POSITION_UPDATED_EVENT =
   'event PositionUpdated(address locker, bytes32 poolId, bytes32 positionId, int128 liquidityDelta, bytes32 balanceUpdate, bytes32 stateAfter)'
+const STAKE_CHANGED_EVENT = 'event StakeChanged(address owner, bytes32 stakeId, int256 delta)'
 const GET_POSITION_LIQUIDITY =
   'function getPositionLiquidity(uint256, (address,address,bytes32), int32, int32) view returns (uint128 liquidity, uint128 principal0, uint128 principal1)'
 
+/** Extracts the extension address from a packed Ekubo PoolConfig. */
 function getExtension(config) {
   return config.slice(0, 42).toLowerCase()
 }
 
+/** Decodes a Ve33Positions NFT id and signed tick bounds from a Core position id. */
 function decodePositionId(positionId) {
   const value = BigInt(positionId)
   let tickLower = Number((value >> 32n) & 0xffffffffn)
@@ -35,6 +39,7 @@ function decodePositionId(positionId) {
   }
 }
 
+/** Returns the current token principal in every active STONX Ve33 LP position. */
 async function tvl(api) {
   const poolLogs = await getLogs({
     api,
@@ -104,10 +109,24 @@ async function tvl(api) {
   }
 }
 
+/** Returns the net STONX locked in Ve33 stakes. */
+async function staking(api) {
+  const stakeLogs = await getLogs({
+    api,
+    target: VE33,
+    eventAbi: STAKE_CHANGED_EVENT,
+    fromBlock: DEPLOYMENT_BLOCK,
+    extraKey: 'stonx-stakes',
+  })
+
+  const staked = stakeLogs.reduce((total, { args }) => total + BigInt(args.delta), 0n)
+  api.add(STONX, staked)
+}
+
 module.exports = {
   methodology:
-    'TVL is the current token principal in every active STONX Ve33 liquidity position on Ekubo. Active positions are reconstructed from Ekubo Core events, then their token amounts are read from the canonical Ve33Positions manager. Core swap fees and veSTONX staking are excluded.',
+    'TVL is the current token principal in every active STONX Ve33 liquidity position on Ekubo. Active positions are reconstructed from Ekubo Core events, then their token amounts are read from the canonical Ve33Positions manager. Core swap fees and claimable STONX rewards are excluded. Locked STONX is reported separately under staking based on net StakeChanged events.',
   doublecounted: true,
   timetravel: false,
-  robinhood: { tvl },
+  robinhood: { tvl, staking },
 }

--- a/projects/stonx/index.js
+++ b/projects/stonx/index.js
@@ -127,6 +127,5 @@ module.exports = {
   methodology:
     'TVL is the current token principal in every active STONX Ve33 liquidity position on Ekubo. Active positions are reconstructed from Ekubo Core events, then their token amounts are read from the canonical Ve33Positions manager. Core swap fees and claimable STONX rewards are excluded. Locked STONX is reported separately under staking based on net StakeChanged events.',
   doublecounted: true,
-  timetravel: false,
   robinhood: { tvl, staking },
 }

--- a/projects/stonx/index.js
+++ b/projects/stonx/index.js
@@ -1,0 +1,113 @@
+const { getLogs } = require('../helper/cache/getLogs')
+
+const CORE = '0x00000000000014aa86c5d3c41765bb24e11bd701'
+const VE33 = '0xD18685A514E59b06d59824e16Db07e73345d9953'
+const VE33_POSITIONS = '0xda38ac72ce7220c4dd7719d114ef94edadb8f068'
+
+// Ve33 was deployed at block 18,269,246. The first position managed by
+// Ve33Positions was updated at block 23,649,680.
+const DEPLOYMENT_BLOCK = 18269246
+const FIRST_POSITION_BLOCK = 23649680
+
+const POOL_INITIALIZED_EVENT =
+  'event PoolInitialized(bytes32 poolId, (address token0, address token1, bytes32 config) poolKey, int32 tick, uint96 sqrtRatio)'
+const POSITION_UPDATED_EVENT =
+  'event PositionUpdated(address locker, bytes32 poolId, bytes32 positionId, int128 liquidityDelta, bytes32 balanceUpdate, bytes32 stateAfter)'
+const GET_POSITION_LIQUIDITY =
+  'function getPositionLiquidity(uint256, (address,address,bytes32), int32, int32) view returns (uint128 liquidity, uint128 principal0, uint128 principal1)'
+
+function getExtension(config) {
+  return config.slice(0, 42).toLowerCase()
+}
+
+function decodePositionId(positionId) {
+  const value = BigInt(positionId)
+  let tickLower = Number((value >> 32n) & 0xffffffffn)
+  let tickUpper = Number(value & 0xffffffffn)
+
+  if (tickLower >= 0x80000000) tickLower -= 0x100000000
+  if (tickUpper >= 0x80000000) tickUpper -= 0x100000000
+
+  return {
+    id: (value >> 64n).toString(),
+    tickLower,
+    tickUpper,
+  }
+}
+
+async function tvl(api) {
+  const poolLogs = await getLogs({
+    api,
+    target: CORE,
+    eventAbi: POOL_INITIALIZED_EVENT,
+    fromBlock: DEPLOYMENT_BLOCK,
+    extraKey: 'stonx-pools',
+  })
+
+  const pools = new Map()
+  for (const { args } of poolLogs) {
+    const poolKey = args.poolKey
+    if (getExtension(poolKey.config) !== VE33.toLowerCase()) continue
+
+    pools.set(args.poolId.toLowerCase(), {
+      token0: poolKey.token0,
+      token1: poolKey.token1,
+      config: poolKey.config,
+    })
+  }
+
+  const positionLogs = await getLogs({
+    api,
+    target: CORE,
+    eventAbi: POSITION_UPDATED_EVENT,
+    fromBlock: FIRST_POSITION_BLOCK,
+    extraKey: 'stonx-positions',
+  })
+
+  const positions = new Map()
+  for (const { args } of positionLogs) {
+    if (args.locker.toLowerCase() !== VE33_POSITIONS.toLowerCase()) continue
+
+    const poolId = args.poolId.toLowerCase()
+    if (!pools.has(poolId)) continue
+
+    const key = `${poolId}-${args.positionId.toLowerCase()}`
+    const position = positions.get(key) ?? {
+      poolId,
+      positionId: args.positionId,
+      liquidity: 0n,
+    }
+    position.liquidity += BigInt(args.liquidityDelta)
+    positions.set(key, position)
+  }
+
+  const activePositions = [...positions.values()].filter(({ liquidity }) => liquidity > 0n)
+  const calls = activePositions.map(({ poolId, positionId }) => {
+    const pool = pools.get(poolId)
+    const { id, tickLower, tickUpper } = decodePositionId(positionId)
+    return {
+      params: [id, [pool.token0, pool.token1, pool.config], tickLower, tickUpper],
+    }
+  })
+
+  const liquidities = await api.multiCall({
+    target: VE33_POSITIONS,
+    abi: GET_POSITION_LIQUIDITY,
+    calls,
+  })
+
+  for (let i = 0; i < activePositions.length; i++) {
+    const pool = pools.get(activePositions[i].poolId)
+    const [, principal0, principal1] = liquidities[i]
+    api.add(pool.token0, principal0)
+    api.add(pool.token1, principal1)
+  }
+}
+
+module.exports = {
+  methodology:
+    'TVL is the current token principal in every active STONX Ve33 liquidity position on Ekubo. Active positions are reconstructed from Ekubo Core events, then their token amounts are read from the canonical Ve33Positions manager. Core swap fees and veSTONX staking are excluded.',
+  doublecounted: true,
+  timetravel: false,
+  robinhood: { tvl },
+}


### PR DESCRIPTION
# Add STONX (Ekubo Ve33) TVL adapter

Please enable **Allow edits by maintainers** on the pull request.

##### Name (to be shown on DefiLlama):

STONX

##### Twitter Link:

https://x.com/EkuboProtocol

##### List of audit links if any:

- https://docs.ekubo.org/reference/audits/
- https://github.com/EkuboProtocol/evm-contracts/blob/main/audits/ve33-audit-invariant-verification.md

##### Website Link:

https://ekubo.org

##### Logo (High resolution, will be shown with rounded borders):

https://ekubo.org/logo.svg

##### Current TVL:

As of 2026-08-21, the adapter calculated approximately $1.00 million in liquidity TVL and $321,600 of locked STONX reported separately under staking at the latest Robinhood Chain block.

##### Treasury Addresses (if the protocol has treasury)

None. The Ekubo DAO address is a regular STONX depositor/user, not a STONX treasury.

##### Chain:

Robinhood Chain

##### Coingecko ID:



##### Coinmarketcap ID:



##### Short Description (to be shown on DefiLlama):

STONX is Ekubo's Ve33 liquidity marketplace on Robinhood Chain, where STONX voters direct incentives and pool fee settings across tokenized-asset liquidity pools.

##### Token address and ticker if any:

STONX: `0x570c5aa79c798e7a418412cc8399ae5bcce570c5`

##### Category:

Dexs

##### Oracle Provider(s):

None.

##### Implementation Details:

STONX does not integrate an external price oracle for pool accounting. Pools use Ekubo Core's on-chain concentrated-liquidity state and swap-driven prices.

##### Documentation/Proof:

- https://blog.ekubo.org/ve33-liquidity-marketplace/
- https://github.com/EkuboProtocol/evm-contracts/blob/main/src/extensions/Ve33.sol
- https://github.com/EkuboProtocol/evm-contracts/blob/main/src/Ve33Positions.sol

##### forkedFrom:

No. STONX is an official Ekubo Ve33 deployment, not a fork.

##### methodology:

TVL is the current token principal in every active STONX Ve33 liquidity position on Ekubo Core. The adapter reconstructs active positions from `PoolInitialized` and `PositionUpdated` events, filters them to the STONX Ve33 extension and canonical Ve33Positions manager, and reads current token principal with `Ve33Positions.getPositionLiquidity`. Core swap fees and claimable STONX rewards are excluded. Locked STONX is reported separately under staking based on net `StakeChanged` events. The adapter is marked double-counted because these assets are also held by the shared Ekubo Core singleton.

##### Github org/user:

EkuboProtocol

##### Does this project have a referral program?

No.

## Validation

`node test.js projects/stonx/index.js`

Result on 2026-08-21: Robinhood Chain liquidity TVL approximately $996,170 across 24 assets; 356,673.8348 locked STONX (approximately $321,600) was reported separately under staking.

Replay-boundary validation: an independent on-chain scan from the Ve33 deployment block (18,269,246) through block 23,649,680 found 98 Core `PositionUpdated` events. The only event whose locker is the canonical Ve33Positions manager is at block 23,649,680, confirming that `FIRST_POSITION_BLOCK` does not omit earlier STONX liquidity.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added STONX support for Ekubo pool TVL reporting.
  * Added tracking of active Ve33 liquidity positions.
  * Added STONX staking metrics based on net locked balances.
  * Reports locked STONX separately from pool TVL.
* **Documentation**
  * Clarified that swap fees and claimable STONX rewards are excluded from TVL calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->