### PR TITLE
Create index.js

### DIFF
--- a/projects/southpole/index.js
+++ b/projects/southpole/index.js
@@ -1,0 +1,13 @@
+// DefiLlama TVL adapter — SouthPole USDC Vault (ERC-4626) on Arbitrum
+const USDC = "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"; // Arbitrum native USDC
+const VAULT = "0xeA59d9343FF0d70470DD6709cfCD5Bc735d9aDBC"; // SouthPole USDC Vault
+
+async function tvl(api) {
+  return api.sumTokens({ owner: VAULT, tokens: [USDC] });
+}
+
+module.exports = {
+  methodology:
+    "TVL counts the USDC deposited into the SouthPole USDC vault (a standard ERC-4626 vault) on Arbitrum.",
+  arbitrum: { tvl },
+};


### PR DESCRIPTION
##### Name (to be shown on DefiLlama): SouthPole

##### Twitter Link: https://x.com/southpoleapp

##### List of audit links if any: No external audit. Contract uses only audited OpenZeppelin v5.1.0 ERC-4626/ERC-20 base classes with zero custom logic.

##### Website Link: https://southpole.app

##### Logo (High resolution): 
<img width="1168" height="784" alt="logo2" src="https://github.com/user-attachments/assets/4db52b57-d69f-4345-9932-5ba900918340" />

##### Current TVL: ~$10 (USDC)

##### Treasury Addresses (if any): N/A

##### Chain: Arbitrum

##### Coingecko ID: 

##### Coinmarketcap ID: 

##### Short Description: SouthPole USDC Vault — a standard, non-upgradeable, adminless ERC-4626 vault on Arbitrum. Users deposit USDC and mint spUSDC, withdrawable anytime.

##### Token address and ticker: spUSDC — 0xeA59d9343FF0d70470DD6709cfCD5Bc735d9aDBC

##### Category: Dexs

##### forkedFrom: N/A

##### methodology: TVL = USDC held by the ERC-4626 vault contract (0xeA59d9343FF0d70470DD6709cfCD5Bc735d9aDBC) on Arbitrum. Users deposit USDC and mint spUSDC 1:1; assets sit in the contract and are withdrawable anytime. Non-upgradeable, adminless, no strategy.

##### Github org/user: davidhwua

Verified: Sourcify exact match + Arbiscan Source Code. Local test passed: `node test.js projects/southpole/index.js` → arbitrum TVL 10.00.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for the SouthPole USDC Vault on Arbitrum.
  * Added methodology information describing how the vault’s total value is calculated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->