### PR TITLE
Add PerpMe (token launchpad on HyperEVM)

### DIFF
--- a/registries/sumTokens.js
+++ b/registries/sumTokens.js
@@ -22238,6 +22238,21 @@ const configs = {
       "token": ADDRESSES.corn.USDT0
     },
   },
+  "perpme": {
+    "methodology": "TVL is the quote side (HYPE, USDC, USD₮0 or PURR) of the Uniswap V3 liquidity positions locked in the PerpMe locker. Every launch mints its whole supply as a single-sided PRJX position and sends the LP NFT to the locker, which has no function to decrease liquidity or move the position. PerpMe-launched coins are excluded: each one's only market is the very pool being measured. Liquidity lives in PRJX (Uniswap V3) pools, so this is flagged doublecounted.",
+    "doublecounted": true,
+    "hyperliquid": {
+      "owner": "0x07c4f2dBBfaf75afC4c947e6bFEa13fEa8Eb267F",
+      "resolveUniV3": true,
+      "uniV3WhitelistedTokens": [
+        ADDRESSES.hyperliquid.WHYPE,
+        ADDRESSES.hyperliquid.USDC,
+        ADDRESSES.hyperliquid.USDT0,
+        "0x9b498C3c8A0b8CD8BA1D9851d40D186F1872b44E"
+      ],
+      "uniV3ExtraConfig": { "nftAddress": "0xeaD19AE861c29bBb2101E834922B2FEee69B9091" }
+    }
+  },
   "perpl": {
     "methodology": "TVL is the total AUSD collateral deposited in the Perpl Exchange contract.",
     "monad": {


### PR DESCRIPTION
Adds **PerpMe**, a token launchpad on HyperEVM (chain 999), as an entry in `registries/sumTokens.js`.

- Website: https://perpme.fun
- Twitter: https://x.com/perpmefun
- Chain: hyperliquid (HyperEVM, 999)
- Locker: [`0x07c4f2dBBfaf75afC4c947e6bFEa13fEa8Eb267F`](https://hyperevmscan.io/address/0x07c4f2dBBfaf75afC4c947e6bFEa13fEa8Eb267F)
- Position manager (PRJX, Uniswap V3 fork): `0xeaD19AE861c29bBb2101E834922B2FEee69B9091`

### Methodology

Every launch mints its whole supply as a single-sided Uniswap V3 position on PRJX and sends the LP NFT to the locker, which has no function to decrease liquidity or transfer the position out — the liquidity is locked permanently. TVL is the **quote side** of those positions: HYPE, USDC, USD₮0 or PURR, whitelisted explicitly so that PerpMe-launched coins are excluded. Counting them would be circular, since each coin's only market is the very pool being measured.

Flagged `doublecounted: true`, since the liquidity lives in PRJX (Uniswap V3) pools.

This follows the same shape as the existing `hoodpump` entry, and the same locked-single-sided-V3 model as `noxa-fun`.

### Local test

```
$ node test.js perpme

--- hyperliquid ---
WHYPE                     23.34 k
USDC                      2.15 k
PURR                      2.11 k
USDT0                     168.58
Total: 27.77 k

------ TVL ------
hyperliquid               27.77 k
total                     27.77 k
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Hyperliquid registry support for Perpme, including TVL tracking and token coverage.
  * Added configuration for Uniswap V3 resolution and NFT-related data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->