### PR TITLE
Fix Turtle Treasury

### DIFF
--- a/projects/TurtleClub/assets.js
+++ b/projects/TurtleClub/assets.js
@@ -174,6 +174,14 @@ const tokenMappingERC20 = {
     ],
 };
 
+const TURTLE = '0x66fd8de541c0594b4dccdfc13bf3a390e50d3afd';
+
+const ownTokens = {
+    ethereum: [
+        TURTLE,
+    ],
+};
+
 const treasuryNFTs = {
     avax: [
         { name: 'PHAR', veNft: '0xAAAEa1fB9f3DE3F70E89f37B69Ab11B47eb9Ce6F', baseToken: tokens.avax.PHAR, owner: '0x58A916AD66584811C939AA844025036e5078E811' }, // Pharaoh Exchange - vePHAR
@@ -239,6 +247,7 @@ module.exports = {
     treasuryMultisigs,
     tokenMapping,
     tokenMappingERC20,
+    ownTokens,
     treasuryNFTs,
     turtleVaults,
 };

--- a/projects/treasury/turtleclub.js
+++ b/projects/treasury/turtleclub.js
@@ -1,88 +1,134 @@
-const { tokens, treasuryMultisigs, treasuryNFTs, defaultTokens, tokenMappingERC20, tokenMapping } = require('../TurtleClub/assets');
+const {
+    tokens,
+    treasuryMultisigs,
+    treasuryNFTs,
+    defaultTokens,
+    tokenMappingERC20,
+    tokenMapping,
+    ownTokens,
+} = require('../TurtleClub/assets');
 const { sumTokens2, unwrapSolidlyVeNft } = require('../helper/unwrapLPs');
 const SOLIDLY_VE_NFT_ABI = require('../helper/abis/solidlyVeNft.json');
 const { createIncrementArray } = require('../helper/utils');
-const balanceOfNft_erc721 = 'function balanceOfNFT(uint256) returns (uint256)';
 
-function formatForTreasuryExport(tokens = {}) {
-    const treasuryExportsFormat = {};
-    for (const [chain, tokenList] of Object.entries(tokens)) {
-        treasuryExportsFormat[chain] = { owners: treasuryMultisigs, tokens: Object.values(tokenList) };
-    }
-    return treasuryExportsFormat;
-}
+const BALANCE_OF_NFT = 'function balanceOfNFT(uint256) returns (uint256)';
+const STAKED_XREX = '0xedd7cbc9c47547d0b552d5bc2be76135f49c15b1';
+
+const getTreasuryOwners = () => treasuryMultisigs;
+const nonZero = balance => balance && balance !== '0';
+const normalizeBalances = balances => balances.filter(nonZero).map(Number);
+
+const addMappedBalance = (api, { token, coingeckoId, decimals }, balance) => {
+    if (coingeckoId) return api.add(coingeckoId, balance / (10 ** decimals), { skipChain: true });
+    return api.add(token, balance);
+};
 
 async function sumNFTs(api, NFTs) {
-    const waitNFTs = [];
-    for (const treasuryNFT of NFTs) {
+    const nftBalanceCalls = NFTs.map(async treasuryNFT => {
         const { veNft, owner, baseToken, useLocked = true } = treasuryNFT;
 
-        waitNFTs.push((async () => {
-            if (useLocked) await unwrapSolidlyVeNft({ api, isAltAbi: true, veNft, owner, baseToken });
-            else {
-                const count = await api.call({ abi: 'erc20:balanceOf', target: veNft, params: owner });
-                const tokenIds = await api.multiCall({ abi: SOLIDLY_VE_NFT_ABI.tokenOfOwnerByIndex, calls: createIncrementArray(count).map(i => ({ params: [owner, i] })), target: veNft });
-                const bals = await api.multiCall({ abi: balanceOfNft_erc721, calls: tokenIds, target: veNft });
-                bals.forEach(i => api.add(baseToken, i));
-            }
-        })());
-    }
-    return await Promise.allSettled(waitNFTs);
+        if (useLocked) return unwrapSolidlyVeNft({ api, isAltAbi: true, veNft, owner, baseToken });
+
+        const count = await api.call({ abi: 'erc20:balanceOf', target: veNft, params: owner });
+        const tokenIds = await api.multiCall({
+            abi: SOLIDLY_VE_NFT_ABI.tokenOfOwnerByIndex,
+            calls: createIncrementArray(count).map(i => ({ params: [owner, i] })),
+            target: veNft,
+        });
+        const balances = await api.multiCall({ abi: BALANCE_OF_NFT, calls: tokenIds, target: veNft });
+        balances.forEach(balance => api.add(baseToken, balance));
+    });
+
+    return Promise.allSettled(nftBalanceCalls);
 }
 
-function turtleTreasuryExports(config, treasuryNFTs) {
-    const chains = Object.keys(config);
+function buildTreasuryConfig(chain, tokenList) {
+    const protocolOwnedTokens = ownTokens[chain] ?? [];
+    const config = {
+        owners: getTreasuryOwners(),
+        tokens: Object.values(tokenList),
+        ownTokens: protocolOwnedTokens,
+        permitFailure: true,
+    };
+
+    if (defaultTokens[chain]) config.tokens = [config.tokens, defaultTokens[chain]].flat();
+
+    return {
+        ...config,
+        blacklistedTokens: [...protocolOwnedTokens],
+    };
+}
+
+async function sumMappedERC20s(api, chain) {
+    const mappings = tokenMappingERC20[chain] ?? [];
+
+    await Promise.allSettled(mappings.map(async ({ token, use, coingeckoId, decimals }) => {
+        const balances = await api.multiCall({
+            abi: 'erc20:balanceOf',
+            calls: getTreasuryOwners().map(owner => ({
+                target: token,
+                params: owner,
+            })),
+            permitFailure: true,
+        });
+
+        normalizeBalances(balances).forEach(balance => {
+            addMappedBalance(api, { token: use, coingeckoId, decimals }, balance);
+        });
+    }));
+}
+
+async function sumStakedXRex(api, chain) {
+    if (chain !== 'linea') return;
+
+    const xRex = tokens.linea.xREX;
+    const xRexMapping = tokenMapping.linea[xRex];
+    const balances = await api.multiCall({
+        abi: 'function balanceOf(address) view returns (uint256)',
+        calls: getTreasuryOwners().map(owner => ({ params: [owner] })),
+        target: STAKED_XREX,
+        permitFailure: true,
+    });
+
+    normalizeBalances(balances).forEach(balance => {
+        addMappedBalance(api, { token: xRex, ...xRexMapping }, balance);
+    });
+}
+
+function buildTvlExport(chain, config) {
+    return async api => {
+        await sumMappedERC20s(api, chain);
+        await sumStakedXRex(api, chain);
+        await sumTokens2({ api, ...config });
+
+        if (treasuryNFTs[chain]?.length > 0) await sumNFTs(api, treasuryNFTs[chain]);
+    };
+}
+
+function buildOwnTokensExport(config) {
+    if (!config.ownTokens.length) return undefined;
+
+    return api => sumTokens2({
+        api,
+        owners: config.owners,
+        tokens: config.ownTokens,
+        permitFailure: true,
+    });
+}
+
+function turtleTreasuryExports() {
     const exportObj = {};
-    for (const chain of chains) {
-        // From treasuryExports
-        const tvlConfig = { permitFailure: true, ...config[chain] };
-        if (defaultTokens[chain]) {
-            tvlConfig.tokens = [tvlConfig.tokens, defaultTokens[chain]].flat();
-        }
 
-        const tvl = async (api) => {
-            if (tokenMappingERC20[chain]?.length > 0) {
-                const es = [];
-                tokenMappingERC20[chain].forEach(async ({ token, use, coingeckoId, decimals }) => {
-                    const balanceLogic = coingeckoId ?
-                        bal => api.add(coingeckoId, bal / (10 ** decimals), { skipChain: true }) :
-                        bal => api.add(use, bal);
-                    es.push((async () => {
-                        const balances = await api.multiCall({
-                            abi: 'erc20:balanceOf',
-                            calls: treasuryMultisigs.map(owner => ({
-                                target: token,
-                                params: owner,
-                            })),
-                            permitFailure: true
-                        });
-                        balances.filter(b => b !== '0' && !!b).map(bal => Number(bal)).forEach(balanceLogic);
-                    })());
-                });
-                await Promise.allSettled(es);
-            }
+    for (const [chain, tokenList] of Object.entries(tokens)) {
+        const config = buildTreasuryConfig(chain, tokenList);
+        const chainExports = { tvl: buildTvlExport(chain, config) };
+        const ownTokensExport = buildOwnTokensExport(config);
 
-            const xRexAddr = tokens.linea.xREX;
-            const xRexStakedBalances = await api.multiCall({
-                abi: 'function balanceOf(address) view returns (uint256)',
-                calls: treasuryMultisigs.map(owner => ({ params: [owner] })),
-                target: '0xedd7cbc9c47547d0b552d5bc2be76135f49c15b1', // VoteModule staking contract
-                permitFailure: true,
-            });
-            xRexStakedBalances.filter(b => b && b !== '0').map(bal => Number(bal)).forEach(balance => {
-                const xRexMapping = tokenMapping.linea[xRexAddr];
-                if (xRexMapping)
-                    api.add(xRexMapping.coingeckoId, balance / (10 ** xRexMapping.decimals), { skipChain: true });
-                else
-                    api.add(xRexAddr, balance);
-            });
-
-            await sumTokens2({ ...api, api, ...tvlConfig });
-            if (treasuryNFTs[chain]?.length > 0) await sumNFTs(api, treasuryNFTs[chain]);
-        };
-        exportObj[chain] = { tvl };
+        if (ownTokensExport) chainExports.ownTokens = ownTokensExport;
+        exportObj[chain] = chainExports;
     }
+
     return exportObj;
 }
 
-module.exports = turtleTreasuryExports(formatForTreasuryExport(tokens), treasuryNFTs);
+module.exports = turtleTreasuryExports();


### PR DESCRIPTION
```
------ TVL ------
ethereum-ownTokens        21.75 M
ownTokens                 21.75 M
ethereum                  268.23 k
linea                     35.69 k
base                      10.01 k
avax                      283.00
arbitrum                  43.00
mantle                    0.00
mode                      0.00
blast                     0.00
berachain                 0.00
scroll                    0.00
polygon                   0.00

total                    314.26 k 
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking protocol-owned TURTLE tokens on Ethereum.
  * Treasury reporting now includes configured owned tokens alongside ERC20, staked, and NFT holdings.

* **Bug Fixes**
  * Improved treasury balance collection and token handling across supported chains.
  * Restricted staked xREX reporting to Linea for more accurate results.
  * Prevented protocol-owned tokens from being double-counted in general TVL totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->