### PR TITLE
add checks for sumTokens and cex dups

### DIFF
--- a/cex/index.js
+++ b/cex/index.js
@@ -77,7 +77,6 @@ const configs = {
         "0xb03eDB668008459B3c6D948ab5Ab305581DbF69c",
         "0x3d79007ba1a68de986eb641a3c24d58a0c69587e",
         "0xF884B1bC1d91Cdf824e7f35D61EdfdB042c28C83",
-        "0xAd8E5cEb7D77e10403Be8430717c515273c31b8d",
         "0x16572Dc0f727C7E3012baD8dbE6B2CE1Cdc31670",
         "0xD888d549B511CE54efFa084f33744a59D452C729",
         "0x2c02f34e06f75380844F928b0CBAb1265338Ae27"
@@ -145,7 +144,6 @@ const configs = {
         "0xd3D3a295bE556Cf8cef2a7FF4cda23D22c4627E8",
         "0x909C1c195FC0a31758C7169B321B707C9F44886B",
         "0xF7b7775f6D31eC2d14984f1cA3e736F5FB896DA2",
-        "0xAd8E5cEb7D77e10403Be8430717c515273c31b8d",
         "0x74E7Fd0b532f88cf8cC50922F7a8f51e3F320Fa7",
         "0xA1195F0d9B010F86633E1553F1286d74F80eF52B"
       ]
@@ -656,14 +654,10 @@ const configs = {
         "0x76d90b0f8150797d9eb4ce91bca2829f494c3766",
         "0x8332086fa910f6e72e9793778d91b6f9ef2d719d",
         "0xa63811cd3abdbc0bd0f668a9eb98b97a96ead95f",
-        "0x9b9B873F2Bf299B0E8C5b2E8Ff220Dc5cb4330E1",
         "0xFBcE3974014022853136989149787df66D54E623",
-        "0x66AAD5CA93438D565909De0bF444b45e543d98E9",
         "0x2355969e0692D41bCbB5e695513C0cF4Ae6059C2",
         "0x0733E99402D268D4475A8F5E45987Db04bA66181",
         "0xd83Daa277d9DAD1f34aDE22002806251f04f4a28",
-        "0x748577Ce82346C61e9d6e52628Eda8dFaB3241b3",
-        "0xaDc7cf570DDf2Ff99C723F946c7F5A5D34cF868C"
       ]
     },
     bitcoin: "coin8",
