### PR TITLE
Add Gage lending TVL and borrowing on Robinhood

### DIFF
--- a/projects/gage/index.js
+++ b/projects/gage/index.js
@@ -1,0 +1,97 @@
+const { unwrapUniswapV3NFT, unwrapUniswapV4NFTs } = require('../helper/unwrapLPs')
+
+// Immutable deployments; new vaults must be added explicitly.
+// https://docs.gage.cash/protocol/addresses
+const vaults = [
+  { address: '0x3D979740785ABd8b7Dd5c2Ff7Bf100CBe86fcBDF', fromBlock: 57067880, kind: 1 },
+  { address: '0xc23A08282AA1A9141C6fD7A29e7dFbFe841cC6B6', fromBlock: 57225875, kind: 1 },
+  { address: '0xe3628a01eaca2e7b0EC71Ed7bA616b997fEf9cDE', fromBlock: 57272387, kind: 2 },
+]
+const stateViewer = '0xF3334192D15450CdD385c8B70e03f9A6bD9E673b'
+const ownTokens = [
+  '0x7163ae1b5aea2f09ebc609c52b4dcac0a7a4bc2d', // GAGE
+  '0x78c88cf8f6e612955526ceb501be82bf3279bd5d', // sGAGE
+]
+const dealAbi = 'function getDeal(uint256) view returns ((address borrower, uint8 kind, uint8 state, uint32 term, uint40 listingExpiry, address token, uint40 fundedAt, uint40 expiry, uint256 amountOrTokenId, uint128 cap, uint128 minPrice, address lender, uint128 price, uint128 fee))'
+
+async function getVaults(api) {
+  const block = await api.getBlock() // Pin discovery, custody and LP state to the same block.
+  return Promise.all(vaults.filter(v => block >= v.fromBlock).map(async (vault) => {
+    const [count, usdg] = await Promise.all([
+      api.call({ target: vault.address, abi: 'uint256:dealCount' }),
+      api.call({ target: vault.address, abi: 'address:USDG' }),
+    ])
+    const length = Number(count)
+    if (!Number.isSafeInteger(length) || length < 0) throw new Error('Invalid Gage deal count')
+    const deals = length ? await api.multiCall({
+      target: vault.address, abi: dealAbi,
+      calls: Array.from({ length }, (_, i) => i + 1),
+    }) : []
+    return { ...vault, usdg, deals }
+  }))
+}
+
+async function tvl(api) {
+  for (const vault of await getVaults(api)) {
+    const [feeSink, manager] = await Promise.all([
+      api.call({ target: vault.address, abi: 'address:FEE_SINK' }),
+      api.call({ target: vault.address, abi: 'address:POSITION_MANAGER' }),
+    ])
+    // Include tokens from settled and delisted deals: withdrawals are a separate transaction.
+    const tokens = [...new Set([vault.usdg, ...vault.deals.filter(d => Number(d.kind) === 0).map(d => d.token)]
+      .map(t => t.toLowerCase()))].filter(t => !ownTokens.includes(t))
+    const [balances, protocolFees] = await Promise.all([
+      api.multiCall({ abi: 'erc20:balanceOf', calls: tokens.map(target => ({ target, params: vault.address })) }),
+      api.call({ target: vault.address, abi: 'function balanceUSDG(address) view returns (uint256)', params: feeSink }),
+    ])
+    tokens.forEach((token, i) => {
+      let amount = BigInt(balances[i])
+      if (token === vault.usdg.toLowerCase()) amount -= BigInt(protocolFees)
+      if (amount < 0n) throw new Error(`Gage fee credit exceeds USDG custody: ${vault.address}`)
+      api.add(token, amount.toString())
+    })
+
+    const nftDeals = vault.deals.filter(d => Number(d.kind) !== 0)
+    if (nftDeals.some(d => Number(d.kind) !== vault.kind || d.token.toLowerCase() !== manager.toLowerCase()))
+      throw new Error(`Unexpected Gage position manager or kind: ${vault.address}`)
+    // Settled positions stay in TVL until their user credit is withdrawn. A withdrawn NFT can
+    // later be burned; do not call ownerOf for it or count unsolicited transferFrom donations.
+    const settled = nftDeals.filter(d => [3, 4, 5].includes(Number(d.state)))
+    const owed = settled.length ? await api.multiCall({
+      target: vault.address, abi: 'function owedNFT(address,uint256) view returns (bool)',
+      calls: settled.map(d => ({ params: [Number(d.state) === 4 ? d.lender : d.borrower, d.amountOrTokenId] })),
+    }) : []
+    const positionIds = [...new Set([
+      ...nftDeals.filter(d => [1, 2].includes(Number(d.state))),
+      ...settled.filter((_, i) => owed[i]),
+    ].map(d => String(d.amountOrTokenId)))]
+    const owners = positionIds.length ? await api.multiCall({
+      target: manager, abi: 'function ownerOf(uint256) view returns (address)',
+      calls: positionIds,
+    }) : []
+    if (owners.some(owner => typeof owner !== 'string' || owner.toLowerCase() !== vault.address.toLowerCase()))
+      throw new Error(`Gage user NFT is missing from vault custody: ${vault.address}`)
+    if (!positionIds.length) continue // An empty v4 ID list would trigger unsupported subgraph discovery.
+
+    const config = { api, balances: api.getBalances(), nftAddress: manager, blacklistedTokens: ownTokens }
+    if (vault.kind === 1) await unwrapUniswapV4NFTs({ ...config, stateViewer, uniV4ExtraConfig: { positionIds } })
+    else await unwrapUniswapV3NFT({ ...config, uniV3ExtraConfig: { positionIds } })
+  }
+}
+
+async function borrowed(api) {
+  for (const vault of await getVaults(api)) {
+    // Gross funded principal remains outstanding until reclaim/claim, including the grace period.
+    // Repayment caps are not balances, and proceeds awaiting withdrawal are still gross funded loans.
+    const amount = vault.deals.filter(d => Number(d.state) === 2).reduce((sum, d) => sum + BigInt(d.price), 0n)
+    api.add(vault.usdg, amount.toString())
+  }
+}
+
+module.exports = {
+  timetravel: true, // Historical runs require an archive RPC, e.g. https://rpc.ordofi.network.
+  doublecounted: true, // Escrowed LP underlying assets are also counted by Uniswap V3/V4.
+  start: '2026-09-07',
+  methodology: 'Counts user ERC20 collateral and USDG held in all three Gage lending vaults, including assets awaiting withdrawal, excluding protocol fee credits. Vault-owned Uniswap V3/V4 NFTs are unwrapped into underlying principal, excluding uncollected LP fees. These LP assets overlap with Uniswap V3/V4 TVL. Outstanding gross funded principal is reported separately under borrowed until reclaim or claim, including overdue unsettled deals and proceeds awaiting withdrawal. Excludes GAGE/sGAGE, reward reserves, treasury and the external GAGE/sGAGE pool. Historical runs require an archive RPC; token balances are priced by DefiLlama.',
+  robinhood: { tvl, borrowed },
+}

