### PR TITLE
Mark prism-dex as sunset

### DIFF
--- a/registries/uniswapV3.js
+++ b/registries/uniswapV3.js
@@ -68,6 +68,8 @@ const uniV3Configs = {
   },
   'prism-dex': {
     start: 7845865,
+    deadFrom: '2026-09-09',
+    hallmarks: [['2026-09-09', 'Prism DEX shut down']],
     megaeth: { factory: '0x1adb8f973373505bb206e0e5d87af8fb1f5514ef', fromBlock: 7845865 },
   },
   'superswap-v3': {


### PR DESCRIPTION
## Summary
- Prism DEX is shutting down. This marks `prism-dex` with `deadFrom: 2026-09-09` and a shutdown hallmark so historical TVL stays, but Llama no longer treats it as a live product.
- Follows the same pattern as `stationdex-v3` in `registries/uniswapV3.js` (keep the adapter, stop collection).
- Original listing: https://github.com/DefiLlama/DefiLlama-Adapters/pull/17569

Please do not delete the protocol. We only need collection to stop.

If you also want the listing renamed to Prism DEX (Sunset) or the description updated, we can email metadata@defillama.com.

## Test plan
- [ ] Confirm `deadFrom` / hallmarks match other sunset UniV3 registry entries
- [ ] Confirm historical MegaETH TVL is retained after merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Marked Prism DEX as shut down effective September 9, 2026.
  - Added a corresponding shutdown notice for Prism DEX.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->