### PR TITLE
Add Anchored TVL adapter

### DIFF
--- a/projects/anchored/index.js
+++ b/projects/anchored/index.js
@@ -157,7 +157,7 @@ const tvl = async (api) => {
 
 module.exports = {
   methodology:
-    "TVL is the onchain supply of every Anchored token valued at its onchain reference price. Tokenized stocks and ETFs are enumerated from Anchored's token factory on each chain and priced with the StockOracle contract, which publishes one price per underlying ticker. Tokenized funds are enumerated from the fund controller on Ethereum and valued at the latest NAV per share published to the onchain nav registry. Every token is backed 1:1 by the underlying share or fund interest held in regulated custody, and reserves are attested independently at https://accountable.anchored.finance.",
+    'TVL = sum of (tokenized stock supply x oracle price) + sum of (fund share supply x latest NAV per share). Stocks and ETFs are enumerated per chain from the AncTokenFactory registry and valued with StockOracle.latestPrice, keyed by keccak256 of the uppercase underlying ticker. Funds are enumerated from AncFundController on Ethereum and valued at the latest NAV per share published to AncFundNavRecord. Nothing is hardcoded and no Anchored API is called: both the asset list and the prices come from contract reads, so newly issued assets are picked up without an adapter change. Every token is backed 1:1 by the underlying share or fund interest held in regulated custody, and reserves are attested independently at https://accountable.anchored.finance.',
   ethereum: { tvl },
   monad: { tvl },
   base: { tvl },

--- a/projects/anchored/index.js
+++ b/projects/anchored/index.js
@@ -28,10 +28,9 @@ const PRICE_CHAIN = 'arbitrum'
 const PRICE_DECIMALS = 8
 const NAV_DECIMALS = 6
 
-// fundConfigs is indexed by a 1-based fundId with no length getter, and nav
-// records are a gapless 1-based sequence, so both are probed in windows until
-// the first miss.
-const FUND_ID_SCAN = 32
+// The nav registry keeps its record counter private, so its gapless 1-based
+// sequence is probed in windows until the first miss. Funds need no such scan:
+// the controller exposes its own counter.
 const NAV_SCAN_WINDOW = 100
 
 const abi = {
@@ -39,6 +38,7 @@ const abi = {
   tokenAtIndex: 'function tokenAtIndex(uint16 index) view returns (address)',
   latestPrice:
     'function latestPrice(bytes32 priceId) view returns ((int128 price, int128 bestBid, int128 bestAsk, uint64 feedUpdateTimestamp, uint64 publishedAt, uint80 roundId, uint8 session))',
+  nextFundId: 'function nextFundId() view returns (uint16)',
   fundConfigs:
     'function fundConfigs(uint16 fundId) view returns ((uint16 index, uint16 feeBps, address shareToken, uint64 subscriptionWindow, uint64 currentRedemptionSchedule, uint64 nextRedemptionSchedule, uint32 minSubscriptionUsd))',
   getNavRecord:
@@ -88,11 +88,15 @@ async function addStocks(api) {
 }
 
 async function addFunds(api) {
+  // Fund ids are handed out from a 1-based counter, so the registry is exactly
+  // 1..nextFundId-1 with no gaps and no scanning.
+  const nextFundId = Number(await api.call({ target: FUND_CONTROLLER, abi: abi.nextFundId }))
+  if (nextFundId < 2) return
+
   const configs = await api.multiCall({
     target: FUND_CONTROLLER,
     abi: abi.fundConfigs,
-    calls: [...Array(FUND_ID_SCAN).keys()].map((i) => i + 1),
-    permitFailure: true,
+    calls: [...Array(nextFundId - 1).keys()].map((i) => i + 1),
   })
 
   const shareTokens = {}

--- a/projects/anchored/index.js
+++ b/projects/anchored/index.js
@@ -1,0 +1,165 @@
+const sdk = require('@defillama/sdk')
+const { ethers } = require('ethers')
+
+/**
+ * Anchored issues tokenized US stocks/ETFs (`aAAPL`, `aSPY`, ...) and tokenized
+ * funds (`aDHF`, `aLSF`, `aAIF`). Every token is an ERC20 backed 1:1 by the
+ * underlying held in regulated custody, so TVL is the onchain supply of those
+ * tokens valued at the reference price published onchain by Anchored's own
+ * oracle contracts.
+ *
+ * Nothing here is hardcoded per asset: the stock tokens are enumerated from the
+ * onchain token factory and the funds from the onchain fund controller, so
+ * newly issued assets are picked up without an adapter change.
+ */
+
+// Deployed at the same deterministic address on every supported chain.
+const TOKEN_FACTORY = '0x500769f4544c5cc75436a615101f27ff4350469a'
+const STOCK_ORACLE = '0x037848af338c38e1e0ab722be80bf4c2e612a1f7'
+
+// Funds are issued on Ethereum only.
+const FUND_CONTROLLER = '0xfdc272fd757075388e35f8ddab42fac510b87e73'
+const FUND_NAV_RECORD = '0x66a534c68f27e5523081243b7fa02e68711a1a04'
+
+// The stock oracle carries a registered priceId per underlying ticker on this
+// chain; prices are the same reference price on every chain the token exists on.
+const PRICE_CHAIN = 'arbitrum'
+
+const PRICE_DECIMALS = 8
+const NAV_DECIMALS = 6
+
+// fundConfigs is indexed by a 1-based fundId with no length getter, and nav
+// records are a gapless 1-based sequence, so both are probed in windows until
+// the first miss.
+const FUND_ID_SCAN = 32
+const NAV_SCAN_WINDOW = 100
+
+const abi = {
+  tokenCount: 'function tokenCount() view returns (uint16)',
+  tokenAtIndex: 'function tokenAtIndex(uint16 index) view returns (address)',
+  latestPrice:
+    'function latestPrice(bytes32 priceId) view returns ((int128 price, int128 bestBid, int128 bestAsk, uint64 feedUpdateTimestamp, uint64 publishedAt, uint80 roundId, uint8 session))',
+  fundConfigs:
+    'function fundConfigs(uint16 fundId) view returns ((uint16 index, uint16 feeBps, address shareToken, uint64 subscriptionWindow, uint64 currentRedemptionSchedule, uint64 nextRedemptionSchedule, uint32 minSubscriptionUsd))',
+  getNavRecord:
+    'function getNavRecord(uint64 navRecordId) view returns (uint16 fundId, uint128 nav, uint32 sourceUpdatedAt, uint32 recordedAt)',
+}
+
+const field = (result, name, index) => (Array.isArray(result) ? result[index] : result[name])
+
+async function addStocks(api) {
+  const tokens = await api.fetchList({
+    lengthAbi: abi.tokenCount,
+    itemAbi: abi.tokenAtIndex,
+    target: TOKEN_FACTORY,
+  })
+
+  const [supplies, symbols, decimals] = await Promise.all([
+    api.multiCall({ abi: 'erc20:totalSupply', calls: tokens }),
+    api.multiCall({ abi: 'erc20:symbol', calls: tokens }),
+    api.multiCall({ abi: 'erc20:decimals', calls: tokens }),
+  ])
+
+  // `aAAPL` tracks `AAPL`; the oracle keys each asset by keccak256 of the
+  // uppercase underlying ticker.
+  const priceIds = symbols.map((symbol) => ethers.id(symbol.replace(/^a/, '').toUpperCase()))
+
+  const priceApi =
+    api.chain === PRICE_CHAIN ? api : new sdk.ChainApi({ chain: PRICE_CHAIN, timestamp: api.timestamp })
+  // permitFailure covers the odd ticker that has no registered priceId yet; a
+  // reverted read for every one of them means the oracle itself is unreachable,
+  // which must not be reported as an empty chain.
+  const payloads = await priceApi.multiCall({
+    target: STOCK_ORACLE,
+    abi: abi.latestPrice,
+    calls: priceIds,
+    permitFailure: true,
+  })
+  if (tokens.length && !payloads.some((payload) => payload))
+    throw new Error(`Anchored: no price resolved on ${PRICE_CHAIN} for any of ${tokens.length} tokens`)
+
+  supplies.forEach((supply, i) => {
+    const payload = payloads[i]
+    if (!payload || !supply) return
+    const price = Number(field(payload, 'price', 0)) / 10 ** PRICE_DECIMALS
+    if (!(price > 0)) return
+    api.addUSDValue((Number(supply) / 10 ** Number(decimals[i])) * price)
+  })
+}
+
+async function addFunds(api) {
+  const configs = await api.multiCall({
+    target: FUND_CONTROLLER,
+    abi: abi.fundConfigs,
+    calls: [...Array(FUND_ID_SCAN).keys()].map((i) => i + 1),
+    permitFailure: true,
+  })
+
+  const shareTokens = {}
+  configs.forEach((config, i) => {
+    if (!config) return
+    const shareToken = field(config, 'shareToken', 2)
+    if (!shareToken || shareToken === ethers.ZeroAddress) return
+    shareTokens[i + 1] = shareToken
+  })
+  if (!Object.keys(shareTokens).length) return
+
+  const navs = await latestNavs(api)
+  const funds = Object.entries(shareTokens).filter(([fundId]) => navs[fundId] !== undefined)
+  // Every live fund has published at least one nav, so an empty result means the
+  // registry read failed rather than that the funds are worth nothing.
+  if (!funds.length)
+    throw new Error(`Anchored: no nav record found for any of ${Object.keys(shareTokens).length} funds`)
+
+  const [supplies, decimals] = await Promise.all([
+    api.multiCall({ abi: 'erc20:totalSupply', calls: funds.map(([, token]) => token) }),
+    api.multiCall({ abi: 'erc20:decimals', calls: funds.map(([, token]) => token) }),
+  ])
+
+  funds.forEach(([fundId], i) => {
+    if (!supplies[i]) return
+    const nav = Number(navs[fundId]) / 10 ** NAV_DECIMALS
+    if (!(nav > 0)) return
+    api.addUSDValue((Number(supplies[i]) / 10 ** Number(decimals[i])) * nav)
+  })
+}
+
+/**
+ * The nav registry keys records by an incrementing id shared by all funds and
+ * exposes neither the counter nor a per-fund pointer, so the sequence is walked
+ * until it runs out and the last record seen for each fund wins.
+ */
+async function latestNavs(api) {
+  const navs = {}
+  for (let start = 1; ; start += NAV_SCAN_WINDOW) {
+    const records = await api.multiCall({
+      target: FUND_NAV_RECORD,
+      abi: abi.getNavRecord,
+      calls: [...Array(NAV_SCAN_WINDOW).keys()].map((i) => start + i),
+      permitFailure: true,
+    })
+
+    let found = 0
+    records.forEach((record) => {
+      if (!record) return
+      found++
+      navs[Number(field(record, 'fundId', 0))] = field(record, 'nav', 1)
+    })
+
+    if (found < NAV_SCAN_WINDOW) return navs
+  }
+}
+
+const tvl = async (api) => {
+  await addStocks(api)
+  if (api.chain === 'ethereum') await addFunds(api)
+}
+
+module.exports = {
+  methodology:
+    "TVL is the onchain supply of every Anchored token valued at its onchain reference price. Tokenized stocks and ETFs are enumerated from Anchored's token factory on each chain and priced with the StockOracle contract, which publishes one price per underlying ticker. Tokenized funds are enumerated from the fund controller on Ethereum and valued at the latest NAV per share published to the onchain nav registry. Every token is backed 1:1 by the underlying share or fund interest held in regulated custody, and reserves are attested independently at https://accountable.anchored.finance.",
+  ethereum: { tvl },
+  monad: { tvl },
+  base: { tvl },
+  arbitrum: { tvl },
+}


### PR DESCRIPTION
Anchored issues tokenized US stocks, ETFs and fund strategies as ERC-20 tokens backed 1:1 by the underlying held in regulated custody.

Both asset sets are enumerated onchain rather than hardcoded — stocks from the AncTokenFactory registry that is deployed at the same address on all four chains, funds from the fund controller on Ethereum — so newly issued assets are picked up without an adapter change. Supply is valued with Anchored's own onchain oracles: a per-ticker reference price for stocks and the latest published NAV per share for funds.

The stock oracle only has registered price ids on Monad and Arbitrum, so prices are read from Arbitrum and applied across chains; the reference price is per underlying ticker, not per chain.

**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).

2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** Please send a mail to metadata@defillama.com
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes

---
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama): 
Anchored Finance

##### Twitter Link: 
https://x.com/AnchoredFi

##### List of audit links if any: 
https://files.gitbook.com/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FzoanOJXsy8CjcaPvtHGj%2Fuploads%2F8Te8C7AqJDC9jSrd0LF0%2F20260402-sherlock.pdf?alt=media&token=ad51d120-b299-4843-9b4e-f79fc63a8f5e

##### Website Link: 
https://anchored.finance/

##### Logo (High resolution, will be shown with rounded borders): 
https://github.com/AnchoredLabs/assets/blob/main/logo/Anchored_logo.png

##### Current TVL:
1.1196M

##### Treasury Addresses (if the protocol has treasury)
N/A

##### Chain: 
Ethereum, Base, Arbitrum and Monad

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): 
N/A

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): 
N/A

##### Short Description (to be shown on DefiLlama): 
Anchored Finance provides institutional-grade infrastructure for the compliant issuance, redemption and distribution of tokenized stocks and fund products, fully backed 1:1 by underlying assets held in regulated custody.

##### Token address and ticker if any:
N/A

##### Category (full list at https://defillama.com/categories) \*Please choose only one: 
RWA

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
N/A

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
N/A

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
N/A

##### forkedFrom (Does your project originate from another project): 
No

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL = Σ (stock token totalSupply × oracle price) + Σ (fund share totalSupply × latest NAV per share)

Tokenized stocks and ETFs are enumerated per chain from AncTokenFactory (tokenCount / tokenAtIndex) and valued with StockOracle.latestPrice, keyed by keccak256(uppercase underlying ticker) at 8 decimals. Tokenized funds are enumerated from AncFundController.fundConfigs on Ethereum and valued at the latest NAV per share published to AncFundNavRecord at 6 decimals. Summing across Ethereum, Monad, Base and Arbitrum gives total TVL.

Nothing is hardcoded and no Anchored API is called — both the asset list and the prices come from contract reads, so newly issued assets are picked up without an adapter change. Every token is backed 1:1 by the underlying share or fund interest held in regulated custody; reserves are attested independently at https://accountable.anchored.finance.

##### Github org/user (Optional, if your code is open source, we can track activity): 
https://github.com/AnchoredLabs

##### Does this project have a referral program?
No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for Anchored tokenized stocks, ETFs, and funds.
  * Added support for Ethereum, Monad, Base, and Arbitrum networks.
  * Values tokenized assets using onchain oracle prices and fund NAV data.
  * Automatically discovers eligible assets and includes valid USD-valued supplies.
  * Added methodology metadata describing the TVL calculation and supported asset types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->