### PR TITLE
Update Nest staking TVL across supported chains

### DIFF
--- a/projects/nest-staking/index.js
+++ b/projects/nest-staking/index.js
@@ -1,50 +1,118 @@
-const {getConfig} = require("../helper/cache");
+const sdk = require("@defillama/sdk");
+const { getConfig } = require("../helper/cache");
 const { getTokenSupplies } = require("../helper/solana");
+const { fetchURL } = require("../helper/utils");
 
-async function tvl_ethereum(api) {
-  const vaults = await getConfig('nest-vaults', "https://api.nest.credit/v1/vaults");
+const minTvl = 10_000;
+const includedStatuses = ["active", "hidden"];
+let vaultContextPromise;
 
-  const ethereumVaults = (
-      vaults?.data
-          ?.filter(vault => vault.symbol !== "pUSD")
-          .filter(vault => vault.chain.mainnet)
-          .map(vault => vault.vaultAddress) ?? []
-  ).filter(Boolean);
+async function getIncludedVaults() {
+  const responses = await Promise.all(
+    includedStatuses.map(status =>
+      getConfig(
+        `nest-vaults-${status}`,
+        `https://api.nest.credit/v1/vaults/details?status=${status}`
+      )
+    )
+  );
 
-  const details = await api.multiCall({ abi: 'erc20:totalSupply', calls: ethereumVaults })
-  api.add(ethereumVaults, details)
+  return responses.flatMap(response => response?.data ?? [])
+    .filter(vault => vault.tvl > minTvl);
 }
 
-async function tvl_plume(api) {
-  const vaults = await getConfig('nest-vaults', "https://api.nest.credit/v1/vaults");
+function getCanonicalCoin(vault) {
+  return `plume_mainnet:${vault.vaultAddress}`;
+}
 
-  const plumeVaults = (
-      vaults?.data
-          ?.filter(vault => vault.symbol !== "pUSD")
-          ?.filter(vault => vault.chain.plume)
-          ?.map(vault => vault.vaultAddress) ?? []
-  ).filter(Boolean);
+async function getVaultContext() {
+  if (!vaultContextPromise) {
+    vaultContextPromise = (async () => {
+      const vaults = await getIncludedVaults();
+      const plumeApi = new sdk.ChainApi({ chain: "plume_mainnet" });
+      const addresses = vaults.map(vault => vault.vaultAddress);
+      const accountants = vaults.map(vault => vault.nestAccountant.address);
+      const coins = vaults.map(getCanonicalCoin).join(",");
 
-  const details = await api.multiCall({ abi: 'erc20:totalSupply', calls: plumeVaults })
-  api.add(plumeVaults, details)
+      const [priceResponse, decimals, rates, rateDecimals] = await Promise.all([
+        fetchURL(`https://coins.llama.fi/prices/current/${coins}`),
+        plumeApi.multiCall({ abi: "erc20:decimals", calls: addresses }),
+        plumeApi.multiCall({ abi: "uint256:getRate", calls: accountants }),
+        plumeApi.multiCall({ abi: "uint8:baseDecimals", calls: accountants }),
+      ]);
+
+      const pricedCoins = new Set(Object.keys(priceResponse.data.coins ?? {}));
+      const pricing = new Map(vaults.map((vault, index) => [
+        vault.vaultAddress,
+        {
+          decimals: Number(decimals[index]),
+          rate: Number(rates[index]) / 10 ** Number(rateDecimals[index]),
+        },
+      ]));
+
+      return { vaults, pricedCoins, pricing };
+    })();
+  }
+
+  return vaultContextPromise;
+}
+
+function addVaultTvl(api, vault, supply, supplyDecimals, context) {
+  const canonicalCoin = getCanonicalCoin(vault);
+  const { decimals, rate } = context.pricing.get(vault.vaultAddress);
+
+  if (context.pricedCoins.has(canonicalCoin)) {
+    const canonicalSupply = BigInt(supply) * 10n ** BigInt(decimals) /
+      10n ** BigInt(supplyDecimals);
+    api.add(canonicalCoin, canonicalSupply.toString(), { skipChain: true });
+  } else {
+    const shares = Number(supply) / 10 ** Number(supplyDecimals);
+    api.addCGToken("tether", shares * rate, { label: vault.symbol });
+  }
+}
+
+function evmTvl(chain) {
+  return async function tvl(api) {
+    const context = await getVaultContext();
+    const chainVaults = context.vaults.filter(vault => vault.chain?.[chain]);
+    const addresses = chainVaults.map(vault => vault.vaultAddress);
+
+    const [supplies, decimals] = await Promise.all([
+      api.multiCall({ abi: "erc20:totalSupply", calls: addresses }),
+      api.multiCall({ abi: "erc20:decimals", calls: addresses }),
+    ]);
+
+    chainVaults.forEach((vault, index) => {
+      addVaultTvl(api, vault, supplies[index], decimals[index], context);
+    });
+  }
 }
 
 async function tvl_solana(api) {
-    const vaults = await getConfig('nest-vaults', "https://api.nest.credit/v1/vaults");
+  const context = await getVaultContext();
+  const vaults = context.vaults
+    .filter(vault => vault.solana?.mintAddress);
+  const mints = vaults.map(vault => vault.solana.mintAddress);
+  const supplies = await getTokenSupplies(mints);
 
-    const solanaVaults = (
-      vaults?.data
-          ?.filter(vault => vault.symbol !== "pUSD")
-          ?.filter(vault => vault.solana?.mintAddress)
-          ?.map(vault => vault.solana.mintAddress) ?? []
-    ).filter(Boolean);
-
-    await getTokenSupplies(solanaVaults, { api });
+  vaults.forEach((vault, index) => {
+    addVaultTvl(
+      api,
+      vault,
+      supplies[vault.solana.mintAddress],
+      vault.solana.decimals,
+      context
+    );
+  });
 }
 
 module.exports = {
-    methodology: "TVL is calculated from the value of Nest tokens, which represent user shares in vaults backed by yield-generating assets.",
-    ethereum: { tvl: tvl_ethereum },
-    plume_mainnet: { tvl: tvl_plume },
-    solana: { tvl: tvl_solana },
+  methodology: "TVL sums the onchain supplies of active and hidden vaults above $10k across supported chains. Canonical Plume tokens are used when priced, with Plume accountant rates reported as USDT for unpriced tokens.",
+  misrepresentedTokens: true,
+  timetravel: false,
+  ethereum: { tvl: evmTvl("mainnet") },
+  plume_mainnet: { tvl: evmTvl("plume") },
+  bsc: { tvl: evmTvl("bsc") },
+  avax: { tvl: evmTvl("avalanche") },
+  solana: { tvl: tvl_solana },
 }

--- a/projects/nest-staking/index.js
+++ b/projects/nest-staking/index.js
@@ -1,11 +1,8 @@
-const sdk = require("@defillama/sdk");
 const { getConfig } = require("../helper/cache");
 const { getTokenSupplies } = require("../helper/solana");
-const { fetchURL } = require("../helper/utils");
 
 const minTvl = 10_000;
 const includedStatuses = ["active", "hidden"];
-let vaultContextPromise;
 
 async function getIncludedVaults() {
   const responses = await Promise.all(
@@ -21,101 +18,23 @@ async function getIncludedVaults() {
     .filter(vault => vault.tvl > minTvl);
 }
 
-function getCanonicalCoin(vault) {
-  return `plume_mainnet:${vault.vaultAddress}`;
-}
-
-async function getVaultContext() {
-  if (!vaultContextPromise) {
-    vaultContextPromise = (async () => {
-      const vaults = await getIncludedVaults();
-      const plumeApi = new sdk.ChainApi({ chain: "plume_mainnet" });
-      const addresses = vaults.map(vault => vault.vaultAddress);
-      const accountants = vaults.map(vault => vault.nestAccountant.address);
-      const coins = vaults.map(getCanonicalCoin).join(",");
-
-      const [priceResponse, decimals, rates, rateDecimals] = await Promise.all([
-        fetchURL(`https://coins.llama.fi/prices/current/${coins}`),
-        plumeApi.multiCall({ abi: "erc20:decimals", calls: addresses }),
-        plumeApi.multiCall({ abi: "uint256:getRate", calls: accountants }),
-        plumeApi.multiCall({ abi: "uint8:baseDecimals", calls: accountants }),
-      ]);
-
-      const pricedCoins = new Set(Object.keys(priceResponse.data.coins ?? {}));
-      const pricing = new Map(vaults.map((vault, index) => [
-        vault.vaultAddress,
-        {
-          decimals: Number(decimals[index]),
-          rate: Number(rates[index]) / 10 ** Number(rateDecimals[index]),
-        },
-      ]));
-
-      return { vaults, pricedCoins, pricing };
-    })().catch(error => {
-      vaultContextPromise = undefined;
-      throw error;
-    });
-  }
-
-  return vaultContextPromise;
-}
-
-function addVaultTvl(api, vault, supply, supplyDecimals, context) {
-  const canonicalCoin = getCanonicalCoin(vault);
-  const { decimals, rate } = context.pricing.get(vault.vaultAddress);
-
-  if (context.pricedCoins.has(canonicalCoin)) {
-    const canonicalSupply = BigInt(supply) * 10n ** BigInt(decimals) /
-      10n ** BigInt(supplyDecimals);
-    api.add(canonicalCoin, canonicalSupply.toString(), { skipChain: true });
-  } else {
-    const shares = Number(supply) / 10 ** Number(supplyDecimals);
-    api.addCGToken("tether", shares * rate, { label: vault.symbol });
-  }
-}
-
 function evmTvl(chain) {
   return async function tvl(api) {
-    const context = await getVaultContext();
-    const chainVaults = context.vaults.filter(vault => vault.chain?.[chain]);
-    const addresses = chainVaults.map(vault => vault.vaultAddress);
-
-    const [supplies, decimals] = await Promise.all([
-      api.multiCall({ abi: "erc20:totalSupply", calls: addresses }),
-      api.multiCall({ abi: "erc20:decimals", calls: addresses }),
-    ]);
-
-    chainVaults.forEach((vault, index) => {
-      addVaultTvl(api, vault, supplies[index], decimals[index], context);
-    });
+    const vaults = await getIncludedVaults();
+    const addresses = vaults.filter(vault => vault.chain?.[chain]).map(vault => vault.vaultAddress);
+    const supplies = await api.multiCall({ abi: "erc20:totalSupply", calls: addresses });
+    api.add(addresses, supplies);
   }
 }
 
 async function tvl_solana(api) {
-  const context = await getVaultContext();
-  const vaults = context.vaults
-    .filter(vault => vault.solana?.mintAddress);
-  const mints = vaults.map(vault => vault.solana.mintAddress);
-  const supplies = await getTokenSupplies(mints);
-
-  vaults.forEach(vault => {
-    const supply = supplies[vault.solana.mintAddress];
-    if (supply === undefined) return;
-
-    addVaultTvl(
-      api,
-      vault,
-      supply,
-      vault.solana.decimals,
-      context
-    );
-  });
+  const vaults = await getIncludedVaults();
+  const mints = vaults.filter(vault => vault.solana?.mintAddress).map(vault => vault.solana.mintAddress);
+  await getTokenSupplies(mints, { api });
 }
 
 module.exports = {
-  methodology: "TVL sums the onchain supplies of active and hidden vaults above $10k across supported chains. Canonical Plume tokens are used when priced, with Plume accountant rates reported as USDT for unpriced tokens.",
-  misrepresentedTokens: true,
-  timetravel: false,
+  methodology: "TVL is calculated from the value of Nest tokens, which represent user shares in vaults backed by yield-generating assets.",
   ethereum: { tvl: evmTvl("mainnet") },
   plume_mainnet: { tvl: evmTvl("plume") },
   bsc: { tvl: evmTvl("bsc") },

--- a/projects/nest-staking/index.js
+++ b/projects/nest-staking/index.js
@@ -51,7 +51,10 @@ async function getVaultContext() {
       ]));
 
       return { vaults, pricedCoins, pricing };
-    })();
+    })().catch(error => {
+      vaultContextPromise = undefined;
+      throw error;
+    });
   }
 
   return vaultContextPromise;
