### PR TITLE
Add ZOFIA TVL calculation for QuickSwap pool

### DIFF
--- a/projects/zofia/index.js
+++ b/projects/zofia/index.js
@@ -1,0 +1,21 @@
+// projects/zofia/index.js
+
+const ZOFIA_TOKEN = '0x2e6576c64b27aed687556a4ef39b1547534429ad';
+const POOL_CONTRACT = '0x23190194f76A7c93a4e64a9DFb38C2c45721d587'; // QuickSwap ZOFIA/USDC pool
+
+async function tvl(api) {
+  const balance = await api.call({
+    abi: 'erc20:balanceOf',
+    target: ZOFIA_TOKEN,
+    params: [POOL_CONTRACT],
+  });
+  api.add(ZOFIA_TOKEN, balance);
+}
+
+module.exports = {
+  methodology: 'TVL is calculated as the total ZOFIA tokens locked in the QuickSwap ZOFIA/USDC liquidity pool.',
+  start: 0,
+  polygon: {
+    tvl,
+  },
+};

--- a/projects/zofia/index.js
+++ b/projects/zofia/index.js
@@ -1,3 +1,7 @@
+// projects/zofia/index.js
+// ZOFIA adapter for DefiLlama — Polygon QuickSwap ZOFIA/USDC pool TVL
+// Verified Polygon addresses (token & pool)
+
 const ZOFIA_TOKEN = '0x2e6576c64b27aed687556a4ef39b1547534429ad';
 const POOL_CONTRACT = '0x23190194f76A7c93a4e64a9DFb38C2c45721d587';
 
@@ -17,7 +21,7 @@ async function tvl(api) {
 
 module.exports = {
   methodology: 'TVL is calculated as the total ZOFIA tokens locked in the QuickSwap ZOFIA/USDC liquidity pool.',
-  start: 1784819550,
+  start: 1784905950,
   polygon: {
     tvl,
   },

--- a/projects/zofia/index.js
+++ b/projects/zofia/index.js
@@ -1,6 +1,11 @@
 const ZOFIA_TOKEN = '0x2e6576c64b27aed687556a4ef39b1547534429ad';
 const POOL_CONTRACT = '0x23190194f76A7c93a4e64a9DFb38C2c45721d587';
 
+/**
+ * Calculates the Total Value Locked (TVL) for ZOFIA by querying the ZOFIA balance
+ * in the QuickSwap ZOFIA/USDC pool on Polygon.
+ * @param {Object} api - The DeFiLlama SDK API object.
+ */
 async function tvl(api) {
   const balance = await api.call({
     abi: 'erc20:balanceOf',
@@ -12,7 +17,7 @@ async function tvl(api) {
 
 module.exports = {
   methodology: 'TVL is calculated as the total ZOFIA tokens locked in the QuickSwap ZOFIA/USDC liquidity pool.',
-  start: 1784905950,
+  start: 1784819550,
   polygon: {
     tvl,
   },

--- a/projects/zofia/index.js
+++ b/projects/zofia/index.js
@@ -1,7 +1,5 @@
-// projects/zofia/index.js
-
 const ZOFIA_TOKEN = '0x2e6576c64b27aed687556a4ef39b1547534429ad';
-const POOL_CONTRACT = '0x23190194f76A7c93a4e64a9DFb38C2c45721d587'; // QuickSwap ZOFIA/USDC pool
+const POOL_CONTRACT = '0x23190194f76A7c93a4e64a9DFb38C2c45721d587';
 
 async function tvl(api) {
   const balance = await api.call({
@@ -14,7 +12,7 @@ async function tvl(api) {
 
 module.exports = {
   methodology: 'TVL is calculated as the total ZOFIA tokens locked in the QuickSwap ZOFIA/USDC liquidity pool.',
-  start: 0,
+  start: 1784905950,
   polygon: {
     tvl,
   },


### PR DESCRIPTION
This PR adds a Polygon TVL adapter for ZOFIA by fetching the ZOFIA token balance locked in the QuickSwap ZOFIA/USDC pool.

Please enable "Allow edits by maintainers" for this PR.

**Project Metadata:**
- **Name:** ZOFIA
- **Twitter:** https://x.com/zofiacoin
- **Website:** https://zofia-official.vercel.app
- **Logo:** https://zofia-official.vercel.app/logo.png
- **Audit:** CertiK audit in progress (Ongoing)
- **Chain:** Polygon
- **Token Address:** 0x2e6576c64b27aed687556a4ef39b1547534429ad (ZOFIA)
- **Category:** DeFi
- **Current TVL:** $0 (Initial listing, liquidity pool is active)
- **Treasury Address:** 0x4050f1fc2B92C4d45037af2b961FE88F9240bF78
- **Coingecko ID:** (leave empty)
- **Coinmarketcap ID:** (leave empty)
- **Short Description:** A next-generation DeFi token on Polygon with staking, governance, and deflationary mechanics.
- **Oracle Provider(s):** N/A (Uses on-chain DEX data from QuickSwap)
- **Implementation Details:** The adapter queries the `erc20:balanceOf` function directly from the ZOFIA token contract to read the balance locked in the QuickSwap pool address.
- **Whitepaper:** https://zofia-official.vercel.app/ZOFIA_Whitepaper_FINAL.pdf
- **Forked From:** No
- **Methodology:** TVL is calculated as the total ZOFIA tokens locked in the QuickSwap ZOFIA/USDC liquidity pool on Polygon. The balance is fetched directly from the blockchain using the standard ERC-20 balanceOf ABI.
- **GitHub Org/User:** https://github.com/zofiacoin
- **Referral Program:** No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for the ZOFIA token held in the QuickSwap ZOFIA/USDC pool on Polygon.
  * Included methodology details and historical tracking from the specified start point.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->