### PR TITLE
Add HoodSale (Robinhood Chain presale launchpad)

### DIFF
--- a/projects/hoodsale/index.js
+++ b/projects/hoodsale/index.js
@@ -13,19 +13,6 @@ const abi = {
   locks: 'function locks(uint256) view returns (address token, address owner, uint256 amount, uint64 unlockTime, bool withdrawn)',
 }
 
-/**
- * TVL of HoodSale on Robinhood Chain.
- *
- * Adds the native ETH every presale contract holds, which is what a running sale escrows for its
- * contributors, and the LP held by each liquidity locker, unwrapped to the underlying tokens.
- * Every address is resolved from the factory, so a locker that is replaced with
- * `PresaleFactory.setLocker` keeps being counted: a sale stores the locker it was created with as
- * an immutable, so reading `locker()` off the sales themselves yields every locker in use, past
- * or present, and the factory's current one covers a locker no sale has reached yet.
- *
- * @param {object} api the chain api DefiLlama injects
- * @returns {Promise<object>} balances keyed by token
- */
 async function tvl(api) {
   const presales = await api.fetchList({
     lengthAbi: abi.allPresalesLength,
@@ -35,7 +22,7 @@ async function tvl(api) {
 
   const [currentLocker, saleLockers] = await Promise.all([
     api.call({ abi: abi.locker, target: PRESALE_FACTORY }),
-    api.multiCall({ abi: abi.locker, calls: presales, permitFailure: true }),
+    api.multiCall({ abi: abi.locker, calls: presales }),
   ])
   const lockers = [...new Set([currentLocker, ...saleLockers].filter(i => i && i !== ADDRESSES.null))]
 
@@ -56,12 +43,17 @@ async function tvl(api) {
     if (tokens.length) ownerTokens.push([tokens, lockers[i]])
   })
 
-  return sumTokens2({ api, ownerTokens, resolveLP: true })
+  await sumTokens2({ api, ownerTokens, resolveLP: true })
+
+  const quoteAssets = new Set([ADDRESSES.null, ADDRESSES.robinhood.WETH].map(a => a.toLowerCase()))
+  for (const key of Object.keys(api.getBalances())) {
+    const token = key.split(':').pop()
+    if (!quoteAssets.has(token.toLowerCase())) api.removeTokenBalance(token)
+  }
 }
 
 module.exports = {
-  methodology:
-    'ETH escrowed in HoodSale presale contracts while a sale is running (contributions are held by the sale until it launches or refunds), plus the liquidity locked in the HoodSale LiquidityLocker by sales that chose to lock their LP instead of burning it, unwrapped to its underlying tokens. Lockers are read from the factory and from the sales themselves, so a locker replaced through setLocker stays counted. Locked LP also sits in the DEX pools tracked separately, so it is marked as double counted. Platform revenue held by the Treasury is not counted.',
+  methodology: 'ETH escrowed in HoodSale presale contracts while a sale is running (contributions are held by the sale until it launches or refunds), plus the liquidity locked in the HoodSale LiquidityLocker by sales that chose to lock their LP instead of burning it, unwrapped to its underlying tokens. Lockers are read from the factory and from the sales themselves, so a locker replaced through setLocker stays counted. Locked LP also sits in the DEX pools tracked separately, so it is marked as double counted. Platform revenue held by the Treasury is not counted.',
   doublecounted: true,
   start: '2026-09-04',
   robinhood: { tvl },

--- a/projects/hoodsale/index.js
+++ b/projects/hoodsale/index.js
@@ -1,0 +1,46 @@
+const ADDRESSES = require('../helper/coreAssets.json')
+const { sumTokens2 } = require('../helper/unwrapLPs')
+
+// HoodSale, the presale launchpad on Robinhood Chain. Two on-chain sources of locked value:
+// the ETH a running sale escrows for its contributors, and the LP a finished sale locked.
+const PRESALE_FACTORY = '0x8dcC19e98713C2EC024dd337Edea18BEBC490942'
+const LIQUIDITY_LOCKER = '0xfF7E28d54f1927565Ab02781b635178b9b2683B7'
+
+const abi = {
+  allPresales: 'function allPresales(uint256) view returns (address)',
+  allPresalesLength: 'uint256:allPresalesLength',
+  lockCount: 'uint256:lockCount',
+  locks: 'function locks(uint256) view returns (address token, address owner, uint256 amount, uint64 unlockTime, bool withdrawn)',
+}
+
+async function tvl(api) {
+  // Every sale the factory ever created. A sale holds its contributions as native ETH until it
+  // launches or refunds, so its balance is the escrow; a settled sale simply holds nothing.
+  const presales = await api.fetchList({
+    lengthAbi: abi.allPresalesLength,
+    itemAbi: abi.allPresales,
+    target: PRESALE_FACTORY,
+  })
+
+  // LP locked by a sale that chose Lock over Burn. Balances are read from the locker itself, so
+  // a lock that has been withdrawn drops out on its own; the list only supplies the token set.
+  const locks = await api.fetchList({
+    lengthAbi: abi.lockCount,
+    itemAbi: abi.locks,
+    target: LIQUIDITY_LOCKER,
+  })
+  const lockedTokens = [...new Set(locks.map(i => i.token))]
+
+  const ownerTokens = presales.map(presale => [[ADDRESSES.null], presale])
+  if (lockedTokens.length) ownerTokens.push([lockedTokens, LIQUIDITY_LOCKER])
+
+  return sumTokens2({ api, ownerTokens, resolveLP: true })
+}
+
+module.exports = {
+  methodology:
+    'ETH escrowed in HoodSale presale contracts while a sale is running (contributions are held by the sale until it launches or refunds), plus the liquidity locked in the HoodSale LiquidityLocker by sales that chose to lock their LP instead of burning it, unwrapped to its underlying tokens. Locked LP also sits in the DEX pools tracked separately, so it is marked as double counted. Platform revenue held by the Treasury is not counted.',
+  doublecounted: true,
+  start: '2026-09-04',
+  robinhood: { tvl },
+}

--- a/projects/hoodsale/index.js
+++ b/projects/hoodsale/index.js
@@ -4,42 +4,64 @@ const { sumTokens2 } = require('../helper/unwrapLPs')
 // HoodSale, the presale launchpad on Robinhood Chain. Two on-chain sources of locked value:
 // the ETH a running sale escrows for its contributors, and the LP a finished sale locked.
 const PRESALE_FACTORY = '0x8dcC19e98713C2EC024dd337Edea18BEBC490942'
-const LIQUIDITY_LOCKER = '0xfF7E28d54f1927565Ab02781b635178b9b2683B7'
 
 const abi = {
   allPresales: 'function allPresales(uint256) view returns (address)',
   allPresalesLength: 'uint256:allPresalesLength',
+  locker: 'address:locker',
   lockCount: 'uint256:lockCount',
   locks: 'function locks(uint256) view returns (address token, address owner, uint256 amount, uint64 unlockTime, bool withdrawn)',
 }
 
+/**
+ * TVL of HoodSale on Robinhood Chain.
+ *
+ * Adds the native ETH every presale contract holds, which is what a running sale escrows for its
+ * contributors, and the LP held by each liquidity locker, unwrapped to the underlying tokens.
+ * Every address is resolved from the factory, so a locker that is replaced with
+ * `PresaleFactory.setLocker` keeps being counted: a sale stores the locker it was created with as
+ * an immutable, so reading `locker()` off the sales themselves yields every locker in use, past
+ * or present, and the factory's current one covers a locker no sale has reached yet.
+ *
+ * @param {object} api the chain api DefiLlama injects
+ * @returns {Promise<object>} balances keyed by token
+ */
 async function tvl(api) {
-  // Every sale the factory ever created. A sale holds its contributions as native ETH until it
-  // launches or refunds, so its balance is the escrow; a settled sale simply holds nothing.
   const presales = await api.fetchList({
     lengthAbi: abi.allPresalesLength,
     itemAbi: abi.allPresales,
     target: PRESALE_FACTORY,
   })
 
-  // LP locked by a sale that chose Lock over Burn. Balances are read from the locker itself, so
-  // a lock that has been withdrawn drops out on its own; the list only supplies the token set.
-  const locks = await api.fetchList({
+  const [currentLocker, saleLockers] = await Promise.all([
+    api.call({ abi: abi.locker, target: PRESALE_FACTORY }),
+    api.multiCall({ abi: abi.locker, calls: presales, permitFailure: true }),
+  ])
+  const lockers = [...new Set([currentLocker, ...saleLockers].filter(i => i && i !== ADDRESSES.null))]
+
+  // A sale holds its contributions as native ETH until it launches or refunds, so the balance is
+  // the escrow; a settled sale simply holds nothing, which is why no status filter is needed.
+  const ownerTokens = presales.map(presale => [[ADDRESSES.null], presale])
+
+  // Locked LP, for the sales that locked their liquidity instead of burning it. Balances come
+  // from the locker itself, so a lock that has been withdrawn drops out on its own; the lock list
+  // only supplies the token set.
+  const lockLists = await Promise.all(lockers.map(locker => api.fetchList({
     lengthAbi: abi.lockCount,
     itemAbi: abi.locks,
-    target: LIQUIDITY_LOCKER,
+    target: locker,
+  })))
+  lockLists.forEach((locks, i) => {
+    const tokens = [...new Set(locks.map(lock => lock.token))]
+    if (tokens.length) ownerTokens.push([tokens, lockers[i]])
   })
-  const lockedTokens = [...new Set(locks.map(i => i.token))]
-
-  const ownerTokens = presales.map(presale => [[ADDRESSES.null], presale])
-  if (lockedTokens.length) ownerTokens.push([lockedTokens, LIQUIDITY_LOCKER])
 
   return sumTokens2({ api, ownerTokens, resolveLP: true })
 }
 
 module.exports = {
   methodology:
-    'ETH escrowed in HoodSale presale contracts while a sale is running (contributions are held by the sale until it launches or refunds), plus the liquidity locked in the HoodSale LiquidityLocker by sales that chose to lock their LP instead of burning it, unwrapped to its underlying tokens. Locked LP also sits in the DEX pools tracked separately, so it is marked as double counted. Platform revenue held by the Treasury is not counted.',
+    'ETH escrowed in HoodSale presale contracts while a sale is running (contributions are held by the sale until it launches or refunds), plus the liquidity locked in the HoodSale LiquidityLocker by sales that chose to lock their LP instead of burning it, unwrapped to its underlying tokens. Lockers are read from the factory and from the sales themselves, so a locker replaced through setLocker stays counted. Locked LP also sits in the DEX pools tracked separately, so it is marked as double counted. Platform revenue held by the Treasury is not counted.',
   doublecounted: true,
   start: '2026-09-04',
   robinhood: { tvl },


### PR DESCRIPTION
Adds HoodSale, the presale launchpad on Robinhood Chain. One new file, `projects/hoodsale/index.js`. Robinhood Chain is already supported (`robinhood`) and its WETH is already in `coreAssets.json`, so nothing else is touched. No new dependencies.

Tested with `LLAMA_DEBUG_MODE=true node test.js projects/hoodsale/index.js`. The unrecognised tokens in the output are presale tokens with no market yet; they add nothing to the total, only the WETH side of each locked pool is priced.

A note on the current figure: TVL on a launchpad of this shape is intermittent by nature. A sale escrows its contributions only while it runs, and a sale that burns its LP instead of locking it leaves nothing behind afterwards. The platform's own token sale opens on 13 September and the locker accumulates as further projects choose to lock rather than burn.

##### Name (to be shown on DefiLlama):
HoodSale

##### Twitter Link:
https://x.com/hoodpresale

##### List of audit links if any:
No third party audit. Every contract is verified on Sourcify, for example the PresaleFactory: https://repo.sourcify.dev/4663/0x8dcC19e98713C2EC024dd337Edea18BEBC490942

##### Website Link:
https://hoodsale.io

##### Logo (High resolution, will be shown with rounded borders):
https://raw.githubusercontent.com/hoodsale/contracts/main/brand/logo-512.png

##### Current TVL:
About $40 at the time of writing, held as locked liquidity. See the note above.

##### Treasury Addresses (if the protocol has treasury)
0x52C4fa5E853e556000429763A50cd9A0cdA971e7 (Robinhood Chain)

##### Chain:
Robinhood Chain

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed):

##### Short Description (to be shown on DefiLlama):
Presale launchpad on Robinhood Chain. Projects create a token and run a presale in a few clicks; the contracts collect the contributions, add the liquidity, lock or burn the LP and deliver the tokens.

##### Token address and ticker if any:
HOODS, 0xFa00A62D38c5C4fe9BEc719c24A4D5E97D98f28e

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Launchpad

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
None. No part of the protocol reads a price feed.

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
Not applicable.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
Not applicable.

##### forkedFrom (Does your project originate from another project):
Not a fork. The contracts are original and are published at https://github.com/hoodsale/contracts

##### methodology (what is being counted as tvl, how is tvl being calculated):
Two on chain sources, both read with chain calls, no API.

1. The native ETH each presale contract holds. Contributions stay in the sale contract until it launches or refunds, so that balance is the escrow. Sales are enumerated from `PresaleFactory.allPresales` (0x8dcC19e98713C2EC024dd337Edea18BEBC490942); a settled sale simply holds nothing, so no status filter is needed.
2. The LP held by the platform's LiquidityLocker (0xfF7E28d54f1927565Ab02781b635178b9b2683B7) for sales that locked their liquidity instead of burning it, unwrapped to the underlying tokens with `sumTokens2({ resolveLP: true })`. The token set comes from `locks`, the amounts from the locker's own balances, so a withdrawn lock drops out on its own.

Locked LP also sits in the DEX pools that are tracked separately, so the adapter sets `doublecounted: true`. Platform revenue held by the Treasury is not counted.

##### Github org/user (Optional, if your code is open source, we can track activity):
https://github.com/hoodsale

##### Does this project have a referral program?
No.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added HoodSale TVL tracking on Robinhood Chain.
  - TVL now includes native ETH from presales and assets held in liquidity-locker positions.
  - Coverage includes the current factory locker, historical sale-specific lockers, and replacement lockers.
  - Locked LP tokens are accounted for based on their underlying native ETH or WETH.
  - Invalid addresses and withdrawn locks are excluded from calculations.
  - Added methodology, coverage start date, and double-counting status for transparent reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->