### PR TITLE
Add Otomate Tydro vault TVL on Ink

### DIFF
--- a/projects/otomate/index.js
+++ b/projects/otomate/index.js
@@ -1,0 +1,24 @@
+const { sumERC4626VaultsExport2 } = require('../helper/erc4626')
+
+// Creation blocks from https://explorer.inkonchain.com/address/<vault>.
+// Filter by block so refills before March 15 do not call undeployed vaults.
+const vaults = [
+  { address: '0x919C57BF59484798Ff2f90018640fd0A08242aC2', block: 39817878 }, // USDT0
+  { address: '0x2baA4C3f66Fa6f0c2d56242BaAE446a4De878B98', block: 40073655 }, // kBTC
+  { address: '0xcc7DcF43b17D8EdC437a6e33a6A325C57eba1ED7', block: 40073901 }, // WETH
+  { address: '0x59046e5a0cbb5b64981b4668a31ab3a5ed0e7dd0', block: 40074036 }, // USDC
+]
+
+async function tvl(api) {
+  const block = await api.getBlock()
+  const activeVaults = vaults.filter(v => v.block <= block).map(v => v.address)
+  if (!activeVaults.length) return {}
+  return sumERC4626VaultsExport2({ vaults: activeVaults })(api)
+}
+
+module.exports = {
+  start: '2026-03-12',
+  methodology: 'Underlying assets in Otomate ERC-4626 vaults on Ink, measured with totalAssets net of accrued protocol fees. Assets are supplied to Tydro and already included in Tydro TVL.',
+  doublecounted: true, // The same deposits are counted by the Tydro lending adapter.
+  ink: { tvl },
+}


### PR DESCRIPTION
Otomate is already listed at https://defillama.com/protocol/otomate with Nado builder fees and trading volume. This adds the four Otomate Earn ERC-4626 wrappers on Ink to its TVL coverage.

Website: https://otomate.trade
Twitter: https://x.com/otomate_trade

TVL is the sum of each deployed vault's `totalAssets()`, denominated in its underlying asset and priced by DefiLlama. It excludes accrued protocol fees. `doublecounted: true` names the overlap with the already-listed Tydro lending protocol. A small custom adapter uses the existing ERC-4626 helper and filters by verified deployment block; the plain registry list fails historical calls before the later vaults exist.

Validation:
- `INK_RPC=https://rpc-gel.inkonchain.com node test.js projects/otomate/index.js`: passed; approximately $585.41k across all four assets, no unknown-token warnings.
- Same command with `2026-03-13`: passed; approximately $65.23, only the USDT0 vault existed.
- Package manifests and lockfiles unchanged.

Please attach this TVL adapter to the existing Otomate listing. This is an adapter addition, not a duplicate protocol listing or a metadata/category change. Deployment begins on 2026-03-12. Existing metadata should remain in place. Enable Allow edits by maintainers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TVL tracking for Otomate ERC-4626 vaults on the Ink network.
  * Supports USDT0, kBTC, WETH, and USDC vaults.
  * Accounts for vault deployment timing and accrued protocol fees when calculating total assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->