### PR TITLE
feat: add TVL of GrowStreams

### DIFF
--- a/projects/vara-grow-streams/index.js
+++ b/projects/vara-grow-streams/index.js
@@ -41,10 +41,10 @@ async function rpc(method, params) {
   return response.result
 }
 
-async function getSpendableNative(addresses) {
-  const at = await rpc('chain_getFinalizedHead', [])
+async function getSpendableNative(addresses, at) {
+  const blockHash = at ?? await rpc('chain_getFinalizedHead', [])
   const keys = addresses.map(accountStorageKey)
-  const result = await rpc('state_queryStorageAt', [keys, at])
+  const result = await rpc('state_queryStorageAt', [keys, blockHash])
   const values = new Map(keys.map(key => [key, null]))
 
   for (const changeSet of result || [])
@@ -64,10 +64,12 @@ async function getSpendableNative(addresses) {
   })
 }
 
-async function getTotalSupply(program, service) {
+async function getTotalSupply(program, service, at) {
   const prefix = route(service, 'TotalSupply')
   const payload = `0x${prefix.toString('hex')}`
-  const result = await rpc('gear_calculateReplyForHandle', [ZERO_ACCOUNT, program, payload, GAS_LIMIT, 0])
+  const params = [ZERO_ACCOUNT, program, payload, GAS_LIMIT, 0]
+  if (at) params.push(at)
+  const result = await rpc('gear_calculateReplyForHandle', params)
 
   if (!result || !result.payload || result.payload === '0x' || !result.code || !result.code.Success)
     throw new Error(`vara-grow-streams: failed to read TotalSupply from ${program}: ${JSON.stringify(result && result.code)}`)
@@ -80,10 +82,11 @@ async function getTotalSupply(program, service) {
 }
 
 async function tvl(api) {
+  const at = await rpc('chain_getFinalizedHead', [])
   const [[vaultNative, wvaraNative, gvaraNative], wvaraSupply, gvaraSupply] = await Promise.all([
-    getSpendableNative([TOKEN_VAULT, WVARA, GVARA]),
-    getTotalSupply(WVARA, 'Vft'),
-    getTotalSupply(GVARA, 'SuperTokenService'),
+    getSpendableNative([TOKEN_VAULT, WVARA, GVARA], at),
+    getTotalSupply(WVARA, 'Vft', at),
+    getTotalSupply(GVARA, 'SuperTokenService', at),
   ])
 
   // Wrapper token balances are claims on these same reserves, so counting both

--- a/projects/vara-grow-streams/index.js
+++ b/projects/vara-grow-streams/index.js
@@ -1,0 +1,101 @@
+const blake = require('blakejs')
+const { post } = require('../helper/http')
+
+const VARA_RPC = 'https://rpc.vara.network'
+const GAS_LIMIT = 750000000000
+const ZERO_ACCOUNT = '0x' + '0'.repeat(64)
+const VARA_DECIMALS = 1e12
+
+const TOKEN_VAULT = '0x20099b7637ae936670f54464c4109d1f028fbb63230e151ea4ef29c4a94cbcef'
+const WVARA = '0xf5e9cb1d1e46b0cda6578dd1684b30f281a45dfaa390e4945b7bfc8ab3e27f3d'
+const GVARA = '0x04314af41b7dbac322e3e66920211d2f799719e1cdc3122a99752f72b6ae84ee'
+
+// twox128("System") ++ twox128("Account")
+const SYSTEM_ACCOUNT_PREFIX = '26aa394eea5630e07c48ae0c9558cef7b99d880ec681799c0cf30e8886371da9'
+
+function scaleString(value) {
+  const bytes = Buffer.from(value, 'utf8')
+  if (bytes.length >= 64) throw new Error('vara-grow-streams: route segment is too long')
+  return Buffer.concat([Buffer.from([bytes.length << 2]), bytes])
+}
+
+function route(service, method) {
+  return Buffer.concat([scaleString(service), scaleString(method)])
+}
+
+function u128LE(bytes, offset = 0) {
+  let value = 0n
+  for (let i = 15; i >= 0; i--) value = (value << 8n) | BigInt(bytes[offset + i])
+  return value
+}
+
+function accountStorageKey(address) {
+  const account = Buffer.from(address.slice(2), 'hex')
+  const hash = Buffer.from(blake.blake2b(account, undefined, 16))
+  return `0x${SYSTEM_ACCOUNT_PREFIX}${hash.toString('hex')}${account.toString('hex')}`
+}
+
+async function rpc(method, params) {
+  const response = await post(VARA_RPC, { jsonrpc: '2.0', id: 1, method, params })
+  if (response.error) throw new Error(`vara-grow-streams: ${method} failed: ${JSON.stringify(response.error)}`)
+  return response.result
+}
+
+async function getSpendableNative(addresses) {
+  const at = await rpc('chain_getFinalizedHead', [])
+  const keys = addresses.map(accountStorageKey)
+  const result = await rpc('state_queryStorageAt', [keys, at])
+  const values = new Map(keys.map(key => [key, null]))
+
+  for (const changeSet of result || [])
+    for (const [key, value] of changeSet.changes || []) values.set(key, value)
+
+  return keys.map(key => {
+    const raw = values.get(key)
+    if (!raw) return 0n
+    const bytes = Buffer.from(raw.slice(2), 'hex')
+    if (bytes.length < 64) throw new Error(`vara-grow-streams: malformed System.Account response for ${key}`)
+
+    // AccountInfo contains four u32 fields, followed by AccountData. `free` and
+    // `frozen` are the first and third u128 values in AccountData respectively.
+    const free = u128LE(bytes, 16)
+    const frozen = u128LE(bytes, 48)
+    return free > frozen ? free - frozen : 0n
+  })
+}
+
+async function getTotalSupply(program, service) {
+  const prefix = route(service, 'TotalSupply')
+  const payload = `0x${prefix.toString('hex')}`
+  const result = await rpc('gear_calculateReplyForHandle', [ZERO_ACCOUNT, program, payload, GAS_LIMIT, 0])
+
+  if (!result || !result.payload || result.payload === '0x' || !result.code || !result.code.Success)
+    throw new Error(`vara-grow-streams: failed to read TotalSupply from ${program}: ${JSON.stringify(result && result.code)}`)
+
+  const bytes = Buffer.from(result.payload.slice(2), 'hex')
+  if (bytes.length < prefix.length + 16 || !bytes.subarray(0, prefix.length).equals(prefix))
+    throw new Error(`vara-grow-streams: malformed TotalSupply response from ${program}`)
+
+  return u128LE(bytes, prefix.length)
+}
+
+async function tvl(api) {
+  const [[vaultNative, wvaraNative, gvaraNative], wvaraSupply, gvaraSupply] = await Promise.all([
+    getSpendableNative([TOKEN_VAULT, WVARA, GVARA]),
+    getTotalSupply(WVARA, 'Vft'),
+    getTotalSupply(GVARA, 'SuperTokenService'),
+  ])
+
+  // Wrapper token balances are claims on these same reserves, so counting both
+  // the VFT balances and their native backing would double-count the TVL.
+  const wvaraBacking = wvaraNative < wvaraSupply ? wvaraNative : wvaraSupply
+  const gvaraBacking = gvaraNative < gvaraSupply ? gvaraNative : gvaraSupply
+  const total = vaultNative + wvaraBacking + gvaraBacking
+
+  api.addCGToken('vara-network', Number(total) / VARA_DECIMALS)
+}
+
+module.exports = {
+  methodology: 'Counts spendable native VARA held by the GrowStreams token vault plus the native collateral backing the wVARA and gVARA wrappers. Wrapper backing is capped at each token total supply, and wrapper-token balances are excluded to prevent double counting. Mandatory Vara program existential deposits and unbacked/excess operational balances are not counted.',
+  vara: { tvl },
+}

--- a/projects/vara-grow-streams/index.js
+++ b/projects/vara-grow-streams/index.js
@@ -64,41 +64,15 @@ async function getSpendableNative(addresses, at) {
   })
 }
 
-async function getTotalSupply(program, service, at) {
-  const prefix = route(service, 'TotalSupply')
-  const payload = `0x${prefix.toString('hex')}`
-  const params = [ZERO_ACCOUNT, program, payload, GAS_LIMIT, 0]
-  if (at) params.push(at)
-  const result = await rpc('gear_calculateReplyForHandle', params)
-
-  if (!result || !result.payload || result.payload === '0x' || !result.code || !result.code.Success)
-    throw new Error(`vara-grow-streams: failed to read TotalSupply from ${program}: ${JSON.stringify(result && result.code)}`)
-
-  const bytes = Buffer.from(result.payload.slice(2), 'hex')
-  if (bytes.length < prefix.length + 16 || !bytes.subarray(0, prefix.length).equals(prefix))
-    throw new Error(`vara-grow-streams: malformed TotalSupply response from ${program}`)
-
-  return u128LE(bytes, prefix.length)
-}
-
 async function tvl(api) {
   const at = await rpc('chain_getFinalizedHead', [])
-  const [[vaultNative, wvaraNative, gvaraNative], wvaraSupply, gvaraSupply] = await Promise.all([
-    getSpendableNative([TOKEN_VAULT, WVARA, GVARA], at),
-    getTotalSupply(WVARA, 'Vft', at),
-    getTotalSupply(GVARA, 'SuperTokenService', at),
-  ])
-
-  // Wrapper token balances are claims on these same reserves, so counting both
-  // the VFT balances and their native backing would double-count the TVL.
-  const wvaraBacking = wvaraNative < wvaraSupply ? wvaraNative : wvaraSupply
-  const gvaraBacking = gvaraNative < gvaraSupply ? gvaraNative : gvaraSupply
-  const total = vaultNative + wvaraBacking + gvaraBacking
+  const [vaultNative, wvaraNative, gvaraNative] = await getSpendableNative([TOKEN_VAULT, WVARA, GVARA], at)
+  const total = vaultNative + wvaraNative + gvaraNative
 
   api.addCGToken('vara-network', Number(total) / VARA_DECIMALS)
 }
 
 module.exports = {
-  methodology: 'Counts spendable native VARA held by the GrowStreams token vault plus the native collateral backing the wVARA and gVARA wrappers. Wrapper backing is capped at each token total supply, and wrapper-token balances are excluded to prevent double counting. Mandatory Vara program existential deposits and unbacked/excess operational balances are not counted.',
+  methodology: 'GrowStreams deploys and owns the token vault and its wVARA and gVARA wrapper programs. TVL is the combined spendable native VARA held by all three: the vault balance plus the native VARA backing wVARA and gVARA tokens.',
   vara: { tvl },
 }


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):

