### PR TITLE
Add Nullark TVL adapter

### DIFF
--- a/projects/nullark/index.js
+++ b/projects/nullark/index.js
@@ -1,0 +1,25 @@
+const POOL = '0xf2F67b5Cbf2dEfCB447218ef903bE6AeF5fb2995'
+const DEPLOYMENT_BLOCK = 53812864n
+
+async function tvl(api) {
+  if (api.block !== undefined && BigInt(api.block) < DEPLOYMENT_BLOCK) return
+
+  const [deposited, withdrawn, accruedFees] = await Promise.all([
+    api.call({ target: POOL, abi: 'uint256:totalDepositedAccounting' }),
+    api.call({ target: POOL, abi: 'uint256:totalWithdrawnAccounting' }),
+    api.call({ target: POOL, abi: 'uint256:accruedProtocolFees' }),
+  ])
+
+  const depositedWei = BigInt(deposited)
+  const withdrawnAndFeesWei = BigInt(withdrawn) + BigInt(accruedFees)
+  if (withdrawnAndFeesWei > depositedWei)
+    throw new Error('Nullark accounting exceeds deposits')
+
+  api.addGasToken(depositedWei - withdrawnAndFeesWei)
+}
+
+module.exports = {
+  methodology:
+    'Native ETH principal represented by unspent Nullark notes, calculated as cumulative deposits minus cumulative net withdrawals and cumulative protocol fees. Protocol fees and excess ETH are excluded.',
+  robinhood: { tvl },
+}

--- a/projects/nullark/index.js
+++ b/projects/nullark/index.js
@@ -1,25 +1,16 @@
 const POOL = '0xf2F67b5Cbf2dEfCB447218ef903bE6AeF5fb2995'
-const DEPLOYMENT_BLOCK = 53812864n
 
 async function tvl(api) {
-  if (api.block !== undefined && BigInt(api.block) < DEPLOYMENT_BLOCK) return
+  const bal = BigInt(await api.getEthBalance(POOL))
+  const accruedFees = BigInt(await api.call({ target: POOL, abi: 'uint256:accruedProtocolFees' }))
 
-  const [deposited, withdrawn, accruedFees] = await Promise.all([
-    api.call({ target: POOL, abi: 'uint256:totalDepositedAccounting' }),
-    api.call({ target: POOL, abi: 'uint256:totalWithdrawnAccounting' }),
-    api.call({ target: POOL, abi: 'uint256:accruedProtocolFees' }),
-  ])
+  if (bal < accruedFees) throw new Error('Nullark fees exceeds balance')
 
-  const depositedWei = BigInt(deposited)
-  const withdrawnAndFeesWei = BigInt(withdrawn) + BigInt(accruedFees)
-  if (withdrawnAndFeesWei > depositedWei)
-    throw new Error('Nullark accounting exceeds deposits')
-
-  api.addGasToken(depositedWei - withdrawnAndFeesWei)
+  api.addGasToken(bal - accruedFees)
 }
 
 module.exports = {
-  methodology:
-    'Native ETH principal represented by unspent Nullark notes, calculated as cumulative deposits minus cumulative net withdrawals and cumulative protocol fees. Protocol fees and excess ETH are excluded.',
+  methodology: 'Native ETH principal represented by unspent Nullark notes, calculated as pool native balance minus accrued protocol fees.',
+  start: '2026-09-03',
   robinhood: { tvl },
 }


### PR DESCRIPTION
Nullark (https://nullark.com) is a fixed-denomination shielded ETH pool on Robinhood Chain. It uses Groth16 proofs and bundle-child notes: one public commitment can contain two independently spendable private child notes, each with its own secret and nullifier.

Pool: `0xf2F67b5Cbf2dEfCB447218ef903bE6AeF5fb2995`

The adapter reports shielded native ETH principal from on-chain accounting while excluding accrued protocol fees and unsolicited excess ETH.

Twitter: https://x.com/nullarkcom

Validated with `node test.js projects/nullark/index.js`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Updates**
  - Nullark TVL is now calculated from the pool’s actual native ETH balance, after accounting for accrued protocol fees.
  - TVL reporting now includes the resulting gas-token balance.
  - Historical tracking now begins from a defined start timestamp.
  - Reporting raises an error when accrued fees exceed the pool’s native ETH balance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->