### PR TITLE
klaystation: book the delegated KLAY, the sKLAY feed leaves TVL at $0 on 22 of 30 days

### DIFF
--- a/projects/klaystation/index.js
+++ b/projects/klaystation/index.js
@@ -1,7 +1,13 @@
+const stakingPool = '0x77777779ee2d933da027ee1fb3590c41529046c8'
+
 async function tvl(api) {
-	const sKlay = '0xa323d7386b671e8799dca3582d6658fdcdcd940a'
-	const supply = await api.call({  abi: 'erc20:totalSupply', target: sKlay})
-	api.add(sKlay, supply)
+	// getPoolStat returns the sKLAY supply and the KLAY delegated behind it. Book the KLAY:
+	// sKLAY's own price feed only quotes a third of the days, so reading its supply left TVL at $0 most days.
+	const { totalStaking } = await api.call({
+		abi: 'function getPoolStat() view returns (uint256 totalSupply, uint256 totalStaking)',
+		target: stakingPool,
+	})
+	api.addGasToken(totalStaking)
 }
 
 module.exports = {


### PR DESCRIPTION
Klaystation has published **$0 TVL on 22 of the last 30 days**, against a live pool holding 45.1M KLAY.

## Not the balance read, the pricing of the receipt token

The adapter booked `totalSupply` of sKLAY and left it to the price feed:

```js
const supply = await api.call({ abi: 'erc20:totalSupply', target: sKlay })
api.add(sKlay, supply)
```

sKLAY is quoted about a third of the days. An unpriced token contributes nothing rather than erroring, so the series alternates between $0 and ~$1.2M:

```
08-11  $0          08-16  $1,134,763
08-12  $0          08-17  $0
08-13  $0          08-18  $0
08-14  $0          08-19  $0
08-15  $1,135,096  08-20  $1,002,241
```

Feed density, same 30 day window:

```
sKLAY  klaytn:0xa323d7386b671e8799dca3582d6658fdcdcd940a   10 / 30 days
KLAY   klaytn:0x0000000000000000000000000000000000000000   30 / 30 days
```

## Change

Read `getPoolStat()` on the staking pool `0x77777779ee2d933da027ee1fb3590c41529046c8` and book the KLAY it reports. That value is the TVL directly, so nothing depends on a feed for the receipt token any more.

## Why those fields are what I say they are

`getPoolStat()` returns two words. The first is `31,110,251.684462417895948218`, which equals sKLAY `totalSupply()` to the wei, and that is what identifies them:

```
[0] 31,110,251.68  sKLAY supply
[1] 45,153,627.84  KLAY delegated
```

The implied rate is monotonic across 45 days, as an accruing LST has to be. Read from archival state on the pool:

| block date | rate |
| --- | --- |
| 2026-07-07 | 1.443733 |
| 2026-07-28 | 1.447885 |
| 2026-08-07 | 1.449348 |
| 2026-08-14 | 1.450374 |
| 2026-08-21 | 1.451407 |

That is about 4.5%/yr, consistent with KLAY staking.

The same series derived from the sKLAY feed instead is **not** monotonic and drifts low: 1.4254 on 07-08, 1.4378 on 07-16, 1.4144 on 07-29, 1.3491 on 08-19. By 08-19 the feed is 7.0% under the on-chain rate. So on the days it does quote, it is also mispricing.

`api.addGasToken` is right here because the amount is KLAY by construction, and `projects/klayportal/index.js` already uses it on this chain.

## Test

```
Before  SKLAY  1.27 M
After   KLAY   1.29 M
```

Worth being straight about this: today is one of the 8 days sKLAY *is* quoted, so the local run does not reproduce the $0. It only shows the 1.7% the feed is currently low by. The evidence for the bug is the published series and the feed density above, not this run.

No liquidity read available to cross-check against: sKLAY returns zero pairs on dexscreener, which is consistent with a receipt token that is redeemed rather than traded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the accuracy of the staking pool’s total value locked (TVL) calculation.
  * Delegated KLAY is now correctly included as a gas token, replacing the previous sKLAY-based accounting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->