### PR TITLE
StonkBrokers: add Smart LP (Volatility Farming) vault TVL

### DIFF
--- a/projects/stonkbrokers/index.js
+++ b/projects/stonkbrokers/index.js
@@ -13,6 +13,12 @@ const UP_SLIPSTREAM_NFPM = '0x07F44c47743A2f36414A82b9F558ECFCf0EEdCEf'
 const STONK_ESCROW = '0x799AE26fA515ceF145e8bC8636F7fFF87B05Cf62'
 const STONKBROKER = '0xe934e36A439C94017B64a3FecE66AF12099aBF50'
 
+// Smart LP (Volatility Farming) — immutable concentrated-liquidity vaults on
+// canonical Uniswap V3 pools. The on-chain registry is the single discovery
+// surface; each listed vault owns exactly one NFPM position plus small idle
+// token balances between compounds.
+const SMART_LP_REGISTRY = '0xE8749183Fbf6A657EB58B3a4D3E4B9Cc09560146'
+
 async function tvl(api) {
   // Uniswap V3 box positions (WETH side only — meme pair legs stay unpriced).
   await sumTokens2({
@@ -31,12 +37,31 @@ async function tvl(api) {
     nftAddress: UP_SLIPSTREAM_NFPM,
     whitelistedTokens: [ADDRESSES.robinhood.WETH],
   })
+  // Smart LP vaults: registry-enumerated, each vault owns one Uniswap V3
+  // position on the canonical NFPM. Both position legs are counted (quote
+  // legs are WETH/USDG; base legs are tokenized stocks / ecosystem tokens),
+  // plus the idle token0/token1 balances each vault holds between compounds.
+  const smartLpVaults = await api.call({ abi: 'address[]:all', target: SMART_LP_REGISTRY })
+  if (smartLpVaults.length) {
+    await sumTokens2({
+      api,
+      owners: smartLpVaults,
+      resolveUniV3: true,
+      uniV3ExtraConfig: { nftAddress: UNI_V3_NFPM },
+    })
+    const [token0s, token1s] = await Promise.all([
+      api.multiCall({ abi: 'address:token0', calls: smartLpVaults }),
+      api.multiCall({ abi: 'address:token1', calls: smartLpVaults }),
+    ])
+    const ownerTokens = smartLpVaults.map((vault, i) => [[token0s[i], token1s[i]], vault])
+    await sumTokens2({ api, ownerTokens })
+  }
   return api.getBalances()
 }
 
 module.exports = {
   methodology:
-    'TVL is the liquidity permanently locked in the Safety Deposit Box lockers: Uniswap V3 position NFTs escrowed in the V3 box, plus up. DEX (Slipstream) positions escrowed in the up. box — including every Stonklauncher / Safe Launch graduation pool across the V1 ETH pad, V1 quoted lanes, V2 lanes, and r2 pads (raise + LP tax reserve locked forever at bond; V2 Uniswap-v3 venue bonds land in the V3 box). Only the WETH side of each position is counted (meme-token legs stay unpriced). Staking tracks STONKBROKER tokens in the escrow contract.',
+    'TVL is the liquidity permanently locked in the Safety Deposit Box lockers: Uniswap V3 position NFTs escrowed in the V3 box, plus up. DEX (Slipstream) positions escrowed in the up. box — including every Stonklauncher / Safe Launch graduation pool across the V1 ETH pad, V1 quoted lanes, V2 lanes, and r2 pads (raise + LP tax reserve locked forever at bond; V2 Uniswap-v3 venue bonds land in the V3 box). Only the WETH side of each locker position is counted (meme-token legs stay unpriced). Plus the Smart LP (Volatility Farming) vaults: registry-listed immutable concentrated-liquidity vaults on canonical Uniswap V3 pools — each vault owns one position NFT (both legs counted: WETH/USDG quote side and the tokenized-stock / ecosystem-token base side) plus idle balances held between compounds. Staking tracks STONKBROKER tokens in the escrow contract.',
   doublecounted: true,
   robinhood: {
     tvl,


### PR DESCRIPTION
Adds the Smart LP vault fleet on Robinhood Chain to the existing stonkbrokers TVL adapter (no existing entries removed).

**What it adds**
- Smart LP is StonkBrokers' concentrated-liquidity vault wing (Jones-style auto-managed Uniswap v3 positions: full range / balanced band / single sided). 159+ vaults live.
- Vault addresses are enumerated from the on-chain `SmartLpRegistry` `0xE8749183Fbf6A657EB58B3a4D3E4B9Cc09560146` (`all()`), so newly listed vaults are picked up with no adapter change.
- Each vault holds exactly one Uniswap v3 NFPM position — resolved with `resolveUniV3` + `uniV3ExtraConfig` — plus small idle token0/token1 working balances summed via `ownerTokens`.

**Test**
`node test.js projects/stonkbrokers/index.js` passes: robinhood TVL $1.37M (previously ~$680k from the locker positions alone), staking unchanged at $15.8M.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Smart LP (Volatility Farming) vaults in Stonkbrokers TVL tracking.
  * TVL calculations now include Uniswap V3 positions and idle token balances across discovered vaults.
  * Updated coverage descriptions to reflect the additional vaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->