### PR TITLE
r25: add hyb vault

### DIFF
--- a/registries/erc4626.js
+++ b/registries/erc4626.js
@@ -267,6 +267,7 @@ const configs = {
       vRPCSemiYearlyVault: '0xee26bb0989691735c997dfdc49a4a607f75e190b',
       pCreditVault: '0x39976f3Ef143a5824d4E4c28c204d556113dCF7f',
       apcVault: '0xd0428799fbc35557834d33121ba4472692c8908a',
+      hybVault: '0x6Ce4bc043398Ac40392d1E063328048072b2075d',
     }),
     methodology: "TVL represents the total value of assets held within the vault. Each vault token is minted using USDC and appreciates in line with the performance of the underlying asset.",
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `hybVault` address in the Pharos vault configuration for the `r25` protocol.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->