### PR TITLE
add Aquifer TVL adapter

### DIFF
--- a/projects/aquifer/index.js
+++ b/projects/aquifer/index.js
@@ -1,0 +1,33 @@
+const { PublicKey } = require('@solana/web3.js')
+const { getConnection, sumTokens2 } = require('../helper/solana')
+
+const PROGRAM_ID = new PublicKey('AQU1FRd7papthgdrwPTTq5JacJh8YtwEXaBfKU3bTz45')
+const DEX = 'CNC5TaeNQEoSPfQKZ7GgfM4R8WYAJRKRSHFCHkf2H7ko'
+const COIN_ACCOUNT_SIZE = 1056
+const COIN_DEX_OFFSET = 1016
+
+async function tvl(api) {
+  const coins = await getConnection().getProgramAccounts(PROGRAM_ID, {
+    filters: [
+      { dataSize: COIN_ACCOUNT_SIZE },
+      { memcmp: { offset: COIN_DEX_OFFSET, bytes: DEX } },
+    ],
+    dataSlice: { offset: 0, length: 0 },
+  })
+
+  const tokenAccounts = coins.map(({ pubkey }) =>
+    PublicKey.findProgramAddressSync(
+      [Buffer.from('coin_managed_ta'), pubkey.toBuffer()],
+      PROGRAM_ID,
+    )[0].toString(),
+  )
+
+  return sumTokens2({ api, tokenAccounts })
+}
+
+module.exports = {
+  timetravel: false,
+  methodology:
+    "TVL is the value of assets held in the program-derived token account of every Coin registered to Aquifer's official Solana DEX.",
+  solana: { tvl },
+}


### PR DESCRIPTION
## Summary

Adds an on-chain TVL adapter for Aquifer on Solana.

Aquifer is already listed on DefiLlama with DEX volume tracking. This PR adds TVL tracking for the assets held in the token accounts associated with Aquifer's registered Coin accounts.

The adapter:

- discovers Aquifer Coin accounts directly from the deployed Solana program;
- restricts discovery to Coin accounts registered to Aquifer's official DEX;
- derives the managed token account associated with each Coin;
- sums the balances of those token accounts using DefiLlama's existing Solana helper.

Future assets registered to the same Aquifer DEX are discovered automatically.


## Methodology

TVL is the USD value of assets held in the program-derived token account of every Coin registered to Aquifer's official Solana DEX.

Coin accounts are discovered using `getProgramAccounts` with the following filters:

| Filter | Value |
| --- | --- |
| Program owner | `AQU1FRd7papthgdrwPTTq5JacJh8YtwEXaBfKU3bTz45` |
| Coin account size | `1056` bytes |
| DEX field offset | `1016` |
| Required DEX | `CNC5TaeNQEoSPfQKZ7GgfM4R8WYAJRKRSHFCHkf2H7ko` |

For each discovered Coin account, the corresponding token account is derived as:

```js
PublicKey.findProgramAddressSync(
  [Buffer.from('coin_managed_ta'), coinPublicKey.toBuffer()],
  PROGRAM_ID,
)
```

The resulting token-account addresses are passed to DefiLlama's `sumTokens2` Solana helper. DefiLlama reads the token account balances and performs token pricing.

## Official address verification

Aquifer's official website displays both addresses used by the adapter in its header:
Official sources:
- [Aquifer official website](https://aquiferdex.io/)




## Time travel

The adapter exports:

```js
timetravel: false
```
This is intentional because Coin discovery uses the current state returned by Solana's `getProgramAccounts`. Historical execution could otherwise combine a current Coin registry with historical token-account balances.

## Current result

At the time of testing, the adapter discovered 44 token accounts and returned approximately:

```text
solana    2.78 M
total     2.78 M
```

## Testing

The following commands were run:

```bash
node test.js projects/aquifer/index.js
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Aquifer TVL tracking on Solana.
  * Reports token balances held in Aquifer-managed accounts.
  * Includes a methodology description and indicates that historical time-travel data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->