### PR TITLE
Add UltraYield Morpho V2 vaults

### DIFF
--- a/projects/ultrayield-by-edge-capital/index.js
+++ b/projects/ultrayield-by-edge-capital/index.js
@@ -1,9 +1,10 @@
-// Сurator adapter that computes TVL for five vault types:
+// Сurator adapter that computes TVL for six vault types:
 // 1) ERC-4626 (totalAssets())
-// 2) MidasIssuance (supply)
-// 3) Boring (rate × supply via hook → accountant)
-// 4) Pre-deposit (same as MidasIssuance)
-// 5) Edge Capital Euler vaults (via curator)
+// 2) Morpho V1/V2 (via curator, with nested-vault de-duplication)
+// 3) MidasIssuance (supply)
+// 4) Boring (rate × supply via hook → accountant)
+// 5) Pre-deposit (same as MidasIssuance)
+// 6) Edge Capital Euler vaults (via curator)
 
 const { CONFIG } = require('./tvl.addresses.js');
 const { getCuratorTvl } = require("../helper/curators");
@@ -94,6 +95,14 @@ async function tvl(api) {
         getBoringTVL(api, config.boring)
     ]
 
+    // Morpho V1/V2 vaults are processed together to avoid nested-vault double counting.
+    if (config.morpho || config.morphoVaultOwners) {
+        promises.push(getCuratorTvl(api, {
+            morpho: config.morpho,
+            morphoVaultOwners: config.morphoVaultOwners,
+        }))
+    }
+
     // Handle curator functionality for Euler vaults
     if (config.eulerVaultOwners) {
         promises.push(getCuratorTvl(api, { eulerVaultOwners: config.eulerVaultOwners }))
@@ -106,7 +115,7 @@ async function tvl(api) {
 
 const adapters = {
     doublecounted: true,
-    methodology: 'TVL = sum of underlying balances: ERC-4626 via totalAssets(); Issuance/Pre-deposit via share totalSupply; Boring via accountant.getRate × vault.totalSupply; Edge Capital Euler vaults via curator.',
+    methodology: 'TVL = sum of underlying balances: ERC-4626 via totalAssets(); Morpho V1/V2 and Euler via the curator helper; Issuance/Pre-deposit via share totalSupply; Boring via accountant.getRate × vault.totalSupply.',
 }
 
 Object.keys(CONFIG).forEach((chain) => {

--- a/projects/ultrayield-by-edge-capital/tvl.addresses.js
+++ b/projects/ultrayield-by-edge-capital/tvl.addresses.js
@@ -1,6 +1,8 @@
 // Just addresses by chains. No ABI/logic here.
     // Format:
     // {
+    //   morphoVaultOwners: [ownerAddr, ...],
+    //   morpho:             [vaultAddr, ...],
     //   erc4626:        [vaultAddr, ...],
     //   issuanceTokens: [tokenAddr, ...],
     //   predeposit:     [tokenAddr, ...],
@@ -9,20 +11,25 @@
 
 const CONFIG = {
   ethereum: {
+    morphoVaultOwners: [
+      '0x1280e86cd7787ffa55d37759c0342f8cd3c7594a', // initial owner of UltraYield/Edge Morpho deployments
+    ],
+    morpho: [
+      '0x0562ae950276b24f3eae0d0a518dadb7ad2f8d66', // Morpho V1 UltraYield USDC
+      '0x965ec3552427b8258bd0a0c7baa234618fc98d01', // Morpho V1 UltraYield USDT
+      '0x62efa7cacc11caa959a8f956ec4f683302397e5c', // Morpho V1 YieldNest RWA
+    ],
     erc4626: [
       '0xc824a08db624942c5e5f330d56530cd1598859fd', // Kelp High Growth ETH
       '0x59d675f75f973835b94d02b6d27b8539757dc65f', // Term UltraYield ETH
       '0x2be901715468c3c5393efa841525a713c583a8ec', // Term UltraYield USDC
-      '0x0562ae950276b24f3eae0d0a518dadb7ad2f8d66', // Morpho Edge UltraYield USDC
       '0x9a6340ce1282e01cb4ec9faae5fc5f4b60ca8839', // Mellow UltraYield x Edge x Allnodes
       '0x8ecc0b419dfe3ae197bc96f2a03636b5e1be91db', // Kelp sbUSD Vault
       '0xeaa3b922e9febca37d1c02d2142a59595094c605', // Upshift upEDGE Vault
       '0x472425cc95be779126afa4aa17980210d299914f', // UltraYield BTC
       '0x546329a16dcedc46e93f7b03a65f49a84700bca1', // UltraYield USD
       '0xaa3cb36be406e6cf208d218fd214e0f1a71e957d', // LoopedBTC
-      '0x965ec3552427b8258bd0a0c7baa234618fc98d01', // Edge UltraYield USDT (Morpho, Ethereum)
       '0xfacaa225fcfcd8644a77f2cce833907537198ae9', // Resolv USR Ecosystem Vault
-      '0x62efa7cacc11caa959a8f956ec4f683302397e5c', // YieldNest RWA
       '0xc46efcc8e39c8f02425e367423871cd4633b7908', // UltraYield ETH
       '0x36bdaefd92579da58bfe207e16dafa39835bbcb3', // Edge Credit Vault
     ],


### PR DESCRIPTION
## Summary

- Add UltraYield/Edge's verified initial deployment owner to `morphoVaultOwners`, so its Ethereum Morpho V1/V2 vaults are discovered from canonical factory events.
- Preserve the existing explicit Morpho V1 addresses under `morpho` and pass them together with owner discovery to the same helper.
- Process discovered and explicit Morpho vaults with the existing `getCuratorTvl` helper so duplicate addresses and nested V2 → V1 positions can be de-duplicated.

## Vaults added

| Vault | Asset | Chain | Address |
| --- | --- | --- | --- |
| UltraYield USDC Core | USDC | Ethereum | `0x244f46262D9aD408B746E74aBdD010E9002fb7eE` |
| UltraYield USDT Core | USDT | Ethereum | `0x85F3d81a39dF458E45d5EA20f9EB937fAafd282f` |
| UltraYield WETH Core | WETH | Ethereum | `0xD42fD04D99912bB4900d8126cA1ad4fA09AEA5ce` |
| UltraYield cbBTC Core | cbBTC | Ethereum | `0xcbaD74fFe6498c7eD166EEEA331dBBaAA3D44Fe7` |

All four vaults were deployed by the Ethereum Morpho Vault V2 factory `0xA1D94F746dEfa1928926b84fB2596c06926C0405` with `0x1280e86Cd7787FfA55d37759C0342F8CD3c7594a` as the initial owner recorded in `CreateVaultV2.owner`.

That same initial owner also created additional Morpho V1/V2 deployments, including YieldNest RWA. Owner discovery intentionally includes them: unlisted, empty or future deployments remain eligible, while an empty vault contributes zero. The three Morpho V1 addresses already present in the adapter remain explicit and are de-duplicated against owner discovery by the curator helper.

The four vaults represented approximately **$200k** of TVL at verification time. 


## Verification links

- USDC Core: https://app.morpho.org/ethereum/vault/0x244f46262D9aD408B746E74aBdD010E9002fb7eE/ultrayield-usdc-core
- USDT Core: https://app.morpho.org/ethereum/vault/0x85F3d81a39dF458E45d5EA20f9EB937fAafd282f/ultrayield-usdt-core
- WETH Core: https://app.morpho.org/ethereum/vault/0xD42fD04D99912bB4900d8126cA1ad4fA09AEA5ce
- cbBTC Core: https://app.morpho.org/ethereum/vault/0xcbaD74fFe6498c7eD166EEEA331dBBaAA3D44Fe7

## Tests

```bash
 node test.js projects/ultrayield-by-edge-capital/index.js
```




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for tracking TVL across Morpho V1 and V2 vaults.
  - Added Ethereum coverage for Morpho vault owners and deployment addresses.
  - Morpho vaults are now processed alongside their owners to prevent nested-vault TVL from being counted twice.
  - Updated vault categorization so Morpho deployments are tracked separately from standard ERC-4626 vaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->