### PR TITLE
fix(blend-pools-v2): stop deriving TVL from the backstop reward zone

### DIFF
--- a/projects/blend-pools-v2/index.js
+++ b/projects/blend-pools-v2/index.js
@@ -5,15 +5,21 @@ const BACKSTOP_ID = "CAQQR5SWBXKIGZKPBZDH3KM5GQ5GUTPKB7JAFCINLZBC5WXPJKRG3IM7";
 
 // Blend V2 pools.
 //
-// The backstop's reward_zone() is the only on-chain enumeration of pools, but
-// it lists the pools currently eligible for BLND emissions, not the pools that
-// hold funds. Governance can empty or rotate it while every pool still
-// custodies user deposits, so TVL must not be derived from it alone. Pools are
-// listed explicitly here and unioned with the reward zone, so a new pool is
-// picked up automatically and an empty zone cannot zero the protocol.
+// The backstop's reward_zone() is the only on-chain enumeration, but it lists
+// the pools currently eligible for BLND emissions, not the pools that hold
+// funds. Eligibility depends on a backstop threshold priced through the Comet
+// BLND-USDC pool, and while that price reads zero no pool clears the threshold,
+// so the zone empties even though every pool still custodies user deposits.
+//
+// Blend's own UI carries this same list for the same reason, see
+// blend-ui/src/components/markets/MarketsList.tsx ("pools don't meet threshold
+// due to comet bug"). Unioned with the reward zone so a newly added pool is
+// still picked up automatically once emissions are working again.
 const POOLS = [
   "CAJJZSGMMM3PD7N33TAPHGBUGTB43OC73HVIK2L2G6BNGGGYOSSYBXBD", // Fixed V2
   "CCCCIQSDILITHMM7PBSLVDT5MISSY7R26MNZXCX4H7J5JQ5FPIYOGYFS", // YieldBlox V2
+  "CDMAVJPFXPADND3YRL4BSM3AKZWCTFMX27GLLXCML3PD62HEQS5FPVAI",
+  "CC4HHXPKR3FIXUQEC53MAK2IVWD6APAEBBXP5XCIW5FISN6PQOAC6UXG",
 ];
 
 // b_rate / d_rate are 12-decimal fixed point, so shares * rate / 1e12 gives the

--- a/projects/blend-pools-v2/index.js
+++ b/projects/blend-pools-v2/index.js
@@ -1,23 +1,63 @@
-const { stellar } = require("../helper/chain/rpcProxy");
+const { callSoroban } = require("../helper/chain/stellar");
 const methodologies = require("../helper/methodologies");
+
 const BACKSTOP_ID = "CAQQR5SWBXKIGZKPBZDH3KM5GQ5GUTPKB7JAFCINLZBC5WXPJKRG3IM7";
 
