### PR TITLE
fix: include Ammalgam borrowed liquidity

### DIFF
--- a/projects/ammalgam/index.js
+++ b/projects/ammalgam/index.js
@@ -1,4 +1,10 @@
 const FACTORY = '0x1a411b0fd1f368d2f413a8cbb6aad425c923015b'
+const DEPOSIT_L = 0
+const BORROW_L = 3
+const BORROW_X = 4
+const BORROW_Y = 5
+
+const ceilDiv = (numerator, denominator) => (numerator + denominator - 1n) / denominator
 
 async function getPairData(api) {
   const pairs = await api.fetchList({
@@ -22,20 +28,35 @@ async function tvl(api) {
 
 async function borrowed(api) {
   const { pairs, underlyingTokens } = await getPairData(api)
-  // totalAssetsAndShares returns 6 token types: [depositL, depositX, depositY, borrowL, borrowX, borrowY]
-  // borrowX/borrowY (indices 4/5) are the borrowed amounts of the two underlying tokens.
-  const allAssets = await api.multiCall({
-    abi: 'function totalAssetsAndShares(bool withInterest) view returns (uint112[6] allAssets, uint112[6] allShares)',
-    calls: pairs.map(pair => ({ target: pair, params: [true] })),
-  })
+  const [allAssets, reserves] = await Promise.all([
+    api.multiCall({
+      abi: 'function totalAssetsAndShares(bool withInterest) view returns (uint112[6] allAssets, uint112[6] allShares)',
+      calls: pairs.map(pair => ({ target: pair, params: [true] })),
+    }),
+    api.multiCall({
+      abi: 'function getReserves() view returns (uint112 reserveXAssets, uint112 reserveYAssets, uint32 lastTimestamp)',
+      calls: pairs,
+    })
+  ])
   pairs.forEach((_, i) => {
     const [tokenX, tokenY] = underlyingTokens[i]
-    api.add(tokenX, allAssets[i].allAssets[4])
-    api.add(tokenY, allAssets[i].allAssets[5])
+    const assets = allAssets[i].allAssets
+    const reserveXAssets = BigInt(reserves[i].reserveXAssets ?? reserves[i][0])
+    const reserveYAssets = BigInt(reserves[i].reserveYAssets ?? reserves[i][1])
+    const borrowLAssets = BigInt(assets[BORROW_L])
+    const activeLiquidityAssets = BigInt(assets[DEPOSIT_L]) - borrowLAssets
+
+    api.add(tokenX, assets[BORROW_X])
+    api.add(tokenY, assets[BORROW_Y])
+
+    if (borrowLAssets > 0n && activeLiquidityAssets > 0n) {
+      api.add(tokenX, ceilDiv(borrowLAssets * reserveXAssets, activeLiquidityAssets))
+      api.add(tokenY, ceilDiv(borrowLAssets * reserveYAssets, activeLiquidityAssets))
+    }
   })
 }
 
 module.exports = {
-  methodology: 'TVL counts the underlying token balances held by every pair created by the Ammalgam factory. Borrowed counts the assets borrowed out of the pairs.',
+  methodology: 'Ammalgam is a Decentralized Lending Exchange (DLEX), combining lending and trading in one pool primitive. TVL counts the underlying token balances held by every pair created by the Ammalgam factory. Borrowed counts assets borrowed out of the pairs, including direct token borrows and borrowed liquidity converted into its underlying token amounts.',
   ethereum: { tvl, borrowed },
 }

--- a/projects/ammalgam/index.js
+++ b/projects/ammalgam/index.js
@@ -28,18 +28,28 @@ async function tvl(api) {
 
 async function borrowed(api) {
   const { pairs, underlyingTokens } = await getPairData(api)
+
+ // totalAssetsAndShares(true) reverts on pairs with no liquidity so we filter first
+  const baseAssets = await api.multiCall({
+    abi: 'function totalAssetsAndShares(bool withInterest) view returns (uint112[6] allAssets, uint112[6] allShares)',
+    calls: pairs.map(pair => ({ target: pair, params: [false] })),
+  })
+  const nonZeroPairs = pairs
+    .map((pair, i) => ({ pair, tokenX: underlyingTokens[i][0], tokenY: underlyingTokens[i][1] }))
+    .filter((_, i) => BigInt(baseAssets[i].allAssets[DEPOSIT_L]) > 0n)
+
   const [allAssets, reserves] = await Promise.all([
     api.multiCall({
       abi: 'function totalAssetsAndShares(bool withInterest) view returns (uint112[6] allAssets, uint112[6] allShares)',
-      calls: pairs.map(pair => ({ target: pair, params: [true] })),
+      calls: nonZeroPairs.map(({ pair }) => ({ target: pair, params: [true] })),
     }),
     api.multiCall({
       abi: 'function getReserves() view returns (uint112 reserveXAssets, uint112 reserveYAssets, uint32 lastTimestamp)',
-      calls: pairs,
+      calls: nonZeroPairs.map(({ pair }) => pair),
     })
   ])
-  pairs.forEach((_, i) => {
-    const [tokenX, tokenY] = underlyingTokens[i]
+
+  nonZeroPairs.forEach(({ tokenX, tokenY }, i) => {
     const assets = allAssets[i].allAssets
     const reserveXAssets = BigInt(reserves[i].reserveXAssets ?? reserves[i][0])
     const reserveYAssets = BigInt(reserves[i].reserveYAssets ?? reserves[i][1])


### PR DESCRIPTION
## Summary
- Include `BORROW_L` in Ammalgam borrowed TVL by converting borrowed liquidity into tokenX/tokenY amounts with current reserves and active liquidity.
- Keep TVL balance-based and unchanged.
- Add DLEX wording to the Ammalgam methodology. The display-name metadata request from "Ammalgam Lending" to "Ammalgam DLEX" was sent separately to metadata@defillama.com.

## Test Plan
- Mocked borrowed-liquidity regression check against `projects/ammalgam/index.js`
- `PATH=/Users/wfey/.nvm/versions/node/v18.18.2/bin:$PATH node test.js projects/ammalgam/index.js`
- `PATH=/Users/wfey/.nvm/versions/node/v18.18.2/bin:$PATH npx eslint -c eslint.config.js projects/ammalgam/index.js`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded borrow reporting to include direct token borrows and liquidity-based borrowing.
  - Converts borrowed liquidity into underlying token amounts using pool reserve proportions.
  - Filters out zero-liquidity pairs for more accurate reporting.
  - Fetches pool assets and reserves concurrently.

- **Documentation**
  - Updated methodology details to explain the expanded borrow accounting and conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->