### PR TITLE
hipo: exclude the deficit from TVL

### DIFF
--- a/projects/hipo/index.js
+++ b/projects/hipo/index.js
@@ -3,18 +3,23 @@ const { call } = require('../helper/chain/ton')
 module.exports = {
   timetravel: false,
   methodology:
-    'GRAM controlled by the Hipo treasury: coins backing hGRAM (including coins lent to validators) plus deposits pending for the next validation round',
+    'GRAM controlled by the Hipo treasury: coins backing hGRAM (including coins lent to validators) plus deposits pending for the next validation round, less any shortfall left behind by a defaulting borrower',
   hallmarks: [
     ['2023-10-30', 'Hipo Launch'],
     ['2024-03-19', 'Hipo v2'],
   ],
   ton: {
     tvl: async () => {
+      // get_treasury_state is append-only, so these positions are fixed
       const result = await call({ target: 'EQCLyZHP4Xe8fpchQz76O-_RmUhaVc_9BAoGyJrwJrcbz2eZ', abi: 'get_treasury_state' })
       const totalCoins = result[0] / 1e9
       const pendingDeposits = result[2] / 1e9
+      // Pool money a defaulting borrower's collateral could not cover. The treasury deliberately
+      // leaves it inside total_coins so the exchange rate never moves down for a loss, which makes
+      // total_coins a claim rather than a balance -- these coins are gone. Normally zero.
+      const deficit = result[5] / 1e9
       return {
-        'coingecko:the-open-network': totalCoins + pendingDeposits,
+        'coingecko:the-open-network': totalCoins + pendingDeposits - deficit,
       }
     },
   },


### PR DESCRIPTION
Existing adapter, TVL correction. No new dependencies, no listing changes.

Hipo's treasury tracks a `deficit`: pool money a defaulting borrower's collateral could not cover. It is deliberately **not** subtracted from `total_coins` on chain, because the hGRAM exchange rate must never move down for a loss — the counter is the record that the balance is short by that much, and the governor zeroes it after topping the treasury back up ([`treasury.fc`](https://github.com/HipoFinance/contract/blob/main/contracts/treasury.fc)).

That makes `total_coins` a claim rather than a balance, so TVL read straight off it would keep counting coins that are gone. This subtracts the deficit, which has its own value at position 5 of the append-only `get_treasury_state` tuple.

It is zero on mainnet today and always has been, so this changes no reported number now — it is a guard for the day it isn't.

```
$ node test.js projects/hipo/index.js
--- ton ---
GRAM                      9.72 M
Total: 9.72 M

------ TVL ------
ton                       9.72 M
total                     9.72 M
```

##### methodology (what is being counted as tvl, how is tvl being calculated):
GRAM controlled by the Hipo treasury: coins backing hGRAM (including coins lent to validators) plus deposits pending for the next validation round, less any shortfall left behind by a defaulting borrower.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gpytSTyKW21AkBzNNHrd6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hipo TVL reporting now accounts for treasury deficits, improving the accuracy of displayed totals.

* **Documentation**
  * Updated methodology details to explain how treasury shortfalls are reflected in TVL calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->