### PR TITLE
add Deepstate TVL adapter

### DIFF
--- a/projects/deepstate/index.js
+++ b/projects/deepstate/index.js
@@ -1,0 +1,20 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+const { sumTokensExport } = require('../helper/unwrapLPs')
+
+const ROUTER = '0x6cf19308C22FC82ea620Fa0B3E94948d20f27B96'
+
+// Assets in the markets listed by the official Deepstate interface.
+const TOKENS = [
+  ADDRESSES.robinhood.USDG,
+  '0xd0601CE157Db5bdC3162BbaC2a2C8aF5320D9EEC', // NVDA
+  '0x1DA24f6Bb623b9d1aFEae3F3146659A2662D6d27', // DEEP
+]
+
+module.exports = {
+  methodology:
+    'TVL is the value of USDG, NVDA, and DEEP held by the Deepstate router as collateral for resting orders or as matched proceeds awaiting maker claims.',
+  start: '2026-08-14',
+  robinhood: {
+    tvl: sumTokensExport({ owner: ROUTER, tokens: TOKENS }),
+  },
+}


### PR DESCRIPTION
## Summary

Adds an on-chain TVL adapter for Deepstate on Robinhood Chain.

Deepstate is already listed on DefiLlama with fees, revenue, and DEX volume:

* https://defillama.com/protocol/deepstate
* https://github.com/DefiLlama/dimension-adapters/blob/master/dexs/deepstate/index.ts

This PR adds TVL calculation.

## TVL methodology

TVL is calculated from the balances of USDG, NVDA, and DEEP held by the DeepstateV1 router.

The router holds these assets as:

* collateral backing resting limit orders; and
* matched proceeds that remain in the router until makers claim them.


The adapter uses an explicit token allowlist because Deepstate pool creation is permissionless and the current `BookInitialized` event exposes hashed pool and book identifiers without exposing the underlying token addresses.


## Contract and token sources

| Item                          | Address                                      | Source                                                                                                                                                                                                                  |
| ----------------------------- | -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| DeepstateV1 router            | `0x6cf19308C22FC82ea620Fa0B3E94948d20f27B96` | [[Official Deepstate deployments](https://docs-production-cdea.up.railway.app/contracts/deployments/)](https://docs-production-cdea.up.railway.app/contracts/deployments/)                                                                                                                    |
| USDG                          | `0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168` | [[Official Deepstate deployments](https://docs-production-cdea.up.railway.app/contracts/deployments/)](https://docs-production-cdea.up.railway.app/contracts/deployments/) and [`[coreAssets.json](https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/helper/coreAssets.json)`](https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/helper/coreAssets.json) |
| NVDA                          | `0xd0601CE157Db5bdC3162BbaC2a2C8aF5320D9EEC` | [[Official Deepstate deployments](https://docs-production-cdea.up.railway.app/contracts/deployments/)](https://docs-production-cdea.up.railway.app/contracts/deployments/)                                                                                                                    |
| DEEP                          | `0x1DA24f6Bb623b9d1aFEae3F3146659A2662D6d27` | [[Official Deepstate deployments](https://docs-production-cdea.up.railway.app/contracts/deployments/)](https://docs-production-cdea.up.railway.app/contracts/deployments/)                                                                                                                    |
                                                                                          

Additional protocol sources:

* [[Official contract overview](https://docs-production-cdea.up.railway.app/contracts/overview)](https://docs-production-cdea.up.railway.app/contracts/overview)
* [[DeepstateV1 source code](https://github.com/Deepstate-Protocol/deepstate-contracts/blob/master/src/DeepstateV1.sol)](https://github.com/Deepstate-Protocol/deepstate-contracts/blob/master/src/DeepstateV1.sol)
* [[Existing Deepstate dimensions adapter](https://github.com/DefiLlama/dimension-adapters/blob/master/dexs/deepstate/index.ts)](https://github.com/DefiLlama/dimension-adapters/blob/master/dexs/deepstate/index.ts)
* [[Official Deepstate website](https://deepstate.sh/)](https://deepstate.sh/)
* [[Official Deepstate documentation](https://deepstate.sh/docs)](https://deepstate.sh/docs)

The existing dimensions adapter uses the same production router.

## Validation

Command:

```bash
node test.js projects/deepstate/index.js
```

Result at testing time:

```text
--- robinhood ---
USDG                      325.18 k
NVDA                      233.69 k
DEEP                       21.11 k
Total:                    579.99 k

------ TVL ------
robinhood                 579.99 k
total                     579.99 k
```
---

## Listing information

Deepstate already has an existing DefiLlama protocol page. 

##### Name (to be shown on DefiLlama):

Deepstate



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for Robinhood, covering USDG, NVDA, and DEEP assets.
  * Included methodology details and tracking availability beginning August 14, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->