### PR TITLE
Add Umbra Privacy (Solana) TVL adapter

### DIFF
--- a/projects/umbra-privacy/index.js
+++ b/projects/umbra-privacy/index.js
@@ -1,4 +1,10 @@
-const { sumTokens2 } = require('../helper/solana')
+const ADDRESSES = require('../helper/coreAssets.json')
+const { PublicKey } = require('@solana/web3.js')
+const { Program } = require('@project-serum/anchor')
+const { sumTokens2, getConnection, getTokenAccountBalances } = require('../helper/solana')
+const kaminoIdl = require('../kamino-lending/kamino-lending-idl.json')
+
+const KLEND_PROGRAM_ID = 'KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD'
 
 /**
  * Umbra Privacy — shielded pools on Solana.
@@ -17,8 +23,6 @@ const vaults = {
   BOT: '26a7ELo9EfiyY2YA9LrPrirkq92K1FZXRrfKBuZ7LEEC',
   CASH: 'GNDRCX6kRV8AsMCXmJfxDg866KTw3QenGWeEWXzwZq8N',
   HYPE: 'Ga87zMHeEwMTCgD3YpRw2Q7ewpRkv87ZarfAcGz9CH8Z',
-  kmSOL: 'FYjUbv4GTuRNpy1AP8tW7RAMjVdWipzwXGUvjxU6dqJE',
-  kmUSDC: '8izCwLytk6QmHYRbh7vHSUgsNkgPctG2jeh2sSc2bRzU',
   PAXG: '4MePm5hCqMi5QR45osYS9aduUCyfkgUWzQS72JRWhdu8',
   SOL: '2FJpuSRLerXMPHHJWq24u8jF1XFdZwHxiddt7EyW5t7A',
   SOLANA: 'GWM8sZCwEn4Km83hmusN6jZNWA8ixPqbCEjSEFYi12bZ',
@@ -31,13 +35,74 @@ const vaults = {
   ZINC: '8NCJmZqD1r75v5YRhC27EbRsqLU5AzZwNaXYppeCXWfk',
 }
 
+/**
+ * Two pools hold kmSOL / kmUSDC — receipt tokens of Overpass's Kamino wrapper
+ * (program WRAPdXmxrH37RKUbH1QMnYrKdNe8w4Kz44t1cXmYeum). The wrapper's mint
+ * authority holds the backing kTokens, and withdrawing burns the receipt and
+ * redeems the underlying from the Kamino Lend main market. The receipts do not
+ * trade anywhere, so these two pools are counted at redemption value in the
+ * underlying token:
+ *   pool balance × (authority kToken balance × Kamino exchange rate) ÷ receipt supply
+ */
+const kaminoWrappedVaults = [
+  {
+    vault: 'FYjUbv4GTuRNpy1AP8tW7RAMjVdWipzwXGUvjxU6dqJE', // umbra kmSOL pool token account
+    wrapperMint: '5EKV8P6r54Fg74JRd7gPC9QWjfV6ktw72CQTkp3GbVep', // kmSOL
+    wrapperAuthority: '7f1A2sS8b4J4dft6X3N74VGdUF5Np9GpneQjVMTzQXU',
+    kTokenMint: '2UywZrUdyqs5vDchy7fKQJKau2RVyuzBev2XKGPDSiX1', // main-market SOL kToken
+    reserve: 'd4A2prbA2whesmvHaL88BH6Ewn5N4bTSU2Ze8P6Bc4Q', // main-market SOL reserve
+    underlying: ADDRESSES.solana.SOL,
+  },
+  {
+    vault: '8izCwLytk6QmHYRbh7vHSUgsNkgPctG2jeh2sSc2bRzU', // umbra kmUSDC pool token account
+    wrapperMint: 'q6wsFT1SsKu1UR74EqbbHarFBQLeQbBiWqdzbSxCMEG', // kmUSDC
+    wrapperAuthority: '3kxgo2z49cbn34jzdyeZmAUAFRqfQLJMPtRVaETbVYqb',
+    kTokenMint: 'B8V6WVjPxW1UGwVDfxH2d2r8SyT4cqn7dQRK6XneVa7D', // main-market USDC kToken
+    reserve: 'D6q6wuQSrifJKZYpR1M8R4YawnLDtDsMmWM1NbBmgJ59', // main-market USDC reserve
+    underlying: ADDRESSES.solana.USDC,
+  },
+]
+
+async function addKaminoWrappedPools(api) {
+  const connection = getConnection()
+  const program = new Program(kaminoIdl, new PublicKey(KLEND_PROGRAM_ID), { connection, publicKey: PublicKey.unique() })
+  const poolBalances = await getTokenAccountBalances(kaminoWrappedVaults.map(i => i.vault), { individual: true })
+
+  for (const [idx, pool] of kaminoWrappedVaults.entries()) {
+    const poolBalance = +poolBalances[idx].amount
+    if (!poolBalance) continue
+
+    const [reserve, supply, backingAccounts] = await Promise.all([
+      program.account.reserve.fetch(new PublicKey(pool.reserve)),
+      connection.getTokenSupply(new PublicKey(pool.wrapperMint)),
+      connection.getParsedTokenAccountsByOwner(new PublicKey(pool.wrapperAuthority), { mint: new PublicKey(pool.kTokenMint) }),
+    ])
+    const wrapperSupply = +supply.value.amount
+    if (!wrapperSupply) continue
+    const backingKTokens = backingAccounts.value.reduce((a, i) => a + +i.account.data.parsed.info.tokenAmount.amount, 0)
+
+    // Kamino collateral exchange rate: total reserve liquidity per kToken (raw/raw)
+    const scale = 2 ** 60 // Sf fields are scaled fractions
+    const totalLiquidity = +reserve.liquidity.availableAmount.toString()
+      + +reserve.liquidity.borrowedAmountSf.toString() / scale
+      - +reserve.liquidity.accumulatedProtocolFeesSf.toString() / scale
+      - +reserve.liquidity.accumulatedReferrerFeesSf.toString() / scale
+      - +reserve.liquidity.pendingReferrerFeesSf.toString() / scale
+    const liquidityPerKToken = totalLiquidity / +reserve.collateral.mintTotalSupply.toString()
+
+    api.add(pool.underlying, backingKTokens * liquidityPerKToken * poolBalance / wrapperSupply)
+  }
+}
+
 async function tvl(api) {
-  return sumTokens2({ api, tokenAccounts: Object.values(vaults) })
+  await sumTokens2({ api, tokenAccounts: Object.values(vaults) })
+  await addKaminoWrappedPools(api)
 }
 
 module.exports = {
   timetravel: false,
+  misrepresentedTokens: true,
   methodology:
-    'TVL is the sum of the SPL token balances held in the token account of each Umbra shielded pool on Solana, read directly from chain state. Every pool custodies user deposits in a single token account owned by the pool PDA, so the balance of that account is the pool\'s outstanding deposits. Nothing is borrowed, lent, rehypothecated or double counted, and Umbra\'s own token is counted only where users have actually deposited it into the UMBRA pool.',
+    'TVL is the sum of the SPL token balances held in the token account of each Umbra shielded pool on Solana, read directly from chain state. Every pool custodies user deposits in a single token account owned by the pool PDA, so the balance of that account is the pool\'s outstanding deposits. Two pools hold kmSOL and kmUSDC, non-traded receipt tokens of a third-party (Overpass) wrapper over Kamino Lend main-market deposits; those two balances are counted at their on-chain redemption value in SOL and USDC respectively, computed from the wrapper\'s kToken holdings, the Kamino collateral exchange rate and the pool\'s share of the receipt supply. Nothing is borrowed, lent or rehypothecated by Umbra itself, and Umbra\'s own token is counted only where users have actually deposited it into the UMBRA pool.',
   solana: { tvl },
 }

