### PR TITLE
Add Umia Protocol adapter (Base) + venture treasuries

### DIFF
--- a/projects/treasury/umia.js
+++ b/projects/treasury/umia.js
@@ -1,33 +1,38 @@
 const { sumTokens2 } = require('../helper/unwrapLPs')
 
 const HUB = '0x120dbCDd58Bb787309573e29159fE6D37A1983F6'
+// Ventures 1-6 are test deployments that predate the first real launch.
+const FIRST_REAL_VENTURE_ID = 7
+
+const VENTURE_BY_ID =
+  'function ventureById(uint256) view returns (tuple(uint256 id, address venture, string name, uint256 createdAt))'
 
 async function getVentures(api) {
   const count = await api.call({ target: HUB, abi: 'uint256:ventureCount' })
-  const ids = Array.from({ length: +count }, (_, i) => i + 1) // venture ids are 1-based
-  const infos = await api.multiCall({
-    target: HUB,
-    abi: 'function ventureById(uint256) view returns (tuple(uint256 id, address venture, string name, uint256 createdAt))',
-    calls: ids,
-  })
+  const ids = []
+  for (let id = FIRST_REAL_VENTURE_ID; id <= +count; id++) ids.push(id)
+  if (!ids.length) return { ids, ventures: [] }
+  const infos = await api.multiCall({ target: HUB, abi: VENTURE_BY_ID, calls: ids })
   return { ids, ventures: infos.map(v => v.venture) }
 }
 
 module.exports = {
   base: {
-    // cumulative value held by the venture treasuries (raised money tokens etc.)
+    // Raised capital held by the venture treasuries, in each venture's money token.
     tvl: async (api) => {
       const { ventures } = await getVentures(api)
+      if (!ventures.length) return api.getBalances()
       const moneyTokens = await api.multiCall({ abi: 'address:moneyToken', calls: ventures })
-      const tokensAndOwners = ventures.map((v, i) => [moneyTokens[i], v])
-      return sumTokens2({ api, tokensAndOwners })
+      return sumTokens2({ api, tokensAndOwners: ventures.map((v, i) => [moneyTokens[i], v]) })
     },
-    // each venture's own token held by its treasury
+    // Each venture's own token held by its treasury.
     ownTokens: async (api) => {
       const { ids, ventures } = await getVentures(api)
-      const tokens = await api.multiCall({ target: HUB, abi: 'function ventureTokenById(uint256) view returns (address)', calls: ids })
-      const tokensAndOwners = ventures.map((v, i) => [tokens[i], v])
-      return sumTokens2({ api, tokensAndOwners })
+      if (!ventures.length) return api.getBalances()
+      const tokens = await api.multiCall({
+        target: HUB, abi: 'function ventureTokenById(uint256) view returns (address)', calls: ids,
+      })
+      return sumTokens2({ api, tokensAndOwners: ventures.map((v, i) => [tokens[i], v]) })
     },
   },
 }

--- a/projects/treasury/umia.js
+++ b/projects/treasury/umia.js
@@ -1,0 +1,33 @@
+const { sumTokens2 } = require('../helper/unwrapLPs')
+
+const HUB = '0x120dbCDd58Bb787309573e29159fE6D37A1983F6'
+
+async function getVentures(api) {
+  const count = await api.call({ target: HUB, abi: 'uint256:ventureCount' })
+  const ids = Array.from({ length: +count }, (_, i) => i + 1) // venture ids are 1-based
+  const infos = await api.multiCall({
+    target: HUB,
+    abi: 'function ventureById(uint256) view returns (tuple(uint256 id, address venture, string name, uint256 createdAt))',
+    calls: ids,
+  })
+  return { ids, ventures: infos.map(v => v.venture) }
+}
+
+module.exports = {
+  base: {
+    // cumulative value held by the venture treasuries (raised money tokens etc.)
+    tvl: async (api) => {
+      const { ventures } = await getVentures(api)
+      const moneyTokens = await api.multiCall({ abi: 'address:moneyToken', calls: ventures })
+      const tokensAndOwners = ventures.map((v, i) => [moneyTokens[i], v])
+      return sumTokens2({ api, tokensAndOwners })
+    },
+    // each venture's own token held by its treasury
+    ownTokens: async (api) => {
+      const { ids, ventures } = await getVentures(api)
+      const tokens = await api.multiCall({ target: HUB, abi: 'function ventureTokenById(uint256) view returns (address)', calls: ids })
+      const tokensAndOwners = ventures.map((v, i) => [tokens[i], v])
+      return sumTokens2({ api, tokensAndOwners })
+    },
+  },
+}

