### PR TITLE
fix(re7): track Base and Optimism Morpho V2 vaults

### DIFF
--- a/projects/helper/curators/configs.js
+++ b/projects/helper/curators/configs.js
@@ -191,6 +191,12 @@ const MorphoConfigs = {
         fromBlock: 130770189,
       },
     ],
+    vaultFactoriesV2: [
+      {
+        address: '0x6128b680b277Bf4Df80DFE9D8c55A498660870ef',
+        fromBlock: 142122059,
+      },
+    ],
   },
   hemi: {
     vaultFactories: [

--- a/registries/curators.js
+++ b/registries/curators.js
@@ -695,6 +695,12 @@ const configs = {
         base: {
           morphoVaultOwners: [
             '0xD8B0F4e54a8dac04E0A57392f5A630cEdb99C940',
+            '0xE5EAE3770750dC9E9eA5FB1B1d81A0f9C6c3369c', // Re7 USDC V2 initial owner
+          ],
+        },
+        optimism: {
+          morphoVaultOwners: [
+            '0xf86199f0D9F126CB548f4bc1756b6833121E132C', // Re7 WETH V2 initial owner
           ],
         },
         sonic: {


### PR DESCRIPTION
## Summary

Extends the existing `re7` curator adapter to discover RE7 Morpho V2 vaults on Base and Optimism through `morphoVaultOwners`:

- Base : adds the Re7 USDC V2 initial owner `0xE5EAE3770750dC9E9eA5FB1B1d81A0f9C6c3369c`
- Optimism : adds the Re7 WETH V2 initial owner `0xf86199f0D9F126CB548f4bc1756b6833121E132C`

The discovered vaults currently include:

- Base : Re7 USDC V2: `0x618495ccC4e751178C4914b1E939C0fe0FB07b9b`
- Optimism : Re7 WETH V2: `0x3d63934715b6D4c4DFbBC1a00Fe2A2145079DD76`

## Sources

- Base vault: https://app.morpho.org/base/vault/0x618495ccC4e751178C4914b1E939C0fe0FB07b9b/re7-usdc
- Optimism vault: https://app.morpho.org/opmainnet/vault/0x3d63934715b6D4c4DFbBC1a00Fe2A2145079DD76/re7-weth
- Base explorer: https://basescan.org/address/0x618495ccC4e751178C4914b1E939C0fe0FB07b9b
- Optimism explorer: https://optimistic.etherscan.io/address/0x3d63934715b6D4c4DFbBC1a00Fe2A2145079DD76

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tracking for Re7 Labs Morpho vault owners on Base and Optimism networks.
  * Added support for detecting Morpho vaults created through a new Optimism factory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->