@@ -671,19 +665,16 @@ const configs = {
       owners: [
         "0x3465136aa1ab5fd78bae06a91c280157532c62b8",
         "0xebb54920eda335dfcde8a904f8293bcb5ac64aff",
-        "0x66AAD5CA93438D565909De0bF444b45e543d98E9"
       ]
     },
     bsc: {
       owners: [
         "0x8f3d8dde9f2687d93640ecede2a91b1dc3404bd6",
         "0xef01a7711d046af41597c308369b9c8d5873ae96",
-        "0x9b9B873F2Bf299B0E8C5b2E8Ff220Dc5cb4330E1",
         "0xF4271F1c5ABa50B9c18d229311FD22C4Cc7B70b6",
         "0xa089b8de0eA45db84CCadE5751EE165A88F90b4F",
         "0xFBcE3974014022853136989149787df66D54E623",
         "0xC349541773D5eCa27D36E9bD95094920f4B7A536",
-        "0x66AAD5CA93438D565909De0bF444b45e543d98E9"
       ]
     },
     solana: {
@@ -699,17 +690,14 @@ const configs = {
     },
     polygon: {
       owners: [
-        "0x66AAD5CA93438D565909De0bF444b45e543d98E9"
       ]
     },
     avax: {
       owners: [
-        "0x66AAD5CA93438D565909De0bF444b45e543d98E9"
       ]
     },
     tron: {
       owners: [
-        "TWGV42YRYpK1rfMHZCYYxhK1fZDbTNrqzz",
         "TZD1mbbNqnffBRSr8zEjWo6L37vk3nxhvT",
         "TFjKKNBqrsjRhmPnimyArxTuPxq5HkG9T7"
       ]
@@ -793,19 +781,13 @@ const configs = {
   'coinstore': {
     ethereum: {
       owners: [
-        "0x9b9B873F2Bf299B0E8C5b2E8Ff220Dc5cb4330E1",
-        "0x66AAD5CA93438D565909De0bF444b45e543d98E9",
-        "0x748577Ce82346C61e9d6e52628Eda8dFaB3241b3",
         "0xf2067abfab8bc621211935431519d41825d2f344",
-        "0xaDc7cf570DDf2Ff99C723F946c7F5A5D34cF868C"
       ]
     },
     bsc: {
       owners: [
-        "0x9b9B873F2Bf299B0E8C5b2E8Ff220Dc5cb4330E1",
         "0xa089b8de0eA45db84CCadE5751EE165A88F90b4F",
         "0x20664cacdcfeb318c8e145a03c75e34bc2cc4a3b",
-        "0x66AAD5CA93438D565909De0bF444b45e543d98E9",
         "0x6148f792622c3B85F04f87E8a09474a591E71C5f",
         "0xC349541773D5eCa27D36E9bD95094920f4B7A536",
         "0x40C847f59600286cFEE8d6De6640E967a7824d57"
@@ -813,18 +795,15 @@ const configs = {
     },
     arbitrum: {
       owners: [
-        "0x66AAD5CA93438D565909De0bF444b45e543d98E9",
         "0x2a6e62f040a7f0b830847da101539a7eef7bb040"
       ]
     },
     optimism: {
       owners: [
-        "0x66AAD5CA93438D565909De0bF444b45e543d98E9"
       ]
     },
     polygon: {
       owners: [
-        "0x66AAD5CA93438D565909De0bF444b45e543d98E9",
         "0x65e1615efc11c63e15c00ac4447c56af294135a9"
       ]
     },
@@ -835,7 +814,6 @@ const configs = {
     },
     base: {
       owners: [
-        "0x66AAD5CA93438D565909De0bF444b45e543d98E9"
       ]
     },
     bitcoin: {
@@ -852,10 +830,8 @@ const configs = {
     },
     tron: {
       owners: [
-        "TWGV42YRYpK1rfMHZCYYxhK1fZDbTNrqzz",
         "TBhbX5S51L1C34wBExL9efV5YfTE5NAFi1",
         "TJa4jS3qsAa2je4ksDP9BD7NzsffuWfRQK",
-        "TM7rxykbNRuFd2iZ1zVH4P8xrpSCduw9vD"
       ]
     }
   },

--- a/cex/index.js
+++ b/cex/index.js
@@ -672,9 +672,7 @@ const configs = {
         "0x8f3d8dde9f2687d93640ecede2a91b1dc3404bd6",
         "0xef01a7711d046af41597c308369b9c8d5873ae96",
         "0xF4271F1c5ABa50B9c18d229311FD22C4Cc7B70b6",
-        "0xa089b8de0eA45db84CCadE5751EE165A88F90b4F",
         "0xFBcE3974014022853136989149787df66D54E623",
-        "0xC349541773D5eCa27D36E9bD95094920f4B7A536",
       ]
     },
     solana: {
@@ -786,10 +784,8 @@ const configs = {
     },
     bsc: {
       owners: [
-        "0xa089b8de0eA45db84CCadE5751EE165A88F90b4F",
         "0x20664cacdcfeb318c8e145a03c75e34bc2cc4a3b",
         "0x6148f792622c3B85F04f87E8a09474a591E71C5f",
-        "0xC349541773D5eCa27D36E9bD95094920f4B7A536",
         "0x40C847f59600286cFEE8d6De6640E967a7824d57"
       ]
     },

--- a/cex/index.js
+++ b/cex/index.js
@@ -2461,4 +2461,6 @@ for (const [name, rawConfig] of Object.entries(configs)) {
   allProtocols[name] = Object.assign(cexExports(config), meta)
 }
 
+// expose the configs for the duplicate-owner checker
+Object.defineProperty(allProtocols, '_rawConfigs', { value: configs, enumerable: false })
 module.exports = allProtocols

--- a/cex/phemex.js
+++ b/cex/phemex.js
@@ -82,7 +82,6 @@ module.exports = {
       'THAABzWrhp84Nr7gxss7qhtzA5mp3d1qUo',
       'TMHKjGvQ2trQkBEnAgx7RvV77Xn8w1JDP7',
       'THe3CVBSKGdfeW58B2MLCJ9u5W74MCGL8M',
-      'TM7rxykbNRuFd2iZ1zVH4P8xrpSCduw9vD',
       'TEdkCXtBpmze8VmmbMV1WEBiagvrUf7Hk5'
     ],
   },

--- a/registries/sumTokens.js
+++ b/registries/sumTokens.js
@@ -17823,16 +17823,6 @@ const configs = {
       ]
     },
   },
-  "manta-myield": {
-    "manta": {
-      "owner": "0x1B9bcc6644CC9b5e1F89aBaAb66904F5a562d4a1",
-      "tokens": [
-        "0x1468177DbCb2a772F3d182d2F1358d442B553089",
-        "0xACCBC418a994a27a75644d8d591afC22FaBA594e",
-        "0x649d4524897cE85A864DC2a2D5A11Adb3044f44a"
-      ]
-    },
-  },
   "marspoolin": {
     "ethereum": {
       "tokensAndOwners2": [

--- a/registries/sumTokens.js
+++ b/registries/sumTokens.js
@@ -42175,4 +42175,6 @@ for (const [name, cfg] of Object.entries(configs)) {
   }
   allProtocols[name] = out
 }
+// expose the configs for the duplicate-owner checker
+Object.defineProperty(allProtocols, '_rawConfigs', { value: configs, enumerable: false })
 module.exports = allProtocols

--- a/registries/sumTokens/covalent.js
+++ b/registries/sumTokens/covalent.js
@@ -509,12 +509,6 @@ module.exports = {
       "fetchCoValentTokens": true
     },
   },
-  "metisBridge": {
-    "ethereum": {
-      "owner": "0x3980c9ed79d2c191A89E02Fa3529C60eD6e9c04b",
-      "fetchCoValentTokens": true
-    },
-  },
   "mint-chain": {
     "ethereum": {
       "owners": [

--- a/registries/sumTokens/covalent.js
+++ b/registries/sumTokens/covalent.js
@@ -409,18 +409,6 @@ module.exports = {
       ]
     },
   },
-  "hemi-locked": {
-    "ethereum": {
-      "owners": [
-        "0x5eaa10F99e7e6D177eF9F74E519E319aa49f191e",
-        "0x39a0005415256B9863aFE2d55Edcf75ECc3A4D7e"
-      ],
-      "fetchCoValentTokens": true,
-      "blacklistedTokens": [
-        "0xeb964a1a6fab73b8c72a0d15c7337fa4804f484d"
-      ]
-    },
-  },
   "immutable-zkevm": {
     "ethereum": {
       "owner": "0xBa5E35E26Ae59c7aea6F029B68c6460De2d13eB6",
@@ -658,13 +646,6 @@ module.exports = {
     "ethereum": {
       "owner": "0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe",
       "fetchCoValentTokens": true
-    },
-  },
-  "pulsechain": {
-    "ethereum": {
-      "owner": "0x1715a3E4A142d8b698131108995174F37aEBA10D",
-      "fetchCoValentTokens": true,
-      "permitFailure": true
     },
   },
   "pulsechain-bridge": {

--- a/registries/sumTokens/data2.js
+++ b/registries/sumTokens/data2.js
@@ -689,7 +689,7 @@ module.exports = {
     },
     "ethereum": {
       "tvl": {
-        "owners": ["0x1B5668Ca8edfC8AF5DcB9De014b4B08ed5d0615F", "0x3111653DB0e7094b111b8e435Df9193b62C2C576", "0xd6572c7cd671ecf75d920adcd200b00343959600", "0xa97Fe3E9c1d3Be7289030684eD32A6710d2d02bA", "0xeea3A032f381AB1E415e82Fe08ebeb20F513c42c"],
+        "owners": ["0x1B5668Ca8edfC8AF5DcB9De014b4B08ed5d0615F", "0x3111653DB0e7094b111b8e435Df9193b62C2C576", "0xa97Fe3E9c1d3Be7289030684eD32A6710d2d02bA", "0xeea3A032f381AB1E415e82Fe08ebeb20F513c42c"],
         "tokens": [ADDRESSES.ethereum.USDC, "0x7122985656e38bdc0302db86685bb972b145bd3c", ADDRESSES.ethereum.USDT, "0x7122985656e38BDC0302Db86685bb972b145bD3C"]
       }
     },
@@ -700,7 +700,7 @@ module.exports = {
       }
     },
     "manta": {
-      "tvl": { "owners": ["0x19727db22Cba70B1feE40337Aba69D83c6741caF"], "tokens": [ADDRESSES.berachain.STONE] }
+      "tvl": { "owners": [], "tokens": [ADDRESSES.berachain.STONE] }
     },
     "bsc": {
       "tvl": {

--- a/registries/sumTokens/data2.js
+++ b/registries/sumTokens/data2.js
@@ -699,9 +699,6 @@ module.exports = {
         "tokens": [ADDRESSES.arbitrum.USDT, ADDRESSES.arbitrum.USDC_CIRCLE]
       }
     },
-    "manta": {
-      "tvl": { "owners": [], "tokens": [ADDRESSES.berachain.STONE] }
-    },
     "bsc": {
       "tvl": {
         "owners": ["0x40a25786937eCc0643e78ca40Df02Db4dff27bb0", "0xF8aeD4da2598d3dF878488F40D982d6EcC8B13Ad", "0xBA43F3C8733b0515B5C23DFF46F47Af6EB46F85C", "0x0A80028d73Faaee6e57484E3335BeFda0de7f455"],

--- a/utils/scripts/checkRegistriesDups.js
+++ b/utils/scripts/checkRegistriesDups.js
@@ -5,14 +5,26 @@ const axios = require('axios');
 const { getEnv } = require('../../projects/helper/env');
 
 const REGISTRY_DIR = path.join(__dirname, '../../registries');
+const CEX_INDEX = path.join(__dirname, '../../cex/index.js');
+const SUMTOKENS_INDEX = path.join(__dirname, '../../registries/sumTokens.js');
 const ADDRESS_RE = /^0x[0-9a-fA-F]{40}$|^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
 
 // Keys that identify a tracked contract
 const KEYS = new Set(['factory', 'comptroller', 'masterchef', 'vault', 'registry', 'address']);
 
+// Keys that identify an owner/wallet (cex + sumTokens)
+const OWNER_KEYS = new Set(['owner', 'owners', 'solOwners', 'tokenAccounts']);
+
+// metadata keys to ignore
+const META = new Set(['methodology', 'start', 'timetravel', 'hallmarks', 'doublecounted', 'misrepresentedTokens']);
+
 const IGNORED = new Set([
   '0x7C10a3b7EcD42dd7D79C0b9d58dDB812f92B574A' // DogeShrek rebranded to ChewySwap and was listed again; we cant fix by backfilling since dogechain's RPC fails on the necessary historical queries
 ].map(a => a.toLowerCase()));
+
+// Owner-collision allow-list, keyed by protocol: owners known to be legitimately shared.
+// e.g. { 'some-cex': ['0xabc...'], 'some-other': ['solanaAddr...'] }
+const IGNORED_OWNERS = {};
 
 // Based on defillama-server/defi/src/utils/discord.ts
 async function sendDiscord(message, formatted = true) {
@@ -57,21 +69,35 @@ function extractTrackedAddresses(chainConfig, found = new Set()) {
   return found;
 }
 
+function collectOwnerAddrs(value, found) {
+  if (typeof value === 'string') addIfAddress(value, found);
+  else if (Array.isArray(value)) value.forEach(v => collectOwnerAddrs(v, found));
+  // functions (dynamic owner lists) and objects are ignored for now
+}
+
+// Pull owner addresses from a chain config, they can sit at the chain level
+// or nested inside a tvl/staking/pool2/
+function extractOwners(node, found = new Set()) {
+  if (!node || typeof node !== 'object') return found;
+  if (Array.isArray(node)) { node.forEach(item => extractOwners(item, found)); return found; }
+  for (const [key, value] of Object.entries(node)) {
+    if (OWNER_KEYS.has(key)) collectOwnerAddrs(value, found);
+    else if (key === 'tokensAndOwners' && Array.isArray(value)) {
+      for (const pair of value) if (Array.isArray(pair)) addIfAddress(pair[1], found);
+    } else if (value && typeof value === 'object') {
+      extractOwners(value, found);
+    }
+  }
+  return found;
+}
+
 function loadRawConfigs(filePath) {
   return require(filePath)._rawConfigs;
 }
 
-function formatDuplicates(duplicates) {
-  const entries = Object.entries(duplicates);
-  if (!entries.length) return null;
-  const lines = [`Found ${entries.length} duplicate registry entries:`, ''];
-  for (const [key, protocols] of entries) lines.push(`${key}\n  → ${protocols}`);
-  return lines.join('\n');
-}
-
-async function run() {
+function findContractDuplicates() {
   const registryFiles = fs.readdirSync(REGISTRY_DIR)
-    .filter(f => f.endsWith('.js') && f !== 'index.js' && f !== 'utils.js')
+    .filter(f => f.endsWith('.js') && !['index.js', 'utils.js', 'sumTokens.js'].includes(f))
     .map(f => ({ name: f, fullPath: path.join(REGISTRY_DIR, f) }));
 
   const duplicates = {};
@@ -84,7 +110,6 @@ async function run() {
       console.warn(`Skipping ${name} (could not load)`);
       continue;
     }
-
     if (!configs || typeof configs !== 'object') continue;
 
     const addressMap = {};
@@ -108,11 +133,71 @@ async function run() {
     }
   }
 
-  console.table(Object.entries(duplicates));
+  return duplicates;
+}
 
-  const message = formatDuplicates(duplicates);
-  if (message) await sendDiscord(message);
-  else console.log('No duplicate registry entries found.');
+// Find owners listed under more than one protocol within a registry (cex or sumTokens).
+function findOwnerDuplicates(rawConfigs) {
+  if (!rawConfigs || typeof rawConfigs !== 'object') return {};
+
+  const ownerMap = {}; // `${chain}:${owner}` -> [protocols]
+  for (const [protocol, config] of Object.entries(rawConfigs)) {
+    if (!config || typeof config !== 'object') continue;
+    const ignoredForProto = new Set((IGNORED_OWNERS[protocol] || []).map(a => a.toLowerCase()));
+    for (const [chain, chainConfig] of Object.entries(config)) {
+      if (META.has(chain)) continue;
+      for (const owner of extractOwners(chainConfig)) {
+        if (ignoredForProto.has(owner)) continue;
+        const key = `${chain}:${owner}`;
+        if (!ownerMap[key]) ownerMap[key] = [];
+        if (!ownerMap[key].includes(protocol)) ownerMap[key].push(protocol);
+      }
+    }
+  }
+
+  const duplicates = {};
+  for (const [key, protocols] of Object.entries(ownerMap)) {
+    if (protocols.length > 1) duplicates[key] = protocols.join(', ');
+  }
+  return duplicates;
+}
+
+function ownerDuplicatesFor(filePath, label) {
+  try {
+    return findOwnerDuplicates(loadRawConfigs(filePath));
+  } catch (e) {
+    console.warn(`Skipping ${label} owner check (could not load): ${e.message}`);
+    return {};
+  }
+}
+
+function formatSection(title, duplicates) {
+  const entries = Object.entries(duplicates);
+  if (!entries.length) return null;
+  const lines = [`${title} (${entries.length}):`, ''];
+  for (const [key, protocols] of entries) lines.push(`${key}\n  -> ${protocols}`);
+  return lines.join('\n');
+}
+
+async function run() {
+  const contractDups = findContractDuplicates();
+  const cexOwnerDups = ownerDuplicatesFor(CEX_INDEX, 'cex');
+  const sumTokensOwnerDups = ownerDuplicatesFor(SUMTOKENS_INDEX, 'sumTokens');
+
+  const sections = [
+    formatSection('Registry tracked-contract duplicates', contractDups),
+    formatSection('CEX owner duplicates', cexOwnerDups),
+    formatSection('sumTokens owner duplicates', sumTokensOwnerDups),
+  ].filter(Boolean);
+
+  if (!sections.length) {
+    console.log('No duplicate registry entries found.');
+    return;
+  }
+
+  const message = sections.join('\n\n');
+  console.log(message);
+  await sendDiscord(message);
 }
 
 run().catch(async (e) => {

--- a/utils/scripts/checkRegistriesDups.js
+++ b/utils/scripts/checkRegistriesDups.js
@@ -15,15 +15,14 @@ const KEYS = new Set(['factory', 'comptroller', 'masterchef', 'vault', 'registry
 // Keys that identify an owner/wallet (cex + sumTokens)
 const OWNER_KEYS = new Set(['owner', 'owners', 'solOwners', 'tokenAccounts']);
 
-// metadata keys to ignore
+// Metadata keys to ignore
 const META = new Set(['methodology', 'start', 'timetravel', 'hallmarks', 'doublecounted', 'misrepresentedTokens']);
 
 const IGNORED = new Set([
   '0x7C10a3b7EcD42dd7D79C0b9d58dDB812f92B574A' // DogeShrek rebranded to ChewySwap and was listed again; we cant fix by backfilling since dogechain's RPC fails on the necessary historical queries
 ].map(a => a.toLowerCase()));
 
-// Owner-collision allow-list, keyed by protocol: owners known to be legitimately shared.
-// e.g. { 'some-cex': ['0xabc...'], 'some-other': ['solanaAddr...'] }
+// e.g. { 'some-cex': ['0xabc...'], ... }
 const IGNORED_OWNERS = {};
 
 // Based on defillama-server/defi/src/utils/discord.ts
@@ -103,13 +102,7 @@ function findContractDuplicates() {
   const duplicates = {};
 
   for (const { name, fullPath } of registryFiles) {
-    let configs;
-    try {
-      configs = loadRawConfigs(fullPath);
-    } catch {
-      console.warn(`Skipping ${name} (could not load)`);
-      continue;
-    }
+    const configs = loadRawConfigs(fullPath);
     if (!configs || typeof configs !== 'object') continue;
 
     const addressMap = {};
@@ -136,7 +129,7 @@ function findContractDuplicates() {
   return duplicates;
 }
 
-// Find owners listed under more than one protocol within a registry (cex or sumTokens).
+// Find owners listed under more than one protocol within a registry (cex or sumTokens)
 function findOwnerDuplicates(rawConfigs) {
   if (!rawConfigs || typeof rawConfigs !== 'object') return {};
 
@@ -162,15 +155,6 @@ function findOwnerDuplicates(rawConfigs) {
   return duplicates;
 }
 
-function ownerDuplicatesFor(filePath, label) {
-  try {
-    return findOwnerDuplicates(loadRawConfigs(filePath));
-  } catch (e) {
-    console.warn(`Skipping ${label} owner check (could not load): ${e.message}`);
-    return {};
-  }
-}
-
 function formatSection(title, duplicates) {
   const entries = Object.entries(duplicates);
   if (!entries.length) return null;
@@ -181,8 +165,8 @@ function formatSection(title, duplicates) {
 
 async function run() {
   const contractDups = findContractDuplicates();
-  const cexOwnerDups = ownerDuplicatesFor(CEX_INDEX, 'cex');
-  const sumTokensOwnerDups = ownerDuplicatesFor(SUMTOKENS_INDEX, 'sumTokens');
+  const cexOwnerDups = findOwnerDuplicates(loadRawConfigs(CEX_INDEX));
+  const sumTokensOwnerDups = findOwnerDuplicates(loadRawConfigs(SUMTOKENS_INDEX));
 
   const sections = [
     formatSection('Registry tracked-contract duplicates', contractDups),


### PR DESCRIPTION
Removed:
- `hemi-locked` - no metadata object on the server, duplicate of `hemi-l2`
- `manta-myield` - metadata is commented out, duplicate of `manta-cedefi-stake` 
- `pulsechain` - duplicate of `pulsechain-bridge`
- `metisBridge` - no metadata object on the server, duplicate of `metis`
- All duplicates shared between `coinstore`, `coin8`, and `phemex`
- Duplicate shared between `biconomy-cex` and `bing-cex`
- `free-protocol` - metadata is commented out, removed two duplicates it shared with `bridgem`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved detection of duplicate ownership and contract entries across supported registries.
- Reduced false positives through refined validation and protocol-specific exceptions.
- Removed outdated exchange owner records and token registry entries.
- Expanded validation coverage for exchange and token configurations.

## Chores

- Grouped duplicate-check results by entry type for clearer reporting.
- Improved handling and reporting of registry loading failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->