### PR TITLE
add Monarq TVL adapter

### DIFF
--- a/registries/curators.js
+++ b/registries/curators.js
@@ -778,7 +778,7 @@ const configs = {
   },
   "monarq": {
     config: {
-      methodology: 'Count FXRP managed by the Monarq XRP Yield Vault through its on-chain getTotalAssets value. .',
+      methodology: 'Count FXRP managed by the Monarq XRP Yield Vault through its on-chain getTotalAssets value.',
       blockchains: {
         flare: {
           upshiftV2: ['0x2439D4bb753A0f3777d4C9011AFacc475ba6B951'],

--- a/registries/curators.js
+++ b/registries/curators.js
@@ -776,6 +776,16 @@ const configs = {
       },
     },
   },
+  "monarq": {
+    config: {
+      methodology: 'Count FXRP managed by the Monarq XRP Yield Vault through its on-chain getTotalAssets value. .',
+      blockchains: {
+        flare: {
+          upshiftV2: ['0x2439D4bb753A0f3777d4C9011AFacc475ba6B951'],
+        },
+      },
+    },
+  },
   "mt-pelerin": {
     config: {
       methodology: 'Sum settled underlying assets in the Mt Pelerin USD, ETH and BTC strategy pools on Lagoon.',


### PR DESCRIPTION
## What this PR does
Add Monarq  curator.

## Estimated TVL added

$9,678,438 net attributable curator TVL.

## Chains

flare.

## Contracts / programs and source of addresses

| Contract / fund | Chain | Address / explorer | Primary address source |
| --- | --- | --- | --- |
| Monarq XRP Yield Vault | flare | [0x2439D4bb753A0f3777d4C9011AFacc475ba6B951](https://flare-explorer.flare.network/address/0x2439D4bb753A0f3777d4C9011AFacc475ba6B951) | [Official source](https://app.upshift.finance/pools/14/0x2439D4bb753A0f3777d4C9011AFacc475ba6B951) |

## Methodology

Use the existing upshiftV2 curator pattern for the verified Flare vault

## Test results

Command: `node test.js monarq`.

------ TVL ------                                                                                                      
flare                     9.64 M                                                                                                                                                                                                                total                    9.64 M  


## Official documentation / app comparison
- https://app.upshift.finance/vaults/flare-mainnet/monarq-xrp-yield-vault

- [Official Flare launch](https://flare.network/de/news/monarq-flare-and-upshift-launch-mxrpy-a-multi-strategy-xrp-yield-vault-on-flare)

## New listing metadata

- Name: Monarq
- Website: https://www.monarq-am.com/
- Category: Risk Curators
- Description: Digital asset manager curating the MXRPY yield vault on Flare.
- Chains: flare
- Logo: https://cdn.prod.website-files.com/64fdb8f831c829a80ba674f9/6838f6f2a47b33a0423ccefa_S-Gold.svg
- Governance token / ticker: none 
- Treasury: None
- Twitter: https://x.com/monarq_mgmt
-  public GitHub organization, CoinGecko/CMC IDs: N/A
- Referral program: N/A
- forkedFrom: N/A
- Oracle/valuation: N/A
- Infrastructure audits: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected punctuation in the Monarq curator methodology description.
  * Removed the duplicate trailing period for clearer presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->