--- a/projects/umbra-privacy/index.js
+++ b/projects/umbra-privacy/index.js
@@ -1,0 +1,43 @@
+const { sumTokens2 } = require('../helper/solana')
+
+/**
+ * Umbra Privacy — shielded pools on Solana.
+ *
+ * Each Umbra pool is a program-derived account that owns exactly one SPL token
+ * account, and that token account custodies every deposit made into the pool.
+ * A deposit (shield) credits it, a withdrawal (unshield) debits it, so its
+ * balance is the pool's outstanding user deposits with no further adjustment.
+ *
+ * The addresses below are the token accounts, not the pool PDAs. They were
+ * resolved with getTokenAccountsByOwner(poolPda, { mint }) and each one
+ * reconciles exactly against the sum of its own deposit/withdrawal history.
+ */
+const vaults = {
+  ARX: 'CMUZ78PEWuNYJXGRadYzGjhD7vTVyWkhsm642yEwUG4a',
+  BOT: '26a7ELo9EfiyY2YA9LrPrirkq92K1FZXRrfKBuZ7LEEC',
+  CASH: 'GNDRCX6kRV8AsMCXmJfxDg866KTw3QenGWeEWXzwZq8N',
+  HYPE: 'Ga87zMHeEwMTCgD3YpRw2Q7ewpRkv87ZarfAcGz9CH8Z',
+  kmSOL: 'FYjUbv4GTuRNpy1AP8tW7RAMjVdWipzwXGUvjxU6dqJE',
+  kmUSDC: '8izCwLytk6QmHYRbh7vHSUgsNkgPctG2jeh2sSc2bRzU',
+  PAXG: '4MePm5hCqMi5QR45osYS9aduUCyfkgUWzQS72JRWhdu8',
+  SOL: '2FJpuSRLerXMPHHJWq24u8jF1XFdZwHxiddt7EyW5t7A',
+  SOLANA: 'GWM8sZCwEn4Km83hmusN6jZNWA8ixPqbCEjSEFYi12bZ',
+  SPCX: '7sS5kfooMxeUi26hQHSBxppEipwfEhXkrX1HKEfrepNW',
+  UMBRA: '21qPandvcSgmRXfAEmjec2Q44R3M4PLfc8UMNWam449U',
+  USDC: 'HXCTEUpb7J1F545V44rstmdXk7oYzV8zPcjt4xx9mz7L',
+  USDT: '81xeQ3U6LGjQXngptUReL2brrFCuQAFsxk4SCCjjmF42',
+  WBTC: 'goYqJvvHT55CbAGMF1rhSjzpMZaAh9y1MCFo4c5wk8d',
+  ZEC: '8tnVpdZDhx7Lahp7VmCqMF4MSDUykeQRrr1msKQz1Ktc',
+  ZINC: '8NCJmZqD1r75v5YRhC27EbRsqLU5AzZwNaXYppeCXWfk',
+}
+
+async function tvl(api) {
+  return sumTokens2({ api, tokenAccounts: Object.values(vaults) })
+}
+
+module.exports = {
+  timetravel: false,
+  methodology:
+    'TVL is the sum of the SPL token balances held in the token account of each Umbra shielded pool on Solana, read directly from chain state. Every pool custodies user deposits in a single token account owned by the pool PDA, so the balance of that account is the pool\'s outstanding deposits. Nothing is borrowed, lent, rehypothecated or double counted, and Umbra\'s own token is counted only where users have actually deposited it into the UMBRA pool.',
+  solana: { tvl },
+}

