### PR TITLE
archade: TVL methodology in one sentence

### DIFF
--- a/projects/archade/index.js
+++ b/projects/archade/index.js
@@ -47,6 +47,6 @@ async function tvl(api) {
 
 module.exports = {
   timetravel: false,
-  methodology: 'TVL is the SOL held as quote reserve inside every active bonding curve launched through Archade. Each coin launched on Archade trades on its own bonding curve: buyers deposit SOL into the curve and sellers withdraw from it, so the curve reserve is the value locked. Curves that have migrated to a DEX pool are excluded because their liquidity has left the curve. Trading fees accrued to Archade, creators and partners are not counted.',
+  methodology: 'SOL held in the bonding curves of coins launched through Archade. Curves that have graduated to a DEX pool are excluded.',
   solana: { tvl },
 }


### PR DESCRIPTION
Wording only, no logic change. The methodology paragraph merged in #20830 is three sentences; this makes it one, in line with the protocol's fees methodology.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PHwZvwGBYY1NccbShYDenF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified the Archade Solana adapter’s methodology description.
  * Clarified that TVL includes SOL held in bonding curves for Archade-launched coins and excludes curves that graduated to a DEX pool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->