### PR TITLE
add rannta chain key

### DIFF
--- a/projects/helper/chains.json
+++ b/projects/helper/chains.json
@@ -395,6 +395,7 @@
   "qubic",
   "quicksilver",
   "radixdlt",
+  "rannta",
   "rari",
   "rbn",
   "real",


### PR DESCRIPTION
Adds the RANNTA chain key to the adapter chain allowlist.\n\nChain facts verified:\n- DefiLlama chain key/slug requested: \annta\\n- RANNTA X-Chain chainId: \13113\ / \

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `rannta` chain identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->