### PR TITLE
mystic-finance: add flare and citrea vaults

### DIFF
--- a/projects/mystic-finance/index.js
+++ b/projects/mystic-finance/index.js
@@ -8,14 +8,36 @@ const config = {
       '0xBB748a1346820560875CB7a9cD6B46c203230E07'
     ],
   },
+  flare: {
+    morphoVaults: [
+      '0xE8dd6A1e13244A27bDaa19CcBf33013647C675d1',
+      '0x53184aDaBF312b490BF1EbcFdC896FEfF6019a14',
+      '0x1aEadA3C251215f1294720B80FcB3D1D005F3585'
+    ],
+  },
+  citrea: {
+    morphoVaults: [
+      '0x72f8C254548839Fa1Db4156aE01d8C6ae5885EE4',
+    ]
+  }
 }
 
 module.exports = {
   doublecounted: true,
-  plume_mainnet: { 
+  plume_mainnet: {
     tvl: getMorphoVaultTvl(undefined, {
-    vaults: config.plume_mainnet.morphoVaults,
-    morphoFactory: "0x2525D453D9BA13921D5aB5D8c12F9202b0e19456",
-    }), 
+      vaults: config.plume_mainnet.morphoVaults,
+      morphoFactory: "0x2525D453D9BA13921D5aB5D8c12F9202b0e19456",
+    }),
   },
+  flare: {
+    tvl: getMorphoVaultTvl(undefined, {
+      vaults: config.flare.morphoVaults,
+    }),
+  },
+  citrea: {
+    tvl: getMorphoVaultTvl(undefined, {
+      vaults: config.citrea.morphoVaults,
+    }),
+  }
 }


### PR DESCRIPTION
Adds Flare and Citrea coverage to the `mystic-finance` adapter (Mystic Finance Lending), which previously only counted Plume.

**Scope / why only these two chains:** Mystic operates white-label Morpho Stack deployments on emerging chains (Plume, Flare, Citrea). Its app also lists vaults on Morpho's canonical deployments (Ethereum, Base) — those vaults are indexed on app.morpho.org, belong to third-party curators (Gauntlet, Steakhouse, etc.), and are not Mystic TVL, so they are intentionally excluded.

**Added vaults:**
- Flare: `0xE8dd6A1e13244A27bDaa19CcBf33013647C675d1` (Core USDT0), `0x53184aDaBF312b490BF1EbcFdC896FEfF6019a14` (Core FXRP), `0x1aEadA3C251215f1294720B80FcB3D1D005F3585` (Core wFLR)
- Citrea: `0x72f8C254548839Fa1Db4156aE01d8C6ae5885EE4`

**Verification** — `node test.js projects/mystic-finance/index.js`:

```
flare            26.54 M
citrea           4.64 M
plume_mainnet    4.92 M
total            36.10 M
```

Matches the per-chain Total Deposits shown on app.mysticfinance.xyz (Flare ≈ $26.5M, Citrea ≈ $4.6M).

**Note:** `doublecounted: true` is kept — the Flare vaults are also counted under the Clearstar curator listing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for tracking Mystic Finance vaults on the Flare and Citrea networks.
  - Added TVL reporting for both newly supported networks.
  - Retained existing TVL tracking for the Plume network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->