### PR TITLE
Add Helios V2 + V3 (RISE)

### DIFF
--- a/projects/helper/env.js
+++ b/projects/helper/env.js
@@ -55,6 +55,7 @@ const DEFAULTS = {
   ROBINHOOD_RPC: 'https://robinhoodchain.blockscout.com/api/eth-rpc',
   ETHEREUMCLASSIC_RPC: 'https://etc.blockscout.com/api/eth-rpc',
   FLARE_ARCHIVAL_RPC: 'https://flare-explorer.flare.network/api/eth-rpc',
+  RISE_ARCHIVAL_RPC: 'https://explorer.risechain.com/api/eth-rpc', // public rpc.risechain.com caps eth_getLogs at 5000 blocks
 }
 
 const ENV_KEYS = [

--- a/registries/uniswapV2.js
+++ b/registries/uniswapV2.js
@@ -3131,7 +3131,11 @@ const uniV2Configs = {
       },
       fetchBalances: true,
     },
-  }
+  },
+  'helios-v2': {
+    start: '2026-05-31',
+    rise: '0xd479E71C45aEB1E846A7B549c346D62fE77B39bA',
+  },
 }
 
 module.exports = buildProtocolExports(uniV2Configs, uniV2ExportFn)

--- a/registries/uniswapV3.js
+++ b/registries/uniswapV3.js
@@ -1814,7 +1814,11 @@ const uniV3Configs = {
       fromBlock: 4904397,
       isAlgebra: true,
     },
-  }
+  },
+  'helios-v3': {
+    start: '2026-05-31',
+    rise: { factory: '0xbF30bD8567628Dc4E120b7536d051EaFaA3fD0fa', fromBlock: 12557099 },
+  },
 }
 
 module.exports = buildProtocolExports(uniV3Configs, uniV3Export)


### PR DESCRIPTION
Adds TVL adapters for **Helios** (https://app.helios.trade), a Uniswap V2 + V3 fork DEX live on **RISE** (chainId 4153, already supported as `rise`), as registry entries: `helios-v2` in `registries/uniswapV2.js` and `helios-v3` in `registries/uniswapV3.js`.

---
## New listing details

##### Name (to be shown on DefiLlama):
Helios V2 and Helios V3 — please group both under a parent protocol **Helios**

##### Twitter Link:
https://x.com/heliosdottrade

##### List of audit links if any:
None. The contracts are a faithful Uniswap V2 / V3 fork (solc 0.5.16 / 0.7.6, stock bytecode); the only change is protocol-fee configuration (V2 `feeTo` enabled at deploy; every V3 pool initializes with `feeProtocol = 68`, i.e. 25% of swap fees to the protocol).

##### Website Link:
https://app.helios.trade (landing: https://helios.trade · docs: https://docs.helios.trade · Discord: https://discord.com/invite/ezCcexutrd)

##### Logo (High resolution, will be shown with rounded borders):
![Helios logo](https://raw.githubusercontent.com/JosephSaw/DefiLlama-Adapters/pr-assets/helios-logo-400.png)

##### Current TVL:
Helios V3 ≈ $2.01k · Helios V2 $0 (V2 factory has no pairs yet) — `node test.js helios-v3` / `node test.js helios-v2`, 2026-08-26

##### Treasury Addresses (if the protocol has treasury)
`0x468Cc05a64d44b6CE108BF0e9E927f9B32AF32DE` (V2 protocol-fee recipient / `feeTo`, RISE)

##### Chain:
RISE

##### Coingecko ID:
(none — no token yet)

##### Coinmarketcap ID:
(none)

##### Short Description (to be shown on DefiLlama):
Helios is a Uniswap V2 + V3 fork DEX on RISE for swapping ETH, USDC.e, WBTC.e, USDR and RISE-ecosystem tokens.

##### Token address and ticker if any:
None yet

##### Category:
Dexs

##### Oracle Provider(s):
None (AMM pricing only)

##### Implementation Details:
N/A — no external oracle is used.

##### Documentation/Proof:
N/A

##### forkedFrom:
Uniswap V2 (`helios-v2`), Uniswap V3 (`helios-v3`)

##### methodology:
TVL = token balances held in the V2 pairs / V3 pools enumerated from the factories (standard `getUniTVL` / `uniV3Export` helpers).

##### Github org/user (Optional):
—

##### Does this project have a referral program?
Yes (on-chain referral fee rebates, see https://helios.trade)

---
## Contracts (Blockscout-verified: https://explorer.risechain.com)

| Contract | Address | Deploy block |
|---|---|---|
| UniswapV2Factory | `0xd479E71C45aEB1E846A7B549c346D62fE77B39bA` | 12556219 |
| UniswapV3Factory | `0xbF30bD8567628Dc4E120b7536d051EaFaA3fD0fa` | 12557099 |

Deployed 2026-05-31.

## Infra note — `RISE_ARCHIVAL_RPC` default (1 line in `projects/helper/env.js`)

The SDK's default RISE RPC (`https://rpc.risechain.com`, the only RPC listed for chainId 4153) caps `eth_getLogs` at **5,000 blocks** (`-32602: query exceeds max block range 5000`). The V3 factory is ~7.6M blocks old, so the `PoolCreated` scan falls back to 1,500+ sequential chunks and blows through the 10-minute test timeout. RISE's Blockscout `eth-rpc` proxy serves the whole range in one call, so this PR adds

```js
RISE_ARCHIVAL_RPC: 'https://explorer.risechain.com/api/eth-rpc'
```

— the same pattern as `MEGAETH_ARCHIVAL_RPC` / `FLARE_ARCHIVAL_RPC`. Only log fetches use it; `eth_call`/multicall traffic stays on the public RPC (no behaviour change for existing `rise` adapters). With it, `helios-v3` runs in ~7 s.

## Test output

```
$ node test.js helios-v3
--- rise ---
USDR                      1.31 k
WETH                      579.62
USDC                      104.53
WBTC.e                    14.54
Total: 2.01 k
------ TVL ------
rise                      2.01 k
total                    2.01 k

$ node test.js helios-v2
------ TVL ------
rise                      0.00
total                    0.00
```

A dimension-adapters PR for volume/fees follows once this is merged (the uniV3 log adapter reads the pool-log cache this adapter populates).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for connecting to the Rise Chain archival network.
  - Added Uniswap V2 and V3 protocol configurations for Rise Chain, including deployment details and indexing start points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->