### PR TITLE
add Stake DAO curator TVL

### DIFF
--- a/registries/curators.js
+++ b/registries/curators.js
@@ -1043,6 +1043,23 @@ const configs = {
       }
     },
   },
+  "stake-dao-curator": {
+    config: {
+      methodology: 'Counts all assets deposited in Morpho vaults curated by Stake DAO.',
+      start: '2025-11-04',
+      blockchains: {
+        ethereum: {
+          morphoVaultOwners: [
+            '0xB0552b6860CE5C0202976Db056b5e3Cc4f9CC765', // Stake DAO governance : frxUSD v1/v2
+          ],
+          morpho: [
+            '0x13AA4f80AD5F06cE4f1A3a3cA58C37059F0EE4c5', // Stake DAO USDC v1
+            '0x8EDCC305E633d29BFB383872e79401c506cE9E6f', // Stake DAO USDC v2
+          ],
+        },
+      },
+    },
+  },
   "steakhouse": {
     config: {
       methodology: 'Count all assets are deposited in all vaults curated by Steakhouse Financial.',


### PR DESCRIPTION
## Summary

Adds `stake-dao-curator` to `registries/curators.js` to track Stake DAO's Morpho V1/V2 vaults on Ethereum.

The adapter uses the repository-native `getCuratorExport` helper and reads TVL on-chain through each vault's `asset()` and `totalAssets()` values. 

The current scope is:

- Stake DAO USDC v1: `0x13AA4f80AD5F06cE4f1A3a3cA58C37059F0EE4c5`
- Stake DAO USDC v2: `0x8EDCC305E633d29BFB383872e79401c506cE9E6f`
- Stake DAO frxUSD v1: `0xB2376cC88EA47C80fFC3De60dAe8F2F48BC872a3`
- Stake DAO frxUSD v2: `0xCE13e39534082FCF8f13F6D84e6D95414D14271e`

The official Stake DAO governance address `0xB0552b6860CE5C0202976Db056b5e3Cc4f9CC765` is used for factory-event discovery. It currently discovers both frxUSD vaults. The two officially documented USDC vaults are listed explicitly because their initial creation owner, `0x52ea58f4FC3CEd48fa18E909226c1f8A0EF887DC`, is not present in Stake DAO's official address book.

The curator helper de-duplicates repeated addresses and nested Morpho V1/V2 exposure. When a V2 vault routes assets through a V1 vault in the same tracked set, it counts `V1 totalAssets + V2 totalAssets - V2 assets deposited in V1`.

## Existing Stake DAO adapter and double-counting

The four vault addresses are absent from the existing `projects/stakedao/index.js` adapter and from the Stake DAO strategy/locker endpoints consumed by that adapter. This PR therefore does not duplicate the current Stake DAO Yield TVL.

The supplied USDC and frxUSD are already represented in Morpho's TVL. `getCuratorExport` accordingly marks this curator listing as `doublecounted: true`.

## Listing/grouping request

Please list this module as a separate `Stake DAO Curator` product in the `Risk Curators` category and group it with the existing Stake DAO Yield product under one Stake DAO parent.

Keeping the products separate ensures that only the curator TVL is marked double-counted against Morpho. 

## Validation

```bash
node test.js stake-dao-curator
```

```text
------ TVL ------
ethereum                  1.39 M

total                    1.39 M
```



## New listing information

##### Name (to be shown on DefiLlama):

Stake DAO Curator

##### Twitter Link:

https://x.com/StakeDAOHQ

##### List of audit links if any:

##### Website Link:

https://lending.stakedao.org/earn

##### Logo (High resolution, will be shown with rounded borders):

Please reuse the logo of the existing Stake DAO listing: https://icons.llamao.fi/icons/protocols/stake-dao

##### Current TVL:

Approximately $1.390M .

##### Treasury Addresses (if the protocol has treasury)


##### Chain:

Ethereum

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):
 

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):
 

##### Short Description (to be shown on DefiLlama):

Stake DAO curates Morpho lending vaults that supply USDC and frxUSD.


##### Token address and ticker if any:

N/A

##### Category (full list at https://defillama.com/categories) *Please choose only one:

Risk Curators

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
N/A

##### Implementation Details: Briefly describe how the oracle is integrated into your project:


##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

- https://docs.stakedao.org/lending/oracles
- https://docs.stakedao.org/lending/markets
- https://docs.stakedao.org/addresses
- https://github.com/stake-dao/contracts-monorepo/tree/main/packages/periphery/src/lending
- https://app.morpho.org/ethereum/vault/0x8EDCC305E633d29BFB383872e79401c506cE9E6f
- https://app.morpho.org/ethereum/vault/0xCE13e39534082FCF8f13F6D84e6D95414D14271e

##### forkedFrom (Does your project originate from another project):

No.  

##### methodology (what is being counted as tvl, how is tvl being calculated):

Counts the underlying assets represented by `totalAssets()` across Stake DAO's Ethereum Morpho V1/V2 vaults. Vaults created with the official Stake DAO governance address are discovered from canonical Morpho factory events; the two officially documented USDC vaults are included explicitly. The helper obtains each ERC-4626 underlying through `asset()`, de-duplicates addresses and removes nested V1/V2 exposure. 

##### Github org/user (Optional, if your code is open source, we can track activity):

https://github.com/stake-dao

##### Does this project have a referral program?

No referral program is documented for these Morpho curator vaults.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking assets deposited in Morpho vaults curated by Stake DAO.
  * Coverage includes specified Ethereum Morpho vaults and begins with activity from November 4, 2025.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->