### PR TITLE
add gamma research tvl adapter

### DIFF
--- a/registries/curators.js
+++ b/registries/curators.js
@@ -597,6 +597,19 @@ const configs = {
       },
     },
   },
+  "gamma-research": {
+    config: {
+      methodology: 'TVL is the AUSD managed by the earnAUSD vault curated by Gamma Research, measured on Monad through the vault\'s getTotalAssets() value.',
+      start: '2025-11-24',
+      blockchains: {
+        monad: {
+          upshiftV2: [
+            '0x36eDbF0C834591BFdfCaC0Ef9605528c75c406aA', // Upshift earnAUSD
+          ],
+        },
+      },
+    },
+  },
   "hakutora": {
     config: {
       methodology: 'Count all assets are deposited in all vaults curated by Hakutora.',


### PR DESCRIPTION
## Summary

Adds Gamma Research as a risk curator and tracks its earnAUSD vault on Monad.

## Validation

```text
node test.js gamma-research
monad: 23.65 M USD
total: 23.65 M USD
```


##### Name (to be shown on DefiLlama):

Gamma Research

##### Twitter Link:

https://x.com/Gamma_Research_

##### List of audit links if any:

The vault infrastructure is provided by Upshift/August. Its official audit page lists Hacken, ChainSecurity, Sigma Prime, Zellic and other reports:

https://docs.upshift.finance/developer-docs/smart-contract-audits

##### Website Link:

https://gammaresearch.xyz/

##### Logo (High resolution, will be shown with rounded borders):

Official Gamma Research SVG used by Upshift:

https://imagedelivery.net/JKqfgGWnlUbSJb3LhpWg6w/3420017b-034c-4968-b299-09c410956900/public

##### Current TVL:

Approximately $23.65M at the time of testing on September 2, 2026.

##### Treasury Addresses (if the protocol has treasury):

N/A  

##### Chain:

Monad

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):

N/A  

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):

N/A 

##### Short Description (to be shown on DefiLlama):

Gamma Research provides institutional risk management and strategy curation for on-chain vaults.

##### Token address and ticker if any:


##### Category (full list at https://defillama.com/categories) *Please choose only one:

Risk Curators

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):



##### Implementation Details: Briefly describe how the oracle is integrated into your project:



##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

- earnAUSD documentation, curator, strategies, launch date and contract: https://www.upshift.finance/blog/earning-stablecoin-yield-on-monad-with-earnausd
- Official earnAUSD vault page: https://app.upshift.finance/pools/143/0x36eDbF0C834591BFdfCaC0Ef9605528c75c406aA
- Verified Monad contract: https://monadscan.com/address/0x36eDbF0C834591BFdfCaC0Ef9605528c75c406aA


##### forkedFrom (Does your project originate from another project):

N/A 

##### methodology (what is being counted as tvl, how is tvl being calculated):

TVL is the AUSD managed by the earnAUSD vault curated by Gamma Research. It is measured on Monad by calling `asset()` and `getTotalAssets()` on `0x36eDbF0C834591BFdfCaC0Ef9605528c75c406aA`. 

##### Github org/user (Optional, if your code is open source, we can track activity):

##### Does this project have a referral program?

No Gamma Research referral program was identified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tracking for the Monad Upshift V2 earnAUSD vault through the gamma-research curator.
  * Documented the methodology used to calculate AUSD total value locked (TVL).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->