### PR TITLE
treasury: remove stonkbrokers entry (protocol team request)

### DIFF
--- a/registries/treasury.js
+++ b/registries/treasury.js
@@ -5505,13 +5505,6 @@ const configs = {
       ],
     },
   },
-  'treasury/stonkbrokers': {
-    robinhood: {
-      owners: ['0x16027b596e210c63f750E0bdD156f00bb2749868'],
-      tokens: [nullAddress],
-      ownTokens: ['0xe934e36A439C94017B64a3FecE66AF12099aBF50']
-    }
-  },
   'treasury/stout': {
     sonic: {
       owners: ['0x12684d18BDBA8e31936f40aBcE1175366874114f',],


### PR DESCRIPTION
Hi — StonkBrokers team here (we maintain `projects/stonkbrokers`, `fees/stonkbrokers` and `dexs/clutch-anvil`).

Please drop the `treasury/stonkbrokers` registry entry. We did not submit it and it misrepresents the protocol:

- The tracked owner `0x16027b596e210c63f750E0bdD156f00bb2749868` on Robinhood Chain is our **ProtocolFeeSink contract** — an in-flight fee accumulator that is swept on a schedule, not a team treasury. Reporting it as a Treasury metric implies protocol-owned reserves that do not exist.
- The `ownTokens` leg then double-labels $STONKBROKER sitting in that same sink as treasury holdings.

This PR only deletes the registry block. TVL (`projects/stonkbrokers`), fees and dexs adapters are untouched.

If the treasury sub-protocol (`8246-treasury`) also needs to be unlinked on the server side, could you please handle that too? Happy to follow up wherever is easiest. Thanks!

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the `treasury/stonkbrokers` treasury configuration from the registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->