### PR TITLE
feat: add Robinhood Chain to Bonker TVL

### DIFF
--- a/projects/bonker/index.js
+++ b/projects/bonker/index.js
@@ -2,9 +2,30 @@ const { getLogs2 } = require('../helper/cache/getLogs')
 const { sumTokens2 } = require('../helper/unwrapLPs')
 const ADDRESSES = require('../helper/coreAssets.json')
 
-const LP_LOCKER = '0xBf05b1d5E356f3219D0086A4e09c969ADbe2e7d0'
-const POSITION_MANAGER = '0x7C5f5A4bBd8fD63184577525326123B519429bDc'
-const START_BLOCK = 43_000_832
+const CONFIG = {
+  base: {
+    lpLockers: [
+      {
+        address: '0xBf05b1d5E356f3219D0086A4e09c969ADbe2e7d0',
+        startBlock: 43_000_832,
+      },
+    ],
+    positionManager: '0x7C5f5A4bBd8fD63184577525326123B519429bDc',
+    weth: ADDRESSES.base.WETH,
+  },
+  robinhood: {
+    // Existing positions remain owned by this locker after its successor is deployed,
+    // so historical lockers must stay in the list when a new one is added.
+    lpLockers: [
+      {
+        address: '0xae2a15309cd4401AF710CE014ec61246a7706B08',
+        startBlock: 53_621_593,
+      },
+    ],
+    positionManager: '0x58daec3116aae6d93017baaea7749052e8a04fa7',
+    weth: ADDRESSES.robinhood.WETH,
+  },
+}
 
 const TOKEN_REWARD_ADDED_EVENT =
   'event TokenRewardAdded(address token, (address currency0, address currency1, uint24 fee, int24 tickSpacing, address hooks) poolKey, uint256 poolSupply, uint256 positionId, uint256 numPositions, uint16[] rewardBps, address[] rewardAdmins, address[] rewardRecipients, int24[] tickLower, int24[] tickUpper, uint16[] positionBps)'
@@ -12,33 +33,38 @@ const TOKEN_REWARD_ADDED_EVENT =
 const OWNER_OF_ABI = 'function ownerOf(uint256 tokenId) view returns (address)'
 
 const tvl = async (api) => {
-  const launches = await getLogs2({
-    api,
-    target: LP_LOCKER,
-    eventAbi: TOKEN_REWARD_ADDED_EVENT,
-    fromBlock: START_BLOCK,
-  })
-
-  const positionIds = [
-    ...new Set(
-      launches.flatMap(({ positionId, numPositions }) =>
-        Array.from({ length: Number(numPositions) }, (_, i) =>
-          (BigInt(positionId) + BigInt(i)).toString(),
+  const config = CONFIG[api.chain]
+  const positionIdsByLocker = await Promise.all(
+    config.lpLockers.map(async ({ address, startBlock }) => {
+      const launches = await getLogs2({
+        api,
+        target: address,
+        eventAbi: TOKEN_REWARD_ADDED_EVENT,
+        fromBlock: startBlock,
+      })
+      const positionIds = [
+        ...new Set(
+          launches.flatMap(({ positionId, numPositions }) =>
+            Array.from({ length: Number(numPositions) }, (_, i) =>
+              (BigInt(positionId) + BigInt(i)).toString(),
+            ),
+          ),
         ),
-      ),
-    ),
-  ]
-  if (!positionIds.length) return {}
+      ]
+      if (!positionIds.length) return []
 
-  const owners = await api.multiCall({
-    target: POSITION_MANAGER,
-    abi: OWNER_OF_ABI,
-    calls: positionIds,
-    permitFailure: true,
-  })
-  const lockedPositionIds = positionIds.filter(
-    (_, i) => owners[i]?.toLowerCase() === LP_LOCKER.toLowerCase(),
+      const owners = await api.multiCall({
+        target: config.positionManager,
+        abi: OWNER_OF_ABI,
+        calls: positionIds,
+        permitFailure: true,
+      })
+      return positionIds.filter(
+        (_, i) => owners[i]?.toLowerCase() === address.toLowerCase(),
+      )
+    }),
   )
+  const lockedPositionIds = [...new Set(positionIdsByLocker.flat())]
   if (!lockedPositionIds.length) return {}
 
   return sumTokens2({
@@ -46,15 +72,16 @@ const tvl = async (api) => {
     resolveUniV4: true,
     uniV4ExtraConfig: {
       positionIds: lockedPositionIds,
-      whitelistedTokens: [ADDRESSES.base.WETH],
+      whitelistedTokens: [config.weth],
     },
   })
 }
 
 module.exports = {
   methodology:
-    'Counts the WETH side of Uniswap V4 liquidity positions created by the Bonker factory and permanently held by the Bonker LP locker. Positions are enumerated on-chain from TokenRewardAdded events, and launchpad-minted tokens are excluded to avoid circular pricing.',
+    'Counts the WETH side of Uniswap V4 liquidity positions created by the Bonker factory on Base and Robinhood Chain and permanently held by Bonker LP lockers. Positions are enumerated on-chain from TokenRewardAdded events, and launchpad-minted tokens are excluded to avoid circular pricing.',
   start: '2026-03-06',
   doublecounted: true,
   base: { tvl },
+  robinhood: { tvl },
 }


### PR DESCRIPTION
## Summary

Extends the existing Bonker TVL adapter from Base to Robinhood Chain (chain ID 4663). This is an update to the existing listing, not a second Bonker protocol submission.

## Robinhood Chain configuration

- LP locker: [`0xae2a15309cd4401AF710CE014ec61246a7706B08`](https://robinhoodchain.blockscout.com/address/0xae2a15309cd4401AF710CE014ec61246a7706B08)
- Uniswap v4 Position Manager: [`0x58daec3116aae6d93017baaea7749052e8a04fa7`](https://robinhoodchain.blockscout.com/address/0x58daec3116aae6d93017baaea7749052e8a04fa7)
- WETH: [`0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73`](https://robinhoodchain.blockscout.com/address/0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73)
- Scan start: block `53,621,593` (Bonker factory deployment, 2026-09-03)

## Methodology

The adapter discovers Bonker-created Uniswap v4 positions from each LP locker's on-chain `TokenRewardAdded` events, confirms that each position NFT is still owned by that locker, and counts only the WETH side. Bonker-launched tokens remain excluded to avoid circular pricing. TVL remains marked `doublecounted` because this liquidity may also be attributed to Uniswap.

The configuration intentionally stores lockers as a list. Existing positions remain owned by their historical locker after a successor is deployed, so an old locker must not be replaced in-place.

## Validation

`node test.js projects/bonker/index.js 2026-09-05`

- Base: approximately $1.34k
- Robinhood Chain: approximately $1.52
- Aggregate: approximately $1.35k
- ESLint and `git diff --check`: passed
- No package or lockfile changes

A current Robinhood-only read also returned approximately $42.81 before the Base RPC providers briefly disagreed with the indexed head by several blocks.

## Draft status

Robinhood's current locker remains the owner of the positions counted here, but Bonker has a successor locker redeploy planned because the current locker's fee-conversion route is incompatible with this chain's forked Universal Router. Keep this PR in draft until the successor address is known; then append it to `lpLockers` (without removing the historical locker) and rerun validation.