### PR TITLE
Add Ignix TVL adapter

### DIFF
--- a/projects/ignix/index.js
+++ b/projects/ignix/index.js
@@ -1,0 +1,43 @@
+const { getLogs } = require("../helper/cache/getLogs");
+
+// Current production Manager and deployment block on X Layer.
+// Explorer: https://www.okx.com/web3/explorer/xlayer/address/0x96b51c57e5346d0c0198899243cf851d1e23c309
+const MANAGER = "0x96b51c57e5346d0c0198899243cf851d1e23c309";
+const FROM_BLOCK = 68_373_506;
+const ZERO = "0x0000000000000000000000000000000000000000";
+const ZERO_POOL = `0x${"0".repeat(64)}`;
+
+const TOKEN_CREATED =
+  "event TokenCreated(address indexed token,address indexed creator,address indexed quote,uint256 graduation,string metadataURI,address vault,address tracker,uint16 templateId)";
+const TOKEN_STATE =
+  "function tokens(address) view returns (address creator,uint16 buyFeeBps,uint16 sellFeeBps,uint16 taxBuyBps,uint16 taxSellBps,address quote,uint16 snipeStartBps,uint16 snipeMins,uint64 createdAt,uint128 vQuote,uint128 vToken,uint128 sold,uint128 collected,uint128 sellable,uint128 reserve,bytes32 poolId)";
+
+async function tvl(api) {
+  const launches = await getLogs({
+    api,
+    target: MANAGER,
+    eventAbi: TOKEN_CREATED,
+    fromBlock: FROM_BLOCK,
+    onlyArgs: true,
+  });
+  const tokens = [...new Set(launches.map((log) => log.token.toLowerCase()))];
+  if (!tokens.length) return;
+  const calls = tokens.map((token) => ({ target: MANAGER, params: [token] }));
+  const [states, pairs] = await Promise.all([
+    api.multiCall({ abi: TOKEN_STATE, calls }),
+    api.multiCall({ abi: "function pairOf(address) view returns (address)", calls }),
+  ]);
+
+  for (let i = 0; i < tokens.length; i++) {
+    const state = states[i];
+    if (state.poolId !== ZERO_POOL || pairs[i] !== ZERO) continue;
+    if (state.quote === ZERO) api.addGasToken(state.collected);
+    else api.add(state.quote, state.collected);
+  }
+}
+
+module.exports = {
+  methodology:
+    "Counts quote principal held in live Ignix bonding curves. V2- and V4-graduated liquidity is excluded to avoid double-counting Uniswap TVL.",
+  xlayer: { tvl },
+};

--- a/projects/ignix/index.js
+++ b/projects/ignix/index.js
@@ -1,43 +1,30 @@
-const { getLogs } = require("../helper/cache/getLogs");
+const { getLogs2 } = require("../helper/cache/getLogs");
 
-// Current production Manager and deployment block on X Layer.
-// Explorer: https://www.okx.com/web3/explorer/xlayer/address/0x96b51c57e5346d0c0198899243cf851d1e23c309
 const MANAGER = "0x96b51c57e5346d0c0198899243cf851d1e23c309";
 const FROM_BLOCK = 68_373_506;
-const ZERO = "0x0000000000000000000000000000000000000000";
-const ZERO_POOL = `0x${"0".repeat(64)}`;
 
