### PR TITLE
kpk fix locking

### DIFF
--- a/utils/scripts/kpkTreasuryIR.js
+++ b/utils/scripts/kpkTreasuryIR.js
@@ -1952,6 +1952,7 @@ function staleReason(holder) {
 
 function acquireLock() {
   if (flags["no-lock"]) return console.error("  --no-lock: running without the single-instance lock")
+  if (lockHeld) return
   for (let attempt = 0; attempt < 2; attempt++) {
     try {
       // wx fails if the file exists; the create-or-fail is atomic on both win32 and posix


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cache runs failing with a misleading “another cache run holds” error when the same process already held the cache lock.
  * Cache operations can now safely acquire the lock across multiple internal steps without triggering a false conflict.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->