### PR TITLE
cex: restore the deduped owner addresses to the exchange that listed them first

### DIFF
--- a/cex/index.js
+++ b/cex/index.js
@@ -144,6 +144,7 @@ const configs = {
         "0xd3D3a295bE556Cf8cef2a7FF4cda23D22c4627E8",
         "0x909C1c195FC0a31758C7169B321B707C9F44886B",
         "0xF7b7775f6D31eC2d14984f1cA3e736F5FB896DA2",
+        "0xAd8E5cEb7D77e10403Be8430717c515273c31b8d",
         "0x74E7Fd0b532f88cf8cC50922F7a8f51e3F320Fa7",
         "0xA1195F0d9B010F86633E1553F1286d74F80eF52B"
       ]
@@ -654,10 +655,14 @@ const configs = {
         "0x76d90b0f8150797d9eb4ce91bca2829f494c3766",
         "0x8332086fa910f6e72e9793778d91b6f9ef2d719d",
         "0xa63811cd3abdbc0bd0f668a9eb98b97a96ead95f",
+        "0x9b9B873F2Bf299B0E8C5b2E8Ff220Dc5cb4330E1",
         "0xFBcE3974014022853136989149787df66D54E623",
+        "0x66AAD5CA93438D565909De0bF444b45e543d98E9",
         "0x2355969e0692D41bCbB5e695513C0cF4Ae6059C2",
         "0x0733E99402D268D4475A8F5E45987Db04bA66181",
         "0xd83Daa277d9DAD1f34aDE22002806251f04f4a28",
+        "0x748577Ce82346C61e9d6e52628Eda8dFaB3241b3",
+        "0xaDc7cf570DDf2Ff99C723F946c7F5A5D34cF868C"
       ]
     },
     bitcoin: "coin8",
