### PR TITLE
Update INFINIT TVL description

### DIFF
--- a/projects/infinit/index.js
+++ b/projects/infinit/index.js
@@ -68,5 +68,5 @@ module.exports = {
   bsc: {
     staking: sumTokensExport({ "owners": ["0xc8e6c14ccebed218a64df570025c5a1eeb0cdadc"], "tokens": ["0x61fac5f038515572d6f42d4bcb6b581642753d50"] }),
   },
-  methodology: "TVL is calculated per vault based on its lifecycle stage. Before the withdrawal period opens, it equals the share token totalSupply. Shares are minted 1:1 with asset-token deposits, so the supply represents committed capital (during trading, assets sit in Hyperliquid/DEX trading wallets). Once the withdrawal period opens, it equals the actual asset-token balance held by the vault contract, including trading PnL."
+  methodology: "TVL is the sum of all vaults, each valued based on its lifecycle stage. Before the withdrawal period opens, it equals the share token total supply. Shares are minted 1:1 with asset-token deposits, so the supply represents committed capital (during trading, assets sit in Hyperliquid/ DEX trading wallets). Once the withdrawal period opens, it equals the actual asset token balance held by the vault contract, including trading PnL."
 };


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).

2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** Please send a mail to metadata@defillama.com
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes

---

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL is the sum of all vaults, each valued based on its lifecycle stage. Before the withdrawal period opens, it equals the share token total supply. Shares are minted 1:1 with asset-token deposits, so the supply represents committed capital (during trading, assets sit in Hyperliquid/ DEX trading wallets). Once the withdrawal period opens, it equals the actual asset token balance held by the vault contract, including trading PnL.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the description of how total value locked (TVL) is calculated across vaults.
  * Corrected spacing in the reference to Hyperliquid/DEX trading wallets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->