### PR TITLE
expand AlphaGrowth TVL adapter

### DIFF
--- a/projects/alpha-growth/index.js
+++ b/projects/alpha-growth/index.js
@@ -7,6 +7,21 @@ const configs = getCuratorExport({
   blockchains: {
     base: {
       eulerVaultOwners: ["0x44102929B2248b1cefe2E65e9D580893B6D6823A"],
+      // AlphaGrowth Base AI: creator differs from the owner discovered above.
+      // https://github.com/euler-xyz/euler-labels/blob/master/8453/products.json
+      euler: [
+        "0x9F876520F1937D4B4f6F4DefE29fa5EA6d4526d0", // AERO
+        "0xC64FD6138f980a5587412dAC75E04363046aE32E", // WETH
+        "0xEef57677c2FC1a930eed234E3545e750C88f6743", // USDC
+      ],
+    },
+    ethereum: {
+      // Additional Mainnet RWA collateral vaults, absent from the sunset list.
+      // https://github.com/euler-xyz/euler-labels/blob/master/1/products.json
+      euler: [
+        "0x05E09415398659B19C5aeF202289270B37F1Fb31", // PAXG
+        "0xF81b08Cb4669049049B9C2A38c7D27d480655Bb3", // reUSDe
+      ],
     },
     unichain: {
       eulerVaultOwners: ["0x8d9fF30f8ecBA197fE9492A0fD92310D75d352B9"],


### PR DESCRIPTION
## What this PR does

Add the five officially attributed Euler vaults through the existing helper. Keep the separate sunset attribution/date intact.

## Why the current adapter is missing TVL

Base AI vaults use a creator missing from the existing allowlist. Ethereum PAXG/reUSDe vaults are also absent from the fixed EulerDAO-sunset transfer list.

## Estimated TVL added

$754,662 added; approximately +10.69% versus the saved DefiLlama snapshot. 

## Chains

linea, unichain, ethereum, base, monad. Added underlying tokens: PAXG, reUSDe, WETH, USDC, AERO.

## Contracts / programs and source of addresses

| Contract / fund | Chain | Address / explorer | Primary address source |
| --- | --- | --- | --- |
| AlphaGrowth Base AI | base | [0x9F876520F1937D4B4f6F4DefE29fa5EA6d4526d0](https://base.blockscout.com/address/0x9F876520F1937D4B4f6F4DefE29fa5EA6d4526d0) | [Official source](https://github.com/euler-xyz/euler-labels/blob/master/8453/products.json) |
| AlphaGrowth Base AI | base | [0xC64FD6138f980a5587412dAC75E04363046aE32E](https://base.blockscout.com/address/0xC64FD6138f980a5587412dAC75E04363046aE32E) | [Official source](https://github.com/euler-xyz/euler-labels/blob/master/8453/products.json) |
| AlphaGrowth Base AI | base | [0xEef57677c2FC1a930eed234E3545e750C88f6743](https://base.blockscout.com/address/0xEef57677c2FC1a930eed234E3545e750C88f6743) | [Official source](https://github.com/euler-xyz/euler-labels/blob/master/8453/products.json) |
| AlphaGrowth Mainnet RWA | ethereum | [0x05E09415398659B19C5aeF202289270B37F1Fb31](https://eth.blockscout.com/address/0x05E09415398659B19C5aeF202289270B37F1Fb31) | [Official source](https://github.com/euler-xyz/euler-labels/blob/master/1/products.json) |
| AlphaGrowth Mainnet RWA | ethereum | [0xF81b08Cb4669049049B9C2A38c7D27d480655Bb3](https://eth.blockscout.com/address/0xF81b08Cb4669049049B9C2A38c7D27d480655Bb3) | [Official source](https://github.com/euler-xyz/euler-labels/blob/master/1/products.json) |

## Methodology

Add the five officially attributed Euler vaults through the existing helper.

## Double-counting considerations

Count curator vault AUM using the existing Euler pattern; 

## Test results

Command: `node test.js projects/alpha-growth/index.js`.

## Official documentation / app comparison

- [Official Base market labels](https://github.com/euler-xyz/euler-labels/blob/master/8453/products.json)
- [Official Ethereum RWA market labels](https://github.com/euler-xyz/euler-labels/blob/master/1/products.json)
- [EulerDAO sunset context](https://forum.euler.finance/t/sunsetting-of-dao-managed-market-and-vaults/1828)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded AlphaGrowth vault coverage on Base for AERO, WETH, and USDC AI vaults.
  - Added Ethereum Mainnet support for RWA collateral vaults, including PAXG and reUSDe.
  - Vault address listings are now organized by blockchain for more accurate curator exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->