-async function tvlInfo() {
-  return stellar.blendPoolInfo(BACKSTOP_ID)
+// Blend V2 pools.
+//
+// The backstop's reward_zone() is the only on-chain enumeration of pools, but
+// it lists the pools currently eligible for BLND emissions, not the pools that
+// hold funds. Governance can empty or rotate it while every pool still
+// custodies user deposits, so TVL must not be derived from it alone. Pools are
+// listed explicitly here and unioned with the reward zone, so a new pool is
+// picked up automatically and an empty zone cannot zero the protocol.
+const POOLS = [
+  "CAJJZSGMMM3PD7N33TAPHGBUGTB43OC73HVIK2L2G6BNGGGYOSSYBXBD", // Fixed V2
+  "CCCCIQSDILITHMM7PBSLVDT5MISSY7R26MNZXCX4H7J5JQ5FPIYOGYFS", // YieldBlox V2
+];
+
+// b_rate / d_rate are 12-decimal fixed point, so shares * rate / 1e12 gives the
+// underlying token amount in its own base units.
+const RATE_SCALAR = 10n ** 12n;
+
+async function getPools() {
+  let rewardZone = [];
+  try {
+    rewardZone = await callSoroban(BACKSTOP_ID, "reward_zone");
+  } catch (e) {
+    // A backstop that cannot be read must not silently shrink the pool set.
+  }
+  return [...new Set([...POOLS, ...rewardZone])];
 }
 
-async function tvl() {
-  return (await tvlInfo()).tvl
+async function sumPools(api, pick) {
+  const pools = await getPools();
+  await Promise.all(
+    pools.map(async (pool) => {
+      const assets = await callSoroban(pool, "get_reserve_list");
+      await Promise.all(
+        assets.map(async (asset) => {
+          const { data } = await callSoroban(pool, "get_reserve", [asset]);
+          const supplied =
+            (BigInt(data.b_supply) * BigInt(data.b_rate)) / RATE_SCALAR;
+          const borrowed =
+            (BigInt(data.d_supply) * BigInt(data.d_rate)) / RATE_SCALAR;
+          api.add(asset, pick(supplied, borrowed).toString());
+        })
+      );
+    })
+  );
 }
 
-async function borrowed() {
-  return (await tvlInfo()).borrowed
-}
+// Borrowed tokens are not in the contract, so TVL is supplied minus borrowed.
+const tvl = (api) => sumPools(api, (supplied, borrowed) => supplied - borrowed);
+const borrowed = (api) => sumPools(api, (_supplied, borrowed) => borrowed);
 
 module.exports = {
   timetravel: false,
-  methodology: `${methodologies.lendingMarket}. TVL is calculated and totaled for all Blend V2 pools in the Blend reward zone.`,
+  methodology: `${methodologies.lendingMarket} TVL is totalled across all Blend V2 pools. Outstanding debt is reported separately as borrowed.`,
   stellar: {
-    tvl, borrowed,
+    tvl,
+    borrowed,
   },
 };


### PR DESCRIPTION
Blend V2 has reported **$0 TVL since 2026-08-27**, down from $152.7M the day before:

```
2026-08-25   $164,249,620
2026-08-26   $152,745,739
2026-08-27   $0        <- cliff
2026-08-28   $0
```

The funds are still there. The adapter totalled TVL over the backstop's reward zone, and `reward_zone()` now returns `[]`.

### Why the reward zone is the wrong source

It tracks which pools are eligible for BLND emissions, not which pools hold deposits. Governance can empty or rotate it while every pool still custodies user funds, so any emissions change silently zeroes reported TVL.

The FixedV2 pool alone currently holds, read on-chain:

| Asset | Supplied | Borrowed |
|---|---|---|
| XLM | 765,472,603 | 1,306,810 |
| USDC | 49,030,780 | 39,324,902 |
| EURC | 537,492 | 125,269 |

with `last_time` showing interest accrued within the hour.

### The fix

Read the pools directly rather than the emissions list:

- `get_reserve_list()` per pool, then `get_reserve(asset)` per reserve
- token amount = `shares * rate / 1e12` (`b_rate`/`d_rate` are 12-decimal fixed point)
- TVL is supplied minus borrowed, since borrowed tokens are not in the contract; debt is reported separately as `borrowed`

Pools are listed explicitly and **unioned with the reward zone**, so a newly added pool is still picked up automatically, while an empty zone can no longer zero the protocol.

### Result

```
--- tvl ---                    --- borrowed ---
XLM        141.14 M            USDC     39.39 M
USDC         9.72 M            XLM     251.31 k
EURC       480.90 k            EURC    146.62 k
AQUA         2.53 k            AQUA      1.78 k
CETES        2.17 k            PYUSD    875.00
USDGLO      680.00             CETES     35.00
PYUSD       294.00
Total:     151.34 M            Total:   39.79 M
```

$151.34M against the $152.75M reported on 2026-08-26, the last day before the regression.

I do not have visibility into the `blendPoolInfo` proxy this adapter previously called, so this replaces the call with direct contract reads rather than changing the proxy. `blend-pools` (V1) is left alone — that backstop has no `reward_zone` function, and its decline looks like genuine migration to V2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Blend pool data retrieval for more reliable metrics.
  * Expanded pool coverage to include pools identified through backstop configuration.
  * Updated supplied and borrowed balance calculations for more accurate reserve-level reporting.
  * TVL now reflects supplied assets minus borrowed assets.
  * Updated methodology details to describe the revised TVL and balance calculations.
  * Added defensive handling when reward-zone information is unavailable, helping preserve reporting continuity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->