### PR TITLE
Llamalend v2 (Curve): add Ethereum

### DIFF
--- a/projects/llamalend-v2-curve/index.js
+++ b/projects/llamalend-v2-curve/index.js
@@ -35,5 +35,5 @@ module.exports = Object.keys(chainContracts).reduce((all, chain) => ({
 module.exports.methodology = 'TVL is the sum of collateral and borrowed tokens held in LLAMMA AMMs and market controllers. Borrowed is total debt across all v2 markets.'
 module.exports.hallmarks = [
   ['2026-06-10', 'Llamalend v2 launch on Optimism'],
-  ['2026-07-14', 'Llamalend v2 launch on Ethereum'],
+  ['2026-07-15', 'Llamalend v2 launch on Ethereum'],
 ]

--- a/projects/llamalend-v2-curve/index.js
+++ b/projects/llamalend-v2-curve/index.js
@@ -1,4 +1,5 @@
 const chainContracts = {
+  ethereum: "0x8f6B56ec5DdF1f2691a1059f1D3cd97AC9EAB0Bd",
   optimism: "0x5F94073E3f51c1FFf92ffc6b4B06b7Af193B3640",
 }
 
@@ -34,4 +35,5 @@ module.exports = Object.keys(chainContracts).reduce((all, chain) => ({
 module.exports.methodology = 'TVL is the sum of collateral and borrowed tokens held in LLAMMA AMMs and market controllers. Borrowed is total debt across all v2 markets.'
 module.exports.hallmarks = [
   ['2026-06-10', 'Llamalend v2 launch on Optimism'],
+  ['2026-07-14', 'Llamalend v2 launch on Ethereum'],
 ]


### PR DESCRIPTION
Adds Ethereum to the existing `llamalend-v2-curve` adapter. Curve's Llamalend V2 launched on Ethereum on 2026-07-14 and currently has ~$31.8M TVL that the adapter does not see, because `chainContracts` only lists Optimism.

### Change

One line — the rest of the adapter is already chain-agnostic (it discovers markets from the factory via `market_count` / `markets`, then reads `controller`, `amm`, `collateral_token`, `borrowed_token`, `total_debt`).

```diff
 const chainContracts = {
+  ethereum: "0x8f6B56ec5DdF1f2691a1059f1D3cd97AC9EAB0Bd",
   optimism: "0x5F94073E3f51c1FFf92ffc6b4B06b7Af193B3640",
 }
```

Plus a hallmark for the Ethereum launch.

### Factory

`0x8f6B56ec5DdF1f2691a1059f1D3cd97AC9EAB0Bd` — Curve Llamalend V2 OneWay factory on Ethereum, deployed 2026-07-13 (block 25,523,555). It exposes the same interface as the Optimism factory; every call the adapter makes was executed against it and returned valid data.

It currently reports `market_count() = 4`:

| Collateral | Borrows | Vault (ERC-4626) | Controller |
|---|---|---|---|
| sfrxUSD | crvUSD | `0x3Da0F110079012387F47C6Fc6e878F10262E300a` | `0x3cD4d86a2c65e57ce4b4121b67E2D2224BA41bbe` |
| sDOLA | crvUSD | `0x2b5a321C3cb1F33e1ABECD047C2649D0b4C47eBa` | `0xC77d97cF01737EB7aCE46cAb7cd9F60eC51a40c0` |
| syrupUSDC | crvUSD | `0xD0D347E14fbF1872affeaCb49d0b8B7182680E6C` | `0x2fb54c8eae57767A9A509A395b9C4FA0702e2675` |
| svZCHF | crvUSD | `0xCb6e2c3d9Dba8fe6245B2c969320F2485dFce2FD` | `0xFd85e847cDd2549f213E276e4B57B0690169F043` |

### Expected numbers

Ethereum, block 25,931,733, priced with `coins.llama.fi`:

- **TVL ≈ $31,772,500** (sfrxUSD $14.46M, sDOLA $7.48M, crvUSD $6.98M, syrupUSDC $2.74M, svZCHF $0.12M)
- **Borrowed ≈ $22,463,991** (22,467,236 crvUSD across the four markets)

"Curve LlamaLend V2" currently shows $1,079,182 (Optimism only), so it should land around $32.9M.

**Sanity check on the method:** running the same computation against the *Optimism* factory at block 156,630,345 gives TVL $1,081,570 and borrowed $446,123, against the $1,079,182 / $446,010 the API reports for this protocol right now — i.e. the same numbers at a slightly different block.

### No double counting

`projects/llamalend-curve/index.js` (V1) reads a different set of factories — `0xeA6876DDE9e3467564acBeE1Ed5bac88783205E0` (ethereum), `0xcaec110c784c9df37240a8ce096d352a75922dea` (arbitrum), `0xf3c9bdAB17B7016fBE3B77D17b1602A7db93ac66` (fraxtal), `0x5ea8f3d674c70b020586933a0a5b250734798bef` (optimism) — and a different item ABI (`controllers`, not `markets`). The V2 factory is not among them, so nothing is counted twice.

---

The listing questionnaire below is for new listings; this is an existing listing (`Curve LlamaLend V2`) gaining a chain, so I've left it out. Happy to fill anything in if you need it.

Website: https://curve.finance · Docs: https://docs.curve.finance


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Ethereum support for Llamalend v2, including TVL and borrowed metrics.
  - Recorded the Llamalend v2 launch on Ethereum, dated July 15, 2026.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->