### PR TITLE
add AlphaQ TVL adapter

### DIFF
--- a/projects/alphaq/index.js
+++ b/projects/alphaq/index.js
@@ -1,0 +1,28 @@
+const { PublicKey } = require('@solana/web3.js')
+const { getConnection, sumTokens2 } = require('../helper/solana')
+
+const PROGRAM_ID = new PublicKey('ALPHAQmeA7bjrVuccPsYPiCvsi428SNwte66Srvs4pHA')
+const MARKET_ACCOUNT_SIZE = 672
+const VAULTS_OFFSET = 112
+
+async function tvl(api) {
+  const markets = await getConnection().getProgramAccounts(PROGRAM_ID, {
+    filters: [{ dataSize: MARKET_ACCOUNT_SIZE }],
+    dataSlice: { offset: VAULTS_OFFSET, length: 64 },
+  })
+
+  const vaults = new Set()
+  for (const { account } of markets) {
+    vaults.add(new PublicKey(account.data.subarray(0, 32)).toBase58())
+    vaults.add(new PublicKey(account.data.subarray(32, 64)).toBase58())
+  }
+
+  return sumTokens2({ api, tokenAccounts: [...vaults] })
+}
+
+module.exports = {
+  timetravel: false,
+  methodology:
+    'TVL is the value of assets held in the two token vaults recorded by every AlphaQ market account on Solana.',
+  solana: { tvl },
+}


### PR DESCRIPTION
## Summary

Adds an on-chain TVL adapter for **AlphaQ** on Solana.

AlphaQ is already listed on DefiLlama with DEX volume, fees, and revenue tracking. This PR adds TVL tracking for the token inventory held in AlphaQ's market vaults.

---

## Methodology

The adapter:

* Queries all 672-byte market accounts owned by the AlphaQ program.
* Reads the two consecutive token-vault public keys stored at byte offsets `112` and `144` in every market account.
* The helper reads the current token-account balances and aggregates them by mint. 

---

## Program and Account Verification

**AlphaQ Program:**  
`ALPHAQmeA7bjrVuccPsYPiCvsi428SNwte66Srvs4pHA`

This is the same program used by DefiLlama's existing AlphaQ dimension adapter:  
https://github.com/DefiLlama/dimension-adapters/blob/master/dexs/alphaq/index.ts

The published AlphaQ IDL identifies the swap accounts as:
* `market`
* `market_state`
* `vault_token_account_a`
* `vault_token_account_b`
* `token_a_authority`
* `token_b_authority`

**IDL Source:**  
https://github.com/bitquery/solana-idl-lib/blob/main/alphaq/alphaq.json


## Time Travel

`timetravel: false` is set because Solana `getProgramAccounts` discovers the current set of market accounts. Returning the current market set for an earlier timestamp would produce incorrect historical results.

---

## Testing

The following commands were used for validation:

```bash
 node test.js projects/alphaq/index.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for AlphaQ on Solana.
  * Reports combined token balances held across AlphaQ market vaults.
  * Includes methodology details and does not support historical time-travel data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->