### PR TITLE
api3: add Base Kabu WETH vault

### DIFF
--- a/projects/api3/index.js
+++ b/projects/api3/index.js
@@ -7,6 +7,11 @@ const api3CirculatingSupply = "0xcD34bC5B03C954268d27c9Bc165a623c318bD0a8"
 
 const configs = {
   blockchains: {
+    base: {
+      morphoVaultOwners: [
+        '0x9f0566F2E8Ff51901DD0C0E7aad937A94931f75C'
+      ]
+    },
     ethereum: {
       morphoVaultOwners: [
         '0x9f0566F2E8Ff51901DD0C0E7aad937A94931f75C',


### PR DESCRIPTION
## Summary

- Track Api3's official Kabu WETH Morpho V2 vault on Base.
- Discover Base Morpho V1/V2 vaults from the verified initial deployment owner `0x9f0566F2E8Ff51901DD0C0E7aad937A94931f75C`.


## Contract and sources

- Chain: Base
- Vault: `0x4D72Fed1b6cE42F8Dea811F7b6685EbE4Ec04E01`
- Underlying asset: WETH (`0x4200000000000000000000000000000000000006`)
- Api3 documentation: https://docs.api3.org/curation/
- Morpho vault: https://app.morpho.org/base/vault/0x4D72Fed1b6cE42F8Dea811F7b6685EbE4Ec04E01/kabu-weth
- BaseScan: https://basescan.org/address/0x4D72Fed1b6cE42F8Dea811F7b6685EbE4Ec04E01


## Validation

```bash
node test.js projects/api3/index.js
```

The Base export was observed at approximately `522.0667 WETH` (`~$1.27m`) 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added blockchain configuration for the Base network, including the Api3 Morpho vault owner address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->