### PR TITLE
binance: report Binance-Peg backing wallets separately from CEX reserves

### DIFF
--- a/projects/binance-peg-backing/index.js
+++ b/projects/binance-peg-backing/index.js
@@ -1,0 +1,82 @@
+const { defaultTokens } = require('../helper/cex')
+const { sumTokensExport } = require('../helper/sumTokens')
+const { nullAddress } = require('../helper/unwrapLPs')
+const { getConfig } = require('../helper/cache')
+
+// Collateral Binance locks on the native chain to back Binance-Peg tokens issued on
+// other chains (mostly BNB Chain). The liabilities behind these wallets are peg-token
+// holders, not exchange customers, so they are tracked here rather than under the
+// Binance CEX entry. Same endpoint the CEX adapter uses for its wrapped-token blacklist.
+const LOCK_INFO_ENDPOINT = "https://www.binance.com/bapi/tokencanal/v2/tokencanal/lockinfo"
+
+// BTC is deliberately excluded: the backing for Binance-Peg BTC is already tracked
+// by DefiLlama as its own Bridge entry ("Binance Bitcoin"), so including it here
+// would double count. (It also has to stay out of the generic path because Base58
+// P2SH addresses are case-sensitive and the shared owner-dedupe lowercases them.)
+const binanceToDefillama = {
+  ETH: 'ethereum',
+  BEP20: 'bsc',
+  BSC: 'bsc',
+  TRX: 'tron',
+  TRON: 'tron',
+  AVAX: 'avax',
+  AVAXC: 'avax',
+  MATIC: 'polygon',
+  ARB: 'arbitrum',
+  ARBITRUM: 'arbitrum',
+  OP: 'optimism',
+  OPTIMISM: 'optimism',
+  LTC: 'litecoin',
+  XRP: 'ripple',
+  SOL: 'solana',
+  DOT: 'polkadot',
+  ALGO: 'algorand',
+  APT: 'aptos',
+  BASE: 'base',
+  NEAR: 'near',
+  DOGE: 'doge',
+  XLM: 'stellar',
+}
+
+const chainToNetworks = {}
+for (const [network, chain] of Object.entries(binanceToDefillama)) {
+  const c = chain.toLowerCase()
+  const n = network.toUpperCase()
+  if (!chainToNetworks[c]) chainToNetworks[c] = []
+  if (!chainToNetworks[c].includes(n)) chainToNetworks[c].push(n)
+}
+
+const evmChains = ['ethereum', 'bsc', 'polygon', 'arbitrum', 'optimism', 'avax', 'base']
+
+async function getLockAddresses(chain) {
+  const networks = chainToNetworks[chain]
+  const isEvm = evmChains.includes(chain)
+  const lockInfoData = await getConfig('binance-peg-backing/lock-info', LOCK_INFO_ENDPOINT)
+
+  const addresses = []
+  lockInfoData.tokens.forEach(token => {
+    (token.lockInfo || []).forEach(li => {
+      if (!networks.includes(li.network.toUpperCase())) return
+      if (!li.address || /^[A-Z0-9]+-[A-Z0-9]+$/i.test(li.address)) return
+      if (isEvm && (!/^0x[0-9a-fA-F]{40}$/.test(li.address))) return
+      addresses.push(li.address)
+    })
+  })
+  return [...new Set(addresses)]
+}
+
+const tvl = async (api) => {
+  const chain = api.chain.toLowerCase()
+  const owners = await getLockAddresses(chain)
+  if (!owners.length) return {}
+
+  const options = { owners, chain, permitFailure: true }
+  if (chain === 'solana') options.solOwners = owners
+  else options.tokens = defaultTokens[chain] || [nullAddress]
+
+  return sumTokensExport(options)(api)
+}
+
+module.exports = { methodology: 'Assets held in the wallets Binance publishes as the on-chain backing for Binance-Peg tokens (tokencanal lockinfo endpoint). These back peg-token holders on the destination chain, not exchange customer deposits, so they are reported separately from the Binance CEX entry.' }
+
+Object.values(binanceToDefillama).forEach(chain => { module.exports[chain] = { tvl } })