--- a/projects/gage/index.js
+++ b/projects/gage/index.js
@@ -8,11 +8,15 @@ const vaults = [
   { address: '0xe3628a01eaca2e7b0EC71Ed7bA616b997fEf9cDE', fromBlock: 57272387, kind: 2 },
 ]
 const stateViewer = '0xF3334192D15450CdD385c8B70e03f9A6bD9E673b'
-const ownTokens = [
+const blacklistedTokens = [
   '0x7163ae1b5aea2f09ebc609c52b4dcac0a7a4bc2d', // GAGE
   '0x78c88cf8f6e612955526ceb501be82bf3279bd5d', // sGAGE
+  '0x647d46c0577453be8c75039f829740b5d2e44938', // GAGE-RECEIPT: 1-wei internal receipt, deals are router round-trips with no collateral
 ]
 const dealAbi = 'function getDeal(uint256) view returns ((address borrower, uint8 kind, uint8 state, uint32 term, uint40 listingExpiry, address token, uint40 fundedAt, uint40 expiry, uint256 amountOrTokenId, uint128 cap, uint128 minPrice, address lender, uint128 price, uint128 fee))'
+const bidAbi = 'function getBid(uint256) view returns ((uint256 dealId, address lender, uint128 price, uint40 expiry, uint8 state))'
+const balanceUSDGAbi = 'function balanceUSDG(address) view returns (uint256)'
+const isBlacklisted = (token) => blacklistedTokens.includes(token.toLowerCase())
 
 async function getVaults(api) {
   const block = await api.getBlock() // Pin discovery, custody and LP state to the same block.
@@ -23,12 +27,31 @@ async function getVaults(api) {
     ])
     const length = Number(count)
     if (!Number.isSafeInteger(length) || length < 0) throw new Error('Invalid Gage deal count')
-    const deals = length ? await api.multiCall({
+    const allDeals = length ? await api.multiCall({
       target: vault.address, abi: dealAbi,
       calls: Array.from({ length }, (_, i) => i + 1),
     }) : []
-    return { ...vault, usdg, deals }
+    // allDeals is kept for USDG credit accounting; deals excludes blacklisted collateral from tvl and borrowed.
+    const deals = allDeals.filter(d => !isBlacklisted(d.token))
+    return { ...vault, usdg, deals, allDeals }
   }))