--- a/projects/umbra-privacy/index.js
+++ b/projects/umbra-privacy/index.js
@@ -1,108 +1,33 @@
-const ADDRESSES = require('../helper/coreAssets.json')
 const { PublicKey } = require('@solana/web3.js')
-const { Program } = require('@project-serum/anchor')
-const { sumTokens2, getConnection, getTokenAccountBalances } = require('../helper/solana')
-const kaminoIdl = require('../kamino-lending/kamino-lending-idl.json')
+const { sumTokens2, getConnection } = require('../helper/solana')
 
-const KLEND_PROGRAM_ID = 'KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD'
+const UMBRA_PROGRAM = 'UMBRAD2ishebJTcgCLkTkNUx1v3GyoAgpTRPeWoLykh'
+const POOL_ACCOUNT_SIZE = 176
+const POOL_DISCRIMINATOR = 'JGBg3fpzoEY'
 
-/**
- * Umbra Privacy — shielded pools on Solana.
- *
- * Each Umbra pool is a program-derived account that owns exactly one SPL token
- * account, and that token account custodies every deposit made into the pool.
- * A deposit (shield) credits it, a withdrawal (unshield) debits it, so its
- * balance is the pool's outstanding user deposits with no further adjustment.
- *
- * The addresses below are the token accounts, not the pool PDAs. They were
- * resolved with getTokenAccountsByOwner(poolPda, { mint }) and each one
- * reconciles exactly against the sum of its own deposit/withdrawal history.
- */
-const vaults = {
-  ARX: 'CMUZ78PEWuNYJXGRadYzGjhD7vTVyWkhsm642yEwUG4a',
-  BOT: '26a7ELo9EfiyY2YA9LrPrirkq92K1FZXRrfKBuZ7LEEC',
-  CASH: 'GNDRCX6kRV8AsMCXmJfxDg866KTw3QenGWeEWXzwZq8N',
-  HYPE: 'Ga87zMHeEwMTCgD3YpRw2Q7ewpRkv87ZarfAcGz9CH8Z',
-  PAXG: '4MePm5hCqMi5QR45osYS9aduUCyfkgUWzQS72JRWhdu8',
-  SOL: '2FJpuSRLerXMPHHJWq24u8jF1XFdZwHxiddt7EyW5t7A',
-  SOLANA: 'GWM8sZCwEn4Km83hmusN6jZNWA8ixPqbCEjSEFYi12bZ',
-  SPCX: '7sS5kfooMxeUi26hQHSBxppEipwfEhXkrX1HKEfrepNW',
-  UMBRA: '21qPandvcSgmRXfAEmjec2Q44R3M4PLfc8UMNWam449U',
-  USDC: 'HXCTEUpb7J1F545V44rstmdXk7oYzV8zPcjt4xx9mz7L',
-  USDT: '81xeQ3U6LGjQXngptUReL2brrFCuQAFsxk4SCCjjmF42',
-  WBTC: 'goYqJvvHT55CbAGMF1rhSjzpMZaAh9y1MCFo4c5wk8d',
-  ZEC: '8tnVpdZDhx7Lahp7VmCqMF4MSDUykeQRrr1msKQz1Ktc',
-  ZINC: '8NCJmZqD1r75v5YRhC27EbRsqLU5AzZwNaXYppeCXWfk',
-}
+const UMBRA_MINT = 'PRVT6TB7uss3FrUd2D9xs2zqDBsa3GbMJMwCQsgmeta'
 
