### PR TITLE
remove okexchain from gate

### DIFF
--- a/projects/gate-io/index.js
+++ b/projects/gate-io/index.js
@@ -1405,10 +1405,10 @@ const config = {
   },
   "okexchain": {
     "owners": [
-      "0x0d0707963952f2fba59dd06f2b425ace40b492fe",
-      "0x1c4b70a3968436b9a0a9cf5205c787eb81bb558c",
-      "0xc882b111a75c0c657fc507c04fbfcd2cc984f071",
-      "0xffeb0f61871acdb4838dfc6d5082f063e738e421"
+  //     "0x0d0707963952f2fba59dd06f2b425ace40b492fe",
+  //     "0x1c4b70a3968436b9a0a9cf5205c787eb81bb558c",
+  //     "0xc882b111a75c0c657fc507c04fbfcd2cc984f071",
+  //     "0xffeb0f61871acdb4838dfc6d5082f063e738e421"
     ]
   },
   "ontology": {


### PR DESCRIPTION
Causing the adapter to fail, there is real historical tvl so we remove owners instead of deleting the chain export 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Disabled the listed owner addresses for the OkexChain integration.
  * OkexChain currently has no active owners configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->