+}
+
+// USDG held by a vault is either lender escrow for OPEN bids or a balanceUSDG credit awaiting withdrawal
+// (borrower loan proceeds, lender repayments, withdrawn bids, protocol fees). Only the escrow is TVL:
+// subtract every credit holder's balance. Credit holders are the fee sink, deal parties and bid lenders.
+async function getUsdgCredits(api, vault, feeSink) {
+  const bidCount = Number(await api.call({ target: vault.address, abi: 'uint256:bidCount' }))
+  const bids = bidCount ? await api.multiCall({
+    target: vault.address, abi: bidAbi,
+    calls: Array.from({ length: bidCount }, (_, i) => i + 1),
+  }) : []
+  const creditHolders = [feeSink]
+  for (const d of vault.allDeals) creditHolders.push(d.borrower, d.lender) // unfunded deals have a zero lender, which simply reads 0
+  for (const b of bids) creditHolders.push(b.lender)
+  const parties = [...new Set(creditHolders.map(a => a.toLowerCase()))]
+  const credits = await api.multiCall({ target: vault.address, abi: balanceUSDGAbi, calls: parties })
+  return credits.reduce((sum, c) => sum + BigInt(c), 0n)
 }
 
 async function tvl(api) {
@@ -39,15 +62,15 @@ async function tvl(api) {
     ])
     // Include tokens from settled and delisted deals: withdrawals are a separate transaction.
     const tokens = [...new Set([vault.usdg, ...vault.deals.filter(d => Number(d.kind) === 0).map(d => d.token)]
-      .map(t => t.toLowerCase()))].filter(t => !ownTokens.includes(t))
-    const [balances, protocolFees] = await Promise.all([
+      .map(t => t.toLowerCase()))].filter(t => !isBlacklisted(t))
+    const [balances, usdgCredits] = await Promise.all([
       api.multiCall({ abi: 'erc20:balanceOf', calls: tokens.map(target => ({ target, params: vault.address })) }),
-      api.call({ target: vault.address, abi: 'function balanceUSDG(address) view returns (uint256)', params: feeSink }),
+      getUsdgCredits(api, vault, feeSink),
     ])
     tokens.forEach((token, i) => {
       let amount = BigInt(balances[i])
-      if (token === vault.usdg.toLowerCase()) amount -= BigInt(protocolFees)
-      if (amount < 0n) throw new Error(`Gage fee credit exceeds USDG custody: ${vault.address}`)
+      if (token === vault.usdg.toLowerCase()) amount -= usdgCredits
+      if (amount < 0n) throw new Error(`Gage USDG credits exceed custody: ${vault.address}`)
       api.add(token, amount.toString())
     })
 
@@ -73,7 +96,7 @@ async function tvl(api) {
       throw new Error(`Gage user NFT is missing from vault custody: ${vault.address}`)
     if (!positionIds.length) continue // An empty v4 ID list would trigger unsupported subgraph discovery.
 
-    const config = { api, balances: api.getBalances(), nftAddress: manager, blacklistedTokens: ownTokens }
+    const config = { api, balances: api.getBalances(), nftAddress: manager, blacklistedTokens }
     if (vault.kind === 1) await unwrapUniswapV4NFTs({ ...config, stateViewer, uniV4ExtraConfig: { positionIds } })
     else await unwrapUniswapV3NFT({ ...config, uniV3ExtraConfig: { positionIds } })
   }
