### PR TITLE
unicrypt: add robinhood locker v2, fix locked token caching

### DIFF
--- a/projects/unicrypt/apiCache.js
+++ b/projects/unicrypt/apiCache.js
@@ -33,7 +33,7 @@ function tvl(contracts) {
         cCache.lastTotalDepositId = +size
 
         const tokens = await api.multiCall({ abi: entry.getLockedTokenAtIndexABI, calls, permitFailure: true })
-        tokens.forEach(({ token } = {}) =>  token  && cCache.tokens.push(token))
+        tokens.forEach(token => token && cCache.tokens.push(token))
         cCache.tokens = getUniqueAddresses(cCache.tokens.filter(i => i))
       })
     )

--- a/projects/unicrypt/apiCache.js
+++ b/projects/unicrypt/apiCache.js
@@ -1,7 +1,7 @@
 const sdk = require('@defillama/sdk');
 const { config, protocolPairs, tokens, stakingContracts,
   ethereumContractData, baseContractData, bscContractData, polygonContractData,
-  avalancheContractData, gnosisContractData, arbitrumContractData, optimismContractData, } = require('./config')
+  avalancheContractData, gnosisContractData, arbitrumContractData, optimismContractData, robinhoodContractData, } = require('./config')
 const { getCache, setCache, } = require("../helper/cache")
 const { vestingHelper, } = require("../helper/unknownTokens")
 const project = 'bulky/unicrypt'
@@ -100,6 +100,7 @@ module.exports = {
   avax: { tvl: tvl(avalancheContractData) },
   arbitrum: { tvl: tvl(arbitrumContractData) },
   optimism: { tvl: tvl(optimismContractData) },
+  robinhood: { tvl: tvl(robinhoodContractData) },
   xdai: {
     tvl: tvl(gnosisContractData),
     pool2: pool2s([config.honeyswap.locker],

--- a/projects/unicrypt/config.js
+++ b/projects/unicrypt/config.js
@@ -266,6 +266,16 @@ const bscContractData = [
 ]
 
 
+const robinhoodContractData = [
+  { // Uniswap v2
+    chain: 'robinhood',
+    contract: '0xB560307e7e02a58dBB03562aaB32700255140E37',
+    getNumLockedTokensABI: getNumLockedTokens,
+    getLockedTokenAtIndexABI: getLockedTokenAtIndex,
+    factory: '0x8bcEaA40B9AcdfAedF85AdF4FF01F5Ad6517937f'
+  },
+]
+
 const polygonContractData = [
   { // Quickswap
     chain: config.quickswap.chain,
@@ -375,6 +385,7 @@ module.exports = {
   gnosisContractData,
   arbitrumContractData,
   optimismContractData,
+  robinhoodContractData,
   governanceTokens,
   stakingContracts,
   protocolPairs,


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).

2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** Please send a mail to metadata@defillama.com
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes

---

## (Needs to be filled only for new listings)

This is an **adapter update** (not a new listing), so the listing fields below do not apply.

---

## Summary

- Adds the Unicrypt v2 locker on **Robinhood chain**: `0xB560307e7e02a58dBB03562aaB32700255140E37` (Uniswap v2 factory `0x8bcEaA40B9AcdfAedF85AdF4FF01F5Ad6517937f`).
- **Bug fix** in `apiCache.js`: `api.multiCall` returns plain values, but the cache loop destructured each entry as `({ token })`, so `token` was always `undefined` and **locked LP tokens were never added to the cache** for vaults first scanned after the "Optimize unicrypt + pinksale" refactor. Fixed to `tokens.forEach(token => token && cCache.tokens.push(token))`. This was silently undercounting TVL on existing chains (e.g. base, bsc) and blocking the robinhood vault entirely.
- The robinhood locker was verified on-chain (`getNumLockedTokens()` = 2, both locked tokens are UNI-V2 pairs).

## Changes

| File | Change |
|------|--------|
| `projects/unicrypt/config.js` | Added `robinhoodContractData` entry for the v2 locker + Uniswap v2 factory |
| `projects/unicrypt/apiCache.js` | Wired `robinhood: { tvl }`; fixed `tokens.forEach` destructure bug so `multiCall` outputs are cached correctly |

## Test Plan

- [x] `node test.js projects/unicrypt` runs without errors
- [x] robinhood TVL reported: **3.52k**
- [x] Other chains now include previously missed locked LPs (bsc 36.1M → 38.1M, base 1.35M → 2.92M)
- [x] `npx eslint projects/unicrypt/config.js projects/unicrypt/apiCache.js` passes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for tracking total value locked on the Robinhood chain.
  - Added Robinhood Uniswap v2 locker contract configuration for retrieving locked-token data.

- **Bug Fixes**
  - Improved token caching to retain the complete values returned by the locker contract, ensuring accurate token data is stored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->