### PR TITLE
add Dialectic Meccanico TVL adapter

### DIFF
--- a/projects/dialectic-meccanico/index.js
+++ b/projects/dialectic-meccanico/index.js
@@ -1,0 +1,85 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+const { getCuratorTvl } = require('../helper/curators')
+
+const DIALECTIC_MORPHO_OWNER = '0x8c9918AbE972F3c8A478e9A5912ECdc0a2e0BA0c'
+const SR_ROY_USDC = '0xcD9f5907F92818bC06c9Ad70217f089E190d2a32'
+const ROY_WST_ETH = '0x41ce72e04d349eb957bdc373baa9c69207032c56'
+
+const STRATEGY_TYPE_CROSSCHAIN = 2
+const getStrategiesAbi = 'function getStrategies() view returns (address[])'
+const strategyTypeAbi = 'function strategyType() view returns (uint8)'
+const getMakinaMachineAbi = 'function getMakinaMachine() view returns (address)'
+const hubCaliberAbi = 'function hubCaliber() view returns (address)'
+const convertToAssetsAbi = 'function convertToAssets(uint256 shares) view returns (uint256 assets)'
+
+async function resolveStrategies(api, vault) {
+  const strategies = await api.call({ abi: getStrategiesAbi, target: vault })
+  if (!strategies.length) return []
+
+  const types = await api.multiCall({ abi: strategyTypeAbi, calls: strategies })
+  const crosschain = strategies.filter((_, i) => Number(types[i]) === STRATEGY_TYPE_CROSSCHAIN)
+  const selfCustody = strategies.filter((_, i) => Number(types[i]) !== STRATEGY_TYPE_CROSSCHAIN)
+
+  if (!crosschain.length) return selfCustody
+
+  const machines = await api.multiCall({ abi: getMakinaMachineAbi, calls: crosschain })
+  const calibers = await api.multiCall({ abi: hubCaliberAbi, calls: machines })
+
+  return [...selfCustody, ...calibers]
+}
+
+async function addRoyWstEth(api) {
+  const totalAssets = await api.call({
+    abi: 'uint256:totalAssets',
+    target: ROY_WST_ETH,
+  })
+
+  api.add(ADDRESSES.ethereum.WSTETH, totalAssets)
+
+  const strategies = await resolveStrategies(api, ROY_WST_ETH)
+  if (!strategies.length) return
+
+  const shares = await api.multiCall({
+    abi: 'erc20:balanceOf',
+    calls: strategies.map(strategy => ({
+      target: SR_ROY_USDC,
+      params: [strategy],
+    })),
+  })
+
+  const calls = strategies
+    .map((_, i) => ({
+      target: SR_ROY_USDC,
+      params: [shares[i]],
+    }))
+    .filter((_, i) => BigInt(shares[i]) > 0n)
+
+  if (!calls.length) return
+
+  const nestedUsdc = await api.multiCall({
+    abi: convertToAssetsAbi,
+    calls,
+  })
+
+  nestedUsdc.forEach(usdc => {
+    api.add(ADDRESSES.ethereum.USDC, -BigInt(usdc))
+  })
+}
+
+async function tvl(api) {
+  await getCuratorTvl(api, {
+    morphoVaultOwners: [DIALECTIC_MORPHO_OWNER],
+    erc4626: [SR_ROY_USDC],
+  })
+
+  await addRoyWstEth(api)
+
+  return api.getBalances()
+}
+
+module.exports = {
+  doublecounted: true,
+  start: '2026-04-17',
+  methodology: 'Counts assets managed by Dialectic Meccanico across Senior Royco USDC, Royco ETH and Dialectic Morpho vaults. Royco ETH is added from its on-chain totalAssets() and its nested srRoyUSDC position is subtracted using the same strategy-holder resolution used by the Royco V2 adapter, preventing internal double counting. The curator listing is marked double counted because the same assets are also represented in the underlying protocol TVLs.',
+  ethereum: { tvl },
+}


### PR DESCRIPTION
## Summary

Adds an Ethereum TVL listing for Dialectic Meccanico using DefiLlama's curator helpers plus a small Royco-specific internal deduplication.

The adapter tracks three top-level curated components:

- Senior Royco USDC (`srRoyUSDC`): `0xcD9f5907F92818bC06c9Ad70217f089E190d2a32`
- Royco ETH (`roywstETH`): `0x41ce72e04d349eb957bdc373baa9c69207032c56`
- Dialectic AUSD RWA on Morpho V2: `0x2C4BC0EC9fdD2b1F38eD5120184d62288d3e9DCe`, discovered from the canonical Morpho V2 factory using its verified initial owner `0x8c9918AbE972F3c8A478e9A5912ECdc0a2e0BA0c`

