### PR TITLE
Add WESO DeFi TVL adapter (Terra Classic)

### DIFF
--- a/projects/weso-defi/index.js
+++ b/projects/weso-defi/index.js
@@ -7,6 +7,13 @@ const FACTORY = 'terra1veqa6znu8lfdmz9kp9v047chfmn84q5k3pacme75gl8ywmplk92q6xnq2
 // Counting them would double-count the same assets already sitting in AMM pools.
 const EXCLUDED_PAIR_TYPES = new Set(['token_bonding', 'converter'])
 
+// 1:1 CW20 wraps. Price as the native denom so AMM balances count in TVL
+// before CoinGecko lists CWLUNC/CWUSTC. Wrap contracts themselves stay excluded.
+const PRICE_AS_NATIVE = {
+  terra10fusc7487y4ju2v5uavkauf3jdpxx9h8sc7wsqdqg4rne8t4qyrq8385q6: 'uluna', // CWLUNC
+  terra1uncwzdhxdktqpx4rj6mkuhl0ekv0raua0058rr7zgnapm9najyyqgtpf6h: 'uusd',  // CWUSTC
+}
+
 function pairTypeKey(pairType) {
   if (!pairType) return ''
   if (typeof pairType === 'string') return pairType.toLowerCase()
@@ -20,6 +27,17 @@ function pairTypeKey(pairType) {
 
 function isAmmPair(pair) {
   return !EXCLUDED_PAIR_TYPES.has(pairTypeKey(pair.pair_type))
+}
+
+function addAsset(api, info, amount) {
+  if (info.native_token) {
+    api.add(info.native_token.denom, amount)
+    return
+  }
+  if (info.token) {
+    const addr = info.token.contract_addr
+    api.add(PRICE_AS_NATIVE[addr] || addr, amount)
+  }
 }
 
 async function getAllPairs() {
@@ -46,8 +64,7 @@ async function tvl(api) {
       for (const asset of result?.assets ?? []) {
         const { info, amount } = asset
         if (!amount || amount === '0') continue
-        if (info.native_token) api.add(info.native_token.denom, amount)
-        else if (info.token) api.add(info.token.contract_addr, amount)
+        addAsset(api, info, amount)
       }
     })
 
@@ -58,6 +75,6 @@ async function tvl(api) {
 
 module.exports = {
   timetravel: false,
-  methodology: 'TVL is the sum of assets in WESO DeFi AMM liquidity pools listed by the factory on Terra Classic. Wrap/unwrap (token_bonding and converter) contracts are excluded to avoid double-counting CWLUNC and CWUSTC backing.',
+  methodology: 'TVL is the sum of assets in WESO DeFi AMM liquidity pools listed by the factory on Terra Classic. Wrap/unwrap (token_bonding and converter) contracts are excluded to avoid double-counting CWLUNC and CWUSTC backing. CWLUNC and CWUSTC balances inside AMM pools are priced as native LUNC and USTC (1:1 wraps).',
   terra: { tvl },
 }

--- a/projects/weso-defi/index.js
+++ b/projects/weso-defi/index.js
@@ -1,0 +1,63 @@
+const { queryContract, queryContractWithRetries } = require('../helper/chain/cosmos')
+const { PromisePool } = require('@supercharge/promise-pool')
+
+const FACTORY = 'terra1veqa6znu8lfdmz9kp9v047chfmn84q5k3pacme75gl8ywmplk92q6xnq2k'
+
+// Wrap/unwrap pair types hold native LUNC/USTC backing for CWLUNC/CWUSTC.
+// Counting them would double-count the same assets already sitting in AMM pools.
+const EXCLUDED_PAIR_TYPES = new Set(['token_bonding', 'converter'])
+
+function pairTypeKey(pairType) {
+  if (!pairType) return ''
+  if (typeof pairType === 'string') return pairType.toLowerCase()
+  if (typeof pairType === 'object') {
+    const key = Object.keys(pairType)[0]
+    if (key === 'custom' && typeof pairType.custom === 'string') return pairType.custom.toLowerCase()
+    return (key || '').toLowerCase()
+  }
+  return ''
+}
+
+function isAmmPair(pair) {
+  return !EXCLUDED_PAIR_TYPES.has(pairTypeKey(pair.pair_type))
+}
+
+async function getAllPairs() {
+  const allPairs = []
+  let currentPairs
+  do {
+    const query = { pairs: { limit: 30 } }
+    if (allPairs.length) query.pairs.start_after = allPairs[allPairs.length - 1].asset_infos
+    currentPairs = (await queryContract({ contract: FACTORY, chain: 'terra', data: query })).pairs ?? []
+    allPairs.push(...currentPairs)
+  } while (currentPairs.length > 0)
+  return allPairs
+}
+
+async function tvl(api) {
+  const pairs = (await getAllPairs()).filter(isAmmPair)
+  const poolContracts = pairs.map(p => p.contract_addr).filter(Boolean)
+
+  const { errors } = await PromisePool
+    .withConcurrency(10)
+    .for(poolContracts)
+    .process(async (pool) => {
+      const result = await queryContractWithRetries({ contract: pool, chain: 'terra', data: { pool: {} } })
+      for (const asset of result?.assets ?? []) {
+        const { info, amount } = asset
+        if (!amount || amount === '0') continue
+        if (info.native_token) api.add(info.native_token.denom, amount)
+        else if (info.token) api.add(info.token.contract_addr, amount)
+      }
+    })
+
+  if (errors.length > poolContracts.length / 2) {
+    throw new Error(`Too many pool query failures: ${errors.length}/${poolContracts.length}`)
+  }
+}
+
+module.exports = {
+  timetravel: false,
+  methodology: 'TVL is the sum of assets in WESO DeFi AMM liquidity pools listed by the factory on Terra Classic. Wrap/unwrap (token_bonding and converter) contracts are excluded to avoid double-counting CWLUNC and CWUSTC backing.',
+  terra: { tvl },
+}

--- a/projects/weso-defi/index.js
+++ b/projects/weso-defi/index.js
@@ -2,13 +2,13 @@ const { queryContract, queryContractWithRetries } = require('../helper/chain/cos
 const { PromisePool } = require('@supercharge/promise-pool')
 
 const FACTORY = 'terra1veqa6znu8lfdmz9kp9v047chfmn84q5k3pacme75gl8ywmplk92q6xnq2k'
+const WESO = 'terra13ryrrlcskwa05cd94h54c8rnztff9l82pp0zqnfvlwt77za8wjjsld36ms'
 
 // Wrap/unwrap pair types hold native LUNC/USTC backing for CWLUNC/CWUSTC.
 // Counting them would double-count the same assets already sitting in AMM pools.
 const EXCLUDED_PAIR_TYPES = new Set(['token_bonding', 'converter'])
 
-// 1:1 CW20 wraps. Price as the native denom so AMM balances count in TVL
-// before CoinGecko lists CWLUNC/CWUSTC. Wrap contracts themselves stay excluded.
+// 1:1 CW20 wraps. Price as the native denom so AMM balances count in TVL.
 const PRICE_AS_NATIVE = {
   terra10fusc7487y4ju2v5uavkauf3jdpxx9h8sc7wsqdqg4rne8t4qyrq8385q6: 'uluna', // CWLUNC
   terra1uncwzdhxdktqpx4rj6mkuhl0ekv0raua0058rr7zgnapm9najyyqgtpf6h: 'uusd',  // CWUSTC
@@ -71,10 +71,17 @@ async function tvl(api) {
   if (errors.length > poolContracts.length / 2) {
     throw new Error(`Too many pool query failures: ${errors.length}/${poolContracts.length}`)
   }
+
+  // $WESO is a cw20_bonding curve vs native LUNC, not a factory AMM pair.
+  // TVL is the LUNC reserve locked in the curve. CWLUNC/CWUSTC wraps stay excluded.
+  const curve = await queryContractWithRetries({ contract: WESO, chain: 'terra', data: { curve_info: {} } })
+  if (curve?.reserve && curve.reserve !== '0') {
+    api.add(curve.reserve_denom || 'uluna', curve.reserve)
+  }
 }
 
 module.exports = {
   timetravel: false,
-  methodology: 'TVL is the sum of assets in WESO DeFi AMM liquidity pools listed by the factory on Terra Classic. Wrap/unwrap (token_bonding and converter) contracts are excluded to avoid double-counting CWLUNC and CWUSTC backing. CWLUNC and CWUSTC balances inside AMM pools are priced as native LUNC and USTC (1:1 wraps).',
+  methodology: 'TVL is AMM pool reserves on the WESO DeFi factory plus the native LUNC locked in the $WESO bonding curve (terra13ryrrlcskwa05cd94h54c8rnztff9l82pp0zqnfvlwt77za8wjjsld36ms). Wrap/unwrap (token_bonding and converter) contracts for CWLUNC and CWUSTC are excluded to avoid double-counting. CWLUNC and CWUSTC balances inside AMM pools are priced as native LUNC and USTC (1:1 wraps).',
   terra: { tvl },
 }

--- a/projects/weso-defi/index.js
+++ b/projects/weso-defi/index.js
@@ -8,12 +8,6 @@ const WESO = 'terra13ryrrlcskwa05cd94h54c8rnztff9l82pp0zqnfvlwt77za8wjjsld36ms'
 // Counting them would double-count the same assets already sitting in AMM pools.
 const EXCLUDED_PAIR_TYPES = new Set(['token_bonding', 'converter'])
 
-// 1:1 CW20 wraps. Price as the native denom so AMM balances count in TVL.
-const PRICE_AS_NATIVE = {
-  terra10fusc7487y4ju2v5uavkauf3jdpxx9h8sc7wsqdqg4rne8t4qyrq8385q6: 'uluna', // CWLUNC
-  terra1uncwzdhxdktqpx4rj6mkuhl0ekv0raua0058rr7zgnapm9najyyqgtpf6h: 'uusd',  // CWUSTC
-}
-
 function pairTypeKey(pairType) {
   if (!pairType) return ''
   if (typeof pairType === 'string') return pairType.toLowerCase()
@@ -36,7 +30,7 @@ function addAsset(api, info, amount) {
   }
   if (info.token) {
     const addr = info.token.contract_addr
-    api.add(PRICE_AS_NATIVE[addr] || addr, amount)
+    api.add(addr, amount)
   }
 }
 
@@ -46,7 +40,9 @@ async function getAllPairs() {
   do {
     const query = { pairs: { limit: 30 } }
     if (allPairs.length) query.pairs.start_after = allPairs[allPairs.length - 1].asset_infos
-    currentPairs = (await queryContract({ contract: FACTORY, chain: 'terra', data: query })).pairs ?? []
+    const { pairs } = await queryContract({ contract: FACTORY, chain: 'terra', data: query })
+    if (!Array.isArray(pairs)) throw new Error('WESO factory returned a malformed pairs response')
+    currentPairs = pairs
     allPairs.push(...currentPairs)
   } while (currentPairs.length > 0)
   return allPairs
@@ -56,21 +52,19 @@ async function tvl(api) {
   const pairs = (await getAllPairs()).filter(isAmmPair)
   const poolContracts = pairs.map(p => p.contract_addr).filter(Boolean)
 
-  const { errors } = await PromisePool
+  await PromisePool
     .withConcurrency(10)
     .for(poolContracts)
+    .handleError((error) => { throw error })
     .process(async (pool) => {
       const result = await queryContractWithRetries({ contract: pool, chain: 'terra', data: { pool: {} } })
-      for (const asset of result?.assets ?? []) {
+      if (!Array.isArray(result?.assets)) throw new Error(`WESO pool ${pool} returned a malformed assets response`)
+      for (const asset of result.assets) {
         const { info, amount } = asset
         if (!amount || amount === '0') continue
         addAsset(api, info, amount)
       }
     })
-
-  if (errors.length > poolContracts.length / 2) {
-    throw new Error(`Too many pool query failures: ${errors.length}/${poolContracts.length}`)
-  }
 
   // $WESO is a cw20_bonding curve vs native LUNC, not a factory AMM pair.
   // TVL is the LUNC reserve locked in the curve. CWLUNC/CWUSTC wraps stay excluded.
@@ -82,6 +76,6 @@ async function tvl(api) {
 
 module.exports = {
   timetravel: false,
-  methodology: 'TVL is AMM pool reserves on the WESO DeFi factory plus the native LUNC locked in the $WESO bonding curve (terra13ryrrlcskwa05cd94h54c8rnztff9l82pp0zqnfvlwt77za8wjjsld36ms). Wrap/unwrap (token_bonding and converter) contracts for CWLUNC and CWUSTC are excluded to avoid double-counting. CWLUNC and CWUSTC balances inside AMM pools are priced as native LUNC and USTC (1:1 wraps).',
+  methodology: 'TVL is AMM pool reserves on the WESO DeFi factory plus the native LUNC locked in the $WESO bonding curve (terra13ryrrlcskwa05cd94h54c8rnztff9l82pp0zqnfvlwt77za8wjjsld36ms). Wrap/unwrap (token_bonding and converter) contracts for CWLUNC and CWUSTC are excluded to avoid double-counting.',
   terra: { tvl },
 }


### PR DESCRIPTION
# Add WESO DeFi TVL adapter (Terra Classic)

## Summary
Adds a TVL adapter for WESO DeFi on Terra Classic (`terra`, not terra2).

Factory: `terra1veqa6znu8lfdmz9kp9v047chfmn84q5k3pacme75gl8ywmplk92q6xnq2k`

TVL is:
1. AMM pool reserves from the factory (`reflective` / `cumulative`).
2. Native LUNC locked in the $WESO bonding curve.

`$WESO` (`terra13ryrrlcskwa05cd94h54c8rnztff9l82pp0zqnfvlwt77za8wjjsld36ms`) is a `cw20_bonding` token vs `uluna`, not a factory AMM pair. Query `curve_info` and count `reserve`.

`token_bonding` and `converter` factory pairs for CWLUNC/CWUSTC are excluded so native LUNC/USTC wrap backing is not double-counted. CWLUNC and CWUSTC still appear as CW20 balances inside AMM pools and are priced 1:1 as `uluna` / `uusd`.

## Tokens that must show
- WESO: `terra13ryrrlcskwa05cd94h54c8rnztff9l82pp0zqnfvlwt77za8wjjsld36ms`
- CWLUNC (CW20 1:1 wrap of uluna): `terra10fusc7487y4ju2v5uavkauf3jdpxx9h8sc7wsqdqg4rne8t4qyrq8385q6`
- CWUSTC (CW20 1:1 wrap of uusd): `terra1uncwzdhxdktqpx4rj6mkuhl0ekv0raua0058rr7zgnapm9najyyqgtpf6h`

No CoinGecko IDs yet for WESO, CWLUNC, or CWUSTC. Native LUNC = `terra-luna`, USTC = `terrausd`.

## Live factory (2026-08-29)
8 pairs total: 5 AMM (mDOT, ASTRO, JURIS, ampLUNC, WAVAX vs CWLUNC), 2 token_bonding (CWLUNC and CWUSTC wraps), 1 converter. $WESO lives on its own bonding-curve contract, not in `factory.pairs`.

## Metadata
- website = https://weso.world
- x = https://x.com/WESOWorld
- description = WESO DeFi is an AMM DEX on Terra Classic with a $WESO LUNC bonding curve and CW20 wraps (CWLUNC, CWUSTC) for tax-efficient swaps.
- category = Dexs
- tokens = WESO, CWLUNC, CWUSTC (CW20 on Terra Classic)

## Test
```
node test.js weso-defi
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tracking for WESO DeFi’s total value locked on Terra Classic.
  * Includes liquidity from factory AMM pools and the WESO bonding curve.
  * Adds native reserve reporting for LUNC and USTC.
  * Reports CW20 wrapper balances by their contract addresses.
* **Bug Fixes**
  * Improved data integrity by rejecting malformed or incomplete pool responses instead of returning partial TVL results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->