### PR TITLE
Add PopcornCine TVL adapter

### DIFF
--- a/projects/popcorncine/index.js
+++ b/projects/popcorncine/index.js
@@ -1,11 +1,14 @@
 const { sumTokensExport } = require('../helper/unwrapLPs')
 const ADDRESSES = require('../helper/coreAssets.json')
 
-// Morph Payments merchant receiving / settlement wallet for PopcornCine
-const TREASURY = '0xeb2afb2af45f3be8d8b1cc5b9bce603be9721760'
+// CINE ONE PASS NFT contract treasury on BSC (mint USDT/USDC payments settle here)
+const BSC_TREASURY = '0x24a2d2503ed27418d7e5b21b617d4bc03aec55e1'
+
+// Morph Payments merchant receiving wallet (Morph checkout settlements)
+const MORPH_TREASURY = '0xeb2afb2af45f3be8d8b1cc5b9bce603be9721760'
 
 const morphTokens = [
-  ADDRESSES.morph.USDT0, // Morph checkout USDT used by PopcornCine Morph config
+  ADDRESSES.morph.USDT0,
   ADDRESSES.morph.USDT,
   ADDRESSES.morph.USDC,
   ADDRESSES.morph.USDC_1,
@@ -18,16 +21,16 @@ const bscTokens = [
 
 module.exports = {
   methodology:
-    'Counts USDT and USDC held in the PopcornCine Morph settlement treasury used for CINE ONE PASS mints and prediction/battle payments on Morph L2 (and BNB Chain if present). Atlas Oracle feeds are excluded because they do not custody user deposits. The CINE ONE PASS NFT is a utility access credential and is not counted as TVL.',
+    'Counts USDT and USDC held in PopcornCine treasury wallets: BSC mint payments settle to the CINE ONE PASS contract treasury (0x24a2d2503ed27418d7e5b21b617d4bc03aec55e1); Morph Payments checkout settlements settle to the merchant receiving wallet (0xeb2afb2af45f3be8d8b1cc5b9bce603be9721760). Atlas Oracle feeds and the PASS NFT are excluded.',
   morph: {
     tvl: sumTokensExport({
-      owners: [TREASURY],
+      owners: [MORPH_TREASURY],
       tokens: morphTokens,
     }),
   },
   bsc: {
     tvl: sumTokensExport({
-      owners: [TREASURY],
+      owners: [BSC_TREASURY],
       tokens: bscTokens,
     }),
   },

--- a/projects/popcorncine/index.js
+++ b/projects/popcorncine/index.js
@@ -1,0 +1,34 @@
+const { sumTokensExport } = require('../helper/unwrapLPs')
+const ADDRESSES = require('../helper/coreAssets.json')
+
+// Morph Payments merchant receiving / settlement wallet for PopcornCine
+const TREASURY = '0xeb2afb2af45f3be8d8b1cc5b9bce603be9721760'
+
+const morphTokens = [
+  ADDRESSES.morph.USDT0, // Morph checkout USDT used by PopcornCine Morph config
+  ADDRESSES.morph.USDT,
+  ADDRESSES.morph.USDC,
+  ADDRESSES.morph.USDC_1,
+].filter(Boolean)
+
+const bscTokens = [
+  ADDRESSES.bsc.USDT,
+  ADDRESSES.bsc.USDC,
+].filter(Boolean)
+
+module.exports = {
+  methodology:
+    'Counts USDT and USDC held in the PopcornCine Morph settlement treasury used for CINE ONE PASS mints and prediction/battle payments on Morph L2 (and BNB Chain if present). Atlas Oracle feeds are excluded because they do not custody user deposits. The CINE ONE PASS NFT is a utility access credential and is not counted as TVL.',
+  morph: {
+    tvl: sumTokensExport({
+      owners: [TREASURY],
+      tokens: morphTokens,
+    }),
+  },
+  bsc: {
+    tvl: sumTokensExport({
+      owners: [TREASURY],
+      tokens: bscTokens,
+    }),
+  },
+}


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
PopcornCine

##### Twitter Link:
https://x.com/Popcorncine_

##### List of audit links if any:


##### Website Link:
https://www.popcorncine.io

##### Logo (High resolution, will be shown with rounded borders):
https://www.popcorncine.io/images/logo-icon.png

##### Current TVL:
Variable / currently low — treasury balances fluctuate with Morph settlement and payouts

##### Treasury Addresses (if the protocol has treasury)
0xeb2afb2af45f3be8d8b1cc5b9bce603be9721760 (Morph settlement / Morph Payments receiving wallet)

##### Chain:
morph, bsc

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):


##### Short Description (to be shown on DefiLlama):
PopcornCine lets users Predict Culture and Predict Markets — entertainment prediction markets and Real World Assets bStock battles on BNB Chain, with Morph Payments checkout and Atlas Oracle pricing.

##### Token address and ticker if any:
CINE ONE PASS is a BNB Chain utility NFT access credential at 0xec995b05cc6c7bdcd96ac5f6575b862ec122b5c6 (not counted in TVL).

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Prediction Market

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
Atlas Oracle

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
Atlas Oracle bStock price feeds on BNB Chain are used to resolve Real World Assets / weekly bStock battles (e.g. NVDAB, QQQB, MSFTB).

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
https://docs.atlasoracle.io/developers/atlas-oracle/integrate-the-push-mode
https://www.popcorncine.io/battles
https://www.popcorncine.io/markets

##### forkedFrom (Does your project originate from another project):
No

##### methodology (what is being counted as tvl, how is tvl being calculated):
Counts USDT and USDC held in the PopcornCine Morph settlement treasury (0xeb2afb2af45f3be8d8b1cc5b9bce603be9721760) used for CINE ONE PASS mints and prediction/battle payments. Atlas feed contracts and the PASS NFT are excluded.

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/PascalV777/popcorncine_v3

##### Does this project have a referral program?
Yes — referral attribution / XP growth tracking (not an on-chain liquidity-mining vault).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for PopcornCine across the Morph and BSC networks.
  * Tracks assets held in the appropriate settlement treasury for each network.
  * Includes methodology details describing the separate treasury wallets and their respective asset flows.

* **Bug Fixes**
  * Improved TVL accuracy by separating the BSC NFT contract treasury from the Morph Payments merchant wallet.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->