### PR TITLE
add coinbarrel

### DIFF
--- a/projects/coinbarrel/index.js
+++ b/projects/coinbarrel/index.js
@@ -2,32 +2,6 @@ const ADDRESSES = require('../helper/coreAssets.json')
 const { getLogs2 } = require('../helper/cache/getLogs')
 const { sumTokens2 } = require('../helper/unwrapLPs')
 
-// Coinbarrel (https://coinbarrel.com) is a token launchpad on Robinhood Chain (4663).
-//
-// A launch is one transaction: the launcher initializes a Uniswap V4 pool that
-// carries the Coinbarrel hook, mints the whole token supply as a single-sided
-// position, and sends that PositionManager NFT straight into an ownerless,
-// non-upgradeable custody contract with no transfer, approve, withdraw or
-// decrease-liquidity path. Traders buying into the pool leave quote asset (ETH
-// or USDG) inside those positions, and nobody, Coinbarrel included, can take it
-// out again. That locked quote-side balance is what this adapter counts.
-//
-// Enumeration is on-chain: every NFT the custody holds arrived through an
-// ERC-721 Transfer on the Uniswap V4 PositionManager with `to == custody`
-// (mints on launch, plus the migrations that moved the legacy Advanced-hook
-// positions into the same custody). Ownership is re-verified with ownerOf.
-//
-// Launched tokens themselves are excluded (whitelist of quote assets only) to
-// avoid circular pricing. Third-party liquidity in the same pools belongs to
-// its own LPs and is left to the Uniswap V4 listing.
-//
-// Legacy "Simple" launches (July 2026, before the V4 hook generation) sit on
-// Uniswap V3 with the same permanent-custody design; their NFTs are enumerated
-// directly from the V3 NonfungiblePositionManager.
-//
-// Addresses: https://coinbarrel.com/integrations/robinhood/deployments.json
-// Docs:      https://docs.coinbarrel.com/protocol/liquidity-custody
-
 const config = {
   robinhood: {
     v4: {
@@ -106,7 +80,6 @@ module.exports = {
   doublecounted: true, // positions live in Uniswap V4 / V3 pools counted by the Uniswap listings
   hallmarks: [
     ['2026-07-28', 'Hook V5 generation live (unified launcher on Uniswap V4)'],
-    ['2026-08-01', 'Flat 1% platform fee model'],
   ],
   robinhood: { tvl },
 }

--- a/projects/coinbarrel/index.js
+++ b/projects/coinbarrel/index.js
@@ -1,0 +1,112 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+const { getLogs2 } = require('../helper/cache/getLogs')
+const { sumTokens2 } = require('../helper/unwrapLPs')
+
+// Coinbarrel (https://coinbarrel.com) is a token launchpad on Robinhood Chain (4663).
+//
+// A launch is one transaction: the launcher initializes a Uniswap V4 pool that
+// carries the Coinbarrel hook, mints the whole token supply as a single-sided
+// position, and sends that PositionManager NFT straight into an ownerless,
+// non-upgradeable custody contract with no transfer, approve, withdraw or
+// decrease-liquidity path. Traders buying into the pool leave quote asset (ETH
+// or USDG) inside those positions, and nobody, Coinbarrel included, can take it
+// out again. That locked quote-side balance is what this adapter counts.
+//
+// Enumeration is on-chain: every NFT the custody holds arrived through an
+// ERC-721 Transfer on the Uniswap V4 PositionManager with `to == custody`
+// (mints on launch, plus the migrations that moved the legacy Advanced-hook
+// positions into the same custody). Ownership is re-verified with ownerOf.
+//
+// Launched tokens themselves are excluded (whitelist of quote assets only) to
+// avoid circular pricing. Third-party liquidity in the same pools belongs to
+// its own LPs and is left to the Uniswap V4 listing.
+//
+// Legacy "Simple" launches (July 2026, before the V4 hook generation) sit on
+// Uniswap V3 with the same permanent-custody design; their NFTs are enumerated
+// directly from the V3 NonfungiblePositionManager.
+//
+// Addresses: https://coinbarrel.com/integrations/robinhood/deployments.json
+// Docs:      https://docs.coinbarrel.com/protocol/liquidity-custody
+
+const config = {
+  robinhood: {
+    v4: {
+      positionManager: '0x58daec3116aae6d93017baaea7749052e8a04fa7', // Uniswap V4 PositionManager
+      stateView: '0xf3334192d15450cdd385c8b70e03f9a6bd9e673b',       // Uniswap V4 StateView
+      custody: '0x418ece71c4ece08b71db8c53d59b6bc345efc659',         // PermanentV4PositionCustody
+      fromBlock: 11467067,                                            // custody deployment (2026-07-16)
+      quoteAssets: [ADDRESSES.null, ADDRESSES.robinhood.WETH, ADDRESSES.robinhood.USDG],
+    },
+    v3: {
+      nftManager: '0x73991a25c818bf1f1128deaab1492d45638de0d3',      // Uniswap V3 NonfungiblePositionManager
+      custody: '0x0e88ba639f062feaa5f36a8d5f689d3e93bce593',         // PermanentV3PositionCustody
+      quoteAssets: [ADDRESSES.robinhood.WETH],
+    },
+  },
+}
+
+const TRANSFER_TOPIC = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
+const TRANSFER_EVENT = 'event Transfer(address indexed from, address indexed to, uint256 indexed id)'
+
+function padAddress(address) {
+  return '0x' + address.toLowerCase().replace('0x', '').padStart(64, '0')
+}
+
+async function tvl(api) {
+  const { v4, v3 } = config[api.chain]
+
+  // 1. Uniswap V4 positions locked in the permanent custody (hook generations 1-5).
+  const transfers = await getLogs2({
+    api,
+    target: v4.positionManager,
+    eventAbi: TRANSFER_EVENT,
+    topics: [TRANSFER_TOPIC, null, padAddress(v4.custody)],
+    fromBlock: v4.fromBlock,
+    extraKey: 'coinbarrel-custody',
+  })
+  const candidateIds = [...new Set(transfers.map((log) => log.id.toString()))]
+
+  if (candidateIds.length) {
+    const owners = await api.multiCall({
+      target: v4.positionManager,
+      abi: 'function ownerOf(uint256 tokenId) view returns (address)',
+      calls: candidateIds,
+      permitFailure: true,
+    })
+    const positionIds = candidateIds.filter((_, i) => owners[i]?.toLowerCase() === v4.custody)
+
+    if (positionIds.length) {
+      await sumTokens2({
+        api,
+        resolveUniV4: true,
+        uniV4ExtraConfig: {
+          positionIds,
+          nftAddress: v4.positionManager,
+          stateViewer: v4.stateView,
+          whitelistedTokens: v4.quoteAssets,
+        },
+      })
+    }
+  }
+
+  // 2. Legacy Simple launches: Uniswap V3 positions locked in the V3 custody.
+  return sumTokens2({
+    api,
+    owner: v3.custody,
+    resolveUniV3: true,
+    uniV3ExtraConfig: { nftAddress: v3.nftManager },
+    uniV3WhitelistedTokens: v3.quoteAssets,
+  })
+}
+
+module.exports = {
+  methodology:
+    'Quote-asset side (ETH, WETH, USDG) of the Uniswap V4 launch positions permanently held by Coinbarrel\'s ownerless custody contract, enumerated on-chain from PositionManager Transfer events into the custody and re-verified with ownerOf, plus the WETH side of legacy Uniswap V3 launch positions held by the V3 custody. Launched tokens are excluded to avoid circular pricing. Marked doublecounted because these positions already sit inside Uniswap V4 and Uniswap V3 TVL on Robinhood Chain.',
+  start: '2026-07-13', // first Coinbarrel launcher deployed on Robinhood Chain (block 8955028)
+  doublecounted: true, // positions live in Uniswap V4 / V3 pools counted by the Uniswap listings
+  hallmarks: [
+    ['2026-07-28', 'Hook V5 generation live (unified launcher on Uniswap V4)'],
+    ['2026-08-01', 'Flat 1% platform fee model'],
+  ],
+  robinhood: { tvl },
+}


### PR DESCRIPTION
## New listing information

##### Name (to be shown on DefiLlama):

Coinbarrel

##### Twitter Link:

https://x.com/coinbarrel

##### List of audit links if any:

No third-party audit. Contracts are source-verified on Blockscout (https://robinhoodchain.blockscout.com) and published with ABIs at https://coinbarrel.com/integrations/robinhood/deployments.json.

##### Website Link:

https://coinbarrel.com/

##### Logo (High resolution, will be shown with rounded borders):

https://coinbarrel.com/assets/CB-Logo-Solo.svg (vector). A 512x512 PNG of the same mark ships with the next site deploy at https://coinbarrel.com/assets/CB-Logo-Solo-512.png; happy to attach it here if you prefer a raster.

##### Current TVL:

~$40k on Robinhood Chain at the time of local testing (quote-asset side of the permanently locked launch positions only).

##### Treasury Addresses (if the protocol has treasury)

Robinhood Chain: 0x2FE3C1cc641B2463CEE2857Ac520E111fbE11fDF

##### Chain:

Robinhood Chain

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):



##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):



##### Short Description (to be shown on DefiLlama):

Coinbarrel is a token launchpad on Robinhood Chain. A launch is one transaction that creates a Uniswap V4 pool with a Coinbarrel hook, locks the launch liquidity permanently, and routes a creator-configured trading fee to creators, holder rewards, reinvestment or burn.

##### Token address and ticker if any:

CB, 0x26E82171eb01204eE114e2B8C34Be035B8bc029E (Robinhood Chain); Solana mint FG53WF6VGMb3eg19A76p4x6Ht267q2kze89h79MhZ9CB (same supply, bridged over LayerZero)

##### Category (full list at https://defillama.com/categories) \*Please choose only one:

Launchpad

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

None

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

N/A

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

N/A

##### forkedFrom (Does your project originate from another project):

No. Built on Uniswap V4 hooks (launch pools live on the canonical Uniswap V4 PoolManager on Robinhood Chain).

##### methodology (what is being counted as tvl, how is tvl being calculated):

Quote-asset side (ETH, WETH, USDG) of the Uniswap V4 launch positions permanently held by Coinbarrel's ownerless, non-upgradeable custody contract (0x418eCe71c4ECe08B71dB8C53D59B6bc345EFc659; no transfer, approve, withdraw or decrease-liquidity path), enumerated on-chain from PositionManager Transfer events into the custody and re-verified with ownerOf, plus the WETH side of the legacy Uniswap V3 launch positions held by the V3 custody (0x0e88ba639f062feaa5f36a8d5f689d3e93bce593). Launched tokens are excluded to avoid circular pricing. Marked `doublecounted` because these positions sit inside Uniswap V4 and Uniswap V3 pools that the Uniswap listings already count on Robinhood Chain.

##### Github org/user (Optional, if your code is open source, we can track activity):

(private)

##### Does this project have a referral program?

No

## Testing

```bash
node test.js projects/coinbarrel/index.js
```

Enumerates 117 Uniswap V4 positions in the permanent custody plus the legacy V3 custody positions and returns non-zero Robinhood Chain TVL in ETH, WETH and USDG only (no unknown tokens).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Total Value Locked (TVL) tracking for Coinbarrel on Robinhood Chain.
  * Includes eligible Uniswap V4 and legacy Uniswap V3 custody positions.
  * Supports valuation of approved quote assets and displays deployment details.

* **Documentation**
  * Added methodology and coverage notes.
  * Clarified that reported TVL may overlap with Uniswap listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->