### PR TITLE
[fix] bulk-trade - update TVL methodology for mainnet custody vault

### DIFF
--- a/registries/sumTokens/data1.js
+++ b/registries/sumTokens/data1.js
@@ -31,7 +31,7 @@ module.exports = {
   },
   "bulk-trade": {
     "timetravel": false,
-    "methodology": "Counts USDC deposited into the Bulk Trade Season 1 pre-deposits.",
+    "methodology": "Counts USDC held in BULK's Solana mainnet custody vault, which backs collateral deposited for trading and margin.",
     "solana": { "tokenAccounts": ["HwdwwKH1tMXo7ggTKcA5cdQrpcgqSoVib2eQh3BiyEQL"] }
   },
   "stakenova": {


### PR DESCRIPTION
## Summary

Updates the existing `bulk-trade` registry methodology after the 2026-09-05 mainnet launch. The tracked Solana USDC token account is unchanged; only the obsolete Season 1 pre-deposit wording changes.

- Website: https://www.bulk.trade/
- X: https://x.com/bulktrade
- Mainnet launch: https://x.com/bulktrade/status/2096229604654551302
- Live Solana custody vault: https://solscan.io/account/HwdwwKH1tMXo7ggTKcA5cdQrpcgqSoVib2eQh3BiyEQL
- Program source: https://github.com/Bulk-trade/bulk-program/blob/dbf07caa05dc3c2c095bfc7ee1852e3f4895bcf1/program/src/instructions/deposit.rs#L18-L40

The methodology now states that TVL is USDC held in BULK's Solana mainnet custody vault for trading and margin.

## Validation

- `node test.js bulk-trade`
- `npm run lint` (0 errors; one pre-existing warning in `projects/helper/dune.js`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the bulk-trade registry methodology description to clarify that it counts USDC held in BULK’s Solana custody vault, which supports trading and margin collateral.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->