### PR TITLE
add missing 9summits vaults

### DIFF
--- a/registries/curators.js
+++ b/registries/curators.js
@@ -17,6 +17,13 @@ const configs = {
             '0x1E2aAaDcF528b9cC08F43d4fd7db488cE89F5741', // co-curator with tulip-capital
             '0x0bB2751a90fFF62e844b1521637DeD28F3f5046A', // co-curator with tulip-capital
           ],
+          erc4626: [
+            '0x03D1eC0D01b659b89a87eAbb56e4AF5Cb6e14BFc', // Lagoon: 9Summits Flagship USDC
+            '0x07ed467acD4ffd13023046968b0859781cb90D9B', // Lagoon: 9Summits Flagship ETH
+            '0xD0C4C9386F7509c44987F43136BE7d4349Ccddc9', // Lagoon: 9Summits Flagship EURC
+            '0x7f35dEa44a192764aa50d50e5f0eCE1d5a8b0e45', // Lagoon: Flint USD
+            '0xB09F761Cb13baCa8eC087Ac476647361b6314F98', // Lagoon: Flagship cbBTC, co-curated with Tulipa Capital
+          ],
           turtleclub: [
             '0xa853d8f5f253468495c5a92d54a3fe6cca2aa26b',
             '0x7388d4b5c4cfc96c9105de913717ba7519178129',
@@ -32,6 +39,12 @@ const configs = {
         unichain: {
           morphoVaultOwners: [
             '0x59e608E4842162480591032f3c8b0aE55C98d104',
+          ],
+        },
+        avax: {
+          erc4626: [
+            '0x3048925B3EA5A8C12eeCCcb8810F5F7544dB54af', // Lagoon: Turtle Avalanche USDC
+            '0x4aF3aBE954259fb70b97C57EBD7Ac1eb822028Ef', // Euler Earn: 9Summits USDC
           ],
         },
       }


### PR DESCRIPTION
## Summary

This updates the existing 9Summits curator adapter to include missing ERC-4626 vaults on Ethereum and Avalanche.

- Adds 9Summits-attributed Lagoon vaults on Ethereum.
- Adds the Lagoon and Euler Earn USDC vaults on Avalanche.


## Methodology

The adapter remains marked `doublecounted` because curator vault assets can also be counted by Lagoon, Euler, Morpho and other underlying protocols.

## Vaults added

| Chain | Vault | Address | Source |
| --- | --- | --- | --- |
| Ethereum | 9Summits Flagship USDC | `0x03D1eC0D01b659b89a87eAbb56e4AF5Cb6e14BFc` | [Lagoon](https://app.lagoon.finance/vault/1/0x03d1ec0d01b659b89a87eabb56e4af5cb6e14bfc) |
| Ethereum | 9Summits Flagship ETH | `0x07ed467acD4ffd13023046968b0859781cb90D9B` | [Lagoon](https://app.lagoon.finance/vault/1/0x07ed467acd4ffd13023046968b0859781cb90d9b) |
| Ethereum | 9Summits Flagship EURC | `0xD0C4C9386F7509c44987F43136BE7d4349Ccddc9` | [Lagoon](https://app.lagoon.finance/vault/1/0xd0c4c9386f7509c44987f43136be7d4349ccddc9) |
| Ethereum | Flint USD | `0x7f35dEa44a192764aa50d50e5f0eCE1d5a8b0e45` | [Lagoon](https://app.lagoon.finance/vault/1/0x7f35dEa44a192764aa50d50e5f0eCE1d5a8b0e45) |
| Ethereum | Flagship cbBTC | `0xB09F761Cb13baCa8eC087Ac476647361b6314F98` | [Lagoon — Tulipa Capital & 9Summits](https://app.lagoon.finance/vault/1/0xb09f761cb13baca8ec087ac476647361b6314f98) |
| Avalanche | Turtle Avalanche USDC | `0x3048925B3EA5A8C12eeCCcb8810F5F7544dB54af` | [Lagoon — Tulipa Capital & 9Summits](https://app.lagoon.finance/vault/43114/0x3048925b3ea5a8c12eecccb8810f5f7544db54af) |
| Avalanche | 9Summits USDC Earn | `0x4aF3aBE954259fb70b97C57EBD7Ac1eb822028Ef` | [Euler](https://app.euler.finance/earn/0x4af3abe954259fb70b97c57ebd7ac1eb822028ef?network=avalanche) |


## Tests

```bash
LLAMA_RUN_LOCAL=true LLAMA_DEBUG_MODE=true node test.js 9summits
```

The added vaults were worth approximately $19.79m at test time. 


## Existing listing

- DefiLlama: https://defillama.com/protocol/9summits
- Website: https://9summits.io
- Vault interface: https://vaults.9summits.io



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added five Ethereum vaults and two Avalanche vaults to the available 9Summits curated vault listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->