### PR TITLE
Add Surge (prize-linked staking on Sui)

### DIFF
--- a/projects/surge/index.js
+++ b/projects/surge/index.js
@@ -1,31 +1,21 @@
-const { getLogs } = require('../helper/cache/getLogs')
-const { sumTokens2 } = require('../helper/unwrapLPs')
+const sui = require('../helper/chain/sui')
+const ADDRESSES = require('../helper/coreAssets.json')
 
-const config = {
-  arbitrum: { factory: '0x503A14768e23456620fB3Cb61e37A36A2736Cbd0', fromBlock: 107875529, }
+// Surge's V6 vault: principal is held 1:1 in the vault (no-loss design — the
+// vault's total_principal field IS the TVL). Unlike LST protocols (see
+// haedal/index.js) there's no rewards/fees/unstaked math needed here: the
+// contract enforces that total_principal always equals the sum of active
+// stakers' deposits, denominated directly in SUI mist.
+const V6_VAULT = '0xcc6a5e55e3099b2b9d777b9f51b6a5807a03888c613be0b401468a94cc3f1ba5'
+
+async function tvl(api) {
+  const { fields: vault } = await sui.getObject(V6_VAULT)
+  api.add(ADDRESSES.sui.SUI, vault.total_principal)
 }
 
-Object.keys(config).forEach(chain => {
-  const { factory, fromBlock, } = config[chain]
-  const _getLogs = (api) => getLogs({
-    api,
-    target: factory,
-    topics: ['0xfd4f84c703fbc9ed47d26b2769a6133a02ea690b88125c716c7321699d0115fa'],
-    eventAbi: 'event PoolDeployed(uint256 poolId, address pool, address indexed collateralToken, address indexed loanToken, uint256 indexed maxCollateralRatioMantissa, uint256 surgeMantissa, uint256 collateralRatioFallDuration, uint256 collateralRatioRecoveryDuration, uint256 minRateMantissa, uint256 surgeRateMantissa, uint256 maxRateMantissa)',
-    onlyArgs: true,
-    fromBlock,
-  })
-  module.exports[chain] = {
-    tvl: async (api) => {
-      const logs = await _getLogs(api)
-      const ownerTokens = logs.map(l => [[l.collateralToken, l.loanToken], l.pool])
-      return sumTokens2({ api, ownerTokens, })
-    },
-    borrowed: async (api) => {
-      const logs = await _getLogs(api)
-      const borrowed = await api.multiCall({  abi: 'uint256:lastTotalDebt', calls: logs.map(i => i.pool) })
-      api.addTokens(logs.map(i => i.loanToken), borrowed)
-      return api.getBalances()
-    },
-  }
-})
+module.exports = {
+  methodology: 'TVL is the total SUI principal staked in the Surge prize-linked staking vault (V6). Principal is held 1:1 and never used for anything other than covering staker withdrawals — enforced on-chain, verifiable via the V6_VAULT object.',
+  sui: {
+    tvl,
+  },
+}


### PR DESCRIPTION
Name (to be shown on DefiLlama):
Surge

Twitter Link:
https://x.com/Surge_Sui

List of audit links if any:
None yet — protocol is currently unaudited (early-stage, stated transparently on the site)

Website Link:
https://surgeonsui.com/

Logo (High resolution, will be shown with rounded borders):
(hab ich als Datei aus dem Projekt — lad ich dir unten hoch, musst du nur ins PR-Formular ziehen)

Current TVL:
~47 SUI (~$38)

Treasury Addresses (if the protocol has treasury):
N/A — no separate treasury

Chain:
Sui

Coingecko ID:
(leer lassen — kein Token)

Coinmarketcap ID:
(leer lassen — kein Token)

Short Description (to be shown on DefiLlama):
No-loss prize-linked staking on Sui. Principal stays yours — only the staking yield funds periodic on-chain prize draws.

Token address and ticker if any:
N/A — no protocol token

Category:
Staking Pool

Oracle Provider(s):
None — TVL is read directly from on-chain vault state, no price oracle dependency for principal accounting

Implementation Details:
N/A (no oracle used)

Documentation/Proof:
https://github.com/PBerHH/surge-protocol

forkedFrom:
No — original build. Uses Haedal's haSUI (liquid staking) as the underlying yield source, but the prize-draw mechanism itself is original.

methodology:
TVL is the total SUI principal staked in the vault (V6 contract), read directly from the on-chain total_principal field. Principal is held 1:1 and is never at risk — only the accrued staking yield (via haSUI appreciation) is periodically harvested to fund prize draws.

Github org/user:
PBerHH (github.com/PBerHH/surge-protocol)

Does this project have a referral program?
Yes — a points-based referral system (no direct monetary payout). Referrers earn a scaling bonus (+10% per active referred wallet, capped at +50%) to their loyalty points multiplier, active only while the referred wallet remains staked.

<img width="1092" height="1092" alt="surge-logo" src="https://github.com/user-attachments/assets/27521d1a-4fad-4544-bc46-5d56bdcd0c78" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for tracking the Surge V6 vault on Sui.
  - Reports vault principal as SUI-denominated TVL.
  - Added methodology information describing the 1:1 principal accounting.

- **Updates**
  - Replaced Arbitrum pool and borrowing metrics with Sui vault TVL reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->