### PR TITLE
Add VS

### DIFF
--- a/projects/vs/index.js
+++ b/projects/vs/index.js
@@ -1,0 +1,29 @@
+const { sumTokens2 } = require('../helper/unwrapLPs')
+
+// VS — onchain relative-performance markets on Robinhood Chain (chainId 4663).
+// Every market is an immutable VSMarket contract that custodies USDG collateral
+// backing outstanding complete sets (1 USDG = 1 A + 1 B) plus the AMM pool.
+// The factory keeps the canonical list of markets.
+const FACTORY = '0xE96F3d1F98f91842EA209acA197844040E241990'
+const USDG = '0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168'
+
+async function tvl(api) {
+  const markets = await api.call({ target: FACTORY, abi: 'address[]:allMarkets' })
+  if (!markets.length) return api.getBalances()
+
+  // Protocol fees accrue inside each market until swept to the treasury; they are
+  // not user collateral, so subtract them from the raw USDG balance.
+  const accruedFees = await api.multiCall({ abi: 'uint256:accruedFees', calls: markets })
+  await sumTokens2({ api, owners: markets, tokens: [USDG] })
+  accruedFees.forEach((fee) => api.add(USDG, -BigInt(fee)))
+  return api.getBalances()
+}
+
+module.exports = {
+  methodology:
+    'TVL is the USDG collateral held by every VSMarket contract created by the VS factory ' +
+    '(minus protocol fees accrued but not yet swept to the treasury). Each market holds ' +
+    '1 USDG for every outstanding complete set of outcome shares, plus the AMM pool liquidity.',
+  start: 1788478718, // 2026-09-03, factory deployment (block 53808598)
+  robinhood: { tvl },
+}

--- a/projects/vs/index.js
+++ b/projects/vs/index.js
@@ -1,11 +1,9 @@
 const { sumTokens2 } = require('../helper/unwrapLPs')
+const ADDRESSES = require('../helper/coreAssets.json')
 
-// VS — onchain relative-performance markets on Robinhood Chain (chainId 4663).
 // Every market is an immutable VSMarket contract that custodies USDG collateral
 // backing outstanding complete sets (1 USDG = 1 A + 1 B) plus the AMM pool.
-// The factory keeps the canonical list of markets.
 const FACTORY = '0xE96F3d1F98f91842EA209acA197844040E241990'
-const USDG = '0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168'
 
 async function tvl(api) {
   const markets = await api.call({ target: FACTORY, abi: 'address[]:allMarkets' })
@@ -14,9 +12,8 @@ async function tvl(api) {
   // Protocol fees accrue inside each market until swept to the treasury; they are
   // not user collateral, so subtract them from the raw USDG balance.
   const accruedFees = await api.multiCall({ abi: 'uint256:accruedFees', calls: markets })
-  await sumTokens2({ api, owners: markets, tokens: [USDG] })
-  accruedFees.forEach((fee) => api.add(USDG, -BigInt(fee)))
-  return api.getBalances()
+  await sumTokens2({ api, owners: markets, tokens: [ADDRESSES.robinhood.USDG] })
+  accruedFees.forEach((fee) => api.add(ADDRESSES.robinhood.USDG, -BigInt(fee)))
 }
 
 module.exports = {
@@ -24,6 +21,6 @@ module.exports = {
     'TVL is the USDG collateral held by every VSMarket contract created by the VS factory ' +
     '(minus protocol fees accrued but not yet swept to the treasury). Each market holds ' +
     '1 USDG for every outstanding complete set of outcome shares, plus the AMM pool liquidity.',
-  start: 1788478718, // 2026-09-03, factory deployment (block 53808598)
+  start: '2026-09-03',
   robinhood: { tvl },
 }


### PR DESCRIPTION
TVL adapter for VS, an onchain relative-performance market on Robinhood Chain. Sums USDG collateral held by every VSMarket listed by the factory, minus protocol fees accrued but not yet swept to the treasury.

**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).

2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** Please send a mail to metadata@defillama.com
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes

---
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
VS Trade

##### Twitter Link:
https://x.com/vstrade_fun

##### List of audit links if any:

##### Website Link:
https://vstrade.fun/

##### Logo (High resolution, will be shown with rounded borders):
https://vstrade.fun/logo.png

##### Current TVL:
$45.43

##### Treasury Addresses (if the protocol has treasury)

##### Chain:
Robinhood Chain

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama):
VS Trade is a relative performance market protocol that allows users to bet on which stock will outperform the other.

##### Token address and ticker if any:

##### Category (full list at https://defillama.com/categories) \*Please choose only one:
Derivatives

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
Chainlink
##### Implementation Details: Briefly describe how the oracle is integrated into your project:
Every VS market compares the relative performance of two Robinhood Stock Tokens (e.g. NVDA vs AMD) over a fixed window. Settlement reads Chainlink Data Feeds on Robinhood Chain through our `ChainlinkOracleAdapter` (0x72CC887908F4627274cF6855459450E787414E69), which maps each asset to its Chainlink V3 AggregatorV3Interface proxy. Feeds are register-once (the owner can never overwrite a feed). `open()` snapshots `getPriceAt(startTime)` and `resolve()` snapshots `getPriceAt(endTime)` by walking back aggregator rounds (≤ 200) to the latest observation at or before the target timestamp; the adapter validates answer > 0, round completeness and freshness (observation age ≤ maxPriceAge, default 1h). Both calls are permissionless. The asset whose end/start ratio is higher pays 1 USDG per share; if no valid feed data exists inside the resolution window the market is cancelled and every share refunds 0.5 USDG. No admin can choose a winner or edit a price. Prices are only used for settlement; TVL is plain USDG balances and does not depend on the oracle.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
- Chainlink feeds on Robinhood Chain: https://docs.chain.link/data-feeds/price-feeds/addresses?network=robinhood
- ChainlinkOracleAdapter (mainnet): https://robinhoodchain.blockscout.com/address/0x72CC887908F4627274cF6855459450E787414E69
- Factory: https://robinhoodchain.blockscout.com/address/0xE96F3d1F98f91842EA209acA197844040E241990
- Example market (reads oracleA/oracleB from the adapter): https://robinhoodchain.blockscout.com/address/0xa6D327ffBE5c24D4F4c19df88944457C56A5d249

##### forkedFrom (Does your project originate from another project):
No.

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL is the USDG collateral held by every VSMarket contract created by the VS factory, minus protocol fees accrued but not yet swept to the treasury. Each market holds exactly 1 USDG for every outstanding complete set of outcome shares (1 USDG = 1 A + 1 B) plus the AMM pool liquidity, so the USDG balance is the full collateral backing of the protocol. Markets are enumerated onchain via factory.allMarkets(). No staking, pool2 or borrowed component.

##### Github org/user (Optional, if your code is open source, we can track activity):

##### Does this project have a referral program?
No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for VS, an on-chain relative-performance markets protocol on Robinhood Chain.
  * Reports USDG collateral held across all active VS markets.
  * Excludes accrued but unswept protocol fees from reported balances.
  * Includes deployment start-date and methodology metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->