### PR TITLE
feat(arcadia-finance-v2): add Robinhood chain

### DIFF
--- a/projects/arcadia-finance-v2/index.js
+++ b/projects/arcadia-finance-v2/index.js
@@ -47,6 +47,20 @@ const config = {
     resolveSlipstreamV2: false,
     resolveSlipstreamV3: true,
   },
+  robinhood: {
+    chainId: 4663,
+    factory: "0xDa14Fdd72345c4d2511357214c5B89A919768e59",
+    uniNFT: "0x73991a25C818Bf1f1128dEAaB1492D45638DE0D3",
+    uniV4NFT: "0x58daec3116aae6D93017bAAea7749052E8a04fA7",
+    // Neither Slipstream nor Aerodrome is deployed on Robinhood, so Arcadia
+    // registers only the Uniswap V3 and V4 asset modules there.
+    pools: [
+      "0x803ea69c7e87D1d6C86adeB40CB636cC0E6B98E2", // wethPool
+      "0xf37c0C5996503Fdd2b5CCCE36E659cD30393AE59", // usdgPool
+    ],
+    resolveSlipstreamV2: false,
+    resolveSlipstreamV3: false,
+  },
   unichain: {
     chainId: 130,
     factory: "0xDa14Fdd72345c4d2511357214c5B89A919768e59",
@@ -107,12 +121,18 @@ async function unwrapArcadiaAeroLP({ api, ownerIds, chainConfig }) {
     }
   }
 
-  const wrappedData = await api.multiCall({ abi: abi.positionState, calls: wAERONFTIds, target: wAeroNFT });
-  const stakedData = await api.multiCall({ abi: abi.stakedAeroPositionState, calls: sAERONFTIds, target: sAeroNFT });
-  wrappedData.forEach((data) => api.add(data.pool, data.amountWrapped));
-  stakedData.forEach((data) => api.add(data.pool, data.amountStaked));
+  if (wAeroNFT && wAERONFTIds.length) {
+    const wrappedData = await api.multiCall({ abi: abi.positionState, calls: wAERONFTIds, target: wAeroNFT });
+    wrappedData.forEach((data) => api.add(data.pool, data.amountWrapped));
+  }
+  if (sAeroNFT && sAERONFTIds.length) {
+    const stakedData = await api.multiCall({ abi: abi.stakedAeroPositionState, calls: sAERONFTIds, target: sAeroNFT });
+    stakedData.forEach((data) => api.add(data.pool, data.amountStaked));
+  }
 
-  await uwrapStakedSlipstreamLP({ api, sSlipNftIds, nft: slipNFT });
+  if (slipNFT) {
+    await uwrapStakedSlipstreamLP({ api, sSlipNftIds, nft: slipNFT });
+  }
   if (slipV2NFT) {
     await uwrapStakedSlipstreamLP({ api, sSlipNftIds: sSlipV2NftIds, nft: slipV2NFT });
   }
@@ -231,7 +251,7 @@ async function tvl (api) {
   if (uniV4Ids.length > 0) {
     await sumTokens2({ api, resolveUniV4: true, uniV4ExtraConfig: {"positionIds":uniV4Ids}})
   }
-  return sumTokens2({ api, owners: accs, resolveUniV3: true, resolveSlipstream: true, resolveSlipstreamV2: !!resolveSlipstreamV2, resolveSlipstreamV3: !!resolveSlipstreamV3 })
+  return sumTokens2({ api, owners: accs, resolveUniV3: true, resolveSlipstream: !!slipNFT, resolveSlipstreamV2: !!resolveSlipstreamV2, resolveSlipstreamV3: !!resolveSlipstreamV3 })
 }
 
 module.exports = {

--- a/projects/helper/unwrapLPs.js
+++ b/projects/helper/unwrapLPs.js
@@ -328,6 +328,7 @@ async function unwrapUniswapV3NFTs({ balances = {}, nftsAndOwners = [], api, own
         case 'flare': nftAddress = '0xD9770b1C7A6ccd33C75b5bcB1c0078f46bE46657'; break;
         case 'hyperliquid': nftAddress = '0x6eDA206207c09e5428F281761DdC0D300851fBC8'; break;
         case 'unichain': nftAddress = '0x943e6e07a7E8E791dAFC44083e54041D743C46E9'; break;
+        case 'robinhood': nftAddress = '0x73991a25C818Bf1f1128dEAaB1492D45638DE0D3'; break;
         case 'stable': nftAddress = '0x3BdC3437405f7D801b6036532713fc1F179136a6'; break; // stableswap
         default: throw new Error('missing default uniswap nft address chain: ' + chain)
       }


### PR DESCRIPTION
Arcadia will go live on Robinhood Chain (4663) with two lending pools, wETH and USDG, and the Uniswap V3 and V4 asset modules. 

Three things also changed:

* `resolveSlipstream` was passed unconditionally, but unwrapSlipstreamNFTs has no default NFT address for a chain without Slipstream and throws ("missing default uniswap nft address chain: robinhood"), which would have failed the whole chain's TVL. It is now derived from whether the chain has a Slipstream NFT configured, which leaves every existing chain unchanged.

* unwrapArcadiaAeroLP read the wrapped and staked Aerodrome position state with `target` set to an address the chain may not have, and unwrapped staked Slipstream against an undefined NFT. The id lists are empty on a chain without those modules, each is now gated on the module existing.

* unwrapUniswapV3NFTs got a Robinhood entry: the adapter resolves Uniswap V3 positions without passing an NFT address, so it relies on that switch, and every chain the adapter supports is already listed there. The V4 resolver already carries robinhood.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Robinhood chain, including Uniswap V3 and V4 liquidity pool integrations.
  * Added support for unwrapping Uniswap V3 NFT positions on Robinhood.

* **Bug Fixes**
  * Improved compatibility with chains that do not provide Aerodrome or Slipstream NFT modules by safely skipping unavailable operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->