### PR TITLE
fix(perena-yield): track Vault V2 TVL

### DIFF
--- a/projects/perena-yield/index.js
+++ b/projects/perena-yield/index.js
@@ -1,28 +1,22 @@
-const { Program } = require("@coral-xyz/anchor");
-const { PublicKey } = require('@solana/web3.js');
-const { getProvider, } = require("../helper/solana");
+const { Program } = require("@coral-xyz/anchor")
+const { PublicKey } = require("@solana/web3.js")
+const { getProvider } = require("../helper/solana")
+
+const PROGRAM_ID = new PublicKey("save8RQVPMWNTzU18t3GBvBkN9hT7jsGjiCQ28FpD9H")
 
 async function tvl(api) {
   const provider = getProvider()
+  const idl = await Program.fetchIdl(PROGRAM_ID, provider)
 
-  const programId = new PublicKey('save8RQVPMWNTzU18t3GBvBkN9hT7jsGjiCQ28FpD9H')
-  const idl = await Program.fetchIdl(programId, provider)
+  if (!idl) throw new Error("Perena Vaults IDL not found")
+
   const program = new Program(idl, provider)
+  const vaults = await program.account.vault.all()
 
-  const usdStarVaults = (await program.account.vaultGenState.all()).filter(
-    (x) =>
-      x.account.config.bank.equals(
-        new PublicKey("sM6P4mh53CnG4faN4Fo3seY7wMSAiHdy8o6gKjwQF7A") // USD* bank
-      )
-  );
-
-  for (let i = 0; i < usdStarVaults.length; i++) {
-    const vault = usdStarVaults[i];
-    const tvl = vault.account.accounting.yieldingTvl.toNumber() / 10 ** 6 * 10 ** vault.account.config.yieldingMintDecimals;
-    const token = vault.account.config.yieldingTokenMint.toString()
-    api.add(token, tvl);
+  for (const { account } of vaults) {
+    const tvl = Number(account.accounting.tvl.toString()) / 10 ** account.config.assetDecimals
+    api.addUSDValue(tvl)
   }
-
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary

Fixes the Perena Vaults TVL adapter after the Vault V2 migration.

## Changes

- remove legacy `VaultGenState` discovery
- discover the current on-chain `Vault` accounts directly from the Perena program
- sum each vault's canonical `accounting.tvl`

## Why

Perena Vault V2 re-architected the vault model. The previous adapter continued querying legacy state, which caused DefiLlama to report effectively zero TVL while the current Perena Vaults product still has material TVL.

## Methodology

TVL is read directly from all live Perena V2 `Vault` accounts on Solana. 

## Validation

Tested with:

```bash
node test.js projects/perena-yield/index.js

------ TVL ------
solana                    11.83 M
total                    11.83 M

```


## Sources / proof
- Live TVL : https://app.perena.org/earn
- Perena Solana program:
https://orbmarkets.io/address/save8RQVPMWNTzU18t3GBvBkN9hT7jsGjiCQ28FpD9H/anchor-idl
- Existing DefiLlama protocol:
  https://defillama.com/protocol/perena-vaults

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Perena yield TVL reporting by including all relevant vault accounts.
  - Updated TVL calculations to use each asset’s configured decimal precision.
  - Reported vault TVL directly as a USD value for more consistent portfolio and dashboard totals.
  - Added clearer handling when required yield-program metadata is unavailable, helping prevent misleading or incomplete results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->