### PR TITLE
Twofold: count vTWO governance deposits as staking, price TWO via CoinGecko

### DIFF
--- a/projects/twofold/index.js
+++ b/projects/twofold/index.js
@@ -9,6 +9,11 @@ const REGISTRY = "0x1b66DD14C9281A18E696dbdb40cFB5070842c0C2";
 const TWO = "0x2A4a33A2163D005d8E7f1D9aC08d14c98db288d5";
 const STAKING_VAULT_V2 = "0x06E463fDa4BEb4aA096142E673240aB9719fB3A9";
 const TWO_STAKING_USDG = "0x9CF18bB1dD9AfBF75B579Cc0C473B2975c16E9e3";
+// vTWO is the 1:1 governance wrapper; the TWO it holds is locked for voting.
+const VTWO = "0x5c02401e945d86FB7109EC77F358498D6DA05950";
+// TWO is priced by CoinGecko (id twofold); its Robinhood Chain address is not in
+// the coins service, so every TWO balance is re-keyed to the CoinGecko id.
+const TWO_CG_ID = "twofold";
 const POSITION_LOCKER = "0x485690D46e344127aa2EB45D8d9BAcbb5856D58b";
 const GENESIS_POSITION_ID = 1076283;
 
@@ -24,6 +29,14 @@ const abi = {
   totalStaked: "function totalStaked() view returns (uint256)",
   getReserves: "function getReserves(tuple(address currency0, address currency1, uint24 fee, int24 tickSpacing, address hooks) key) view returns (uint256 token0, uint256 token1)",
 };
