### PR TITLE
Add ArcX listing and Starknet TVL adapter

### DIFF
--- a/projects/arcx-trade/index.js
+++ b/projects/arcx-trade/index.js
@@ -1,0 +1,176 @@
+const axios = require('axios')
+const { hash } = require('starknet')
+
+const CONFIGURED_STARKNET_RPC = process.env.STARKNET_RPC
+const STARKNET_RPC = !CONFIGURED_STARKNET_RPC || CONFIGURED_STARKNET_RPC.includes('rpc.starknet.lava.build')
+  ? 'https://api.cartridge.gg/x/starknet/mainnet'
+  : CONFIGURED_STARKNET_RPC
+const REGISTRY = '0x37ad81bcfa789e849216f5ea973c6ac22b5c9cdb05c29e9d5667252440d8300'
+const REGISTRY_DEPLOYMENT_BLOCK = 10474202
+const START = 1780637758 // 2026-06-05 05:35:58 UTC, first non-zero ArcX TVL
+const ETHEREUM_LZ_EID = 30101
+
+const VTOKEN_ADDED = hash.getSelectorFromName('VTokenAdded')
+const OMNICHAIN_VTOKEN_ADDED = hash.getSelectorFromName('OmnichainVTokenAdded')
+
+let requestId = 0
+let registryEventsPromise
+const timestampBlockPromises = new Map()
+
+async function rpc(method, params) {
+  const { data } = await axios.post(STARKNET_RPC, {
+    jsonrpc: '2.0',
+    id: ++requestId,
+    method,
+    params,
+  })
+
+  if (data.error) throw new Error(data.error.message)
+  return data.result
+}
+
+async function getBlockTimestamp(blockNumber) {
+  const block = await rpc('starknet_getBlockWithTxHashes', [{ block_number: blockNumber }])
+  return block.timestamp
+}
+
+async function findBlockAtOrBefore(timestamp) {
+  let low = REGISTRY_DEPLOYMENT_BLOCK
+  let high = await rpc('starknet_blockNumber', [])
+
+  if (timestamp < await getBlockTimestamp(low)) return null
+  if (timestamp >= await getBlockTimestamp(high)) return high
+
+  while (low < high) {
+    const middle = Math.ceil((low + high) / 2)
+    if (await getBlockTimestamp(middle) <= timestamp) low = middle
+    else high = middle - 1
+  }
+
+  return low
+}
+
+function getBlockAtOrBefore(timestamp) {
+  if (!timestampBlockPromises.has(timestamp))
+    timestampBlockPromises.set(timestamp, findBlockAtOrBefore(timestamp))
+
+  return timestampBlockPromises.get(timestamp)
+}
+
+async function starknetCall(contractAddress, entrypoint, blockNumber) {
+  return rpc('starknet_call', [
+    {
+      contract_address: contractAddress,
+      entry_point_selector: hash.getSelectorFromName(entrypoint),
+      calldata: [],
+    },
+    { block_number: blockNumber },
+  ])
+}
+
+function parseUint256(result) {
+  return BigInt(result[0] ?? 0) + (BigInt(result[1] ?? 0) << 128n)
+}
+
+function normalizeFelt(value) {
+  return `0x${BigInt(value).toString(16)}`
+}
+
+function normalizeEvmAddress(value) {
+  return `0x${BigInt(value).toString(16).padStart(40, '0')}`
+}
+
+async function fetchRegistryEvents() {
+  const events = []
+  let continuationToken
+
+  do {
+    const filter = {
+      from_block: { block_number: REGISTRY_DEPLOYMENT_BLOCK },
+      to_block: 'latest',
+      address: REGISTRY,
+      keys: [[VTOKEN_ADDED, OMNICHAIN_VTOKEN_ADDED]],
+      chunk_size: 1000,
+    }
+
+    if (continuationToken) filter.continuation_token = continuationToken
+
+    const page = await rpc('starknet_getEvents', [filter])
+    events.push(...page.events)
+    continuationToken = page.continuation_token
+  } while (continuationToken)
+
+  return events.map((event) => {
+    if (BigInt(event.keys[0]) === BigInt(VTOKEN_ADDED)) {
+      return {
+        type: 'legacy',
+        block: event.block_number,
+        vToken: normalizeFelt(event.keys[1]),
+      }
+    }
+
+    return {
+      type: 'omnichain',
+      block: event.block_number,
+      vToken: normalizeFelt(event.keys[1]),
+      asset: normalizeEvmAddress(event.keys[3]),
+      adapter: normalizeEvmAddress(event.data[0]),
+      lzEid: Number(BigInt(event.data[2])),
+    }
+  })
+}
+
+function getRegistryEvents() {
+  if (!registryEventsPromise) registryEventsPromise = fetchRegistryEvents()
+  return registryEventsPromise
+}
+
+async function starknetTvl(api) {
+  const block = api.block ?? await getBlockAtOrBefore(api.timestamp)
+  if (block === null) return
+
+  const events = await getRegistryEvents()
+  const vaults = events.filter(({ type, block: eventBlock }) =>
+    type === 'legacy' && eventBlock <= block)
+
+  const balances = await Promise.all(vaults.map(async ({ vToken }) => {
+    const [assetResult, totalAssetsResult] = await Promise.all([
+      starknetCall(vToken, 'asset', block),
+      starknetCall(vToken, 'total_assets', block),
+    ])
+
+    return {
+      asset: normalizeFelt(assetResult[0]),
+      amount: parseUint256(totalAssetsResult),
+    }
+  }))
+
+  balances.forEach(({ asset, amount }) => api.add(asset, amount))
+}
+
+async function ethereumTvl(api) {
+  const starknetBlock = await getBlockAtOrBefore(api.timestamp)
+  if (starknetBlock === null) return
+
+  const events = await getRegistryEvents()
+  const vaults = events.filter(({ type, block, lzEid }) =>
+    type === 'omnichain' && block <= starknetBlock && lzEid === ETHEREUM_LZ_EID)
+
+  if (!vaults.length) return
+
+  const availableBacking = await api.multiCall({
+    abi: 'uint256:availableBacking',
+    calls: vaults.map(({ adapter }) => adapter),
+  })
+
+  vaults.forEach(({ asset }, index) => api.add(asset, availableBacking[index]))
+}
+
+module.exports = {
+  start: START,
+  timetravel: true,
+  doublecounted: true,
+  methodology: 'Discovers ArcX vaults from VTokenAdded and OmnichainVTokenAdded events emitted by the ArcX Registry. For legacy Starknet vaults, TVL is each vToken total_assets balance denominated in its underlying asset. For omnichain Ethereum vaults, TVL is the source-chain asset held as availableBacking by each registered OFT adapter. ST, EPT, and destination-chain vToken supplies are excluded because they are derivative claims on those same assets. Legacy vault capital is deployed through Wildcat, so this TVL is marked as double-counted with Wildcat.',
+  starknet: { tvl: starknetTvl },
+  ethereum: { tvl: ethereumTvl },
+}

