### PR TITLE
Monetrix: split mxHYPE into its own TVL adapter

### DIFF
--- a/projects/monetrix-mxhype/index.js
+++ b/projects/monetrix-mxhype/index.js
@@ -1,0 +1,35 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+
+const HYPE_ACCOUNTANT = '0xAcE53c4ef6619E7850E7d5fa45b8410C725D266D'
+
+// First production mxHYPE deposit: 2026-08-17 08:54:56 UTC (block 43,412,473).
+const START_TIMESTAMP = 1786956896
+
+const TOTAL_BACKING_ABI = 'function totalBackingSigned() view returns (int256)'
+
+async function tvl(api) {
+  if (api.timestamp && api.timestamp < START_TIMESTAMP) return
+
+  // Native HYPE backing mxHYPE: HYPE held by the HypeVault and RedeemEscrow,
+  // plus the HypeVault's Hyperliquid Core account equity, denominated in HYPE.
+  const hypeBacking = await api.call({ target: HYPE_ACCOUNTANT, abi: TOTAL_BACKING_ABI })
+
+  // Book native HYPE as WHYPE so DefiLlama can price the backing.
+  // negative backing (mark-to-market drawdown) clamps to zero
+  if (BigInt(hypeBacking) > 0n) api.add(ADDRESSES.hyperliquid.WHYPE, hypeBacking)
+}
+
+module.exports = {
+  misrepresentedTokens: true,
+  methodology:
+    'TVL is the native HYPE collateral backing mxHYPE: HYPE held by the HypeVault ' +
+    'and RedeemEscrow on HyperEVM plus the HypeVault\'s Hyperliquid Core account equity, ' +
+    'read on-chain from the HypeAccountant (totalBackingSigned) and denominated in HYPE. ' +
+    'Staked mxHYPE (smxHYPE) is a receipt token and is not counted separately. ' +
+    'The protocol-owned insurance fund is excluded. The USDC-denominated USDM vault is ' +
+    'tracked separately under Monetrix.',
+  start: START_TIMESTAMP,
+  hyperliquid: {
+    tvl,
+  },
+}

--- a/projects/monetrix/index.js
+++ b/projects/monetrix/index.js
@@ -3,34 +3,33 @@ const ADDRESSES = require('../helper/coreAssets.json')
 const MONETRIX_GENESIS_VAULT = '0xc50A1dd2866A822c81bd0aA00B638c4BdDc9cd63'
 const USDM_ACCOUNTANT = '0x8950A5136f3994f82b998e37e1183b8A37c12705'
 
