### PR TITLE
add ElfomoFi TVL adapter

### DIFF
--- a/projects/elfomofi/index.js
+++ b/projects/elfomofi/index.js
@@ -1,0 +1,55 @@
+const { getLogs2 } = require('../helper/cache/getLogs')
+
+const MANAGERS = [
+  {
+    target: '0x64f8be47a011df0fab47319d5de258d18e93f4ef',
+    fromBlock: 44952928,
+  },
+  {
+    target: '0xe34cd3682af9c04303386499fba215b38eff6106',
+    fromBlock: 45354975,
+  },
+]
+
+const VAULT_CREATED =
+  'event VaultCreated(uint256 indexed vaultId, address indexed vaultAddress, address indexed lpTokenAddress, uint8 curatorId)'
+
+async function tvl(api) {
+  const block = await api.getBlock()
+
+  const logs = await Promise.all(
+    MANAGERS.filter(({ fromBlock }) => fromBlock <= block).map(
+      ({ target, fromBlock }) =>
+        getLogs2({
+          api,
+          target,
+          fromBlock,
+          eventAbi: VAULT_CREATED,
+          transform: ({ vaultAddress }) => vaultAddress.toLowerCase(),
+        }),
+    ),
+  )
+
+  const vaults = [...new Set(logs.flat())]
+
+  if (!vaults.length) return
+
+  const [tokens, balances] = await Promise.all([
+    api.multiCall({
+      calls: vaults,
+      abi: 'address:refToken',
+    }),
+    api.multiCall({
+      calls: vaults,
+      abi: 'uint256:currentTotalAssetsInRef',
+    }),
+  ])
+
+  api.add(tokens, balances)
+}
+
+module.exports = {
+  methodology:
+    "TVL is the sum of the latest settled total asset value of all vaults registered by ElfomoFi's Base VaultsManager contracts, read on-chain in each vault's reference token.",
+  base: { tvl },
+}

