### PR TITLE
feat(rubin): track USDC locked in the Polygon bridge

### DIFF
--- a/registries/sumTokens.js
+++ b/registries/sumTokens.js
@@ -24682,7 +24682,7 @@ const configs = {
     },
   },
   "rubin": {
-    "methodology": "Counts USDC collateral deposited on Rubin through the ethereum and arbitrum bridges.",
+    "methodology": "Counts USDC collateral deposited on Rubin through the ethereum, arbitrum and polygon bridges.",
     "arbitrum": {
       "owner": "0x26206BFdEE32128739f08Aa12f57505A3a4CcaaF",
       "tokens": [
@@ -24693,6 +24693,12 @@ const configs = {
       "owner": "0x26206BFdEE32128739f08Aa12f57505A3a4CcaaF",
       "tokens": [
         ADDRESSES.ethereum.USDC
+      ]
+    },
+    "polygon": {
+      "owner": "0x902c48Ee25529Ac2C67F45B1Dfdf5E322798fCA2",
+      "tokens": [
+        ADDRESSES.polygon.USDC_CIRCLE
       ]
     }
   },


### PR DESCRIPTION
Follow-up to #19881, which refactored #19833 to track the bridge balances instead of the chain REST API.

Rubin now also accepts USDC deposits through a bridge on **Polygon**, so the current config under-reports TVL by the amount locked there (~11% right now).

### Added

- `polygon` — owner [`0x902c48Ee25529Ac2C67F45B1Dfdf5E322798fCA2`](https://polygonscan.com/address/0x902c48Ee25529Ac2C67F45B1Dfdf5E322798fCA2), token `ADDRESSES.polygon.USDC_CIRCLE` (native Circle USDC `0x3c499c54…c3359` — the bridge holds native USDC, balance of bridged `USDC.e` `0x2791Bca1…` is 0)
- methodology string updated to mention polygon

### Reconciliation (2026-09-04)

Locked balances still match the `uusdc` supply on Rubin 1:1:

| Source | USD |
| --- | --- |
| Ethereum `0x26206BFd…CcaaF` | 1,446.41 |
| Arbitrum `0x26206BFd…CcaaF` | 18,710.44 |
| **Polygon `0x902c48Ee…8fCA2`** | **2,401.23** |
| **Total locked** | **22,558.08** |
| Rubin `uusdc` supply (`22558091713 / 1e6`) | **22,558.09** |

The remaining $0.01 arrived over IBC from Noble.

### Unrelated ask: protocol icon

Could you also swap the `rubin-trade` protocol icon? The current one is cropped edge-to-edge and renders poorly in the listings. Replacement (512×512 PNG, 27 KB, with padding):

https://storage.yandexcloud.net/ritbit-static/rubin/rubin_avatar.png

I couldn't find a public repo to PR this into — `DefiLlama/icons` reads from S3 — so flagging it here. Happy to send it another way if there's a better channel.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Polygon bridge support to the Rubin registry.
  - Added support for the Polygon USDC Circle token.
  - Updated registry methodology information to include Polygon alongside Ethereum and Arbitrum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->