### PR TITLE
Add Umbrae pool TVL on Base

### DIFF
--- a/projects/umbrae/index.js
+++ b/projects/umbrae/index.js
@@ -1,0 +1,65 @@
+const { sumTokens2 } = require('../helper/unwrapLPs')
+
+/**
+ * Umbrae runs two AMM designs on Base, both deployed from factories that expose
+ * the same enumeration surface (`allPairsLength()` / `allPairs(uint256)`) and
+ * whose pairs expose `tokenX()` / `tokenY()`:
+ *
+ *  - DLMM  — a Liquidity Book style discrete-bin concentrated-liquidity AMM.
+ *            Two generations are live: the original factory, which is paused
+ *            for trading but still open for LP withdrawals (so it still holds
+ *            user funds and must be counted), and the current v2 factory.
+ *  - DAMM  — a dynamic-fee constant-product AMM.
+ *
+ * In both designs the pair contract custodies the liquidity directly, so TVL is
+ * the pair's balance of its own two tokens.
+ */
+// `fromBlock` is each factory's own deployment block. TVL is also computed at
+// historical blocks where a later factory does not exist yet, and calling
+// `allPairsLength()` on an empty address reverts, so factories are filtered by
+// block before they are queried.
+const factories = [
+  { factory: '0x17Da44dcbdffD8c715be7A368E19F252C2940Fee', fromBlock: 43528312 }, // DLMM, original deployment (withdrawal-only)
+  { factory: '0x9DBB9289d0D75508b5D8EE01FfE4eb7c412F733b', fromBlock: 50392460 }, // DLMM v2
+  { factory: '0xD14322b444415d78DBBF646BB369Ec325a1aCD5c', fromBlock: 45693740 }, // DAMM v4
+]
+
+const abi = {
+  allPairsLength: 'uint256:allPairsLength',
+  allPairs: 'function allPairs(uint256) view returns (address)',
+  tokenX: 'address:tokenX',
+  tokenY: 'address:tokenY',
+}
+
+async function tvl(api) {
+  const tokensAndOwners = []
+  const block = await api.getBlock()
+
+  for (const { factory, fromBlock } of factories) {
+    if (block < fromBlock) continue
+
+    const pairs = await api.fetchList({
+      target: factory,
+      lengthAbi: abi.allPairsLength,
+      itemAbi: abi.allPairs,
+    })
+    const tokenX = await api.multiCall({ abi: abi.tokenX, calls: pairs })
+    const tokenY = await api.multiCall({ abi: abi.tokenY, calls: pairs })
+
+    pairs.forEach((pair, i) => {
+      tokensAndOwners.push([tokenX[i], pair])
+      tokensAndOwners.push([tokenY[i], pair])
+    })
+  }
+
+  return sumTokens2({ api, tokensAndOwners })
+}
+
+module.exports = {
+  methodology:
+    'TVL is the sum of both pair tokens held by every liquidity pool Umbrae has deployed on Base. Pools are enumerated on chain from the three pair factories (the original DLMM factory, which is paused for trading but still holds withdrawable LP funds; the current DLMM v2 factory; and the DAMM v4 factory) via allPairsLength()/allPairs(), and each pool contributes its own balance of tokenX and tokenY. DLMM is a Liquidity Book style discrete-bin concentrated-liquidity AMM and DAMM is a dynamic-fee constant-product AMM; in both, the pair contract custodies liquidity directly, so no LP unwrapping is required.',
+  start: 1773845971, // 2026-03-18, Base block 43528312 — first DLMM factory deployment
+  base: {
+    tvl,
+  },
+}

--- a/projects/umbrae/index.js
+++ b/projects/umbrae/index.js
@@ -31,6 +31,11 @@ const abi = {
   tokenY: 'address:tokenY',
 }
 
