### PR TITLE
fix(gauntlet): include Morpho V2 Katana vault

### DIFF
--- a/projects/gauntlet/index.js
+++ b/projects/gauntlet/index.js
@@ -111,6 +111,7 @@ const configs = {
     katana: {
       morphoVaultOwners: [
         '0x5D8C96b76A342c640d9605187daB780f8365F69f',
+        '0x66200a81fC7e131C7cf04b3FF02a06aFbf544358', // Morpho V2 USDT
       ],
     },
     tempo: {


### PR DESCRIPTION
## Summary

Adds the initial owner used by Gauntlet's USDT Morpho Vault V2 deployment on Katana to the Gauntlet curator configuration.

## Changes

- Added `0x66200a81fC7e131C7cf04b3FF02a06aFbf544358` to Gauntlet's Katana `morphoVaultOwners`.
- Enables automatic discovery of the Gauntlet USDT vault at `0xaC596AD9771a8d0D4DF108ae0406e6f913aEdceb`.
 https://app.morpho.org/katana/vault/0xaC596AD9771a8d0D4DF108ae0406e6f913aEdceb/gauntlet-usdt#overview 

## Methodology

The existing Gauntlet methodology and double-counting treatment remain unchanged.

## Sources

- Gauntlet USDT: https://katanascan.com/address/0xaC596AD9771a8d0D4DF108ae0406e6f913aEdceb
- https://app.morpho.org/katana/vault/0xaC596AD9771a8d0D4DF108ae0406e6f913aEdceb/gauntlet-usdt#overview
~~~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking an additional Morpho V2 USDT vault on the Katana network.
  * Katana total value locked (TVL) reporting now includes this vault.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->