### PR TITLE
expand Galaxy TVL adapter

### DIFF
--- a/registries/curators.js
+++ b/registries/curators.js
@@ -574,6 +574,9 @@ const configs = {
       blockchains: {
         ethereum: {
           morphoVaultOwners: ["0x42D510eDeb9257f8D920d5B9f5109D95cB22419d"],
+          morpho: [
+            '0xd95fE7adF5075fad9D6Bf853E0f9Fe53369E8D96', // Galaxy USDC Enhanced; deployed by a different initial owner
+          ],
         },
         base: {
           morphoVaultOwners: ["0x42D510eDeb9257f8D920d5B9f5109D95cB22419d"],


### PR DESCRIPTION
## What this PR does

Add the verified vault explicitly to ethereum.morpho. Do not allowlist the other initial owner globally: it also created other stuff.

## Why the current adapter is missing TVL

The existing factory discovery only includes creation events whose initial owner is 0x42D510eDeb9257f8D920d5B9f5109D95cB22419d. This vault has that current owner but was created with initial owner 0x4cd8558Edd19A79b432eF88b351d9aEF0a2C0E04, so it is omitted.

## Estimated TVL added

Approximately $8,048,209.

## Chains

ethereum, base. Only Ethereum coverage is changed.

## Contracts / programs and source of addresses

https://app.morpho.org/ethereum/vault/0xd95fE7adF5075fad9D6Bf853E0f9Fe53369E8D96/galaxy-usdc-enhanced?tab=vault#overview


## Test results

Command: `node test.js galaxy`. Baseline: 69 M; patched: 77. M.
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Galaxy USDC Enhanced vault to the tracked Ethereum Morpho vaults.
  * The vault is now included in the Galaxy curator configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->