### PR TITLE
sunswap-v2: load the api adapter and stop the staleness guard throwing on every live run

### DIFF
--- a/projects/sunswap-v2/api.js
+++ b/projects/sunswap-v2/api.js
@@ -3,23 +3,21 @@ const { getUniTVL } = require('../helper/unknownTokens.js')
 
 const onChainTvl = getUniTVL({ factory: 'TKWJdrQkqHisa1X8HUdHEfREvTzw4pMAaY', useDefaultCoreAssets: true, queryBatched: 11 })
 
-const API_LAG_SECONDS = 24 * 3600
+const API_LAG_SECONDS = 3 * 24 * 3600
 const URL = 'https://pabc.endjgfsv.link/swapv2/scan/getAllLiquidityVolume'
 
 async function httpTvl(api) {
   try {
     // SunSwap's API publishes one snapshot per day with a >24h lag (Pattern from projects/anyhedge/index.js)
     const target = api.timestamp ?? Math.floor(Date.now() / 1000)
-    const cutoff = Math.floor(Date.now() / 1000) - API_LAG_SECONDS
-    if (target > cutoff) throw new Error('SunSwap TVL not yet available — awaiting next daily snapshot')
 
     const { data } = await get(URL)
     if (!data?.length) throw new Error('SunSwap API returned no snapshots')
-    
+
     const match = data
-      .filter(p => Math.abs(p.time - target) <= API_LAG_SECONDS)
+      .filter(p => p.time <= target + 3600 && target - p.time <= API_LAG_SECONDS)
       .reduce((best, p) => (!best || p.time > best.time ? p : best), null)
-    if (!match) throw new Error(`No SunSwap snapshot within 24h of ${target}`)
+    if (!match) throw new Error(`No SunSwap snapshot within 3 days of ${target}`)
 
     api.addUSDValue(+match.liquidity)
   } catch (e) {

--- a/projects/sunswap-v2/index.js
+++ b/projects/sunswap-v2/index.js
@@ -1,3 +1,3 @@
-const {getExports} = require('../helper/heroku-api')
+const indexExports = require('./api')
 
-module.exports = getExports("sunswap-v2", ['tron'])
+module.exports = indexExports


### PR DESCRIPTION
Fixes #20803

`sunswap-v2` has published $0 since 2026-03-11 while SunSwap's api reports $255.8m, and SUNSwap V1 and V3 report $56.2m and $212.4m on the same chain.

two things had to change.

`index.js` is the file this protocol loads (`module` and `tvlCodePath` both name it) and it resolves TVL through `heroku-api` -> `readFromElastic`, which returns nothing for `tron-tvl` now. the working implementation was already sitting unused in `api.js`, which is why #19624 fixing that file in june did not move the number. `projects/sushiswap/index.js` made the same move off `heroku-api` already, so this follows it.

the guard in `api.js` could also never pass on a live run:

```js
const target = api.timestamp ?? Math.floor(Date.now() / 1000)
const cutoff = Math.floor(Date.now() / 1000) - API_LAG_SECONDS
if (target > cutoff) throw
```

`target` is now, `cutoff` is now minus a day, so it threw every time and fell through to `onChainTvl`, which errors on the tron multicall and gives 0. removed it, widened the window to 3 days as #19624 intended, and made the match take the newest snapshot at or before the target rather than `Math.abs`, which could pick a snapshot from after the requested day on a backfill.

```
$ node test.js projects/sunswap-v2
tron                      255.77 M

$ node test.js projects/sunswap-v2 1787702400      # 2026-08-26
tron                      257.57 M
```

api has 257,603,994 for 2026-08-26. the on-chain path is untouched and still catches a genuinely frozen source after 3 days.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated SunSwap data retrieval to support more recent snapshots, including data from the past three days.
  * Improved snapshot selection for requests near the current time.
  * Updated missing-data messaging to reflect the expanded availability window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->