### PR TITLE
add dropswap and lotoworld

### DIFF
--- a/registries/sumTokens/data3.js
+++ b/registries/sumTokens/data3.js
@@ -921,5 +921,12 @@ module.exports = {
     "base": {
       "tvl": { "owners": ["0x833Be2DC319b80365eB53C19932ad2f347c39cD9"], "tokens": [ADDRESSES.null] }
     }
+  },
+  "lotoworld": {
+    "methodology": "TVL is the USDT balance held in the Lotoworld lottery contract, representing the current prize pool awaiting the next draw.",
+    "start": "2026-09-08",
+    "arbitrum": {
+      "tvl": { "owners": ["0xdefcC8E8dB82D1D722045f704f8af29F94207439"], "tokens": [ADDRESSES.arbitrum.USDT] }
+    }
   }
 }

--- a/registries/uniswapV2.js
+++ b/registries/uniswapV2.js
@@ -3171,6 +3171,10 @@ const uniV2Configs = {
       staking: ['0x868ae20E6c1EA3b6Fdab5042Ea721eB51b237183', '0xD6af4536baB5EA74bCF872CA181619Cc3157683E'],
     },
   },
+  'dropswap': {
+    arbitrum: '0xDCed5445409398dc609C2f87849B44bc9479664A',
+    robinhood: '0xDCed5445409398dc609C2f87849B44bc9479664A'
+  }
 }
 
 module.exports = buildProtocolExports(uniV2Configs, uniV2ExportFn)


### PR DESCRIPTION
resolves #20968
resolves #20963

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Lotoworld lottery prize pool tracking on Arbitrum, including its USDT balance.
  - Added Dropswap integration with support for both Arbitrum and Robinhood.
  - Lotoworld tracking begins on September 8, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->