### PR TITLE
Add CheomaYield TVL adapter

### DIFF
--- a/projects/cheomayield/index.js
+++ b/projects/cheomayield/index.js
@@ -1,0 +1,62 @@
+const { getConfig } = require('../helper/cache')
+
+const TVL_ENDPOINT = 'https://api.cheomayield.xyz/api/tvl'
+
+// Fallback registry — mirrors `TVL_VAULTS` in the CheomaYield points-server.
+// Used only if the /api/tvl endpoint is unreachable or returns no vaults.
+// token addresses are DefiLlama coreAssets (USDC on Base, USDG on Robinhood 4663).
+const FALLBACK_VAULTS = [
+  { chain: 'base', address: '0xadaacbfda2ab1744b804f241e81533187a0da843', token: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913' }, // wave1 — USDC
+  { chain: 'robinhood', address: '0xd487e29c9f628395252707f72b220eB9D9afECBB', token: '0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168' }, // giwa — USDG
+]
+
+// Map CheomaYield's internal chain names to DefiLlama chain ids + coreAssets token addresses.
+const TOKEN_BY_CHAIN = {
+  base: { USDC: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913' },
+  robinhood: { USDG: '0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168' },
+}
+
+async function tvl(api) {
+  const chain = api.chain
+  let vaults = []
+
+  // Single source of truth: CheomaYield's own aggregated TVL endpoint enumerates every live
+  // mainnet vault (chain + address + deposit asset). TVL is still measured on-chain below.
+  try {
+    const data = await getConfig('cheomayield/tvl', TVL_ENDPOINT)
+    if (data && Array.isArray(data.vaults)) {
+      vaults = data.vaults.filter(v => v.chain === chain)
+    }
+  } catch (e) {
+    // fall through to fallback registry
+  }
+
+  if (!vaults.length) {
+    vaults = FALLBACK_VAULTS.filter(v => v.chain === chain).map(v => ({ ...v, token: undefined, _token: v.token }))
+  }
+
+  for (const v of vaults) {
+    // Resolve the deposit-asset token address: prefer the on-chain `asset()`/`token()` getter,
+    // fall back to the coreAssets address keyed by the vault's declared token symbol.
+    let token = v._token || (v.token && TOKEN_BY_CHAIN[chain]?.[v.token])
+
+    if (!token) {
+      token = await api.call({ abi: 'address:asset', target: v.address }).catch(() => null)
+    }
+
+    if (!token) continue
+
+    // totalAssets() = principal + accrued yield, the true value locked (vs totalSupply which
+    // is only receipt-token / principal supply).
+    const totalAssets = await api.call({ abi: 'uint256:totalAssets', target: v.address }).catch(() => null)
+    if (totalAssets != null) api.add(token, totalAssets)
+  }
+}
+
+module.exports = {
+  methodology:
+    'TVL is the sum of totalAssets() (principal + accrued yield) across all CheomaYield pre-deposit vaults, measured on-chain. Vault list is sourced from api.cheomayield.xyz/api/tvl (single source of truth), with USDC vaults on Base and USDG vaults on Robinhood.',
+  timetravel: false,
+  base: { tvl },
+  robinhood: { tvl },
+}

--- a/projects/cheomayield/index.js
+++ b/projects/cheomayield/index.js
@@ -1,6 +1,8 @@
+const axios = require('axios')
 const { getConfig } = require('../helper/cache')
 
 const TVL_ENDPOINT = 'https://api.cheomayield.xyz/api/tvl'
+const REQUEST_TIMEOUT_MS = 15000
 
 // Fallback registry — mirrors `TVL_VAULTS` in the CheomaYield points-server.
 // Used only if the /api/tvl endpoint is unreachable or returns no vaults.
@@ -23,7 +25,9 @@ async function tvl(api) {
   // Single source of truth: CheomaYield's own aggregated TVL endpoint enumerates every live
   // mainnet vault (chain + address + deposit asset). TVL is still measured on-chain below.
   try {
-    const data = await getConfig('cheomayield/tvl', TVL_ENDPOINT)
+    const data = await getConfig('cheomayield/tvl', undefined, {
+      fetcher: () => axios.get(TVL_ENDPOINT, { timeout: REQUEST_TIMEOUT_MS }).then(r => r.data),
+    })
     if (data && Array.isArray(data.vaults)) {
       vaults = data.vaults.filter(v => v.chain === chain)
     }
@@ -36,12 +40,12 @@ async function tvl(api) {
   }
 
   for (const v of vaults) {
-    // Resolve the deposit-asset token address: prefer the on-chain `asset()`/`token()` getter,
-    // fall back to the coreAssets address keyed by the vault's declared token symbol.
-    let token = v._token || (v.token && TOKEN_BY_CHAIN[chain]?.[v.token])
+    // Resolve the deposit-asset token address: prefer the on-chain `asset()` getter,
+    // fall back to the configured address keyed by the vault's declared token symbol.
+    let token = await api.call({ abi: 'address:asset', target: v.address }).catch(() => null)
 
     if (!token) {
-      token = await api.call({ abi: 'address:asset', target: v.address }).catch(() => null)
+      token = v._token || (v.token && TOKEN_BY_CHAIN[chain]?.[v.token])
     }
 
     if (!token) continue


### PR DESCRIPTION
Adds a TVL adapter for CheomaYield (cheomayield.xyz), a fixed-yield pre-deposit protocol.

## Protocol
CheomaYield offers fixed-APR pre-deposit vaults. Depositors lock USDC (Base) or USDG (Robinhood) and receive soulbound receipt tokens; yield accrues linearly against principal at a fixed APY. TVL is measured as `totalAssets()` (principal + accrued yield) across all mainnet pre-deposit vaults.

## Vaults
- Wave 1 Pre-Deposit (Base, USDC): `0xadaacbfda2ab1744b804f241e81533187a0da843`
- GIWA Markets Partner Vault (Robinhood, USDG): `0xd487e29c9f628395252707f72b220eB9D9afECBB`

## Methodology
`TVL = sum of totalAssets()` across all CheomaYield pre-deposit vaults, measured on-chain. The vault list is discovered from the project's own aggregated endpoint (`api.cheomayield.xyz/api/tvl`), with an on-chain fallback registry.

## Links
- Website: https://cheomayield.xyz
- Twitter: https://x.com/cheomayield_xyz
- Telegram: https://t.me/cheomayield


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CheomaYield TVL tracking for the Base and Robinhood networks.
  * Added support for measuring assets held in pre-deposit vaults using on-chain data.
  * Added coverage for vault and token data from multiple sources, helping maintain accurate tracking when remote registry information is unavailable.
  * Added support for resolving supported vault assets across the available network configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->