### Internal deduplication

Royco ETH can deploy capital into `srRoyUSDC`. Since both vaults are included on the Dialectic curator page, adding their full NAVs independently would double count that nested position.

This adapter therefore follows the same strategy-holder resolution used by DefiLlama's existing `royco-v2` adapter:

1. add Royco ETH's on-chain `totalAssets()` as wstETH;
2. resolve the vault's strategy holders;
3. read each holder's `srRoyUSDC` share balance;
4. convert those shares to USDC with `convertToAssets()`;
5. subtract that USDC amount from the curator TVL.

The listing remains `doublecounted: true` because these top-level vault assets are also represented in the underlying Royco/Morpho protocol TVLs.

## Test

```bash
node test.js projects/dialectic-meccanico/index.js
```

Current result at PR time:

```text
--- tvl ---
USDC                      8.97 M
wstETH                    284.59 k
AUSD                      100.65 k
Total: 9.36 M

------ TVL ------
ethereum                  9.36 M

total                    9.36 M
```

---

## New listing information

##### Name (to be shown on DefiLlama):

Dialectic 

##### Twitter Link:

https://x.com/Dialectic_Group

##### List of audit links if any:
N/A

##### Website Link:

https://dialectic.com/

##### Logo (High resolution, will be shown with rounded borders):

https://pbs.twimg.com/profile_images/2034571389437714432/JMEvBkoB_400x400.png

##### Current TVL:

$ 9.36 Million.

##### Treasury Addresses (if the protocol has treasury)

N/A

##### Chain:

Ethereum

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):



##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):



##### Short Description (to be shown on DefiLlama):

Dialectic  curates vaults across protocols including Royco and Morpho.

##### Token address and ticker if any:

None.

##### Category (full list at https://defillama.com/categories) *Please choose only one:

Risk Curators

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

N/A

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
 N/A

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:


##### forkedFrom (Does your project originate from another project):


##### methodology (what is being counted as tvl, how is tvl being calculated):

TVL represents the net AUM of the top-level Ethereum vaults curated by Dialectic Meccanico. The adapter counts full `totalAssets()` for Senior Royco USDC and Dialectic's Morpho vaults, plus Royco ETH's wstETH `totalAssets()`. Because Royco ETH can hold `srRoyUSDC`, the adapter resolves Royco ETH's strategy holders, converts their `srRoyUSDC` shares into USDC with `convertToAssets()`, and subtracts that amount to remove the overlap between two Dialectic vaults included on the same curator page. Underlying third-party strategy positions are not recursively unwound because they form part of each vault's NAV. The listing is marked double counted relative to the underlying protocol TVLs.

##### Github org/user (Optional, if your code is open source, we can track activity):

https://github.com/dialecticch

##### Does this project have a referral program?

N/A

## Sources

- Dialectic announcement naming Dialectic as curator of Royco Dawn / srRoyUSDC: https://dialecticgroup.substack.com/p/royco-dawn-vaults-are-now-curated
- Royco vault products documentation: https://docs.royco.org/vault-products
- Royco ETH documentation: https://docs.royco.org/royco-dawn/vault-products/royco-eth-roywsteth
- DefiLlama Royco V2 adapter showing the Royco ETH -> srRoyUSDC deduction: https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/royco-v2/index.js
- DefiLlama PR that introduced/reviewed the Royco V2 deduplication: https://github.com/DefiLlama/DefiLlama-Adapters/pull/20108
- Morpho forum introduction for Dialectic Meccanico: https://forum.morpho.org/t/introducing-dialectic-meccanico-by-dialectic-vaults-on-morpho/2334
- Official Morpho vault page: https://app.morpho.org/ethereum/vault/0x2C4BC0EC9fdD2b1F38eD5120184d62288d3e9DCe/dialectic-ausd-rwa
- Senior Royco USDC vault: https://www.royco.org/vault/1/0xcd9f5907f92818bc06c9ad70217f089e190d2a32


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added TVL tracking for the Dialectic Meccanico protocol on Ethereum.
  - Reports assets held across the Morpho vault owner, Senior Royco USDC vault, and Royco ETH positions.
  - Improves reported totals by accounting for nested strategies and preventing the same assets from being counted more than once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->