### PR TITLE
Add Astro (astro-fun) TVL adapter

### DIFF
--- a/projects/astro-fun/index.js
+++ b/projects/astro-fun/index.js
@@ -1,0 +1,18 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+const { sumTokensExport } = require('../helper/unwrapLPs')
+
+// BankrollVault is the only contract that custodies funds: it is the ERC-4626
+// vault holding the LP bankroll (ASTROLP shares), the players' withdrawable
+// balances, and the stake wagered in the round currently in play. The CrashGame
+// contract never holds tokens - bets are pulled straight into the vault - so a
+// single balance read covers the whole protocol without double counting.
+const BANKROLL_VAULT = '0x58D2f2D46af20C357885d540A9c02fDD791Ee1CF'
+
+module.exports = {
+  methodology:
+    'Counts the USDG held by the Astro BankrollVault on Robinhood Chain: the liquidity provided by LPs to the bankroll (ERC-4626 ASTROLP), the players\' withdrawable balances, and the stakes wagered in the round currently in play.',
+  robinhood: {
+    start: '2026-08-11', // BankrollVault deployment
+    tvl: sumTokensExport({ owner: BANKROLL_VAULT, tokens: [ADDRESSES.robinhood.USDG] }),
+  },
+}


### PR DESCRIPTION
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
Astro

##### Twitter Link:
https://x.com/astrofungame

##### List of audit links if any:
None

##### Website Link:
https://astro.fun

##### Logo (High resolution, will be shown with rounded borders):
![Astro logo](https://astro.fun/icons/icon-512.png)

https://astro.fun/icons/icon-512.png (512×512)

##### Current TVL:
~$80k

##### Treasury Addresses (if the protocol has treasury)
None

##### Chain:
Robinhood Chain (chain id 4663)

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):


##### Short Description (to be shown on DefiLlama):
Astro is a provably fair crash game that settles in USDG. Users can either play or deposit and hold ASTROLP shares to take the House side.

##### Token address and ticker if any:
None (no protocol token)

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Gambling

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
N/A — no oracle used

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
N/A — round results come from a pre-generated, verifiable hash chain, not from a price feed.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
N/A

##### forkedFrom (Does your project originate from another project):
No — original code

##### methodology (what is being counted as tvl, how is tvl being calculated):
Counts the USDG held by the Astro BankrollVault (`0x58D2f2D46af20C357885d540A9c02fDD791Ee1CF`) on Robinhood Chain: the liquidity provided by LPs to the bankroll (ERC-4626 ASTROLP), the players' withdrawable balances, and the stakes wagered in the round currently in play. The CrashGame contract never holds tokens (bets are pulled straight into the vault), so a single balance read covers the whole protocol without double counting.

##### Github org/user (Optional, if your code is open source, we can track activity):


##### Does this project have a referral program?
No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added TVL tracking for the Astro BankrollVault on Robinhood Chain.
  - Reports the vault’s USDG holdings in USD.
  - Includes coverage methodology and tracking from the vault’s deployment date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->