--- a/projects/arcx-trade/index.js
+++ b/projects/arcx-trade/index.js
@@ -1,6 +1,5 @@
 const axios = require('axios')
 const { hash } = require('starknet')
-const BigNumber = require('bignumber.js')
 
 const CONFIGURED_STARKNET_RPC = process.env.STARKNET_RPC
 const STARKNET_RPC = !CONFIGURED_STARKNET_RPC || CONFIGURED_STARKNET_RPC.includes('rpc.starknet.lava.build')
@@ -8,8 +7,6 @@ const STARKNET_RPC = !CONFIGURED_STARKNET_RPC || CONFIGURED_STARKNET_RPC.include
   : CONFIGURED_STARKNET_RPC
 const REGISTRY = '0x37ad81bcfa789e849216f5ea973c6ac22b5c9cdb05c29e9d5667252440d8300'
 const REGISTRY_DEPLOYMENT_BLOCK = 10474202
-const START = 1780637758 // 2026-06-05 05:35:58 UTC, first non-zero ArcX TVL
-// Source chains identify prices only; all balance reads and TVL attribution are Starknet.
 const PRICE_CHAIN_BY_LZ_EID = { 30101: 'ethereum' }
 
 const VTOKEN_ADDED = hash.getSelectorFromName('VTokenAdded')
@@ -114,67 +111,60 @@ async function fetchRegistryEvents() {
       type: 'omnichain',
       block: event.block_number,
       vToken: normalizeFelt(event.keys[1]),
+      gateway: normalizeEvmAddress(event.data[0]),
       asset: normalizeEvmAddress(event.keys[3]),
       lzEid: Number(BigInt(event.data[2])),
     }
   })
 }
 