+
+function priceTwoViaCoinGecko(api) {
+  const key = Object.keys(api.getBalances()).find((k) => k.toLowerCase() === ("robinhood:" + TWO).toLowerCase());
+  if (!key) return;
+  const raw = api.getBalances()[key];
+  api.removeTokenBalance(TWO);
+  api.addCGToken(TWO_CG_ID, Number(raw) / 1e18);
+}
 
 function resolveKey(listing) {
   for (const tickSpacing of TICK_SPACINGS) {
@@ -52,17 +65,20 @@ async function tvl(api) {
 
   // The genesis TWO/WETH launch position (Uniswap v4 NFT) is permanently held by
   // PositionLocker, which has no transfer, decrease or burn path.
-  return sumTokens2({ api, owner: POSITION_LOCKER, resolveUniV4: true, uniV4ExtraConfig: { positionIds: [GENESIS_POSITION_ID] } });
+  await sumTokens2({ api, owner: POSITION_LOCKER, resolveUniV4: true, uniV4ExtraConfig: { positionIds: [GENESIS_POSITION_ID] } });
+  priceTwoViaCoinGecko(api);
 }
 
 async function stakingTvl(api) {
   const staked = await api.multiCall({ abi: abi.totalStaked, calls: [STAKING_VAULT_V2, TWO_STAKING_USDG] });
   staked.forEach((amount) => api.add(TWO, amount));
+  await sumTokens2({ api, owner: VTWO, tokens: [TWO] });
+  priceTwoViaCoinGecko(api);
 }
 
 module.exports = {
   methodology:
-    "TVL is the two-sided reserves of every active Twofold DualPool pool, read from the hook (getReserves) for each pool listed in the Twofold Registry, plus the permanently locked TWO/WETH genesis position in Uniswap v4. Staking is totalStaked TWO in the two staking vaults (StakingVaultV2 and TwoStakingUSDG); undistributed reward balances are excluded. Marked doublecounted because the hook keeps its reserves as ERC-6909 claims in the Uniswap v4 PoolManager and as deposits in the Steakhouse USDG vaults (Morpho), and the genesis position sits in a Uniswap v4 pool, all of which are counted by those listings.",
+    "TVL is the two-sided reserves of every active Twofold DualPool pool, read from the hook (getReserves) for each pool listed in the Twofold Registry, plus the permanently locked TWO/WETH genesis position in Uniswap v4. Staking is totalStaked TWO in the two staking vaults (StakingVaultV2 and TwoStakingUSDG) plus the TWO held by the vTWO governance wrapper; undistributed reward balances are excluded. Marked doublecounted because the hook keeps its reserves as ERC-6909 claims in the Uniswap v4 PoolManager and as deposits in the Steakhouse USDG vaults (Morpho), and the genesis position sits in a Uniswap v4 pool, all of which are counted by those listings.",
   doublecounted: true,
   start: "2026-08-28",
   robinhood: {

--- a/projects/twofold/index.js
+++ b/projects/twofold/index.js
@@ -11,9 +11,6 @@ const STAKING_VAULT_V2 = "0x06E463fDa4BEb4aA096142E673240aB9719fB3A9";
 const TWO_STAKING_USDG = "0x9CF18bB1dD9AfBF75B579Cc0C473B2975c16E9e3";
 // vTWO is the 1:1 governance wrapper; the TWO it holds is locked for voting.
 const VTWO = "0x5c02401e945d86FB7109EC77F358498D6DA05950";
-// TWO is priced by CoinGecko (id twofold); its Robinhood Chain address is not in
-// the coins service, so every TWO balance is re-keyed to the CoinGecko id.
-const TWO_CG_ID = "twofold";
 const POSITION_LOCKER = "0x485690D46e344127aa2EB45D8d9BAcbb5856D58b";
 const GENESIS_POSITION_ID = 1076283;
 
@@ -29,14 +26,6 @@ const abi = {
   totalStaked: "function totalStaked() view returns (uint256)",
   getReserves: "function getReserves(tuple(address currency0, address currency1, uint24 fee, int24 tickSpacing, address hooks) key) view returns (uint256 token0, uint256 token1)",
 };
-
-function priceTwoViaCoinGecko(api) {
-  const key = Object.keys(api.getBalances()).find((k) => k.toLowerCase() === ("robinhood:" + TWO).toLowerCase());
-  if (!key) return;
-  const raw = api.getBalances()[key];
-  api.removeTokenBalance(TWO);
-  api.addCGToken(TWO_CG_ID, Number(raw) / 1e18);
-}
 
 function resolveKey(listing) {
   for (const tickSpacing of TICK_SPACINGS) {
@@ -66,14 +55,12 @@ async function tvl(api) {
   // The genesis TWO/WETH launch position (Uniswap v4 NFT) is permanently held by
   // PositionLocker, which has no transfer, decrease or burn path.
   await sumTokens2({ api, owner: POSITION_LOCKER, resolveUniV4: true, uniV4ExtraConfig: { positionIds: [GENESIS_POSITION_ID] } });
-  priceTwoViaCoinGecko(api);
 }
 
 async function stakingTvl(api) {
   const staked = await api.multiCall({ abi: abi.totalStaked, calls: [STAKING_VAULT_V2, TWO_STAKING_USDG] });
   staked.forEach((amount) => api.add(TWO, amount));
   await sumTokens2({ api, owner: VTWO, tokens: [TWO] });
-  priceTwoViaCoinGecko(api);
 }
 
 module.exports = {


### PR DESCRIPTION
Follow-up to #20870 (Twofold, Robinhood Chain). Two changes to `projects/twofold/index.js`:

1. Staking now also counts the TWO held by the vTWO governance wrapper (`0x5c02401e945d86FB7109EC77F358498D6DA05950`), which locks TWO 1:1 for voting, alongside the two staking vaults.
2. TWO balances are re-keyed to `coingecko:twofold`. The token is listed on CoinGecko (id `twofold`) but the coins service has no entry for its Robinhood Chain address (`0x2A4a33A2163D005d8E7f1D9aC08d14c98db288d5`), so the merged adapter reported staking as 0 and dropped the TWO side of every pool. If you prefer to add the address mapping on your side instead, happy to drop that part.

`node test.js projects/twofold` output:

```
robinhood                 187.35 k
robinhood-staking         473.91 k
staking                   473.91 k
total                    187.35 k
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Staking TVL now includes TWO held by the vTWO governance wrapper.
- **Updates**
  - TVL and staking TVL methodology now reflects vTWO holdings.
  - TWO pricing is no longer sourced through the removed CoinGecko-based calculation path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->