### PR TITLE
add otomate and update coffer methodology

### DIFF
--- a/projects/cube/index.js
+++ b/projects/cube/index.js
@@ -1,9 +1,9 @@
 const { PublicKey } = require("@solana/web3.js");
 const { getConnection, sumTokens2, getAssociatedTokenAddress } = require("../helper/solana");
 
-// Cube DEX pool program (Solana mainnet). The on-chain Rust module is
-// named `cubic_pool` (legacy name from before the protocol rebrand to Cube).
-// Source of truth: sdk/src/config/networks.ts in cubee.ee/sdk.
+// Coffer DEX pool program (Solana mainnet). The on-chain Rust module is
+// named `cubic_pool` (legacy name from before the protocol rebrand to Coffer).
+// Source of truth: sdk/src/config/networks.ts in github.com/coffer-so/sdk.
 const PROGRAM_ID = "8iQtGj9mcUfFUGaiCpPy89swC3s8YTC8FhVZWfgeZhwu";
 
 // CubicPool account anchor discriminator (first 8 bytes of the account
@@ -99,7 +99,7 @@ async function tvl(api) {
 module.exports = {
   timetravel: false,
   methodology:
-    "Sum of USD value of all tokens locked in Cube weighted pools. Reads every CubicPool account from the Cube program (handling both legacy and v4 layouts that coexist during migration) and sums balances of each pool's token vaults (derived as ATA(pool, mint, token_program)).",
+    "Sum of USD value of all tokens locked in Coffer weighted pools. Reads every CubicPool account from the Coffer program (handling both legacy and v4 layouts that coexist during migration) and sums balances of each pool's token vaults (derived as ATA(pool, mint, token_program)).",
   solana: {
     tvl,
   },

--- a/registries/erc4626.js
+++ b/registries/erc4626.js
@@ -508,6 +508,12 @@ const configs = {
   'southpole': {
     methodology: "TVL counts the USDC deposited into the SouthPole USDC vault (a standard ERC-4626 vault) on Arbitrum.",
     arbitrum: ['0xeA59d9343FF0d70470DD6709cfCD5Bc735d9aDBC']
+  },
+  'otomate': {
+    start: '2026-03-12',
+    doublecounted: true,
+    methodology: "Underlying assets in Otomate ERC-4626 vaults on Ink, measured with totalAssets net of accrued protocol fees. Assets are supplied to Tydro and already included in Tydro TVL.",
+    ink: ['0x919C57BF59484798Ff2f90018640fd0A08242aC2', '0x2baA4C3f66Fa6f0c2d56242BaAE446a4De878B98', '0xcc7DcF43b17D8EdC437a6e33a6A325C57eba1ED7', '0x59046e5a0cbb5b64981b4668a31ab3a5ed0e7dd0']
   }
 }
 


### PR DESCRIPTION
resolves #20979
resolves #20976

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Rebranded the Cube adapter as **Coffer** in its displayed methodology and description.
  - Added **otomate** to the ERC4626 protocol registry with four Ink-chain vaults and TVL tracking based on underlying assets after accrued protocol fees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->