--- a/projects/binance-peg-backing/index.js
+++ b/projects/binance-peg-backing/index.js
@@ -9,10 +9,13 @@ const { getConfig } = require('../helper/cache')
 // Binance CEX entry. Same endpoint the CEX adapter uses for its wrapped-token blacklist.
 const LOCK_INFO_ENDPOINT = "https://www.binance.com/bapi/tokencanal/v2/tokencanal/lockinfo"
 
-// BTC is deliberately excluded: the backing for Binance-Peg BTC is already tracked
-// by DefiLlama as its own Bridge entry ("Binance Bitcoin"), so including it here
-// would double count. (It also has to stay out of the generic path because Base58
-// P2SH addresses are case-sensitive and the shared owner-dedupe lowercases them.)
+// BTC is deliberately excluded, for two independent reasons:
+//  1. the backing for Binance-Peg BTC is already tracked as its own Bridge entry
+//     ("Binance Bitcoin"), so including it here would double count;
+//  2. the lockinfo endpoint returns the BTC wallet lowercased
+//     ("3lyjfcfhpxyjremsask2jkn69lweykzexb"), which fails Base58Check and 404s on
+//     explorers. The correct-case address is already in helper/bitcoin-book as
+//     `binance2`, which is what projects/binance uses for the bitcoin chain.
 const binanceToDefillama = {
   ETH: 'ethereum',
   BEP20: 'bsc',

--- a/projects/binance-peg-backing/index.js
+++ b/projects/binance-peg-backing/index.js
@@ -52,12 +52,17 @@ async function getLockAddresses(chain) {
   const networks = chainToNetworks[chain]
   const isEvm = evmChains.includes(chain)
   const lockInfoData = await getConfig('binance-peg-backing/lock-info', LOCK_INFO_ENDPOINT)
+  // getConfig falls back to the cached config when the endpoint is unavailable, and an
+  // adapter on its first run has no cache to fall back to - so the shape is not guaranteed.
+  const tokens = Array.isArray(lockInfoData?.tokens) ? lockInfoData.tokens : []
 
   const addresses = []
-  lockInfoData.tokens.forEach(token => {
-    (token.lockInfo || []).forEach(li => {
+  tokens.forEach(token => {
+    const locks = Array.isArray(token?.lockInfo) ? token.lockInfo : []
+    locks.forEach(li => {
+      if (typeof li?.network !== 'string' || typeof li?.address !== 'string') return
       if (!networks.includes(li.network.toUpperCase())) return
-      if (!li.address || /^[A-Z0-9]+-[A-Z0-9]+$/i.test(li.address)) return
+      if (/^[A-Z0-9]+-[A-Z0-9]+$/i.test(li.address)) return
       if (isEvm && (!/^0x[0-9a-fA-F]{40}$/.test(li.address))) return
       addresses.push(li.address)
     })

--- a/projects/binance/index.js
+++ b/projects/binance/index.js
@@ -141,15 +141,8 @@ const tvl = async (api) => {
   const evmChains = ['ethereum', 'bsc', 'celo', 'chz', 'polygon', 'arbitrum', 'optimism', 'avax', 'fantom', 'base', 'era', 'manta', 'ronin', 'op_bnb', 'scroll', 'sonic', 'plasma']
   const isEvm = evmChains.includes(chain)
 
-  const lockInfoAddresses = []
   const wrappedTokens = []
   lockInfoData.tokens.forEach(token => {
-    (token.lockInfo || []).forEach(li => {
-      if (!networks.includes(li.network.toUpperCase())) return
-      if (!li.address || /^[A-Z0-9]+-[A-Z0-9]+$/i.test(li.address)) return
-      if (isEvm && (!/^0x[0-9a-fA-F]{40}$/.test(li.address))) return
-      lockInfoAddresses.push(li.address)
-    });
     (token.wrapInfo || []).forEach(wi => {
       if (!networks.includes(wi.network.toUpperCase())) return
       if (!wi.address || /^[A-Z0-9]+-[A-Z0-9]+$/i.test(wi.address)) return
@@ -158,7 +151,7 @@ const tvl = async (api) => {
     })
   })
 
-  const owners = [...new Set([...contracts, ...lockInfoAddresses])]
+  const owners = [...new Set(contracts)]
 
   const binanceTokensOnChain = await getCEXTokensOnBinanceOnChain(chain)
   const options = buildConfig(chain, owners, binanceTokensOnChain, wrappedTokens)
@@ -173,7 +166,7 @@ chains.forEach((chain) => { chainExports[chain] = { tvl } })
 const ethStakedExport = { ethereum: { tvl: getStakedEthTVL({ withdrawalAddresses, size: 200, sleepTime: 20_000, proxy: true }) } }
 
 module.exports = mergeExports([chainExports, ethStakedExport])
-module.exports.methodology = 'All assets in wallets mentioned in Binance PoR api & wallets holding backing of binance pegged tokens are included in the tvl. We are not counting the Binance Recovery Fund wallet. On Ethereum, we also include staked ETH tracked via known withdrawal addresses.'
+module.exports.methodology = 'All assets in wallets mentioned in Binance PoR api are included in the tvl. Wallets holding the backing of Binance-Peg tokens are NOT included here - they back peg-token holders on other chains rather than exchange customer deposits, and are tracked separately (see projects/binance-peg-backing). We are not counting the Binance Recovery Fund wallet. On Ethereum, we also include staked ETH tracked via known withdrawal addresses.'
 
 module.exports.bitcoin = { tvl: bitcoinTvl }
 


### PR DESCRIPTION
## What this changes

`projects/binance/index.js` currently merges two different address sets into one `owners` list:

```js
const ENDPOINT = ".../apex/market/por/address"              // Binance PoR — customer reserves
const LOCK_INFO_ENDPOINT = ".../tokencanal/lockinfo"        // collateral backing Binance-Peg tokens
...
const owners = [...new Set([...contracts, ...lockInfoAddresses])]
```

This PR reports the second set under its own adapter (`projects/binance-peg-backing`) instead of folding it into the CEX entry.

**This is a methodology proposal, not a bug report.** The current behaviour is deliberate and documented — `module.exports.methodology` says "wallets holding backing of binance pegged tokens are included in the tvl". I'm proposing a different split, and it's entirely reasonable for you to decline.

## Why

The liabilities behind the two sets are different parties. PoR wallets back exchange customer deposits. The lockinfo wallets back **Binance-Peg token holders on the destination chain** — the same relationship a bridge has to its wrapped supply. The CEX page is read as "what the exchange holds against customer balances", and Binance's own PoR does not include these wallets, so the aggregator currently reports more than the exchange itself claims.

There's also an internal-consistency argument: DefiLlama already lists **"Binance Bitcoin"** (category *Bridge*, ~$5.4B) for the BTC backing Binance-Peg BTC. The same economic object on Ethereum/BSC/etc. is currently inside the CEX entry. This PR makes the non-BTC side match how you already treat the BTC side.

**Counter-argument, stated fairly:** these assets *are* controlled by Binance. If the CEX list is defined as "all assets the exchange controls", the current behaviour is self-consistent and this PR is unnecessary. That's your call, not mine — which is why this splits rather than deletes.

## Scope

Per-chain address counts (case-normalised, live endpoints):

| chain | PoR | lockinfo | overlap | net moved out |
|---|---|---|---|---|
| ethereum | 37 | 2 | 0 | **2** |
| bsc | 33 | 5 | 0 | **5** |
| tron / litecoin / ripple / solana / base / near / stellar | — | 1 each | 0 | 1 each |
| **doge** | 41 | 1 | **1** | **0** — already in PoR, unaffected |
| bitcoin | 61 | 1 | 0 | n/a — see below |

`bitcoin` is unaffected either way: `module.exports.bitcoin` overrides the generic path and uses `helper/bitcoin-book`, so lockinfo never reached it. The new adapter **deliberately excludes BTC** — that backing is already the "Binance Bitcoin" Bridge entry, and including it would double count. (It also cannot use the generic path: the lockinfo endpoint returns that wallet lowercased — `3lyjfcfhpxyjremsask2jkn69lweykzexb` — which fails Base58Check and 404s on explorers. The correct-case address is already in `helper/bitcoin-book` as `binance2`.)

`wrapInfo` handling is untouched — it is still read from the same endpoint and used as a blacklist so wrapped tokens are not double counted.

## Verification

New adapter, `node test.js projects/binance-peg-backing/index.js`:

```
ethereum   12.37 B
doge      179.73 M
near       27.28 M
tron       16.69 M
bsc            10.00
total      12.59 B
FAILED (1): solana — public RPC rate limit, environmental
```

The Ethereum figure is the two wallets `0x47ac0fb4…d503` and `0xffa69c00…5a5e`. Reading them straight off a public node (native ETH + USDT + USDC + USD1 only) gives **$12.11B**, consistent with the $12.37B the adapter reports across all default tokens.

Address-set change on `projects/binance/index.js`, ethereum: `owners` goes 39 → 37, and the removed entries are exactly the lockinfo ones.

**What I could not verify locally:** the end-to-end Binance CEX ethereum TVL delta. `mergeExports` pulls in `getStakedEthTVL`, which needs `RPC_PROXY_URL`; without it the ethereum leg fails on `main` and on this branch alike, so the total is unchanged in both local runs and I have no honest before/after number for it. Expect ethereum to drop by roughly the $12.37B above once it runs in your environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added tracking for Binance-Peg token backing wallets across supported blockchain networks.
  - Added chain-specific TVL reporting for backing assets across EVM, Solana, and non-EVM networks.
  - Added validation and filtering to improve the accuracy of reported backing-wallet data.

- **Bug Fixes**
  - Prevented Binance-Peg backing wallets from being counted twice in Binance TVL reporting.
  - Clarified TVL methodology by separating backing-asset tracking from the main Binance entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## New listing details

The CI flagged that this adds an adapter without the new-listing fields, so:

| field | value |
|---|---|
| **Name** | Binance-Peg Backing |
| **Category** | Bridge |
| **Chain(s)** | Ethereum, BSC, Tron, Doge, Near, Base, Stellar, Litecoin, Ripple, Solana, Polygon, Arbitrum, Optimism, Avalanche, Polkadot, Algorand, Aptos |
| **Current TVL** | ~$12.59B (Ethereum ~$12.37B) |
| **Website** | https://www.binance.com/en/busd (Binance-Peg token docs) |
| **Logo** | same as Binance — no new asset needed if it inherits, otherwise please tell me the format you want |
| **Short description** | Collateral Binance locks on native chains to back Binance-Peg tokens issued on other chains. |
| **Methodology** | Wallets published by Binance's `tokencanal/lockinfo` endpoint as the on-chain backing for Binance-Peg tokens. These back peg-token holders on the destination chain rather than exchange customer deposits, so they are reported separately from the Binance CEX entry. BTC is excluded — that backing is already listed as "Binance Bitcoin" (Bridge). |
| **Token** | none |
| **Audits / TVL breakdown** | n/a |
| **Twitter / Forked from / Oracles** | n/a |

I've marked *Bridge* to match how **"Binance Bitcoin"** is already categorised, since it's the same kind of object. If you'd rather this stayed inside the Binance CEX entry, that's a legitimate call and this PR should just be closed — the split is the proposal, not a defect claim.
