### PR TITLE
add Tessera V TVL

### DIFF
--- a/registries/sumTokens/data1.js
+++ b/registries/sumTokens/data1.js
@@ -732,4 +732,10 @@ module.exports = {
     "methodology": "Counts BTC (cbBTC) received from mining held in the Sats Vault.",
     "solana": { "tokenAccounts": ["2zpcctvd7sCdtWe4bAYcNmfVFzaiFVtH81tfMAWCtMh9"] }
   },
+  "tessera-v": {
+    "methodology": "TVL is the value of SPL and Token-2022 balances held in Tessera V vaults controlled by its Solana authority account.",
+    "solana": {
+      "owner": "8ekCy2jHHUbW2yeNGFWYJT9Hm9FW7SvZcZK66dSZCDiF"
+    }
+  },
 }


### PR DESCRIPTION
# Summary

Adds on-chain TVL tracking for the existing Tessera V listing on Solana.

Tessera V is already listed on DefiLlama with a DEX volume adapter. This PR adds the missing TVL calculation using DefiLlama's static `sumTokens` registry.

**Existing listing:** <https://defillama.com/protocol/tessera-v>

---

## Methodology

TVL is the USD value of all SPL Token and Token-2022 balances held in token accounts controlled by the Tessera V authority:

`8ekCy2jHHUbW2yeNGFWYJT9Hm9FW7SvZcZK66dSZCDiF`

The authority controls the token accounts used as Tessera V's trading inventory. These assets are available to the protocol for executing swaps.

---

## Implementation

The adapter is configured in:  
`registries/sumTokens/data1.js`

The registry passes the Tessera V authority to DefiLlama's existing `sumTokensExport` helper:

```json
"tessera-v": {
  "methodology": "TVL is the value of SPL and Token-2022 balances held in Tessera V vaults controlled by its Solana authority account.",
  "solana": {
    "owner": "8ekCy2jHHUbW2yeNGFWYJT9Hm9FW7SvZcZK66dSZCDiF"
  }
}
```

* For Solana, the helper discovers the SPL Token and Token-2022 accounts whose token authority matches the supplied owner and sums their on-chain balances.
* No token addresses are hardcoded, so newly created Tessera V inventory accounts controlled by the same authority are discovered automatically.

---

## Address evidence

* DefiLlama's existing Tessera V dimension adapter identifies the Solana program as `TessVdML9pBGgG9yGks7o4HewRaXVAMuoVj4x83GLQH`:  
  <https://github.com/DefiLlama/dimension-adapters/blob/master/dexs/tessera/index.ts>
* This on-chain swap transaction identifies `8ekCy2jHHUbW2yeNGFWYJT9Hm9FW7SvZcZK66dSZCDiF` as the Tessera V authority and includes the Tessera V program:  
  
---

## Testing
Only worked with Private RPC.
```bash
SOLANA_RPC="https://mainnet.helius-rpc.com/?api-key=XXXXXXXXXXXXXXXXX" LLAMA_DEBUG_MODE=true node test.js tessera-v
```

The adapter successfully returns Tessera V's on-chain token balances and total TVL on Solana.
------ TVL ------
solana                    7.15 M

total                    7.15 M

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Tessera V to supported value tracking.
  * TVL now includes SPL and Token-2022 balances held in Tessera V vaults on Solana.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->