### PR TITLE
add DYORSwap TVL on Stable

### DIFF
--- a/projects/dyorswap/index.js
+++ b/projects/dyorswap/index.js
@@ -1,3 +1,4 @@
+const ADDRESSES = require('../helper/coreAssets.json')
 const { getUniTVL } = require("../helper/unknownTokens")
 
 const config = {
@@ -13,6 +14,14 @@ const config = {
   soneium: '0x4f0c1b4c6FdF983f2d385Cf24DcbC8c68f345E40',
   unichain: '0x6c86ab200661512fDBd27Da4Bb87dF15609A2806',
   plasma: '0xA9F2c3E18E22F19E6c2ceF49A88c79bcE5b482Ac',
+  stable: '0x61a425ab7e1f6b3fa1eb6af6162cf471fa0e7c62',
+}
+
+const coreAssets = {
+  stable: [
+    ...Object.values(ADDRESSES.stable),
+    '0x817997Ca8394E26CCE3dE3A076a4889b27DbF9dE',
+  ],
 }
 
 module.exports = {
@@ -21,6 +30,10 @@ module.exports = {
 
 Object.keys(config).forEach(chain => {
   module.exports[chain] = {
-    tvl: getUniTVL({ factory: config[chain], useDefaultCoreAssets: true }),
+    tvl: getUniTVL({
+      factory: config[chain],
+      coreAssets: coreAssets[chain],
+      useDefaultCoreAssets: true,
+    }),
   }
 })


### PR DESCRIPTION
## Summary

Adds DYORSwap AMM's Stable Chain deployment to the existing on-chain TVL adapter.

DYORSwap AMM is already listed on DefiLlama, but its Stable Chain factory was missing from `projects/dyorswap/index.js`.

Existing DefiLlama page:

https://defillama.com/protocol/dyorswap-amm

## Changes

- Adds the DYORSwap Stable factory:
  `0x61a425ab7e1f6b3fa1eb6af6162cf471fa0e7c62`
- Adds DYORSwap's Stable WgUSDT as a chain-specific core asset:
  `0x817997Ca8394E26CCE3dE3A076a4889b27DbF9dE`
- Reuses the existing `getUniTVL` factory-discovery helper.




## Contract evidence

### Official DYORSwap announcement

DYORSwap published both the Stable factory and WgUSDT address:

https://x.com/DYORSWAPDEX/status/2079997097395589512

```text
Factory:
0x61a425ab7e1f6b3fa1eb6af6162cf471fa0e7c62

WgUSDT:
0x817997Ca8394E26CCE3dE3A076a4889b27DbF9dE
```

### Factory

StableScan:

https://stablescan.xyz/address/0x61a425ab7e1f6b3fa1eb6af6162cf471fa0e7c62


## Validation

```bash
 node test.js projects/dyorswap/index.js
```
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved total value locked (TVL) reporting for supported chains by including a broader set of stable assets.
  * Added support for an additional stable asset, helping ensure more complete and accurate displayed metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->