GrowStreams

##### Twitter Link:

- https://x.com/GrowwStreams

##### List of audit links if any:

- N/A

##### Website Link:

- https://growstreams.xyz

##### Logo (High resolution, will be shown with rounded borders):

- https://growstreams.xyz/_next/image?url=%2Flogo.png&w=384&q=75

##### Current TVL:

- near 30$, but this is payment protocol that allows you to create cash flow (e.g., per second, per minute, per hour, etc.) that can be paused, stopped, or replenished. TVL is small, but they've already created 2,200+ streams (https://idea.gear-tech.io/state/sails/0x8298c2eea5c6bbe55a9cfe72283b5399098fd6a54d9a2a14c2bedba8eea50659?node=wss%3A%2F%2Frpc.vara.network, query -> total streams) and processed approximately 777,000 VARA (~$350).

##### Treasury Addresses (if the protocol has treasury)

- https://vara.subscan.io/account/kGiaMA7wophBP4BuJRyCUPTrkrgMfYFL78KaZmAF44WYjuPM2
- https://idea.gear-tech.io/state/sails/0x8298c2eea5c6bbe55a9cfe72283b5399098fd6a54d9a2a14c2bedba8eea50659?node=wss%3A%2F%2Frpc.vara.network (query -> get config)

```json
{
    "admin": "0x868111d85b4c429dbf5f2d54111c580cd9bc12a53ac377760d89bfe2813e7410",
    "min_buffer_seconds": 3600,
    "next_stream_id": 2212,
    "token_vault": "0x20099b7637ae936670f54464c4109d1f028fbb63230e151ea4ef29c4a94cbcef",
    "super_token_count": 1,
    "fee_bps": 250,
    "treasury": "0x868111d85b4c429dbf5f2d54111c580cd9bc12a53ac377760d89bfe2813e7410"
}
```