--- a/projects/elfomofi/index.js
+++ b/projects/elfomofi/index.js
@@ -51,5 +51,6 @@ async function tvl(api) {
 module.exports = {
   methodology:
     "TVL is the sum of the latest settled total asset value of all vaults registered by ElfomoFi's Base VaultsManager contracts, read on-chain in each vault's reference token.",
+  doublecounted: true,
   base: { tvl },
 }


### PR DESCRIPTION
## Summary

Adds an on-chain TVL adapter for ElfomoFi vaults on Base.

ElfomoFi is already listed on DefiLlama through its volume, fees, and revenue dimension adapter. This PR adds TVL tracking for its public vault infrastructure.

The adapter uses DefiLlama's `getLogs2` helper to discover vaults from the `VaultCreated` events emitted by the known `VaultsManager` contracts. It then reads the following values directly from every discovered vault:

- `refToken()` identifies the token in which the vault is accounted.
- `currentTotalAssetsInRef()` returns the latest settled total asset value in that reference token.

Duplicate vault addresses are removed before their balances are added. Future vaults registered by either known manager will therefore be discovered automatically.


## Contract and deployment verification

### VaultsManager contracts

| Deployment | VaultsManager | From block | Source |
| --- | --- | ---: | --- |
| Initial Base deployment | [`0x64f8bE47A011DF0fAB47319d5De258D18E93f4ef`](https://basescan.org/address/0x64f8bE47A011DF0fAB47319d5De258D18E93f4ef) | `44952928` | [Official ElfomoFi vault documentation](https://docs.elfomo.fi/vaults/) |
| Current Base deployment | [`0xE34CD3682AF9C04303386499FBa215B38Eff6106`](https://basescan.org/address/0xE34CD3682AF9C04303386499FBa215B38Eff6106) | `45354975` | [Existing DefiLlama ElfomoFi dimension adapter](https://github.com/DefiLlama/dimension-adapters/blob/master/dexs/elfomofi/index.ts) and [merged PR #7091](https://github.com/DefiLlama/dimension-adapters/pull/7091) |

The current ElfomoFi documentation still displays the initial deployment. The newer manager is already used by DefiLlama's accepted ElfomoFi fees and revenue adapter.

### VaultCreated verification

| Manager | Discovered vault | Registration transaction |
| --- | --- | --- |
| Initial manager | [`0xB140d7671db11FBd7d9F474c01700715b6DD98f4`](https://basescan.org/address/0xB140d7671db11FBd7d9F474c01700715b6DD98f4) | [`0x04d997f6...a69f`](https://basescan.org/tx/0x04d997f697626995afa698087dd2d642611e0c99a95c2f127bc224c44920a69f) |
| Current manager | [`0x8d385B9393591476016D74009bF36a3960a4fD51`](https://basescan.org/address/0x8d385B9393591476016D74009bF36a3960a4fD51) | [`0x6a9e65a6...3c67`](https://basescan.org/tx/0x6a9e65a64a7fe63096c2b29cb61c1d670baa5fe25663df9f86a1414f99b73c67) |

The official source code defines and emits:

```solidity
event VaultCreated(
    uint256 indexed vaultId,
    address indexed vaultAddress,
    address indexed lpTokenAddress,
    uint8 curatorId
);
```

Relevant sources:

- [`VaultsManagerBase.sol`](https://github.com/ElfomoFi/elfomofi-vaults/blob/main/src/vaults/manager/VaultsManagerBase.sol)
- [`VaultsManagerAdmin.sol`](https://github.com/ElfomoFi/elfomofi-vaults/blob/main/src/vaults/manager/VaultsManagerAdmin.sol)
- [`EpochBasedVault.sol`](https://github.com/ElfomoFi/elfomofi-vaults/blob/main/src/vaults/EpochBasedVault.sol)

ElfomoFi currently deploys each `VaultsManager` directly and does not publish an on-chain manager factory or registry. New vaults created by the configured managers are discovered automatically. A future manager deployment would require adding its manager address and deployment block.

## TVL verification

At the time of on-chain verification on August 23, 2026:

| Vault | Reference token | Settled assets |
| --- | --- | ---: |
| `0xB140...98f4` | Base USDC | `405,250.62 USDC` |
| `0x8d38...fD51` | Base USDC | `654,284.33 USDC` |
| **Total** | **Base USDC** | **1,059,534.95 USDC** |

The common reference token is Base USDC:

[`0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`](https://basescan.org/token/0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913)



## Testing

The following commands were run successfully:

```bash

node test.js projects/elfomofi/index.js 2026-04-19
node test.js projects/elfomofi/index.js 2026-04-25
node test.js projects/elfomofi/index.js
```

---

## Listing information

##### Name (to be shown on DefiLlama):

ElfomoFi

##### Twitter Link:

https://x.com/elfomo_fi

##### List of audit links if any:

- Hexens — ElfomoFi Vault Accounting Layer Security Review, April 2026:
  https://hexens.io/audit-reports/elfomofi-vault-accounting-layer-apr-2026

##### Website Link:

https://elfomo.fi/

##### Logo (High resolution, will be shown with rounded borders):

ElfomoFi already has a logo in its existing DefiLlama listing:

https://icons.llamao.fi/icons/protocols/elfomofi?w=400&h=400

##### Current TVL:

Approximately `$1.06 million` at the time of on-chain verification on August 23, 2026.

Verification breakdown:

- Initial Base vault: `405,250.62 USDC`
- Current Base vault: `654,284.33 USDC`
- Total: `1,059,534.95 USDC`

##### Treasury Addresses (if the protocol has treasury)
N/A
##### Chain:

Base

##### Coingecko ID:

N/A

##### Coinmarketcap ID:

N/A

##### Short Description (to be shown on DefiLlama):

ElfomoFi is a hybrid Prop-AMM on EVM that combines actively managed market-making strategies with public vaults offering exposure to market-making returns.

##### Token address and ticker if any:
N/A

##### Category:

Dexs

##### Oracle Provider(s):


##### Implementation Details:

##### Documentation/Proof:

- Existing DefiLlama listing: https://defillama.com/protocol/elfomofi
- Official website: https://elfomo.fi/
- Official documentation: https://docs.elfomo.fi/
- Official vault documentation and initial contract addresses: https://docs.elfomo.fi/vaults/
- Official vault source code: https://github.com/ElfomoFi/elfomofi-vaults
- Existing DefiLlama dimension adapter: https://github.com/DefiLlama/dimension-adapters/blob/master/dexs/elfomofi/index.ts
- Merged dimension adapter PR introducing the current manager: https://github.com/DefiLlama/dimension-adapters/pull/7091
- Hexens vault accounting audit: https://hexens.io/audit-reports/elfomofi-vault-accounting-layer-apr-2026

##### forkedFrom:
N/A

##### methodology:

TVL is the sum of the latest settled total asset value of every vault registered by ElfomoFi's known Base `VaultsManager` contracts. Vaults are discovered from on-chain `VaultCreated` events. For each vault, the adapter reads `refToken()` and `currentTotalAssetsInRef()` and adds the returned amount under its reference token. Duplicate vault addresses are removed before balances are added.

##### Github org/user:

https://github.com/ElfomoFi

##### Does this project have a referral program?

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added TVL tracking for ElfomoFi vaults on Base.
  - Automatically discovers deployed vaults and includes their current assets in TVL calculations.
  - Added methodology metadata describing the TVL calculation.
  - Improved handling of multiple vaults and empty results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->