### PR TITLE
feat: list Ilyris (Robinhood Chain discrete-bin AMM)

### DIFF
--- a/projects/ilyris/index.js
+++ b/projects/ilyris/index.js
@@ -3,15 +3,18 @@ const ADDRESSES = require('../helper/coreAssets.json')
 // Ilyris — pull-based discrete-bin AMM on Robinhood Chain (4663).
 // Factory enumerates every pool; TVL is ERC-20 balances held by those pools.
 // No router: LPs deposit straight into each BinPool.
+// FeeStaking holds user-staked YRIS (+ reward inventory when funded).
 
 const FACTORY = '0x3Bf76F2E41Ac7996c822455f4c78fa2026465C4D'
+const FEE_STAKING = '0x868ae20E6c1EA3b6Fdab5042Ea721eB51b237183'
+const YRIS = '0xD6af4536baB5EA74bCF872CA181619Cc3157683E'
 
 // Known quote / base assets on Hood. Unknown tokens (e.g. YRIS before a
 // DefiLlama price exists) are still summed; Llama prices what it can.
 const KNOWN = [
   ADDRESSES.robinhood.WETH,
   ADDRESSES.robinhood.USDG,
-  '0xD6af4536baB5EA74bCF872CA181619Cc3157683E', // YRIS
+  YRIS,
 ]
 
 async function tvl(api) {
@@ -34,9 +37,18 @@ async function tvl(api) {
   return api.sumTokens({ ownerTokens })
 }
 
+// Staked YRIS + any reward inventory (WETH/USDG) sitting in FeeStaking.
+// Kept off main tvl so DEX liquidity is not inflated by the native token.
+async function staking(api) {
+  return api.sumTokens({
+    owners: [FEE_STAKING],
+    tokens: [YRIS, ADDRESSES.robinhood.WETH, ADDRESSES.robinhood.USDG],
+  })
+}
+
 module.exports = {
   methodology:
-    'TVL is the ERC-20 balances held inside every BinPool enumerated by BinFactory.allPools on Robinhood Chain. Pools are the swap and LP entry point (there is no router). Empty factory slots contribute zero. FeeStaking / treasury / user wallets are not counted. Token prices come from DefiLlama; assets without a price (e.g. YRIS before listing) may under-report until priced.',
+    'TVL is the ERC-20 balances held inside every BinPool enumerated by BinFactory.allPools on Robinhood Chain. Pools are the swap and LP entry point (there is no router). Empty factory slots contribute zero. Staking is YRIS (and any WETH/USDG reward inventory) held in FeeStaking — reported separately, not in DEX TVL. Treasury wallets are not included. Token prices come from DefiLlama; assets without a price (e.g. YRIS before listing) may under-report until priced.',
   start: 1788149794, // factory deploy 2026-08-31 04:16:34 UTC (tx 0x7710b875…b96368)
-  robinhood: { tvl },
+  robinhood: { tvl, staking },
 }

--- a/projects/ilyris/index.js
+++ b/projects/ilyris/index.js
@@ -1,0 +1,42 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+
+// Ilyris — pull-based discrete-bin AMM on Robinhood Chain (4663).
+// Factory enumerates every pool; TVL is ERC-20 balances held by those pools.
+// No router: LPs deposit straight into each BinPool.
+
+const FACTORY = '0x3Bf76F2E41Ac7996c822455f4c78fa2026465C4D'
+
+// Known quote / base assets on Hood. Unknown tokens (e.g. YRIS before a
+// DefiLlama price exists) are still summed; Llama prices what it can.
+const KNOWN = [
+  ADDRESSES.robinhood.WETH,
+  ADDRESSES.robinhood.USDG,
+  '0xD6af4536baB5EA74bCF872CA181619Cc3157683E', // YRIS
+]
+
+async function tvl(api) {
+  const n = await api.call({ target: FACTORY, abi: 'uint256:allPoolsLength' })
+  const indices = Array.from({ length: Number(n) }, (_, i) => i)
+  const pools = await api.multiCall({
+    target: FACTORY,
+    abi: 'function allPools(uint256) view returns (address)',
+    calls: indices,
+  })
+
+  const tokenXs = await api.multiCall({ abi: 'address:tokenX', calls: pools })
+  const tokenYs = await api.multiCall({ abi: 'address:tokenY', calls: pools })
+
+  const ownerTokens = pools.map((pool, i) => {
+    const tokens = [...new Set([tokenXs[i], tokenYs[i], ...KNOWN].map((t) => t.toLowerCase()))]
+    return [tokens, pool]
+  })
+
+  return api.sumTokens({ ownerTokens })
+}
+
+module.exports = {
+  methodology:
+    'TVL is the ERC-20 balances held inside every BinPool enumerated by BinFactory.allPools on Robinhood Chain. Pools are the swap and LP entry point (there is no router). Empty factory slots contribute zero. FeeStaking / treasury / user wallets are not counted. Token prices come from DefiLlama; assets without a price (e.g. YRIS before listing) may under-report until priced.',
+  start: 1788149794, // factory deploy 2026-08-31 04:16:34 UTC (tx 0x7710b875…b96368)
+  robinhood: { tvl },
+}


### PR DESCRIPTION
**NOTE:** Please enable "Allow edits by maintainers".

Volume/fees adapters are out of scope for this PR (dimension-adapters later).
Treasury wallets not included yet.

##### Name (to be shown on DefiLlama):
Ilyris

##### Twitter Link:
https://x.com/Ilyris_ag

##### List of audit links if any:
None - unaudited. Extensively tested in-repo (Foundry + off-chain sim parity); tests are not an audit.

##### Website Link:
https://ilyris.ag

##### Logo (High resolution, will be shown with rounded borders):
https://gist.githubusercontent.com/combatwombat1915/3ad1f8c62615c78e66f327de68aef0ef/raw/ilyris-mark.svg

##### Current TVL:
~$156–291 pool TVL (WETH/USDG primary). Separate staking: ~148M YRIS in FeeStaking (USD ~0 until YRIS is priced); WETH rewards unfunded.

##### Treasury Addresses (if the protocol has treasury)
None for this listing.

##### Chain:
Robinhood Chain (4663)

##### Coingecko ID:

##### Coinmarketcap ID:

##### Short Description (to be shown on DefiLlama):
Discrete-bin AMM on Robinhood Chain. Pools are the swap entry point (pull-based, no router).

##### Token address and ticker if any:
YRIS - 0xD6af4536baB5EA74bCF872CA181619Cc3157683E (Robinhood Chain)

##### Category (choose only one):
Dexes

##### Oracle Provider(s):
None for swaps. Optional ContinuousMarketGuard on some pools (pause/freeze) - not a price oracle.

##### Implementation Details:
N/A - no price oracle. Market guard is pause/freeze, not used for TVL.

##### Documentation/Proof:
https://ilyris.ag/docs

##### forkedFrom:
Original (not a Uni V2/V3 fork; discrete-bin AMM).

##### methodology:
TVL is ERC-20 balances held in every BinPool returned by BinFactory.allPools on Robinhood Chain. Empty pools contribute zero. Staking is YRIS (and any WETH/USDG reward inventory) held in FeeStaking 0x868ae20E6c1EA3b6Fdab5042Ea721eB51b237183 — reported under staking, not DEX TVL. Treasury wallets excluded.

##### Github org/user (Optional):
combatwombat1915/ilyris (private) - source-verified on Blockscout:
- Factory 0x3Bf76F2E41Ac7996c822455f4c78fa2026465C4D
- FeeStaking 0x868ae20E6c1EA3b6Fdab5042Ea721eB51b237183
- Lens 0x306d65eA97421D33923cCe592dBd22792a789090
- WETH/USDG 0xeEc7cdd6834b4f1feA1D63D32eE0cB7CbB3f24D7
- WETH/YRIS 0xcbb584e1c1259047f2fe03cCB34E8e2086c9F8Ad

##### Does this project have a referral program?
No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Ilyris TVL tracking for Robinhood Chain.
  - TVL now includes assets held across BinFactory liquidity pools and their supported token pairs.
  - Added separate YRIS staking metrics.
  - Added tracking for WETH and USDG rewards held by the FeeStaking contract.
  - Included methodology details and the deployment start date for improved transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->