### PR TITLE
Add Orixium on Robinhood Chain

### DIFF
--- a/projects/cavewatch/index.js
+++ b/projects/cavewatch/index.js
@@ -1,0 +1,36 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+
+const OIX = '0xA9Ad4Da4b2FEd87CCe1f91225609bF4ccFacc7Fb'
+const VAULT = '0x8a745eF816a0d241cb0cEDCE253A30433D3cF366'
+
+const ETH_HOLDERS = [
+  '0x345fA314427518F608FA72d1B61249f6dBd3Ff63', // Hunt
+  '0x6576EB3b3B95BEBdb3635b0d6B8cF6611Bc6543a', // Motherlode
+  '0xdb6A919e7502B45c5a299c9f0b2782fD7FAaf1f8', // Lucky Vein
+  '0xD902868cf0F9D5016B66E40ADf95C7Bea24D935a', // Auto Hunt
+]
+
+async function tvl(api) {
+  await api.sumTokens({
+    tokens: [ADDRESSES.null],
+    owners: ETH_HOLDERS,
+  })
+}
+
+async function staking(api) {
+  const locked = await api.call({
+    target: VAULT,
+    abi: 'uint256:accountedLockedTokens',
+  })
+
+  api.add(OIX, locked)
+}
+
+module.exports = {
+  methodology:
+    'TVL counts native ETH held in CaveWatch Hunt, Motherlode, Lucky Vein and Auto Hunt contracts. Recoverable OIX locked in the OIX Vault is reported as staking. Permanently sacrificed OIX, OIX release inventory, treasury balances, Vault reward ETH and game-held OIX are excluded.',
+  robinhood: {
+    tvl,
+    staking,
+  },
+}

--- a/projects/cavewatch/index.js
+++ b/projects/cavewatch/index.js
@@ -18,17 +18,24 @@ async function tvl(api) {
 }
 
 async function staking(api) {
-  const locked = await api.call({
-    target: VAULT,
-    abi: 'uint256:accountedLockedTokens',
-  })
+  const [locked, sacrificed] = await Promise.all([
+    api.call({
+      target: VAULT,
+      abi: 'uint256:accountedLockedTokens',
+    }),
+    api.call({
+      target: VAULT,
+      abi: 'uint256:totalSacrificed',
+    }),
+  ])
 
   api.add(OIX, locked)
+  api.add(OIX, sacrificed)
 }
 
 module.exports = {
   methodology:
-    'TVL counts native ETH held in CaveWatch Hunt, Motherlode, Lucky Vein and Auto Hunt contracts. Recoverable OIX locked in the OIX Vault is reported as staking. Permanently sacrificed OIX, OIX release inventory, treasury balances, Vault reward ETH and game-held OIX are excluded.',
+    'TVL counts native ETH held in CaveWatch Hunt, Motherlode, Lucky Vein and Auto Hunt contracts. Recoverable OIX locked in the OIX Vault and permanently sacrificed OIX that remains economically committed to the Vault and continues receiving Vault reward weight are reported as staking. Sacrificed OIX is non-withdrawable and represents a permanent Vault position. OIX release inventory, treasury balances, Vault reward ETH and game-held OIX are excluded.',
   robinhood: {
     tvl,
     staking,


### PR DESCRIPTION
##### Name (to be shown on DefiLlama): Orixium

##### Twitter Link: https://x.com/cavewatch

##### List of audit links if any: NA

##### Website Link: https://cave.watch

##### Logo (High resolution, will be shown with rounded borders):  https://github.com/Oggchain/Logo/blob/main/180x180%20OIX.png?raw=true

##### Current TVL: 
Approximately $1.01k of currently priceable native ETH TVL at the time of submission. The Vault additionally accounts for approximately 1,159,356 OIX in economically committed Vault positions, comprising approximately 199,031 recoverably locked OIX and 960,325 permanently sacrificed OIX. OIX is not yet indexed by DefiLlama’s price service, so the staking component currently resolves to $0 in local DefiLlama tests.

Sacrificed OIX is non-withdrawable but remains an active Vault position and continues participating in ETH reward distributions through Vault weight.

##### Treasury Addresses (if the protocol has treasury): 

Protocol treasury balances are not included in this TVL adapter and are excluded from the reported TVL.

##### Chain: Robinhood Chain

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): https://www.geckoterminal.com/robinhood/pools/0xb5a45e60e596f007ec8a079e8fe7ee21d2068b13d4ed126fea650dbd6cbd14e0

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama): Orixium powers CaveWatch, a gamified on-chain mining protocol on Robinhood Chain. Users participate in ETH-funded Hunts, mine OIX, compete for ETH reward pools and progressive jackpots, and commit OIX to Vault positions that participate in protocol ETH revenue distributions.

