### PR TITLE
near: drop the linear-protocol coingecko mapping so LiNEAR prices off its own key

### DIFF
--- a/projects/helper/chain/near.js
+++ b/projects/helper/chain/near.js
@@ -20,7 +20,6 @@ const endpoints = [
 const tokenMapping = {
   'wrap.near': { name: 'near', decimals: 24, },
   'meta-pool.near': { name: 'staked-near', decimals: 24, },
-  [ADDRESSES.near.LINA]: { name: 'linear-protocol', decimals: 24, },
   "storage.herewallet.near": { name: 'here-staking', decimals: 24, },
   'usn': { name: 'usn', decimals: 18, },
   'aurora': { name: 'ethereum', decimals: 18, },


### PR DESCRIPTION
Fixes #20773

`coingecko:linear-protocol` has had no price since 08-28, so LiNEAR balances are being discarded by `computeTVL` and rhea lend is publishing $37.3m against $78.9m the day before, with 16,128,974 LiNEAR still sitting in `contract.main.burrow.near`. rhea dex, allstake and jumbo lost $2.1m, $649k and $59k on the same run.

`near:linear-protocol.near` is priced continuously and matches `ft_price()` x wNEAR to 0.04%, so this is just the adapter asking for the wrong key. removing the mapping makes `sumSingleBalance` fall through `transformAddress` to `near:linear-protocol.near` with the raw amount, which coins already reports at decimals 24.

this is the same failure as #20581, which was closed on 08-25 with the server pricing switched to the exchange-rate method. that fix is live and correct; it just lands on a key the adapter never emits.

harness on `projects/burrow.cash/index.js`:

```
            master        this branch
LINEAR      (absent)      42.92 M
total       37.36 M       80.27 M
```

\42.92m is `16,128,974.54941 x $2.660878` independently. `projects/reffinance.js` goes to 28.64m with LINEAR at 2.11m, covering the direct `sumSingleBalance` path as well as `sumTokens`; burrow's `borrowed` leg picks it up too.

`linear-protocol` is not referenced anywhere else; line 52's `linear-protocol-lnr` is the bridged ethereum token and `linear-near.js` stakes NEAR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an outdated token mapping for the Linear Protocol token on the Near network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->