### PR TITLE
fix(fiamma): read TVL from on-chain FIABTC supply

### DIFF
--- a/projects/fiamma/index.js
+++ b/projects/fiamma/index.js
@@ -1,14 +1,49 @@
-const axios = require("axios")
+const sdk = require("@defillama/sdk")
+const { function_view, timestampToVersion } = require("../helper/chain/aptos")
 
-const btc_locked = async (api) => {
-    const response = (await axios.post('https://bridge-api.fiammachain.io', { "jsonrpc": "2.0", "id": 1, "method": "frontend_queryBridgeTVL", "params": {} })).data
-    const locked = response.result.total_tvl / 1e8
-    api.addCGToken('bitcoin', locked)
+const EVM_FIABTC = {
+  ethereum: "0x22F0E0a4c97ff43546dad16d43Ef854C773F0e08",
+  sei: "0x60C230c38aF6d86b0277a98a1CAeAA345a7B061F",
+  core: "0x60C230c38aF6d86b0277a98a1CAeAA345a7B061F",
+  arbitrum: "0x60C230c38aF6d86b0277a98a1CAeAA345a7B061F",
+  base: "0x60C230c38aF6d86b0277a98a1CAeAA345a7B061F",
+  polygon: "0x60C230c38aF6d86b0277a98a1CAeAA345a7B061F",
+  unichain: "0x60C230c38aF6d86b0277a98a1CAeAA345a7B061F",
+  plume_mainnet: "0x60C230c38aF6d86b0277a98a1CAeAA345a7B061F",
+}
+
+const APTOS_FIABTC = "0x75de592a7e62e6224d13763c392190fda8635ebb79c798a5e9dd0840102f3f93"
+
+const tvl = async (api) => {
+  const supplies = await Promise.all(
+    Object.entries(EVM_FIABTC).map(([chain, target]) =>
+      new sdk.ChainApi({ chain, timestamp: api.timestamp }).call({ abi: "erc20:totalSupply", target })
+    )
+  )
+  let totalBtc = supplies.reduce((sum, supply) => sum + supply / 1e8, 0)
+
+  const isHistorical = api.timestamp && Date.now() / 1000 - api.timestamp > 2 * 3600
+  let aptosAmount = 0
+  try {
+    const aptosSupply = await function_view({
+      functionStr: "0x1::fungible_asset::supply",
+      type_arguments: ["0x1::fungible_asset::Metadata"],
+      args: [APTOS_FIABTC],
+      ledgerVersion: isHistorical ? await timestampToVersion(new Date(api.timestamp * 1000)) : undefined,
+    })
+    aptosAmount = aptosSupply && aptosSupply.vec && aptosSupply.vec.length ? Number(aptosSupply.vec[0]) : 0
+  } catch (e) {
+    if (!isHistorical) throw e
+  }
+  totalBtc += aptosAmount / 1e8
+
+  api.addCGToken("bitcoin", totalBtc)
 }
 
 module.exports = {
-    methodology: "Fiamma BTC TVL represents the total amount of Bitcoin bridged across all chains through the Fiamma Bridge, a trust‑minimized bridge built on the BitVM2 protocol.",
-    bitcoin: {
-      tvl: btc_locked,
-    }
-  };
+  methodology:
+    "TVL is the total FIABTC minted across all destination chains, which is 1:1 backed by BTC locked in the Fiamma BitVM2 bridge. The minted supply is read on-chain because the bridge's TVL API is offline.",
+  bitcoin: {
+    tvl,
+  },
+}


### PR DESCRIPTION
## Summary

Fixes #19030.

Fiamma's TVL adapter depended on `bridge-api.fiammachain.io`, which is offline. This change derives BTC TVL from the on-chain FIABTC minted supply instead:

- Reads FIABTC `totalSupply` across the supported EVM destination chains.
- Reads Aptos FIABTC supply through the Aptos fungible asset view function.
- Resolves historical Aptos ledger versions from the adapter timestamp.
- Reports the 1:1 BTC-backed amount under the existing `bitcoin` bucket.

## Validation

- `node test.js projects/fiamma/index.js` -> `$1.31M`
- `node test.js projects/fiamma/index.js 2026-08-01` -> `$893.53K`
- `npx eslint -c eslint.config.js projects/fiamma/index.js`
- `git diff --check`

Please keep **Allow edits and access to secrets by maintainers** enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Fiamma TVL reporting now calculates FIABTC supply directly from on-chain data across supported EVM and Aptos networks.
  - Bitcoin-denominated TVL includes Aptos fungible-asset supply, with values normalized for reporting.
- **Bug Fixes**
  - Improved handling of historical TVL requests and temporary Aptos query failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->