### PR TITLE
expand Steakhouse TVL adapter

### DIFF
--- a/registries/curators.js
+++ b/registries/curators.js
@@ -1090,6 +1090,7 @@ const configs = {
             '0xec0Caa2CbAe100CEAaC91A665157377603a6B766', // v2 USDT/ETH/AUSD
           ],
           morpho: [
+            '0xbEEF00A59B577423653A1526c7009bdE103F542B', // Steakhouse Confidential Prime USDC
             '0x6cbF3Eed95976D226FFB0bEb09550A9407f47b60', // Steakhouse High Yield ETH
             '0xbeef003E31546C7210687f1A7b40d096BE83ec58', // Steakhouse Prime EURC
             '0xbeef009FF4FB1727297BF2526806F4A73E4b99aD', // Steakhouse Prime frxUSD


### PR DESCRIPTION
## What this PR does

Add this verified vault to the existing ethereum morpho list. Keep discovery and all other chains unchanged.

## Why the current adapter is missing TVL

The factory discovery filters the owner recorded at deployment. This vault was deployed with initial owner 0x25fc16504b809Ff3c730000544B8583011eE7545, which is absent from the existing owner allowlist. 

## Estimated TVL added

Approximately $39 Millions

## Chains

Only Ethereum coverage is changed.

## Contracts / programs and source of addresses

- [0xbEEF00A59B577423653A1526c7009bdE103F542B](https://etherscan.io/address/0xbEEF00A59B577423653A1526c7009bdE103F542B#code)

- [Official vault dashboard](https://app.steakhouse.financial/earn/1/0xbEEF00A59B577423653A1526c7009bdE103F542B/steakhouse-confidential-prime-usdc)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Steakhouse Confidential Prime USDC vault to the Steakhouse curator’s Ethereum registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->