### PR TITLE
Add Uniswap V3 TVL on Stable

### DIFF
--- a/projects/uniswap/index.js
+++ b/projects/uniswap/index.js
@@ -82,6 +82,7 @@ const uniV3Config = {
   '0g': { factory: '0xcb2436774C3e191c85056d248EF4260ce5f27A9D', fromBlock: 6673868 },
   megaeth: { factory: '0x3a5f0cd7d62452b7f899b2a5758bfa57be0de478', fromBlock: 7009646 },
   robinhood: { factory: '0x1f7d7550B1b028f7571E69A784071F0205FD2EfA', fromBlock: 8930 },
+  stable: { factory: '0x88F0a512eF09175D456bc9547f914f48C013E4aA', fromBlock: 3442899 },
 }
 
 Object.keys(uniV3Config).forEach(chain => {


### PR DESCRIPTION
## Summary

Adds the canonical Uniswap V3 deployment on Stable to the existing Uniswap TVL adapter.

## Configuration

- Chain: `stable` (chain ID 988)
- Factory: `0x88F0a512eF09175D456bc9547f914f48C013E4aA`
- Deployment block: `3442899`

## Sources

- https://docs.stable.xyz/en/reference/dexes
- https://stablescan.xyz/address/0x88F0a512eF09175D456bc9547f914f48C013E4aA
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Uniswap V3 TVL export support for the stable chain.
  * Configured the stable chain with the required factory address and starting block.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->