--- a/projects/treasury/umia.js
+++ b/projects/treasury/umia.js
@@ -9,50 +9,24 @@ const VENTURE_BY_ID =
 const VENTURE_TOKEN_BY_ID = 'function ventureTokenById(uint256) view returns (address)'
 
 /**
- * Enumerates real venture treasuries from the hub.
- *
- * Venture ids are 1-based and never reused, so slicing off the leading test
- * deployments by id needs no maintenance as new ventures are created.
- *
- * @param {object} api - DefiLlama chain api
- * @returns {Promise<{ids: number[], ventures: string[]}>} venture ids and treasury addresses
- */
-async function getVentures(api) {
-  const count = await api.call({ target: HUB, abi: 'uint256:ventureCount' })
-  const ids = []
-  for (let id = FIRST_REAL_VENTURE_ID; id <= +count; id++) ids.push(id)
-  if (!ids.length) return { ids, ventures: [] }
-  const infos = await api.multiCall({ target: HUB, abi: VENTURE_BY_ID, calls: ids })
-  return { ids, ventures: infos.map(v => v.venture) }
-}
-
-/**
  * Raised capital held by the venture treasuries, in each venture's money token.
  *
  * No overlap with the protocol adapter: auction bids are escrowed in the launch
  * contract pre-settlement and only reach the treasury afterwards.
- *
- * @param {object} api - DefiLlama chain api
- * @returns {Promise<object>} token balances
  */
 async function tvl(api) {
-  const { ventures } = await getVentures(api)
-  if (!ventures.length) return api.getBalances()
-  const moneyTokens = await api.multiCall({ abi: 'address:moneyToken', calls: ventures })
-  return sumTokens2({ api, tokensAndOwners: ventures.map((v, i) => [moneyTokens[i], v]) })
+  const ventures = await api.fetchList({ lengthAbi: 'ventureCount', itemAbi: VENTURE_BY_ID, target: HUB, field: 'venture', startFrom: FIRST_REAL_VENTURE_ID, startFromOne: true, })
+  const moneyTokens = await api.multiCall({ abi: 'address:moneyToken', calls: ventures, })
+  return api.sumTokens({ tokensAndOwners2: [moneyTokens, ventures] })
 }
 
 /**
  * Each venture's own token held by its treasury, reported separately from TVL.
- *
- * @param {object} api - DefiLlama chain api
- * @returns {Promise<object>} token balances
  */
 async function ownTokens(api) {
-  const { ids, ventures } = await getVentures(api)
-  if (!ventures.length) return api.getBalances()
-  const tokens = await api.multiCall({ target: HUB, abi: VENTURE_TOKEN_BY_ID, calls: ids })
-  return sumTokens2({ api, tokensAndOwners: ventures.map((v, i) => [tokens[i], v]) })
+  const ventures = await api.fetchList({ lengthAbi: 'ventureCount', itemAbi: VENTURE_BY_ID, target: HUB, field: 'venture', startFrom: FIRST_REAL_VENTURE_ID, startFromOne: true, })
+  const tokens = await api.fetchList({ lengthAbi: 'ventureCount', itemAbi: VENTURE_TOKEN_BY_ID, target: HUB, startFrom: FIRST_REAL_VENTURE_ID, startFromOne: true, })
+  return api.sumTokens({ tokensAndOwners2: [tokens, ventures] })
 }
 
 module.exports = {

--- a/projects/treasury/umia.js
+++ b/projects/treasury/umia.js
@@ -6,7 +6,17 @@ const FIRST_REAL_VENTURE_ID = 7
 
 const VENTURE_BY_ID =
   'function ventureById(uint256) view returns (tuple(uint256 id, address venture, string name, uint256 createdAt))'
+const VENTURE_TOKEN_BY_ID = 'function ventureTokenById(uint256) view returns (address)'
 
+/**
+ * Enumerates real venture treasuries from the hub.
+ *
+ * Venture ids are 1-based and never reused, so slicing off the leading test
+ * deployments by id needs no maintenance as new ventures are created.
+ *
+ * @param {object} api - DefiLlama chain api
+ * @returns {Promise<{ids: number[], ventures: string[]}>} venture ids and treasury addresses
+ */
 async function getVentures(api) {
   const count = await api.call({ target: HUB, abi: 'uint256:ventureCount' })
   const ids = []
@@ -16,23 +26,35 @@ async function getVentures(api) {
   return { ids, ventures: infos.map(v => v.venture) }
 }
 
+/**
+ * Raised capital held by the venture treasuries, in each venture's money token.
+ *
+ * No overlap with the protocol adapter: auction bids are escrowed in the launch
+ * contract pre-settlement and only reach the treasury afterwards.
+ *
+ * @param {object} api - DefiLlama chain api
+ * @returns {Promise<object>} token balances
+ */
+async function tvl(api) {
+  const { ventures } = await getVentures(api)
+  if (!ventures.length) return api.getBalances()
+  const moneyTokens = await api.multiCall({ abi: 'address:moneyToken', calls: ventures })
+  return sumTokens2({ api, tokensAndOwners: ventures.map((v, i) => [moneyTokens[i], v]) })
+}
+
+/**
+ * Each venture's own token held by its treasury, reported separately from TVL.
+ *
+ * @param {object} api - DefiLlama chain api
+ * @returns {Promise<object>} token balances
+ */
+async function ownTokens(api) {
+  const { ids, ventures } = await getVentures(api)
+  if (!ventures.length) return api.getBalances()
+  const tokens = await api.multiCall({ target: HUB, abi: VENTURE_TOKEN_BY_ID, calls: ids })
+  return sumTokens2({ api, tokensAndOwners: ventures.map((v, i) => [tokens[i], v]) })
+}
+
 module.exports = {
-  base: {
-    // Raised capital held by the venture treasuries, in each venture's money token.
-    tvl: async (api) => {
-      const { ventures } = await getVentures(api)
-      if (!ventures.length) return api.getBalances()
-      const moneyTokens = await api.multiCall({ abi: 'address:moneyToken', calls: ventures })
-      return sumTokens2({ api, tokensAndOwners: ventures.map((v, i) => [moneyTokens[i], v]) })
-    },
-    // Each venture's own token held by its treasury.
-    ownTokens: async (api) => {
-      const { ids, ventures } = await getVentures(api)
-      if (!ventures.length) return api.getBalances()
-      const tokens = await api.multiCall({
-        target: HUB, abi: 'function ventureTokenById(uint256) view returns (address)', calls: ids,
-      })
-      return sumTokens2({ api, tokensAndOwners: ventures.map((v, i) => [tokens[i], v]) })
-    },
-  },
+  base: { tvl, ownTokens },
 }

--- a/projects/umia/index.js
+++ b/projects/umia/index.js
@@ -1,35 +1,42 @@
 const { sumTokens2 } = require('../helper/unwrapLPs')
 const { nullAddress } = require('../helper/tokenMapping')
+const { uniV4HookExport } = require('../helper/uniswapV4')
 
 const HUB = '0x120dbCDd58Bb787309573e29159fE6D37A1983F6'
+// Singleton Uniswap v4 hook: every Umia spot pool is registered on it at migration
+const UMIA_HOOK = '0x752E82933B1629Cdf1A50F4D71F8D1C9Eb1C7A80'
 
-async function tvl(api) {
+async function getVentures(api) {
   const count = await api.call({ target: HUB, abi: 'uint256:ventureCount' })
   const ids = Array.from({ length: +count }, (_, i) => i + 1) // venture ids are 1-based
-  const ventures = (await api.multiCall({
+  return (await api.multiCall({
     target: HUB,
     abi: 'function ventureById(uint256) view returns (tuple(uint256 id, address venture, string name, uint256 createdAt))',
     calls: ids,
   })).map(v => v.venture)
+}
+
+async function tvl(api) {
+  const ventures = await getVentures(api)
   const lbps = await api.multiCall({ abi: 'address:lbp', calls: ventures })
   const auctions = await api.multiCall({ abi: 'address:initializer', calls: lbps })
-  const vaults = await api.multiCall({
-    target: HUB,
-    abi: 'function ventureLiquidityVault(address) view returns (address)',
-    calls: ventures,
-  })
   const currencies = await api.multiCall({ abi: 'address:currency', calls: lbps })
 
+  // bids escrowed in each live launch: the launch contract and its Continuous Clearing Auction
   const tokensAndOwners = []
   lbps.forEach((lbp, i) => {
-    for (const owner of [lbp, auctions[i], vaults[i]])
+    for (const owner of [lbp, auctions[i]])
       if (owner && owner !== nullAddress) tokensAndOwners.push([currencies[i], owner])
   })
-  return sumTokens2({ api, tokensAndOwners })
+  await sumTokens2({ api, tokensAndOwners })
+
+  // protocol-owned spot liquidity: at migration each launch seeds a Uniswap v4 pool on the hook
+  await uniV4HookExport({ hook: UMIA_HOOK })(api)
+  return api.getBalances()
 }
 
 module.exports = {
   methodology:
-    'Money tokens (USDC) locked in Umia launches: escrowed bids held by each venture launch contract and its Uniswap Continuous Clearing Auction, plus the protocol-owned Uniswap v4 liquidity vault seeded at migration. Ventures are enumerated from the Umia hub.',
+    'Bids escrowed in each Umia launch (the launch contract and its Uniswap Continuous Clearing Auction, in the launch currency), plus the liquidity of the Uniswap v4 pools registered on the Umia hook, which each launch seeds at migration. Launches are enumerated from the Umia hub; treasuries are tracked separately as a treasury adapter.',
   base: { tvl },
 }

--- a/projects/umia/index.js
+++ b/projects/umia/index.js
@@ -16,16 +16,9 @@ const TOTAL_ASSETS = 'function totalAssets() view returns (uint256 ventureAssets
  * Venture ids are 1-based and never reused, so slicing off the leading test
  * deployments by id needs no maintenance as new ventures are created.
  *
- * @param {object} api - DefiLlama chain api
- * @returns {Promise<string[]>} venture treasury addresses
  */
 async function getVentures(api) {
-  const count = await api.call({ target: HUB, abi: 'uint256:ventureCount' })
-  const ids = []
-  for (let id = FIRST_REAL_VENTURE_ID; id <= +count; id++) ids.push(id)
-  if (!ids.length) return []
-  const infos = await api.multiCall({ target: HUB, abi: VENTURE_BY_ID, calls: ids })
-  return infos.map(v => v.venture)
+  return api.fetchList({ lengthAbi: 'ventureCount', itemAbi: VENTURE_BY_ID, target: HUB, field: 'venture', startFrom: FIRST_REAL_VENTURE_ID, startFromOne: true, })
 }
 
 /**
@@ -36,46 +29,37 @@ async function getVentures(api) {
  * on loan to live decision markets, which a pool-only reading would drop for the
  * duration of each market.
  *
- * @param {object} api - DefiLlama chain api
- * @returns {Promise<object>} token balances
  */
 async function tvl(api) {
   const ventures = await getVentures(api)
   if (!ventures.length) return api.getBalances()
 
   const lbps = await api.multiCall({ abi: 'address:lbp', calls: ventures })
-  const [auctions, currencies] = await Promise.all([
-    api.multiCall({ abi: 'address:initializer', calls: lbps }),
-    api.multiCall({ abi: 'address:currency', calls: lbps }),
-  ])
+  const auctions = await api.multiCall({ abi: 'address:initializer', calls: lbps })
+  const currencies = await api.multiCall({ abi: 'address:currency', calls: lbps })
+
   const tokensAndOwners = []
   lbps.forEach((lbp, i) => {
-    for (const owner of [lbp, auctions[i]])
-      if (owner && owner !== nullAddress) tokensAndOwners.push([currencies[i], owner])
+    tokensAndOwners.push([currencies[i], auctions[i]])
+    tokensAndOwners.push([currencies[i], lbp])
   })
-  await sumTokens2({ api, tokensAndOwners })
 
-  const vaults = (
-    await api.multiCall({ target: HUB, abi: VENTURE_VAULT, calls: ventures })
-  ).filter(v => v && v !== nullAddress)
-  if (vaults.length) {
-    const [assets, ventureTokens, moneyTokens] = await Promise.all([
-      api.multiCall({ abi: TOTAL_ASSETS, calls: vaults }),
-      api.multiCall({ abi: 'address:ventureToken', calls: vaults }),
-      api.multiCall({ abi: 'address:moneyToken', calls: vaults }),
-    ])
-    vaults.forEach((_, i) => {
-      api.add(ventureTokens[i], assets[i].ventureAssets)
-      api.add(moneyTokens[i], assets[i].moneyAssets)
-    })
-  }
+  await sumTokens2({ api, tokensAndOwners, blacklistedOwners: [nullAddress] })
 
-  return api.getBalances()
+  const vaults = (await api.multiCall({ target: HUB, abi: VENTURE_VAULT, calls: ventures })).filter(v => v && v !== nullAddress)
+
+  const assets = await api.multiCall({ abi: TOTAL_ASSETS, calls: vaults })
+  const ventureTokens = await api.multiCall({ abi: 'address:ventureToken', calls: vaults })
+  const moneyTokens = await api.multiCall({ abi: 'address:moneyToken', calls: vaults })
+
+  api.add(ventureTokens, assets.map(a => a.ventureAssets))
+  api.add(moneyTokens, assets.map(a => a.moneyAssets))
+
 }
 
 module.exports = {
   methodology:
     'Bids escrowed in each Umia launch (the launch contract and its Uniswap Continuous Clearing Auction, in the launch currency), plus the canonical spot liquidity held by each venture SpotLiquidityVault -- its Uniswap v4 pool reserves, idle balances, and amounts on loan to live decision markets. The vault is the pool\'s only permitted liquidity operator, so it holds 100% of canonical liquidity. Launches are enumerated from the Umia hub; venture treasuries are tracked separately as a treasury adapter.',
-  start: 1787694409,
+  start: '2026-08-25',
   base: { tvl },
 }

--- a/projects/umia/index.js
+++ b/projects/umia/index.js
@@ -1,0 +1,35 @@
+const { sumTokens2 } = require('../helper/unwrapLPs')
+const { nullAddress } = require('../helper/tokenMapping')
+
+const HUB = '0x120dbCDd58Bb787309573e29159fE6D37A1983F6'
+
+async function tvl(api) {
+  const count = await api.call({ target: HUB, abi: 'uint256:ventureCount' })
+  const ids = Array.from({ length: +count }, (_, i) => i + 1) // venture ids are 1-based
+  const ventures = (await api.multiCall({
+    target: HUB,
+    abi: 'function ventureById(uint256) view returns (tuple(uint256 id, address venture, string name, uint256 createdAt))',
+    calls: ids,
+  })).map(v => v.venture)
+  const lbps = await api.multiCall({ abi: 'address:lbp', calls: ventures })
+  const auctions = await api.multiCall({ abi: 'address:initializer', calls: lbps })
+  const vaults = await api.multiCall({
+    target: HUB,
+    abi: 'function ventureLiquidityVault(address) view returns (address)',
+    calls: ventures,
+  })
+  const currencies = await api.multiCall({ abi: 'address:currency', calls: lbps })
+
+  const tokensAndOwners = []
+  lbps.forEach((lbp, i) => {
+    for (const owner of [lbp, auctions[i], vaults[i]])
+      if (owner && owner !== nullAddress) tokensAndOwners.push([currencies[i], owner])
+  })
+  return sumTokens2({ api, tokensAndOwners })
+}
+
+module.exports = {
+  methodology:
+    'Money tokens (USDC) locked in Umia launches: escrowed bids held by each venture launch contract and its Uniswap Continuous Clearing Auction, plus the protocol-owned Uniswap v4 liquidity vault seeded at migration. Ventures are enumerated from the Umia hub.',
+  base: { tvl },
+}

--- a/projects/umia/index.js
+++ b/projects/umia/index.js
@@ -1,28 +1,34 @@
 const { sumTokens2 } = require('../helper/unwrapLPs')
 const { nullAddress } = require('../helper/tokenMapping')
-const { uniV4HookExport } = require('../helper/uniswapV4')
 
 const HUB = '0x120dbCDd58Bb787309573e29159fE6D37A1983F6'
-// Singleton Uniswap v4 hook: every Umia spot pool is registered on it at migration
-const UMIA_HOOK = '0x752E82933B1629Cdf1A50F4D71F8D1C9Eb1C7A80'
+// Ventures 1-6 are "Koi3 TEST" deployments that predate the first real launch.
+const FIRST_REAL_VENTURE_ID = 7
+
+const VENTURE_BY_ID =
+  'function ventureById(uint256) view returns (tuple(uint256 id, address venture, string name, uint256 createdAt))'
+const VENTURE_VAULT = 'function ventureLiquidityVault(address) view returns (address)'
+const TOTAL_ASSETS = 'function totalAssets() view returns (uint256 ventureAssets, uint256 moneyAssets)'
 
 async function getVentures(api) {
   const count = await api.call({ target: HUB, abi: 'uint256:ventureCount' })
-  const ids = Array.from({ length: +count }, (_, i) => i + 1) // venture ids are 1-based
-  return (await api.multiCall({
-    target: HUB,
-    abi: 'function ventureById(uint256) view returns (tuple(uint256 id, address venture, string name, uint256 createdAt))',
-    calls: ids,
-  })).map(v => v.venture)
+  const ids = []
+  for (let id = FIRST_REAL_VENTURE_ID; id <= +count; id++) ids.push(id)
+  if (!ids.length) return []
+  const infos = await api.multiCall({ target: HUB, abi: VENTURE_BY_ID, calls: ids })
+  return infos.map(v => v.venture)
 }
 
 async function tvl(api) {
   const ventures = await getVentures(api)
-  const lbps = await api.multiCall({ abi: 'address:lbp', calls: ventures })
-  const auctions = await api.multiCall({ abi: 'address:initializer', calls: lbps })
-  const currencies = await api.multiCall({ abi: 'address:currency', calls: lbps })
+  if (!ventures.length) return api.getBalances()
 
-  // bids escrowed in each live launch: the launch contract and its Continuous Clearing Auction
+  // Bids escrowed in each live launch: the launch contract and its Continuous Clearing Auction.
+  const lbps = await api.multiCall({ abi: 'address:lbp', calls: ventures })
+  const [auctions, currencies] = await Promise.all([
+    api.multiCall({ abi: 'address:initializer', calls: lbps }),
+    api.multiCall({ abi: 'address:currency', calls: lbps }),
+  ])
   const tokensAndOwners = []
   lbps.forEach((lbp, i) => {
     for (const owner of [lbp, auctions[i]])
@@ -30,13 +36,30 @@ async function tvl(api) {
   })
   await sumTokens2({ api, tokensAndOwners })
 
-  // protocol-owned spot liquidity: at migration each launch seeds a Uniswap v4 pool on the hook
-  await uniV4HookExport({ hook: UMIA_HOOK })(api)
+  // Canonical spot liquidity. The venture's SpotLiquidityVault is the pool's only permitted LP,
+  // and totalAssets() covers in-pool reserves, idle balances, and amounts currently on loan to
+  // live decision markets -- so it stays correct across hook redeployments and market cycles.
+  const vaults = (
+    await api.multiCall({ target: HUB, abi: VENTURE_VAULT, calls: ventures })
+  ).filter(v => v && v !== nullAddress)
+  if (vaults.length) {
+    const [assets, ventureTokens, moneyTokens] = await Promise.all([
+      api.multiCall({ abi: TOTAL_ASSETS, calls: vaults }),
+      api.multiCall({ abi: 'address:ventureToken', calls: vaults }),
+      api.multiCall({ abi: 'address:moneyToken', calls: vaults }),
+    ])
+    vaults.forEach((_, i) => {
+      api.add(ventureTokens[i], assets[i].ventureAssets)
+      api.add(moneyTokens[i], assets[i].moneyAssets)
+    })
+  }
+
   return api.getBalances()
 }
 
 module.exports = {
   methodology:
-    'Bids escrowed in each Umia launch (the launch contract and its Uniswap Continuous Clearing Auction, in the launch currency), plus the liquidity of the Uniswap v4 pools registered on the Umia hook, which each launch seeds at migration. Launches are enumerated from the Umia hub; treasuries are tracked separately as a treasury adapter.',
+    'Bids escrowed in each Umia launch (the launch contract and its Uniswap Continuous Clearing Auction, in the launch currency), plus the canonical spot liquidity held by each venture SpotLiquidityVault -- its Uniswap v4 pool reserves, idle balances, and amounts on loan to live decision markets. Launches are enumerated from the Umia hub; venture treasuries are tracked separately as a treasury adapter.',
+  start: 1787694409,
   base: { tvl },
 }

--- a/projects/umia/index.js
+++ b/projects/umia/index.js
@@ -2,7 +2,7 @@ const { sumTokens2 } = require('../helper/unwrapLPs')
 const { nullAddress } = require('../helper/tokenMapping')
 
 const HUB = '0x120dbCDd58Bb787309573e29159fE6D37A1983F6'
-// Ventures 1-6 are "Koi3 TEST" deployments that predate the first real launch.
+// Ventures 1-6 are test deployments that predate the first real launch.
 const FIRST_REAL_VENTURE_ID = 7
 
 const VENTURE_BY_ID =
@@ -10,6 +10,15 @@ const VENTURE_BY_ID =
 const VENTURE_VAULT = 'function ventureLiquidityVault(address) view returns (address)'
 const TOTAL_ASSETS = 'function totalAssets() view returns (uint256 ventureAssets, uint256 moneyAssets)'
 
+/**
+ * Enumerates real venture treasuries from the hub.
+ *
+ * Venture ids are 1-based and never reused, so slicing off the leading test
+ * deployments by id needs no maintenance as new ventures are created.
+ *
+ * @param {object} api - DefiLlama chain api
+ * @returns {Promise<string[]>} venture treasury addresses
+ */
 async function getVentures(api) {
   const count = await api.call({ target: HUB, abi: 'uint256:ventureCount' })
   const ids = []
@@ -19,11 +28,21 @@ async function getVentures(api) {
   return infos.map(v => v.venture)
 }
 
+/**
+ * Sums escrowed launch bids and canonical spot liquidity across all live ventures.
+ *
+ * Spot liquidity is read from each venture's SpotLiquidityVault rather than from the
+ * Uniswap v4 pool directly: `totalAssets()` also covers idle vault balances and amounts
+ * on loan to live decision markets, which a pool-only reading would drop for the
+ * duration of each market.
+ *
+ * @param {object} api - DefiLlama chain api
+ * @returns {Promise<object>} token balances
+ */
 async function tvl(api) {
   const ventures = await getVentures(api)
   if (!ventures.length) return api.getBalances()
 
-  // Bids escrowed in each live launch: the launch contract and its Continuous Clearing Auction.
   const lbps = await api.multiCall({ abi: 'address:lbp', calls: ventures })
   const [auctions, currencies] = await Promise.all([
     api.multiCall({ abi: 'address:initializer', calls: lbps }),
@@ -36,9 +55,6 @@ async function tvl(api) {
   })
   await sumTokens2({ api, tokensAndOwners })
 
-  // Canonical spot liquidity. The venture's SpotLiquidityVault is the pool's only permitted LP,
-  // and totalAssets() covers in-pool reserves, idle balances, and amounts currently on loan to
-  // live decision markets -- so it stays correct across hook redeployments and market cycles.
   const vaults = (
     await api.multiCall({ target: HUB, abi: VENTURE_VAULT, calls: ventures })
   ).filter(v => v && v !== nullAddress)
@@ -59,7 +75,7 @@ async function tvl(api) {
 
 module.exports = {
   methodology:
-    'Bids escrowed in each Umia launch (the launch contract and its Uniswap Continuous Clearing Auction, in the launch currency), plus the canonical spot liquidity held by each venture SpotLiquidityVault -- its Uniswap v4 pool reserves, idle balances, and amounts on loan to live decision markets. Launches are enumerated from the Umia hub; venture treasuries are tracked separately as a treasury adapter.',
+    'Bids escrowed in each Umia launch (the launch contract and its Uniswap Continuous Clearing Auction, in the launch currency), plus the canonical spot liquidity held by each venture SpotLiquidityVault -- its Uniswap v4 pool reserves, idle balances, and amounts on loan to live decision markets. The vault is the pool\'s only permitted liquidity operator, so it holds 100% of canonical liquidity. Launches are enumerated from the Umia hub; venture treasuries are tracked separately as a treasury adapter.',
   start: 1787694409,
   base: { tvl },
 }


### PR DESCRIPTION
Adds a TVL adapter for Umia Protocol on Base, plus a treasury adapter for its venture treasuries.

Umia is a launchpad and decision-market (futarchy) protocol. Each venture runs a launch through a Continuous Clearing Auction, then migrates into a Uniswap v4 pool behind a custom hook.

@alezvillo wrote the original adapter in the first two commits. The later two correct it against live mainnet state and add docstrings.

---

## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
Umia

##### Twitter Link:
https://twitter.com/umia_finance

##### List of audit links if any:
https://www.certora.com/reports/umia

Certora, 13 April 2026. Manual code review plus invariant and attack-vector analysis. Certora confirmed the resolution of all high-severity issues.

##### Website Link:
https://www.umia.finance

##### Logo (High resolution, will be shown with rounded borders):
https://umia-mainnet-uploads.s3.us-east-1.amazonaws.com/projects/a9345361-1745-48fd-8f05-e1ceabe8b1bb/logo-a3aa271e5d7e.webp

512×512 WebP.

##### Current TVL:
$0. The hub holds seven ventures. Ids 1 to 6 are test deployments from rollout, and only venture 7 is a real launch. Its auction has not taken bids yet: `migrated: false`, no escrow, no liquidity vault. Both adapters start at `FIRST_REAL_VENTURE_ID`, so they skip the test ventures instead of counting them as protocol TVL. That is why the CI precheck reports 0.00.

The filter keys on venture id because timestamps cannot separate these ventures. The team created all seven inside a 25-hour window, with 88 minutes between the last test venture and the first real one. Venture ids increment and never repeat, so the filter needs no maintenance when ventures 8 and 9 arrive.

##### Treasury Addresses (if the protocol has treasury)
The adapter reads treasuries from the hub, so the code hardcodes none. Venture 7 holds the only real one today: [`0x57fbe5581A16bf5384e5195f3DD8c8A876f4FB05`](https://basescan.org/address/0x57fbe5581A16bf5384e5195f3DD8c8A876f4FB05)

##### Chain:
Base (8453)

##### Coingecko ID:
`umia` (https://www.coingecko.com/en/coins/umia)

##### Coinmarketcap ID:
Not listed.

##### Short Description (to be shown on DefiLlama):
Umia is the onchain venture protocol: a full-stack platform for launching, funding, and governing token-based projects onchain.

##### Token address and ticker if any:
UMIA, [`0x56ab53b77F07DA3af732150E8aeC4783eB5BbA7D`](https://basescan.org/token/0x56ab53b77F07DA3af732150E8aeC4783eB5BbA7D). 18 decimals, 50,000,000 supply.

##### Category:
Launchpad

##### Oracle Provider(s):
TWAP, from the protocol's own contracts. Umia uses no external oracle provider.

- Spot TWAP: `UmiaHook` [`0x128BedebaA9304Db74726efba848A98E7fB53A80`](https://basescan.org/address/0x128BedebaA9304Db74726efba848A98E7fB53A80)
- Decision-market TWAP: `ConditionalMarketOracle` [`0x114C446Ce246b6C5c432Eb001fBeB17864Fc1d34`](https://basescan.org/address/0x114C446Ce246b6C5c432Eb001fBeB17864Fc1d34), read by the core through `hub.conditionalMarketOracle()`

##### Implementation Details:
The protocol's own Uniswap v4 hook (`UmiaHook`) records a price observation on swap and liquidity events, then exposes a TWAP over that history. The TWAP gates decision-market settlement and milestone conditions. It does not price TVL: this adapter reports token balances, and DefiLlama prices them.

##### Documentation/Proof:
Docs at https://www.umia.finance/docs. Contracts at https://github.com/umiafinance/protocol.

Oracle source:
- [`src/periphery/UmiaHook.sol`](https://github.com/umiafinance/protocol/blob/main/src/periphery/UmiaHook.sol) exposes `observe()` and `observeLong()`
- [`src/libraries/SpotMarketOracle.sol`](https://github.com/umiafinance/protocol/blob/main/src/libraries/SpotMarketOracle.sol) holds the observation ring and TWAP math
- [`src/periphery/ConditionalMarketOracle.sol`](https://github.com/umiafinance/protocol/blob/main/src/periphery/ConditionalMarketOracle.sol) scores decision markets

##### forkedFrom (Does your project originate from another project):
Not a fork. Umia builds on Uniswap v4 with a custom hook, and uses MetaVesT for vesting.

##### methodology (what is being counted as tvl, how is tvl being calculated):
**`projects/umia/index.js`** covers protocol TVL in two parts:
1. Bids that each live launch holds in escrow, across the launch contract and its Continuous Clearing Auction, denominated in the launch currency (USDC).
2. Canonical spot liquidity, read from each venture's `SpotLiquidityVault` through `totalAssets()`.

The adapter calls `totalAssets()` instead of reading the v4 pool, because that covers in-pool reserves, idle vault balances, and amounts on loan to live decision markets. The protocol pulls a share of spot liquidity into each decision market and returns it at settlement, so a pool-only reading would drop that capital for the market's duration. `totalAssets()` also reads on-chain at the queried block, which keeps historical TVL correct and needs no Graph API key.

The full pool balance belongs to the protocol. `UmiaHook.beforeAddLiquidity` restricts liquidity to the registered operator, so the vault is the pool's only LP.

**`projects/treasury/umia.js`** covers venture treasuries, and reports each venture's own token under `ownTokens`. It does not overlap the main adapter: launches hold auction bids in escrow before settlement, and the treasury receives them after.

Both adapters enumerate ventures, launches, auctions and vaults from the hub [`0x120dbCDd58Bb787309573e29159fE6D37A1983F6`](https://basescan.org/address/0x120dbCDd58Bb787309573e29159fE6D37A1983F6), so the code hardcodes no per-venture addresses.

##### Github org/user (Optional, if your code is open source, we can track activity):
`umiafinance`. Contracts are open source at https://github.com/umiafinance/protocol.

##### Does this project have a referral program?
No.

---

### Testing

```
node test.js projects/umia/index.js       # runs clean, $0.00 (no real launch yet)
node test.js projects/treasury/umia.js    # runs clean, $0.00
npx eslint -c eslint.config.js projects/umia/index.js projects/treasury/umia.js   # clean
```

No new npm dependencies, and `pnpm-lock.yaml` is untouched.

Tracking issue: umiafinance/umia#176

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for Umia, including venture assets, money assets, and launch-related escrow.
  * Added discovery of ventures and liquidity vault balances through the Umia hub.
  * Added methodology metadata and an updated tracking start date.

* **Improvements**
  * Improved treasury balance aggregation and token ownership reporting.
  * Enhanced handling of empty results and excluded invalid vault or owner entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->