### PR TITLE
avantgarde: discover Morpho V2 vaults by the new owner

### DIFF
--- a/registries/curators.js
+++ b/registries/curators.js
@@ -167,13 +167,19 @@ const configs = {
   },
   "avantgarde": {
     config: {
-      methodology: 'Count all assets are deposited in all vaults curated by Avantgarde.',
+      methodology: 'Counts all assets deposited in all vaults curated by Avantgarde.',
       blockchains: {
         ethereum: {
           morphoVaultOwners: [
             '0xb263237E30fe9be53d6F401FCC50dF125D60F01a',
+            '0xc714F33c2527BF61749C06eA0389EC957D8153D4',
           ],
         },
+        base: {
+          morphoVaultOwners: [
+            '0x80C6c6438a438Ad3B3736a02B47793D6f854f2bF',
+           ],
+         },
       }
     },
   },


### PR DESCRIPTION
## Summary

Completes the existing Avantgarde Curator adapter by discovering Morpho vaults created by Avantgarde's chain-specific initial owners on Ethereum and Base.

## Changes

- Adds Avantgarde's Morpho vault creation owner for Ethereum and Base.

## Discovery owners

- Ethereum: `0xc714F33c2527BF61749C06eA0389EC957D8153D4`
- Base: `0x80C6c6438a438Ad3B3736a02B47793D6f854f2bF`

## Vaults

### Ethereum

- WETH Conservative: `0x132Fe294ea9b6faD8cA00554D211d5F2b905c1AD`
- USDC Conservative: `0xeBBaE8CfAbB0092d5B32f00EBeE0c8139d24dDcd`
- USDC Dynamic: `0x8E56CB6Bc1a8961ed9062B99045D3299b27CDb4D`

### Base

- USDC Conservative: `0xE34D43CA9152D198B60654868C8cD197196a492f`

## Sources

- Morpho curator page: https://app.morpho.org/curator/avantgarde

## Test

```bash
node test.js avantgarde
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Avantgarde’s curator methodology information.

* **New Features**
  * Added tracking for an Ethereum Morpho vault owner.
  * Added tracking for Base Morpho vault owners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->