### PR TITLE
dexlaunch: add HyperEVM deployment

### DIFF
--- a/projects/dexlaunch/index.js
+++ b/projects/dexlaunch/index.js
@@ -1,8 +1,17 @@
 const ADDRESSES = require("../helper/coreAssets.json");
 const { sumTokens2 } = require("../helper/unwrapLPs");
 
+// One stateless ProtocolLens per deployment (docs: https://dexlaunch.fun/docs, "Deployed
+// contracts"); it resolves every downstream singleton through the SaleFactory per call.
 const config = {
-  robinhood: { lens: "0x99572E63B8C8C64D42Dba1Be1e2f78AD9cD6FC1d" },
+  robinhood: {
+    lens: "0x99572E63B8C8C64D42Dba1Be1e2f78AD9cD6FC1d",
+    wnative: ADDRESSES.robinhood.WETH,
+  },
+  hyperliquid: {
+    lens: "0x5aF7A226F75AF0F0bA99DFdaE05D7167e5B1fc16",
+    wnative: ADDRESSES.hyperliquid.WHYPE,
+  },
 };
 
 const abi = {
@@ -10,10 +19,10 @@ const abi = {
 };
 
 async function tvl(api) {
-  const { lens } = config[api.chain];
+  const { lens, wnative } = config[api.chain];
   const src = await api.call({ target: lens, abi: abi.getTvlSources });
 
-  // 1. Bonding-curve pad: exact ETH backing live curves.
+  // 1. Bonding-curve pad: exact native backing of live curves.
   api.add(ADDRESSES.null, src.padEthWei);
 
   // 2. Locked graduation LP + every sale's funding asset.
@@ -31,13 +40,13 @@ async function tvl(api) {
     resolveLP: true,
     resolveUniV3: Boolean(uniV3ExtraConfig),
     uniV3ExtraConfig,
-    uniV3WhitelistedTokens: [ADDRESSES.robinhood.WETH],
+    uniV3WhitelistedTokens: [wnative],
   });
 }
 
 module.exports = {
   methodology:
-    "TVL is the ETH held by live bonding curves (ProtocolLens.getPadEthTvl), WETH locked in the shared TokenLocker (LP unwrapped to underlyings; locked graduation LP included; V3 positions priced by id), and each active presale's funding-asset balance.",
+    "TVL is the native asset held by live bonding curves (ProtocolLens.getPadEthTvl), wrapped-native locked in the shared TokenLocker (LP unwrapped to underlyings; locked graduation LP included; V3 positions priced by id), and each active presale's funding-asset balance. Same lens-driven sources on every deployed chain.",
   start: '2026-08-01',
 };
 Object.keys(config).forEach((chain) => {


### PR DESCRIPTION
DexLaunch expanded to HyperEVM (satellite deployment of the same contracts; announcement: https://x.com/dexlaunchfun).

Adds the `hyperliquid` chain to the existing dexlaunch adapter. Same lens-driven methodology as Robinhood Chain — a stateless ProtocolLens per deployment returns every TVL source in one call:
- lens (hyperliquid): `0x5aF7A226F75AF0F0bA99DFdaE05D7167e5B1fc16` (resolves the locker/pad/sales through the SaleFactory `0x7d80788C12b15812AA7a9550bA5A3e8c506Fa545` per call)
- native curve backing + locked V3 graduation LP (priced by position id, WHYPE-whitelisted) + presale funding balances

Tested:
```
--- robinhood ---   WETH 8.37k
--- hyperliquid --- WHYPE 0.00 (fresh deployment, first locked position resolves)
```