### PR TITLE
fix: add Fluid Lite USD vault

### DIFF
--- a/projects/instadapp-lite/index.js
+++ b/projects/instadapp-lite/index.js
@@ -5,7 +5,10 @@ const vaults = [
     { "vault": "0xEC363faa5c4dd0e51f3D9B5d0101263760E7cdeB", "token": ADDRESSES.ethereum.WBTC },
     { "vault": "0x40a9d39aa50871Df092538c5999b107f34409061", "token": ADDRESSES.ethereum.DAI }
 ]
-const vaultsV2 = ["0xA0D3707c569ff8C87FA923d3823eC5D81c98Be78"]
+const vaultsV2 = [
+    "0xA0D3707c569ff8C87FA923d3823eC5D81c98Be78", // Fluid Lite ETH
+    "0x273DA948ACa9261043fbdb2a857BC255ECC29012", // Fluid Lite USD
+]
 
 async function tvl(api) {
     const calls = vaults.map(v => ({ target: v.vault }))


### PR DESCRIPTION
## Summary

Adds the official Fluid Lite USD ERC-4626 vault to the existing Ethereum TVL adapter.

$43.59 M  in TVL added.

## What changed

- Added `0x273DA948ACa9261043fbdb2a857BC255ECC29012` to `vaultsV2`.


## Evidence

- Official Fluid Lite USD deployment documentation: https://docs.fluid.instadapp.io/lite-usd/addresses.html
- Etherscan: https://etherscan.io/address/0x273DA948ACa9261043fbdb2a857BC255ECC29012

## Methodology

TVL remains the underlying assets held by the listed Fluid Lite vaults. .

## Validation

- `node test.js projects/instadapp-lite/index.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Fluid Lite USD vault assets to Ethereum TVL calculations.
  - Ethereum TVL now includes both Fluid Lite ETH and Fluid Lite USD vaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->