### PR TITLE
[tvl] cook-market - add Robinhood Chain adapter

### DIFF
--- a/projects/cook-market/index.js
+++ b/projects/cook-market/index.js
@@ -1,0 +1,16 @@
+// Cook Market is a memecoin launchpad on Robinhood Chain. Every launch opens a Uniswap v4 pool
+// guarded by CookHook, which runs the bonding curve and then graduates the pool in place.
+// https://cook.market
+// CookHook: https://robinhoodchain.blockscout.com/address/0xfe3eFA722DCAB53e87E94593cB41Bc706C1E3044
+
+// No TVL is reported: a coin never leaves its pool. The bonding-curve reserve sits in the Uniswap
+// v4 PoolManager from the first swap and stays there through graduation, so every dollar is
+// already counted by the uniswap-v4 listing on this chain. Volume and fees are tracked separately
+// in dimension-adapters/fees/cook-market.
+module.exports = {
+  methodology:
+    'Cook Market reports no TVL of its own. Launches trade on Uniswap v4 pools from the first swap, so the quote asset backing each coin lives in the v4 PoolManager and is already counted under Uniswap v4 on Robinhood Chain. Counting it here as well would double count it.',
+  robinhood: {
+    tvl: () => ({}),
+  },
+}


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).

2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** Please send a mail to metadata@defillama.com
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes

---

This is a TVL-only listing. It adds no fees or volume, those were merged separately in DefiLlama/dimension-adapters#9350.

## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama): Cook Market

##### Twitter Link: https://x.com/cookdotmarket

##### List of audit links if any: None

##### Website Link: https://cook.market/

##### Logo (High resolution, will be shown with rounded borders): https://cook.market/icon.png

##### Current TVL: None. Cook Market launches trade on Uniswap v4 pools from the first swap, so the quote asset backing each coin sits in the v4 PoolManager and is already counted under Uniswap v4 on Robinhood Chain. Counting it here as well would double count it, so this adapter reports no TVL of its own.

##### Treasury Addresses (if the protocol has treasury) robinhood:

##### Chain: Robinhood Chain

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): None

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): None

##### Short Description (to be shown on DefiLlama): Fair-launch memecoin platform where tokens launch through bonding curves and graduate to Uniswap v4 liquidity pools.

##### Token address and ticker if any: None

##### Category (full list at https://defillama.com/categories) \*Please choose only one: Launchpad

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.): None, prices come from the pool itself

##### Implementation Details: Briefly describe how the oracle is integrated into your project: Not applicable, no external oracle is used

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage: Not applicable

##### forkedFrom (Does your project originate from another project): No

##### methodology (what is being counted as tvl, how is tvl being calculated): No TVL is reported. Each launch opens a Uniswap v4 pool guarded by CookHook and trades there from the first swap, through graduation. The quote asset therefore lives in the v4 PoolManager and is already counted under Uniswap v4 on this chain, so counting it again here would double count it. Fees and volume are tracked separately in dimension-adapters/fees/cook-market, merged in DefiLlama/dimension-adapters#9350.

##### Github org/user (Optional, if your code is open source, we can track activity): None

##### Does this project have a referral program? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Cook Market coverage for the Robinhood Chain.
  - Cook Market is now represented in reporting with no separately attributed TVL, avoiding duplicate accounting of liquidity already tracked through associated Uniswap v4 pools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->