### PR TITLE
Add Phase Stake (YIELD) stake pool

### DIFF
--- a/registries/solanaStakePool.js
+++ b/registries/solanaStakePool.js
@@ -104,6 +104,10 @@ const configs = {
     methodology: "Total SOL staked in the Phase Delegation stake pool, read on chain from the SPL stake pool account's totalLamports",
     solana: 'aero2ePURjuEgLKTzcUmF6RypBncBGd7pMUYCoSsVJ6',
   },
+  'phase-yield': {
+    methodology: "Total SOL staked in the Phase Stake pool, read on chain from the stake pool account's totalLamports",
+    solana: 'phasejkG1akKgqkLvfWzWY17evnH6mSWznnUspmpyeG',
+  },
   // getStakedSol adapters
   'thevault': {
     solana: { type: 'staked', address: 'GdNXJobf8fbTR5JSE7adxa6niaygjx4EEbnnRaDCHMMW' },


### PR DESCRIPTION
Adds Phase Stake (YIELD) to `registries/solanaStakePool.js`.

YIELD is Phase's liquid staking token for its institutional validator service. It's a multi-validator stake pool on the Sanctum multi-validator stake pool program (`SPMBzsVUuoHA4Jm6KunbsotaahvVikZs1JyTW6iJvbn`), the same program jupSOL uses, so the existing `getSolBalanceFromStakePool` helper handles it and no new adapter is needed.

Companion to #20720, which added Phase Delegation (pdSOL) and is now merged.

**Addresses**
- Stake pool: `phasejkG1akKgqkLvfWzWY17evnH6mSWznnUspmpyeG`
- YIELD mint: `phaseZSfPxTDBpiVb96H4XFSD8xHeHxZre5HerehBJG`

**Methodology**

Total SOL staked in the pool, read on chain from the stake pool account's `totalLamports`. Same approach as the other entries in this registry.

**Verification**

Decoded the pool account directly:

- `totalLamports`: 18,076.53 SOL
- `poolTokenSupply`: 15,256.77 YIELD
- rate: 1.184821 SOL per YIELD
- 611-byte account, same layout as the other entries here

Cross-checks: the rate and total both match Phase's own public dashboard (18,076.50 SOL, 1.18482 SOL per YIELD), and independently match the sum of the pool's stake accounts derived via the stake withdraw authority.

Not double counted with #20720: the two pools hold separate stake accounts delegated to different validator sets, and neither reserve holds the other's LST.

Slug note: deliberately `phase-yield` rather than `yield-sol`, since an unrelated `yieldSOL` (`yLdBrBJAYYkNMNSE48BAXYLTXhZsbHWtmWEFHgHSD6a`) already exists on the same program.

Happy to supply metadata (logo, description, website, socials) through whichever channel you prefer, and to have this grouped with Phase Delegation under a shared parent if that's easiest on your side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `phase-yield` Solana stake pool, including its methodology details and account address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->