### PR TITLE
k3: add missing Euler Earn vaults

### DIFF
--- a/projects/k3/index.js
+++ b/projects/k3/index.js
@@ -18,6 +18,9 @@ const configs = {
         "0x0243755a22E37b835486fdAE9A839523ADABd336",
       ],
       erc4626: [
+        "0x3B4802FDb0E5d74aA37d58FD77d63e93d4f9A4AF", // Euler Earn: K3 Capital Earn USDC
+        "0x84fcb0eb9d7ab4EdFd26CCa8AD20AaB4c5aD49CD", // Euler Earn: K3 Capital Earn WETH
+        "0xb072b2779F1EF1A6A9D2d5fAa1766F341B92aB3a", // Euler Earn: K3 Capital Earn USDT
         "0x50bd66d59911f5e086ec87ae43c811e0d059dd11",
         "0xf5503d3d4bd254c2c17690eed523bcb2935db6de",
         "0x866C6c6627303Be103814150fC0e886BE5D9ea83",
@@ -45,6 +48,11 @@ const configs = {
         "0x5Bb012482Fa43c44a29168C6393657130FDF0506",
         "0x2E28c94eE56Ac6d82600070300d86b3a14D5d71A",
       ],
+      erc4626: [
+        "0x5685fed1008ec25Be9f40E12685c38031Be2d4dD", // Euler Earn: K3 bStocks USDT Lending
+        "0xD98b0B1281E06f2f5036B6B1ef1eaAD3304Daa52", // Euler Earn: K3 Capital USDT Earn Vault
+        "0x27Ec22e4DcB70F7FfE1F6bb89e3284529492c05E", // Euler Earn: K3 Capital USD1
+      ],
     },
     bob: {
       eulerVaultOwners: ["0xDb81B93068B886172988A1A4Dd5A1523958a23f0"],
@@ -55,6 +63,8 @@ const configs = {
     plasma: {
       eulerVaultOwners: ["0x060DB084bF41872861f175d83f3cb1B5566dfEA3"],
       erc4626: [
+        "0xe818ad0D20D504C55601b9d5e0E137314414dec4", // Euler Earn: K3 Capital USDT0 Vault
+        "0xf5C972B760dBa38Bf57Ddb2912244F856E4F6812", // Euler Earn: K3 USDe Earn Vault
         "0x539b2ee4f3a04f33d53c0813f77e65148963f72b",
         "0xAADEA03f6D6F198Bdc9229bD8113aceD19031773",
         "0x767d33217e7d2670695FfE2a104548B780f4F5d8",
@@ -80,6 +90,12 @@ const configs = {
     monad: {
       accountableVaults: [
         "0x0143C3eF3a76Ed825Fd5201953f65b52aCEfD799",
+      ],
+      erc4626: [
+        "0x2C803c8C3C57b9D4A9abA011615561315c2b6aC1", // Euler Earn: K3 Capital Earn WETH
+        "0x598035A2E984993229f6FA4C8C3eCf6c52aD51b5", // Euler Earn: K3 Capital Earn AUSD
+        "0x9D42b0D57e88771B365e30c0A589Fcdbeca8828c", // Euler Earn: K3 Capital Earn WMON
+        "0xA981f053C118FE4dB0e1aEBA192AAD20Ec7F7801", // Euler Earn: K3 Capital Earn USDC
       ],
       eulerVaultOwners: [
         "0x987C5739F3905FbA98eCCf4aceBc88730E0eE53D",


### PR DESCRIPTION
## What this PR does

Adds 12 missing K3 Capital Euler Earn ERC-4626 vaults on Ethereum, BSC, Plasma and Monad to the existing K3 curator adapter.

## Methodology

The existing `getCuratorExport` helper reads each vault's underlying `asset()` and `totalAssets()`, deduplicates configured addresses and marks the resulting TVL as double-counted. Explicit vault addresses are used because Euler Earn vaults on the same chain expose the shared factory as creator, which is not curator-specific.

## Validation

- node test.js projects/k3/index.js`
- Targeted live validation on 2026-09-04 found approximately $94.8m of additional TVL

## Sources

- https://app.euler.finance/explore?riskManager=K3+Capital&network=143
- K3: https://www.k3.capital/
- Euler Earn documentation: https://docs.euler.finance/introduction/
- Each configured address is linked from the Euler app in the sources below.

## sourcesnotes
 Ethereum | USDC | `0x3B4802FDb0E5d74aA37d58FD77d63e93d4f9A4AF` | https://app.euler.finance/earn/0x3B4802FDb0E5d74aA37d58FD77d63e93d4f9A4AF?network=1 |
| Ethereum | WETH | `0x84fcb0eb9d7ab4EdFd26CCa8AD20AaB4c5aD49CD` | https://app.euler.finance/earn/0x84fcb0eb9d7ab4EdFd26CCa8AD20AaB4c5aD49CD?network=1 |
| Ethereum | USDT | `0xb072b2779F1EF1A6A9D2d5fAa1766F341B92aB3a` | https://app.euler.finance/earn/0xb072b2779F1EF1A6A9D2d5fAa1766F341B92aB3a?network=1 |
| BSC | USDT | `0x5685fed1008ec25Be9f40E12685c38031Be2d4dD` | https://app.euler.finance/earn/0x5685fed1008ec25Be9f40E12685c38031Be2d4dD?network=56 |
| BSC | USDT | `0xD98b0B1281E06f2f5036B6B1ef1eaAD3304Daa52` | https://app.euler.finance/earn/0xD98b0B1281E06f2f5036B6B1ef1eaAD3304Daa52?network=56 |
| BSC | USD1 | `0x27Ec22e4DcB70F7FfE1F6bb89e3284529492c05E` | https://app.euler.finance/earn/0x27Ec22e4DcB70F7FfE1F6bb89e3284529492c05E?network=56 |
| Plasma | USDT0 | `0xe818ad0D20D504C55601b9d5e0E137314414dec4` | https://app.euler.finance/earn/0xe818ad0D20D504C55601b9d5e0E137314414dec4?network=9745 |
| Plasma | USDe | `0xf5C972B760dBa38Bf57Ddb2912244F856E4F6812` | https://app.euler.finance/earn/0xf5C972B760dBa38Bf57Ddb2912244F856E4F6812?network=9745 |
| Monad | WETH | `0x2C803c8C3C57b9D4A9abA011615561315c2b6aC1` | https://app.euler.finance/earn/0x2C803c8C3C57b9D4A9abA011615561315c2b6aC1?network=143 |
| Monad | AUSD | `0x598035A2E984993229f6FA4C8C3eCf6c52aD51b5` | https://app.euler.finance/earn/0x598035A2E984993229f6FA4C8C3eCf6c52aD51b5?network=143 |
| Monad | WMON | `0x9D42b0D57e88771B365e30c0A589Fcdbeca8828c` | https://app.euler.finance/earn/0x9D42b0D57e88771B365e30c0A589Fcdbeca8828c?network=143 |
| Monad | USDC | `0xA981f053C118FE4dB0e1aEBA192AAD20Ec7F7801` | https://app.euler.finance/earn/0xA981f053C118FE4dB0e1aEBA192AAD20Ec7F7801?network=143 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for additional ERC-4626 vaults across Ethereum, BSC, Plasma, and Monad networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->