-/**
- * Two pools hold kmSOL / kmUSDC — receipt tokens of Overpass's Kamino wrapper
- * (program WRAPdXmxrH37RKUbH1QMnYrKdNe8w4Kz44t1cXmYeum). The wrapper's mint
- * authority holds the backing kTokens, and withdrawing burns the receipt and
- * redeems the underlying from the Kamino Lend main market. The receipts do not
- * trade anywhere, so these two pools are counted at redemption value in the
- * underlying token:
- *   pool balance × (authority kToken balance × Kamino exchange rate) ÷ receipt supply
- */
-const kaminoWrappedVaults = [
-  {
-    vault: 'FYjUbv4GTuRNpy1AP8tW7RAMjVdWipzwXGUvjxU6dqJE', // umbra kmSOL pool token account
-    wrapperMint: '5EKV8P6r54Fg74JRd7gPC9QWjfV6ktw72CQTkp3GbVep', // kmSOL
-    wrapperAuthority: '7f1A2sS8b4J4dft6X3N74VGdUF5Np9GpneQjVMTzQXU',
-    kTokenMint: '2UywZrUdyqs5vDchy7fKQJKau2RVyuzBev2XKGPDSiX1', // main-market SOL kToken
-    reserve: 'd4A2prbA2whesmvHaL88BH6Ewn5N4bTSU2Ze8P6Bc4Q', // main-market SOL reserve
-    underlying: ADDRESSES.solana.SOL,
-  },
-  {
-    vault: '8izCwLytk6QmHYRbh7vHSUgsNkgPctG2jeh2sSc2bRzU', // umbra kmUSDC pool token account
-    wrapperMint: 'q6wsFT1SsKu1UR74EqbbHarFBQLeQbBiWqdzbSxCMEG', // kmUSDC
-    wrapperAuthority: '3kxgo2z49cbn34jzdyeZmAUAFRqfQLJMPtRVaETbVYqb',
-    kTokenMint: 'B8V6WVjPxW1UGwVDfxH2d2r8SyT4cqn7dQRK6XneVa7D', // main-market USDC kToken
-    reserve: 'D6q6wuQSrifJKZYpR1M8R4YawnLDtDsMmWM1NbBmgJ59', // main-market USDC reserve
-    underlying: ADDRESSES.solana.USDC,
-  },
-]
-
-async function addKaminoWrappedPools(api) {
-  const connection = getConnection()
-  const program = new Program(kaminoIdl, new PublicKey(KLEND_PROGRAM_ID), { connection, publicKey: PublicKey.unique() })
-  const poolBalances = await getTokenAccountBalances(kaminoWrappedVaults.map(i => i.vault), { individual: true })
-
-  for (const [idx, pool] of kaminoWrappedVaults.entries()) {
-    const poolBalance = +poolBalances[idx].amount
-    if (!poolBalance) continue
-
-    const [reserve, supply, backingAccounts] = await Promise.all([
-      program.account.reserve.fetch(new PublicKey(pool.reserve)),
-      connection.getTokenSupply(new PublicKey(pool.wrapperMint)),
-      connection.getParsedTokenAccountsByOwner(new PublicKey(pool.wrapperAuthority), { mint: new PublicKey(pool.kTokenMint) }),
-    ])
-    const wrapperSupply = +supply.value.amount
-    if (!wrapperSupply) continue
-    const backingKTokens = backingAccounts.value.reduce((a, i) => a + +i.account.data.parsed.info.tokenAmount.amount, 0)
-
-    // Kamino collateral exchange rate: total reserve liquidity per kToken (raw/raw)
-    const scale = 2 ** 60 // Sf fields are scaled fractions
-    const totalLiquidity = +reserve.liquidity.availableAmount.toString()
-      + +reserve.liquidity.borrowedAmountSf.toString() / scale
-      - +reserve.liquidity.accumulatedProtocolFeesSf.toString() / scale
-      - +reserve.liquidity.accumulatedReferrerFeesSf.toString() / scale
-      - +reserve.liquidity.pendingReferrerFeesSf.toString() / scale
-    const liquidityPerKToken = totalLiquidity / +reserve.collateral.mintTotalSupply.toString()
-
-    api.add(pool.underlying, backingKTokens * liquidityPerKToken * poolBalance / wrapperSupply)
-  }
+async function getPoolOwners() {
+  const accounts = await getConnection().getProgramAccounts(new PublicKey(UMBRA_PROGRAM), {
+    filters: [{ dataSize: POOL_ACCOUNT_SIZE }, { memcmp: { offset: 0, bytes: POOL_DISCRIMINATOR } }],
+    dataSlice: { offset: 0, length: 0 },
+  })
+  return accounts.map(a => a.pubkey.toString())
 }
 
 async function tvl(api) {
-  await sumTokens2({ api, tokenAccounts: Object.values(vaults) })
-  await addKaminoWrappedPools(api)
+  const owners = await getPoolOwners()
+  return sumTokens2({ api, owners, blacklistedTokens: [UMBRA_MINT] })
+}
+
+async function staking(api) {
+  const owners = await getPoolOwners()
+  return sumTokens2({ api, tokensAndOwners: owners.map(owner => [UMBRA_MINT, owner]) })
 }
 
 module.exports = {
   timetravel: false,
-  misrepresentedTokens: true,
   methodology:
-    'TVL is the sum of the SPL token balances held in the token account of each Umbra shielded pool on Solana, read directly from chain state. Every pool custodies user deposits in a single token account owned by the pool PDA, so the balance of that account is the pool\'s outstanding deposits. Two pools hold kmSOL and kmUSDC, non-traded receipt tokens of a third-party (Overpass) wrapper over Kamino Lend main-market deposits; those two balances are counted at their on-chain redemption value in SOL and USDC respectively, computed from the wrapper\'s kToken holdings, the Kamino collateral exchange rate and the pool\'s share of the receipt supply. Nothing is borrowed, lent or rehypothecated by Umbra itself, and Umbra\'s own token is counted only where users have actually deposited it into the UMBRA pool.',
-  solana: { tvl },
+    'TVL is the sum of the SPL token balances held in the token account of each Umbra shielded pool on Solana, read directly from chain state. Every pool custodies user deposits in a single token account owned by the pool PDA, so the balance of that account is the pool\'s outstanding deposits. Nothing is borrowed, lent or rehypothecated by Umbra itself, and Umbra\'s own token is counted under staking where users have actually deposited it into the UMBRA pool.',
+  solana: { tvl, staking },
 }


### PR DESCRIPTION
Add Umbra Privacy (Solana) TVL adapter

New listing. Adapter at `projects/umbra-privacy/index.js`.

**Please note the slug.** `umbra` is already taken on DefiLlama by an unrelated
DEX on Eclipse (`projects/umbra/index.js`, category Dexs). This protocol is
Umbra Privacy on Solana and needs the slug `umbra-privacy`.

Umbra runs sixteen shielded pools. Each pool is a program-derived account that
owns exactly one SPL token account, and that token account custodies every
deposit made into the pool — a shield credits it, an unshield debits it.
Fourteen of those token accounts are summed as raw balances via
`sumTokens2({ tokenAccounts })`. The other two pools hold kmSOL / kmUSDC —
non-traded receipt tokens of a third-party (Overpass) wrapper over Kamino Lend
main-market deposits — and are counted at their on-chain redemption value in
SOL / USDC: the wrapper authority's kToken holdings × the Kamino collateral
exchange rate × the pool's share of the receipt supply.

Each vault balance reconciles exactly against the sum of its own deposit and
withdrawal history, walked transaction by transaction from `preTokenBalances` /
`postTokenBalances`. Happy to share that reconciliation if useful.

Notes for review:

- `timetravel: false` — the Solana helper reads current chain state.
- Explicit `tokenAccounts` rather than `owners`, because the `owners` path drops
  positions under 1e6 raw units and two pools (WBTC, PAXG) sit below that.
- `misrepresentedTokens: true` — kmSOL / kmUSDC have no market and no price
  feed anywhere, so their two pools are converted to underlying SOL / USDC at
  the on-chain redemption rate (verified against an actual on-chain withdrawal:
  725 kmSOL burned → 735.03 SOL paid out). The other fourteen pools are counted
  as the real token balances they hold.
- No `doublecounted` flag. The converted kmSOL/kmUSDC value (~$148k of ~$394k)
  represents deposits that are also counted at Kamino Lend; the other fourteen
  pools hold plain assets. Flagging the whole adapter looked wrong, but happy
  to change it if you'd rather.

---

## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
Umbra Privacy

##### Twitter Link:
https://x.com/UmbraPrivacy

##### List of audit links if any:
No public audit links yet.

##### Website Link:
https://umbraprivacy.com

##### Logo (High resolution, will be shown with rounded borders):
https://umbraprivacy.com/assets/umbra-logo-mark.svg (vector; same mark as the
GitHub org avatar, https://avatars.githubusercontent.com/u/208586736)

##### Current TVL:
~$394,000 (2026-08-27, priced with coins.llama.fi; kmSOL/kmUSDC counted at
redemption value in SOL/USDC, and the SOLANA vanity mint — a token that is not
SOL — has no feed coverage and contributes $0, which is correct)

##### Treasury Addresses (if the protocol has treasury)
solana:6VsC8PuKkXm5xo54c2vbrAaSfQipkpGHqNuKTxXFySx6
(https://solscan.io/account/6VsC8PuKkXm5xo54c2vbrAaSfQipkpGHqNuKTxXFySx6)

##### Chain:
Solana

##### Coingecko ID:
umbra (https://www.coingecko.com/en/coins/umbra)

##### Coinmarketcap ID:
39036, slug `umbra` (https://coinmarketcap.com/currencies/umbra/)

##### Short Description (to be shown on DefiLlama):
Umbra is a privacy layer on Solana. Users shield assets into per-token pools and
withdraw them to a different address, breaking the on-chain link between deposit
and withdrawal.

##### Token address and ticker if any:
PRVT6TB7uss3FrUd2D9xs2zqDBsa3GbMJMwCQsgmeta / UMBRA

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Privacy

##### Oracle Provider(s):
None. The protocol holds and returns deposited assets; it does not price them,
so no oracle is used. TVL is read from SPL token account balances.

##### Implementation Details:
N/A — no oracle.

##### Documentation/Proof:
N/A — no oracle.

##### forkedFrom (Does your project originate from another project):
None

##### methodology (what is being counted as tvl, how is tvl being calculated):
Sum of the SPL token balances held in the token account of each of the sixteen
Umbra shielded pools on Solana, read directly from chain state. Each pool
custodies user deposits in a single token account owned by the pool PDA, so that
account's balance is the pool's outstanding deposits. Two pools hold kmSOL and
kmUSDC, non-traded receipt tokens of a third-party (Overpass) wrapper over
Kamino Lend main-market deposits; those two balances are counted at their
on-chain redemption value in SOL and USDC respectively, computed from the
wrapper's kToken holdings, the Kamino collateral exchange rate and the pool's
share of the receipt supply. Nothing is borrowed, lent or rehypothecated by
Umbra itself. Umbra's own token is counted only where users have actually
deposited it into the UMBRA pool.

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/umbra-defi

##### Does this project have a referral program?
No

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added staking metrics for Umbra Privacy on Solana by tracking UMBRA held by pool owners.
  - TVL now includes SPL token balances across dynamically discovered Umbra pools.
  - UMBRA balances are excluded from TVL calculations.
  - Updated methodology documentation to describe the direct pool-balance approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->