### PR TITLE
GlueHook: include V2 deployment in TVL

### DIFF
--- a/projects/gluehook/index.js
+++ b/projects/gluehook/index.js
@@ -6,30 +6,110 @@ const { ethers } = require('ethers')
 // GlueHook (https://gluehook.trade) — a free, keyless, general-purpose Uniswap V4 hook:
 // per-pool buyback pot (pump on buys, sell absorption), burn cascade, self-compounding LP.
 // Not upgradeable, no owner/admin keys, 0% protocol fee.
-// Deployed via CREATE from a nonce-0 deployer — SAME address on every chain.
+// Deployed via CREATE from a nonce-0 deployer — SAME address on every chain of a given version.
+// V2 is a fresh redeployment (Glue-integrated burns, static-fee-only). V1 pools remain live.
 // Live metrics: https://dune.com/lalilulel0x0869/gluehook-live
-const HOOK = '0xb216070c3509047ea597E2E626A29cea427a60C8'
+const HOOK_V1 = '0xb216070c3509047ea597E2E626A29cea427a60C8'
+const HOOK_V2 = '0x0F41715dc432692b66A5aDF8dCfef6Ac407b20c8'
 
-// hook deployment block + Uniswap V4 PoolManager per chain
+// Uniswap V4 PoolManager + per-version hook deploy blocks
 const config = {
-  ethereum: { fromBlock: 25703029, poolManager: '0x000000000004444c5dc75cB358380D2e3dE08A90' },
-  base: { fromBlock: 49657824, poolManager: '0x498581fF718922c3f8e6A244956aF099B2652b2b' },
-  unichain: { fromBlock: 55356883, poolManager: '0x1F98400000000000000000000000000000000004' },
-  arbitrum: { fromBlock: 492046075, poolManager: '0x360E68faCcca8cA495c1B759Fd9EEe466db9FB32' },
-  optimism: { fromBlock: 155253116, poolManager: '0x9a13F98Cb987694C9F086b1F5eB990EeA8264Ec3' },
-  bsc: { fromBlock: 114546905, poolManager: '0x28e2Ea090877bF75740558f6BFB36A5ffeE9e9dF' },
-  polygon: { fromBlock: 91600016, poolManager: '0x67366782805870060151383F4BbFF9daB53e5cD6' },
-  wc: { fromBlock: 33384712, poolManager: '0xb1860D529182ac3BC1F51Fa2ABd56662b7D13f33' },
-  zora: { fromBlock: 49705618, poolManager: '0x0575338e4C17006aE181B47900A84404247CA30f' },
-  soneium: { fromBlock: 26485168, poolManager: '0x360E68faCcca8cA495c1B759Fd9EEe466db9FB32' },
-  megaeth: { fromBlock: 23308084, poolManager: '0xaCB7e78fa05D562e0A5D3089ec896D57D057d38E' },
-  robinhood: { fromBlock: 30206983, poolManager: '0x8366a39CC670B4001A1121B8F6A443A643e40951' },
-  tempo: { fromBlock: 33657201, poolManager: '0x33620f62C5b9B2086dD6b62F4A297A9f30347029' },
-  avax: { fromBlock: 92242906, poolManager: '0x06380C0e0912312B5150364B9DC4542BA0DbBc85' },
-  blast: { fromBlock: 38647660, poolManager: '0x1631559198A9e474033433b2958daBC135ab6446' },
-  celo: { fromBlock: 74204388, poolManager: '0x288dc841A52FCA2707c6947B3A777c5E56cd87BC' },
-  monad: { fromBlock: 93918120, poolManager: '0x188d586Ddcf52439676Ca21A244753fA19F9Ea8e' },
-  xlayer: { fromBlock: 67336132, poolManager: '0x360E68faCcca8cA495c1B759Fd9EEe466db9FB32' },
+  ethereum: {
+    poolManager: '0x000000000004444c5dc75cB358380D2e3dE08A90',
+    hooks: [
+      { address: HOOK_V1, fromBlock: 25703029 },
+      { address: HOOK_V2, fromBlock: 25814686 },
+    ],
+  },
+  base: {
+    poolManager: '0x498581fF718922c3f8e6A244956aF099B2652b2b',
+    hooks: [
+      { address: HOOK_V1, fromBlock: 49657824 },
+      { address: HOOK_V2, fromBlock: 50330047 },
+    ],
+  },
+  unichain: {
+    poolManager: '0x1F98400000000000000000000000000000000004',
+    hooks: [
+      { address: HOOK_V1, fromBlock: 55356883 },
+      { address: HOOK_V2, fromBlock: 56701906 },
+    ],
+  },
+  arbitrum: {
+    poolManager: '0x360E68faCcca8cA495c1B759Fd9EEe466db9FB32',
+    hooks: [
+      { address: HOOK_V1, fromBlock: 492046075 },
+      { address: HOOK_V2, fromBlock: 497395639 },
+    ],
+  },
+  optimism: {
+    poolManager: '0x9a13F98Cb987694C9F086b1F5eB990EeA8264Ec3',
+    hooks: [
+      { address: HOOK_V1, fromBlock: 155253116 },
+      { address: HOOK_V2, fromBlock: 155925598 },
+    ],
+  },
+  bsc: {
+    poolManager: '0x28e2Ea090877bF75740558f6BFB36A5ffeE9e9dF',
+    hooks: [
+      { address: HOOK_V1, fromBlock: 114546905 },
+      { address: HOOK_V2, fromBlock: 117531972 },
+    ],
+  },
+  polygon: {
+    poolManager: '0x67366782805870060151383F4BbFF9daB53e5cD6',
+    hooks: [
+      { address: HOOK_V1, fromBlock: 91600016 },
+      { address: HOOK_V2, fromBlock: 92496642 },
+    ],
+  },
+  wc: {
+    poolManager: '0xb1860D529182ac3BC1F51Fa2ABd56662b7D13f33',
+    hooks: [
+      { address: HOOK_V1, fromBlock: 33384712 },
+      { address: HOOK_V2, fromBlock: 34057331 },
+    ],
+  },
+  zora: { poolManager: '0x0575338e4C17006aE181B47900A84404247CA30f', hooks: [{ address: HOOK_V1, fromBlock: 49705618 }] },
+  soneium: {
+    poolManager: '0x360E68faCcca8cA495c1B759Fd9EEe466db9FB32',
+    hooks: [
+      { address: HOOK_V1, fromBlock: 26485168 },
+      { address: HOOK_V2, fromBlock: 27157781 },
+    ],
+  },
+  megaeth: {
+    poolManager: '0xaCB7e78fa05D562e0A5D3089ec896D57D057d38E',
+    hooks: [
+      { address: HOOK_V1, fromBlock: 23308084 },
+      { address: HOOK_V2, fromBlock: 24653311 },
+    ],
+  },
+  robinhood: {
+    poolManager: '0x8366a39CC670B4001A1121B8F6A443A643e40951',
+    hooks: [
+      { address: HOOK_V1, fromBlock: 30206983 },
+      { address: HOOK_V2, fromBlock: 43628009 },
+    ],
+  },
+  tempo: { poolManager: '0x33620f62C5b9B2086dD6b62F4A297A9f30347029', hooks: [{ address: HOOK_V1, fromBlock: 33657201 }] },
+  avax: {
+    poolManager: '0x06380C0e0912312B5150364B9DC4542BA0DbBc85',
+    hooks: [
+      { address: HOOK_V1, fromBlock: 92242906 },
+      { address: HOOK_V2, fromBlock: 93461396 },
+    ],
+  },
+  blast: { poolManager: '0x1631559198A9e474033433b2958daBC135ab6446', hooks: [{ address: HOOK_V1, fromBlock: 38647660 }] },
+  celo: { poolManager: '0x288dc841A52FCA2707c6947B3A777c5E56cd87BC', hooks: [{ address: HOOK_V1, fromBlock: 74204388 }] },
+  monad: { poolManager: '0x188d586Ddcf52439676Ca21A244753fA19F9Ea8e', hooks: [{ address: HOOK_V1, fromBlock: 93918120 }] },
+  xlayer: {
+    poolManager: '0x360E68faCcca8cA495c1B759Fd9EEe466db9FB32',
+    hooks: [
+      { address: HOOK_V1, fromBlock: 67336132 },
+      { address: HOOK_V2, fromBlock: 68681331 },
+    ],
+  },
 }
 
 // emitted once when a pool's pot is initialized: carries the pool's token pair
