### PR TITLE
Theo Network: add thUSD adapter, update thBILL reserves, request parent

### DIFF
--- a/projects/theo-network-thbill/index.js
+++ b/projects/theo-network-thbill/index.js
@@ -1,10 +1,28 @@
 const ADDRESSES = require('../helper/coreAssets.json')
-const { sumTokensExport } = require("../helper/unwrapLPs")
-const { getConnection } = require("../helper/solana")
-const { PublicKey } = require("@solana/web3.js")
+const { sumTokensExport } = require('../helper/unwrapLPs')
+const { getConnection } = require('../helper/solana')
+const { PublicKey } = require('@solana/web3.js')
 
+// Reserve wallets
+const BACKING     = '0xAECCa546baFB16735b273702632C8Cbb83509d8F' // thBILL backing wallet (EVM, all chains)
+const FILQ_WALLET = '0x8397ac82204352c8bafcbaa22e9674a4d638aee3' // FILQ-A holding wallet (Ethereum)
+
+// Ethereum reserve assets
+const ULTRA_ETH = '0x50293DD8889B931EB3441d2664dce8396640B419' // Delta Wellington Ultra Short Treasury Fund
+const FILQ_A    = '0x54a4fC78431F9201824643e99BeC891BB7462a1D' // Fidelity USD Digital Liquidity Fund (Acc)
+const aEthUSDC  = '0x98C23E9d8f34FEFb1B7BD6a91B7FF122F4e16F5c' // Aave v3
+const GTUSDCP   = '0x8c106eedad96553e64287a5a6839c3cc78afa3d0' // Morpho Gauntlet USDC Prime
+const GTUSDTP   = '0xf3557ad5e984211ac8a0874a670344f2c3376471' // Morpho Gauntlet USDT Prime
+const STEAKUSDT = '0xbeef003c68896c7d2c3c60d363e8d71a49ab2bf9' // Morpho Steakhouse USDT
+
+// Other chains
+const ULTRA_ARB    = '0xc26af85ede9cc25d449bcebef866bb85afd5d346'
+const GTUSDCP_BASE = '0x050ce30b927da55177a4914ec73480238bad56f0' // Morpho Gauntlet USDC Prime (Base)
+const aMonUSDC     = '0x35a73bacb179d3740395a3cecc87ff2e581d6042' // Aave v3 on Monad
+
+// Solana
 const ULTRA_TOKEN_ACCOUNT = '6fk5UwZXF1Zs327zV5Fbmay2xTYCqg7eM5QeNQyyu7ae'
