### PR TITLE
fix: track missing Aerodrome Slipstream CL factories

### DIFF
--- a/projects/aerodrome-CL/index.js
+++ b/projects/aerodrome-CL/index.js
@@ -27,4 +27,28 @@ const export2 = {
   }
 }
 
-module.exports = mergeExports([export1, export2])
+const export3 = {
+  base: {
+    tvl: getUniTVL({
+      factory: '0x9592CD9B267748cbfBDe90Ac9F7DF3c437A6d51B', blacklistedTokens, fetchBalances: true, abis: {
+        allPairsLength: 'uint256:allPoolsLength',
+        allPairs: "function allPools(uint) view returns (address)",
+      },
+      permitFailure: true,
+    })
+  }
+}
+
+const export4 = {
+  base: {
+    tvl: getUniTVL({
+      factory: '0xf8f2eB4940CFE7d13603DDDD87f123820Fc061Ef', blacklistedTokens, fetchBalances: true, abis: {
+        allPairsLength: 'uint256:allPoolsLength',
+        allPairs: "function allPools(uint) view returns (address)",
+      },
+      permitFailure: true,
+    })
+  }
+}
+
+module.exports = mergeExports([export1, export2, export3, export4])


### PR DESCRIPTION
## Summary

This PR extends the existing Aerodrome Slipstream TVL adapter on Base to include the two CLFactories that were still missing:

- `0x9592CD9B267748cbfBDe90Ac9F7DF3c437A6d51B`
- `0xf8f2eB4940CFE7d13603DDDD87f123820Fc061Ef`

The adapter previously tracked only:

- `0x5e7BB104d84c7CB9B682AaC2F3d509f5F406809A`
- `0xaDe65c38CD4849aDBA595a4323a8C7DdfE89716a`

Aerodrome's official indexer configuration currently lists four Base CLFactories. The `0x9592...d51B` factory has created 22 pools, while `0xf8f2...61Ef` is the newest CLFactory paired with `CLGaugeFactoryV3`.

## Changes

- Added a `getUniTVL` export for `0x9592CD9B267748cbfBDe90Ac9F7DF3c437A6d51B`.
- Added a `getUniTVL` export for `0xf8f2eB4940CFE7d13603DDDD87f123820Fc061Ef`.
- Merged both exports with the two existing factory exports.
- Reused the existing `allPoolsLength()` / `allPools(uint256)` enumeration and `fetchBalances: true` logic.

## Methodology

For each CLFactory, `getUniTVL` enumerates every pool through `allPoolsLength()` and `allPools(uint256)`. It then sums the balances of `token0` and `token1` held by every pool contract.

Each pool is enumerated by its deployment factory, so the four factory results can be merged without counting the same pool twice.

No `fromBlock` is required because the adapter reads the current on-chain factory state rather than discovering pools from event logs.

## Verification sources

- Current DefiLlama adapter:
  https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/aerodrome-CL/index.js
- Official Aerodrome/Velodrome indexer configuration listing the four Base CLFactories:
  https://github.com/velodrome-finance/indexer/blob/main/config.yaml

## Tests

```bash
node test.js projects/aerodrome-CL/index.js
```

````

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for two additional Aerodrome concentrated-liquidity pool factories.
  * Expanded coverage to include all four configured Aerodrome CL deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->