### PR TITLE
Update methodology description for TVL calculation

### DIFF
--- a/projects/wise-token/index.js
+++ b/projects/wise-token/index.js
@@ -21,6 +21,6 @@ async function tvl(api) {
 module.exports = {
   misrepresentedTokens: true,
   doublecounted: true,
-  methodology: 'TVL = ownerless (unclaimed) share of ETH in the WISE/ETH Uniswap LP',
+  methodology: 'TVL = ownerless (LP tokens burned) share of ETH in the WISE/ETH Uniswap LP',
   ethereum: { tvl }
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that TVL measures the ETH share represented by burned LP tokens, rather than unclaimed LP tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->