@@ -65,44 +145,54 @@ function positionAmounts(sqrtPriceX96, tickLower, tickUpper, liquidity) {
   return [Math.floor(amount0), Math.floor(amount1)]
 }
 
+async function addHookTvl(api, poolManager, hook) {
+  const logs = await getLogs2({ api, target: hook.address, eventAbi, fromBlock: hook.fromBlock })
+
+  // 1. the hook's own balances: buyback pots, parked donations, pending
+  //    fee splits, permanently-held (unburnable) tokens
+  const tokens = [nullAddress]
+  logs.forEach((log) => tokens.push(log.main, log.secondary))
+
+  // 2. the hook-owned LP: each pool's program position lives inside the
+  //    PoolManager under the hook's own address. Value it from the
+  //    program's liquidity at the pool's live sqrtPrice (both read on-chain).
+  const poolIds = logs.map((log) => log.poolId)
+  if (poolIds.length) {
+    const [programs, slot0s] = await Promise.all([
+      api.multiCall({ abi: programAbi, target: hook.address, calls: poolIds }),
+      api.multiCall({ abi: extsloadAbi, target: poolManager, calls: poolIds.map(slot0Slot) }),
+    ])
+    logs.forEach((log, i) => {
+      const p = programs[i]
+      if (!p || !p.exists) return
+      const sqrtPriceX96 = BigInt(slot0s[i]) & ((1n << 160n) - 1n)
+      if (!sqrtPriceX96) return
+      const [amount0, amount1] = positionAmounts(sqrtPriceX96, Number(p.tickLower), Number(p.tickUpper), p.liquidity)
+      // v4 orders the pair by address, native (0x0) first
+      const [token0, token1] = [log.main, log.secondary].sort((a, b) => (a.toLowerCase() < b.toLowerCase() ? -1 : 1))
+      api.add(token0, amount0)
+      api.add(token1, amount1)
+    })
+  }
+
+  return tokens
+}
+
 Object.keys(config).forEach((chain) => {
-  const { fromBlock, poolManager } = config[chain]
+  const { poolManager, hooks } = config[chain]
   module.exports[chain] = {
     tvl: async (api) => {
-      const logs = await getLogs2({ api, target: HOOK, eventAbi, fromBlock })
-
-      // 1. the hook's own balances: buyback pots, parked donations, pending
-      //    fee splits, permanently-held (unburnable) tokens
-      const tokens = [nullAddress]
-      logs.forEach((log) => tokens.push(log.main, log.secondary))
-
-      // 2. the hook-owned LP: each pool's program position lives inside the
-      //    PoolManager under the hook's own address. Value it from the
-      //    program's liquidity at the pool's live sqrtPrice (both read on-chain).
-      const poolIds = logs.map((log) => log.poolId)
-      const [programs, slot0s] = await Promise.all([
-        api.multiCall({ abi: programAbi, target: HOOK, calls: poolIds }),
-        api.multiCall({ abi: extsloadAbi, target: poolManager, calls: poolIds.map(slot0Slot) }),
-      ])
-      logs.forEach((log, i) => {
-        const p = programs[i]
-        if (!p || !p.exists) return
-        const sqrtPriceX96 = BigInt(slot0s[i]) & ((1n << 160n) - 1n)
-        if (!sqrtPriceX96) return
-        const [amount0, amount1] = positionAmounts(sqrtPriceX96, Number(p.tickLower), Number(p.tickUpper), p.liquidity)
-        // v4 orders the pair by address, native (0x0) first
-        const [token0, token1] = [log.main, log.secondary].sort((a, b) => (a.toLowerCase() < b.toLowerCase() ? -1 : 1))
-        api.add(token0, amount0)
-        api.add(token1, amount1)
-      })
-
-      return sumTokens2({ api, owner: HOOK, tokens })
+      const tokens = []
+      for (const hook of hooks) {
+        tokens.push(...(await addHookTvl(api, poolManager, hook)))
+      }
+      return sumTokens2({ api, owners: hooks.map((h) => h.address), tokens })
     },
   }
 })
 
 module.exports.methodology =
