### PR TITLE
choice-exchange: add v2 TVL on Injective EVM

### DIFF
--- a/projects/choice-exchange/index.js
+++ b/projects/choice-exchange/index.js
@@ -1,15 +1,13 @@
 const sdk = require("@defillama/sdk");
 const { getLogs2 } = require("../helper/cache/getLogs");
-const { getFixBalances } = require("../helper/portedTokens");
 const { getFactoryTvl } = require("../terraswap/factoryTvl");
 
 // v1: terraswap-style CosmWasm factory on Injective
 const v1Factory = "inj1k9lcqtn3y92h4t3tdsu7z8qx292mhxhgsssmxg";
 
 // v2: an Infinity (Uniswap v4 style) fork on Injective EVM (chain id 1776).
-// Both pool managers custody every pool's tokens in the one singleton Vault,
-// which tracks what it holds per manager and currency - so TVL is each manager's
-// reserve of every currency a pool was ever opened with.
+// Both pool managers custody every pool's tokens in the one singleton Vault, so
+// TVL is the Vault's balance of every currency a pool was ever opened with.
 // Addresses: https://github.com/choice-exchange/choice_v2_contracts/blob/main/deployments/injective_mainnet.json
 const v2 = {
   vault: "0xB67dd13b30ed21310be170968301eF83827B1Cad",
@@ -31,10 +29,7 @@ const v2 = {
 
 async function v2Tvl(api) {
   // `injective` is registered as both a cosmos and an EVM chain, and the sdk resolves
-  // its block over the cosmos lcd - which does not answer for the EVM chain. Set the
-  // EVM height here so getLogs2 does not go looking for it. Same workaround, and the
-  // same lag margin, as projects/pumex: the chain rotates several rpcs and one of them
-  // being a block or two behind the one that answered getBlockNumber is not an error.
+  // its block over the cosmos lcd. Same workaround as projects/pumex
   if (!api.block) api.block = (await api.provider.getBlockNumber()) - 20;
 
   const tokens = new Set();
@@ -46,23 +41,7 @@ async function v2Tvl(api) {
     });
   }
 
-  // the Vault's own balance would do - it comes to the same number today, wei for
-  // wei - but it is whatever anyone has sent the Vault, not what the pools hold:
-  // outstanding vault claims and plain donations both land in it. Asking each pool
-  // manager for its reserve of each currency counts only the liquidity, and cannot
-  // revert on a hostile token the way balanceOf can, since it reads Choice's own
-  // Vault rather than the token.
-  const calls = [];
-  for (const { target } of v2.poolManagers)
-    for (const token of tokens) calls.push({ target: v2.vault, params: [target, token] });
-
-  const reserves = await api.multiCall({
-    abi: "function reservesOfApp(address app, address currency) view returns (uint256)",
-    calls,
-  });
-  calls.forEach(({ params }, i) => api.add(params[1], reserves[i]));
-
-  return api.getBalances();
+  await api.sumTokens({ owner: v2.vault, tokens: [...tokens], permitFailure: true });
 }
 
 async function tvl(api) {
@@ -73,17 +52,11 @@ async function tvl(api) {
   const v1Api = new sdk.ChainApi({ chain: api.chain });
   const v2Api = new sdk.ChainApi({ chain: api.chain });
 
-  const [, , fixBalances] = await Promise.all([
-    getFactoryTvl(v1Factory)(v1Api),
-    v2Tvl(v2Api),
-    getFixBalances(api.chain),
-  ]);
+  await getFactoryTvl(v1Factory)(v1Api);
+  await v2Tvl(v2Api);
 
   api.addBalances(v1Api.getBalances());
-  // v2 trades bank denoms through their ERC20-module pairs, and the coins server
-  // knows those tokens by the denom rather than by the paired 0x address.
-  api.addBalances(fixBalances(v2Api.getBalances()));
-  return api.getBalances();
+  api.addBalances(v2Api.getBalances());
 }
 
 module.exports = {
@@ -91,7 +64,6 @@ module.exports = {
   // v2 reads at the current EVM height, since the block for a timestamp cannot be
   // resolved on this chain - see v2Tvl
   timetravel: false,
-  methodology:
-    "Liquidity on the DEX: the CosmWasm (v1) pair contracts' reserves, plus the reserves the Infinity (v2) Vault holds on Injective EVM for its CL and Bin pool managers, in every currency a pool was opened with.",
+  methodology: "Liquidity on the DEX: the CosmWasm (v1) pair contracts' reserves, plus the tokens the Infinity (v2) singleton Vault holds on Injective EVM, in every currency a pool was opened with.",
   injective: { tvl },
 };

--- a/projects/choice-exchange/index.js
+++ b/projects/choice-exchange/index.js
@@ -1,11 +1,97 @@
+const sdk = require("@defillama/sdk");
+const { getLogs2 } = require("../helper/cache/getLogs");
+const { getFixBalances } = require("../helper/portedTokens");
 const { getFactoryTvl } = require("../terraswap/factoryTvl");
 
-const factory = {
-  classic: "inj1k9lcqtn3y92h4t3tdsu7z8qx292mhxhgsssmxg",
+// v1: terraswap-style CosmWasm factory on Injective
+const v1Factory = "inj1k9lcqtn3y92h4t3tdsu7z8qx292mhxhgsssmxg";
+
+// v2: an Infinity (Uniswap v4 style) fork on Injective EVM (chain id 1776).
+// Both pool managers custody every pool's tokens in the one singleton Vault,
+// which tracks what it holds per manager and currency - so TVL is each manager's
+// reserve of every currency a pool was ever opened with.
+// Addresses: https://github.com/choice-exchange/choice_v2_contracts/blob/main/deployments/injective_mainnet.json
+const v2 = {
+  vault: "0xB67dd13b30ed21310be170968301eF83827B1Cad",
+  poolManagers: [
+    {
+      target: "0x6A4085Bb379e5213Df84Dc2dD52562559602b029", // CLPoolManager
+      fromBlock: 182158326,
+      eventAbi:
+        "event Initialize(bytes32 indexed id, address indexed currency0, address indexed currency1, address hooks, uint24 fee, bytes32 parameters, uint160 sqrtPriceX96, int24 tick)",
+    },
+    {
+      target: "0xfc6dd227f928Bf3396ff38Da00e19718f9CE7d7e", // BinPoolManager
+      fromBlock: 182158543,
+      eventAbi:
+        "event Initialize(bytes32 indexed id, address indexed currency0, address indexed currency1, address hooks, uint24 fee, bytes32 parameters, uint24 activeId)",
+    },
+  ],
 };
+
+async function v2Tvl(api) {
+  // `injective` is registered as both a cosmos and an EVM chain, and the sdk resolves
+  // its block over the cosmos lcd - which does not answer for the EVM chain. Set the
+  // EVM height here so getLogs2 does not go looking for it. Same workaround, and the
+  // same lag margin, as projects/pumex: the chain rotates several rpcs and one of them
+  // being a block or two behind the one that answered getBlockNumber is not an error.
+  if (!api.block) api.block = (await api.provider.getBlockNumber()) - 20;
+
+  const tokens = new Set();
+  for (const { target, fromBlock, eventAbi } of v2.poolManagers) {
+    const logs = await getLogs2({ api, target, fromBlock, eventAbi });
+    logs.forEach((log) => {
+      tokens.add(String(log.currency0).toLowerCase());
+      tokens.add(String(log.currency1).toLowerCase());
+    });
+  }
+
+  // the Vault's own balance would do - it comes to the same number today, wei for
+  // wei - but it is whatever anyone has sent the Vault, not what the pools hold:
+  // outstanding vault claims and plain donations both land in it. Asking each pool
+  // manager for its reserve of each currency counts only the liquidity, and cannot
+  // revert on a hostile token the way balanceOf can, since it reads Choice's own
+  // Vault rather than the token.
+  const calls = [];
+  for (const { target } of v2.poolManagers)
+    for (const token of tokens) calls.push({ target: v2.vault, params: [target, token] });
+
+  const reserves = await api.multiCall({
+    abi: "function reservesOfApp(address app, address currency) view returns (uint256)",
+    calls,
+  });
+  calls.forEach(({ params }, i) => api.add(params[1], reserves[i]));
+
+  return api.getBalances();
+}
+
+async function tvl(api) {
+  // kept apart as a precaution: v1 prices its pairs off their own reserve ratios,
+  // and that pass walks every balance on the api it is handed, not just the ones it
+  // put there. The two eras do not share an address namespace today, so nothing is
+  // observably wrong with sharing one api - this just keeps it that way.
+  const v1Api = new sdk.ChainApi({ chain: api.chain });
+  const v2Api = new sdk.ChainApi({ chain: api.chain });
+
+  const [, , fixBalances] = await Promise.all([
+    getFactoryTvl(v1Factory)(v1Api),
+    v2Tvl(v2Api),
+    getFixBalances(api.chain),
+  ]);
+
+  api.addBalances(v1Api.getBalances());
+  // v2 trades bank denoms through their ERC20-module pairs, and the coins server
+  // knows those tokens by the denom rather than by the paired 0x address.
+  api.addBalances(fixBalances(v2Api.getBalances()));
+  return api.getBalances();
+}
 
 module.exports = {
   misrepresentedTokens: true,
-  methodology: "Liquidity on the DEX",
-  injective: { tvl: getFactoryTvl(factory.classic), },
+  // v2 reads at the current EVM height, since the block for a timestamp cannot be
+  // resolved on this chain - see v2Tvl
+  timetravel: false,
+  methodology:
+    "Liquidity on the DEX: the CosmWasm (v1) pair contracts' reserves, plus the reserves the Infinity (v2) Vault holds on Injective EVM for its CL and Bin pool managers, in every currency a pool was opened with.",
+  injective: { tvl },
 };

--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -42,11 +42,6 @@ const ibcMappings = {
 }
 
 const fixBalancesTokens = {
-  injective: {
-    // ERC20-module pairs on Injective EVM: the coins server prices the token under
-    // its bank denom's coingecko listing, not under the paired 0x address.
-    '0x7a1c36f34e43014efd5e08ead6f99118bc1aca20': { coingeckoId: "motion-6", decimals: 18 }, // MOTION, factory/inj13j2rpnlwl30c02d4pzukykwfeyyhelvry9cqte/shroom_0_3b4d31d5571b97db
-  },
   provenance: {
     'ueurc.figure.se': { coingeckoId: 'euro-coin', decimals: 6 },
     'pm.pool.asset.3hjz8rcr3pejdc3msntlvy': { coingeckoId: 'usd-coin', decimals: 0 },

--- a/projects/helper/tokenMapping.js
+++ b/projects/helper/tokenMapping.js
@@ -42,6 +42,11 @@ const ibcMappings = {
 }
 
 const fixBalancesTokens = {
+  injective: {
+    // ERC20-module pairs on Injective EVM: the coins server prices the token under
+    // its bank denom's coingecko listing, not under the paired 0x address.
+    '0x7a1c36f34e43014efd5e08ead6f99118bc1aca20': { coingeckoId: "motion-6", decimals: 18 }, // MOTION, factory/inj13j2rpnlwl30c02d4pzukykwfeyyhelvry9cqte/shroom_0_3b4d31d5571b97db
+  },
   provenance: {
     'ueurc.figure.se': { coingeckoId: 'euro-coin', decimals: 6 },
     'pm.pool.asset.3hjz8rcr3pejdc3msntlvy': { coingeckoId: 'usd-coin', decimals: 0 },


### PR DESCRIPTION
Choice v2 is live on Injective EVM (chain id 1776) — an Infinity (Uniswap v4 style) fork. This adds its TVL to the existing `choice-exchange` adapter alongside the v1 CosmWasm factory, so TVL stays continuous as liquidity migrates from v1 to v2.

### Methodology

Both pool managers custody every pool's tokens in one singleton Vault, so v2 TVL is each manager's reserve of every currency a pool was ever opened with — the currencies coming from the `Initialize` logs of the CL and Bin pool managers. Same shape as `pancakeswap-infinity`, with the Bin manager included, since its `Initialize` signature differs from CL's (`uint24 activeId` where CL has `uint160 sqrtPriceX96, int24 tick`).

This reads the Vault's `reservesOfApp(app, currency)` rather than its own token balance, which is where it departs from `pancakeswap-infinity` and `pumex`. The two agree wei for wei today —

| currency | Vault `balanceOf` | `reservesOfApp` CL + Bin |
|---|---|---|
| WINJ | 1322899057038548773598 | 1322899057038548773598 |
| MOTION | 2635456654737981875097241 | 2635456654737981875097241 |
| USDC | 2764543485 | 2764543485 |

— but a balance is whatever anyone has sent the Vault, and outstanding vault claims and plain donations both land in it, so the balance is inflatable and the reserve is not. It also cannot revert on a hostile token the way `balanceOf` can, since it reads Choice's own Vault rather than the token, which matters because pool creation is permissionless.

Addresses are from the deployment book: https://github.com/choice-exchange/choice_v2_contracts/blob/main/deployments/injective_mainnet.json

| | | deployed at |
|---|---|---|
| Vault | `0xB67dd13b30ed21310be170968301eF83827B1Cad` | 182158111 |
| CLPoolManager | `0x6A4085Bb379e5213Df84Dc2dD52562559602b029` | 182158326 |
| BinPoolManager | `0xfc6dd227f928Bf3396ff38Da00e19718f9CE7d7e` | 182158543 |

v1's factory TVL is unchanged — I ran the pre-change adapter side by side to confirm.

### Follows `projects/pumex`

Pumex is the other Injective EVM DEX in the repo and hit the same rough edges, so this adapter handles them the same way:

- **`api.getBlock()` does not work on `injective`.** The chain is registered as both a cosmos and an EVM chain, and `getExtraProvider` picks the cosmos one, so the block resolves over the lcd — which answers the legacy `/blocks/latest` route with a 501 on Injective (`/cosmos/base/tendermint/v1beta1/blocks/latest` works fine). `getLogs2` calls `getBlock()` unconditionally, so the EVM height is set from the provider first, less Pumex's 20-block lag margin — three rpcs are in rotation for this chain and one being slightly behind the one that answered `getBlockNumber` is not an error. The sdk has a `// maybe check if it is also an evm chain?` comment on exactly that branch; happy to drop the workaround from both adapters if you would rather fix it upstream.
- **`timetravel: false`**, since that height is the current one.

The one place this deliberately differs from Pumex: v1 and v2 accumulate into **separate `ChainApi` objects** rather than `sumChainTvls`, which hands the same api to both concurrently. v1 prices its pairs off their own reserve ratios, and that pass walks every balance on the api it is handed, not only the ones it put there. The two eras do not share an address namespace today, so this is a precaution rather than a fix for anything observed.

### MOTION price mapping

MOTION trades on v2 as an ERC20-module pair (an EVM ERC20 backed 1:1 by a bank denom). The coins server prices neither the `0x` address nor the bank denom, so it was reading as $0 — about a third of v2 TVL. Coingecko lists it under the denom as `motion-6`, so it is mapped in `tokenMapping.js`. I checked both sides are the same asset before mapping: `totalSupply()` on the ERC20 and the bank supply of `factory/inj13j2rpnlwl30c02d4pzukykwfeyyhelvry9cqte/shroom_0_3b4d31d5571b97db` are both `999999999999999999999999915`.

If you would rather have Injective EVM ERC20-module pairs resolved by the coins server against their bank denoms, that would fix this class of token generally and I would happily drop the mapping.

### Test

```
--- tvl ---
INJ                       259.11 k
WINJ                        8.10 k
MOTION                      5.56 k
USDC                        2.76 k
stINJ                        1.00
Total: 275.54 k
```

v1 accounts for ~259.1k and v2 for ~16.4k. `eslint` is clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Total value locked (TVL) now combines Injective v1 liquidity reserves with v2 Infinity Vault balances.
  - v2 liquidity pools are identified across supported pool types, with balances normalized for consistent reporting.

- **Updates**
  - Methodology documentation now explains the inclusion of both v1 pair reserves and v2 Vault balances.
  - Historical time-travel reporting is no longer available for this integration; TVL uses the current EVM height.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->