### PR TITLE
expand SingularV TVL adapter

### DIFF
--- a/registries/curators.js
+++ b/registries/curators.js
@@ -1052,6 +1052,7 @@ const configs = {
           morphoVaultOwners: [
             '0x46057881E0B9d190920FB823F840B837f65745d5',
           ],
+          upshiftV2: ['0x73B04B604DF15A6d920Ee62E228548cD88DD3549'], // SingularV USDC Max Yield
         },
       }
     },


### PR DESCRIPTION
## What this PR does

For the curator SingularV : add the verified vault to ethereum.upshiftV2 without changing existing Morpho discovery.

## Why the current adapter is missing TVL

The registry only discovers Morpho vaults; its separate Upshift USDC Max Yield deployment is not included.

## Estimated TVL added

$2 million added.

## Chains

ethereum.

## Contracts / programs and source of addresses

| Contract / fund | Chain | Address / explorer | Primary address source |
| --- | --- | --- | --- |
| SingularV USDC Max Yield | ethereum | [0x73B04B604DF15A6d920Ee62E228548cD88DD3549](https://eth.blockscout.com/address/0x73B04B604DF15A6d920Ee62E228548cD88DD3549) | [Official source](https://app.upshift.finance/pools/1/0x73B04B604DF15A6d920Ee62E228548cD88DD3549) |

## Methodology

Add the verified vault to ethereum.upshiftV2 without changing existing Morpho discovery. 

## Test results

Command: `node test.js singularv`.
------ TVL ------
ethereum                  2.43 M

total                    2.43 M


## Official documentation / app comparison

- [Official SingularV vault](https://app.upshift.finance/pools/1/0x73B04B604DF15A6d920Ee62E228548cD88DD3549)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the SingularV USDC Max Yield Upshift V2 vault to the available Ethereum curator configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->