-  'TVL = the liquidity of every hook-owned LP program position inside the Uniswap V4 PoolManager (valued from the program liquidity at the pool\'s live price) + every token held by the GlueHook contract itself (per-pool buyback pots, parked donations, pending fee splits, permanently-held unburnable tokens). Pools are enumerated from PotInitialized events. Live metrics: https://dune.com/lalilulel0x0869/gluehook-live'
+  'TVL = the liquidity of every hook-owned LP program position inside the Uniswap V4 PoolManager (valued from the program liquidity at the pool\'s live price) + every token held by the GlueHook contracts themselves (per-pool buyback pots, parked donations, pending fee splits, permanently-held unburnable tokens). Pools are enumerated from PotInitialized events on both the original (V1) hook and the V2 redeployment. Live metrics: https://dune.com/lalilulel0x0869/gluehook-live'
 // the same tokens are also counted by the uniswap-v4 adapter (PoolManager balances),
 // same as other hook protocols e.g. bunni-v2
 module.exports.doublecounted = true


### PR DESCRIPTION
## Update: count the V2 GlueHook redeployment

GlueHook was redeployed at a new CREATE address. V1 pools are still live, so this adapter now enumerates `PotInitialized` events and sums hook-held tokens + hook-owned LP programs on **both** deployments.

- **Website:** https://gluehook.trade
- **Docs:** https://gluehook.trade/docs
- **Source:** https://github.com/glue-finance/GlueHook
- **V1 (original):** `0xb216070c3509047ea597E2E626A29cea427a60C8` — 18 chains (unchanged)
- **V2 (new):** `0x0F41715dc432692b66A5aDF8dCfef6Ac407b20c8` — 13 chains (Ethereum, Base, Unichain, Arbitrum, Optimism, BNB, Polygon, Avalanche, X Layer, World Chain, Soneium, MegaETH, Robinhood)

Methodology is the same: TVL = hook-owned LP positions inside the V4 PoolManager + every token held by the hook contracts themselves (pots, parked donations, pending fee splits, held unburnable tokens). `doublecounted = true` is unchanged (same overlap with `uniswap-v4`).

### Test output

`node test.js projects/gluehook/index.js` runs clean on all 18 chains. Combined TVL at test time was ~$12.9k (dominated by existing V1 pots on Ethereum, Robinhood and BNB).

**Live metrics:** https://dune.com/lalilulel0x0869/gluehook-live


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for separate GlueHook V1 and V2 deployments across supported chains.
  * TVL now combines token balances from all configured hooks.
  * Added support for including V2 liquidity-provider positions.
  * Improved handling of pools without initialization logs.

* **Documentation**
  * Updated methodology details to describe combined holdings across both deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->