### PR TITLE
add DACM TVL adapter

### DIFF
--- a/registries/curators.js
+++ b/registries/curators.js
@@ -499,6 +499,16 @@ const configs = {
       },
     },
   },
+  "dacm": {
+    config: {
+      methodology: 'Count settled USDC NAV of the DACM LIT Strategy Lagoon vault.',
+      blockchains: {
+        arbitrum: {
+          erc4626: ['0x018282d5b510f00dcacb8f4a81c3901d2fc9da51'],
+        },
+      },
+    },
+  },
   "edge-capital": {
     config: {
       methodology: 'Counts all assets deposited in vaults curated by Edge-Capital.',


### PR DESCRIPTION
## What this PR does
Add DACM curator.


## Estimated TVL added

$442.79 k net attributable curator TVL. 

## Chains

arbitrum.

## Contracts / programs and source of addresses

| Contract / fund | Chain | Address / explorer | Primary address source |
| --- | --- | --- | --- |
| DACM LIT Strategy | arbitrum | [0x018282d5b510f00dcacb8f4a81c3901d2fc9da51](https://arbiscan.io/address/0x018282d5b510f00dcacb8f4a81c3901d2fc9da51) | [Official source](https://app.lagoon.finance/vault/42161/0x018282d5b510f00dcacb8f4a81c3901d2fc9da51) |

## Methodology

Add the officially attributed fund addresses to the existing curator ERC-4626 registry.


## Test results

Command: `node test.js dacm`.
------ TVL ------
arbitrum                  442.79 k

total                    442.79 k

## Official documentation / app comparison

- [DACM official website](https://dacm.io)
- [Official Lagoon curated vault inventory](https://app.lagoon.finance/api/vaults?pageIndex=0&pageSize=100&includeApr=false)


## New listing metadata

- Name: DACM
- Website: https://dacm.io
- Category: Risk Curators
- Description: DACM is an institutional digital asset fund manager.
- Chains: arbitrum
- Logo: https://cdn.lagoon.finance/curators/dacm
- Governance token / ticker: N/A
- Treasury: N/A
- X: https://x.com/digiassetfund
- public GitHub organization, CoinGecko/CMC IDs: N/A
- Referral program: N/A
- forkedFrom:N/A
- Oracle/valuation: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DACM as a supported curator.
  * Added tracking for the DACM LIT Strategy Lagoon vault on Arbitrum, including its settled USDC NAV.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->