### PR TITLE
fix(uniswap-v4): blacklist mispriced fake SAND on BSC

### DIFF
--- a/projects/uniswap-v4/index.js
+++ b/projects/uniswap-v4/index.js
@@ -41,7 +41,9 @@ const config = {
   bsc: { factory: "0x28e2ea090877bf75740558f6bfb36a5ffee9e9df", fromBlock: 45970610, blacklistedTokens: ['0xb4357054c3dA8D46eD642383F03139aC7f090343', '0x8145eb83744aac883b68ae34060bebb5031d8f5c',
     '0x8d010bf9c26881788b4e6bf5fd1bdc358c8f90b8', // DOT was hacked
     '0x7083609fce4d1d8dc0c979aab8c869ea2c873402', // DOT was hacked
-    '0x44f161ae29361e332dea039dfa2f404e0bc5b5cc' // H hacked 2026-06-08
+    '0x44f161ae29361e332dea039dfa2f404e0bc5b5cc', // H hacked 2026-06-08
+    '0xac531eb26ca1d21b85126de8fb87e80e09002dcf', // fake SAND mispriced on BSC (~$5.6B phantom TVL)
+
   ] },
   unichain: { factory: "0x1F98400000000000000000000000000000000004", fromBlock: 1 },
   monad: { factory: "0x188d586ddcf52439676ca21a244753fa19f9ea8e", fromBlock: 29255895 },


### PR DESCRIPTION
Fixes #20659

## Problem
BSC token `0xac531eb26ca1d21b85126de8fb87e80e09002dcf` reports `name()`/`symbol()` as SAND but is not Binance-Peg SAND (`0x67b725d7e342d7b611fa85e859df9697d9378b2e`). `coins.llama.fi` prices it at ~$0.045 while GeckoTerminal shows ~$1.7e-10, inflating Uniswap v4 BSC TVL by ~$5.6B.

## Fix
Add the token to BSC `blacklistedTokens` in `projects/uniswap-v4/index.js`, same pattern as existing mispriced-token exclusions (BOBO, BLOTIX, etc.).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated BSC token exclusions to prevent a fake SAND token with mispriced TVL from affecting displayed data.
  - Retained protection for the previously identified hacked token address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->