-const ULTRA_MINT = '9DRPPWYud8i6CaSsDsFESs1xyVr8dBCMtjPZji2xiZEa'
+const ULTRA_MINT          = '9DRPPWYud8i6CaSsDsFESs1xyVr8dBCMtjPZji2xiZEa'
 
 async function solanaTvl(api) {
   const connection = getConnection()
@@ -16,13 +34,39 @@ async function solanaTvl(api) {
 }
 
 module.exports = {
+  doublecounted: true,
+  methodology:
+    'thBILL TVL is the value of the reserve assets held in the thBILL backing wallets: tokenized Treasury ' +
+    'fund shares (ULTRA, FILQ-A), stablecoins, and stablecoin lending positions (Aave v3, Morpho vaults) ' +
+    'across Ethereum, Arbitrum, Base, Monad and Solana. About 96% of thBILL supply is held as reserve by ' +
+    'thUSD (see Theo Network thUSD), so this adapter is flagged doublecounted under the Theo Network parent.',
+  hallmarks: [
+    ['2025-11-20', 'Reserve rotated into ULTRA on Ethereum, Arbitrum and Solana'],
+    ['2025-12-16', 'Aave v3 (Ethereum) added to reserve'],
+    ['2026-06-25', 'FILQ-A (Fidelity USD Digital Liquidity Fund) added to reserve'],
+    ['2026-08-06', 'Aave v3 on Monad added to reserve'],
+    ['2026-09-04', 'Solana ULTRA redeemed; USDC proceeds pending'],
+  ],
   ethereum: {
-    tvl: sumTokensExport({ owner: '0xAECCa546baFB16735b273702632C8Cbb83509d8F', tokens: ['0x50293DD8889B931EB3441d2664dce8396640B419', ADDRESSES.ethereum.USDC, '0x98C23E9d8f34FEFb1B7BD6a91B7FF122F4e16F5c'] })
+    tvl: sumTokensExport({
+      owners: [BACKING, FILQ_WALLET],
+      tokens: [
+        ULTRA_ETH, FILQ_A,
+        ADDRESSES.ethereum.USDC, ADDRESSES.ethereum.USDT,
+        aEthUSDC, GTUSDCP, GTUSDTP, STEAKUSDT,
+      ],
+    }),
   },
   arbitrum: {
-    tvl: sumTokensExport({ owner: '0xAECCa546baFB16735b273702632C8Cbb83509d8F', tokens: ['0xc26af85ede9cc25d449bcebef866bb85afd5d346',] })
+    tvl: sumTokensExport({ owner: BACKING, tokens: [ULTRA_ARB, ADDRESSES.arbitrum.USDC_CIRCLE] }),
+  },
+  base: {
+    tvl: sumTokensExport({ owner: BACKING, tokens: [ADDRESSES.base.USDC, GTUSDCP_BASE] }),
+  },
+  monad: {
+    tvl: sumTokensExport({ owner: BACKING, tokens: [aMonUSDC, ADDRESSES.monad.USDC] }),
   },
   solana: {
-    tvl: solanaTvl
+    tvl: solanaTvl,
   },
 }

--- a/projects/theo-network-thusd/index.js
+++ b/projects/theo-network-thusd/index.js
@@ -1,0 +1,48 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+const { sumTokens2 } = require('../helper/unwrapLPs')
+
+// thUSD: yield-bearing stablecoin backed by thBILL and a hedged physical-gold carry book.
+// TVL = circulating thUSD supply, built from the reserve side (same pattern as projects/ethena).
+const thUSD   = '0xa3fE5c7596024E6811E14F029937D5bd8Ae485b3' // 6 decimals
+const thBILL  = '0x5fa487bca6158c64046b2813623e20755091da0b' // 6 decimals, NAV via convertToAssets
+const RESERVE = '0xEc417Ccb6dD26868Cca993a92F37217b1D4b3c2f' // thUSD reserve wallet
+
+module.exports = {
+  methodology:
+    'thUSD TVL equals circulating thUSD supply, built from the reserve side. On-chain reserves held in the ' +
+    'thUSD reserve wallet — thBILL (valued at thBILL contract NAV via convertToAssets, not market price), ' +
+    'USDC and USDT — are reported as those assets. The remainder of supply is backed by physical gold ' +
+    'purchased and leased through StoneX and Monetary Metals and hedged with CME gold futures, and is ' +
+    'reported as thUSD. thBILL held in the reserve is also tracked by the Theo Network thBILL adapter, ' +
+    'which is flagged doublecounted under the Theo Network parent.',
+  hallmarks: [
+    ['2026-04-27', 'thUSD reserve migrated to current reserve wallet'],
+    ['2026-05-01', 'Gold carry strategy funded'],
+  ],
+  ethereum: {
+    tvl: async (api) => {
+      const supply = await api.call({ abi: 'erc20:totalSupply', target: thUSD })
+
+      // 1. Stablecoins held in the reserve wallet
+      await sumTokens2({
+        api,
+        owner: RESERVE,
+        tokens: [ADDRESSES.ethereum.USDC, ADDRESSES.ethereum.USDT],
+      })
+
+      // 2. thBILL held in the reserve, at contract NAV
+      const thbillBal = await api.call({ abi: 'erc20:balanceOf', target: thBILL, params: RESERVE })
+      const thbillUsdc = await api.call({
+        abi: 'function convertToAssets(uint256 shares) view returns (uint256)',
+        target: thBILL,
+        params: thbillBal,
+      })
+      api.add(ADDRESSES.ethereum.USDC, thbillUsdc)
+
+      // 3. Off-chain gold reserves = supply not covered by on-chain reserves
+      const onchainUsd = await api.getBalancesV2().getUSDValue()
+      const offchain = supply - onchainUsd * 1e6
+      if (offchain > 0) api.add(thUSD, offchain)
+    },
+  },
+}

--- a/projects/theo-network-thusd/index.js
+++ b/projects/theo-network-thusd/index.js
@@ -21,6 +21,8 @@ module.exports = {
   ],
   ethereum: {
     tvl: async (api) => {
+      // Every minted thUSD is issued to users: none is held in treasury or escrow, and staked
+      // thUSD sits in the sthUSD vault while remaining user-owned, so totalSupply is circulating supply.
       const supply = await api.call({ abi: 'erc20:totalSupply', target: thUSD })
 
       // 1. Stablecoins held in the reserve wallet
@@ -39,10 +41,11 @@ module.exports = {
       })
       api.add(ADDRESSES.ethereum.USDC, thbillUsdc)
 
-      // 3. Off-chain gold reserves = supply not covered by on-chain reserves
+      // 3. Off-chain gold reserves = the remainder of supply not covered by on-chain reserves.
+      //    Added unconditionally, as in projects/ethena, so the total is always exactly thUSD supply:
+      //    were on-chain reserves ever to exceed supply, this residual goes negative and nets it back down.
       const onchainUsd = await api.getBalancesV2().getUSDValue()
-      const offchain = supply - onchainUsd * 1e6
-      if (offchain > 0) api.add(thUSD, offchain)
+      api.add(thUSD, supply - onchainUsd * 1e6)
     },
   },
 }


### PR DESCRIPTION
## Summary

