### PR TITLE
hinkal: add bsc and tempo, track both pool owners

### DIFF
--- a/projects/hinkal/index.js
+++ b/projects/hinkal/index.js
@@ -4,13 +4,16 @@ const ADDRESSES = require("../helper/coreAssets.json");
 const { sumTokensExport: sumSolanaTokensExport } = require("../helper/solana.js");
 const { sumTokensExport } = require("../helper/sumTokens.js");
 
-const SHARED_OWNER = "0x25e5e82f5702A27C3466fE68f14abDbbAdFca826";
+const SHARED_OWNERS = [
+  "0x25e5e82f5702A27C3466fE68f14abDbbAdFca826",
+  "0x7cb60446d7635C68EDf1c568cac74A1f98c1Cfa4",
+];
 const TRON_VAULT = "TKFUxULu53pSfDkSZwF85PFuKBw1K9axaw";
 const SOLANA_VAULT = "HrcpUS1oFVqeNVZxwHZP2fHSiXJWpv4DTN6qyQX4tAJa";
 
 const tvl = async (api) => {
   const chain = api.chain;
-  const owners = [SHARED_OWNER];
+  const owners = SHARED_OWNERS;
   const tokens = registryTokensByChain[chain];
   const mapping = registryTokensWithUnderlyingAddressesByChain[chain] || {};
 
@@ -33,6 +36,8 @@ module.exports = {
   arbitrum: { tvl },
   optimism: { tvl },
   polygon: { tvl },
+  bsc: { tvl },
+  tempo: { tvl },
   tron: { tvl: sumTokensExport({ owners: [TRON_VAULT], tokens: [ADDRESSES.null, ...registryTokensByChain.tron] }) },
   solana: { tvl: sumSolanaTokensExport({ solOwners: [SOLANA_VAULT], computeTokenAccount: true, allowError: true }) },
 };

--- a/projects/hinkal/registryTokens.js
+++ b/projects/hinkal/registryTokens.js
@@ -984,6 +984,12 @@ const TRON_REGISTRY_TOKENS = [
   ADDRESSES.tron.USDC, // USDC
 ];
 
+const TEMPO_REGISTRY_TOKENS = [
+  "0x20c0000000000000000000000000000000000000", // pathUSD
+  "0x20c000000000000000000000b9537d11c60e8b50", // USDC.e
+  "0x20c00000000000000000000014f22ca97301eb73", // USDT0
+];
+
 const registryTokensByChain = {
   ethereum: ETHEREUM_REGISTRY_TOKENS,
   arbitrum: ARBITRUM_REGISTRY_TOKENS,
@@ -994,6 +1000,7 @@ const registryTokensByChain = {
   base: BASE_REGISTRY_TOKENS,
   blast: BLAST_REGISTRY_TOKENS,
   tron: TRON_REGISTRY_TOKENS,
+  tempo: TEMPO_REGISTRY_TOKENS,
 };
 
 module.exports = registryTokensByChain;


### PR DESCRIPTION
Adds BNB Chain and Tempo, where Hinkal's shielded pool is now deployed.

Also adds a second owner address to the EVM TVL calculation. The pool was redeployed in July 2026 to `0x7cb60446d7635C68EDf1c568cac74A1f98c1Cfa4`, but the funds were never migrated from the previous `0x25e5e82f5702A27C3466fE68f14abDbbAdFca826`. Both contracts currently hold balances, but only the old one was being counted. As a result, TVL on the existing EVM chains increases by the previously unreported deposits, without any double counting.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for tracking Hinkal balances on BNB Smart Chain and Tempo.
  - Expanded shared ownership balance tracking to include multiple owners.
  - Added Tempo registry support for pathUSD, USDC.e, and USDT0 tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->