### PR TITLE
Add Cantex adapter (Canton)

### DIFF
--- a/projects/cantex/index.js
+++ b/projects/cantex/index.js
@@ -1,0 +1,55 @@
+const { get } = require('../helper/http')
+
+const POOLS_STATE_URL = 'https://api.cantex.io/v1/public/pools/state'
+const TOKENS_INFO_URL = 'https://api.cantex.io/v1/public/tokens/info'
+const FETCH_OPTS = { headers: { 'User-Agent': 'DefiLlama-Adapter (cantex)' } }
+
+async function tvl(api) {
+  const [state, tokenInfo] = await Promise.all([
+    get(POOLS_STATE_URL, FETCH_OPTS),
+    get(TOKENS_INFO_URL, FETCH_OPTS),
+  ])
+
+  // Canton instruments are identified by (admin, id); tokens/info maps each to
+  // the CoinGecko coin it represents (null when it has no CoinGecko listing).
+  const coingeckoIds = {}
+  for (const token of tokenInfo?.tokens ?? []) {
+    const info = token.info
+    if (info?.coingecko_id)
+      coingeckoIds[`${info.instrument_admin}:${info.instrument_id}`] = info.coingecko_id
+  }
+  if (!Object.keys(coingeckoIds).length)
+    throw new Error('cantex: tokens/info returned no coingecko ids')
+
+  const pools = state?.data?.pools
+  if (!Array.isArray(pools) || pools.length === 0)
+    throw new Error('cantex: pools/state returned no pools')
+
+  for (const pool of pools) {
+    addReserve(api, coingeckoIds, pool.token_a_instrument, pool.reserve_a)
+    addReserve(api, coingeckoIds, pool.token_b_instrument, pool.reserve_b)
+  }
+}
+
+function addReserve(api, coingeckoIds, instrument, reserve) {
+  if (reserve == null) return // pool with no reserves yet
+  const coingeckoId = coingeckoIds[`${instrument.admin}:${instrument.id}`]
+  if (!coingeckoId) return // token without a CoinGecko listing is excluded from TVL
+  // Reserves are decimal strings in whole token units; do not scale them again.
+  const amount = Number(reserve)
+  if (!Number.isFinite(amount) || amount < 0)
+    throw new Error(`cantex: invalid reserve for ${instrument.id}`)
+  api.addCGToken(coingeckoId, amount)
+}
+
+module.exports = {
+  timetravel: false,
+  methodology:
+    'Cantex is an institutional-grade on-chain exchange built on the Canton Network. ' +
+    'Liquidity providers deposit tokens into Cantex AMM pools; swaps execute against those pool reserves and settle atomically on-chain. ' +
+    'TVL is the sum of the token reserves held in all live Cantex pools, read from the Cantex public API (/v1/public/pools/state), ' +
+    'which serves per-pool reserve balances derived from on-chain Canton ledger events. ' +
+    'Each Canton instrument is mapped to the CoinGecko coin it represents via /v1/public/tokens/info; ' +
+    'tokens without a CoinGecko listing are excluded from TVL. Cantex has no borrow side, so nothing is netted.',
+  canton: { tvl },
+}


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).

2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** Please send a mail to metadata@defillama.com
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes

---
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
Cantex

##### Twitter Link:
https://x.com/Cantex_io

##### List of audit links if any:
None yet

##### Website Link:
https://cantex.io

##### Logo (High resolution, will be shown with rounded borders):
https://docs.cantex.io/assets/images/cantex-logo-icon.svg

##### Current TVL:
$2.1M

##### Treasury Addresses (if the protocol has treasury)
None supplied (Canton party ids are not EVM-style addresses)

##### Chain:
Canton

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):


##### Short Description (to be shown on DefiLlama):
Cantex is an institutional-grade on-chain exchange built on the Canton Network. Users swap Canton-native and bridged assets against AMM liquidity pools, with atomic on-chain settlement and privacy-preserving execution.

##### Token address and ticker if any:
None (Cantex has no protocol token)

##### Category (full list at https://defillama.com/categories) \*Please choose only one:
Dexs

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
None — TVL is raw AMM pool reserves; no oracles are used.

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
N/A (no oracle)

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
https://docs.cantex.io/developers/public-api/ (public API the adapter reads)

##### forkedFrom (Does your project originate from another project):
No — independent implementation (constant-product AMM design)

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL is the sum of the token reserves held in all live Cantex AMM pools. Reserves are read from the Cantex public API (https://api.cantex.io/v1/public/pools/state), which serves per-pool balances derived from on-chain Canton ledger events — Canton's privacy model has no public RPC to read contract state directly, the same approach as the existing Temple adapter on Canton. Each Canton instrument is mapped to the CoinGecko coin it represents via https://api.cantex.io/v1/public/tokens/info; tokens without a CoinGecko listing are excluded. Cantex has no borrow side, so nothing is netted.

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/caviarnine

##### Does this project have a referral program?
No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added TVL tracking for Cantex pools on Canton.
  - Reports eligible pool reserves using token market identifiers and validated pool data.
  - Supports Canton-specific TVL reporting without historical time-travel data.
  - Documents the reserve-based calculation methodology.
  - Excludes tokens without supported market listings and pools with unavailable reserves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->