Two changes for Theo Network (https://theo.xyz):

1. **Update `theo-network-thbill`** (existing, id 6702). The reserve has rotated since listing; the adapter now includes the FILQ-A holding wallet, Aave v3 on Monad, Morpho vaults on Ethereum and Base, USDT, and Arbitrum/Base/Monad USDC. Adds `methodology` and `hallmarks`. Sets `doublecounted: true` because ~96% of thBILL supply is held as reserve by thUSD (below).
2. **Add `theo-network-thusd`** (new). TVL = circulating thUSD supply built from the reserve side, following the `projects/ethena` pattern: on-chain reserves (thBILL at contract NAV, USDC, USDT) reported as those assets; the off-chain gold-carry remainder reported as thUSD.

**Parent request:** please create `Theo Network` as a parent and attach both `theo-network-thbill` (6702) and `theo-network-thusd`. With thBILL flagged doublecounted, the parent nets to thUSD supply, matching how Ethena USDe/USDtb is presented.

Test output attached below.

---

## (Needs to be filled only for new listings) — theo-network-thusd

##### Name (to be shown on DefiLlama):
Theo Network thUSD

##### Twitter Link:
https://twitter.com/Theo_Network

##### List of audit links if any:
- Zellic (thUSD): https://github.com/Zellic/publications/blob/master/ThUSD%20-%20Zellic%20Audit%20Report.pdf
- Zenith (Tokenized Staking Vault): https://github.com/zenith-security/reports/blob/main/reports/Theo%20Tokenized%20Staking%20Vault%20-%20Zenith%20Audit%20Report.pdf
- Pashov (security review, 2026-03-19): https://github.com/pashov/audits/blob/master/team/pdf/Theo-security-review_2026-03-19.pdf

##### Website Link:
https://theo.xyz

##### Logo (High resolution, will be shown with rounded borders):
https://brand.theo.xyz/image/attachment%3Adb873bc3-3b3c-4a1d-a5f5-b7856df46722%3AthUSD.svg?id=3428e640-6108-80db-b154-eadae952cae7&table=block&spaceId=a80f455c-62b2-483c-8bb8-456a080435c3&userId=&cache=v2&imgBuildSrc=requestProxiedImageUrl

##### Current TVL:
~$136M

##### Treasury Addresses (if the protocol has treasury)


##### Chain:
Ethereum

##### Coingecko ID:
theo-usd

##### Coinmarketcap ID:


##### Short Description (to be shown on DefiLlama):
thUSD is a yield-bearing stablecoin backed by thBILL (tokenized U.S. Treasury exposure) and a hedged physical-gold carry strategy; yield accrues to holders who stake into sthUSD.

##### Token address and ticker if any:
thUSD 0xa3fE5c7596024E6811E14F029937D5bd8Ae485b3 · sthUSD (staked) 0xA808Bc9775cb41c52C7842f8b50427fE7A770326

##### Category (full list at https://defillama.com/categories) *Please choose only one:
RWA

##### Oracle Provider(s):
Chainlink (FILQ-A NAV feed); issuer NAV (ULTRA mint rate via UltraManager); thBILL contract NAV (convertToAssets)

##### Implementation Details:
thBILL held in the thUSD reserve is valued with the thBILL contract's convertToAssets, which derives from the underlying fund NAVs. Off-chain gold reserves are represented as the thUSD supply not covered by on-chain reserve assets.

##### Documentation/Proof:
https://docs.theo.xyz/products/thusd

##### forkedFrom:
—

##### methodology:
thUSD TVL equals circulating thUSD supply, built from the reserve side: on-chain reserves (thBILL at contract NAV, USDC, USDT in the reserve wallet 0xEc417Ccb6dD26868Cca993a92F37217b1D4b3c2f) are reported as those assets; the remainder, backed by hedged physical gold at StoneX and Monetary Metals, is reported as thUSD. thBILL in the reserve is also counted by the thBILL adapter, which is flagged doublecounted.

##### Github org/user (Optional):
theo-network

##### Does this project have a referral program?
No

---

## Test output

`node test.js projects/theo-network-thbill/index.js` (2026-09-05)

```
--- base ---
Total: 0.00

--- solana ---
Total: 0.00

--- monad ---
aMonUSDC                  13.59 M
Total: 13.59 M

--- arbitrum ---
ULTRA                     1.06
USDC                      0.21
Total: 1.27

--- ethereum ---
FILQ-A                    20.08 M
USDC                      6.71 k
Total: 20.08 M

------ TVL ------
ethereum                  20.08 M
monad                     13.59 M
arbitrum                  1.00
base                      0.00
solana                    0.00

total                    33.67 M
```

`node test.js projects/theo-network-thusd/index.js` (2026-09-05)

```
--- ethereum ---
thUSD                     77.67 M
USDC                      58.12 M
Total: 135.80 M

------ TVL ------
ethereum                  135.80 M

total                    135.80 M
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for Theo Network’s thUSD stablecoin using its circulating supply and reserve assets, including USDC, USDT, and thBILL.
  * Expanded thBILL TVL coverage across Ethereum, Arbitrum, Base, Monad, and Solana.
  * Added tracking for additional stablecoin, lending, and reserve token positions across supported networks.

* **Documentation**
  * Added methodology descriptions and protocol hallmarks for thBILL and thUSD.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->