### PR TITLE
Fix Ajna V2 Fail on bad token

### DIFF
--- a/projects/ajna-v2/index.js
+++ b/projects/ajna-v2/index.js
@@ -72,5 +72,5 @@ module.exports = Object.keys(factories).reduce((acc, chain) => {
     return acc;
 }, {
     misrepresentedTokens: true,
-    methodology: "TVL = collateral + available quote liquidity across all Ajna ERC20 and ERC721 pools (net of borrows). Borrowed = pool debtInfo. NFT-pool collateral is not priced.",
+    methodology: "TVL = collateral + quote-token balances held across all Ajna ERC20 and ERC721 pools (deposits net of borrows, including escrowed liquidation bonds and unclaimed reserves). Borrowed = pool debtInfo. NFT-pool collateral is not priced.",
 });

--- a/projects/ajna-v2/index.js
+++ b/projects/ajna-v2/index.js
@@ -21,29 +21,11 @@ const factories = {
     polygon: { erc20: '0x1f172F881eBa06Aa7a991651780527C173783Cf6', erc721: '0x8B7f874D15c25BeCC4F7c1906b3677533fe60A6e' },
 };
 
-// Test/spam pools that Ajna itself excludes (see arb-ajna-ui pool-blacklist). Lowercased.
-const blacklistedPools = {
-    ethereum: [
-        '0x618742a3b5a371f3b808af4a860d1ecbab3a2c11',
-        '0x1126e9df5909bc1a45f524e977f1911bc3b01161',
-    ],
-    base: [
-        '0xf44ed07f91be6a46296084d4951a27015c58ff32',
-        '0xdeac8a9a7026a4d17df81d4c03cb2ad059383e7c',
-        '0x8948e6a77a70afb07a84f769605a3f4a8d4ee7ef',
-        '0x0800d4d5bfe01423828b37ffed553d6700eed426',
-        '0xda5cc6f3ee0c9b80b2e4df9a34de7c4c81067c46',
-        '0x9917ef067cec3866c8dbaa5a25b752747452b370',
-    ],
-};
-
 async function getPools(chain, api) {
     const { erc20, erc721 } = factories[chain];
     // permitFailure so a single unreachable/reverting factory can't fail the chain
     const lists = await api.multiCall({ abi: 'address[]:getDeployedPoolsList', calls: [erc20, erc721], permitFailure: true });
-    const blacklist = new Set(blacklistedPools[chain] || []);
-    const keep = pools => (pools || []).filter(p => !blacklist.has(p.toLowerCase()));
-    return { erc20Pools: keep(lists[0]), erc721Pools: keep(lists[1]) };
+    return { erc20Pools: lists[0] || [], erc721Pools: lists[1] || [] };
 }
 
 async function getTvl(chain, api) {
@@ -90,5 +72,5 @@ module.exports = Object.keys(factories).reduce((acc, chain) => {
     return acc;
 }, {
     misrepresentedTokens: true,
-    methodology: "TVL = collateral + available quote liquidity across all Ajna ERC20 and ERC721 pools (net of borrows). Borrowed = pool debtInfo. Ajna's blacklisted test/spam pools are excluded; NFT-pool collateral is not priced.",
+    methodology: "TVL = collateral + available quote liquidity across all Ajna ERC20 and ERC721 pools (net of borrows). Borrowed = pool debtInfo. NFT-pool collateral is not priced.",
 });

--- a/projects/ajna-v2/index.js
+++ b/projects/ajna-v2/index.js
@@ -1,46 +1,94 @@
 const sdk = require("@defillama/sdk");
 const { sumTokens2 } = require('../helper/unwrapLPs');
 
-const poolFactories = {
-    ethereum: '0x6146DD43C5622bB6D12A5240ab9CF4de14eDC625',
-    arbitrum: '0xA3A1e968Bd6C578205E11256c8e6929f21742aAF',
-    avax: '0x2aA2A6e6B4b20f496A4Ed65566a6FD13b1b8A17A',
-    base: '0x214f62B5836D83f3D6c4f71F174209097B1A779C',
-    blast: '0xcfCB7fb8c13c7bEffC619c3413Ad349Cbc6D5c91',
-    bsc: '0x86eE95085F204B525b590f21dec55e2373F6da69',
-    filecoin: '0x0E4a2276Ac259CF226eEC6536f2b447Fc26F2D8a',
-    hemi: '0xE47b3D287Fc485A75146A59d459EC8CD0F8E5021',
-    linea: '0xd72A448C3BC8f47EAfFc2C88Cf9aC9423Bfb5067',
-    mode: '0x62Cf5d9075D1d6540A6c7Fa836162F01a264115A',
-    optimism: '0x609C4e8804fafC07c96bE81A8a98d0AdCf2b7Dfa',
-    polygon: '0x1f172F881eBa06Aa7a991651780527C173783Cf6',
-    rari: '0x10cE36851B0aAf4b5FCAdc93f176aC441D4819c9',
+// Ajna deploys pools through two permissionless factories per chain: an
+// ERC20PoolFactory (fungible collateral) and an ERC721PoolFactory (NFT collateral).
+// getDeployedPoolsList() on each factory returns every pool it has deployed, so new
+// pools are picked up automatically.
+const factories = {
+    ethereum: { erc20: '0x6146DD43C5622bB6D12A5240ab9CF4de14eDC625', erc721: '0x27461199d3b7381De66a85D685828E967E35AF4c' },
+    arbitrum: { erc20: '0xA3A1e968Bd6C578205E11256c8e6929f21742aAF', erc721: '0x6ae3324612bEfD4AE460244c369f30Ab9CB8cAE2' },
+    avax: { erc20: '0x2aA2A6e6B4b20f496A4Ed65566a6FD13b1b8A17A', erc721: '0xB3d773147A086A23fB72dcc03828C66DcE5D6627' },
+    base: { erc20: '0x214f62B5836D83f3D6c4f71F174209097B1A779C', erc721: '0xeefEC5d1Cc4bde97279d01D88eFf9e0fEe981769' },
+    blast: { erc20: '0xcfCB7fb8c13c7bEffC619c3413Ad349Cbc6D5c91', erc721: '0x6C046C4b072404ce7865a7c317b432B5e269822A' },
+    bsc: { erc20: '0x86eE95085F204B525b590f21dec55e2373F6da69', erc721: '0x8A4DaF211979f60339D26b9Eb1407D74fA36a52a' },
+    filecoin: { erc20: '0x0E4a2276Ac259CF226eEC6536f2b447Fc26F2D8a', erc721: '0x07Eb44ca94cddA4016cECCe7FB9C7Ae73DBD4306' },
+    xdai: { erc20: '0x87578E357358163FCAb1711c62AcDB5BBFa1C9ef', erc721: '0xc7Fc13Fa7B697fBE3bdC56D5b9A6586A83254126' },
+    hemi: { erc20: '0xE47b3D287Fc485A75146A59d459EC8CD0F8E5021', erc721: '0x3E0126d3B10596b7E13e42E34B7cBD0E9735e4c0' },
+    linea: { erc20: '0xd72A448C3BC8f47EAfFc2C88Cf9aC9423Bfb5067', erc721: '0x0c1Fa8D707dFb57551efa21C16255BEAb13F5bCD' },
+    mode: { erc20: '0x62Cf5d9075D1d6540A6c7Fa836162F01a264115A', erc721: '0x2189eC0743e36f2CB51BEdaf089d686BC0996e03' },
+    optimism: { erc20: '0x609C4e8804fafC07c96bE81A8a98d0AdCf2b7Dfa', erc721: '0xAAa20ba75A7ed4Fa895E4659861448a828fa6E48' },
+    polygon: { erc20: '0x1f172F881eBa06Aa7a991651780527C173783Cf6', erc721: '0x8B7f874D15c25BeCC4F7c1906b3677533fe60A6e' },
 };
 
-async function getTvl(poolFactory, api) {
-    const pools = await api.call({ abi: 'address[]:getDeployedPoolsList', target: poolFactory });
-    const collaterals = await api.multiCall({ abi: 'address:collateralAddress', calls: pools });
-    const borrows = await api.multiCall({ abi: 'address:quoteTokenAddress', calls: pools });
-    const ownerTokens = pools.map((v, i) => [[collaterals[i], borrows[i]], v]);
-    return sumTokens2({ ownerTokens, api });
+// Test/spam pools that Ajna itself excludes (see arb-ajna-ui pool-blacklist). Lowercased.
+const blacklistedPools = {
+    ethereum: [
+        '0x618742a3b5a371f3b808af4a860d1ecbab3a2c11',
+        '0x1126e9df5909bc1a45f524e977f1911bc3b01161',
+    ],
+    base: [
+        '0xf44ed07f91be6a46296084d4951a27015c58ff32',
+        '0xdeac8a9a7026a4d17df81d4c03cb2ad059383e7c',
+        '0x8948e6a77a70afb07a84f769605a3f4a8d4ee7ef',
+        '0x0800d4d5bfe01423828b37ffed553d6700eed426',
+        '0xda5cc6f3ee0c9b80b2e4df9a34de7c4c81067c46',
+        '0x9917ef067cec3866c8dbaa5a25b752747452b370',
+    ],
+};
+
+async function getPools(chain, api) {
+    const { erc20, erc721 } = factories[chain];
+    // permitFailure so a single unreachable/reverting factory can't fail the chain
+    const lists = await api.multiCall({ abi: 'address[]:getDeployedPoolsList', calls: [erc20, erc721], permitFailure: true });
+    const blacklist = new Set(blacklistedPools[chain] || []);
+    const keep = pools => (pools || []).filter(p => !blacklist.has(p.toLowerCase()));
+    return { erc20Pools: keep(lists[0]), erc721Pools: keep(lists[1]) };
 }
 
-async function getBorrowed(poolFactory, api) {
-    const pools = await api.call({ abi: 'address[]:getDeployedPoolsList', target: poolFactory });
-    const debts = await api.multiCall({ abi: 'function debtInfo() external view returns (uint256, uint256, uint256, uint256)', calls: pools });
-    const borrows = await api.multiCall({ abi: 'address:quoteTokenAddress', calls: pools });
-    const borrowScale = await api.multiCall({ abi: 'uint:quoteTokenScale', calls: pools });
+async function getTvl(chain, api) {
+    const { erc20Pools, erc721Pools } = await getPools(chain, api);
+    const ownerTokens = [];
+
+    if (erc20Pools.length) {
+        const collaterals = await api.multiCall({ abi: 'address:collateralAddress', calls: erc20Pools, permitFailure: true });
+        const quotes = await api.multiCall({ abi: 'address:quoteTokenAddress', calls: erc20Pools, permitFailure: true });
+        erc20Pools.forEach((pool, i) => ownerTokens.push([[collaterals[i], quotes[i]].filter(Boolean), pool]));
+    }
+
+    // ERC721 pools hold NFT collateral (balanceOf returns a count, not a priceable
+    // amount), so only the quote token is counted as TVL.
+    if (erc721Pools.length) {
+        const quotes = await api.multiCall({ abi: 'address:quoteTokenAddress', calls: erc721Pools, permitFailure: true });
+        erc721Pools.forEach((pool, i) => ownerTokens.push([[quotes[i]].filter(Boolean), pool]));
+    }
+
+    return sumTokens2({ ownerTokens, api, permitFailure: true });
+}
+
+async function getBorrowed(chain, api) {
+    const { erc20Pools, erc721Pools } = await getPools(chain, api);
+    const pools = [...erc20Pools, ...erc721Pools];
+    const debts = await api.multiCall({ abi: 'function debtInfo() external view returns (uint256, uint256, uint256, uint256)', calls: pools, permitFailure: true });
+    const borrows = await api.multiCall({ abi: 'address:quoteTokenAddress', calls: pools, permitFailure: true });
+    const borrowScale = await api.multiCall({ abi: 'uint:quoteTokenScale', calls: pools, permitFailure: true });
     const balances = {};
-    pools.forEach((v, i) => sdk.util.sumSingleBalance(balances, borrows[i], debts[i][0]/borrowScale[i]));
+    pools.forEach((_, i) => {
+        if (!debts[i] || !borrows[i] || !borrowScale[i]) return;
+        // debtInfo()[0] is the current total pool debt in WAD; dividing by
+        // quoteTokenScale (10^(18-decimals)) yields native quote-token units.
+        sdk.util.sumSingleBalance(balances, borrows[i], debts[i][0] / borrowScale[i]);
+    });
     return balances;
 }
 
-module.exports.methodology = "We are not tracking this tokens: bfBTC and msBTC"
-
-module.exports = Object.keys(poolFactories).reduce((acc, chain) => {
+module.exports = Object.keys(factories).reduce((acc, chain) => {
     acc[chain] = {
-        tvl: (api) => getTvl(poolFactories[chain], api),
-        borrowed: (api) => getBorrowed(poolFactories[chain], api)
+        tvl: (api) => getTvl(chain, api),
+        borrowed: (api) => getBorrowed(chain, api)
     };
     return acc;
-}, { misrepresentedTokens: true });
+}, {
+    misrepresentedTokens: true,
+    methodology: "TVL = collateral + available quote liquidity across all Ajna ERC20 and ERC721 pools (net of borrows). Borrowed = pool debtInfo. Ajna's blacklisted test/spam pools are excluded; NFT-pool collateral is not priced.",
+});


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

  ## Existing listing update

  Updates the Ajna v2 adapter to:

  - Track pools from both ERC20 and ERC721 factories
  - Add Gnosis Chain support
  - Tolerate individual failed contract calls
  - Clarify the TVL methodology

  For ERC721 pools, only quote-token liquidity and borrowed amounts are counted
  because NFT collateral cannot be reliably priced.

  ### Testing

  - `node test.js projects/ajna-v2/index.js`
  - ESLint, syntax validation, and `git diff --check` pass

  No dependencies or lockfiles were changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded TVL tracking to include quote liquidity from both ERC20 and ERC721 pools.
  * Added support for tracking borrowed amounts across both pool types.
  * Improved resilience so individual failed pool calls no longer interrupt chain-wide data collection.

* **Changes**
  * NFT collateral is excluded from TVL because it is not priced.
  * Removed support for the Rari chain.
  * Updated methodology information to clarify TVL and borrowed amount calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->