Convert public key to address: https://ss58.org

##### Chain:

- Vara Network

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

- N/A

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

- N/A

##### Short Description (to be shown on DefiLlama):

Real-time token streaming on Vara Network. Composable smart contracts for payroll, subscriptions, bounties, grants, and revenue sharing.

##### Token address and ticker if any:

- N/A, GROW Token is coming soon?

##### Category (full list at https://defillama.com/categories) \*Please choose only one:

- Payments

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

- N/A

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

- N/A

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

- N/A

##### forkedFrom (Does your project originate from another project):

- Original project

##### methodology (what is being counted as tvl, how is tvl being calculated):

I analyzed all StreamCreated events and they look something like this, and the token field contains the wVARA address. This means that the project primarily supports only VARA for transfers (per second, per minute, etc.), although it also supports wUSDT, wUSDC, WETH, and WBTC from the Vara-Ethereum bridge (but $10,000 in liquidity is probably not enough at the moment, and this is liquidity for RivrDEX). As far as I understand, they have their own gVARA token (GrowStreams VARA with the address 0x04314af41b7dbac322e3e66920211d2f799719e1cdc3122a99752f72b6ae84ee) and it is used for payouts according to the following scheme: the recipient receives min(rate × elapsed, buffer), and the buffer is deposited with the sender. That is, For now, I only need to calculate the native VARA balance for the gVARA smart contract, as I understand the protocol. Once liquidity becomes available, I'll likely add other assets for tracking.

https://idea.gear-tech.io/programs/0x8298c2eea5c6bbe55a9cfe72283b5399098fd6a54d9a2a14c2bedba8eea50659/events?node=wss%3A%2F%2Frpc.vara.network

```json
{
    "id": 2211,
    "sender": "0x1ad30e491c71da3461ff33fc09e6774101430d8b8927a90525ec39dfa5345541",
    "receiver": "0x5c7655911de5a2a59afa5143fe03e81a7729f8da2c408227c53959d6dd2c9610",
    "token": "0xf5e9cb1d1e46b0cda6578dd1684b30f281a45dfaa390e4945b7bfc8ab3e27f3d",
    "flow_rate": 16666666666,
    "start_time": 1787389104,
    "initial_deposit": 97500000000000
}
```

##### Github org/user (Optional, if your code is open source, we can track activity):

- https://github.com/BlockX-AI or me

##### Does this project have a referral program?

- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated Vara GrowStreams TVL tracking to reflect the combined spendable native VARA held by the vault and its wVARA and gVARA wrappers.
  * Removed previous supply-based limits when calculating wrapper-backed value.
  * Updated the TVL methodology description to clearly explain the revised calculation.
  * Continues using finalized on-chain data and response validation for consistent, reliable reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->