### PR TITLE
vectis: add Ethereum TVL for the Accountable ERC-4626 vault

### DIFF
--- a/projects/vectis/index.js
+++ b/projects/vectis/index.js
@@ -16,9 +16,12 @@ module.exports = {
     ["2026-04-01", "Drift hack"]
   ],
   doublecounted: true,
-  methodology: "Calculate sum of spot positions in vaults with unrealized profit and loss",
+  methodology: "Solana: calculate sum of spot positions in vaults with unrealized profit and loss. Ethereum: each ERC-4626 vault is valued at convertToAssets(totalSupply) - the vault deploys its capital out to trading venues, so totalAssets() reads 0 and is not a usable source.",
   solana: {
     tvl,
+  },
+  ethereum: {
+    tvl: evmTvl,
   },
 };
 /**
@@ -89,5 +92,38 @@ async function tvl(api) {
     hyperliquidData = parseInt(hyperliquidData.marginSummary.accountValue);
     api.addCGToken("usd-coin", hyperliquidData);
   }
+}
+
+/**
+ * EVM vaults are ERC-4626 and are listed by the same endpoint as the Solana
+ * ones, carrying `chain` where a Solana vault carries `programId`.
+ *
+ * Valued at convertToAssets(totalSupply), not totalAssets(): the vault deploys
+ * its capital out to the trading venues, so totalAssets() reports what the
+ * contract itself still holds, which is 0 while the shares are outstanding.
+ */
+async function evmTvl(api) {
+  const vaults = (await fetchVaultAddresses())
+    .filter((vault) => vault.chain === api.chain)
+    .map((vault) => vault.address);
+  if (!vaults.length) return;
+
+  const supplies = await api.multiCall({ abi: 'erc20:totalSupply', calls: vaults });
+
+  // convertToAssets reverts on an empty vault, so only price the funded ones
+  const funded = vaults
+    .map((target, i) => ({ target, supply: supplies[i] }))
+    .filter((vault) => +vault.supply > 0);
+  if (!funded.length) return;
+
+  const [assets, values] = await Promise.all([
+    api.multiCall({ abi: 'address:asset', calls: funded.map((i) => i.target) }),
+    api.multiCall({
+      abi: 'function convertToAssets(uint256) view returns (uint256)',
+      calls: funded.map((i) => ({ target: i.target, params: [i.supply] })),
+    }),
+  ]);
+
+  values.forEach((value, i) => api.add(assets[i], value));
 }
 


### PR DESCRIPTION
Update to the existing **vectis** listing — adds Ethereum alongside Solana. Not
a new listing, so only the template fields that actually change are filled in
below.

No new npm dependencies, and `pnpm-lock.yaml` is untouched.

##### Chain:

Ethereum (added). Solana behaviour is unchanged.

##### methodology (what is being counted as tvl, how is tvl being calculated):

Solana: unchanged — sum of spot positions in the vaults with unrealized PnL.

Ethereum: Vectis runs a NAV vault on mainnet. Each ERC-4626 vault is valued at
`convertToAssets(totalSupply())`, read on-chain, and added under the vault's own
`asset()`.

`totalAssets()` is deliberately **not** used. The vault deploys its capital out
to trading venues, so that call reports only what the contract itself still
holds. Measured on mainnet against
[`0x05ED3da1dEeaaa57C8E09986e95AC271572DCf89`](https://etherscan.io/address/0x05ED3da1dEeaaa57C8E09986e95AC271572DCf89):

| call | value |
| --- | --- |
| `totalAssets()` | 0 |
| `USDC.balanceOf(vault)` | 0 |
| `totalSupply()` | 4,148.732365 |
| `convertToAssets(1e6)` | 1.020829 |
| `convertToAssets(totalSupply())` | **4,235.15 USDC** |

## Vault discovery

The vault list comes from the endpoint the adapter already reads for its Solana
vaults, `/strategy/fetchAllVaultAddresses`. EVM entries carry `chain` where a
Solana entry carries `programId`, so the two are told apart by which key is
present and the existing Solana filter is unaffected. Only the address comes
from the API — `asset()`, `totalSupply()` and `convertToAssets()` are all read
from the chain.

## Test

Run against the live endpoint:

```
$ node test.js projects/vectis/index.js

--- ethereum ---
USDC                      4.23 k
Total: 4.23 k

--- solana ---
usdc                      4.65 M
USDC                      1.00
Total: 4.65 M

------ TVL ------
solana                    4.65 M
ethereum                  4.23 k

total                     4.66 M
```

Solana's figure is identical before and after this change.

## Note on double counting

This vault is deployed through Accountable, and the `accountable` adapter
discovers it from its own factory (`0xC0f778b5…`, `strategyProxies(5)`), where
it currently lands under `borrowed` rather than `tvl` because the vault's idle
liquidity is 0. The `vectis` adapter already carries `doublecounted: true`, so
this is flagged rather than silently duplicated — happy to exclude it here
instead if you would rather it be counted only on the Accountable side.

---

Supersedes #20973, which was opened from the wrong account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Ethereum TVL coverage alongside the existing Solana coverage.
  - Ethereum vault balances are now included when they have funding and can be valued reliably.
  - Expanded methodology documentation to explain coverage across both chains and the valuation approach used for vault assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->