-const HYPE_ACCOUNTANT = '0xAcE53c4ef6619E7850E7d5fa45b8410C725D266D'
-const MXHYPE_START = 1786956896 // first deposit
-
 const TOTAL_BACKING_ABI = 'function totalBackingSigned() view returns (int256)'
 
 async function tvl(api) {
   // Pre-launch Genesis Vault USDC; migrates into the main vault as users mint USDM.
   await api.sumTokens({ owners: [MONETRIX_GENESIS_VAULT], tokens: [ADDRESSES.hyperliquid.USDC] })
-  const usdmBacking = await api.call({ target: USDM_ACCOUNTANT, abi: TOTAL_BACKING_ABI })
-  if (BigInt(usdmBacking) > 0n) api.add(ADDRESSES.hyperliquid.USDC, usdmBacking)
 
-  if (!api.timestamp || api.timestamp >= MXHYPE_START) {
-    const hypeBacking = await api.call({ target: HYPE_ACCOUNTANT, abi: TOTAL_BACKING_ABI })
-    if (BigInt(hypeBacking) > 0n) api.add(ADDRESSES.hyperliquid.WHYPE, hypeBacking)
-  }
+  // USDC collateral backing USDM, read from the MonetrixAccountant: EVM USDC in
+  // the MonetrixVault and RedeemEscrow, plus the protocol's Hyperliquid Core
+  // account equity (perp margin, spot hedges, HLP and borrow-lend balances)
+  // valued via Hyperliquid precompiles.
+  const usdmBacking = await api.call({ target: USDM_ACCOUNTANT, abi: TOTAL_BACKING_ABI })
+  // negative backing (mark-to-market drawdown) clamps to zero
+  if (BigInt(usdmBacking) > 0n) api.add(ADDRESSES.hyperliquid.USDC, usdmBacking)
 }
 
 module.exports = {
   misrepresentedTokens: true,
   methodology:
-    'TVL counts the collateral deposited into monetrix vaults, held by the vaults ' +
-    'on HyperEVM plus the protocol\'s Hyperliquid Core account equity ' +
+    'TVL is the USDC collateral backing USDM: USDC held by the MonetrixVault and ' +
+    'RedeemEscrow on HyperEVM plus the protocol\'s Hyperliquid Core account equity ' +
     '(delta-neutral spot + short-perp positions, HLP and borrow-lend balances), read ' +
     'on-chain from the MonetrixAccountant (totalBacking), which marks Core positions ' +
     'to market via Hyperliquid precompiles. USDC still in the pre-launch Genesis Vault ' +
     'is also counted and migrates into the main vault as users mint USDM. Staked USDM ' +
     '(sUSDM), the insurance fund (funded from skimmed yield) and undistributed yield ' +
-    'are excluded.',
+    'are excluded. The HYPE-denominated mxHYPE vault is tracked separately under ' +
+    'Monetrix mxHYPE.',
   hyperliquid: {
     tvl,
   },


### PR DESCRIPTION
Splitting the Monetrix TVL adapter into two, one per vault.

Your metadata team approved this over email (thread with `metadata@defillama.com`, 2026-08-27): *"Understood, please submit the PR and we'll get it merged and split the listing"* — `parent#monetrix` with **Monetrix USDM** (existing id 8019, keeping its history) and a new **Monetrix mxHYPE** child.

## Why

USDM and mxHYPE are two separate vaults with a different unit of account:

| | Monetrix USDM | Monetrix mxHYPE |
|---|---|---|
| Denomination | USDC | native HYPE |
| Strategy | delta-neutral basis trade on Hyperliquid Core | borrowed-USDC overlay, converted to HYPE before distribution |
| Vault | `0x5586c2c8223C73Ec0B41D6352748e6c173372E11` | `0x270A9d32F893A5D3ff1878185010894dd890593D` |
| Accountant | `0x8950A5136f3994f82b998e37e1183b8A37c12705` | `0xAcE53c4ef6619E7850E7d5fa45b8410C725D266D` |
| Staking token | sUSDM | smxHYPE |

Separate contracts, separate accountants, separate collateral, separate staking tokens.

## Changes

- `projects/monetrix/index.js` — USDM only: Genesis Vault USDC plus `MonetrixAccountant.totalBackingSigned()`, booked as USDC.
- `projects/monetrix-mxhype/index.js` — new, mxHYPE only: `HypeAccountant.totalBackingSigned()` booked as WHYPE, gated on the first production deposit (`1786956896`, 2026-08-17).

Both keep the negative-backing clamp so a mark-to-market drawdown floors at zero.

## Totals are preserved

```
node test.js projects/monetrix/index.js
  USDC                      2.53 M

node test.js projects/monetrix-mxhype/index.js
  WHYPE                     1.54 M
```

2.53M + 1.54M = 4.07M, matching what the combined adapter reports today. No double counting, nothing dropped.

## New listing info (Monetrix mxHYPE)

- **Name:** Monetrix mxHYPE
- **Chain:** Hyperliquid L1
- **Current TVL:** ~$1.54M
- **Website:** https://www.monetrix.xyz/
- **Token:** mxHYPE `0x0fAfAD2825aa646fDf343A0786D0dC1A842543b6` · smxHYPE `0xf6B61A1d49B67aC907d825F26e2877F1Ec4f0aE8`
- **Short description:** HYPE-denominated yield vault on Hyperliquid. Deposited HYPE backs a borrowed-USDC delta-neutral overlay on Hyperliquid Core; yield is converted back to HYPE before distribution to smxHYPE stakers.
- **methodology:** TVL is the native HYPE collateral backing mxHYPE — HYPE held by the HypeVault and RedeemEscrow on HyperEVM plus the HypeVault's Hyperliquid Core account equity, read on-chain from `HypeAccountant.totalBackingSigned()` and denominated in HYPE, booked as WHYPE for pricing. Staked mxHYPE (smxHYPE) is a receipt token and is not counted separately. The protocol-owned insurance fund is excluded.

The matching fees split is at DefiLlama/dimension-adapters#9023.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added TVL tracking for the Monetrix mxHYPE vault on Hyperliquid.
  - Reports positive HYPE backing as WHYPE and begins tracking from the vault’s launch date.

- **Improvements**
  - Separated mxHYPE vault accounting from the main Monetrix TVL listing.
  - Updated methodology details to clarify the separate tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->