### PR TITLE
add Pangolins curator TVL adapter

### DIFF
--- a/registries/curators.js
+++ b/registries/curators.js
@@ -779,6 +779,23 @@ const configs = {
       }
     },
   },
+  "pangolins": {
+    config: {
+      methodology: 'TVL is the sum of underlying assets deposited in Pangolins-curated ERC-4626 vaults on Morpho and Lista.',
+      blockchains: {
+        base: {
+          morphoVaultOwners: [
+            '0xB8108fA53B7228D8bfC84712Ba3B870c78Ab7c2E', // initial owner — Pangolins USDC
+          ],
+        },
+        bsc: {
+          erc4626: [
+            '0xEB4F6FFB1038E1cCa701e7d53083B37ec5b6Ba33', // Pangolins USDT by Lista
+          ],
+        },
+      }
+    },
+  },
   "poppie": {
     config: {
       methodology: 'Count all assets deposited in Euler vaults curated by Poppie.',


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):

Pangolins

##### Twitter Link:

https://x.com/PangolinsVault

##### List of audit links if any:
 N/A

##### Website Link:

https://pangolins.io/

##### Logo (High resolution, will be shown with rounded borders):

https://pangolins.io/brand/pangolins-mark.png

##### Current TVL:

Approximately $18M at the time of testing.
------ TVL ------                                                                                                      
 base                      15.75 M                                                                                     
 bsc                       2.91 M                                                                                                                                                                                                                total                    18.67 M         

##### Treasury Addresses (if the protocol has treasury)

N/A. 

##### Chain:

Base, BNB Chain

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

N/A 

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

N/A

##### Short Description (to be shown on DefiLlama):

Pangolins is a non-custodial onchain risk curator that selects lending markets, sets liquidity constraints, and manages risk boundaries for vault depositors.

##### Token address and ticker if any:

N/A
##### Category (full list at https://defillama.com/categories) *Please choose only one:

Risk Curators

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

Market-specific. 

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

N/A

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

N/A
##### forkedFrom (Does your project originate from another project):

No. 

##### methodology (what is being counted as tvl, how is tvl being calculated):

TVL is the sum of the underlying assets deposited in the Pangolins-curated ERC-4626 vaults on Base and BNB Chain.

Vaults:

- Base / Morpho USDC: `0x1401d1271C47648AC70cBcdfA3776D4A87CE006B`
- BNB Chain / Lista USDT: `0xEB4F6FFB1038E1cCa701e7d53083B37ec5b6Ba33`

##### Github org/user (Optional, if your code is open source, we can track activity):

N/A

##### Does this project have a referral program?

No referral program is advertised on the official website.

## Adapter implementation

- Adds a registry-backed curator adapter in `registries/curators.js`.
- Reads TVL entirely on-chain through ERC-4626 `asset()` and `totalAssets()`.

## Test result

Command:

```bash
LLAMA_DEBUG_MODE=true node test.js pangolins
```

Output at test time:

```text
------ TVL ------
base                      15.75 M
bsc                       2.91 M

total                    18.67 M
```

Official vault links:

- https://app.morpho.org/base/vault/0x1401d1271C47648AC70cBcdfA3776D4A87CE006B/pangolins-usdc
- https://lista.org/lending/vault/bsc/0xeb4f6ffb1038e1cca701e7d53083b37ec5b6ba33?tab=vault


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Pangolins as a supported curator.
  * Added tracking for assets deposited in Pangolins-curated vaults on Morpho and Lista across Base and BSC.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->