### PR TITLE
allbridge tvl deprecated

### DIFF
--- a/projects/allbridge-core/index.js
+++ b/projects/allbridge-core/index.js
@@ -43,6 +43,7 @@ function getTVLFunction(chain) {
 
 module.exports = {
   methodology: "All tokens locked in Allbridge Core pool contracts.",
+  deadFrom: "2026-08-31", // deprecated in favor of ccip, x-reserves, and lz
   timetravel: false,
   stellar: { tvl: stellarTvl },
 }


### PR DESCRIPTION
resolves #20855

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Deprecation**
  - The Allbridge Core adapter is scheduled for deprecation beginning August 31, 2026.
  - Users should transition to the supported CCIP, X-Reserves, or LayerZero integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->