### PR TITLE
add streamflow staking tvl

### DIFF
--- a/projects/streamflow/index.js
+++ b/projects/streamflow/index.js
@@ -1,10 +1,41 @@
+const { PublicKey } = require('@solana/web3.js')
 const { getCache } = require('../helper/http')
 const { getWhitelistedTokens } = require('../helper/streamingHelper')
+const { getConnection, sumTokens2: sumSolanaTokens } = require('../helper/solana')
+
+const STAKE_PROGRAM = new PublicKey('STAKEvGqQTtzJZH6BWDcbpzXXn2BBerPAgQ3EGLN2GH')
+const STREAM = 'STREAMribRwybYpMmSYoCsQUdr6MZNXEqHgm7p1gu9M'
+
+// shared between tvl and staking
+let stakePoolsPromise
+async function getStakePools() {
+  if (!stakePoolsPromise)
+    stakePoolsPromise = getConnection()
+      .getProgramAccounts(STAKE_PROGRAM, {
+        dataSlice: { offset: 0, length: 171 },
+        filters: [{ dataSize: 296 }],
+      })
+      .then(accs => accs.map(({ account: { data } }) => ({
+        mint: new PublicKey(data.subarray(10, 42)).toBase58(),
+        vault: new PublicKey(data.subarray(139, 171)).toBase58(),
+      })))
+  return stakePoolsPromise
+}
+
+async function stakeVaults(api, ownToken) {
+  const pools = await getStakePools()
+  const vaults = pools.filter(p => (p.mint === STREAM) === ownToken).map(p => p.vault)
+  if (vaults.length) await sumSolanaTokens({ api, tokenAccounts: [...new Set(vaults)] })
+}
+
+// third-party tokens staked via Streamflow's pools
+const stakingTvl = (api) => stakeVaults(api, false)
+// streamflow's own STREAM token
+const stakingOwn = (api) => stakeVaults(api, true)
 
 const url =
   "https://metabase.internal-streamflow.com/_public/api/v1/stats/accumulated/by-token";
 const chains = [
-  "solana",
   "aptos",
   "bsc",
   "polygon",
@@ -66,4 +97,16 @@ chains.forEach((chain) => {
     tvl, vesting
   };
 });
+
+// solana has staking pools
+async function solanaTvl(api) {
+  await tvl(api)
+  await stakingTvl(api)
+}
+
+module.exports.solana = {
+  tvl: solanaTvl,
+  vesting,
+  staking: stakingOwn,
+}
 // 900K 


### PR DESCRIPTION
staking product launched in 2024: https://x.com/streamflow_fi/status/1818553858031063456

split STREAM in staking pools into `staking` export

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Solana stake-pool discovery and caching.
  * Solana TVL now includes third-party staked tokens alongside regular TVL.
  * Added separate tracking for STREAM token staking.
  * Exposed dedicated staking data for STREAM on Solana.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->