### PR TITLE
fix(xsy): read TVL from Base hub vault

### DIFF
--- a/projects/xsy/index.js
+++ b/projects/xsy/index.js
@@ -13,4 +13,5 @@ async function tvl(api) {
 
 module.exports = {
   base: { tvl },
+  avax: { tvl: () => ({})}
 }

--- a/projects/xsy/index.js
+++ b/projects/xsy/index.js
@@ -1,14 +1,16 @@
 const ADDRESSES = require('../helper/coreAssets.json')
 
+const UTY_VAULT = '0xBA515304d8153c4b162dC79f867E152DF9c127eb'
+
 async function tvl(api) {
-  const totalSupply = await api.call({
-    abi: 'erc20:totalSupply',
-    target: ADDRESSES.avax.UTY,
+  const totalAssets = await api.call({
+    abi: 'uint256:totalAssets',
+    target: UTY_VAULT,
   })
-  api.add(ADDRESSES.avax.UTY, totalSupply)
+
+  api.add(ADDRESSES.base.USDC, totalAssets)
 }
 
 module.exports = {
-  start: 58017291, // block when UTY contract was deployed
-  avax: { tvl },
+  base: { tvl },
 }


### PR DESCRIPTION
## Summary

Fixes the existing XSY TVL adapter after the YieldPoint V2 hub/spoke architecture migration.

The current adapter reads the legacy Avalanche `UTY.totalSupply()`, while the current protocol documentation defines Base as the hub where global vault state lives.

## What changed

- move the XSY TVL export from Avalanche to Base
- read `totalAssets()` from the Base UTY vault
- add the resulting amount as Base USDC


## TVL methodology

TVL is the Base UTY vault's on-chain `totalAssets()` value, denominated in Base USDC.

The YieldPoint documentation states that Base is the hub and that `totalAssets()` is hub-side global vault state. The UTY implementation also tracks managed/custodian assets through its `totalAssets()` override.

## Contracts

- Base UTY vault: `0xBA515304d8153c4b162dC79f867E152DF9c127eb`
- Base USDC: `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`

## Documentation / proof

- State distribution: https://docs.yieldpoint.io/protocol/architecture/state
- Contracts: https://docs.yieldpoint.io/protocol/architecture/contracts
- Existing XSY adapter: https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/xsy/index.js

## Validation

Commands used:

```bash

 node test.js projects/xsy/index.js

------ TVL ------
base                      12.99 M

total                    12.99 M

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added TVL reporting for the XSY vault on Base, denominated in USDC.
  - TVL is calculated from the vault’s total assets.
  - Updated chain coverage to include Base and Avalanche; Avalanche currently returns no TVL data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->