### PR TITLE
add astrofun and fermiswap

### DIFF
--- a/registries/sumTokens/data3.js
+++ b/registries/sumTokens/data3.js
@@ -879,5 +879,17 @@ module.exports = {
     "base": {
       "tvl": { "owners": ["0x0bc585e3c8c47EE507C873eC994b14fC7883793d"], "tokens": [ADDRESSES.base.USDC] },
     },
+  },
+  "fermiswap": {
+    methodology: "TVL is the value of WETH, USDT, USDC, cbBTC, and WBTC held in FermiSwap's inventory vault.",
+    "ethereum": {
+      "tvl": { "owners": ["0xb1076fE3AB5e28005C7c323Bac5AC06a680d452e"], "tokens": [ADDRESSES.ethereum.WETH, ADDRESSES.ethereum.USDT, ADDRESSES.ethereum.USDC, ADDRESSES.ethereum.cbBTC, ADDRESSES.ethereum.WBTC] },
+    },
+  },
+  "astro-fun": {
+    methodology: "Counts the USDG held by the Astro BankrollVault on Robinhood Chain: the liquidity provided by LPs to the bankroll (ERC-4626 ASTROLP), the players\' withdrawable balances, and the stakes wagered in the round currently in play.",
+    "robinhood": {
+      "tvl": { "owners": ["0x58D2f2D46af20C357885d540A9c02fDD791Ee1CF"], "tokens": [ADDRESSES.robinhood.USDG] },
+    },
   }
 }


### PR DESCRIPTION
resolves #20635
resolves #20638

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added TVL tracking for FermiSwap on Ethereum, covering WETH, USDT, USDC, cbBTC, and WBTC.
  - Added TVL tracking for Astro Fun on Robinhood Chain, covering USDG bankroll liquidity and player balances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->