### PR TITLE
fix(stockmon): exclude claimable treasury revenue from TVL

### DIFF
--- a/projects/stockmon/index.js
+++ b/projects/stockmon/index.js
@@ -4,16 +4,28 @@ const ADDRESSES = require('../helper/coreAssets.json')
 const VAULTS = [
   "0xb78edcb4de39355747c62e6d55209c01a2294ad8", // Genesis Vault
 ];
+const WETH = ADDRESSES.robinhood.WETH.toLowerCase()
 
 async function tvl(api) {
   const assetRegistry = await api.call({ abi: 'address:assetRegistry', target:'0xb78edcb4de39355747c62e6d55209c01a2294ad8' });
   const stocks = await api.fetchList({  lengthAbi: 'ASSET_COUNT', itemAbi: 'function assetAt(uint8) view returns (address)', target: assetRegistry})
-  const tokens = stocks.concat([ADDRESSES.robinhood.WETH])
-  return api.sumTokens({ tokens, owners: VAULTS })
+  const tokens = stocks.concat([WETH])
+  await api.sumTokens({ tokens, owners: VAULTS })
+
+  // Treasury revenue remains in the vault until claimed, but it is not user TVL.
+  const claimableTreasuryWeth = await api.multiCall({
+    abi: 'uint256:claimableNonStockQuote',
+    calls: VAULTS.map(target => ({ target })),
+  })
+  const totalClaimableTreasuryWeth = claimableTreasuryWeth.reduce(
+    (total, amount) => total + BigInt(amount), 0n
+  )
+  api.add(WETH, (-totalClaimableTreasuryWeth).toString())
+  return api.getBalances()
 }
 
 module.exports = {
-  methodology: "Value of stocks and WETH held in STOCKMON vaults",
+  methodology: "Value of stock tokens and holder-backed WETH held in STOCKMON vaults, excluding WETH claimable by the protocol treasury",
   robinhood: {
     tvl
   },


### PR DESCRIPTION
## Summary

- exclude WETH that is immediately claimable by the Stockmon protocol treasury from TVL
- continue counting every Stock Token and the WETH backing holder obligations
- update the methodology to describe the holder-backed calculation

## Why

The existing adapter raw-sums the Genesis Vault's WETH balance. Stockmon's Vault keeps the protocol treasury share in that same WETH balance until it is claimed, so the displayed TVL was including protocol-owned revenue.

This change reads `claimableNonStockQuote()` onchain and subtracts that exact `uint256` amount using `BigInt`. It does not alter Stock Token accounting or exclude holder stock-budget, pending, or carry WETH.

At DefiLlama's 2026-08-29 18:58:47 UTC snapshot, the previous adapter reported about $16.87K. Approximately $6.10K was claimable treasury WETH, leaving about $10.77K of holder-backed value.

## Validation

- `node test.js projects/stockmon/index.js` — passes; current TVL approximately $11.01K
- `node test.js projects/stockmon/index.js 1787972400` — passes before the large revenue flush; approximately $4.75K
- `node test.js projects/stockmon/index.js 1787976000` — passes after the flush; approximately $10.00K
- `node test.js projects/stockmon/index.js 1788029927` — reproduces the audited DefiLlama snapshot at approximately $10.80K after excluding Treasury WETH
- `pnpm lint` — 0 errors; 2 unrelated pre-existing warnings
- `git diff --check` — passes
- no dependency or lockfile changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reported total value locked (TVL) for Stockmon vaults by excluding WETH that is already claimable by the protocol.
  - Updated TVL calculations to aggregate claimable amounts across vaults more accurately.
  - Clarified the TVL methodology to reflect this exclusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->