### PR TITLE
rockawayx: price PT-rkuSOL, move Upshift Earn ctUSD to Citrea

### DIFF
--- a/projects/rockawayx/index.js
+++ b/projects/rockawayx/index.js
@@ -70,7 +70,6 @@ const configs = {
         '0xD6d4b804014EF27836dBe9f8f6Bf6c71251548Ec'
       ],
       upshiftV2: [
-        '0xc87DBBB8C67e4F19fCD2E297c05937567b2572Ce', // Upshift Earn ctUSD
         '0xcd69123b3FBBfC666E1f6a501da27B564C00De54', // Upshift Tori
       ],
       midasTokens: [
@@ -80,6 +79,11 @@ const configs = {
       ],
       erc4626: [
         '0x6f576e5192a14f259f7fe7347ecf63b255d7f7d1', // Term Finance - RockawayX Tori USDC (tsvRockXToriUSDC)
+      ],
+    },
+    citrea: {
+      upshiftV2: [
+        '0x68499eAEf8c4994593C56a1257BD151D17950BA2', // Upshift Earn ctUSD
       ],
     },
     base: {

--- a/projects/rockawayx/index.js
+++ b/projects/rockawayx/index.js
@@ -24,9 +24,15 @@ const KAMINO_RESERVES = [
   'DzgYbR8HFQKf8YLCJ6M3E6ricB1xWAiNGZ2TB7X2KDHz',
   // Raiku market
   'J7idSfhvLqdkSmbMvhHMXBAhZMJVxEtzqXo45JB9HZrP',
-  '7272BNf9uoivyX5h8B7799yoxSfF4WDuzcP7HDwSPLqN', // PT-rkuSOL, no price feed: counted as zero
+  '7272BNf9uoivyX5h8B7799yoxSfF4WDuzcP7HDwSPLqN',
   'EMyn5A2HhvYhojiibR3znk5QyafRVnK4oZ725XYzzf2s',
 ];
+
+// Exponent principal tokens have no price feed, count them as the token they redeem into.
+// A PT trades below its underlying until maturity, so this slightly overstates the position.
+const TOKEN_SUBSTITUTES = {
+  '58XmRhDKVsCEt6dD3zxqHth8uzMY8BHhEyeAiUa5UPw9': 'rkubjTrZYioRSeXwDnhwGQzvW3qkcin72JSxUt3WMVp', // PT-rkuSOL-31OCT26 -> rkuSOL
+};
 
 const EMBER_VAULTS = {
   ethereum: [
@@ -178,7 +184,8 @@ async function kaminoReserveTvl(api) {
     const cTokenSupply = BigInt(reserve.collateral.mintTotalSupply.toString());
     const own = ownCTokens[KAMINO_RESERVES[i]] ?? 0n;
     const externalShare = cTokenSupply > 0n ? available - (available * own) / cTokenSupply : available;
-    if (externalShare > 0n) api.add(reserve.liquidity.mintPubkey.toString(), externalShare.toString());
+    const mint = reserve.liquidity.mintPubkey.toString();
+    if (externalShare > 0n) api.add(TOKEN_SUBSTITUTES[mint] ?? mint, externalShare.toString());
   });
 }
 

--- a/projects/rockawayx/index.js
+++ b/projects/rockawayx/index.js
@@ -28,12 +28,6 @@ const KAMINO_RESERVES = [
   'EMyn5A2HhvYhojiibR3znk5QyafRVnK4oZ725XYzzf2s',
 ];
 
-// Exponent principal tokens have no price feed, count them as the token they redeem into.
-// A PT trades below its underlying until maturity, so this slightly overstates the position.
-const TOKEN_SUBSTITUTES = {
-  '58XmRhDKVsCEt6dD3zxqHth8uzMY8BHhEyeAiUa5UPw9': 'rkubjTrZYioRSeXwDnhwGQzvW3qkcin72JSxUt3WMVp', // PT-rkuSOL-31OCT26 -> rkuSOL
-};
-
 const EMBER_VAULTS = {
   ethereum: [
     '0x953972ea0C1703c58F09FB6fD2477Fdcf0FEe074', // eY10K
@@ -188,8 +182,7 @@ async function kaminoReserveTvl(api) {
     const cTokenSupply = BigInt(reserve.collateral.mintTotalSupply.toString());
     const own = ownCTokens[KAMINO_RESERVES[i]] ?? 0n;
     const externalShare = cTokenSupply > 0n ? available - (available * own) / cTokenSupply : available;
-    const mint = reserve.liquidity.mintPubkey.toString();
-    if (externalShare > 0n) api.add(TOKEN_SUBSTITUTES[mint] ?? mint, externalShare.toString());
+    if (externalShare > 0n) api.add(reserve.liquidity.mintPubkey.toString(), externalShare.toString());
   });
 }
 


### PR DESCRIPTION
Two changes to the RockawayX curator adapter, follow-up to #20872.

### 1. PT-rkuSOL

One of the Raiku market reserves holds PT-rkuSOL-31OCT26 (`58XmRhDKVsCEt6dD3zxqHth8uzMY8BHhEyeAiUa5UPw9`) and was left counting as zero because the token has no price feed. It is on neither CoinGecko nor GeckoTerminal, and the same is true of every Exponent principal token on Solana — including the four in the Exponent PT-SOL market that the `kamino-lending` adapter also counts as zero today.

Both mints have 9 decimals, so this counts the reserve as the rkuSOL the PT redeems into at maturity. A PT trades below its underlying until then, so it overstates the position by about 5% right now ($1.35M against the $1.28M Kamino itself reports), converging to zero on 31 Oct 2026. Happy to drop it if you would rather the reserve stay at zero, and it should be removed once a price adapter for Exponent PTs exists.

### 2. Upshift Earn ctUSD moved to Citrea

The Earn ctUSD vault now lives on Citrea at `0x68499eAEf8c4994593C56a1257BD151D17950BA2` (`asset()` is ctUSD, `getTotalAssets()` ~$2.57M, same `upshiftV2` shape). The Ethereum entry it replaces, `0xc87DBBB8C67e4F19fCD2E297c05937567b2572Ce`, is a USDC vault that is no longer curated by RockawayX.

Net effect of both changes: adapter total goes from ~$298M to ~$284M.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted TVL reporting for PT-rkuSOL reserves.
  * Updated the Upshift Earn ctUSD vault configuration, removing it from Ethereum and listing it under Citrea.
* **Configuration**
  * Added support for the Citrea blockchain’s Upshift Earn ctUSD vault.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->