### PR TITLE
Add/mt pelerin tvl

### DIFF
--- a/registries/curators.js
+++ b/registries/curators.js
@@ -760,6 +760,20 @@ const configs = {
       },
     },
   },
+  "mt-pelerin": {
+    config: {
+      methodology: 'Sum settled underlying assets in the Mt Pelerin USD, ETH and BTC strategy pools on Lagoon. Brokerage volume and company equity are not TVL.',
+      blockchains: {
+        ethereum: {
+          erc4626: [
+            '0x28663161f9fa2963eb6102b88a741e195e974df6', // USD
+            '0xb118de4917f4bac5c3a453ea8de915a7cd84891c', // ETH
+            '0xbc6a48b30405cc1660627d8dfb3872505f14bca0', // BTC
+          ],
+        },
+      },
+    },
+  },
   "muscadine": {
     config: {
       methodology: 'Counts all assets deposited in all vaults curated by Muscadine.',

--- a/registries/curators.js
+++ b/registries/curators.js
@@ -762,7 +762,7 @@ const configs = {
   },
   "mt-pelerin": {
     config: {
-      methodology: 'Sum settled underlying assets in the Mt Pelerin USD, ETH and BTC strategy pools on Lagoon. Brokerage volume and company equity are not TVL.',
+      methodology: 'Sum settled underlying assets in the Mt Pelerin USD, ETH and BTC strategy pools on Lagoon.',
       blockchains: {
         ethereum: {
           erc4626: [


### PR DESCRIPTION
## What this PR does

Add the officially attributed fund addresses to the existing curator registry. 

## Estimated TVL added

$1,78 million net attributable curator TVL. Snapshot.

## Chains

ethereum. Added underlying tokens: USDC, WETH, WBTC.

## Contracts / programs and source of addresses

| Contract / fund | Chain | Address / explorer | Primary address source |
| --- | --- | --- | --- |
| Mt Pelerin – USD strategy pool | ethereum | [0x28663161f9fa2963eb6102b88a741e195e974df6](https://eth.blockscout.com/address/0x28663161f9fa2963eb6102b88a741e195e974df6) | [Official source](https://app.lagoon.finance/vault/1/0x28663161f9fa2963eb6102b88a741e195e974df6) |
| Mt Pelerin – ETH strategy pool | ethereum | [0xb118de4917f4bac5c3a453ea8de915a7cd84891c](https://eth.blockscout.com/address/0xb118de4917f4bac5c3a453ea8de915a7cd84891c) | [Official source](https://app.lagoon.finance/vault/1/0xb118de4917f4bac5c3a453ea8de915a7cd84891c) |
| Mt Pelerin – BTC strategy pool | ethereum | [0xbc6a48b30405cc1660627d8dfb3872505f14bca0](https://eth.blockscout.com/address/0xbc6a48b30405cc1660627d8dfb3872505f14bca0) | [Official source](https://app.lagoon.finance/vault/1/0xbc6a48b30405cc1660627d8dfb3872505f14bca0) |

## Methodology

Add the officially attributed fund addresses to the existing curator  registry.

## Test results

Command: `node test.js mt-pelerin`.

------ TVL ------
ethereum                  1.78 M

total                    1.78 M

## Official documentation / app comparison
https://app.lagoon.finance/?curator=curator%3Amt-pelerin

## New listing metadata

- Name: Mt Pelerin
- Website: https://www.mtpelerin.com
- Category: Risk Curators
- Description: Mt Pelerin, active in self-custodial crypto-fiat exchange services.
- Chains: ethereum
- Logo: https://cdn.lagoon.finance/curators/mt-pelerin
- Governance token / ticker: none proposed; vault receipt symbols are not additional TVL.
- Treasury: not part of this TVL contribution.
- Website : https://www.mtpelerin.com/
- X: https://x.com/mtpelerin
- Referral program:  yes https://www.mtpelerin.com/fr/inviter 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking Mt Pelerin USD, ETH, and BTC strategy pools on Lagoon.
  * Added Ethereum ERC-4626 vault tracking for the associated assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->