### PR TITLE
add Scorch TVL adapter

### DIFF
--- a/projects/scorch/index.js
+++ b/projects/scorch/index.js
@@ -1,0 +1,21 @@
+const { PublicKey } = require('@solana/web3.js')
+const { sumTokensExport } = require('../helper/solana')
+
+const SCORCH_PROGRAM = new PublicKey(
+  'SCoRcH8c2dpjvcJD6FiPbCSQyQgu3PcUAWj2Xxx3mqn'
+)
+
+const [SCORCH_AUTHORITY] = PublicKey.findProgramAddressSync(
+  [Buffer.from('authority')],
+  SCORCH_PROGRAM,
+)
+
+module.exports = {
+  methodology:
+    'TVL is the value of SPL and Token-2022 balances controlled by the authority PDA derived from the Scorch program on Solana.',
+  solana: {
+    tvl: sumTokensExport({
+      owner: SCORCH_AUTHORITY.toString(),
+    }),
+  },
+}


### PR DESCRIPTION
### Summary
Adds an on-chain TVL adapter for Scorch on Solana.  
Scorch is already listed on DefiLlama with a DEX volume adapter. This PR adds the missing TVL calculation.  
The adapter derives Scorch's authority PDA directly from the same Solana program recognized by the existing volume integration and sums the SPL Token and Token-2022 balances controlled by that PDA.

---

### Methodology
TVL is the USD value of all SPL Token and Token-2022 balances held in token accounts controlled by Scorch's authority PDA.

The adapter:
1. Uses the Scorch program ID: `SCoRcH8c2dpjvcJD6FiPbCSQyQgu3PcUAWj2Xxx3mqn`
2. Derives the authority PDA using the seed: `authority`
3. Obtains the following deterministic result:
   * **PDA:** `EHcege7dok1iYs7SxL2XzDPvhg6XzMVcx2V5SkMUurJP`
4. Passes the PDA to DefiLlama's existing Solana `sumTokensExport` helper.

The helper discovers token accounts through `getTokenAccountsByOwner` for both the original SPL Token Program and Token-2022. New token vaults controlled by the same Scorch authority are therefore discovered automatically.

---

### On-chain verification

| Item | Address |
| :--- | :--- |
| **Scorch program** | `SCoRcH8c2dpjvcJD6FiPbCSQyQgu3PcUAWj2Xxx3mqn` |
| **Derived authority PDA** | `EHcege7dok1iYs7SxL2XzDPvhg6XzMVcx2V5SkMUurJP` |
| **Example USDC vault** | `34WpFzoe6QGq77Lcrq5f8s83e9nKNDo5K` |
| **Example WSOL vault** | `44GW6aBw7P1J4Yy9wXvC5uUq28tS1gvp` |
---

### Limitations

Scorch is a proprietary AMM and does not currently publish a verified program source, public IDL, or explicit on-chain vault registry.

---

### TVL verification
At the time of live verification, the adapter reported approximately:
* **Solana TVL:** $2.35 million
---

### Testing
The following commands were run:

```bash

SOLANA_RPC="<private-solana-rpc>" LLAMA_DEBUG_MODE=true node test.js projects/scorch/index.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for the Scorch protocol on Solana.
  * Includes balances from both standard SPL tokens and Token-2022 assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->