### PR TITLE
add monetrix vault

### DIFF
--- a/projects/monetrix/index.js
+++ b/projects/monetrix/index.js
@@ -1,28 +1,30 @@
 const ADDRESSES = require('../helper/coreAssets.json')
 
 const MONETRIX_GENESIS_VAULT = '0xc50A1dd2866A822c81bd0aA00B638c4BdDc9cd63'
-const MONETRIX_ACCOUNTANT = '0x8950A5136f3994f82b998e37e1183b8A37c12705'
+const USDM_ACCOUNTANT = '0x8950A5136f3994f82b998e37e1183b8A37c12705'
 
-const USDC = ADDRESSES.hyperliquid.USDC
+const HYPE_ACCOUNTANT = '0xAcE53c4ef6619E7850E7d5fa45b8410C725D266D'
+const MXHYPE_START = 1786956896 // first deposit
+
+const TOTAL_BACKING_ABI = 'function totalBackingSigned() view returns (int256)'
 
 async function tvl(api) {
-  // Pre-launch Genesis Vault USDC; migrates into the main MonetrixVault when users mint USDM
-  await api.sumTokens({ owners: [MONETRIX_GENESIS_VAULT], tokens: [USDC] })
+  // Pre-launch Genesis Vault USDC; migrates into the main vault as users mint USDM.
+  await api.sumTokens({ owners: [MONETRIX_GENESIS_VAULT], tokens: [ADDRESSES.hyperliquid.USDC] })
+  const usdmBacking = await api.call({ target: USDM_ACCOUNTANT, abi: TOTAL_BACKING_ABI })
+  if (BigInt(usdmBacking) > 0n) api.add(ADDRESSES.hyperliquid.USDC, usdmBacking)
 
-  // USDC collateral backing USDM, read from the MonetrixAccountant:
-  // EVM USDC in the MonetrixVault and RedeemEscrow, plus the protocol's
-  // Hyperliquid Core account equity (perp margin, spot hedges, HLP and
-  // borrow-lend balances) valued via Hyperliquid precompiles
-  const totalBackingSigned = await api.call({ target: MONETRIX_ACCOUNTANT, abi: 'function totalBackingSigned() view returns (int256)' })
-  // negative backing (mark-to-market drawdown) clamps to zero
-  if (BigInt(totalBackingSigned) > 0n) api.add(USDC, totalBackingSigned)
+  if (!api.timestamp || api.timestamp >= MXHYPE_START) {
+    const hypeBacking = await api.call({ target: HYPE_ACCOUNTANT, abi: TOTAL_BACKING_ABI })
+    if (BigInt(hypeBacking) > 0n) api.add(ADDRESSES.hyperliquid.WHYPE, hypeBacking)
+  }
 }
 
 module.exports = {
   misrepresentedTokens: true,
   methodology:
-    'TVL is the USDC collateral backing USDM: USDC held by the MonetrixVault and ' +
-    'RedeemEscrow on HyperEVM plus the protocol\'s Hyperliquid Core account equity ' +
+    'TVL counts the collateral deposited into monetrix vaults, held by the vaults ' +
+    'on HyperEVM plus the protocol\'s Hyperliquid Core account equity ' +
     '(delta-neutral spot + short-perp positions, HLP and borrow-lend balances), read ' +
     'on-chain from the MonetrixAccountant (totalBacking), which marks Core positions ' +
     'to market via Hyperliquid precompiles. USDC still in the pre-launch Genesis Vault ' +

--- a/registries/sumTokens.js
+++ b/registries/sumTokens.js
@@ -117,12 +117,9 @@ const configs = {
   },
   "3fmutual": {
     "ethereum": {
-      "owners": [
-        "0x66be1bc6C6aF47900BBD4F3711801bE6C2c6CB32"
-      ],
-      "tokens": [
-        ADDRESSES.null
-      ]
+      "tvl": {
+        "__empty": true
+      }
     },
   },
   "AIDApp": {
@@ -18057,10 +18054,9 @@ const configs = {
   },
   "metavault-bo": {
     "polygon": {
-      "owner": "0x6fd5b386d8bed29b3b62c0856250cdd849b3564d",
-      "tokens": [
-        ADDRESSES.polygon.USDC
-      ]
+      "tvl": {
+        "__empty": true
+      }
     },
   },
   "metera-protocol": {


### PR DESCRIPTION
resolves #20613

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking HYPE-backed USDM collateral in Monetrix TVL.
  * HYPE backing is included for data from the applicable launch date onward.
  * Updated methodology details to describe the additional backing source.

* **Bug Fixes**
  * Corrected TVL registry entries for selected Ethereum and Polygon projects by marking them as unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->