### PR TITLE
tether-gold: stop double counting bridged XAUt0

### DIFF
--- a/projects/tether-gold/index.js
+++ b/projects/tether-gold/index.js
@@ -1,30 +1,15 @@
-const ADDRESSES = require('../helper/coreAssets.json')
-const XAUt = {
-  ethereum: "0x68749665ff8d2d112fa859aa293f07a622782f38",
-  monad: "0x01bFF41798a0BcF287b996046Ca68b395DbC1071",
-  polygon: ADDRESSES.flow.stgUSDC,
-  plasma: "0x1b64b9025eebb9a6239575df9ea4b9ac46d4d193",
-  avax: "0x2775d5105276781b4b85ba6ea6a6653beed1dd32",
-  celo: "0xaf37e8b6c9ed7f6318979f56fc287d76c30847ff",
-  ink: "0xf50258d3c1dd88946c567920b986a12e65b50dac",
-  arbitrum: "0x40461291347e1ecbb09499f3371d3f17f10d7159",
-};
+// XAUt is natively issued on Ethereum only.
+//
+// XAUt0 on other chains - and the BSC token 0x21cAef8A43163Eea865baeE23b9C2E327696A3bf that
+// keeps the plain "XAUt" symbol - are LayerZero OFTs minted against XAUt locked in the Ethereum
+const XAUt = '0x68749665ff8d2d112fa859aa293f07a622782f38'
 
 module.exports = {
-  methodology: "TVL corresponds to the total amount of XAUt minted",
-  ...Object.fromEntries(
-    Object.entries(XAUt).map(([chain, address]) => [
-      chain,
-      {
-        tvl: async (api) => {
-          const totalSupply = await api.call({
-            target: address,
-            abi: "erc20:totalSupply",
-            chain,
-          });
-          api.add(address, totalSupply);
-        },
-      },
-    ])
-  ),
-};
+  methodology: "Counts the total supply of XAUt on Ethereum, the only native Tether Gold issuance. XAUt0 on other chains is a LayerZero wrapper backed 1:1 by XAUt locked in the Ethereum OAdapter.",
+  ethereum: {
+    tvl: async (api) => {
+      const totalSupply = await api.call({ target: XAUt, abi: 'erc20:totalSupply' })
+      api.add(XAUt, totalSupply)
+    },
+  },
+}


### PR DESCRIPTION
Fix double-counting in the Tether Gold adapter.

Only Ethereum `XAUt` is native Tether Gold. The other chains expose `XAUt0`, a LayerZero wrapper backed 1:1 by XAUt locked in the Ethereum OAdapter. Its supply is already included in Ethereum `totalSupply`.

## Changes

* Keep only the Ethereum `totalSupply` leg.
* Remove seven remote `XAUt0` legs.
* Update methodology and add topology/BSC notes to prevent reintroducing the double count.
* Remove the unused `coreAssets` dependency.

## Impact

|              |     Before |      After |
| ------------ | ---------: | ---------: |
| Ethereum     |     $3.27B |     $3.27B |
| Remote XAUt0 |     $26.6M |          — |
| **Total**    | **$3.29B** | **$3.27B** |




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated XAUt TVL tracking to reflect Ethereum’s native XAUt contract only.
  * Removed TVL calculations for unsupported or LayerZero-backed deployments on other networks.

* **Documentation**
  * Clarified that reported TVL represents Ethereum-issued XAUt, while XAUt0 on other networks is backed through LayerZero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->