### PR TITLE
Add Perpshood (Robinhood Chain launchpad)

### DIFF
--- a/projects/perpshood/index.js
+++ b/projects/perpshood/index.js
@@ -1,0 +1,25 @@
+const { get } = require('../helper/http')
+const ADDRESSES = require('../helper/coreAssets.json')
+
+// Perpshood (perpshood.fun) is a launchpad on Robinhood Chain where every coin's trading fees
+// fund a real leveraged perp position backing it. Coins trade on Pons v2 bonding curves until
+// graduation, when liquidity moves to Uniswap V4 and the curve closes.
+//
+// TVL is the quote-side reserves (native ETH or an approved pair token such as a tokenized
+// stock) held by each live curve. The launch factory is shared infrastructure used by several
+// launchpads, so "launched via perpshood" is not derivable on-chain — the platform publishes
+// its own curve list, and every balance is then read from the chain.
+const FEED = 'https://perpshood.fun/api/llama.json'
+
+async function tvl(api) {
+  const { curves } = await get(FEED)
+  return api.sumTokens({
+    ownerTokens: curves.map(({ curve, pair }) => [[pair, ADDRESSES.null], curve]),
+  })
+}
+
+module.exports = {
+  methodology:
+    'TVL is the quote-asset reserves (native ETH or approved pair tokens such as tokenized stocks) held by the Pons v2 bonding curve of every live perpshood-launched coin; balances are read on-chain. The curve list comes from perpshood.fun/api/llama.json because the launch factory is shared infrastructure and perpshood launches are not distinguishable on-chain. Graduated coins (liquidity in Uniswap V4) are excluded, as is the leveraged perp margin backing each coin, which sits on the Lighter venue.',
+  robinhood: { tvl },
+}

--- a/projects/perpshood/index.js
+++ b/projects/perpshood/index.js
@@ -1,4 +1,4 @@
-const { get } = require('../helper/http')
+const { getConfig } = require('../helper/cache')
 const ADDRESSES = require('../helper/coreAssets.json')
 
 // Perpshood (perpshood.fun) is a launchpad on Robinhood Chain where every coin's trading fees
@@ -12,7 +12,7 @@ const ADDRESSES = require('../helper/coreAssets.json')
 const FEED = 'https://perpshood.fun/api/llama.json'
 
 async function tvl(api) {
-  const { curves } = await get(FEED)
+  const { curves } = await getConfig('perpshood', FEED)
   return api.sumTokens({
     ownerTokens: curves.map(({ curve, pair }) => [[pair, ADDRESSES.null], curve]),
   })
@@ -21,5 +21,6 @@ async function tvl(api) {
 module.exports = {
   methodology:
     'TVL is the quote-asset reserves (native ETH or approved pair tokens such as tokenized stocks) held by the Pons v2 bonding curve of every live perpshood-launched coin; balances are read on-chain. The curve list comes from perpshood.fun/api/llama.json because the launch factory is shared infrastructure and perpshood launches are not distinguishable on-chain. Graduated coins (liquidity in Uniswap V4) are excluded, as is the leveraged perp margin backing each coin, which sits on the Lighter venue.',
+  doublecounted: true,
   robinhood: { tvl },
 }


### PR DESCRIPTION
**Perpshood** — launchpad on Robinhood Chain where every coin's trading fees fund a real leveraged perp position backing it (fees -> margin -> take-profit -> buyback & burn).

- **Website:** https://perpshood.fun
- **Chain:** Robinhood Chain (4663)
- **Category:** Launchpad
- **Methodology:** TVL is the quote-asset reserves (native ETH or approved pair tokens such as tokenized stocks) held by the Pons v2 bonding curve of every live coin launched through perpshood; balances are read on-chain via sumTokens. The curve list comes from `https://perpshood.fun/api/llama.json` (CORS-open, refreshed every 10 min) because the launch factory is shared infrastructure used by several launchpads, so "launched via perpshood" is not derivable on-chain. Graduated coins (liquidity moves to Uniswap V4) are excluded, as is the perp margin backing each coin (it sits on the Lighter venue and would double-count with the Lighter listing).
- **Oracle:** none
- **Forked from:** none
- **Audit:** unaudited

Tested with `node test.js projects/perpshood/index.js` — currently ~$12.4K across ETH, cbBTC and tokenized-stock pairs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added TVL tracking for the Perpshood launchpad on Robinhood Chain.
  - Reports quote-side reserves held by active Pons v2 bonding curves.
  - Excludes graduated coins and leveraged perpetual futures margin from reported TVL.
  - Uses the launchpad’s current curve configuration to keep tracked reserves up to date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->