### PR TITLE
goonfi: add TVL adapter

### DIFF
--- a/projects/goonfi/index.js
+++ b/projects/goonfi/index.js
@@ -1,0 +1,48 @@
+const { PublicKey } = require("@solana/web3.js");
+const { getConnection, sumTokens2 } = require("../helper/solana");
+
+const MARKETS = [
+  {
+    program: "goonERTdGsjnkZqWuVjs73BZ3Pb9qoCUdBUL17BnS5j",
+    size: 1833,
+    vaultOffset: 678,
+  },
+  {
+    program: "goonuddtQRrWqqn5nFyczVKaie28f3kDkHWkHtURSLE",
+    size: 2048,
+    discriminator: "99nuWqpQZwP",
+    vaultOffset: 144,
+  },
+];
+
+async function tvl(api) {
+  const connection = getConnection();
+  const markets = await Promise.all(
+    MARKETS.map(({ program, size, discriminator, vaultOffset }) =>
+      connection.getProgramAccounts(new PublicKey(program), {
+        filters: [
+          { dataSize: size },
+          ...(discriminator
+            ? [{ memcmp: { offset: 0, bytes: discriminator } }]
+            : []),
+        ],
+        dataSlice: { offset: vaultOffset, length: 64 },
+      })
+    )
+  );
+
+  const tokenAccounts = markets
+    .flat()
+    .flatMap(({ account }) => [0, 32].map((offset) =>
+      new PublicKey(account.data.subarray(offset, offset + 32)).toBase58()
+    ));
+
+  return sumTokens2({ api, tokenAccounts });
+}
+
+module.exports = {
+  timetravel: false,
+  methodology:
+    "Counts the SPL and Token-2022 balances held in every GoonFi V1 and V2 market's two token vaults. Markets and vault addresses are discovered directly from the GoonFi programs on-chain.",
+  solana: { tvl },
+};


### PR DESCRIPTION
## Summary

Adds an on-chain TVL adapter for GoonFi on Solana.

GoonFi is already listed on DefiLlama with DEX volume tracking. This PR adds the missing TVL calculation for both the V1 and V2 proprietary AMM programs.

The adapter discovers every GoonFi market account directly from the two deployed Solana programs, extracts the two token vaults stored in each market state, and sums their on-chain SPL Token and Token-2022 balances using DefiLlama's existing Solana helper.

## Methodology

TVL is the USD value of the two token vaults recorded in every GoonFi V1 and V2 market account.

Markets are discovered on-chain with `getProgramAccounts`:

- V1 accounts must be owned by the GoonFi V1 program and have a data size of 1,833 bytes.
- V2 accounts must be owned by the GoonFi V2 program, have a data size of 2,048 bytes, and begin with the eight-byte discriminator represented in Base58 as `99nuWqpQZwP`.

Only the 64 bytes containing the two vault public keys are downloaded from each market account. The extracted addresses are passed to DefiLlama's `sumTokens2` helper, which reads and sums both classic SPL Token and Token-2022 accounts.

The adapter reports these balances in the base `tvl` bucket. It does not report `staking`, `pool2`, `borrowed`, treasury holdings, or protocol-token balances.

## Programs and account layouts

### GoonFi V1

- Program: `goonERTdGsjnkZqWuVjs73BZ3Pb9qoCUdBUL17BnS5j`
- Market account size: `1833` bytes

### GoonFi V2

- Program: `goonuddtQRrWqqn5nFyczVKaie28f3kDkHWkHtURSLE`
- Market account size: `2048` bytes
- Account discriminator: bytes `0–7`, Base58 `99nuWqpQZwP`


## On-chain verification

At the time of verification, the adapter discovered:

- 1 V1 market;
- 33 V2 markets;
- 68 token vault addresses;
- 68 unique vault addresses;
- 61 vaults owned by the classic SPL Token Program;
- 7 vaults owned by the Token-2022 Program.

All 68 extracted addresses resolved to valid token accounts. An independent balance and DefiLlama-price cross-check valued the discovered balances at approximately `$5.90 million`. 


## Sources

Existing DefiLlama GoonFi listing:

https://defillama.com/protocol/goonfi

Existing DefiLlama DEX volume configuration (`project: goonfi`, start date `2025-05-22`):

https://github.com/DefiLlama/dimension-adapters/blob/master/factory/duneSolanaDex.ts

Helius research identifying GoonFi as a Solana proprietary AMM and publishing the V1 program address:

https://www.helius.dev/blog/solanas-proprietary-amm-revolution

GoonFi V1 program on Solana Explorer:

https://explorer.solana.com/address/goonERTdGsjnkZqWuVjs73BZ3Pb9qoCUdBUL17BnS5j?cluster=mainnet-beta

GoonFi V2 program on Solana Explorer:

https://explorer.solana.com/address/goonuddtQRrWqqn5nFyczVKaie28f3kDkHWkHtURSLE?cluster=mainnet-beta

Bitquery documentation identifying the GoonFi V2 DEX program:

https://docs.bitquery.io/docs/blockchain/Solana/goonfi-api/

Public GoonFi V1 and V2 swap IDLs:

- https://github.com/bitquery/solana-idl-lib/blob/main/goonfi/goonfi.json
- https://github.com/bitquery/solana-idl-lib/blob/main/goonfi/goonfi_v2.json

Independent V2 account-size and mint-offset reference:

https://gist.github.com/mubarizkyc/959ac9b33dae4f3a86c6e00c331a9901

Representative market accounts:

- https://solscan.io/account/B4RpYxfAxSs7gE26kPES62CUz6WuzFKrDMHqJ3tKM5tm
- https://solscan.io/account/TcMgpxh6SLph4DZNchtSp63KXK115g5Xo9vQ76kwbAZ

## Why `timetravel: false`

Market discovery uses Solana's current `getProgramAccounts` state. A standard public Solana RPC does not expose historical program-account snapshots for arbitrary timestamps, so the adapter explicitly disables time travel rather than presenting current market discovery as historical state.


## Validation

```bash
node test.js projects/goonfi/index.js
```





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for GoonFi on Solana.
  * Supports both GoonFi V1 and V2 markets.
  * Includes token balances from vaults across supported markets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->