@@ -665,14 +670,19 @@ const configs = {
       owners: [
         "0x3465136aa1ab5fd78bae06a91c280157532c62b8",
         "0xebb54920eda335dfcde8a904f8293bcb5ac64aff",
+        "0x66AAD5CA93438D565909De0bF444b45e543d98E9"
       ]
     },
     bsc: {
       owners: [
         "0x8f3d8dde9f2687d93640ecede2a91b1dc3404bd6",
         "0xef01a7711d046af41597c308369b9c8d5873ae96",
+        "0x9b9B873F2Bf299B0E8C5b2E8Ff220Dc5cb4330E1",
         "0xF4271F1c5ABa50B9c18d229311FD22C4Cc7B70b6",
+        "0xa089b8de0eA45db84CCadE5751EE165A88F90b4F",
         "0xFBcE3974014022853136989149787df66D54E623",
+        "0xC349541773D5eCa27D36E9bD95094920f4B7A536",
+        "0x66AAD5CA93438D565909De0bF444b45e543d98E9"
       ]
     },
     solana: {
@@ -688,14 +698,17 @@ const configs = {
     },
     polygon: {
       owners: [
+        "0x66AAD5CA93438D565909De0bF444b45e543d98E9"
       ]
     },
     avax: {
       owners: [
+        "0x66AAD5CA93438D565909De0bF444b45e543d98E9"
       ]
     },
     tron: {
       owners: [
+        "TWGV42YRYpK1rfMHZCYYxhK1fZDbTNrqzz",
         "TZD1mbbNqnffBRSr8zEjWo6L37vk3nxhvT",
         "TFjKKNBqrsjRhmPnimyArxTuPxq5HkG9T7"
       ]
@@ -828,6 +841,7 @@ const configs = {
       owners: [
         "TBhbX5S51L1C34wBExL9efV5YfTE5NAFi1",
         "TJa4jS3qsAa2je4ksDP9BD7NzsffuWfRQK",
+        "TM7rxykbNRuFd2iZ1zVH4P8xrpSCduw9vD"
       ]
     }
   },


### PR DESCRIPTION
## What

#20625 deduped owner addresses that were listed under two exchanges at once. Firing on them was right, those addresses really were being counted twice. The problem is that they were removed from both configs, so nine addresses went from counted twice to counted zero times. Every one of them still holds a balance on chain.

Published totals on the merge date:

| protocol | change_1d |
|---|---|
| Coinstore | -21.3% |
| Coin8 | -21.2% |
| Biconomy.com | -7.3% |
| BingX | -1.5% |

This puts each address back under exactly one exchange, so the dedupe's intent is kept and the balances are counted once.

## Which exchange gets which

Attribution is by which config listed the address first. Nothing is restored to more than one exchange.

| address | listed by | first | then | restored to |
|---|---|---|---|---|
| `0x66AAD5CA...d98E9` | coin8-cex, coinstore | 3725a2c8 2025-01-27 (#13253) | bc9307f1 2026-03-03 (#18231) | coin8-cex |
| `0x9b9B873F...30E1` | coin8-cex, coinstore | 3725a2c8 2025-01-27 | bc9307f1 2026-03-03 | coin8-cex |
| `0x748577Ce...41b3` | coin8-cex, coinstore | 3725a2c8 2025-01-27 | bc9307f1 2026-03-03 | coin8-cex |
| `0xaDc7cf57...868C` | coin8-cex, coinstore | 3725a2c8 2025-01-27 | bc9307f1 2026-03-03 | coin8-cex |
| `0xa089b8de...0b4F` | coin8-cex, coinstore | 3725a2c8 2025-01-27 | bc9307f1 2026-03-03 | coin8-cex |
| `0xC3495417...A536` | coin8-cex, coinstore | 3725a2c8 2025-01-27 | bc9307f1 2026-03-03 | coin8-cex |
| `TWGV42YRYpK1rfMHZCYYxhK1fZDbTNrqzz` | coin8-cex, coinstore | 3725a2c8 2025-01-27 | bc9307f1 2026-03-03 | coin8-cex |
| `TM7rxykbNRuFd2iZ1zVH4P8xrpSCduw9vD` | coinstore, phemex | bc9307f1 2026-03-03 (#18231) | 161ebe7c 2026-06-12 (#19653) | coinstore |
| `0xAd8E5cEb...1b8d` | bing-cex, biconomy-cex | ff8ede3b 2024-07-08 (#10926) | 5b01b664 2025-07-23 (#15624) | bing-cex |

Each address is restored only on the chains the winning config already had it on, so coinstore keeps its own `optimism` and `base` entries empty and coin8 gets its `polygon` and `avax` entries back.

Worth noting the split is not one sided. TM7rxykb stays with coinstore because coinstore listed it three months before phemex did.

## What I could not confirm

The ordering above is what git history says, not proof of ownership. I tried to corroborate it on chain and could not:

- no public name tags on any of the nine, on Blockscout or elsewhere I could reach
- counterparty scans of the disputed addresses against each exchange's non shared wallets returned zero hits in either direction
- `0xAd8E5cEb`'s visible counterparties are an address poisoning cluster (`0xad8e...31b8d` lookalikes sharing its prefix and suffix), not real flow

What does hold up is the shape of the collision. coin8-cex and coinstore shared seven addresses across seven chains. Two unrelated exchanges do not share seven cold wallets, so one config was copied from the other, and the older one is the more likely original.

If you know the true owner differs on any row, the fix is to move those lines to the other config rather than drop them again. The part I am confident about is that zero copies is wrong whichever way each row falls.

## Balances

Measured directly, native plus USDT and USDC only, so these are floors. The adapters scan all tokens.

| address | chain | holdings |
|---|---|---|
| `0x66AAD5CA` | ethereum | 54.881 ETH |
| `0x66AAD5CA` | polygon | 40,768.39 POL |
| `0x66AAD5CA` | bsc / arbitrum / avax | 0.567 BNB, 0.0127 ETH, 1.072 AVAX |
| `0x9b9B873F` | bsc | 3,804.79 BNB |
| `0x9b9B873F` | ethereum | 53,841.75 USDT |
| `0x748577Ce` | ethereum | 4,991,738.22 USDT |
| `0xaDc7cf57` | ethereum | 4,451,626.19 USDT |
| `0xa089b8de` | bsc | 2,333.64 BNB |
| `0xC3495417` | bsc | 300.16 BNB |
| `0xAd8E5cEb` | ethereum | 100.00 ETH + 20,000,000.00 USDT |
| `TM7rxykb` | tron | 8,148,449.19 TRX |
| `TWGV42YRY` | tron | 361.90 TRX |

All nine are EOAs, no contract code.

## Verification

Same shell, before and after, via a temporary harness that re-exports one cex config so `test.js` can run it:

| protocol | before | after | delta |
|---|---|---|---|
| coin8-cex | 45.96 M | 60.66 M | +14.70 M |
| coinstore | 47.82 M | 50.68 M | +2.86 M |
| bing-cex | 550.92 M | 571.31 M | +20.39 M |

Per chain, the movement lands where the balances are: coin8 ethereum 422.83k to 10.57M, coin8 bsc 23.89k to 4.53M, coin8 polygon 0 to 8.70k, coinstore tron 554.17k to 3.37M, bing ethereum 84.62M to 104.86M.

`solana` fails on both runs with `Failed to post https://api.mainnet-beta.solana.com`. That is the public RPC and it is identical before and after, no solana owner is touched here.

The duplicate checker from the same PR was run against this branch and against unmodified master. The output is byte identical: no registry contract duplicates, no cex owner duplicates, and the same four pre existing sumTokens owner duplicates (3fmutual/hakka, buffer/metavault-bo, and two unirouter pairs on bsquared) which are unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added wallet address support for BingX, Coin8, and Coinstore across Ethereum, Arbitrum, BSC, Polygon, Avalanche, Tron, and other supported networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->