### PR TITLE
Add RobinIndex (RBDX) on Robinhood Chain

### DIFF
--- a/projects/robinindex/index.js
+++ b/projects/robinindex/index.js
@@ -1,0 +1,28 @@
+// DefiLlama TVL adapter for RobinIndex ($RBDX) on Robinhood Chain.
+// Place at: projects/robinindex/index.js in github.com/DefiLlama/DefiLlama-Adapters
+// TVL = every Stock Token balance held by the RBDXVault (the index's backing basket).
+// The vault exposes heldTokensList() (tokens with a nonzero balance), so no hardcoded
+// asset list is needed and new listings are picked up automatically.
+
+const { sumTokens2 } = require("../helper/unwrapLPs");
+
+const VAULT = "0xc3ce9C84E9E012A32dFf7B7B0E2d44A30A96477e";
+const REGISTRY = "0x6b61Aa9576Eb6Cbb19ac6aB350519Ac37f9CCE79";
+
+async function tvl(api) {
+  // Prefer the registry's full asset list (covers tokens the vault may hold at 0 today).
+  let tokens;
+  try {
+    tokens = await api.call({ target: REGISTRY, abi: "function getAssetList() view returns (address[])" });
+  } catch (e) {
+    tokens = await api.call({ target: VAULT, abi: "function heldTokensList() view returns (address[])" });
+  }
+  return sumTokens2({ api, owner: VAULT, tokens });
+}
+
+module.exports = {
+  methodology:
+    "TVL is the USD value of all Robinhood Chain Stock Tokens (tokenized equities, priced via Chainlink) held in the RBDXVault contract, which backs the RBDX index token 1:1 by NAV.",
+  start: "2026-09-06",
+  robinhood: { tvl },
+};


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
RobinIndex

##### Twitter Link:
https://x.com/DefiNPCMan

##### List of audit links if any:
None (unaudited, experimental pilot; stated on the site and in the repo)

##### Website Link:
https://robinindex.com

##### Logo (High resolution, will be shown with rounded borders):
https://raw.githubusercontent.com/Marthaerys/RBDX-marketing/main/content/images/logo-512.png

##### Current TVL:
~$398

##### Treasury Addresses (if the protocol has treasury)
None

##### Chain:
Robinhood Chain

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):
(empty)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):
(empty)

##### Short Description (to be shown on DefiLlama):
Index token backed by Robinhood Chain Stock Tokens (tokenized equities). Target weights are computed on-chain from each token's circulating supply × Chainlink price; single-asset mint/redeem with a weight-deviation rebate/penalty keeps the basket at target.

##### Token address and ticker if any:
RBDX — 0x1914C83bc4E8bB36EB8eaA36f866969Fd2252030 (Robinhood Chain, 4663)

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Indexes

##### Oracle Provider(s):
Chainlink

##### Implementation Details:
Each listed Stock Token is registered in AssetRegistry with its Chainlink Data Feed (AggregatorV3Interface.latestRoundData) and a per-asset staleness bound. RBDXVault prices deposits/redemptions and computes NAV from those feeds; target weights use feed price × the Stock Token's totalSupply().

##### Documentation/Proof:
https://github.com/Marthaerys/RobinIndex/blob/main/docs/DESIGN.md
https://github.com/Marthaerys/RobinIndex/blob/main/src/libraries/OracleLib.sol
Verified vault: https://robinhoodchain.blockscout.com/address/0xc3ce9C84E9E012A32dFf7B7B0E2d44A30A96477e?tab=contract

##### forkedFrom (Does your project originate from another project):
No (mechanism inspired by GMX's GLP rebate/penalty design, no code forked)

##### methodology (what is being counted as tvl, how is tvl being calculated):
USD value of all Stock Tokens held by the RBDXVault contract (0xc3ce9C84E9E012A32dFf7B7B0E2d44A30A96477e). Token list is read on-chain from AssetRegistry.getAssetList(); balances via sumTokens2.

##### Github org/user (Optional, if your code is open source, we can track activity):
Marthaerys

##### Does this project have a referral program?
No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for the Robinhood Chain’s RobinIndex vault.
  * Added token valuation using the registry asset list, with a fallback for supported vault-held assets.
  * Added methodology metadata and historical start-date information for the integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->