### PR TITLE
Add Privacy Boost TVL adapter

### DIFF
--- a/projects/privacy-boost/index.js
+++ b/projects/privacy-boost/index.js
@@ -1,0 +1,46 @@
+const { sumTokens2 } = require('../helper/unwrapLPs')
+
+const config = {
+  optimism: {
+    pool: '0xca689828854a422CF1f778be03CA80549408F620',
+    fromBlock: 150294733,
+    start: '2026-04-14',
+  },
+  soneium: {
+    pool: '0x8e11dc9a3579abfc0ecfbfb70be36808dee59e6d',
+    fromBlock: 21888033,
+    start: '2026-04-23',
+  },
+  base: {
+    pool: '0x71A0fD3C76E3E937d8275A3cb6a467b70123bD40',
+    fromBlock: 50794242,
+    start: '2026-09-02',
+  },
+}
+
+async function tvl(api) {
+  const { pool, fromBlock } = config[api.chain]
+  if (await api.getBlock() < fromBlock) return {}
+
+  const registry = await api.call({ target: pool, abi: 'address:tokenRegistry' })
+  const count = await api.call({ target: registry, abi: 'function nextId() view returns (uint16)' })
+  // nextId is the last assigned ID; token IDs start at 1.
+  const tokens = await api.multiCall({
+    target: registry,
+    abi: 'function tokenOf(uint16) view returns (uint8 tokenType, address tokenAddress, uint256 tokenSubId)',
+    calls: Array.from({ length: Number(count) }, (_, i) => i + 1),
+    field: 'tokenAddress',
+  })
+
+  return sumTokens2({ api, owner: pool, tokens })
+}
+
+module.exports = {
+  // Morpho vault shares in the pools overlap with Morpho's TVL.
+  doublecounted: true,
+  methodology: 'Counts registered ERC-20 balances in Privacy Boost pools, including pending deposits and vault shares. Portal funds are included once swept into a pool.',
+}
+
+Object.entries(config).forEach(([chain, { start }]) => {
+  module.exports[chain] = { start, tvl }
+})


### PR DESCRIPTION
## Add Privacy Boost TVL adapter

Adds TVL tracking for Privacy Boost, a protocol for private token transfers and DeFi transactions on EVM chains. The adapter reads the supported-token list on-chain and sums token balances in the protocol's deposit contracts on OP Mainnet, Soneium and Base.

Contract addresses and deployment blocks were checked against deployment receipts. Current and historical TVL queries passed for all three chains; ESLint and syntax checks passed.

##### Name (to be shown on DefiLlama):

Privacy Boost

##### Twitter Link:

https://x.com/PrivacyBoost

##### List of audit links if any:

- [OpenZeppelin, March 2026](https://github.com/sunnyside-io/privacy-boost-protocol/blob/12516dddf1788dc0169125c2b69333c9a2ea8075/audits/2026-03-openzeppelin.pdf)
- [OpenZeppelin, May 2026 — smart wallet signature support](https://github.com/sunnyside-io/privacy-boost-protocol/blob/0408f513489ae010a83e4cefa783f4d8e42b05d0/audits/2026-05-openzeppelin.pdf)
- [OpenZeppelin, September 2026](https://github.com/sunnyside-io/privacy-boost-protocol/blob/ca90d08e11a7a9b435aeb3c967750df8e0e5084c/audits/2026-09-openzeppelin.pdf)

##### Website Link:

https://www.privacyboost.io/

##### Logo (High resolution, will be shown with rounded borders):

<img src="https://raw.githubusercontent.com/sunnyside-io/DefiLlama-Adapters/5b561df3057335ada416dc4cb16c0979a4e37c10/assets/privacy-boost/PB_logo_primary_symbol.png" alt="Privacy Boost logo" width="160" />

##### Current TVL:

Approximately $70.2K as of 2026-09-08.

##### Treasury Addresses (if the protocol has treasury)

From the production deployment configuration:

- OP Mainnet: `0xc82018cbC82A50064e3DdEF79EAdC319710Ffc5e`
- Soneium: `0x29C4f68378965Eb7Dc0F70A8cb60B9dcA0f42067`
- Base: `0x04484B6065A43fa286e05E9C28a6c4Db77d917f8`

##### Chain:

OP Mainnet, Soneium, Base

##### Coingecko ID:



##### Coinmarketcap ID:



##### Short Description (to be shown on DefiLlama):

Privacy Boost is a compliant privacy layer for EVM chains that shields onchain transfers and DeFi activity end to end. Works with EOA, MPC, Safe multisig, and smart account wallets, with built-in Audit View for compliance.

##### Token address and ticker if any:

None.

##### Category:

Privacy

##### Oracle Provider(s):

None.

##### Implementation Details (oracle integration):

N/A.

##### Documentation/Proof (oracle usage):

N/A.

##### forkedFrom:

None.

##### methodology:

TVL is the value of tokens held in Privacy Boost's deposit contracts. Supported tokens are discovered on-chain. Deposited tokens can also represent funds held in other DeFi protocols, such as Morpho vaults. These underlying assets may also be counted in the other protocols' TVL, so the adapter sets `doublecounted: true`.

##### Github org/user (Optional, if your code is open source, we can track activity):

https://github.com/sunnyside-io

Public protocol repository: https://github.com/sunnyside-io/privacy-boost-protocol

##### Does this project have a referral program?

No.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added TVL tracking for Privacy Boost pools on Optimism, Soneium, and Base.
  - Added support for tracking pool-held tokens across supported networks.
  - Added methodology details and coverage start dates for the new tracking integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->