### PR TITLE
add DevFridge TVL adapter

### DIFF
--- a/projects/devfridge/index.js
+++ b/projects/devfridge/index.js
@@ -24,20 +24,19 @@ function decodeLock(data) {
   };
 }
 
+let _locks;
 async function getActiveLocks() {
+  if (!_locks) _locks = _getActiveLocks();
+  return _locks;
+}
+
+async function _getActiveLocks() {
   const connection = getConnection();
 
   const accounts = await connection.getProgramAccounts(PROGRAM_ID, {
-    filters: [
-      { dataSize: LOCK_DATA_SIZE },
-      {
-        memcmp: {
-          offset: 0,
-          bytes: LOCK_DISCRIMINATOR.toString("base64"),
-          encoding: "base64",
-        },
-      },
-    ],
+    // discriminator is checked in decodeLock — the base64 memcmp filter is
+    // silently ignored/mismatched by some RPCs and returns zero accounts
+    filters: [{ dataSize: LOCK_DATA_SIZE }],
   });
 
   const now = Math.floor(Date.now() / 1000);
@@ -48,7 +47,7 @@ async function getActiveLocks() {
     .filter((lock) => lock.unlockAt > now);
 }
 
-async function tvl(api) {
+async function vesting(api) {
   const locks = await getActiveLocks();
 
   for (const lock of locks) {
@@ -69,9 +68,10 @@ async function staking(api) {
 module.exports = {
   timetravel: false,
   methodology:
-    "TVL is the value of circulating Token-2022 assets deposited by users into active DevFridge program-controlled timelock vaults on Solana. Only locks whose unlock_at timestamp is still in the future are counted. DevFridge's own PASTA token is reported separately under staking.",
+    "DevFridge is a token locker: user-locked Token-2022 assets in active program-controlled timelock vaults on Solana are counted as vesting. DevFridge's own PASTA token is reported separately under staking. TVL is zero by design.",
   solana: {
-    tvl,
+    tvl: () => ({}),
+    vesting,
     staking,
   },
 };

--- a/projects/devfridge/index.js
+++ b/projects/devfridge/index.js
@@ -1,0 +1,77 @@
+const { getConnection } = require("../helper/solana");
+const { PublicKey } = require("@solana/web3.js");
+
+const PROGRAM_ID = new PublicKey(
+  "9RY54dNPYTzDyh3TfFqDdt2b2KMM56KW1tw9erRTGQo6"
+);
+
+const PASTA_MINT =
+  "39kMeX4HVRW9qbbiHSPbRQ9xeXUF18GrNP6gL61Ppump";
+
+const LOCK_DATA_SIZE = 105;
+
+const LOCK_DISCRIMINATOR = Buffer.from([
+  8, 255, 36, 202, 210, 22, 57, 137
+]);
+
+function decodeLock(data) {
+  if (!data.slice(0, 8).equals(LOCK_DISCRIMINATOR)) return null;
+
+  return {
+    mint: new PublicKey(data.slice(40, 72)).toBase58(),
+    amount: data.readBigUInt64LE(72),
+    unlockAt: Number(data.readBigInt64LE(88)),
+  };
+}
+
+async function getActiveLocks() {
+  const connection = getConnection();
+
+  const accounts = await connection.getProgramAccounts(PROGRAM_ID, {
+    filters: [
+      { dataSize: LOCK_DATA_SIZE },
+      {
+        memcmp: {
+          offset: 0,
+          bytes: LOCK_DISCRIMINATOR.toString("base64"),
+          encoding: "base64",
+        },
+      },
+    ],
+  });
+
+  const now = Math.floor(Date.now() / 1000);
+
+  return accounts
+    .map(({ account }) => decodeLock(account.data))
+    .filter(Boolean)
+    .filter((lock) => lock.unlockAt > now);
+}
+
+async function tvl(api) {
+  const locks = await getActiveLocks();
+
+  for (const lock of locks) {
+    if (lock.mint === PASTA_MINT) continue;
+    api.add(lock.mint, lock.amount.toString());
+  }
+}
+
+async function staking(api) {
+  const locks = await getActiveLocks();
+
+  for (const lock of locks) {
+    if (lock.mint !== PASTA_MINT) continue;
+    api.add(lock.mint, lock.amount.toString());
+  }
+}
+
+module.exports = {
+  timetravel: false,
+  methodology:
+    "TVL is the value of circulating Token-2022 assets deposited by users into active DevFridge program-controlled timelock vaults on Solana. Only locks whose unlock_at timestamp is still in the future are counted. DevFridge's own PASTA token is reported separately under staking.",
+  solana: {
+    tvl,
+    staking,
+  },
+};


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):

DevFridge

##### Twitter Link:

https://x.com/anonimocommando

##### List of audit links if any:

None

##### Website Link:

https://devfridge.cool

##### Logo (High resolution, will be shown with rounded borders):

https://raw.githubusercontent.com/mikeminer/devfridge/main/logo-lockup.jpg

##### Current TVL:

Approximately $900 at submission time. Calculated from active Token-2022 timelock positions on Solana. TVL is small but fully on-chain, permissionless and independently verifiable.

##### Treasury Addresses (if the protocol has treasury)

None

##### Chain:

Solana

##### Coingecko ID:

N/A

##### Coinmarketcap ID:

N/A

##### Short Description:

DevFridge is a permissionless Token-2022 timelock protocol on Solana. Users and token creators can deposit circulating tokens into program-controlled vaults with an on-chain unlock timestamp. Deposited assets cannot be claimed before the lock matures.

##### Token address and ticker if any:

PASTA — `39kMeX4HVRW9qbbiHSPbRQ9xeXUF18GrNP6gL61Ppump`

##### Category:

Services

##### Oracle Provider(s):

N/A — the timelock mechanism does not rely on a price oracle. The unlock condition is purely temporal (on-chain clock >= unlock_at).

##### Implementation Details:

DevFridge stores each position in an on-chain Anchor Lock account (105 bytes) and transfers the deposited Token-2022 assets into a program-controlled vault associated with that lock. The Lock account contains: depositor, mint, deposited amount, creation timestamp, unlock timestamp, bump, and lock ID. A claim is rejected by the Solana program until the on-chain clock reaches `unlock_at`.

The adapter discovers all Lock accounts via `getProgramAccounts`, filters for active locks (unlock_at > now), and reports Token-2022 balances under `tvl` while PASTA balances are reported separately under `staking`.

##### Documentation/Proof:

- Docs: https://docs.devfridge.cool
- Source: https://github.com/mikeminer/devfridge
- Program ID: `9RY54dNPYTzDyh3TfFqDdt2b2KMM56KW1tw9erRTGQo6`

##### forkedFrom:

No

##### methodology:

TVL is computed directly from Solana mainnet state by discovering DevFridge Lock accounts owned by the program. Only active locks whose `unlock_at` timestamp is still in the future are counted. The adapter sums the Token-2022 amount associated with those active timelock positions. DevFridge's own PASTA token is reported separately under the staking bucket.

Treasury balances, boost payments, burned PASTA and external DEX liquidity are not included.

##### Github org/user:

mikeminer

##### Does this project have a referral program?

No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DevFridge integration for reporting active Solana vesting locks.
  * Added separate reporting for vesting deposits and PASTA staking deposits.
  * Only deposits with future unlock times are included in vesting totals.
  * Solana TVL is reported as zero; vesting and staking metrics are reported separately.

* **Bug Fixes**
  * Improved compatibility with RPC providers that do not reliably apply account filters, helping ensure active locks are detected correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->