### PR TITLE
Marinus: include lend-strategy balances in Harmony TVL

### DIFF
--- a/projects/marinus/index.js
+++ b/projects/marinus/index.js
@@ -8,8 +8,18 @@ const MARKETS = [
 ]
 const STAKING_POOLS = ['0x24770D9780043b5C4fc54F22F72400542c201dCB', '0x2BaE69378cE5a5e94F1AB4BF45AB4c55C847765F']
 
+function isNonZero(addr) {
+  return typeof addr === 'string' && addr.toLowerCase() !== ADDRESSES.null.toLowerCase()
+}
+
 async function tvl(api) {
-  const tokensAndOwners = [...MARKETS, ...STAKING_POOLS.flatMap(p => [[WONE, p], [ADDRESSES.null, p]])]
+  const pools = MARKETS.map(([, pool]) => pool)
+  const strategies = await api.multiCall({ abi: 'address:strategy', calls: pools })
+  const tokensAndOwners = [
+    ...MARKETS,
+    ...MARKETS.map(([token], i) => [token, strategies[i]]).filter(([, owner]) => isNonZero(owner)),
+    ...STAKING_POOLS.flatMap(p => [[WONE, p], [ADDRESSES.null, p]]),
+  ]
   await api.sumTokens({ tokensAndOwners })
   const delegated = await api.multiCall({ abi: 'uint256:totalDelegated', calls: STAKING_POOLS })
   delegated.forEach(d => api.add(ADDRESSES.null, d))
@@ -22,6 +32,6 @@ async function borrowed(api) {
 }
 
 module.exports = {
-  methodology: 'TVL is tracked as the underlying liquidity supplied to Marinus mToken markets (mWONE/mUSDC/mUSDT) on Harmony, ONE in the Validator and Stablecoin-Reward pools (delegated + WONE + native ONE). Borrowed (totalBorrows) is reported separately.',
+  methodology: 'TVL is tracked as the underlying liquidity supplied to Marinus mToken markets (mWONE/mUSDC/mUSDT) on Harmony — pool cash plus each pool\'s lend strategy — and ONE in the Validator and Stablecoin-Reward pools (delegated + WONE + native ONE). Borrowed (totalBorrows) is reported separately.',
   harmony: { tvl, borrowed },
 }


### PR DESCRIPTION
## Summary

Count each Marinus MPool’s `LendHarmonyStrategy` in Harmony TVL. Live `sumTokens` on the pool address alone misses idle cash that `rebalance()` has already transferred to `strategy()`.

**Name:** Marinus  
**Category:** Lending  
**Chain:** Harmony  
**URL:** https://www.marinusprotocol.com/harmony

**Description:** Marinus Finance on Harmony ONE — non-custodial lending (mWONE, mUSDC, mUSDT), validator staking (smONE), and stablecoin reward staking (srONE).

## Why

Each MPool keeps roughly half of unborrowed cash in `LendHarmonyStrategy` (`cToken` is unset; funds sit as underlying on the strategy). DefiLlama currently credits only the MPool token balance, so lending TVL is about **50% low** on those markets.

Staking (VSP + SRP: `totalDelegated` + WONE + native ONE) is already correct. Addresses are unchanged from [PR #20453](https://github.com/DefiLlama/DefiLlama-Adapters/pull/20453).

## Canonical addresses (Harmony, 2026-08-23)

| Market / pool | Contract | Strategy |
|---|---|---|
| mWONE | `0x1B880e387Ef12fc9540Be4a0c6AA7eAA356e1a9D` | `0xab97C48Bf5409477a54803Ca30CaCAbF28A77750` |
| mUSDC | `0xCB6a04a828E54d73eA20bBe061Eb8F72aEd9b0AE` | `0x812FA5a1Cf38aDc3C112Be58866E965E7D4a3F50` |
| mUSDT | `0x461cD43DA018A68dcc0b242448018ef9c9f3e890` | `0x9657c3f94cFDC28A293eae468F286E1fb37af997` |
| smONE (VSP) | `0x24770D9780043b5C4fc54F22F72400542c201dCB` | n/a (validator delegation) |
| srONE (SRP) | `0x2BaE69378cE5a5e94F1AB4BF45AB4c55C847765F` | n/a (validator delegation) |

The adapter reads `strategy()` on-chain so a future `setStrategy` does not require another address PR.

## Change

`tvl` now `multiCall`s `address:strategy` on each MPool and includes those owners in `sumTokens`, then still adds staking `totalDelegated`.

**Methodology:** TVL is tracked as the underlying liquidity supplied to Marinus mToken markets (mWONE/mUSDC/mUSDT) on Harmony — pool cash plus each pool's lend strategy — and ONE in the Validator and Stablecoin-Reward pools (delegated + WONE + native ONE). Borrowed (`totalBorrows`) is reported separately.

## Test

`node test.js projects/marinus` (2026-08-23):

```
--- harmony ---
ONE                       355.63
WONE                      43.34
USDC                      3.98
USDT                      3.93
Total: 406.88

--- harmony-borrowed ---
Total: 0.00
```

USDC/USDT now match on-chain `totalLiquidity` (~$3.98 / $3.93). Previously DefiLlama showed ~$1.96 / $1.94 (pool cash only).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - TVL calculations now include liquidity held by eligible lending strategies alongside pool cash.
  - Zero-address strategies are excluded from the calculation.
  - Methodology documentation now explains the updated TVL calculation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->