### PR TITLE
pyusdx

### DIFF
--- a/projects/saturn-protocol/index.js
+++ b/projects/saturn-protocol/index.js
@@ -2,14 +2,16 @@ const ADDRESSES = require('../helper/coreAssets.json')
 
 const USDat = '0x23238f20b894f29041f48d88ee91131c395aaa71';
 const sUSDat = '0xd166337499e176bbc38a1fbd113ab144e5bd2df7';
-const M = '0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b';
+// Saturn migrated USDat's reserve from M0's $M to PYUSDx (MoonPay/M0 PYUSD-backed
+// extension) in Aug 2026; the $M balance is now 0.
+const PYUSDx = '0xebdb0942ce16386ab90718c7bd10c91cdb66b14d';
 const USDC = ADDRESSES.ethereum.USDC;
 // sUSDat is backed by STRC (Strategy's "Stretch" preferred stock); balances are 6 decimals.
 const STRC_DECIMALS = 6;
 
 async function tvl(api) {
-  // USDat backing: tokenized treasuries (M0's $M) + USDC held by the USDat contract.
-  await api.sumTokens({ owner: USDat, tokens: [M, USDC] });
+  // USDat backing: PYUSDx reserve + USDC held by the USDat contract.
+  await api.sumTokens({ owner: USDat, tokens: [PYUSDx, USDC] });
   // STRC has no on-chain token to price, so value the sUSDat backing via DefiLlama's
   // tradfi STRC feed (coingecko:llama-stock-strc) rather than Saturn's own oracle.
   const strcBalance = await api.call({ target: sUSDat, abi: 'uint256:strcBalance' });
@@ -19,7 +21,7 @@ async function tvl(api) {
 }
 
 module.exports = {
-  methodology: "USDat backing (tokenized treasuries $M and USDC held by the USDat contract) plus the STRC digital-credit backing of sUSDat, priced via DefiLlama's tradfi STRC feed (NASDAQ: STRC).",
+  methodology: "USDat backing (the PYUSDx reserve and USDC held by the USDat contract) plus the STRC digital-credit backing of sUSDat, priced via DefiLlama's tradfi STRC feed (NASDAQ: STRC).",
   ethereum: {
     tvl,
   },

--- a/projects/saturn-protocol/index.js
+++ b/projects/saturn-protocol/index.js
@@ -3,15 +3,17 @@ const ADDRESSES = require('../helper/coreAssets.json')
 const USDat = '0x23238f20b894f29041f48d88ee91131c395aaa71';
 const sUSDat = '0xd166337499e176bbc38a1fbd113ab144e5bd2df7';
 // Saturn migrated USDat's reserve from M0's $M to PYUSDx (MoonPay/M0 PYUSD-backed
-// extension) in Aug 2026; the $M balance is now 0.
+// extension) on 2026-08-19; $M is 0 now but non-zero at earlier blocks, so both are
+// summed to keep historical TVL correct.
+const M = '0x866a2bf4e572cbcf37d5071a7a58503bfb36be1b';
 const PYUSDx = '0xebdb0942ce16386ab90718c7bd10c91cdb66b14d';
 const USDC = ADDRESSES.ethereum.USDC;
 // sUSDat is backed by STRC (Strategy's "Stretch" preferred stock); balances are 6 decimals.
 const STRC_DECIMALS = 6;
 
 async function tvl(api) {
-  // USDat backing: PYUSDx reserve + USDC held by the USDat contract.
-  await api.sumTokens({ owner: USDat, tokens: [PYUSDx, USDC] });
+  // USDat backing: reserve tokens ($M pre-migration, PYUSDx after) + USDC held by the USDat contract.
+  await api.sumTokens({ owner: USDat, tokens: [PYUSDx, M, USDC] });
   // STRC has no on-chain token to price, so value the sUSDat backing via DefiLlama's
   // tradfi STRC feed (coingecko:llama-stock-strc) rather than Saturn's own oracle.
   const strcBalance = await api.call({ target: sUSDat, abi: 'uint256:strcBalance' });
@@ -21,7 +23,7 @@ async function tvl(api) {
 }
 
 module.exports = {
-  methodology: "USDat backing (the PYUSDx reserve and USDC held by the USDat contract) plus the STRC digital-credit backing of sUSDat, priced via DefiLlama's tradfi STRC feed (NASDAQ: STRC).",
+  methodology: "USDat backing (the PYUSDx reserve, legacy $M, and USDC held by the USDat contract) plus the STRC digital-credit backing of sUSDat, priced via DefiLlama's tradfi STRC feed (NASDAQ: STRC).",
   ethereum: {
     tvl,
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated USDat total value locked (TVL) calculations to include legacy `$M`, PYUSDx, and USDC reserves.
  * Preserved accurate historical balances across the August 19, 2026 migration.
  * Revised the displayed methodology to document the legacy `$M` reserve and the expanded reserve calculation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->