-async function starknetTvl(api) {
-  const block = api.block ?? await getBlockAtOrBefore(api.timestamp)
-  if (block === null) return
-
-  // Refresh for each execution so a reused process discovers newly registered vaults.
+async function getRegisteredVaults(timestamp) {
+  const block = timestamp ? await getBlockAtOrBefore(timestamp) : await rpc('starknet_blockNumber', [])
+  if (block === null) return { block: null, vaults: [] }
   const events = await fetchRegistryEvents()
   const vaults = events.filter(({ block: eventBlock }) => eventBlock <= block)
-  const omnichainVaults = vaults.filter(({ type }) => type === 'omnichain')
-  const priceTokens = omnichainVaults.map(({ lzEid, asset }) => {
-    const chain = PRICE_CHAIN_BY_LZ_EID[lzEid]
-    if (!chain) throw new Error(`Missing price-chain mapping for LayerZero endpoint ${lzEid}`)
-    return `${chain}:${asset}`
-  })
-
-  // Price-service metadata converts Starknet units to source-token units without EVM calls.
-  // USD prices themselves are applied by DefiLlama at the requested timestamp.
-  const tokenMetadata = {}
-  for (let i = 0; i < priceTokens.length; i += 20) {
-    const { data } = await axios.get(`https://coins.llama.fi/prices/current/${priceTokens.slice(i, i + 20).join(',')}`)
-    Object.assign(tokenMetadata, data.coins)
+  for (const vault of vaults) {
+    if (vault.type === 'omnichain' && !PRICE_CHAIN_BY_LZ_EID[vault.lzEid])
+      throw new Error(`Missing price-chain mapping for LayerZero endpoint ${vault.lzEid}`)
   }
+  return { block, vaults }
+}
 
-  const balances = await Promise.all(vaults.map(async ({ type, vToken, lzEid, asset }) => {
-    if (type === 'omnichain') {
-      const priceToken = `${PRICE_CHAIN_BY_LZ_EID[lzEid]}:${asset}`
-      const sourceDecimals = tokenMetadata[priceToken]?.decimals
-      if (!Number.isInteger(sourceDecimals)) throw new Error(`Missing token decimals for ${priceToken}`)
+// Starknet: legacy vaults hold their underlying on Starknet - counted at total_assets() in the vault's asset().
+async function starknetTvl(api) {
+  const { block, vaults } = await getRegisteredVaults(api.timestamp)
+  if (block === null) return
+  const legacyVaults = vaults.filter(({ type }) => type === 'legacy')
 
-      const [supplyResult, decimalsResult] = await Promise.all([
-        starknetCall(vToken, 'total_supply', block),
-        starknetCall(vToken, 'decimals', block),
-      ])
-      const decimals = Number(BigInt(decimalsResult[0]))
-      const amount = BigNumber(parseUint256(supplyResult).toString()).shiftedBy(sourceDecimals - decimals).toFixed()
-      return { asset: priceToken, amount, skipChain: true }
-    }
-
+  const balances = await Promise.all(legacyVaults.map(async ({ vToken }) => {
     const [assetResult, totalAssetsResult] = await Promise.all([
       starknetCall(vToken, 'asset', block),
       starknetCall(vToken, 'total_assets', block),
     ])
-
-    return {
-      asset: normalizeFelt(assetResult[0]),
-      amount: parseUint256(totalAssetsResult),
-    }
+    return { asset: normalizeFelt(assetResult[0]), amount: parseUint256(totalAssetsResult) }
   }))
 
-  balances.forEach(({ asset, amount, skipChain = false }) => api.add(asset, amount, { skipChain }))
+  balances.forEach(({ asset, amount }) => api.add(asset, amount))
+}
+
+async function tvl(api) {
+  const { block, vaults } = await getRegisteredVaults(api.timestamp)
+  if (block === null) return
+  const chainVaults = vaults.filter(({ type, lzEid }) => type === 'omnichain' && PRICE_CHAIN_BY_LZ_EID[lzEid] === api.chain)
+  if (!chainVaults.length) return
+
+  const custodyWallets = await api.multiCall({ abi: 'address:mpcWallet', calls: chainVaults.map(({ gateway }) => gateway) })
+  const collateral = await api.multiCall({ abi: 'erc20:balanceOf', calls: chainVaults.map(({ asset }, i) => ({ target: asset, params: [custodyWallets[i]] })) })
+  chainVaults.forEach(({ asset }, i) => api.add(asset, collateral[i]))
 }
 
 module.exports = {
-  start: START,
+  start: '2026-06-05',
   timetravel: true,
   doublecounted: true,
-  methodology: 'Discovers vaults from the ArcX Registry on Starknet. Legacy vaults contribute total_assets in their underlying token. Omnichain vaults contribute their Starknet total_supply, normalized by token decimals and valued as 1:1 claims on the registered source asset using DefiLlama prices. All TVL is attributed to Starknet. Source-chain backing and transfers in flight are not measured; ST and EPT are excluded to avoid counting the same capital twice. Legacy capital is deployed through Wildcat, so the adapter is marked doublecounted.',
+  methodology: 'Discovers vaults from the ArcX Registry on Starknet. Legacy vaults contribute total_assets in their underlying Starknet token. Omnichain vault collateral is custodied in a per-vault MPC wallet, counted as that wallet\'s balance and attributed to the source chain. ST and EPT are excluded to avoid counting the same capital twice. Legacy capital is deployed through Wildcat, so the adapter is marked doublecounted.',
   starknet: { tvl: starknetTvl },
 }
+
+for (const chain of new Set(Object.values(PRICE_CHAIN_BY_LZ_EID)))
+  module.exports[chain] = { tvl }

--- a/projects/arcx-trade/index.js
+++ b/projects/arcx-trade/index.js
@@ -1,5 +1,6 @@
 const axios = require('axios')
 const { hash } = require('starknet')
+const BigNumber = require('bignumber.js')
 
 const CONFIGURED_STARKNET_RPC = process.env.STARKNET_RPC
 const STARKNET_RPC = !CONFIGURED_STARKNET_RPC || CONFIGURED_STARKNET_RPC.includes('rpc.starknet.lava.build')
@@ -8,7 +9,8 @@ const STARKNET_RPC = !CONFIGURED_STARKNET_RPC || CONFIGURED_STARKNET_RPC.include
 const REGISTRY = '0x37ad81bcfa789e849216f5ea973c6ac22b5c9cdb05c29e9d5667252440d8300'
 const REGISTRY_DEPLOYMENT_BLOCK = 10474202
 const START = 1780637758 // 2026-06-05 05:35:58 UTC, first non-zero ArcX TVL
-const ETHEREUM_LZ_EID = 30101
+// Source chains identify prices only; all balance reads and TVL attribution are Starknet.
+const PRICE_CHAIN_BY_LZ_EID = { 30101: 'ethereum' }
 
 const VTOKEN_ADDED = hash.getSelectorFromName('VTokenAdded')
 const OMNICHAIN_VTOKEN_ADDED = hash.getSelectorFromName('OmnichainVTokenAdded')
@@ -114,7 +116,6 @@ async function fetchRegistryEvents() {
       block: event.block_number,
       vToken: normalizeFelt(event.keys[1]),
       asset: normalizeEvmAddress(event.keys[3]),
-      adapter: normalizeEvmAddress(event.data[0]),
       lzEid: Number(BigInt(event.data[2])),
     }
   })
@@ -130,10 +131,37 @@ async function starknetTvl(api) {
   if (block === null) return
 
   const events = await getRegistryEvents()
-  const vaults = events.filter(({ type, block: eventBlock }) =>
-    type === 'legacy' && eventBlock <= block)
+  const vaults = events.filter(({ block: eventBlock }) => eventBlock <= block)
+  const omnichainVaults = vaults.filter(({ type }) => type === 'omnichain')
+  const priceTokens = omnichainVaults.map(({ lzEid, asset }) => {
+    const chain = PRICE_CHAIN_BY_LZ_EID[lzEid]
+    if (!chain) throw new Error(`Missing price-chain mapping for LayerZero endpoint ${lzEid}`)
+    return `${chain}:${asset}`
+  })
 
-  const balances = await Promise.all(vaults.map(async ({ vToken }) => {
+  // Price-service metadata converts Starknet units to source-token units without EVM calls.
+  // USD prices themselves are applied by DefiLlama at the requested timestamp.
+  const tokenMetadata = {}
+  for (let i = 0; i < priceTokens.length; i += 20) {
+    const { data } = await axios.get(`https://coins.llama.fi/prices/current/${priceTokens.slice(i, i + 20).join(',')}`)
+    Object.assign(tokenMetadata, data.coins)
+  }
+
+  const balances = await Promise.all(vaults.map(async ({ type, vToken, lzEid, asset }) => {
+    if (type === 'omnichain') {
+      const priceToken = `${PRICE_CHAIN_BY_LZ_EID[lzEid]}:${asset}`
+      const sourceDecimals = tokenMetadata[priceToken]?.decimals
+      if (!Number.isInteger(sourceDecimals)) throw new Error(`Missing token decimals for ${priceToken}`)
+
+      const [supplyResult, decimalsResult] = await Promise.all([
+        starknetCall(vToken, 'total_supply', block),
+        starknetCall(vToken, 'decimals', block),
+      ])
+      const decimals = Number(BigInt(decimalsResult[0]))
+      const amount = BigNumber(parseUint256(supplyResult).toString()).shiftedBy(sourceDecimals - decimals).toFixed()
+      return { asset: priceToken, amount, skipChain: true }
+    }
+
     const [assetResult, totalAssetsResult] = await Promise.all([
       starknetCall(vToken, 'asset', block),
       starknetCall(vToken, 'total_assets', block),
@@ -145,32 +173,13 @@ async function starknetTvl(api) {
     }
   }))
 
-  balances.forEach(({ asset, amount }) => api.add(asset, amount))
-}
-
-async function ethereumTvl(api) {
-  const starknetBlock = await getBlockAtOrBefore(api.timestamp)
-  if (starknetBlock === null) return
-
-  const events = await getRegistryEvents()
-  const vaults = events.filter(({ type, block, lzEid }) =>
-    type === 'omnichain' && block <= starknetBlock && lzEid === ETHEREUM_LZ_EID)
-
-  if (!vaults.length) return
-
-  const availableBacking = await api.multiCall({
-    abi: 'uint256:availableBacking',
-    calls: vaults.map(({ adapter }) => adapter),
-  })
-
-  vaults.forEach(({ asset }, index) => api.add(asset, availableBacking[index]))
+  balances.forEach(({ asset, amount, skipChain = false }) => api.add(asset, amount, { skipChain }))
 }
 
 module.exports = {
   start: START,
   timetravel: true,
   doublecounted: true,
-  methodology: 'Discovers ArcX vaults from VTokenAdded and OmnichainVTokenAdded events emitted by the ArcX Registry. For legacy Starknet vaults, TVL is each vToken total_assets balance denominated in its underlying asset. For omnichain Ethereum vaults, TVL is the source-chain asset held as availableBacking by each registered OFT adapter. ST, EPT, and destination-chain vToken supplies are excluded because they are derivative claims on those same assets. Legacy vault capital is deployed through Wildcat, so this TVL is marked as double-counted with Wildcat.',
+  methodology: 'Discovers vaults from the ArcX Registry on Starknet. Legacy vaults contribute total_assets in their underlying token. Omnichain vaults contribute their Starknet total_supply, normalized by token decimals and valued as 1:1 claims on the registered source asset using DefiLlama prices. All TVL is attributed to Starknet. Source-chain backing and transfers in flight are not measured; ST and EPT are excluded to avoid counting the same capital twice. Legacy capital is deployed through Wildcat, so the adapter is marked doublecounted.',
   starknet: { tvl: starknetTvl },
-  ethereum: { tvl: ethereumTvl },
 }

--- a/projects/arcx-trade/index.js
+++ b/projects/arcx-trade/index.js
@@ -16,7 +16,6 @@ const VTOKEN_ADDED = hash.getSelectorFromName('VTokenAdded')
 const OMNICHAIN_VTOKEN_ADDED = hash.getSelectorFromName('OmnichainVTokenAdded')
 
 let requestId = 0
-let registryEventsPromise
 const timestampBlockPromises = new Map()
 
 async function rpc(method, params) {
@@ -121,16 +120,12 @@ async function fetchRegistryEvents() {
   })
 }
 
-function getRegistryEvents() {
-  if (!registryEventsPromise) registryEventsPromise = fetchRegistryEvents()
-  return registryEventsPromise
-}
-
 async function starknetTvl(api) {
   const block = api.block ?? await getBlockAtOrBefore(api.timestamp)
   if (block === null) return
 
-  const events = await getRegistryEvents()
+  // Refresh for each execution so a reused process discovers newly registered vaults.
+  const events = await fetchRegistryEvents()
   const vaults = events.filter(({ block: eventBlock }) => eventBlock <= block)
   const omnichainVaults = vaults.filter(({ type }) => type === 'omnichain')
   const priceTokens = omnichainVaults.map(({ lzEid, asset }) => {


### PR DESCRIPTION
Adds ArcX's Starknet TVL adapter and the metadata for a new ArcX listing. Vaults are discovered from the on-chain Registry. Legacy vaults contribute `total_assets`; omnichain vaults contribute Starknet `total_supply`, valued as 1:1 claims on their registered underlying assets. All TVL is attributed to Starknet.

## New listing information

##### Name (to be shown on DefiLlama):

ArcX

##### Twitter Link:

https://x.com/arcxtrade

##### List of audit links if any:

- https://docs.arcx.trade/learn/audits
- https://github.com/NethermindEth/PublicAuditReports/blob/main/NM_0901_arcx_karnot_FINAL.pdf

##### Website Link:

https://arcx.trade

Documentation: https://docs.arcx.trade

##### Logo (High resolution, will be shown with rounded borders):

https://pbs.twimg.com/profile_images/1999023701363453953/I9js-8JU_400x400.png

##### Current TVL:

Approximately $566k, attributed to Starknet (legacy vault assets plus outstanding omnichain vTokens).

##### Treasury Addresses (if the protocol has treasury)

Starknet: `0x06675a585b41597d02fd059a47189bd7de88a389358e0f19163760149a8f63a8`.

Verified through `get_treasury` on the production legacy vToken and wMSTRx omnichain vToken. This is the configured vault fee treasury.

##### Chain:

Starknet. Omnichain vault inputs can originate on Ethereum; their outstanding vTokens and the TVL reported by this adapter are on Starknet.

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):


##### Short Description (to be shown on DefiLlama):

ArcX tokenises points and future dividends from vaults and tokens, enabling users to trade exposure based on their market outlook.

##### Token address and ticker if any:

None

##### Category (full list at https://defillama.com/categories) *Please choose only one:

Yield

Additional requested classification: Interest Rate Derivatives, if multiple classifications are supported. Yield remains the primary selection under this template's single-category requirement.

##### forkedFrom (Does your project originate from another project):

No

##### methodology (what is being counted as tvl, how is tvl being calculated):

The adapter discovers vaults from `VTokenAdded` and `OmnichainVTokenAdded` events emitted by the ArcX Registry on Starknet. Legacy vaults contribute their historical `total_assets`, denominated in the underlying token. Omnichain vaults contribute their historical Starknet `total_supply`, valued as 1:1 claims on the registered source asset. All balances and contract metadata are read on Starknet; source-chain token identifiers are used only for pricing and decimal normalization. ST, EPT, and CreditTokens are not counted separately. Legacy vault capital is deployed through Wildcat, so the adapter is marked `doublecounted`. This supply-based model does not independently measure source-chain backing or transfers in flight.

##### Github org/user (Optional, if your code is open source, we can track activity):

karnotxyz

##### Does this project have a referral program?

Yes

## Adapter design

- All vault quantities are read from Starknet; DefiLlama does not call an ArcX API or an EVM RPC.
- Discovers both legacy and omnichain vaults from the Starknet Registry, including their registration block for correct historical TVL.
- A newly registered Ethereum xStocks vault is included automatically without another adapter PR.
- Adding a new LayerZero source chain requires only a price-chain mapping for its endpoint ID. Additional assets must have DefiLlama price coverage. There is no separate source-chain TVL export.
- This ArcX (`arcx.trade`) listing is separate from the deprecated ARCx staking-only entry already present in the repository.

## Validation

- `node test.js projects/arcx-trade/index.js` — passes; approximately $566.08k, all attributed to Starknet, with USDC and all three xStocks priced.
- `node test.js projects/arcx-trade/index.js 2026-06-06` — passes; approximately $5.44k, USDC only before omnichain vault registration.
- `node test.js projects/arcx-trade/index.js 2026-09-04` — passes; approximately $565.48k, including the three registered omnichain vaults.
- `pnpm exec eslint -c eslint.config.js projects/arcx-trade/index.js`

## Historical listing

The adapter supports historical reads from `2026-06-05 05:35:58 UTC` (first nonzero vault assets). Please backfill the listing from this start date. Historical samples are validated above; publishing the full historical series requires DefiLlama's ingestion/backfill process.

This PR is intentionally kept as a draft for the project team's review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ArcX Trade total value locked (TVL) tracking on Starknet.
  * Supports historical TVL data across legacy and omnichain vaults.
  * Reports vault balances using token decimals and available asset pricing information.
  * Refreshes registered vault information during each TVL update for more current coverage.
  * Includes coverage for underlying assets and omnichain claims using available market data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->