### PR TITLE
Update PumpSpace TVL adapter for AllBlue migration and new V2 deployment

### DIFF
--- a/projects/pumpspace/index.js
+++ b/projects/pumpspace/index.js
@@ -8,14 +8,27 @@ const sdk = require('@defillama/sdk')
 const CHAIN = 'avax'
 
 // --- FACTORIES / CONTRACTS ---
-const PUMP_FACTORY   = '0x26B42c208D8a9d8737A2E5c9C57F4481484d4616' // V2
-const PUMP_V3        = '0xE749c1cA2EA4f930d1283ad780AdE28625037CeD' // V3/Trident
+const LEGACY_PUMPSPACE_V2_FACTORY   = '0x26B42c208D8a9d8737A2E5c9C57F4481484d4616' // V2
+const ALLBLUE_V3_FACTORY        = '0xE749c1cA2EA4f930d1283ad780AdE28625037CeD' // V3/Trident
+const ALLBLUE_V2_FACTORY   = '0x6FEa5651FaC99b854A961dbB41380AdB9F8F9a8b' // V2
 
 // If you later expose staking for other MasterChefs, add here
-const MASTERCHEFS = [
+// Legacy PumpSpace MasterChefs
+const LEGACY_MASTERCHEFS = [
   '0x40a58fc672F7878F068bD8ED234a47458Ec33879', // SHELL
   '0x56b54a1384d35C63cD95b39eDe9339fEf7df3E42', // KRILL
   '0x06C551B19239fE6a425b3c45Eb8b49d28e8283C6', // PEARL
+]
+
+// Current AllBlue MasterChefs
+const ALLBLUE_MASTERCHEFS = [
+  '0xc5101878e56F10A2f5106cA301ADA3Ad0b6A894c', // SHELL
+  '0x3cEC4339b50f62bADFF78e6A05E8558f66a34883', // PEARL
+]
+
+const MASTERCHEFS = [
+  ...LEGACY_MASTERCHEFS,
+  ...ALLBLUE_MASTERCHEFS,
 ]
 
 // --- TOKENS (project/local wrappers + protocol tokens) ---
@@ -31,18 +44,20 @@ const TOKENS = {
 module.exports = {
   misrepresentedTokens: true,
   methodology: `
-  TVL is computed by summing reserves across PumpSpace V2 and V3 (Trident) factories on Avalanche.
-  Single-asset staking (if enabled) reflects tokens deposited in the respective MasterChef contracts.
+  TVL is computed by summing liquidity reserves across the legacy PumpSpace V2 deployment, the current AllBlue V2 deployment, and AllBlue V3 (Trident) on Avalanche.
+  Legacy PumpSpace contracts remain included as part of the migration to AllBlue.
+  The staking bucket includes supported tokens deposited in both legacy PumpSpace and current AllBlue MasterChef contracts.
   `,
     avax: {
     tvl: sdk.util.sumChainTvls([
       // v2FactoryTVL, 
       // v3FactoryTVL,
-      getUniTVL({ factory: PUMP_FACTORY, useDefaultCoreAssets: true }), 
-      getTridentTVL({ chain: CHAIN, factory:PUMP_V3 }),
+      getUniTVL({ factory: LEGACY_PUMPSPACE_V2_FACTORY, useDefaultCoreAssets: true }),
+      getUniTVL({ factory: ALLBLUE_V2_FACTORY,useDefaultCoreAssets: true }),
+      getTridentTVL({ chain: CHAIN, factory:ALLBLUE_V3_FACTORY }),
     ]),
     staking: staking(
-      [MASTERCHEFS[0], MASTERCHEFS[1], MASTERCHEFS[2]], 
+      MASTERCHEFS, 
       [TOKENS.SHELL, TOKENS.SBWPM, TOKENS.SADOL, TOKENS.KRILL, TOKENS.PEARL]
     )
   },


### PR DESCRIPTION
## Summary

This PR updates the existing PumpSpace TVL adapter as part of the migration to AllBlue.

### Changes

- Added the new AllBlue V2 factory on Avalanche
- Kept the legacy PumpSpace V2 factory to continue tracking remaining liquidity
- Kept the existing Trident V3 deployment, now used as AllBlue V3
- Added the current AllBlue MasterChef contracts
- Kept the legacy PumpSpace MasterChef contracts for remaining staked assets
- Updated the methodology to describe the PumpSpace → AllBlue migration

### Contracts

#### Legacy PumpSpace V2
- Factory: `0x26B42c208D8a9d8737A2E5c9C57F4481484d4616`

#### AllBlue V2
- Factory: `0x6FEa5651FaC99b854A961dbB41380AdB9F8F9a8b`

#### AllBlue V3
- Trident Factory: `0xE749c1cA2EA4f930d1283ad780AdE28625037CeD`

#### AllBlue MasterChefs
- SHELL: `0xc5101878e56F10A2f5106cA301ADA3Ad0b6A894c`
- PEARL: `0x3cEC4339b50f62bADFF78e6A05E8558f66a34883`

### Methodology

TVL is computed by summing liquidity reserves across the legacy PumpSpace V2 deployment, the current AllBlue V2 deployment, and AllBlue V3 (Trident) on Avalanche.

Legacy PumpSpace contracts remain included as part of the migration to AllBlue.

The staking bucket includes supported tokens deposited in both legacy PumpSpace and current AllBlue MasterChef contracts.

### Testing

Tested locally with:

```bash
node test.js projects/pumpspace/index.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded Avalanche liquidity tracking to include legacy PumpSpace and current AllBlue V2 and V3 deployments.
  * Updated staking coverage across the supported legacy and AllBlue MasterChef contracts.

* **Documentation**
  * Updated methodology details to reflect the migration from legacy PumpSpace to AllBlue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->