### PR TITLE
fix(nara): update Base staking owner and token to v4 contracts

### DIFF
--- a/registries/stakingOnly.js
+++ b/registries/stakingOnly.js
@@ -166,9 +166,9 @@ const configs = {
     }
   },
   'nara': {
-    methodology: 'TVL is the total NARA locked in NARAEngineV2. Users lock NARA for a chosen duration and earn NARA + ETH rewards every 15-minute epoch.',
+    methodology: 'Total NARA locked in NARAEngineV4 on Base. Users lock NARA for a chosen duration to participate in protocol consensus and earn rewards every 15-minute epoch.',
     base: {
-      staking: { owners: ['0x62250aEE40F37e2eb2cd300E5a429d7096C8868F'], tokens: ['0xE444de61752bD13D1D37Ee59c31ef4e489bd727C']}
+      staking: { owners: ['0x98ab6406D6B548F37dEF7110961bb45A399e5aFC'], tokens: ['0xB6333F5D4cEd8dffA80F3F13697D6aA3BB3f19c1']}
     }
   },
   'venice-protocol': {


### PR DESCRIPTION
### Summary
Updates the NARA Protocol staking configuration in registries/stakingOnly.js on Base to point to the live v4 production contracts.

The previous entry was pointing to the deprecated legacy v2/v3 token and engine contracts, which have 0 balances.

### Verified Contracts on Base Mainnet (8453)
- **NARA Engine (Staking Owner):** [0x98ab6406D6B548F37dEF7110961bb45A399e5aFC](https://basescan.org/address/0x98ab6406D6B548F37dEF7110961bb45A399e5aFC) (replaces legacy 0x62250aEE40F37e2eb2cd300E5a429d7096C8868F)
- **NARA Token:** [0xB6333F5D4cEd8dffA80F3F13697D6aA3BB3f19c1](https://basescan.org/token/0xB6333F5D4cEd8dffA80F3F13697D6aA3BB3f19c1) (replaces legacy 0xE444de61752bD13D1D37Ee59c31ef4e489bd727C)

### Validation
Tested via node test.js nara - passes cleanly with exit code 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Nara staking information to accurately reflect NARA locked in NARAEngineV4 on Base.
  * Corrected the associated owner and token address configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->