### PR TITLE
add BisonFi TVL adapter

### DIFF
--- a/projects/bisonfi/index.js
+++ b/projects/bisonfi/index.js
@@ -1,0 +1,40 @@
+const { PublicKey } = require('@solana/web3.js')
+const { getConnection, sumTokens2 } = require('../helper/solana')
+
+const PROGRAM_ID = new PublicKey(
+  'BiSoNHVpsVZW2F7rx2eQ59yQwKxzU5NvBcmKshCSUypi'
+)
+
+// Base58 encoding of the 8-byte ASCII discriminator `POOLSTAT`.
+const POOL_STATE_DISCRIMINATOR = 'ES78ZeanFtP'
+
+// The two vault public keys are stored consecutively in each pool state:
+// token vault 0 at bytes 120-151 and token vault 1 at bytes 152-183.
+const VAULTS_OFFSET = 120
+const VAULTS_LENGTH = 64
+
+async function tvl(api) {
+  const poolStates = await getConnection().getProgramAccounts(PROGRAM_ID, {
+    filters: [
+      { memcmp: { offset: 0, bytes: POOL_STATE_DISCRIMINATOR } },
+    ],
+    dataSlice: {
+      offset: VAULTS_OFFSET,
+      length: VAULTS_LENGTH,
+    },
+  })
+
+  const tokenAccounts = poolStates.flatMap(({ account }) => [
+    new PublicKey(account.data.subarray(0, 32)).toBase58(),
+    new PublicKey(account.data.subarray(32, 64)).toBase58(),
+  ])
+
+  return sumTokens2({ api, tokenAccounts })
+}
+
+module.exports = {
+  methodology:
+    'TVL is the value of the two SPL Token or Token-2022 vaults recorded in every BisonFi pool-state account. Pool states are discovered on-chain from the BisonFi program using their POOLSTAT discriminator, so newly created pools are included automatically.',
+  timetravel: false,
+  solana: { tvl },
+}


### PR DESCRIPTION
# Summary

Adds an on-chain TVL adapter for **BisonFi** on **Solana**.

BisonFi is already listed on DefiLlama with a DEX volume adapter. This PR adds the TVL calculation.

The adapter discovers every BisonFi pool-state account directly from the deployed Solana program, extracts the two token vaults recorded in each pool state, and sums their on-chain balances using DefiLlama's existing Solana helper.

## Methodology

TVL is the USD value of the two SPL Token or Token-2022 vaults recorded in every BisonFi pool-state account.

Pool states are discovered on-chain by querying accounts:

- owned by the BisonFi program;
- whose first eight bytes match the ASCII discriminator `POOLSTAT`.

The two vault public keys are then extracted from each pool state:

| Pool-state bytes | Value |
| --- | --- |
| `120–151` | First token vault |
| `152–183` | Second token vault |

The extracted vault addresses are passed to DefiLlama's `sumTokens2` helper, which reads and sums their current token balances.

New pools using the same `POOLSTAT` account layout are included automatically without maintaining a hard-coded list of pools, vaults, or token mints.

## Implementation

- **Chain:** Solana
- **Adapter path:** `projects/bisonfi/index.js`
- **BisonFi program:** `BiSoNHVpsVZW2F7rx2eQ59yQwKxzU5NvBcmKshCSUypi`
- **Pool-state discriminator:**
  - ASCII: `POOLSTAT`
  - Hex: `50 4f 4f 4c 53 54 41 54`
  - Base58: `ES78ZeanFtP`
  - Offset: `0`
- **Vault data slice:**
  - Offset: `120`
  - Length: `64`
  - First vault: slice bytes `0–31`
  - Second vault: slice bytes `32–63`
- **Balance helper:** `sumTokens2`
- **Balance input:** explicit pool token-account addresses
- **Historical TVL:** disabled because pool discovery relies on the current Solana account set

## Included Balances

The adapter includes:
- the first token vault recorded in every BisonFi pool state;
- the second token vault recorded in every BisonFi pool state;
- legacy SPL Token accounts;
- Token-2022 accounts;
- newly created pools using the same pool-state layout.


## Program Source

The same BisonFi program is used by DefiLlama's existing DEX volume adapter:

https://github.com/DefiLlama/dimension-adapters/blob/master/dexs/bisonfi/index.ts

Program explorer:
- https://orbmarkets.io/address/BiSoNHVpsVZW2F7rx2eQ59yQwKxzU5NvBcmKshCSUypi/history

## Pool-State Discriminator and Layout Sources

The BisonFi program does not currently have a publicly verified build or public IDL. The discriminator and vault offsets were verified directly from program-owned accounts on Solana.

Example pool-state account:
https://solscan.io/account/9fLzyySS73UnecJRzx2AKcgoSQ1qigzU3b6m9e2iVq6

This account:

- is owned by `BiSoNHVpsVZW2F7rx2eQ59yQwKxzU5NvBcmKshCSUypi`;
- has a 2,048-byte account layout;
- starts with the eight bytes `50 4f 4f 4c 53 54 41 54`;
- therefore starts with the ASCII discriminator `POOLSTAT`;
- records its first token vault at offset `120`;
- records its second token vault at offset `152`;

Base58-encoding the eight `POOLSTAT` bytes produces:

```text
ES78ZeanFtP
```

At the time of verification, the on-chain discovery returned:

- **18** pool-state accounts;
- **36** extracted token vaults;
- **0** invalid token accounts;
- **0** vaults whose token-account authority differed from the corresponding pool-state PDA.

## DefiLlama Helper

The adapter uses DefiLlama's existing Solana helper:

https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/helper/solana.js

`sumTokens2` reads and decodes the extracted token accounts and adds their balances to the Solana TVL result.

Supported token programs include:

- **SPL Token Program:** `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`
- **Token-2022 Program:** `TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb`

## Validation

Validation command:

```bash
node test.js projects/bisonfi/index.js
```

## Existing Listing

BisonFi is already listed on DefiLlama:

https://defillama.com/protocol/bisonfi


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for BisonFi on Solana.
  * TVL calculations include balances from both standard SPL Tokens and Token-2022 vaults.
  * Added methodology details and indicated that historical time-travel data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->