### PR TITLE
add TikTokFun TVL adapter

### DIFF
--- a/registries/uniswapV3.js
+++ b/registries/uniswapV3.js
@@ -1455,6 +1455,13 @@ const uniV3Configs = {
       fromBlock: 2445228,
     },
   },
+  'tiktokfun': {
+    start: '2025-02-28',
+    bsc: {
+      factory: '0xaD18ED8D918E14E5B424d919Fb5c829f4D80A4bd',
+      fromBlock: 47041825,
+    },
+  },
   'tsunami-v3': {
     ink: {
       factory: '0xD8B0826150B7686D1F56d6F10E31E58e1BCF1193',


### PR DESCRIPTION
## TikTokFun TVL adapter

Adds TikTokFun concentrated-liquidity pools on BNB Chain to the shared Uniswap V3 registry.


#### Name (to be shown on DefiLlama):

TikTokFun 

Seems like project rebranded from TikTokFun to bsf.ai .
https://www.tiktokfun.net/ redirect to bsf.ai . But bsf.ai seems unrelated to crypto.
The pools  cotains Approximately $1.89m TVL.
https://www.geckoterminal.com/bsc/tiktokfun/pools



#### Twitter Link:

https://x.com/bsf_ai

Formerly `@TiktokFunNet`; the project branding appears to have migrated to BSF.ai.
https://x.com/bsf_ai/status/1933345710696771948
https://x.com/bsf_ai/status/1969459046102286682


#### List of audit links if any:

Not found.

#### Website Link:

https://www.tiktokfun.net/

The legacy TikTokFun application currently redirects to `app.bsf.ai`, which does not work.

#### Logo (High resolution, will be shown with rounded borders):

https://pbs.twimg.com/profile_images/1969455626112946177/yEEje7H8_400x400.jpg

#### Current TVL:

Approximately $1.89m on BNB Chain at the time of local testing. 

#### Treasury Addresses (if the protocol has treasury):

N/A

#### Chain:

BNB Chain

#### Coingecko ID:

tiktokfun

#### Coinmarketcap ID:

N/A

#### Short Description (to be shown on DefiLlama):

TikTokFun is a concentrated-liquidity decentralized exchange on BNB Chain.

#### Token address and ticker if any:

N/A

#### Category:

Dexs

#### Oracle Provider(s):

N/A

#### Implementation Details:
 N/A 

Factory:

`0xaD18ED8D918E14E5B424d919Fb5c829f4D80A4bd`

Factory creation block:

`47041825`

#### Documentation/Proof:

* Factory: https://bscscan.com/address/0xaD18ED8D918E14E5B424d919Fb5c829f4D80A4bd
* Factory creation transaction: https://bscscan.com/tx/0xd9e3531454ec639534e4ca7041ca478f2bf017adcee2db49f154208e40b45542
* First pool creation transaction: https://bscscan.com/tx/0xdd5ee5f3b07fa23958a16200a381028fca3992ca6a7cefc9c823a0e677e8a364
* GeckoTerminal pools: https://api.geckoterminal.com/api/v2/networks/bsc/dexes/tiktokfun/pools?page=1
* CoinGecko exchange listing: https://www.coingecko.com/en/exchanges/tiktokfun
* Project website: https://www.tiktokfun.net/

#### forkedFrom:

PancakeSwap V3 / Uniswap V3-style factory, inferred from the standard on-chain factory interface.

#### methodology:

Standard Uniswap V3 registry.

#### Github org/user:

N/A 
#### Does this project have a referral program?

N/A

#### Testing

The adapter was tested successfully with:

BSC_RPC="authenticated BSC archive RPC"  LLAMA_DEBUG_MODE=true node test.js tiktokfun

--- bsc ---
raca                      944.04 k
USD1                      521.40 k
WBNB                      424.39 k
USDT                      375.50
Total: 1.89 M

--- tvl ---
raca                      944.04 k
USD1                      521.40 k
WBNB                      424.39 k
USDT                      375.00
Total: 1.89 M

------ TVL ------
bsc                       1.89 M

total                    1.89 M



The test completed successfully and returned the TikTokFun TVL on BNB Chain.

The default public BSC RPC endpoints initially failed, returning limit exceeded, header not found, and HTTP 429 errors.  Changing the RPC provider was the solution.

## Changed files

```text
registries/uniswapV3.js
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking the TikTokFun protocol on BSC, including its launch timing and deployment details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->