### PR TITLE
fix(rate-x): read vault token accounts live instead of a frozen lookup table

### DIFF
--- a/projects/rate-x/index.js
+++ b/projects/rate-x/index.js
@@ -1,33 +1,23 @@
-const { getConnection, runInChunks } = require("../helper/solana");
+const { sumTokens2, getConnection, runInChunks } = require("../helper/solana");
 const { PublicKey } = require("@solana/web3.js");
 
-const TOKEN_PROGRAM_ID = new PublicKey("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
+const TOKEN_PROGRAM_ID = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
 // Published by RateX; lists the vault token accounts of every market.
 const LOOKUP_TABLE = new PublicKey("eP8LuPmLaF1wavSbaB4gbDAZ8vENqfWCL5KaJ2BRVyV");
-const SLEEP_TIME = 200;
-
-const parsedTokenAccount = (account) => {
-  if (!account || !account.owner.equals(TOKEN_PROGRAM_ID)) return null;
-  if (account.data?.parsed?.type !== "account") return null;
-  const info = account.data.parsed.info;
-  return info?.owner && info?.mint ? info : null;
-};
 
 /*
  * The lookup table is a snapshot, not a live view: a vault token account opened after the table was last
  * extended is never counted. For the ONyc market that is most of the balance, 5 of its 7 accounts are
  * listed and the two that are missing hold the larger amounts.
  *
- * So read the table for the (vault authority, mint) pairs it sanctions, then take those pairs' token
- * accounts live. A market's new account is counted as soon as it is funded, while the set of assets that
- * count stays exactly the one the table already defines.
- *
- * The restriction to sanctioned pairs is what makes this safe. Summing every token account of a vault
- * authority instead pulls in whatever else has been sent to it, and today that would add 19.9M units of a
- * pump.fun mint that no vault ever held, alongside RateX's own synthetic tokens, whose u64::MAX supplies
- * would dwarf the real collateral.
+ * So read the table for the (vault authority, mint) pairs it sanctions, then sum those pairs' token
+ * accounts live (sumTokens2 queries getTokenAccountsByOwner per [mint, owner] pair). A market's new
+ * account is counted as soon as it is funded, while the set of assets that count stays exactly the one
+ * the table already defines. Restricting to sanctioned pairs keeps out unrelated airdropped mints and
+ * RateX's own u64::MAX-supply synthetic tokens held by the same vault authorities.
  */
-async function getSanctionedVaultPairs(connection) {
+async function solanaTvl(api) {
+  const connection = getConnection();
   const lookupTable = (await connection.getAddressLookupTable(LOOKUP_TABLE)).value;
   if (!lookupTable) throw new Error("RateX lookup table not found");
 
@@ -36,52 +26,20 @@ async function getSanctionedVaultPairs(connection) {
   const accounts = await runInChunks(
     listed,
     (chunk) => connection.getMultipleParsedAccounts(chunk).then(({ value }) => value),
-    { sleepTime: SLEEP_TIME }
+    { sleepTime: 200 }
   );
 
-  const authorities = new Set();
-  const pairs = new Set();
-  accounts.forEach((account) => {
-    const info = parsedTokenAccount(account);
-    if (!info) return;
-    authorities.add(info.owner);
-    pairs.add(`${info.owner}:${info.mint}`);
-  });
+  const tokensAndOwners = accounts
+    .filter((account) => account?.owner?.toBase58() === TOKEN_PROGRAM_ID && account.data?.parsed?.type === "account")
+    .map(({ data }) => [data.parsed.info.mint, data.parsed.info.owner])
+    .filter(([mint, owner]) => mint && owner);
 
-  if (pairs.size === 0) throw new Error("RateX lookup table held no vault token accounts");
-  return { authorities: [...authorities], pairs };
-}
-
-async function solanaTvl(api) {
-  const connection = getConnection();
-  const { authorities, pairs } = await getSanctionedVaultPairs(connection);
-
-  // One request per authority, run a few at a time so the adapter stays inside RPC rate limits.
-  const holdings = await runInChunks(
-    authorities,
-    (chunk) => Promise.all(chunk.map((authority) => connection
-      .getParsedTokenAccountsByOwner(new PublicKey(authority), { programId: TOKEN_PROGRAM_ID })
-      .then(({ value }) => value.map(({ account }) => account.data.parsed.info)))),
-    { chunkSize: 5, sleepTime: SLEEP_TIME }
-  );
-
-  holdings.flat().forEach((info) => {
-    if (!pairs.has(`${info.owner}:${info.mint}`)) return;
-    api.add(info.mint, info.tokenAmount.amount);
-  });
-
-  return api.getBalances();
+  if (!tokensAndOwners.length) throw new Error("RateX lookup table held no vault token accounts");
+  return sumTokens2({ api, tokensAndOwners });
 }
 
 async function bscTvl(api) {
-  const balance = await api.call({
-    target: "0x77c9b49a58325131D08F9dC120388f20c57c2572",
-    abi: 'erc20:balanceOf',
-    params: ["0xEDBcdD0A45Fd8EBa749fFc10205c65CeA54336D5"],
-  });
-
-  api.add("0x77c9b49a58325131D08F9dC120388f20c57c2572", balance);
-  return api.getBalances();
+  return api.sumTokens({ tokensAndOwners: [["0x77c9b49a58325131D08F9dC120388f20c57c2572", "0xEDBcdD0A45Fd8EBa749fFc10205c65CeA54336D5"]] })
 }
 
 module.exports = {

--- a/projects/rate-x/index.js
+++ b/projects/rate-x/index.js
@@ -1,25 +1,76 @@
-const { sumTokens2 } = require("../helper/solana");
+const { getConnection, runInChunks } = require("../helper/solana");
 const { PublicKey } = require("@solana/web3.js");
-const { getConnection } = require("../helper/solana");
+
+const TOKEN_PROGRAM_ID = new PublicKey("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
+// Published by RateX; lists the vault token accounts of every market.
+const LOOKUP_TABLE = new PublicKey("eP8LuPmLaF1wavSbaB4gbDAZ8vENqfWCL5KaJ2BRVyV");
+const SLEEP_TIME = 200;
+
+const parsedTokenAccount = (account) => {
+  if (!account || !account.owner.equals(TOKEN_PROGRAM_ID)) return null;
+  if (account.data?.parsed?.type !== "account") return null;
+  const info = account.data.parsed.info;
+  return info?.owner && info?.mint ? info : null;
+};
+
+/*
+ * The lookup table is a snapshot, not a live view: a vault token account opened after the table was last
+ * extended is never counted. For the ONyc market that is most of the balance, 5 of its 7 accounts are
+ * listed and the two that are missing hold the larger amounts.
+ *
+ * So read the table for the (vault authority, mint) pairs it sanctions, then take those pairs' token
+ * accounts live. A market's new account is counted as soon as it is funded, while the set of assets that
+ * count stays exactly the one the table already defines.
+ *
+ * The restriction to sanctioned pairs is what makes this safe. Summing every token account of a vault
+ * authority instead pulls in whatever else has been sent to it, and today that would add 19.9M units of a
+ * pump.fun mint that no vault ever held, alongside RateX's own synthetic tokens, whose u64::MAX supplies
+ * would dwarf the real collateral.
+ */
+async function getSanctionedVaultPairs(connection) {
+  const lookupTable = (await connection.getAddressLookupTable(LOOKUP_TABLE)).value;
+  if (!lookupTable) throw new Error("RateX lookup table not found");
+
+  const listed = [...new Set(lookupTable.state.addresses.map((address) => address.toBase58()))]
+    .map((address) => new PublicKey(address));
+  const accounts = await runInChunks(
+    listed,
+    (chunk) => connection.getMultipleParsedAccounts(chunk).then(({ value }) => value),
+    { sleepTime: SLEEP_TIME }
+  );
+
+  const authorities = new Set();
+  const pairs = new Set();
+  accounts.forEach((account) => {
+    const info = parsedTokenAccount(account);
+    if (!info) return;
+    authorities.add(info.owner);
+    pairs.add(`${info.owner}:${info.mint}`);
+  });
+
+  if (pairs.size === 0) throw new Error("RateX lookup table held no vault token accounts");
+  return { authorities: [...authorities], pairs };
+}
 
 async function solanaTvl(api) {
   const connection = getConnection();
-  const lookupTableAddress = new PublicKey("eP8LuPmLaF1wavSbaB4gbDAZ8vENqfWCL5KaJ2BRVyV");
- 
-  const lookupTableAccount = (
-    await connection.getAddressLookupTable(lookupTableAddress)
-  ).value;
+  const { authorities, pairs } = await getSanctionedVaultPairs(connection);
 
-  const tokenAccounts = []
-  for (let i = 0; i < lookupTableAccount.state.addresses.length; i++) {
-    const address = lookupTableAccount.state.addresses[i];
-    tokenAccounts.push(address.toBase58());
-  }
+  // One request per authority, run a few at a time so the adapter stays inside RPC rate limits.
+  const holdings = await runInChunks(
+    authorities,
+    (chunk) => Promise.all(chunk.map((authority) => connection
+      .getParsedTokenAccountsByOwner(new PublicKey(authority), { programId: TOKEN_PROGRAM_ID })
+      .then(({ value }) => value.map(({ account }) => account.data.parsed.info)))),
+    { chunkSize: 5, sleepTime: SLEEP_TIME }
+  );
 
-  return sumTokens2({
-    tokenAccounts,
-    balances: api.getBalances()
-  })
+  holdings.flat().forEach((info) => {
+    if (!pairs.has(`${info.owner}:${info.mint}`)) return;
+    api.add(info.mint, info.tokenAmount.amount);
+  });
+
+  return api.getBalances();
 }
 
 async function bscTvl(api) {
@@ -35,7 +86,7 @@ async function bscTvl(api) {
 
 module.exports = {
   timetravel: false,
-  methodology: "TVL is calculated by summing the value of the traders' vault, LP vault, and earn vault.",
+  methodology: "TVL is the collateral in RateX market vaults. The RateX lookup table defines which (vault authority, mint) pairs count, and those pairs' token accounts are read on-chain so accounts opened after the table was last extended are still included.",
   solana: { tvl: solanaTvl },
   bsc: { tvl: bscTvl }
 };


### PR DESCRIPTION
## What this fixes

`projects/rate-x/index.js` sums the token accounts listed in the hardcoded address lookup table `eP8LuPmLaF1wavSbaB4gbDAZ8vENqfWCL5KaJ2BRVyV`. That table is a snapshot, so a vault token account opened after it was last extended is never counted.

For the ONyc market this is most of the balance: 5 of its 7 vault accounts are listed, and the two that are missing hold the larger amounts. RateX reads as 23,626 ONyc where it holds 196,777, an understatement of roughly 8x. Seven of the table's mints are affected today, ONyc is just the largest.

## Approach

Take the `(vault authority, mint)` pairs the lookup table sanctions, then read those pairs' token accounts on-chain. A market's new account is counted as soon as it is funded, while the set of assets that count stays exactly the one the table already defines.

The pair restriction is deliberate rather than incidental. Summing every token account of a vault authority instead admits whatever else has been sent to it: today that would add 19.9M units of an unrelated pump.fun mint that no vault ever held, plus RateX's own synthetic tokens, whose `u64::MAX` supplies would dwarf the real collateral.

## Verification

Run against mainnet and compared with the current adapter, same block:

| | current | this PR |
|---|---|---|
| ONyc | 23,626 | 196,777 |
| mints reported | 34 | 34 |
| mints added | | none |
| mints removed | | none |
| rejected by the pair filter | | RateX-minted synthetics only, all at `u64::MAX` supply |

Seven mints pick up accounts they were missing. Nothing is introduced and nothing is lost, so the change is strictly the accounts the frozen table could not see.

## Notes

- No new npm dependencies, and `pnpm-lock.yaml` is untouched.
- The extra calls are one `getParsedTokenAccountsByOwner` per vault authority (62 today), paced through the repo's own `runInChunks` helper at 5 per batch with a 200ms gap, so the adapter stays inside RPC rate limits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Solana TVL calculations by including only token balances associated with sanctioned vault authority and mint pairs.
  * Added on-chain account validation to prevent unrelated token accounts from being counted.
  * Simplified BSC TVL balance calculations for more consistent results.

* **Documentation**
  * Updated the TVL methodology description to reflect the sanctioned-pairs calculation approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->