### PR TITLE
mark lore insolvent

### DIFF
--- a/registries/aave.js
+++ b/registries/aave.js
@@ -467,8 +467,11 @@ const aaveConfigs = {
     },
   },
   'lore': {
-    scroll: '0xBc6DE4458b7D6fbf82240ce8cC0CA6a2f4986eb5',
-    deadFrom: "2025-03-24"
+    scroll: {
+      addressesProviderRegistry: '0xBc6DE4458b7D6fbf82240ce8cC0CA6a2f4986eb5',
+      isInsolvent: true,
+      deadFrom: "2025-03-24"
+    },
   },
   'iolend': {
     methodology,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the protocol configuration for the affected chain.
  - Registry details are now associated with the appropriate chain-specific settings.
  - The chain is accurately marked as insolvent and inactive, improving the reliability of status and availability information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->