### PR TITLE
add DAMM Capital TVL adapter

### DIFF
--- a/registries/curators.js
+++ b/registries/curators.js
@@ -509,6 +509,24 @@ const configs = {
       },
     },
   },
+  "damm-capital": {
+    config: {
+      methodology: 'Counts assets in DAMM Capital flagship funds. Internal DAMMethAlgo and DAMMbtcAlgo execution vehicles are excluded because their assets are already represented in the flagship funds.',
+      blockchains: {
+        ethereum: {
+          erc4626: [
+            '0x3c63f3ce75dc83735745cf4e86b63414d95ee355', // DAMMeth
+            '0x7ededf832b5c9d8afa8f7365936100581a6db756', // DAMMbtc
+          ],
+        },
+        arbitrum: {
+          erc4626: [
+            '0xe5d6eb448ac5a762c1ebe8cd1692b9cd08025176', // DAMMstable
+          ],
+        },
+      },
+    },
+  },
   "edge-capital": {
     config: {
       methodology: 'Counts all assets deposited in vaults curated by Edge-Capital.',


### PR DESCRIPTION
## What this PR does

Add a curator registry entry for the three officially documented flagship funds. Exclude the two internal Algo execution vehicles. 

## Why TVL is missing

No DAMM Capital curator entry or standalone adapter was found by name, domain, vault address or symbol.

## Estimated TVL added

$6 Million  attributable TVL; new listing, no baseline percentage. 

## Chains and tokens

ethereum, arbitrum. 

## Contracts / programs

| Fund | Chain | Address and explorer |
| --- | --- | --- |
| DAMMeth | Ethereum | [0x3c63f3ce75dc83735745cf4e86b63414d95ee355](https://eth.blockscout.com/address/0x3c63f3ce75dc83735745cf4e86b63414d95ee355?tab=contract) |
| DAMMbtc | Ethereum | [0x7ededf832b5c9d8afa8f7365936100581a6db756](https://eth.blockscout.com/address/0x7ededf832b5c9d8afa8f7365936100581a6db756?tab=contract) |
| DAMMstable | Arbitrum | [0xe5d6eb448ac5a762c1ebe8cd1692b9cd08025176](https://arbiscan.io/address/0xe5d6eb448ac5a762c1ebe8cd1692b9cd08025176#code) |

## Source of addresses / official documentation

- [Official flagship-fund architecture and exclusion of internal vehicles](https://docs.dammcap.finance/funds).
- [DAMMstable official address](https://docs.dammcap.finance/funds/dammstable-arbitrum).
- [DAMMeth official address](https://docs.dammcap.finance/funds/dammeth).
- [DAMMbtc official address and Algo allocation](https://docs.dammcap.finance/funds/dammbtc).

## Methodology

Sum asset() / totalAssets() for the three flagship funds through the existing curator helper.
.

## Test results

Command: `node test.js damm-capital`. 
------ TVL ------
ethereum                  4.53 M
arbitrum                  1.46 M

total                    5.99 M

 
## Listing metadata

- Name: DAMM Capital
- Website: https://dammcap.finance/
- Twitter: https://x.com/DAMM_Capital
- Category proposed: Risk Curators, using the repository curator architecture.
- Description: DAMM Capital curates tokenized, non-custodial DeFi funds built on Lagoon vaults and Safe accounts.
- Chain: Ethereum, Arbitrum.
- Current TVL: approximately $6.04m at the saved test.
- Logo: https://cdn.lagoon.finance/curators/damm ; 
- GitHub: https://github.com/DAMM-Cap
- Token / ticker: no governance token is introduced by this adapter;
- Coingecko ID / CoinMarketCap ID: none
- Treasury addresses: none
- forkedFrom: none
- Referral program: none 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added DAMM Capital vault tracking for Ethereum and Arbitrum.
  - Added support for monitoring DAMMeth, DAMMbtc, and DAMMstable vaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->