### PR TITLE
stonkbrokers: clarify V2/r2 Stonklauncher locks in TVL methodology

### DIFF
--- a/projects/stonkbrokers/index.js
+++ b/projects/stonkbrokers/index.js
@@ -36,7 +36,7 @@ async function tvl(api) {
 
 module.exports = {
   methodology:
-    'TVL is the liquidity permanently locked in the Safety Deposit Box lockers: Uniswap V3 position NFTs escrowed in the V3 box, plus up. DEX (Slipstream) positions escrowed in the up. box — including every Safe Launch pad graduation pool, whose full raise + LP tax reserve is locked forever at bond. Only the WETH side of each position is counted (meme-token legs stay unpriced). Staking tracks STONKBROKER tokens in the escrow contract.',
+    'TVL is the liquidity permanently locked in the Safety Deposit Box lockers: Uniswap V3 position NFTs escrowed in the V3 box, plus up. DEX (Slipstream) positions escrowed in the up. box — including every Stonklauncher / Safe Launch graduation pool across the V1 ETH pad, V1 quoted lanes, V2 lanes, and r2 pads (raise + LP tax reserve locked forever at bond; V2 Uniswap-v3 venue bonds land in the V3 box). Only the WETH side of each position is counted (meme-token legs stay unpriced). Staking tracks STONKBROKER tokens in the escrow contract.',
   doublecounted: true,
   robinhood: {
     tvl,


### PR DESCRIPTION
## Summary
- Methodology-only: locked LP from all Stonklauncher pad generations (V1 ETH, V1 quoted, V2, r2) already lands in the Safety Deposit Box V3 / up. CL lockers this adapter tracks — spell that out so coverage is obvious after the V2/r2 deploys.

No code/address changes; TVL math unchanged.

## Test plan
- [ ] `node test.js stonkbrokers` still returns the locked-box TVL
- [ ] Confirm methodology text renders on the protocol page after merge


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the methodology description by listing all Safe Launch graduation pool categories.
  * Specified that V2 Uniswap V3 venue bonds are deposited in the V3 box.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->