### PR TITLE
fermiswap: add TVL adapter

### DIFF
--- a/projects/fermiswap/index.js
+++ b/projects/fermiswap/index.js
@@ -1,0 +1,26 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+
+const SWAPPER = '0xb1076fE3AB5e28005C7c323Bac5AC06a680d452e'
+const TOKENS = [
+  ADDRESSES.ethereum.WETH,
+  ADDRESSES.ethereum.USDT,
+  ADDRESSES.ethereum.USDC,
+  ADDRESSES.ethereum.cbBTC,
+  ADDRESSES.ethereum.WBTC,
+]
+
+async function tvl(api) {
+  const owner = await api.call({
+    target: SWAPPER,
+    abi: 'address:traderVault',
+  })
+
+  return api.sumTokens({ owner, tokens: TOKENS })
+}
+
+module.exports = {
+  methodology:
+    "TVL is the value of WETH, USDT, USDC, cbBTC, and WBTC held in FermiSwap's inventory vault.",
+  start: '2026-05-12',
+  ethereum: { tvl },
+}


### PR DESCRIPTION
## Summary

Adds on-chain TVL tracking for FermiSwap on Ethereum.

FermiSwap is already listed on DefiLlama with a volume adapter, this PR does not request any protocol metadata changes.

## Methodology

TVL is calculated by summing the WETH, USDT, USDC, cbBTC, and WBTC balances held by FermiSwap's active inventory vault.

The inventory vault is discovered on-chain by calling `traderVault()` on the original FermiSwap deployment:

`0xb1076fE3AB5e28005C7c323Bac5AC06a680d452e`

The original deployment is used because it covers FermiSwap's full history from `2026-05-12`. Both FermiSwap deployments currently return the same inventory vault:

`0x585d44727129B9C69791B10238Ca605932938B4F`

Only the five assets observed in FermiSwap trading activity are whitelisted, preventing unrelated or spam tokens sent to the vault from being counted.

## Contracts and proof

* Existing DefiLlama FermiSwap page:
  https://defillama.com/protocol/fermiswap

* Existing DefiLlama volume adapter:
  https://github.com/DefiLlama/dimension-adapters/blob/master/dexs/fermiswap/index.ts

* Original accepted FermiSwap volume PR:
  https://github.com/DefiLlama/dimension-adapters/pull/7452

* Gattaca/Titan PropAMM reference implementation identifying the original FermiSwap contract:
  https://github.com/gattaca-com/propamm#targets

* Original FermiSwap deployment and verified source:
  https://etherscan.io/address/0xb1076fE3AB5e28005C7c323Bac5AC06a680d452e#code

* Second FermiSwap deployment and verified source:
  https://etherscan.io/address/0x5979458912F80B96d30D4220af8E2e4925A33320#code

* FermiSwap inventory vault:
  https://etherscan.io/address/0x585d44727129B9C69791B10238Ca605932938B4F

## Tests

The adapter was tested at the current block and at multiple historical dates:

```bash
node --check projects/fermiswap/index.js
node test.js projects/fermiswap/index.js
node test.js projects/fermiswap/index.js 2026-05-12
node test.js projects/fermiswap/index.js 2026-06-09
node test.js projects/fermiswap/index.js 2026-07-15
node test.js projects/fermiswap/index.js 2026-08-01
```

* TVL is computed entirely from Ethereum blockchain data.
* No new dependency was added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FermiSwap TVL tracking on Ethereum.
  * Supports valuation of WETH, USDT, USDC, cbBTC, and WBTC held in the protocol’s trader vault.
  * Includes methodology and tracking start-date information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->