### PR TITLE
Mark Glyph V2 and V4 as deadFrom (Core DEX no longer maintained)

### DIFF
--- a/registries/uniswapV2.js
+++ b/registries/uniswapV2.js
@@ -2408,6 +2408,8 @@ const uniV2Configs = {
     },
   },
   'GlyphExchange': {
+    deadFrom: '2026-09-11',
+    hallmarks: [['2026-09-11', 'Glyph Core DEX no longer maintained']],
     core: { factory: '0x3e723c7b6188e8ef638db9685af45c7cb66f77b9', staking: ["0x6bf16B2645b13db386ecE6038e1dEF76d95696fc", "0xb3A8F0f0da9ffC65318aA39E55079796093029AD"] },
   },
   'KibbleSwap': {

--- a/registries/uniswapV3.js
+++ b/registries/uniswapV3.js
@@ -604,6 +604,8 @@ const uniV3Configs = {
     },
   },
   'glyph-v4': {
+    deadFrom: '2026-09-11',
+    hallmarks: [['2026-09-11', 'Glyph Core DEX no longer maintained']],
     core: {
       factory: '0x74EfE55beA4988e7D92D03EFd8ddB8BF8b7bD597',
       fromBlock: 15770796,


### PR DESCRIPTION
The Glyph team no longer maintains the Core-era DEX. We are not asking to delete the listings or erase historical data.

Please stop updating TVL from 2026-09-11 and keep the existing charts.

- Glyph V2: https://defillama.com/protocol/glyph-v2
- Glyph V4: https://defillama.com/protocol/glyph-v4
- Added deadFrom: 2026-09-11 and a hallmark

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Marked Glyph Core DEX as no longer maintained effective September 11, 2026.
  - Updated its Uniswap V2 and Uniswap V3 registry listings to reflect this status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->