### PR TITLE
fix stacks timetravel: exact block lookup + skip contracts not yet deployed

### DIFF
--- a/projects/helper/chain/stacks-api.js
+++ b/projects/helper/chain/stacks-api.js
@@ -290,105 +290,45 @@ function getCVTypeString(cv) {
 
 const senderAddress = 'ST2F4BK4GZH6YFBNHYDDGN4T1RKBA7DA1BJZPJEJJ'
 
-// Known (height, timestamp) anchors from chain history.
-const BLOCK_TIME_ANCHORS = [
-  { height: 1,       time: 1610645304 },
-  { height: 100000,  time: 1679912897 },
-  { height: 140000,  time: 1708389420 },
-  { height: 160000,  time: 1722366824 },
-  { height: 171355,  time: 1729880265 },
-  { height: 180000,  time: 1730434793 },
-  { height: 200000,  time: 1731241700 },
-  { height: 220000,  time: 1731752958 },
-  { height: 231708,  time: 1731976023 },
-  { height: 307999,  time: 1733685896 },
-  { height: 498146,  time: 1737558943 },
-  { height: 669248,  time: 1740393688 },
-  { height: 793801,  time: 1742225748 },
-  { height: 1023399, time: 1745499538 },
-  { height: 1384524, time: 1748666644 },
-  { height: 1467463, time: 1749012823 },
-  { height: 2007404, time: 1751516354 },
-  { height: 2475460, time: 1754110089 },
-  { height: 3487019, time: 1757736297 },
-  { height: 4043665, time: 1759903744 },
-  { height: 4746510, time: 1763052608 },
-  { height: 5239155, time: 1765409601 },
-  { height: 6174748, time: 1769618139 },
-  { height: 6494525, time: 1770863934 },
-  { height: 6937411, time: 1772584174 },
-]
-
 const blockHashCache = {}
 const blockAtTimestampCache = {}
 
+function cacheBlock(block) {
+  blockHashCache[block.height] = block.index_block_hash.replace('0x', '')
+  return block
+}
+
 async function fetchBlock(height) {
-  const url = `${BASE_URL}/extended/v2/blocks/${height}`
-  const response = await apiFetch(url)
+  const response = await apiFetch(`${BASE_URL}/extended/v2/blocks/${height}`)
   if (!response.ok) {
     const msg = await response.text().catch(() => '')
     throw new Error(`Failed to fetch block ${height}: ${msg}`)
   }
-  return response.json()
+  return cacheBlock(await response.json())
 }
 
 async function getBlockHash(blockHeight) {
   if (blockHashCache[blockHeight]) return blockHashCache[blockHeight]
-  const block = await fetchBlock(blockHeight)
-  const tip = block.index_block_hash.replace('0x', '')
-  blockHashCache[blockHeight] = tip
-  return tip
+  await fetchBlock(blockHeight)
+  return blockHashCache[blockHeight]
 }
 
 async function getBlockAtTimestamp(targetTimestamp) {
-  if (blockAtTimestampCache[targetTimestamp]) return blockAtTimestampCache[targetTimestamp]
+  const timestamp = Math.floor(targetTimestamp)
+  if (blockAtTimestampCache[timestamp]) return blockAtTimestampCache[timestamp]
 
-  if (targetTimestamp <= BLOCK_TIME_ANCHORS[0].time) {
-    blockAtTimestampCache[targetTimestamp] = 1
+  const response = await apiFetch(`${BASE_URL}/extended/v2/blocks/by-block-time/${timestamp}`)
+  if (response.status === 404) {
+    blockAtTimestampCache[timestamp] = 1
     return 1
   }
-
-  let lo = BLOCK_TIME_ANCHORS[0]
-  let hi = BLOCK_TIME_ANCHORS[BLOCK_TIME_ANCHORS.length - 1]
-  for (let i = 0; i < BLOCK_TIME_ANCHORS.length - 1; i++) {
-    if (BLOCK_TIME_ANCHORS[i].time <= targetTimestamp && BLOCK_TIME_ANCHORS[i + 1].time > targetTimestamp) {
-      lo = BLOCK_TIME_ANCHORS[i]
-      hi = BLOCK_TIME_ANCHORS[i + 1]
-      break
-    }
+  if (!response.ok) {
+    const msg = await response.text().catch(() => '')
+    throw new Error(`Failed to fetch block at timestamp ${timestamp}: ${msg}`)
   }
-
-  if (targetTimestamp >= hi.time) {
-    const latestResp = await apiFetch(`${BASE_URL}/extended/v2/blocks?limit=1`)
-    const latest = (await latestResp.json()).results[0]
-    if (targetTimestamp >= latest.block_time) {
-      blockAtTimestampCache[targetTimestamp] = latest.height
-      return latest.height
-    }
-    hi = { height: latest.height, time: latest.block_time }
-  }
-
-  const fraction = (targetTimestamp - lo.time) / (hi.time - lo.time)
-  let guess = Math.floor(lo.height + fraction * (hi.height - lo.height))
-  guess = Math.max(lo.height, Math.min(hi.height, guess))
-
-  let best = await fetchBlock(guess)
-
-  if (best.block_time > targetTimestamp || Math.abs(best.block_time - targetTimestamp) > 30) {
-    const localRate = (hi.time - lo.time) / (hi.height - lo.height)
-    const correction = Math.round((targetTimestamp - best.block_time) / localRate)
-    const corrected = Math.max(lo.height, Math.min(hi.height, guess + correction))
-    if (corrected !== guess) {
-      best = await fetchBlock(corrected)
-    }
-  }
-
-  if (best.block_time > targetTimestamp && best.height > 1) {
-    best = await fetchBlock(best.height - 1)
-  }
-
-  blockAtTimestampCache[targetTimestamp] = best.height
-  return best.height
+  const block = cacheBlock(await response.json())
+  blockAtTimestampCache[timestamp] = block.height
+  return block.height
 }
 
 function isBlockHash(value) {
@@ -406,7 +346,7 @@ async function resolveTip(block) {
   return getBlockHash(block)
 }
 
-async function call({ target, abi, inputArgs = [], block }) {
+async function call({ target, abi, inputArgs = [], block, allowMissing = false }) {
   const [contractAddress, contractName] = target.split('.')
   const functionArgs = inputArgs.map(toClairty)
 
@@ -429,7 +369,10 @@ async function call({ target, abi, inputArgs = [], block }) {
   }
 
   const json = await response.json()
-  if (!json.okay) throw new Error(`Contract call failed: ${json.cause}`)
+  if (!json.okay) {
+    if (allowMissing && String(json.cause).includes('NoSuchContract')) return undefined
+    throw new Error(`Contract call failed: ${json.cause}`)
+  }
   return cvToValue(deserializeCV(json.result))
 
   function toClairty(arg) {

--- a/projects/stackingdao/api.js
+++ b/projects/stackingdao/api.js
@@ -4,9 +4,6 @@ const { nullAddress } = require('../helper/tokenMapping')
 const D = 'SP4SZE494VC2YC5JYG7AYFQ44F5Q4PYV7DVMDPBG'
 const SBTC = 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token'
 
-const STX_V2_CUTOVER = 8712010
-const STBTC_START = 8666589
-
 module.exports = {
   timetravel: true,
   stacks: { tvl },
@@ -16,21 +13,18 @@ function toAmount(v) {
   return String(typeof v === 'object' && v !== null ? v.value : v)
 }
 
+const RESERVES = [
+  { target: `${D}.reserve-v1`, abi: 'get-total-stx', token: nullAddress },
+  { target: `${D}.stx-reserve-v2`, abi: 'get-total-stx', token: nullAddress },
+  { target: `${D}.stbtc-reserve`, abi: 'get-total-sbtc', token: SBTC },
+]
+
 async function tvl(api) {
   const block = api.block ?? (api.timestamp ? await getBlockAtTimestamp(api.timestamp) : undefined)
-  const isLatest = block === undefined
 
-  const reserveV1 = await call({ target: `${D}.reserve-v1`, abi: 'get-total-stx', block })
-  api.add(nullAddress, toAmount(reserveV1))
-
-  if (isLatest || block >= STX_V2_CUTOVER) {
-    const reserveV2 = await call({ target: `${D}.stx-reserve-v2`, abi: 'get-total-stx', block })
-    api.add(nullAddress, toAmount(reserveV2))
-  }
-
-  if (isLatest || block >= STBTC_START) {
-    const sbtcReserve = await call({ target: `${D}.stbtc-reserve`, abi: 'get-total-sbtc', block })
-    api.add(SBTC, toAmount(sbtcReserve))
+  for (const { target, abi, token } of RESERVES) {
+    const value = await call({ target, abi, block, allowMissing: true })
+    if (value !== undefined) api.add(token, toAmount(value))
   }
 
   return api.getBalances()

--- a/projects/zest/api.js
+++ b/projects/zest/api.js
@@ -60,17 +60,14 @@ async function tvl(api) {
     const block = api.block ?? (api.timestamp ? await getBlockAtTimestamp(api.timestamp) : undefined)
     await Promise.all(VAULT_OWNERS.flatMap(owner =>
         V1_ASSETS.map(async (asset) => {
-            try {
-                const bal = await call({
-                    target: getContract(asset),
-                    abi: 'get-balance',
-                    inputArgs: [{ type: 'principal', value: owner }],
-                    block,
-                })
-                api.add(getTokenId(asset), bal?.value ?? bal)
-            } catch (e) {
-                if (e.message?.includes('429')) throw e
-            }
+            const bal = await call({
+                target: getContract(asset),
+                abi: 'get-balance',
+                inputArgs: [{ type: 'principal', value: owner }],
+                block,
+                allowMissing: true,
+            })
+            if (bal !== undefined) api.add(getTokenId(asset), bal?.value ?? bal)
         })
     ))
     return api.getBalances()


### PR DESCRIPTION
The Stacks helper resolved timestamps to blocks by interpolating between a hardcoded anchor table that ends in March 2026. Past that point it extrapolates from the current block rate, and the error is large: a June 1 timestamp resolved to a June 20 block, and even a one-day-old timestamp landed ~4 hours late. Every historical read for Stacks adapters through that range was reading the wrong state.

Changes

- getBlockAtTimestamp now calls Hiro's /extended/v2/blocks/by-block-time/{ts}, which returns the last block at or before the timestamp from the indexed block table. The response includes the index block hash, so it is cached and a historical contract read no longer needs a second fetch. Pre-genesis timestamps still resolve to block 1, matching the old behaviour.
- call() takes an allowMissing option. When the contract does not exist at the requested tip, it returns undefined instead of throwing. Any other failure still throws, so a bad run is not written as zeros.
- zest, zest-v2 and stackingdao use it, so backfills skip vaults and reserves that were not deployed yet. stackingdao drops its two hardcoded cutover block heights and sums whichever reserves exist, which is correct at every point in history.

Verification

- The new lookup matched Hiro exactly on 20 timestamps from block 23 (Jan 2021) through today, including the Nakamoto transition, checked by confirming each timestamp falls between the returned block and its successor.
- Adapters run at pre-deployment tips return empty balances with no error, mid-history runs skip missing contracts, and current-time harness output is unchanged: stackingdao 35.6M, zest-v2 66.4M, zest-v1 2.4M.
- Lint clean. The CI test failure on these adapters is the usual one for heroku-api adapters, which cannot reach Elasticsearch from Actions.

**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).

2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** Please send a mail to metadata@defillama.com
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes

---
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):

##### Twitter Link:

##### List of audit links if any:

##### Website Link:

##### Logo (High resolution, will be shown with rounded borders):

##### Current TVL:

##### Treasury Addresses (if the protocol has treasury)

##### Chain:

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama):

##### Token address and ticker if any:

##### Category (full list at https://defillama.com/categories) \*Please choose only one:

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

##### forkedFrom (Does your project originate from another project):

##### methodology (what is being counted as tvl, how is tvl being calculated):

##### Github org/user (Optional, if your code is open source, we can track activity):

##### Does this project have a referral program?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Historical blockchain data now resolves block information directly from the network, improving accuracy across timestamps.
  - Total value locked calculations now continue when individual reserve or asset balances are unavailable, while still including all defined balances.
  - Missing contracts are handled gracefully without interrupting supported data retrieval.

- **Bug Fixes**
  - Unexpected errors are no longer silently ignored during balance retrieval; rate-limit handling remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->