### PR TITLE
Add DropSwap TVL adapter

### DIFF
--- a/projects/dropswap/index.js
+++ b/projects/dropswap/index.js
@@ -2,7 +2,8 @@ const { getUniTVL } = require('../helper/unknownTokens')
 
 const FACTORY = '0xDCed5445409398dc609C2f87849B44bc9479664A'
 
-const tvl = getUniTVL({
+const getTvl = chain => getUniTVL({
+  chain,
   factory: FACTORY,
   useDefaultCoreAssets: true,
 })
@@ -12,10 +13,10 @@ module.exports = {
     'TVL is the value of tokens held in DropSwap V2 liquidity pools. Pools are discovered on-chain from the DropSwap V2 Factory using allPairsLength() and allPairs(uint256).',
 
   arbitrum: {
-    tvl,
+    tvl: getTvl('arbitrum'),
   },
 
   robinhood: {
-    tvl,
+    tvl: getTvl('robinhood'),
   },
 }

--- a/projects/dropswap/index.js
+++ b/projects/dropswap/index.js
@@ -1,0 +1,21 @@
+const { getUniTVL } = require('../helper/unknownTokens')
+
+const FACTORY = '0xDCed5445409398dc609C2f87849B44bc9479664A'
+
+const tvl = getUniTVL({
+  factory: FACTORY,
+  useDefaultCoreAssets: true,
+})
+
+module.exports = {
+  methodology:
+    'TVL is the value of tokens held in DropSwap V2 liquidity pools. Pools are discovered on-chain from the DropSwap V2 Factory using allPairsLength() and allPairs(uint256).',
+
+  arbitrum: {
+    tvl,
+  },
+
+  robinhood: {
+    tvl,
+  },
+}


### PR DESCRIPTION
Adds TVL tracking for DropSwap V2 on Arbitrum and Robinhood Chain.

DropSwap V2 Factory:
0xDCed5445409398dc609C2f87849B44bc9479664A

Liquidity pools are discovered directly on-chain using
allPairsLength() and allPairs(uint256), so newly created pools
are automatically included.

The adapter uses DefiLlama's standard getUniTVL helper.

Tested with:
node test.js projects/dropswap/index.js

Current test result:
- Arbitrum: ~$3.38k TVL
- Robinhood: ~$9 TVL
- Total: ~$3.39k TVL

Existing DropSwap volume, fees and revenue integrations are unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added DropSwap total value locked (TVL) tracking for the Arbitrum and Robinhood chains.
  - Automatically discovers liquidity pools and calculates their balances for broader coverage.
  - Added a methodology description explaining how DropSwap TVL is measured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->