### PR TITLE
Add new owner address for Robinhood TVL calculation

### DIFF
--- a/projects/privacy-cash/index.js
+++ b/projects/privacy-cash/index.js
@@ -49,7 +49,10 @@ module.exports = {
   },
   robinhood: {
     tvl: evmSumTokensExport({
-      owners: ['0xEC5266c9e44631e1ba22FD6377C38130c1F3B738'],
+      owners: [
+        '0xEC5266c9e44631e1ba22FD6377C38130c1F3B738',
+        '0xBB0C7F576B7bdAa8f2a119cb295076aCD0C9013f'
+      ],
       tokens: [ADDRESSES.null, ADDRESSES.robinhood.USDG],
     })
   },


### PR DESCRIPTION
Currently, USDG TVL isn't tracked because USDG pool address isn't added (https://robinhoodchain.blockscout.com/address/0xEC5266c9e44631e1ba22FD6377C38130c1F3B738).

This PR fixes the bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Robinhood TVL reporting by including an additional owner address.
  - This provides more complete and accurate total value locked data while preserving the existing supported token list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->