##### Token address and ticker if any: OIX - 0xA9Ad4Da4b2FEd87CCe1f91225609bF4ccFacc7Fb

##### Category (full list at https://defillama.com/categories) \*Please choose only one: Gamified Mining

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.): NA - CaveWatch does not rely on a price oracle for the TVL accounting reported by this adapter. Game randomness uses Drand; Drand is a randomness beacon and is not a price oracle. 

##### Implementation Details: Briefly describe how the oracle is integrated into your project: Not applicable for price-oracle integration.

The TVL adapter reads balances and Vault accounting directly from CaveWatch contracts on Robinhood Chain. DefiLlama's own pricing infrastructure is used to convert supported assets into USD.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage: https://cave.watch/litepaper

##### forkedFrom (Does your project originate from another project):  NA

##### methodology (what is being counted as tvl, how is tvl being calculated): TVL is calculated directly from Orixium/CaveWatch contracts on Robinhood Chain.

Native ETH held in the Hunt, Motherlode, Lucky Vein and Auto Hunt contracts is counted as protocol TVL.

OIX Vault staking includes both recoverable OIX locked through accountedLockedTokens() and permanently sacrificed OIX tracked through totalSacrificed().

Sacrificed OIX is non-withdrawable but remains an economically active permanent Vault position and continues receiving Vault reward weight and ETH revenue participation.

The following are deliberately excluded:

OIX emission and release inventory
Protocol treasury balances
ETH held by the Vault for distribution as accrued rewards
OIX held by game contracts for gameplay/accounting purposes

This avoids counting protocol-owned inventory, accrued rewards, treasury assets, or duplicated gameplay balances as TVL.

##### Github org/user (Optional, if your code is open source, we can track activity): OggUgg

##### Does this project have a referral program? Yes.


---

### OIX pricing note

The adapter successfully reads OIX Vault participation on-chain.

At submission time, `coins.llama.fi` does not yet return a price for OIX on Robinhood Chain. As a result, the OIX staking component currently resolves to $0 in the local DefiLlama test even though the on-chain Vault amounts are read successfully.

Current active Vault participation at the submission snapshot:

- Recoverably locked: **199,031.068907703658205641 OIX**
- Permanently sacrificed: **960,325 OIX**
- Total economically active Vault OIX: **1,159,356.068907703658205641 OIX**

Sacrificed OIX is non-withdrawable but remains an active permanent Vault position. It continues participating in Vault reward weight and ETH revenue distributions.

OIX contract:

`0xA9Ad4Da4b2FEd87CCe1f91225609bF4ccFacc7Fb`

Canonical WETH on Robinhood Chain:

`0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73`

OIX/WETH Uniswap V4 pool ID:

`0xb5a45e60e596f007ec8a079e8fe7ee21d2068b13d4ed126fea650dbd6cbd14e0`

GeckoTerminal market:

https://www.geckoterminal.com/robinhood/pools/0xb5a45e60e596f007ec8a079e8fe7ee21d2068b13d4ed126fea650dbd6cbd14e0

Both OIX and WETH use 18 decimals.

DefiLlama already returns a price for the Robinhood Chain WETH contract through `coins.llama.fi`. OIX trades against this WETH asset in the live Robinhood Chain market above.

Local price checks at submission time:

`robinhood:0xa9ad4da4b2fed87cce1f91225609bf4ccfacc7fb` → currently unpriced by `coins.llama.fi`

`robinhood:0x0bd7d308f8e1639fab988df18a8011f41eacad73` → successfully priced by `coins.llama.fi`

Once OIX is indexed by DefiLlama's pricing system, the OIX staking balances already reported by the adapter can be priced without changing the TVL methodology.

---

### Local adapter test

The adapter was tested using DefiLlama's standard TVL test runner.

Current result at submission time:

- Robinhood Chain native ETH TVL: approximately **$1.01k**
- Recoverably locked OIX: approximately **199,031 OIX**
- Permanently sacrificed OIX participating in the Vault: **960,325 OIX**
- Total active Vault participation: approximately **1,159,356 OIX**
- OIX staking USD value: currently **$0** because OIX is not yet indexed by `coins.llama.fi`
- TVL is read directly from Robinhood Chain contracts
- No external CaveWatch API is used for TVL calculation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added CaveWatch tracking for native ETH held by designated holder contracts as TVL.
  - Added staking metrics for recoverable locked OIX and sacrificed OIX held in the OIX Vault.
  - Included methodology details describing which balances are counted and excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->