-const TOKEN_CREATED =
-  "event TokenCreated(address indexed token,address indexed creator,address indexed quote,uint256 graduation,string metadataURI,address vault,address tracker,uint16 templateId)";
-const TOKEN_STATE =
-  "function tokens(address) view returns (address creator,uint16 buyFeeBps,uint16 sellFeeBps,uint16 taxBuyBps,uint16 taxSellBps,address quote,uint16 snipeStartBps,uint16 snipeMins,uint64 createdAt,uint128 vQuote,uint128 vToken,uint128 sold,uint128 collected,uint128 sellable,uint128 reserve,bytes32 poolId)";
+const TOKEN_CREATED = "event TokenCreated(address indexed token,address indexed creator,address indexed quote,uint256 graduation,string metadataURI,address vault,address tracker,uint16 templateId)";
 
 async function tvl(api) {
-  const launches = await getLogs({
+  const launches = await getLogs2({
     api,
     target: MANAGER,
     eventAbi: TOKEN_CREATED,
     fromBlock: FROM_BLOCK,
-    onlyArgs: true,
   });
-  const tokens = [...new Set(launches.map((log) => log.token.toLowerCase()))];
-  if (!tokens.length) return;
-  const calls = tokens.map((token) => ({ target: MANAGER, params: [token] }));
-  const [states, pairs] = await Promise.all([
-    api.multiCall({ abi: TOKEN_STATE, calls }),
-    api.multiCall({ abi: "function pairOf(address) view returns (address)", calls }),
-  ]);
 
-  for (let i = 0; i < tokens.length; i++) {
-    const state = states[i];
-    if (state.poolId !== ZERO_POOL || pairs[i] !== ZERO) continue;
-    if (state.quote === ZERO) api.addGasToken(state.collected);
-    else api.add(state.quote, state.collected);
-  }
+  const quotes = [...new Set(launches.map((l) => l.quote.toLowerCase()))];
+  await api.sumTokens({ ownerTokens: [[quotes, MANAGER]] });
+
+  // exclude platform fees held by the Manager
+  const fees = await api.multiCall({
+    abi: "function platformAccrued(address) view returns (uint256)",
+    calls: quotes.map((q) => ({ target: MANAGER, params: [q] })),
+  });
+  quotes.forEach((q, i) => api.add(q, (-BigInt(fees[i])).toString()));
 }
 
 module.exports = {
-  methodology:
-    "Counts quote principal held in live Ignix bonding curves. V2- and V4-graduated liquidity is excluded to avoid double-counting Uniswap TVL.",
+  methodology: "Counts the quote principal held by the Ignix Manager across all live bonding curves. When a token graduates, its quote migrates into the Uniswap V2/V4 pool and leaves the Manager, so graduated liquidity is naturally excluded.",
   xlayer: { tvl },
 };


### PR DESCRIPTION
## Summary

Adds an on-chain TVL adapter for Ignix, a universal asset launchpad on X Layer.

Related fees and volume PR: https://github.com/DefiLlama/dimension-adapters/pull/9004

The adapter discovers launches from the current production Manager's `TokenCreated` events, reads each launch's quote currency and `collected` principal at the requested block, and counts only live bonding curves. V2 and V4 graduated launches are excluded through `pairOf(token)` and `poolId` so their Uniswap liquidity is not double-counted.

## Protocol information

- Name: Ignix
- Website: https://ignix.bot
- Twitter: https://x.com/Ignixbot
- Logo: https://ignix.bot/logo.svg
- Chain: X Layer
- Category: Launchpad
- Short description: Universal asset launchpad for AI-agent assets, RWA-backed tokens, and community assets on X Layer.
- Token address and ticker: N/A; Ignix has no platform token.
- Audit links: N/A
- Coingecko ID: N/A
- CoinMarketCap ID: N/A
- Oracle provider: N/A. The adapter returns raw on-chain quote-token balances and relies on DefiLlama's pricing layer.
- GitHub org/user: `okasplaunchpad`
- forkedFrom: N/A
- Referral program: No

## Methodology

TVL is the quote principal currently held in live Ignix bonding curves. Launches are discovered on-chain, and their `collected`, `quote`, `poolId`, and V2 `pairOf` state are read at the requested block. Graduated Uniswap liquidity, protocol fees, creator accruals, vault balances, and launched-token market caps are excluded.

Documentation:

- https://ignix.bot/docs
- https://ignix.bot/docs/launching-a-token
- https://ignix.bot/docs/developers/token-types

## Validation

```text
node test.js projects/ignix/index.js 2026-08-25
```

Result: X Layer TVL approximately $37.49k at the tested historical block. ESLint passes for the new adapter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tracking Ignix’s total value locked on X Layer by quote token.
  * Includes balances held by the Ignix Manager across supported quote tokens.

* **Bug Fixes**
  * Improved TVL accuracy by removing accrued platform fees from reported totals.
  * Replaced per-token curve tracking with consolidated quote-token accounting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->