### PR TITLE
kittenswap-algebra: add Robinhood chain TVL

### DIFF
--- a/registries/uniswapV3Graph.js
+++ b/registries/uniswapV3Graph.js
@@ -34,6 +34,7 @@ const configs = {
   },
   'kittenswap-algebra': {
     hyperliquid: { graphURL: 'https://api.goldsky.com/api/public/project_cmcxkn8h7pwwc01x30a5e6t39/subgraphs/cl-analytics-prod/v1.0.0/gn', name: 'kittenswap-algebrahyperliquid', blacklistedTokens: ['0x1d25eeeee9b61fe86cff35b0855a0c5ac20a5feb'] },
+    robinhood: { graphURL: 'https://api.goldsky.com/api/public/project_cmtligog3luwl01y36sh55iex/subgraphs/analytics/v1.0.0/gn', name: 'kittenswap-algebrarobinhood' },
   },
   'hydradex-v3': {
     misrepresentedTokens: true,


### PR DESCRIPTION
## Summary
- Add Robinhood Chain to the existing `kittenswap-algebra` TVL listing (already live on HyperEVM).
- Uses the Algebra Integral 1.2.3 factory subgraph for pool discovery, then on-chain balances via the existing `uniV3GraphExport` helper.

This is not a new protocol listing. KittenSwap Algebra is already tracked: https://defillama.com/protocol/kittenswap-algebra

Factory: `0xf03875b5Ec5eAc83cab83A6c2ab17844304AA7a0`
Subgraph: https://api.goldsky.com/api/public/project_cmtligog3luwl01y36sh55iex/subgraphs/analytics/v1.0.0/gn
First pool: 2026-09-05 (block 54695982)

Local `node test.js kittenswap-algebra`:
- hyperliquid ~709k
- robinhood ~1.86k

## Test plan
- [ ] `node test.js kittenswap-algebra` reports a Robinhood TVL bucket
- [ ] HyperEVM TVL is unchanged in shape
- [ ] Listing shows both chains after UI refresh


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Robinhood network support for the Kittenswap Algebra registry through a new indexed data source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->