### PR TITLE
Add CL8Y DEX (Terra Classic) TVL adapter

### DIFF
--- a/projects/cl8y-dex/index.js
+++ b/projects/cl8y-dex/index.js
@@ -1,0 +1,61 @@
+const { queryContract, queryContractWithRetries } = require('../helper/chain/cosmos')
+const { PromisePool } = require('@supercharge/promise-pool')
+
+// Columbus-5 factory. Same pin as https://gitlab.com/PlasticDigits/cl8y-dex-terraclassic
+const FACTORY = 'terra1ejpgvv7g3hj0u6fpcnxhflqp84g0w3cnaskqkg5733ygwlmf963sfchsea'
+const PAGE_LIMIT = 30
+// 1:1 wrap CW20s of native uluna / uusd. Counted as those denoms so Llama can price them.
+const CLUNC = 'terra1437qslye72t7qmmahn4t5chz50r8a62g45phwkquwpyu2l62u6ksqssgdg'
+const CUSTC = 'terra1nap4dxh9tv35v0ynd9m4k6zt6c0dq6weszc4j5m564kjls56hu7qcr56ch'
+
+function addAsset(api, info, amount) {
+  if (amount == null || String(amount) === '0') return
+  if (info.native_token) {
+    api.add(info.native_token.denom, amount)
+    return
+  }
+  const addr = info.token && info.token.contract_addr
+  if (!addr) return
+  if (addr === CLUNC) api.add('uluna', amount)
+  else if (addr === CUSTC) api.add('uusd', amount)
+  else api.add(addr, amount)
+}
+
+async function getAllPairs() {
+  const allPairs = []
+  let currentPairs
+  do {
+    const query = { pairs: { limit: PAGE_LIMIT } }
+    if (allPairs.length) query.pairs.start_after = allPairs[allPairs.length - 1].asset_infos
+    currentPairs = (await queryContract({ contract: FACTORY, chain: 'terra', data: query })).pairs ?? []
+    allPairs.push(...currentPairs)
+  } while (currentPairs.length > 0)
+  return allPairs
+}
+
+async function tvl(api) {
+  const pairs = await getAllPairs()
+  const poolContracts = pairs.map((p) => p.contract_addr).filter(Boolean)
+
+  const { errors } = await PromisePool
+    .withConcurrency(10)
+    .for(poolContracts)
+    .process(async (pool) => {
+      const result = await queryContractWithRetries({ contract: pool, chain: 'terra', data: { pool: {} } })
+      for (const asset of result?.assets ?? []) {
+        addAsset(api, asset.info || {}, asset.amount)
+      }
+    })
+
+  if (errors.length > poolContracts.length / 2) {
+    throw new Error(`cl8y-dex TVL: ${errors.length}/${poolContracts.length} pool queries failed`)
+  }
+}
+
+module.exports = {
+  timetravel: false,
+  misrepresentedTokens: true,
+  methodology:
+    'TVL is the sum of raw native denoms and CW20 balances returned by factory-listed pair Pool {} queries on Terra Classic. cLUNC and cUSTC (1:1 wraps of uluna / uusd) are counted as those natives so Llama can price them. Other CW20s (UST1, USTR, CL8Y, gems) are added by contract and omitted if unpriced. LP share tokens, limit-book escrow, wrap-mapper native inventory, treasury, and UST1-window inventory are omitted. Indexer USD and CoinGecko liquidity_in_usd are never used.',
+  terra: { tvl },
+}

--- a/projects/cl8y-dex/index.js
+++ b/projects/cl8y-dex/index.js
@@ -1,5 +1,4 @@
-const { queryContract, queryContractWithRetries } = require('../helper/chain/cosmos')
-const { PromisePool } = require('@supercharge/promise-pool')
+const { queryContract, queryManyContracts } = require('../helper/chain/cosmos')
 
 // Columbus-5 factory. Same pin as https://gitlab.com/PlasticDigits/cl8y-dex-terraclassic
 const FACTORY = 'terra1ejpgvv7g3hj0u6fpcnxhflqp84g0w3cnaskqkg5733ygwlmf963sfchsea'