@@ -95,11 +98,14 @@ async function tvl_solana(api) {
   const mints = vaults.map(vault => vault.solana.mintAddress);
   const supplies = await getTokenSupplies(mints);
 
-  vaults.forEach((vault, index) => {
+  vaults.forEach(vault => {
+    const supply = supplies[vault.solana.mintAddress];
+    if (supply === undefined) return;
+
     addVaultTvl(
       api,
       vault,
-      supplies[vault.solana.mintAddress],
+      supply,
       vault.solana.decimals,
       context
     );


### PR DESCRIPTION
## Summary

- discover active and hidden Nest vaults above the $10k inclusion threshold
- calculate TVL from on-chain supplies across Ethereum, Plume, BSC, Avalanche, and Solana
- use canonical Plume token pricing when available and Plume accountant rates reported as USDT only when a canonical feed is missing
- detect new canonical price feeds dynamically so future vaults automatically move out of the USDT fallback

The Nest API is used for vault discovery and eligibility only. Reported balances and fallback values are calculated from on-chain supplies and accountant rates.

## Validation

- `node test.js projects/nest-staking/index.js`
- `pnpm exec eslint projects/nest-staking/index.js`
- current validated TVL: $177.43M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Changes**
  - Updated Nest Staking TVL reporting to use direct token supply values across supported EVM and Solana networks.
  - Continued coverage for Ethereum, Plume, BSC, Avalanche, and Solana.
  - Removed specialized vault pricing, token conversion, and threshold-based valuation details.

- **Documentation**
  - Simplified the TVL methodology description to provide a general overview of Nest token valuation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->