### PR TITLE
Lagoon: add bsc, flare, hemi, rls

### DIFF
--- a/projects/lagoon/index.js
+++ b/projects/lagoon/index.js
@@ -40,6 +40,12 @@ const config = {
       fromBlock: 29100401
     },
   },
+  bsc: {
+    optinProxyFactory: {
+      address: "0x3f680ab9e51eeed9381de5275f4995611ff884d5",
+      fromBlock: 56083879
+    },
+  },
   berachain: {
     vaults: [],
     optinProxyFactory: {
@@ -71,6 +77,18 @@ const config = {
     beaconFactory: {
       address: "0x09C8803f7Dc251f9FaAE5f56E3B91f8A6d0b70ee",
       fromBlock: 22218451
+    },
+  },
+  flare: {
+    optinProxyFactory: {
+      address: "0x70274c69ef1fa492506394d982391c6f3008e785",
+      fromBlock: 67163254
+    },
+  },
+  hemi: {
+    optinProxyFactory: {
+      address: "0xb457e9c025a8af99e32b03668e34f80d20a71d2c",
+      fromBlock: 4091219
     },
   },
   hyperliquid: {
@@ -122,6 +140,12 @@ const config = {
     optinProxyFactory: {
       address: "0x0C0E287f6e4de685f4b44A5282A3ad4A29D05a91",
       fromBlock: 76939871
+    },
+  },
+  rls: {
+    optinProxyFactory: {
+      address: "0xfa032de1214fd89b465c306bf46f778318bde357",
+      fromBlock: 960000
     },
   },
   sonic: {

--- a/projects/lagoon/index.js
+++ b/projects/lagoon/index.js
@@ -43,8 +43,12 @@ const config = {
   bsc: {
     optinProxyFactory: {
       address: "0x3f680ab9e51eeed9381de5275f4995611ff884d5",
-      fromBlock: 56083879
+      fromBlock: 106552832 // day before the first vault deployment, factory logs are empty before
     },
+    // use this vault list if failed to get vault list from factory logs
+    fallbackVaults: [
+      "0x236582bb8e6b5d382e346d2ee80e1a7273d4cd4a", // SPY ETF
+    ],
   },
   berachain: {
     vaults: [],


### PR DESCRIPTION
Adds the remaining networks where Lagoon vault factories are deployed (listed by api.lagoon.finance), following the existing config pattern:

- **bsc** — optin factory `0x3f680ab9…`, fromBlock set a day before the first vault deployment (earlier blocks have no factory logs). Since public BSC RPCs cap getLogs ranges, it also uses the existing `fallbackVaults` mechanism (same as tac) with the one live vault.
- **flare** — optin factory `0x70274c69…`
- **hemi** — optin factory `0xb457e9c0…`
- **rls** (Rayls) — optin factory `0xfa032de1…`

Factory addresses come from Lagoon's public API (`api.lagoon.finance/query`, `chains` query) and start blocks from Lagoon's indexer config (we work with Lagoon).

Test output (`node test.js projects/lagoon/index.js` restricted to these chains):
- bsc: $127 (SPYx)
- hemi: $1 (USDC.e)
- flare: $0 (factory live, no vaults yet)
- rls: $0 (7 vaults discovered from logs, all empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added network configuration for BSC, Flare, Hemi, and RLS.
  * Added deployment start points for improved network data discovery.
  * Added a fallback vault list for BSC when factory log retrieval is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->