### PR TITLE
add icarus and aave v4 hub

### DIFF
--- a/projects/aave-v4/index.js
+++ b/projects/aave-v4/index.js
@@ -5,6 +5,7 @@ module.exports = aaveV4Export({
     "0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9", // Core Hub
     "0x06002e9c4412CB7814a791eA3666D905871E536A", // Plus Hub
     "0x943827DCA022D0F354a8a8c332dA1e5Eb9f9F931", // Prime Hub
+    "0x62d63197660c080236193CA60b70E49A08E90368", // Global Dollar Hub
   ],
   avax: [
     "0xd07369fAE4A5BB13c9Ce446B052c7867B1AbDf6e", // Core Hub

--- a/registries/uniswapV2.js
+++ b/registries/uniswapV2.js
@@ -3106,6 +3106,29 @@ const uniV2Configs = {
   },
   'qomx': {    bsc: '0x356037CbC77B3A2B36E0484d96DF0De247e66785'  },
   'lobsterswap': {    ozone: '0x89687777012E7FF91a6ecDDDc0aebAb38BbC098A'  },
+  'icarus-v2': {
+    start: '2026-01-23',
+    methodology: 'Value of the tokens locked in the classic stable and volatile liquidity pools.',
+    _options: {
+      abis: {
+        allPairsLength: 'uint256:allPoolsLength',
+        allPairs: 'function allPools(uint256) view returns (address)',
+      },
+      hasStablePools: true,
+    },
+    rise: '0xEe10C6a0f158bFEeef3d48Dc0D26130Cf6115615',
+  },
+  'icarus-cl': {
+    start: '2026-01-26',
+    rise: '0x6f7DA11c13Ba09A153dA06d376044e5859Db607B',
+    _options: {
+      abis: {
+        allPairsLength: 'uint256:allPoolsLength',
+        allPairs: 'function allPools(uint256) view returns (address)',
+      },
+      fetchBalances: true,
+    },
+  }
 }
 
 module.exports = buildProtocolExports(uniV2Configs, uniV2ExportFn)


### PR DESCRIPTION
resolves #20532

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Global Dollar Hub to the Ethereum Aave V4 deployment list.
  - Added Icarus V2 and Icarus CL protocol configurations on the Rise network.
  - Added support for tracking their liquidity pools, including stable pools and pool balances where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->