### PR TITLE
Orchard: add the v2 game contract to the TVL adapter (Robinhood Chain)

### DIFF
--- a/projects/orchard/index.js
+++ b/projects/orchard/index.js
@@ -6,7 +6,7 @@ const ORCHARD_V1 = '0xEbB8b167c0992cFdc497A995a8Cf7167acAA0A1A'
 const ORCHARD_V2 = '0x86510b3df745C67a993A66CB08720Ed158d44549' // live since 2026-09-03; v1 stays open for claims
 const SEED_STAKING = '0xd5d5f5Dff96E53fc6337b4aCf549d61b12882F2b'
 
-const GAMES = [ORCHARD_V1, ORCHARD_V2]
+const ORCHARD_V2_START = 1788476509 // v2 deployment
 
 // Orchard is a 5x5 plot game played in AAPL. Two versions of the game contract run side by side.
 //
@@ -23,20 +23,23 @@ const GAMES = [ORCHARD_V1, ORCHARD_V2]
 // subtracted. The staking contract, shared by both versions, holds the staker rake already
 // flushed to it, also in AAPL.
 async function tvl(api) {
+  const v2Live = api.timestamp >= ORCHARD_V2_START
+  const games = v2Live ? [ORCHARD_V1, ORCHARD_V2] : [ORCHARD_V1]
+
   const [held, treasury, admin, stakerRewards] = await Promise.all([
-    api.multiCall({ abi: 'erc20:balanceOf', target: AAPL, calls: GAMES }),
-    api.multiCall({ abi: 'uint256:treasuryAccrued', calls: GAMES }),
-    api.multiCall({ abi: 'uint256:adminAccrued', calls: GAMES }),
+    api.multiCall({ abi: 'erc20:balanceOf', target: AAPL, calls: games }),
+    api.multiCall({ abi: 'uint256:treasuryAccrued', calls: games }),
+    api.multiCall({ abi: 'uint256:adminAccrued', calls: games }),
     api.call({ abi: 'erc20:balanceOf', target: AAPL, params: SEED_STAKING }),
   ])
   let userOwned = BigInt(stakerRewards)
-  GAMES.forEach((_, i) => {
+  games.forEach((_, i) => {
     userOwned += BigInt(held[i]) - BigInt(treasury[i]) - BigInt(admin[i])
   })
   api.add(AAPL, userOwned.toString())
 
   // ETH planted on the open v2 round and ETH deposited by players, still waiting for the seal swap
-  await api.sumTokens({ owner: ORCHARD_V2, tokens: [ADDRESSES.null] })
+  if (v2Live) await api.sumTokens({ owner: ORCHARD_V2, tokens: [ADDRESSES.null] })
 }
 
 // SEED staked for a share of the game's rake

--- a/projects/orchard/index.js
+++ b/projects/orchard/index.js
@@ -1,22 +1,42 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+
 const AAPL = '0xaF3D76f1834A1d425780943C99Ea8A608f8a93f9' // Apple stock token issued by Robinhood
 const SEED = '0x5eED45d9cD4c21280db5b190D9c263f086401b9D' // Orchard's own token
-const ORCHARD = '0xEbB8b167c0992cFdc497A995a8Cf7167acAA0A1A'
+const ORCHARD_V1 = '0xEbB8b167c0992cFdc497A995a8Cf7167acAA0A1A'
+const ORCHARD_V2 = '0x86510b3df745C67a993A66CB08720Ed158d44549' // live since 2026-09-03; v1 stays open for claims
 const SEED_STAKING = '0xd5d5f5Dff96E53fc6337b4aCf549d61b12882F2b'
 
-// Orchard is a 5x5 plot game. ETH planted on a plot is swapped to AAPL inside the same
-// transaction, so the whole game balance is held as AAPL: the pot of rounds that have not
-// been revealed yet, the Golden Apple jackpot, and every harvest share still unclaimed.
-// treasuryAccrued/adminAccrued are protocol-owned fees waiting to be swept, so they are
-// subtracted. The staking contract holds the staker rake already flushed to it, also in AAPL.
+const GAMES = [ORCHARD_V1, ORCHARD_V2]
+
+// Orchard is a 5x5 plot game played in AAPL. Two versions of the game contract run side by side.
+//
+// v1 swaps the ETH planted on a plot to AAPL inside the same transaction, so its whole balance
+// is AAPL: the pot of rounds that have not been revealed yet, the Golden Apple jackpot, and
+// every harvest share still unclaimed.
+//
+// v2 keeps the ETH planted on the open round (and any ETH players deposited for standing
+// orders) as ETH until the keeper seals the round, when the whole round is swapped to AAPL at
+// once. Its AAPL is the sealed pots, the jackpot, unclaimed harvest shares, player balances,
+// and the slice of the claim juice reserved for v1 players who bridge their harvest over.
+//
+// In both, treasuryAccrued/adminAccrued are protocol-owned fees waiting to be swept, so they are
+// subtracted. The staking contract, shared by both versions, holds the staker rake already
+// flushed to it, also in AAPL.
 async function tvl(api) {
-  const [pot, stakerRewards, treasury, admin] = await Promise.all([
-    api.call({ abi: 'erc20:balanceOf', target: AAPL, params: ORCHARD }),
+  const [held, treasury, admin, stakerRewards] = await Promise.all([
+    api.multiCall({ abi: 'erc20:balanceOf', target: AAPL, calls: GAMES }),
+    api.multiCall({ abi: 'uint256:treasuryAccrued', calls: GAMES }),
+    api.multiCall({ abi: 'uint256:adminAccrued', calls: GAMES }),
     api.call({ abi: 'erc20:balanceOf', target: AAPL, params: SEED_STAKING }),
-    api.call({ abi: 'uint256:treasuryAccrued', target: ORCHARD }),
-    api.call({ abi: 'uint256:adminAccrued', target: ORCHARD }),
   ])
-  const userOwned = BigInt(pot) - BigInt(treasury) - BigInt(admin) + BigInt(stakerRewards)
+  let userOwned = BigInt(stakerRewards)
+  GAMES.forEach((_, i) => {
+    userOwned += BigInt(held[i]) - BigInt(treasury[i]) - BigInt(admin[i])
+  })
   api.add(AAPL, userOwned.toString())
+
+  // ETH planted on the open v2 round and ETH deposited by players, still waiting for the seal swap
+  await api.sumTokens({ owner: ORCHARD_V2, tokens: [ADDRESSES.null] })
 }
 
 // SEED staked for a share of the game's rake
@@ -24,10 +44,13 @@ const staking = async (api) => api.sumTokens({ owner: SEED_STAKING, tokens: [SEE
 
 module.exports = {
   methodology:
-    'TVL is the AAPL held by the Orchard game contract - the pot of rounds not yet revealed, ' +
-    'the Golden Apple jackpot and every harvest share still unclaimed - plus the AAPL already ' +
-    'flushed to the SeedStaking contract as staker rewards. Fees accrued to the treasury and to ' +
-    'the admin are protocol-owned and are subtracted. Staking is the SEED staked in SeedStaking.',
+    'TVL is the AAPL held by the two Orchard game contracts (v1 and v2) - the pot of rounds not ' +
+    'yet revealed, the Golden Apple jackpot, every harvest share still unclaimed and, on v2, ' +
+    'player balances and the juice reserved for v1 players bridging over - plus the ETH v2 holds ' +
+    'for the open round and player deposits until the round is sealed and swapped to AAPL, plus ' +
+    'the AAPL already flushed to the SeedStaking contract as staker rewards. Fees accrued to the ' +
+    'treasury and to the admin are protocol-owned and are subtracted. Staking is the SEED staked ' +
+    'in SeedStaking.',
   start: '2026-07-22',
   robinhood: { tvl, staking },
 }


### PR DESCRIPTION
Orchard v2 went live on Robinhood Chain on 2026-09-03 (`0x86510b3df745C67a993A66CB08720Ed158d44549`, deployed at block 53786732). v1 (`0xEbB8b167c0992cFdc497A995a8Cf7167acAA0A1A`) stays open so players can claim what they have there, so the adapter now sums both game contracts.

What changes:
- AAPL held by each game contract is counted, minus that contract's `treasuryAccrued` / `adminAccrued` (protocol-owned fees waiting to be swept), plus the staker rake already flushed to SeedStaking. Same rule as before, applied to the two contracts.
- v2 keeps the ETH planted on the open round (and ETH players deposit for standing orders) as ETH until the keeper seals the round and swaps the whole round to AAPL, so v2's native balance is added as gas token. It is usually small and often zero between rounds.
- Staking (SEED in SeedStaking, shared by both versions) is unchanged.

Validated locally with `node test.js projects/orchard/index.js`: ~$31.4k on `robinhood` (v1 ≈ $31.0k, v2 ≈ $0.35k one day after launch; every accrual bucket of the v2 contract was reconciled against its AAPL balance on-chain). No dependency or lockfile changes.

---

Two things about the listing itself, which this repo can't change:
- The protocol page shows no website. Could you set it to https://orchard.gold?
- The description says the ETH is swapped to AAPL "in the same transaction", which is only true of v1. A version-neutral wording: "Orchard is a 5x5 plot game on Robinhood Chain, played in AAPL (Apple stock token). Players plant ETH or AAPL on a plot; every 75-second round one plot blooms and the players who planted there split the harvest from the other 24 plots, minus a 10% rake that funds SEED stakers, the Golden Apple jackpot and the treasury."


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Orchard total value locked (TVL) reporting by accounting for both the original and current game contracts.
  - Updated calculations to exclude accrued treasury and administrative fees.
  - Included SeedStaking rewards and eligible ETH balances from the current contract.
  - Applied contract coverage according to each version’s active period.

- **Documentation**
  - Updated the TVL methodology to explain coverage of both contract versions and the additional ETH component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->