### PR TITLE
feat: add Base USDC vault for aihedge

### DIFF
--- a/registries/erc4626.js
+++ b/registries/erc4626.js
@@ -404,7 +404,8 @@ const configs = {
     ],
   },
   'aihedge': {
-    ethereum: ['0x469201fA49DB171C0F95371533C2D3Ad5aE60400']
+    ethereum: ['0x469201fA49DB171C0F95371533C2D3Ad5aE60400'],
+    base: ['0x100F0aC3be2c93c76b2ee1B8cA98d8928cDC0871'],
   },
   'secured-finance-vaults': {
     ethereum: ['0x7a6E3635694952dC00F6bA4d4AD1a7B892028789']


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
AI Hedge

##### Twitter Link:
https://x.com/AIHEDGE_finance

##### List of audit links if any:
Built on multi-strategy ERC-4626 vault standard and OpenZeppelin contracts.

##### Website Link:
https://dapp.aihedge.finance

##### Current TVL:
~$2,940 USD

##### Treasury Addresses:
None

##### Chain:
Ethereum, Base

##### Coingecko ID:
None

##### Coinmarketcap ID:
None

##### Short Description:
A decentralized yield optimization protocol built on multi-strategy ERC-4626 vaults, automating routing, rebalancing, and compounding across DeFi strategies.

##### Token address and ticker if any:
- Ethereum: `0x469201fA49DB171C0F95371533C2D3Ad5aE60400` (USDC)
- Base: `0x100F0aC3be2c93c76b2ee1B8cA98d8928cDC0871` (USDC)

##### Category:
Yield Aggregator

##### Oracle Provider(s):
None (Uses on-chain ERC-4626 `convertToAssets` and token balances via `erc4626Sum`)

##### Implementation Details:
Updates `registries/erc4626.js` under `aihedge` to include the Base USDC ERC-4626 vault alongside the existing Ethereum vault.

##### Documentation/Proof:
https://docs.aihedge.finance/

##### forkedFrom:
Yearn V3 Strategy

##### methodology:
TVL calculates total underlying assets (USDC) locked in AI Hedge ERC-4626 vaults on Ethereum and Base mainnets using `api.erc4626Sum`.

##### Github org/user:
https://github.com/aihedge-finance

##### Does this project have a referral program?
No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the AiHedge vault on Base while retaining the existing Ethereum vault configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->