@@ -92,6 +115,6 @@ module.exports = {
   timetravel: true, // Historical runs require an archive RPC, e.g. https://rpc.ordofi.network.
   doublecounted: true, // Escrowed LP underlying assets are also counted by Uniswap V3/V4.
   start: '2026-09-07',
-  methodology: 'Counts user ERC20 collateral and USDG held in all three Gage lending vaults, including assets awaiting withdrawal, excluding protocol fee credits. Vault-owned Uniswap V3/V4 NFTs are unwrapped into underlying principal, excluding uncollected LP fees. These LP assets overlap with Uniswap V3/V4 TVL. Outstanding gross funded principal is reported separately under borrowed until reclaim or claim, including overdue unsettled deals and proceeds awaiting withdrawal. Excludes GAGE/sGAGE, reward reserves, treasury and the external GAGE/sGAGE pool. Historical runs require an archive RPC; token balances are priced by DefiLlama.',
+  methodology: 'Counts user ERC20 collateral held in all three Gage lending vaults, including collateral awaiting withdrawal, plus USDG escrowed for open lender bids. USDG credited to accounts for withdrawal (borrower loan proceeds, lender repayments, withdrawn bids, protocol fees) is excluded. Vault-owned Uniswap V3/V4 NFTs are unwrapped into underlying principal, excluding uncollected LP fees; these LP assets overlap with Uniswap V3/V4 TVL. Outstanding gross funded principal is reported separately under borrowed until reclaim or claim, including overdue unsettled deals. Excludes GAGE/sGAGE, the internal GAGE-RECEIPT token and deals collateralised by it, reward reserves, treasury and the external GAGE/sGAGE pool. Token balances are priced by DefiLlama.',
   robinhood: { tvl, borrowed },
 }


### PR DESCRIPTION
Adds Gage's lending TVL and outstanding borrowing on Robinhood Chain across its three immutable vault deployments. Reads token custody, protocol fee credits, deal state and user LP withdrawal claims on-chain; unwraps collateral NFTs through the existing Uniswap V3/V4 helpers.

## Listing information

##### Name (to be shown on DefiLlama):

Gage

##### Twitter Link:

https://x.com/gagedotcash

##### List of audit links if any:

No independent audit report is published. Source verification and audit status: https://docs.gage.cash/protocol/status. Source verification is not an audit.

##### Website Link:

https://gage.cash

##### Logo (High resolution, will be shown with rounded borders):

https://gage.cash/gage-icon.png (512 × 512 PNG)

##### Current TVL:

Approximately **$51,216.04 in priced TVL**, with **$37,831.08 in borrowing reported separately**, at Robinhood block **57,713,391**, using prices checked **2026-09-08 13:07:08 UTC**.

Pricing coverage note: the vault also holds 120,000 SHROOM (`robinhood:0xab093def657f15df31b33922a95e047add645b29`), whose raw balance is returned by the adapter but which currently has no DeFiLlama price. Its value is omitted from the dollar subtotal. All other nonzero returned assets had usable prices. The project accepts proceeding with that disclosed omission; no custom price substitution is used.

##### Treasury Addresses (if the protocol has treasury):

Operations/ownership wallet: `0x86514e45293fcf111ED8A6bDA7c8bca4A64Dd9E5` on Robinhood Chain. It is an EOA. Protocol fee custody/routing addresses and roles: https://docs.gage.cash/protocol/addresses. Protocol-owned fees and treasury assets are excluded from lending TVL.

##### Chain:

Robinhood Chain (chain ID 4663; adapter key `robinhood`).

##### Coingecko ID:

##### Coinmarketcap ID:

##### Short Description (to be shown on DefiLlama):

Gage is a fixed-term peer-to-peer lending protocol on Robinhood Chain. Borrowers lock tokenized stocks, crypto assets or liquidity positions for USDG, then repay a fixed amount to reclaim collateral or allow the lender to claim it after expiry and grace. Loans have no price-triggered liquidation.

##### Token address and ticker if any:

GAGE: `0x7163aE1B5AeA2f09EBc609C52b4dcAc0a7a4bC2d`.

