### PR TITLE
add Kipseli TVL adapter

### DIFF
--- a/projects/kipseli/index.js
+++ b/projects/kipseli/index.js
@@ -1,0 +1,27 @@
+const LENSES = {
+  bsc: '0x6e56480f8d8e17a1c7148f43bc3762e59c3abe90',
+  base: '0x62aff80b3d2afe0e497f1ef735a6fdc9c3ef1acf',
+  robinhood: '0xaba7c80918d8127c23be2bef649832050a0cf08a',
+}
+
+const abi = {
+  listedTokens: 'function getListedTokens() view returns (address[])',
+  quoteToken: 'function getQuoteToken() view returns (address)',
+  reserveBalances: 'function getReserveBalances(address[] tokens) view returns (uint256[])',
+}
+
+module.exports.methodology =
+  'TVL is the value of all listed assets and quote tokens in Kipseli reserves, as returned by the on-chain QuoteLens contracts.'
+
+async function tvl(api) {
+  const target = LENSES[api.chain]
+  const listedTokens = await api.call({ target, abi: abi.listedTokens })
+  const quoteToken = await api.call({ target, abi: abi.quoteToken })
+  const tokens = [...new Set([...listedTokens, quoteToken].map((token) => token.toLowerCase()))]
+  const balances = await api.call({ target, abi: abi.reserveBalances, params: [tokens] })
+  api.add(tokens, balances)
+}
+
+Object.keys(LENSES).forEach((chain) => {
+  module.exports[chain] = { tvl }
+})

--- a/projects/kipseli/index.js
+++ b/projects/kipseli/index.js
@@ -1,27 +1,35 @@
-const LENSES = {
-  bsc: '0x6e56480f8d8e17a1c7148f43bc3762e59c3abe90',
-  base: '0x62aff80b3d2afe0e497f1ef735a6fdc9c3ef1acf',
-  robinhood: '0xaba7c80918d8127c23be2bef649832050a0cf08a',
+const CONFIG = {
+  bsc: {
+    lens: '0x6e56480f8d8e17a1c7148f43bc3762e59c3abe90',
+    reserve: '0xbee1aa51dce11faa5bfc6c56dbfa5b95d4dfc000',
+  },
+  base: {
+    lens: '0x62aff80b3d2afe0e497f1ef735a6fdc9c3ef1acf',
+    reserve: '0xbee3211ab312a8d065c4fef0247448e17a8da000',
+  },
+  robinhood: {
+    lens: '0xaba7c80918d8127c23be2bef649832050a0cf08a',
+    reserve: '0xca9bf993eb00f641f1d4ebf6f334f1ff04074ef6',
+  },
 }
 
 const abi = {
   listedTokens: 'function getListedTokens() view returns (address[])',
   quoteToken: 'function getQuoteToken() view returns (address)',
-  reserveBalances: 'function getReserveBalances(address[] tokens) view returns (uint256[])',
 }
 
 module.exports.methodology =
-  'TVL is the value of all listed assets and quote tokens in Kipseli reserves, as returned by the on-chain QuoteLens contracts.'
+  'TVL is the value of all listed assets and quote tokens held in Kipseli reserve wallets.'
 
 async function tvl(api) {
-  const target = LENSES[api.chain]
-  const listedTokens = await api.call({ target, abi: abi.listedTokens })
-  const quoteToken = await api.call({ target, abi: abi.quoteToken })
+  const { lens, reserve } = CONFIG[api.chain]
+  const listedTokens = await api.call({ target: lens, abi: abi.listedTokens })
+  const quoteToken = await api.call({ target: lens, abi: abi.quoteToken })
   const tokens = [...new Set([...listedTokens, quoteToken].map((token) => token.toLowerCase()))]
-  const balances = await api.call({ target, abi: abi.reserveBalances, params: [tokens] })
-  api.add(tokens, balances)
+
+  return api.sumTokens({ tokens, owner: reserve })
 }
 
-Object.keys(LENSES).forEach((chain) => {
+Object.keys(CONFIG).forEach((chain) => {
   module.exports[chain] = { tvl }
 })


### PR DESCRIPTION
## Summary

Adds an on-chain TVL adapter for Kipseli PropAMM on Base, BNB Chain, and Robinhood Chain.

Kipseli is already listed on DefiLlama through its Ethereum dimension/volume adapter. This PR adds TVL tracking for the active reserve deployments documented by Kipseli.

The adapter reads the official on-chain `QuoteLens` contracts:

* `getListedTokens()` discovers the currently supported reserve assets.
* `getQuoteToken()` discovers the chain's quote token.
* `getReserveBalances(tokens)` returns the corresponding on-chain reserve balances.

Official documentation: https://docs.kipseli.capital/

## Why these contracts are used

Kipseli's documentation describes `QuoteLens` as the read-only view contract for listed tokens and reserves and publishes the interface used by this adapter:

```solidity
interface IQuoteLens {
    function getListedTokens() external view returns (address[] memory);
    function getQuoteToken() external view returns (address);
    function getReserveBalances(address[] memory tokens) external view returns (uint[] memory);
}
```
https://docs.kipseli.capital/

## Testing

```bash
 node test.js projects/kipseli/index.js 
```
The tests report TVL on Base, BNB Chain, and Robinhood Chain.
---

## Listing information

##### Name (to be shown on DefiLlama):

Kipseli

##### Twitter Link:

Not found

##### List of audit links if any:

No public audit link was identified.

##### Website Link:

https://kipseli.capital/

##### Logo (High resolution, will be shown with rounded borders):

https://kipseli.capital/lovable-uploads/4019076a-0015-4620-bd98-ab280e1a1538.png

https://icons.llamao.fi/icons/protocols/kipseli

##### Current TVL:

Approximately $1.01m at the time of on-chain verification. 

Approximate verification breakdown:

* Base: $576.9k
* BNB Chain: $218.7k
* Robinhood Chain: $217.3k

##### Treasury Addresses (if the protocol has treasury):

N/A

##### Chain:

Base, BNB Chain, Robinhood Chain

##### Coingecko ID:
 N/A

##### Coinmarketcap ID:

 N/A

##### Short Description (to be shown on DefiLlama):

Kipseli is a proprietary on-chain market maker.

##### Token address and ticker if any:

N/A

##### Category:

Dexs

##### Oracle Provider(s):
N/A

##### Implementation Details:

N/A

##### Documentation/Proof:

* Official integration documentation and contract addresses: https://docs.kipseli.capital/
* Official website: https://kipseli.capital/
* Existing DefiLlama listing: https://defillama.com/protocol/kipseli
* Existing DefiLlama dimension adapter: https://github.com/DefiLlama/dimension-adapters/blob/master/dexs/kipseli/index.ts

##### forkedFrom:

N/A

##### methodology:

TVL is the value of all listed assets and quote tokens available in Kipseli's market-making reserves on Base, BNB Chain, and Robinhood Chain. Token lists and balances are read from the official on-chain `QuoteLens` contracts. 
The quote token is combined with the listed reserve tokens, and token addresses are normalized and deduplicated before reserve balances are queried and added to TVL.

##### Github org/user:
 N/A

##### Does this project have a referral program?

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Kipseli TVL tracking for BSC, Base, and Robinhood.
  * Reports listed asset and quote-token balances held in configured reserve wallets.
  * Uses on-chain reserve wallet balances to calculate total value locked.
  * Expanded methodology details to explain the valuation basis and reserve-wallet holdings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->