### PR TITLE
Pons V2: real TVL adapter for Robinhood Chain launchpad

### DIFF
--- a/projects/pons-v2/index.js
+++ b/projects/pons-v2/index.js
@@ -1,0 +1,30 @@
+const { getLogs } = require('../helper/cache/getLogs')
+
+const FACTORY = '0x7eD598BcEf8bd9Edd8C97A195C6d13f40801EC7e'
+const fromBlock = 27000000
+
+// The factory emits one TokenLaunched per coin (the bonding curve holds the quote asset), and one
+// PoolGraduated when a coin leaves its curve for a Uniswap V4 pool.
+const TokenLaunched = 'event TokenLaunched(address indexed token, address indexed curve, address indexed deployer, address pairToken, uint256 launchConfigId, uint256 graduationThreshold)'
+const PoolGraduated = 'event PoolGraduated(address indexed token, uint256 positionId, uint256 tokenAmount, uint256 pairTokenAmount)'
+
+async function tvl(api) {
+  const [launches, graduations] = await Promise.all([
+    getLogs({ api, target: FACTORY, eventAbi: TokenLaunched, onlyArgs: true, fromBlock }),
+    getLogs({ api, target: FACTORY, eventAbi: PoolGraduated, onlyArgs: true, fromBlock }),
+  ])
+  const graduated = new Set(graduations.map(i => i.token.toLowerCase()))
+  // Each active (non-graduated) curve holds its pairToken (native ETH for most coins, or another
+  // approved quote token) as the bonding-curve reserve. A graduated coin's reserve has moved into a
+  // Uniswap V4 pool, so it is excluded to avoid double counting.
+  const ownerTokens = launches
+    .filter(i => !graduated.has(i.token.toLowerCase()))
+    .map(i => [[i.pairToken], i.curve])
+  return api.sumTokens({ ownerTokens })
+}
+
+module.exports = {
+  methodology:
+    'TVL is the quote asset (native ETH and other approved pair tokens) held by active Pons V2 bonding curves on Robinhood Chain. Curves are enumerated from the factory\'s TokenLaunched events and excluded once their PoolGraduated event fires, since a graduated coin\'s reserve moves into a Uniswap V4 pool.',
+  robinhood: { tvl },
+}

--- a/projects/pons-v2/index.js
+++ b/projects/pons-v2/index.js
@@ -1,4 +1,4 @@
-const { getLogs } = require('../helper/cache/getLogs')
+const { getLogs2 } = require('../helper/cache/getLogs')
 
 const FACTORY = '0x7eD598BcEf8bd9Edd8C97A195C6d13f40801EC7e'
 const fromBlock = 27000000
@@ -10,9 +10,10 @@ const PoolGraduated = 'event PoolGraduated(address indexed token, uint256 positi
 
 async function tvl(api) {
   const [launches, graduations] = await Promise.all([
-    getLogs({ api, target: FACTORY, eventAbi: TokenLaunched, onlyArgs: true, fromBlock }),
-    getLogs({ api, target: FACTORY, eventAbi: PoolGraduated, onlyArgs: true, fromBlock }),
+    getLogs2({ api, target: FACTORY, eventAbi: TokenLaunched, fromBlock, extraKey: 'launched' }),
+    getLogs2({ api, target: FACTORY, eventAbi: PoolGraduated, fromBlock, extraKey: 'graduated'}), 
   ])
+
   const graduated = new Set(graduations.map(i => i.token.toLowerCase()))
   // Each active (non-graduated) curve holds its pairToken (native ETH for most coins, or another
   // approved quote token) as the bonding-curve reserve. A graduated coin's reserve has moved into a


### PR DESCRIPTION
## Pons V2 — Robinhood Chain launchpad TVL

Pons V2 is currently listed with the placeholder `dummy.js` adapter (so it shows $0 TVL). This PR adds a real TVL adapter.

**Chain:** Robinhood Chain (`robinhood`, chain id 4663)

**Methodology:** TVL is the quote asset (native ETH and other approved pair tokens) held by active Pons V2 bonding curves. Curves are enumerated from the factory's `TokenLaunched` events (factory `0x7eD598BcEf8bd9Edd8C97A195C6d13f40801EC7e`, first launch at block 27027321) and excluded once their `PoolGraduated` event fires, since a graduated coin's reserve moves into a Uniswap V4 pool.

Note: the `pons-v2` protocol module currently points at `dummy.js` — please repoint it at `pons-v2` on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for Pons V2 on Robinhood Chain.
  * Tracks quote-asset reserves held by active bonding curves.
  * Excludes graduated bonding curves from reported TVL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->