### PR TITLE
fix(steakhouse): include Morpho V2 Katana vaults

### DIFF
--- a/registries/curators.js
+++ b/registries/curators.js
@@ -967,7 +967,8 @@ const configs = {
           morphoVaultOwners: [
             '0x0A0e559bc3b0950a7e448F0d4894db195b9cf8DD',
             '0xe6FC2a011153DD5a230725a9F0c89a9c81aB4887',
-          ],
+            '0x627e54a84134Ffb3C8ee85A5A675CD50C2dB239B', // Morpho V2
+       ],
         },
         monad: {
           morphoVaultOwners: [

--- a/registries/curators.js
+++ b/registries/curators.js
@@ -968,7 +968,7 @@ const configs = {
             '0x0A0e559bc3b0950a7e448F0d4894db195b9cf8DD',
             '0xe6FC2a011153DD5a230725a9F0c89a9c81aB4887',
             '0x627e54a84134Ffb3C8ee85A5A675CD50C2dB239B', // Morpho V2
-       ],
+          ],
         },
         monad: {
           morphoVaultOwners: [


### PR DESCRIPTION
## Summary

Adds the `owner` recorded by the official Morpho Vault V2 factory for two Morpho x Steakhouse vaults on Katana to the Steakhouse curator configuration.

## Changes

- Added `0x627e54a84134Ffb3C8ee85A5A675CD50C2dB239B` to Steakhouse's Katana `morphoVaultOwners`.
- This enables automatic discovery of:
  - Steakhouse Prime USDC: `0xbeef042bAD4472c3F7Eb9A73070703788b5362D7`
  - Steakhouse High Yield USDC: `0xbeeff2d5d126d4809195EeA02b605423917bb6c6`
- No vault addresses are hardcoded in the adapter.

## Methodology

`VaultV2Factory.createVaultV2(owner, asset, salt)` deploys a vault, stores it under `vaultV2[owner][asset][salt]`, and emits:

```solidity
CreateVaultV2(owner, asset, salt, newVaultV2)
```

The shared DefiLlama curator helper reads this event, keeps logs whose `log.owner` matches a configured `morphoVaultOwners` address, and maps the matching logs to `log.newVaultV2`.

The Katana creation transactions establish the following exact mappings:

| Official Morpho x Steakhouse vault | Creation transaction | Factory event fields |
| --- | --- | --- |
| Steakhouse Prime USDC — `0xbeef042bAD4472c3F7Eb9A73070703788b5362D7` | `0xd72a5a0df26ee2fe999620e149e873da4fc865f769f0a619bb00c94d5219d34c`, block `33046983` | `owner = 0x627e54a84134Ffb3C8ee85A5A675CD50C2dB239B`; `newVaultV2 = 0xbeef042bAD4472c3F7Eb9A73070703788b5362D7` |
| Steakhouse High Yield USDC — `0xbeeff2d5d126d4809195EeA02b605423917bb6c6` | `0x7061a0b41266a6f8b58525de15a8e0aec967724ea9fefa36d2a0fcc8816dd183`, block `33046804` | `owner = 0x627e54a84134Ffb3C8ee85A5A675CD50C2dB239B`; `newVaultV2 = 0xbeeff2d5d126d4809195EeA02b605423917bb6c6` |

##Test
node test.js steakhouse

## Sources
- Official Morpho pages identify both vault addresses as Steakhouse vaults.
- The decoded `CreateVaultV2` logs link the same owner to each exact `newVaultV2` address.
- The factory source confirms the meaning and provenance of the event fields.
- The DefiLlama helper source confirms that `log.owner` is filtered and `log.newVaultV2` is included.


- Official Morpho Vault V2 factory source: https://github.com/morpho-org/vault-v2/blob/main/src/VaultV2Factory.sol
- DefiLlama curator helper: https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/helper/curators/index.js
- Official Morpho — Steakhouse Prime USDC: https://app.morpho.org/katana/vault/0xbeef042bAD4472c3F7Eb9A73070703788b5362D7/steakhouse-prime-usdc
- Prime USDC creation logs: https://katanascan.com/tx/0xd72a5a0df26ee2fe999620e149e873da4fc865f769f0a619bb00c94d5219d34c#eventlog
- Official Morpho — Steakhouse High Yield USDC: https://app.morpho.org/katana/vault/0xbeeff2d5d126d4809195EeA02b605423917bb6c6/steakhouse-high-yield-usdc
- High Yield USDC creation logs: https://katanascan.com/tx/0x7061a0b41266a6f8b58525de15a8e0aec967724ea9fefa36d2a0fcc8816dd183#eventlog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for an additional Morpho V2 vault in Steakhouse’s Katana configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->