### PR TITLE
expand Keyring TVL adapter

### DIFF
--- a/registries/curators.js
+++ b/registries/curators.js
@@ -732,6 +732,11 @@ const configs = {
     config: {
       methodology: 'Count all assets are deposited in all vaults curated by Keyring Network.',
       blockchains: {
+        ethereum: {
+          eulerVaultOwners: [
+            '0x0B50beaE6aac0425e31d5a29080F2A7Dec22754a',
+          ],
+        },
         avax: {
           eulerVaultOwners: [
             '0x0B50beaE6aac0425e31d5a29080F2A7Dec22754a',


### PR DESCRIPTION
## What this PR does
For Keyring : Add ethereum eulerVaultOwners.

## Why the current adapter is missing TVL

The Keyring registry entry only configures Avalanche. The official Euler labels also attribute an Ethereum institutional cluster to Keyring. All five verified Ethereum vaults have creator 0x0B50beaE6aac0425e31d5a29080F2A7Dec22754a, the same creator already used in the Avalanche configuration.

## Estimated TVL added

Approximately $2.6 million added .

## Chains

ethereum, avax. Only Ethereum coverage is changed.

## Contracts / programs and source of addresses

- [0x2BE1acAA1B37A769A4618bbfCd35d9ea54133065](https://etherscan.io/address/0x2BE1acAA1B37A769A4618bbfCd35d9ea54133065#code)
- [0xa45EAc8E33168cefa0b225F500E6d93D43B8f1AF](https://etherscan.io/address/0xa45EAc8E33168cefa0b225F500E6d93D43B8f1AF#code)
- [0xAc193c221a2e22990f36Fd388C2974eE2eb0FF50](https://etherscan.io/address/0xAc193c221a2e22990f36Fd388C2974eE2eb0FF50#code)
- [0x71772F99e83ed7F7650BE9A2b8859B12F1aeC028](https://etherscan.io/address/0x71772F99e83ed7F7650BE9A2b8859B12F1aeC028#code)
- [0xBe264Cece20D10bf0a64d0B91C21529C7fa02AA9](https://etherscan.io/address/0xBe264Cece20D10bf0a64d0B91C21529C7fa02AA9#code)

- [Official Euler cluster addresses and Keyring attribution](https://github.com/euler-xyz/euler-labels/blob/master/1/products.json)
- [Official Euler entity metadata](https://github.com/euler-xyz/euler-labels/blob/master/1/entities.json)
- [Official Keyring website](https://keyring.network/)
- [Official Euler vault documentation](https://docs.euler.finance/learn/vaults/)


## Test results

Command: `node test.js keyring`. 

## Official documentation and app comparison

The official Euler labels independently establish the cluster attribution.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ethereum network support for tracking an Euler vault owner address in the keyring curator registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->