### PR TITLE
Add Phase Delegation (pdSOL) stake pool

### DIFF
--- a/registries/solanaStakePool.js
+++ b/registries/solanaStakePool.js
@@ -100,6 +100,10 @@ const configs = {
       'hy1o2kiYu9rUDFqHJSqwJH4j5ZkM23tBJsaEmqkP9sT',
     ],
   },
+  'phase-delegation': {
+    methodology: "Total SOL staked in the Phase Delegation stake pool, read on chain from the SPL stake pool account's totalLamports",
+    solana: 'aero2ePURjuEgLKTzcUmF6RypBncBGd7pMUYCoSsVJ6',
+  },
   // getStakedSol adapters
   'thevault': {
     solana: { type: 'staked', address: 'GdNXJobf8fbTR5JSE7adxa6niaygjx4EEbnnRaDCHMMW' },


### PR DESCRIPTION
Adds Phase Delegation (pdSOL) to `registries/solanaStakePool.js`.

pdSOL is a multi-validator liquid staking pool on Solana, currently delegating across 100+ validators. It runs on the standard SPL Stake Pool program (`SPoo1Ku8WFXoNDMHPsrGSTSG1Y47rzgn41SLUNakuHy`), so it needs no new adapter, just a registry entry using the existing `getSolBalanceFromStakePool` helper.

**Addresses**
- Stake pool: `aero2ePURjuEgLKTzcUmF6RypBncBGd7pMUYCoSsVJ6`
- pdSOL mint: `aeroXvCT6tjGVNyTvZy86tFDwE4sYsKCh7FbNDcrcxF`

**Methodology**

Total SOL staked in the pool, read on chain from the stake pool account's `totalLamports`. Same approach as the other entries in this registry.

**Verification**

Decoded the pool account directly against the SPL Stake Pool layout:

- `totalLamports`: 1,094,341.56 SOL
- `poolTokenSupply`: 952,406.31 pdSOL
- rate: 1.149028 SOL per pdSOL
- account owner: `SPoo1Ku8WFXoNDMHPsrGSTSG1Y47rzgn41SLUNakuHy`, 611-byte account, identical layout to `jagpool-sol` already in this file

At current SOL prices that is roughly $111M. Not double counted: the pool holds native stake accounts, not other LSTs.

Happy to supply metadata (logo, description, website, socials) through whichever channel you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking the Phase Delegation Solana stake pool.
  * Included its pool address and total staked SOL measurement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->