### PR TITLE
remove unirouter duplicates

### DIFF
--- a/registries/sumTokens.js
+++ b/registries/sumTokens.js
@@ -28296,13 +28296,9 @@ const configs = {
   },
   "unirouter": {
     "bsquared": {
-      "owners": [
-        "0xd5B5f1CA0fa5636ac54b0a0007BA374A1513346e",
-        "0xe677F4B6104726D76DeBc681d7a862CE269aA8F3"
-      ],
-      "tokens": [
-        ADDRESSES.null
-      ]
+      "tvl": {
+        "__empty": true
+      }
     },
   },
   "unit-btc": {


### PR DESCRIPTION
both owners are duplicates shared between two existing protocols

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the `unirouter.bsquared` registry configuration to use an empty total value locked (TVL) configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->