### PR TITLE
add waterline curator adapter

### DIFF
--- a/registries/curators.js
+++ b/registries/curators.js
@@ -1432,6 +1432,23 @@ const configs = {
       }
     },
   },
+  "waterline": {
+    config: {
+      methodology: 'Counts all assets deposited in Morpho vaults curated by Waterline.',
+      blockchains: {
+        ethereum: {
+          morpho: [
+            '0xBEeFF047C03714965a54b671A37C18beF6b96210', // Waterline Reservoir USDC (V2)
+            '0xAb5955EB671d150527f8E61A42B703832F86616C', // M1 USDC (V2)
+            '0xbeEFF75262b2eC16a3C62a807F02EE7627654931', // Waterline InfiniFi USDC (V2)
+            '0x7d4741ba166B21cf3168A9A0ea71388531C52FF7', // Tenbin USDC (V2)
+            '0xbeEF346d7099865208Ff331e4f648f4154DDAa05', // Waterline Reservoir USDC (V1)
+            '0xBEeF1f5Bd88285E5B239B6AAcb991d38ccA23Ac9', // Waterline infiniFi USDC (V1)
+          ],
+        },
+      },
+    },
+  },
   "yearn-curating": {
     config: {
       methodology: 'Counts all assets that are deposited in all vaults curated by Yearn.',


### PR DESCRIPTION
## Summary

Adds a Risk Curator TVL adapter for Waterline on Ethereum.

The adapter uses DefiLlama's `getCuratorExport` helper with an explicit vault
list. Waterline's 6 Morpho vaults (4 V2 + 2 V1, including vaults co-curated
with Steakhouse Financial) were deployed via CREATE2 vanity deployers and
ownership was transferred after creation, so factory-event owner filtering
(`morphoVaultOwners`) cannot discover them; the vaults are listed directly.

TVL is read on-chain from each vault's ERC-4626 `asset()` and `totalAssets()`
methods. The curator helper marks the adapter as double counted because these
assets are already included in Morpho TVL.

Curator page: https://app.morpho.org/curator/eco-vaults-shf

## Test

```bash
node test.js projects/waterline/index.js
```

Result at the time of testing:

```text
--- ethereum ---
USDC                      25.33 M
Total                        25.33 M
```

(Consistent with the $25.32M shown on the official Morpho curator page.)

---

##### Name (to be shown on DefiLlama):

Waterline

##### Twitter Link:

N/A

##### List of audit links if any:

The vault contracts are canonical Morpho Vault V1/V2 contracts. Morpho's security reviews are listed here:

- https://docs.morpho.org/get-started/resources/audits/

##### Website Link:

https://www.waterline.build

##### Logo (High resolution, will be shown with rounded borders):

https://cdn.morpho.org/v2/assets/images/waterline.svg

##### Current TVL:

Approximately $25.33M at the time of submission, calculated on-chain. This value changes with deposits, withdrawals, and accrued interest.

##### Treasury Addresses (if the protocol has treasury)

N/A for this Risk Curator listing.

##### Chain:

Ethereum

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):

N/A

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):

N/A

##### Short Description (to be shown on DefiLlama):

Waterline is a risk curator on Morpho, building onchain vault solutions based on client specifications.

##### Token address and ticker if any:

N/A

##### Category (full list at https://defillama.com/categories) *Please choose only one:

Risk Curators

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

Morpho market-specific oracle contracts.

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

N/A (this adapter does not interact with oracles; TVL uses underlying asset prices)

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

- Waterline curator page on Morpho: https://app.morpho.org/curator/eco-vaults-shf
- Waterline website: https://www.waterline.build

##### forkedFrom (Does your project originate from another project):

N/A

##### methodology (what is being counted as tvl, how is tvl being calculated):

Counts all assets deposited in Morpho vaults curated by Waterline. TVL is read on-chain from each vault's ERC-4626 asset() and totalAssets() methods.

##### Github org/user (Optional, if your code is open source, we can track activity):

N/A

##### Does this project have a referral program?

No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for tracking six Ethereum Morpho vaults from Waterline, M1, InfiniFi, and Tenbin across V1 and V2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->