+/**
+ * Read pool token balances without calling factories before their deployment.
+ * @param {import('@defillama/sdk').ChainApi} api Snapshot-bound Base RPC client.
+ * @returns {Promise<object>} Underlying token balances for DefiLlama pricing.
+ */
 async function tvl(api) {
   const tokensAndOwners = []
   const block = await api.getBlock()


### PR DESCRIPTION
## Summary

Add Umbrae pool TVL on Base using on-chain factory enumeration and pair token balances. Covers the original DLMM factory (withdrawable liquidity and historical data), the current DLMM v2 factory, and DAMM v4. Factories are skipped before their deployment blocks so historical requests do not call undeployed contracts.

Only `projects/umbrae/index.js` is added. No dependencies or lockfiles changed. Companion volume/fees submission: https://github.com/DefiLlama/dimension-adapters/pull/9245

## New Listing Metadata

##### Name (to be shown on DefiLlama):
Umbrae

##### Twitter Link:
https://x.com/Umbrae_Ignis

##### List of audit links if any:
- Auditor listing: https://hashlock.com/audits/umbrae
- Smart contract audit: https://hashlock.com/wp-content/uploads/2025/09/Umbrae-Smart-Contract-Audit-Report-Final-Report-v2.pdf
- Penetration test: https://hashlock.com/wp-content/uploads/2025/09/Umbrae-Penetration-Test-Report-Final-Report-v4.pdf

These are separate report types. Linking them does not assert that every currently deployed contract version is in their scope.

##### Website Link:
https://umbrae.io

##### Logo (High resolution, will be shown with rounded borders):
https://umbrae.io/assets/umbrae/umbrae-512.png

##### Current TVL:
Approximately $162.29k on Base in the native adapter run on 2026-09-05. This is a dated measurement, not a fixed figure.

##### Treasury Addresses (if the protocol has treasury)
- Protocol-fee treasury (Base): `0x4247dba63CeD88B862c7578B77187AFf0C745014`
- LP treasury (Base): `0x8F3afDff5eD5d017aa7a21AEd4Fc847cBCDe58f5`

These addresses are metadata only. Their wallet balances are not added to this pool-TVL adapter.

##### Chain:
Base

##### Coingecko ID:
umbra-2-2

Verified against CoinGecko's `platforms.base`, which matches the U1 address below.

##### Coinmarketcap ID:

##### Short Description (to be shown on DefiLlama):
Umbrae is a DeFi trading platform on Base offering DLMM discrete-bin concentrated liquidity and DAMM dynamic-fee constant-product liquidity pools.

##### Token address and ticker if any:
U1 (Base): `0x14a4e80d633aF55Ace1160c320f5a36D41CCEd3E`

##### Category:
Dexs

##### Oracle Provider(s):
No external price-feed dependency in the core AMM swap-pricing paths. Chainlink is used separately for application USD pricing. DefiLlama pricing supplies the adapter's USD valuation.

##### Implementation Details:
DAMM quotes from pool reserves; DLMM quotes from discrete liquidity bins. Application ETH/USD pricing reads Chainlink `latestRoundData()` and is not an input to this adapter. Internal cumulative-price/bin observations are not external feeds.

##### Documentation/Proof:
- DAMM implementation: https://basescan.org/address/0x1d8752A8533668FBC49E4721790592f3111A3D0A#code
- DLMM v2 factory: https://basescan.org/address/0x9DBB9289d0D75508b5D8EE01FfE4eb7c412F733b#code
- Base Chainlink ETH/USD feed used by the application: https://basescan.org/address/0x71041dddad3595f9ced3dccfbe3d1f4b0a16bb70#code

##### forkedFrom (Does your project originate from another project):
DAMM is based on Uniswap V2 mechanics with a dynamic fee model. DLMM follows the Trader Joe Liquidity Book architecture and includes a bit-math helper adapted from Uniswap V3. We are disclosing these origins rather than claiming complete independence; we have not established a single upstream commit representing a wholesale fork. Please use the appropriate DefiLlama classification for these relationships.

##### methodology (what is being counted as tvl, how is tvl being calculated):
Enumerate pairs through `allPairsLength()` / `allPairs(uint256)` on three Base factories and sum each pair's balances of `tokenX()` and `tokenY()` using `sumTokens2`. The original DLMM remains included because its pools retain withdrawable liquidity. No LP-token staking positions, separate lock vaults, treasury-wallet balances, or other venues' liquidity are added. U1 held as underlying pool liquidity is included; its CoinGecko mapping is verified.

Factories and deployment blocks:
- Original DLMM: `0x17Da44dcbdffD8c715be7A368E19F252C2940Fee`, block `43528312`.
- DLMM v2: `0x9DBB9289d0D75508b5D8EE01FfE4eb7c412F733b`, block `50392460`.
- DAMM v4: `0xD14322b444415d78DBBF646BB369Ec325a1aCD5c`, block `45693740`.

##### Github org/user (Optional, if your code is open source, we can track activity):

##### Does this project have a referral program?
No DEX trading referral program was found in the AMM implementation or application paths inspected for this submission. This answer is scoped to the listed DEX, not separate Ignis Elite NFT products.

## Testing

Validation performed by GPT-6 Astra via opencode on 2026-09-05, using the native harness and a public Base RPC (no private service dependency):

```bash
env -i PATH="$PATH" HOME="$HOME" BASE_RPC=https://base-rpc.publicnode.com node test.js projects/umbrae/index.js
env -i PATH="$PATH" HOME="$HOME" BASE_RPC=https://base-rpc.publicnode.com node test.js projects/umbrae/index.js 2026-07-01
node node_modules/eslint/bin/eslint.js -c eslint.config.js projects/umbrae/index.js
git diff --cached --check
```

Native output summaries:

```text
Current:
------ TVL ------
base                      162.29 k
total                    162.29 k

2026-07-01 (before DLMM v2 deployment):
------ TVL ------
base                      148.32 k
total                    148.32 k

Both native tests: exit 0
ESLint: exit 0
Whitespace check: exit 0
No unknown-token warnings in either run.
```

The native harness emits Node's `punycode` deprecation warning. It does not affect the test result. Independent source review found no TVL accounting blocker. The separate reviewer bridge was unavailable due to its runner configuration; it is not represented as an approval.

Maintainer edits are enabled. Please review this as a new protocol listing; CoinMarketCap is intentionally blank because U1 is not listed there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added TVL tracking for Umbrae on Base.
  - Coverage includes liquidity pools across Umbrae’s supported pool deployments.
  - TVL calculations account for token balances held in pools, including funds remaining in the original paused trading deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Review Correction (7bea048)

Added JSDoc for the snapshot-bound TVL function to address the docstring warning. No runtime changes. GPT-6 Astra via opencode reran the native TVL test and ESLint: both exited 0. The new dated native output was Base/total 162.59 k with no unknown-token warnings. The earlier submission measurement above is retained as history, not a fixed current TVL.

```bash
env -i PATH="$PATH" HOME=/tmp/opencode BASE_RPC=https://base-rpc.publicnode.com node test.js projects/umbrae/index.js
node node_modules/eslint/bin/eslint.js -c eslint.config.js projects/umbrae/index.js
```