@@ -37,18 +36,11 @@ async function tvl(api) {
   const pairs = await getAllPairs()
   const poolContracts = pairs.map((p) => p.contract_addr).filter(Boolean)
 
-  const { errors } = await PromisePool
-    .withConcurrency(10)
-    .for(poolContracts)
-    .process(async (pool) => {
-      const result = await queryContractWithRetries({ contract: pool, chain: 'terra', data: { pool: {} } })
-      for (const asset of result?.assets ?? []) {
-        addAsset(api, asset.info || {}, asset.amount)
-      }
-    })
-
-  if (errors.length > poolContracts.length / 2) {
-    throw new Error(`cl8y-dex TVL: ${errors.length}/${poolContracts.length} pool queries failed`)
+  const pools = await queryManyContracts({ contracts: poolContracts, chain: 'terra', data: { pool: {} } })
+  for (const pool of pools) {
+    for (const asset of pool?.assets ?? []) {
+      addAsset(api, asset.info || {}, asset.amount)
+    }
   }
 }
 


### PR DESCRIPTION
**NOTE**

Please keep "Allow edits by maintainers" enabled.

---

## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
CL8Y DEX

##### Twitter Link:


##### List of audit links if any:


##### Website Link:
https://dex.cl8y.com

##### Logo (High resolution, will be shown with rounded borders):
https://dex.cl8y.com/logo.png

##### Current TVL:
~$13.3k on Llama prices after this adapter (`node test.js projects/cl8y-dex/index.js` → terra 13.28k). First-party indexer catalog is higher (~$51k) because it also marks unpriced CW20s (UST1, USTR, CL8Y, gems). Do not treat that catalog USD as Llama TVL.

##### Treasury Addresses (if the protocol has treasury)
terra16j5u6ey7a84g40sr3gd94nzg5w5fm45046k9s2347qhfpwm5fr6sem3lr2

##### Chain:
Terra Classic (`terra`)

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description (to be shown on DefiLlama):
Terra Classic hybrid AMM + on-chain limit book at dex.cl8y.com

##### Token address and ticker if any:
terra16wtml2q66g82fdkx66tap0qjkahqwp4lwq3ngtygacg5q0kzycgqvhpax3 (CL8Y)

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Dexs

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
None for TVL. This adapter does not use an oracle.

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
TVL is raw factory pair `Pool {}` balances. Llama prices tokens.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
https://gitlab.com/PlasticDigits/cl8y-dex-terraclassic/-/blob/main/docs/DEFILLAMA.md

##### forkedFrom (Does your project originate from another project):
Terraswap-style factory/pair query interface. Contracts are original CL8Y (hybrid AMM + limit book).

##### methodology (what is being counted as tvl, how is tvl being calculated):
Paginate columbus-5 factory `Pairs { limit: 30, start_after }` and `api.add` each pair `Pool {}` reserve (native denom or CW20). cLUNC and cUSTC are 1:1 wraps of `uluna` / `uusd` and are counted as those natives (`misrepresentedTokens: true`). LP share tokens, limit-book escrow, wrap-mapper native inventory, treasury, and UST1-window inventory are omitted. Indexer USD and CoinGecko `liquidity_in_usd` are never used. Soft-launch gem pool locks are included as on-chain balances. Unpriced CW20s (UST1, USTR, CL8Y, gems) are omitted on Llama's side.

##### Github org/user (Optional, if your code is open source, we can track activity):
https://gitlab.com/PlasticDigits/cl8y-dex-terraclassic

##### Does this project have a referral program?
No

---

Factory: `terra1ejpgvv7g3hj0u6fpcnxhflqp84g0w3cnaskqkg5733ygwlmf963sfchsea`

Local test:

```
node test.js projects/cl8y-dex/index.js
```

Result (2026-08-25): terra 13.28k (USTC 13.09k + LUNC 189).

Volume and fees adapters are in a separate PR to DefiLlama/dimension-adapters.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for the cl8y-dex exchange on Terra Classic.
  * Reports liquidity across all exchange pairs, including native denominations and CW20 assets.
  * Supports valuation of wrapped cLUNC and cUSTC assets using their corresponding native denominations.
  * Improved pool data collection for more consistent and comprehensive liquidity reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->