### PR TITLE
Add USDR (RISE Dollar) TVL adapter

### DIFF
--- a/projects/usdr/index.js
+++ b/projects/usdr/index.js
@@ -1,0 +1,17 @@
+// USDR (RISE Dollar) is an M^0 extension: every USDR is minted by wrapping $M into the
+// extension contract, so the $M held by that contract is the full backing of the supply.
+const M = '0x866A2BF4E572CbcF37D5071A7a58503Bfb36be1b'
+const USDR = '0x62b7f5A5Be488ea58f660C5aff465647213Bc6e9'
+
+async function tvl(api) {
+  const backing = await api.call({ target: M, abi: 'erc20:balanceOf', params: USDR })
+  // $M is not priced on RISE by coins.llama.fi; it uses the same address on Ethereum,
+  // where it is priced, so the balance is reported under the Ethereum key.
+  api.add('ethereum:' + M, backing, { skipChain: true })
+}
+
+module.exports = {
+  methodology:
+    'TVL is the $M balance held by the USDR extension contract on RISE Chain, which is the collateral backing every minted USDR. $M is priced through its Ethereum listing because RISE is not indexed by coins.llama.fi.',
+  rise: { tvl },
+}


### PR DESCRIPTION
Adds a TVL adapter for USDR (RISE Dollar), an M^0 extension on RISE Chain.

USDR is minted by wrapping $M into the extension contract, so the $M held by that
contract is the full backing of the supply. The adapter reads that balance on-chain.

$M is not priced under the `rise:` key by coins.llama.fi, but it uses the same address
on Ethereum where it is priced, so the balance is reported under the Ethereum key with
`skipChain: true` — same approach as `projects/securitize/index.js`.

Note on double counting: the $M backing USDR is bridged from Ethereum, where M0 is
listed. This mirrors `projects/saturn-protocol/index.js` (Saturn / USDat), which counts
the same $M token as backing and is not flagged `doublecounted`. Happy to add the flag
if you'd prefer it handled differently.

Validation:

```
$ node test.js projects/usdr/index.js
--- rise ---
M                         2.70 M
Total: 2.70 M

------ TVL ------
rise                      2.70 M
```

---

##### Name (to be shown on DefiLlama): USDR

##### Twitter Link: https://x.com/risechain

##### List of audit links if any: https://docs.m0.org/resources/audits (USDR runs M^0's `JMIExtension` contract, covered by the M^0 protocol audits)

##### Website Link: https://docs.risechain.com/docs/rise-evm/usdr

##### Logo (High resolution, will be shown with rounded borders): attached below (SVG)
<img width="1080" height="1080" alt="USDR" src="https://github.com/user-attachments/assets/390e2860-5f5b-4650-8f2d-8b606d09469e" />

##### Current TVL: ~$2.70M

##### Treasury Addresses (if the protocol has treasury): N/A

##### Chain: RISE

##### Coingecko ID: (not listed)

##### Coinmarketcap ID: (not listed)

##### Short Description (to be shown on DefiLlama): USDR is a T-bill backed stablecoin built on top of the M^0 protocol.

##### Token address and ticker if any: USDR — `0x62b7f5A5Be488ea58f660C5aff465647213Bc6e9` (RISE Chain, 6 decimals)

##### Category: Stablecoin Issuer

##### Oracle Provider(s): None. USDR is backed 1:1 by $M held in the extension contract; TVL is read directly from the on-chain $M balance, with pricing supplied by DefiLlama's own $M feed on Ethereum.

##### Implementation Details: N/A (no oracle)

##### Documentation/Proof: N/A (no oracle)

##### forkedFrom: Not a fork. USDR is a deployment of M^0's `JMIExtension` (https://github.com/m0-platform/evm-m-extensions, `src/projects/jmi/JMIExtension.sol`).

##### methodology (what is being counted as tvl, how is tvl being calculated): TVL is the $M balance held by the USDR extension contract `0x62b7f5A5Be488ea58f660C5aff465647213Bc6e9` on RISE Chain, which is the collateral backing every minted USDR. $M is priced through its Ethereum listing because RISE is not indexed by coins.llama.fi.

##### Github org/user (Optional, if your code is open source, we can track activity): (left blank — the contract is M^0's `evm-m-extensions`, not a RISE-owned repo)

##### Does this project have a referral program? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for USDR (RISE Dollar) on the RISE network.
  * Reports USDR’s backing balance using the $M token valuation on Ethereum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->