### PR TITLE
fix: restore YieldCore TVL with V4.3.2 Core

### DIFF
--- a/projects/yieldcore/index.js
+++ b/projects/yieldcore/index.js
@@ -1,0 +1,35 @@
+const { sumTokens2 } = require("../helper/unwrapLPs");
+const ADDRESSES = require("../helper/coreAssets.json");
+
+// YieldCore V4.3.2 Core on BSC. New bond deposits are held here.
+const YIELDCORE_V432_CORE = "0x903407687486b3ae60746622D06b2eD3D75EaCAb";
+
+// Legacy Cores. Their remaining USDT still backs unsettled legacy bonds and
+// must remain in TVL until those obligations have been fully settled.
+const YIELDCORE_V3_CORE = "0x2375Fcc2a256425228aA94d7100093230761639e";
+const YIELDCORE_V431_CORE = "0x6D6CDf89Cc565A04f0Ba99A1Dc13d43d0d005E4E";
+
+// YieldCore's Krystal PrivateVault, where protocol funds can be deployed.
+const KRYSTAL_VAULT = "0xeE9dd48b2Aa7Ab67534c6Da5E1cD261263d46ef7";
+
+async function tvl(api) {
+  return sumTokens2({
+    api,
+    tokens: [ADDRESSES.bsc.USDT],
+    owners: [
+      YIELDCORE_V432_CORE,
+      YIELDCORE_V431_CORE,
+      YIELDCORE_V3_CORE,
+      KRYSTAL_VAULT,
+    ],
+  });
+}
+
+module.exports = {
+  start: "2026-02-06",
+  methodology:
+    "TVL is the USDT backing YieldCore bonds across the active V4.3.2 Core, " +
+    "the legacy V4.3.1 and V3 Cores while unsettled obligations remain, and " +
+    "the YieldCore Krystal strategy vault where protocol funds may be deployed.",
+  bsc: { tvl },
+};


### PR DESCRIPTION
## Summary

- restore the YieldCore TVL adapter that was removed during the June repository migration
- track the active YieldCore V4.3.2 Core on BSC
- retain V4.3.1, V3, and the Krystal strategy vault so legacy obligations and historical TVL are not dropped

## Methodology

TVL is calculated entirely on-chain by summing BSC USDT balances held by:

- V4.3.2 Core: `0x903407687486b3ae60746622D06b2eD3D75EaCAb`
- V4.3.1 Core: `0x6D6CDf89Cc565A04f0Ba99A1Dc13d43d0d005E4E`
- V3 Core: `0x2375Fcc2a256425228aA94d7100093230761639e`
- Krystal strategy vault: `0xeE9dd48b2Aa7Ab67534c6Da5E1cD261263d46ef7`

The legacy Core balances remain included only because they still back unsettled legacy bonds. The adapter performs read-only token balance calls and changes no protocol contracts or services.

## Validation

- `node test.js projects/yieldcore/index.js`: approximately `929.75 USDT`
- `node test.js projects/yieldcore/index.js 2026-04-01`: approximately `155.65 USDT`
- no package or lockfile changes

Website: https://yieldcore.app

Twitter: https://x.com/YieldCoreApp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added YieldCore total value locked (TVL) tracking on BSC.
  * TVL now includes USDT held across active, legacy, and strategy vault contracts.
  * Added methodology details and tracking start date for the new metric.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->