### PR TITLE
fix(curators): add Morpho V2 factory on Katana

### DIFF
--- a/projects/helper/curators/configs.js
+++ b/projects/helper/curators/configs.js
@@ -155,6 +155,12 @@ const MorphoConfigs = {
         fromBlock: 2741420,
       },
     ],
+    vaultFactoriesV2: [
+      {
+        address: '0xFcb8b57E56787bB29e130Fca67f3c5a1232975D1',
+        fromBlock: 13096629,
+      },
+    ],
   },
   plume_mainnet: {
     vaultFactories: [


### PR DESCRIPTION
## Summary

Adds the official Morpho Vault V2 factory deployment on Katana to the shared curator helper configuration.


## Changes

- Added the Katana Morpho Vault V2 factory:
  - Factory: `0xFcb8b57E56787bB29e130Fca67f3c5a1232975D1`
  - Deployment block: `13096629`


## Verification

- Factory address confirmed in the official Morpho deployment registry.
- Deployment transaction confirmed on KatanaScan at block `13096629`.
- ` node test.js yearn-curating`

## Sources

- Morpho contract addresses: https://docs.morpho.org/developers/contracts/addresses/
- Katana factory: https://katanascan.com/address/0xFcb8b57E56787bB29e130Fca67f3c5a1232975D1
- Deployment transaction: https://katanascan.com/tx/0xe85e8bcd09430380050cfbcd218267f6cdce2e44e0335bc57a8ee200491b3fe2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for discovering vaults created by a new vault factory on the Katana network.
  * Vault discovery begins from the appropriate deployment block for improved coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->