### PR TITLE
Add Ammalgam DEX TVL adapter

### DIFF
--- a/projects/ammalgam-dex/index.js
+++ b/projects/ammalgam-dex/index.js
@@ -1,0 +1,45 @@
+const FACTORY = '0x1a411b0fd1f368d2f413a8cbb6aad425c923015b'
+
+const abi = {
+  allPairsLength: 'uint256:allPairsLength',
+  allPairs: 'function allPairs(uint256) view returns (address)',
+  underlyingTokens: 'function underlyingTokens() view returns (address tokenX, address tokenY)',
+  getReserves:
+    'function getReserves() view returns (uint112 reserveXAssets, uint112 reserveYAssets, uint32 lastTimestamp)',
+}
+
+const getTokenX = tokens => tokens.tokenX ?? tokens[0]
+const getTokenY = tokens => tokens.tokenY ?? tokens[1]
+const getReserveX = reserves => reserves.reserveXAssets ?? reserves[0]
+const getReserveY = reserves => reserves.reserveYAssets ?? reserves[1]
+
+async function getPairData(api) {
+  const pairs = await api.fetchList({
+    target: FACTORY,
+    lengthAbi: abi.allPairsLength,
+    itemAbi: abi.allPairs,
+  })
+
+  const [underlyingTokens, reserves] = await Promise.all([
+    api.multiCall({ abi: abi.underlyingTokens, calls: pairs }),
+    api.multiCall({ abi: abi.getReserves, calls: pairs }),
+  ])
+
+  return { pairs, underlyingTokens, reserves }
+}
+
+async function tvl(api) {
+  const { underlyingTokens, reserves } = await getPairData(api)
+
+  reserves.forEach((reserve, index) => {
+    api.add(getTokenX(underlyingTokens[index]), getReserveX(reserve))
+    api.add(getTokenY(underlyingTokens[index]), getReserveY(reserve))
+  })
+}
+
+module.exports = {
+  methodology:
+    'Ammalgam DEX TVL counts only swap reserves: tokenX and tokenY reserve assets returned by getReserves() for every pair created by the Ethereum factory. Broader DLEX supplied and borrowed liquidity is tracked separately under Ammalgam DLEX.',
+  start: '2026-07-03',
+  ethereum: { tvl },
+}


### PR DESCRIPTION
## Summary
- Add a TVL adapter for the existing Ammalgam DEX dimensions slug.
- Enumerate Ammalgam pairs from the Ethereum factory.
- Count only tokenX/tokenY swap reserves returned by `getReserves()`, keeping broader DLEX supplied and borrowed liquidity separate.

## Methodology
Ammalgam DEX TVL counts only swap reserves: tokenX and tokenY reserve assets returned by `getReserves()` for every pair created by the Ethereum factory. Broader DLEX supplied and borrowed liquidity is tracked separately under Ammalgam DLEX.

## Test Plan
- Mocked reserve harness for `ethereum.tvl(api)`
- `eslint -c eslint.config.js projects/ammalgam-dex/index.js`
- `git diff --cached --check`
- `node test.js projects/ammalgam-dex/index.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Ethereum TVL tracking for the Ammalgam DEX.
  - Includes liquidity from both underlying assets in each trading pair.
  - Added project methodology and tracking start date metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->