### PR TITLE
add veiledhood and brokex base

### DIFF
--- a/registries/sumTokens.js
+++ b/registries/sumTokens.js
@@ -3076,7 +3076,7 @@ const configs = {
     },
   },
   "brokex": {
-    "methodology": "TVL is computed by summing the balance of USDC locked in the BrokexVault contract.",
+    "methodology": "TVL is computed by summing the balance of USDC locked in the BrokexVault contracts.",
     "start": 1780443809,
     "pharos": {
       "owner": "0x589178934112DbBa96C17384079206a21B4F20DA",
@@ -3084,6 +3084,12 @@ const configs = {
         ADDRESSES.pharos.USDC
       ]
     },
+    "base": {
+      "owner": "0xB36e1eDF743352D67E8B24C0A8BD8fc2c229EB4e",
+      "tokens": [
+        ADDRESSES.base.USDC
+      ]
+    }
   },
   "brrr": {
     "methodology": "Sum contract token balance",

--- a/registries/sumTokens/data3.js
+++ b/registries/sumTokens/data3.js
@@ -904,5 +904,11 @@ module.exports = {
     "rise": {
       "tvl": { "owners": ["0x62b7f5A5Be488ea58f660C5aff465647213Bc6e9"], "tokens": ["0x866A2BF4E572CbcF37D5071A7a58503Bfb36be1b"] },
     }
+  },
+  "veiledhood": {
+    "methodology": "TVL is the sum of USDG and WETH balances held by VeiledHood's Veiledhood and VeilSwap vault contracts on Robinhood Chain, read directly on-chain. Per-user balances are tracked off-chain via a Merkle-committed ledger, but the vault's aggregate token balances are public and require no private state to compute.",
+    "robinhood": {
+      "tvl": { "owners": ["0x8Ae2D8A767c3d59219556b83d4e8385514b6d72B", "0xa4B90fb94B2bBdf1D66A8191E883D0F57BbC6D0b"], "tokens": [ADDRESSES.robinhood.USDG, ADDRESSES.robinhood.WETH] },
+    }
   }
 }


### PR DESCRIPTION
resolves #20763
resolves #20786

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for tracking Brokex vaults on the Base chain, alongside the existing Pharos chain.
  - Added Robinhood Chain TVL tracking for Veiledhood vaults using USDG and WETH balances.
- **Documentation**
  - Updated the Brokex methodology description to reflect multiple vault contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->