### PR TITLE
fix(bitstamp): per_page cap is 100, paginate until empty page

### DIFF
--- a/projects/bitstamp/index.js
+++ b/projects/bitstamp/index.js
@@ -53,14 +53,14 @@ function getAllData() {
     return getConfig('bitstamp', undefined, {
       fetcher: async () => {
         let page = 1
-        let hasMorePages = true
-        let lastItem
         const walletChainMapping = {}
-        do {
+        // Bitstamp caps per_page at 100; larger values return HTTP 400
+        const PER_PAGE = 100
+        while (true) {
           sdk.log('fetching page', page)
-          const data = await get('https://www.bitstamp.net/api/v2/wallet_transparency/?perPage=1000&page=' + page)
-          const allWallets = Object.values(data.wallets).flat()
-          const currentLastItem = allWallets[allWallets.length - 1]
+          const data = await get(`https://www.bitstamp.net/api/v2/wallet_transparency/?perPage=${PER_PAGE}&page=${page}`)
+          const allWallets = Object.values(data.wallets ?? {}).flat()
+          if (!allWallets.length) break // empty page => no more wallets
 
           allWallets.forEach(({ address, network }) => {
             if (!walletChainMapping[network])
@@ -69,9 +69,7 @@ function getAllData() {
           })
 
           page++
-          hasMorePages = !lastItem || currentLastItem.address !== lastItem.address
-          lastItem = currentLastItem
-        } while (hasMorePages)
+        }
 
         Object.entries(walletChainMapping).forEach(([chain, wallets]) => {
           walletChainMapping[chain] = { owners: Object.keys(wallets) }


### PR DESCRIPTION
## Problem

`projects/bitstamp/index.js` requests the wallet-transparency endpoint with `perPage=1000`. Bitstamp now caps `per_page` at 100 and rejects anything larger:

```console
$ curl -s -o /dev/null -w '%{http_code}\n' \
    'https://www.bitstamp.net/api/v2/wallet_transparency/?perPage=1000&page=1'
400

$ curl -s 'https://www.bitstamp.net/api/v2/wallet_transparency/?perPage=1000&page=1'
{"code": 400, "message": "{'per_page': ['Must be greater than or equal to 1 and less than or equal to 100.']}"}
```

So the fetcher throws on the very first page. `getConfig` catches it and returns the previously cached config instead:

https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/helper/cache.js#L96-L100

```js
} catch (e) {
  // sdk.log(e)
  sdk.log(project, 'tryng to fetch from cache, failed to fetch data from endpoint:', endpoint)
  return getCache(key, project)
```

The adapter keeps "working" against a stale address set, with no failure surfaced.

## Why lowering `perPage` alone is not enough

The loop's stop condition compares the last item of a page with the last item of the previous page:

```js
hasMorePages = !lastItem || currentLastItem.address !== lastItem.address
```

Page contents are not stable across calls, and this fires early. Running the current loop shape with only `perPage=1000` → `100` changed stops after 3 pages and collects **zero** bitcoin addresses — a silent under-count rather than a visible error. It also dereferences `currentLastItem.address` without an empty-page guard, so the first empty page (page 38 today, `{"wallets": {}}`) would throw a `TypeError`.

## Fix

- `perPage=100` (the documented cap).
- Stop when a page returns no wallets, before dereferencing anything.
- Drop the `lastItem` heuristic.

## Verification

Replaying the fetcher loop against the live endpoint:

| variant | pages | chains | bitcoin addrs | ethereum addrs |
|---|---|---|---|---|
| `main` today (`perPage=1000`) | — | — | — | throws `HTTP 400` on page 1 → stale cache |
| `perPage=100`, old stop condition | 3 | 8 | **0** | 12 |
| this PR (`perPage=100` + empty-page stop) | 37 | 42 | **507** | 64 |

The 507 bitcoin addresses (417 `bc1…` + 90 `3…`) match what the endpoint publishes when paginated to exhaustion.

For context, `api.llama.fi/protocol/bitstamp` currently reports ~4.2k BTC for Bitstamp, which is what the stale cached address set resolves to.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bitstamp wallet-transparency data retrieval by handling missing wallet data safely.
  * Updated pagination to avoid request failures and stop correctly when no additional wallets are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->