### PR TITLE
add Bitwise curator TVL

### DIFF
--- a/registries/curators.js
+++ b/registries/curators.js
@@ -50,6 +50,23 @@ const configs = {
       }
     },
   },
+  "bitwise": {
+    config: {
+      methodology: 'Counts all assets deposited in Morpho vaults curated by Bitwise.',
+      blockchains: {
+        ethereum: {
+          morphoVaultOwners: [
+            '0x3585f2427b5D2746472A49406321b71799402a7d',
+          ],
+        },
+        base: {
+          morphoVaultOwners: [
+            '0x510F3b6621D9eA392d4F7632d02aBCf8ba92Bd6F',
+          ],
+        },
+      }
+    },
+  },
   "sharpbyte-capital": {
     config: {
       methodology: 'Counts assets deposited in the SharpByte USDT Prime Morpho V2 vault.',


### PR DESCRIPTION
## Summary

Adds Bitwise to the curator registry .

The adapter discovers Bitwise Morpho vaults from factory events and measures their ERC-4626 `totalAssets()` on-chain. It currently covers:

- Ethereum: Bitwise Premium RWA AUSD (PAPY)  `0xB344e331A3cDa61D329fb3Cca2Be5942da87c418`
- Base: Bitwise Liquid Prime USDC (BPRIME)  `0x5e03f8965e2957291B3c6990C6Cb9023c36d3d30`

The owner addresses are the initial owners emitted by each Morpho V2 factory. This matters because the Ethereum vault later transferred its owner role:

- Ethereum initial owner: `0x3585f2427b5D2746472A49406321b71799402a7d`
- Base initial owner: `0x510F3b6621D9eA392d4F7632d02aBCf8ba92Bd6F`

Creation-event proofs:

- Ethereum: https://etherscan.io/tx/0xeb252832ab985738835282f4b6efe141b73d3049227edd794627d1abe21e05b9#eventlog
- Base: https://basescan.org/tx/0xbf9eb59e8644abaa5da1f5e3d5f625d4f7876dfc2ae4e142582b6bc739495ea6#eventlog

Validation:

```text
 node test.js bitwise

------ TVL ------
ethereum                  7.79 M
base                      176.72 k

total                    7.97 M

```

##### Name (to be shown on DefiLlama):

Bitwise

##### Twitter Link:

https://x.com/Bitwise

##### List of audit links if any:

N/A

##### Website Link:

https://app.morpho.org/curator/bitwise

##### Logo (High resolution, will be shown with rounded borders):

https://cdn.morpho.org/v2/assets/images/bitwise.svg

##### Current TVL:

Approximately $8 million as of September 3, 2026 

##### Treasury Addresses (if the protocol has treasury)

N/A.
##### Chain:

Ethereum and Base

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):

N/A 

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):

N/A

##### Short Description (to be shown on DefiLlama):

Bitwise curates on-chain lending vaults on Morpho, allocating deposited assets across risk-managed Morpho markets.

##### Token address and ticker if any:

N/A

##### Category (full list at https://defillama.com/categories) *Please choose only one:

Risk Curators

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
 N/A

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

N/A

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

-
- Bitwise Ethereum vault and allocations: https://app.morpho.org/ethereum/vault/0xB344e331A3cDa61D329fb3Cca2Be5942da87c418/bitwise-premium-rwa-ausd#allocation
- Bitwise Base vault and allocations: https://app.morpho.org/base/vault/0x5e03f8965e2957291B3c6990C6Cb9023c36d3d30/bitwise-liquid-prime-usdc#allocation

##### forkedFrom (Does your project originate from another project):
N/A

##### methodology (what is being counted as tvl, how is tvl being calculated):

Counts all assets deposited in Morpho vaults curated by Bitwise.

##### Github org/user (Optional, if your code is open source, we can track activity):

N/A

##### Does this project have a referral program?

No referral program identified for these vaults.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Bitwise curator configuration for tracking assets deposited in Morpho vaults on Ethereum and Base.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->