sGAGE reward token: `0x78c88CF8F6E612955526cEB501be82BF3279Bd5d`.

Both are on Robinhood Chain and excluded from base lending TVL.

##### Category:

Lending

##### Oracle Provider(s):

No external price oracle determines loan settlement. LP admission can read the pool tick for a configured in-range requirement.

##### Implementation Details:

Funding and settlement use fixed deal terms. The application's off-chain display prices derive from pool/curve state; they do not determine settlement and are not used as this adapter's USD-price source. The adapter returns on-chain raw balances for DeFiLlama pricing.

##### Documentation/Proof:

https://docs.gage.cash/protocol/invariants (I11)

https://docs.gage.cash/protocol/addresses

Matched contract sources:

- Core: https://repo.sourcify.dev/4663/0x3D979740785ABd8b7Dd5c2Ff7Bf100CBe86fcBDF
- PONS/USDG LP vault: https://repo.sourcify.dev/4663/0xc23A08282AA1A9141C6fD7A29e7dFbFe841cC6B6
- PONS/WETH LP vault: https://repo.sourcify.dev/4663/0xe3628a01eaca2e7b0EC71Ed7bA616b997fEf9cDE

##### forkedFrom:

No upstream lending-protocol fork identified. Gage uses custom DealVault contracts with OpenZeppelin and Uniswap/Pons integrations.

##### methodology:

Counts user ERC20 collateral and USDG held by the core, PONS/USDG LP and PONS/WETH LP vaults, including balances awaiting withdrawal, minus protocol fee credits. Includes active user LP NFTs and settled NFTs with an unwithdrawn user credit, verifies vault ownership, and unwraps their underlying principal. Excludes uncollected LP fees and unsolicited NFTs with no tracked user claim.

Outstanding gross funded principal is reported separately under `borrowed` until reclaim or claim, including overdue unsettled deals and proceeds awaiting withdrawal. Repayment caps are never used as asset values. Excludes GAGE/sGAGE, rewards reserves, treasury and the external GAGE/sGAGE pool from base lending TVL.

`doublecounted: true` documents LP underlying liquidity also counted by the existing Uniswap V3/V4 adapters. `timetravel: true` requires an archive-capable RPC. Each vault is skipped before its deployment block.

##### Github org/user (Optional, if your code is open source, we can track activity):

##### Does this project have a referral program?

No referral program is implemented in the inspected application/contracts or described in the public documentation.

## Validation and backfill

Tested against DefiLlama-Adapters commit `e60d5d74abd7bc16f4f53609c497c2016c378174` with SDK 5.0.228:

```bash
ROBINHOOD_RPC=https://rpc.mainnet.chain.robinhood.com node test.js projects/gage/index.js
ROBINHOOD_RPC=https://rpc.ordofi.network node test.js projects/gage/index.js 2026-09-07T22:25:39Z
ROBINHOOD_RPC=https://rpc.ordofi.network node test.js projects/gage/index.js 2026-09-08T12:00:00Z
pnpm exec eslint projects/gage/index.js
```

All runs pass. A separate current on-chain balance and pricing check passed with only the disclosed SHROOM omission. Fourteen local accounting regression tests cover withdrawals, fee subtraction, funded principal, LP ownership/credits, NFT deduplication and deployment boundaries. The live core has a v4 collateral NFT; the two extension vaults were empty during validation, so their v3/v4 dispatch and custody paths were exercised offline.

**Backfill configuration:** the official public RPC prunes old contract state. The public `https://rpc.ordofi.network` endpoint served historical vault and LP reads and both historical adapter runs; its chain ID and a reference block hash matched the official RPC. It is not in the tested SDK's default provider list, so an archive-capable provider must be configured for backfill. Historical failures are not replaced with current-state reads.

No dependencies or lockfiles changed. The PR contains only `projects/gage/index.js`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tracking Gage lending protocol metrics.
  * Reports total value locked across Gage vault deployments.
  * Reports borrowed amounts for funded lending deals.
  * Accounts for collateral held directly in vaults and assets represented by supported liquidity positions.
  * Excludes specified protocol tokens and withdrawal credits from TVL calculations.
  * Includes open-bid escrow while accounting for supported liquidity positions and their underlying assets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->