### PR TITLE
fix(clearstar): include Morpho V2 Katana vaults

### DIFF
--- a/registries/curators.js
+++ b/registries/curators.js
@@ -313,6 +313,8 @@ const configs = {
         katana: {
           morphoVaultOwners: [
             '0x30988479C2E6a03E7fB65138b94762D41a733458',
+            '0x829A13850b684A575C0580a83322890e19c5eFaa', // Morpho V2 Core USDC
+            '0x8c5FDDE03DFd6AC0D3d492321974f2Ff573DE1bd', // Morpho V2 Core USDT
           ],
           erc4626: [
             '0xc2dEC6328d9EF1eF2ee85901f9C1a8db8DD1C9C1', // vbUSDC Metavault on Spectra


### PR DESCRIPTION
## Summary

Adds the initial owners used by Clearstar's Morpho Vault V2 deployments on Katana to the Clearstar curator configuration.

## Changes

- Added `0x829A13850b684A575C0580a83322890e19c5eFaa` for Clearstar Core USDC.
- Added `0x8c5FDDE03DFd6AC0D3d492321974f2Ff573DE1bd` for Clearstar Core USDT.
- Enables automatic discovery of:
  - Clearstar Core USDC: `0x6a31358E58B8692cE5317181ff3379A5766A7ABA`
  - Clearstar Core USDT: `0xb3C62339B31F1f5a2aEaCd743DeA1eC6e2ACADF6`


## Verification

- Owner-to-vault relationships verified from the Katana on-chain deployment events.
- Adapter test:
  - `node test.js clearstar`

## Sources
- https://app.morpho.org/curator/clearstar?chains=747474
- Clearstar Core USDC: https://katanascan.com/address/0x6a31358E58B8692cE5317181ff3379A5766A7ABA
- Clearstar Core USDT: https://katanascan.com/address/0xb3C62339B31F1f5a2aEaCd743DeA1eC6e2ACADF6
~~~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Clearstar tracking of two additional Morpho V2 Core vaults on the Katana network.
  * Expanded coverage for USDC and USDT vaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->