### PR TITLE
arcus-ptokens: add dynamic TVL adapter

### DIFF
--- a/projects/arcus-ptokens/index.js
+++ b/projects/arcus-ptokens/index.js
@@ -1,0 +1,34 @@
+const { sumERC4626Vaults } = require('../helper/erc4626')
+
+const FACTORY = '0x9c3663FA9ab976E67B42939486EC4966Cb41a0BB'
+
+const TEST_VAULTS = new Set([
+  '0x1193bcbfafeb2f25c516817c46bd3143936d1d5c', // pTEST
+  '0x4595a18b47c6fb46f3a157e2918f5c34cdca35eb', // pTESTR
+])
+
+async function tvl(api) {
+  const allVaults = await api.fetchList({
+    target: FACTORY,
+    lengthAbi: 'uint256:pTokenCount',
+    itemAbi: 'function pTokenAt(uint256) view returns (address)',
+  })
+
+  const vaults = allVaults.filter(
+    (vault) => !TEST_VAULTS.has(vault.toLowerCase())
+  )
+
+  return sumERC4626Vaults({
+    api,
+    calls: vaults,
+    isOG4626: true,
+  })
+}
+
+module.exports = {
+  doublecounted: true,
+  methodology:
+    'TVL is the net asset value of all production Arcus pToken managed perpetual accounts registered by the pToken factory, read on-chain from totalAssets() on each ERC-4626 vault and denominated in USDG. Test vaults are excluded. It is marked doublecounted because pToken collateral is transferred to the Arcus Perps bridge and is already included in Arcus Perps TVL.',
+  start: '2026-08-07',
+  robinhood: { tvl },
+}


### PR DESCRIPTION
### Summary

Adds a dynamic on-chain TVL adapter for Arcus pTokens on Robinhood Chain.

The adapter discovers all pToken vaults registered by the official Arcus pToken factory through `pTokenCount()` and `pTokenAt(index)`. It excludes the two known test vaults and uses DefiLlama's existing ERC-4626 helper to read the USDG-denominated net asset value from `totalAssets()`.

Future production pTokens registered by the same factory will be discovered automatically.

The adapter is marked `doublecounted: true` because pToken collateral is transferred into the Arcus Perps bridge and is already included in the existing `arcus-perp` TVL.

---

### New listing information

**Name (to be shown on DefiLlama):**  
Arcus pTokens
 (part or Arcus)
**Twitter Link:**  
https://x.com/arcus_xyz

**List of audit links if any:**  
No pToken-specific audit has been publicly identified.  

**Website Link:**  
https://arcus.xyz/

**Logo (High resolution, will be shown with rounded borders):**  
Official Arcus brand kit:  
https://arcus.xyz/brand-kit

**Current TVL:**  
Approximately $242k during testing.  
 
**Treasury Addresses (if the protocol has treasury):**  
N/A for this adapter.

**Chain:**  
Robinhood Chain

**Coingecko ID:**  
N/A

**Coinmarketcap ID:**  
N/A

**Short Description (to be shown on DefiLlama):**  
Arcus pTokens are transferable ERC-20 vault shares representing proportional exposure to managed Arcus perpetual accounts with predefined markets, directions and leverage.

**Token address and ticker if any:**  
The factory currently returns seven registered pToken vaults.

*Production vaults currently included:*
* **pBTC3x:** `0x4472C69d299382F8847ebCE4FC6Ed8e295510E3e`
* **pHOOD3x:** `0xe24CABDf76DD1c2576049167eB1755C84b985C36`
* **pBTC:** `0x925F92F055EDB79C42B5d45E64A1b74143b90eA0`
* **sBTC:** `0xC25c966168a8e933b0aBa0DC8A25Cac4A2b2B91D`
* **sBTC3x:** `0xaDccEee8e422050F890522FA798F8A93a4857083`

*Underlying asset for all production vaults:*
* **USDG:** `0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168`

*Excluded test vaults:*
* **pTEST:** `0x1193BcBfaFeB2F25C516817C46BD3143936d1d5C`
* **pTESTR:** `0x4595A18B47c6Fb46F3a157E2918F5C34cDca35EB`

**Category:**  
Derivatives

**Oracle Provider(s):**  
The adapter does not directly query an oracle. It reads the USDG-denominated net asset value returned by `totalAssets()` on each ERC-4626 pToken vault.  


**Implementation Details:**  
N/A

**Documentation/Proof:**  
* Product launch coverage based on information supplied by Arcus: https://www.theblock.co/news/defi/2026-08-25-robinhood-chain-dex-arcus-ptokens-perps-erc-20s-412696
* Official pToken factory: https://robinhoodchain.blockscout.com/address/0x9c3663FA9ab976E67B42939486EC4966Cb41a0BB

*Production vaults:*
* **pBTC3x:**
  * Address: https://robinhoodchain.blockscout.com/address/0x4472C69d299382F8847ebCE4FC6Ed8e295510E3e

* **pHOOD3x:**
  * Address: https://robinhoodchain.blockscout.com/address/0xe24CABDf76DD1c2576049167eB1755C84b985C36
 
* **pBTC:**
  * Address: https://robinhoodchain.blockscout.com/address/0x925F92F055EDB79C42B5d45E64A1b74143b90eA0

* **sBTC:**
  * Address: https://robinhoodchain.blockscout.com/address/0xC25c966168a8e933b0aBa0DC8A25Cac4A2b2B91D

* **sBTC3x:**
  * Address: https://robinhoodchain.blockscout.com/address/0xaDccEee8e422050F890522FA798F8A93a4857083


*Excluded test vaults:*
* **pTEST:** https://robinhoodchain.blockscout.com/address/0x1193BcBfaFeB2F25C516817C46BD3143936d1d5C
* **pTESTR:** https://robinhoodchain.blockscout.com/address/0x4595A18B47c6Fb46F3a157E2918F5C34cDca35EB


**forkedFrom (Does your project originate from another project):**  
No publicly documented fork.

**methodology:**  
TVL is the sum of the USDG-denominated net asset value returned by `totalAssets()` across all production Arcus pToken ERC-4626 vaults registered by the official pToken factory.  
Vault addresses are discovered dynamically through `pTokenCount()` and `pTokenAt(index)`. The known pTEST and pTESTR vaults are excluded.  
The adapter uses DefiLlama's existing ERC-4626 helper. 
The adapter is marked `doublecounted: true` because pToken collateral is transferred into the Arcus Perps bridge and is already represented in the existing `arcus-perp` TVL.

**Github org/user:**  
https://github.com/arcus-xyz

**Does this project have a referral program?**  
Yes.  
https://arcus.xyz/blog/refer-traders-earn-forever

---

### Adapter implementation
* **Requested parent protocol:** Arcus (`parent#arcus`)

---

### Validation
**Command:**
```bash
ode test.js projects/arcus-ptokens/index.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for Arcus pToken vaults.
  * Automatically discovers eligible vaults and calculates their combined value.
  * Added methodology details and tracking start date for the new protocol integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->