### PR TITLE
Add Ammalgam DLEX reserve TVL adapter

### DIFF
--- a/projects/ammalgam-dlex/index.js
+++ b/projects/ammalgam-dlex/index.js
@@ -1,0 +1,51 @@
+const FACTORY = '0x1a411b0fd1f368d2f413a8cbb6aad425c923015b'
+
+const abi = {
+  allPairsLength: 'uint256:allPairsLength',
+  allPairs: 'function allPairs(uint256) view returns (address)',
+  underlyingTokens: 'function underlyingTokens() view returns (address tokenX, address tokenY)',
+  getReserves:
+    'function getReserves() view returns (uint112 reserveXAssets, uint112 reserveYAssets, uint32 lastTimestamp)',
+}
+
+const getTokenX = tokens => tokens.tokenX ?? tokens[0]
+const getTokenY = tokens => tokens.tokenY ?? tokens[1]
+const getReserveX = reserves => reserves.reserveXAssets ?? reserves[0]
+const getReserveY = reserves => reserves.reserveYAssets ?? reserves[1]
+
+/**
+ * Fetches all Ammalgam pairs with their underlying tokens and swap reserves.
+ */
+async function getPairData(api) {
+  const pairs = await api.fetchList({
+    target: FACTORY,
+    lengthAbi: abi.allPairsLength,
+    itemAbi: abi.allPairs,
+  })
+
+  const [underlyingTokens, reserves] = await Promise.all([
+    api.multiCall({ abi: abi.underlyingTokens, calls: pairs }),
+    api.multiCall({ abi: abi.getReserves, calls: pairs }),
+  ])
+
+  return { pairs, underlyingTokens, reserves }
+}
+
+/**
+ * Adds only tokenX/tokenY reserve assets used for swaps.
+ */
+async function tvl(api) {
+  const { underlyingTokens, reserves } = await getPairData(api)
+
+  reserves.forEach((reserve, index) => {
+    api.add(getTokenX(underlyingTokens[index]), getReserveX(reserve))
+    api.add(getTokenY(underlyingTokens[index]), getReserveY(reserve))
+  })
+}
+
+module.exports = {
+  methodology:
+    'Ammalgam DLEX reserve TVL counts only swap reserves: tokenX and tokenY reserve assets returned by getReserves() for every pair created by the Ethereum factory. Broader supplied and borrowed DLEX liquidity is excluded from this reserve-only view.',
+  start: '2026-07-03',
+  ethereum: { tvl },
+}


### PR DESCRIPTION
## Summary
- Add reserve-only TVL tracking under the Ammalgam DLEX adapter path.
- Retarget the reserve TVL work from closed PR #20653 from `projects/ammalgam-dex` to `projects/ammalgam-dlex`.
- Enumerate Ammalgam pairs from the Ethereum factory and count only tokenX/tokenY swap reserves returned by `getReserves()`.
- Exclude broader supplied and borrowed DLEX liquidity from this reserve-only view.

## Context
This follows up on #20669 and the maintainer feedback on #20653 that the existing DEX and DLEX pages will be combined because they track the same factory/pair.

## Test Plan
- `PATH=/Users/wfey/.nvm/versions/node/v18.18.2/bin:$PATH NODE_PATH=/Users/wfey/projects/ammalgam/DefiLlama-Adapters/node_modules node test.js projects/ammalgam-dlex/index.js`
- `PATH=/Users/wfey/.nvm/versions/node/v18.18.2/bin:$PATH /Users/wfey/projects/ammalgam/DefiLlama-Adapters/node_modules/.bin/eslint -c eslint.config.js projects/ammalgam-dlex/index.js`
- `git diff --check HEAD~1..HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ethereum TVL tracking for Ammalgam DLEX.
  * Discovers factory pairs and records token swap reserves.
  * Supports multiple contract response formats and parallel data retrieval.
  * Added reserve-only methodology details and tracking start date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->