### PR TITLE
feat(sivo): add Sivo SLP TVL adapter

### DIFF
--- a/projects/sivo/index.js
+++ b/projects/sivo/index.js
@@ -1,0 +1,24 @@
+// Sivo SLP — receivables-backed liquidity pool token priced by a Chainlink NAV feed.
+// Deposited stablecoin is swept off-chain into receivables deployment, so
+// TVL = SLP outstanding × SLP/USD NAV.
+
+const SLP = '0xda6a067D9435a28549D75Dd459C0016911c26E54'
+const CHAINLINK_SLP_USD = '0x0e095dD47bdE0d7cdb57a72bB98B6419dfBB505b'
+
+async function tvl(api) {
+  const [supply, slpDecimals, round, priceDecimals] = await Promise.all([
+    api.call({ target: SLP, abi: 'erc20:totalSupply' }),
+    api.call({ target: SLP, abi: 'erc20:decimals' }),
+    api.call({ target: CHAINLINK_SLP_USD, abi: 'function latestRoundData() view returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)' }),
+    api.call({ target: CHAINLINK_SLP_USD, abi: 'uint8:decimals' }),
+  ])
+  api.addUSDValue((supply / 10 ** slpDecimals) * (round.answer / 10 ** priceDecimals))
+}
+
+module.exports = {
+  misrepresentedTokens: true,
+  methodology:
+    'TVL is the total supply of SLP valued at the SLP/USD net asset value published by the Chainlink SLP/USD feed, which the protocol uses to price deposits and redemptions. Deposited USDC/USDT is deployed off-chain into short-duration receivables, so SLP supply × NAV represents the assets backing the pool.',
+  start: 1788471503, // first round of the Chainlink SLP/USD feed (2026-09-03)
+  ethereum: { tvl },
+}


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):
Sivo

##### Twitter Link:
https://x.com/sivodefi

##### List of audit links if any:
https://github.com/holasivo/slp-evm/blob/main/audits/CredShields_20260825.pdf (CredShields, August 2026)

##### Website Link:
https://sivo.xyz

##### Logo (High resolution, will be shown with rounded borders):
https://coin-images.coingecko.com/coins/images/102173475/large/SVO-Square.png

##### Current TVL:
~$13.28M (13,152,440 SLP × 1.0106 USD NAV, 11 Sep 2026)

##### Treasury Addresses (if the protocol has treasury)
None

##### Chain:
Ethereum

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)
sivo-defi

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)


##### Short Description (to be shown on DefiLlama):
Sivo is a private-credit protocol that finances short-duration receivables. Depositing USDC or USDT mints SLP, a receivables-backed pool token whose value tracks the pool's net asset value published on-chain by a Chainlink SLP/USD feed; exits go through an on-chain FIFO withdrawal queue filled at NAV.

##### Token address and ticker if any:
0xda6a067D9435a28549D75Dd459C0016911c26E54 (SLP, Ethereum)

##### Category (full list at https://defillama.com/categories) \*Please choose only one:
RWA

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
Chainlink

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
The deposit/withdrawal contract (UniswapHook, 0x0A71509dfF50940945538B6c9137d26B1D4468A8) reads `latestRoundData()` from the Chainlink SLP/USD Exchange Rate feed (0x0e095dD47bdE0d7cdb57a72bB98B6419dfBB505b) for every deposit swap and every withdrawal-queue fill, so deposits mint and redemptions settle at the exact published NAV. The read is fail-closed: rounds older than 25h, incomplete rounds, or answers outside a sanity band halt deposits and fills. USDC/USD and USDT/USD Chainlink feeds additionally gate each stablecoin to a 0.995–1.005 peg band. The adapter reads the same feed.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
- https://docs.sivo.xyz/docs/slp (How NAV is computed and published)
- https://data.chain.link/feeds/ethereum/mainnet/slp-usd-exchange-rate
- https://etherscan.io/address/0x0e095dD47bdE0d7cdb57a72bB98B6419dfBB505b
- https://github.com/holasivo/slp-evm/blob/main/contracts/UniswapHook.sol (oracle read in `_depositSwap` / `_fill`)

##### forkedFrom (Does your project originate from another project):
No

##### methodology (what is being counted as tvl, how is tvl being calculated):
TVL is the total supply of SLP valued at the SLP/USD NAV published by the Chainlink SLP/USD feed, which the protocol uses to price deposits and redemptions. Deposited USDC/USDT is swept off-chain into short-duration receivables purchased from originators, so SLP supply × NAV represents the assets backing the pool.

##### Github org/user (Optional, if your code is open source, we can track activity):
holasivo

##### Does this project have a referral program?
No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Sivo TVL tracking on Ethereum.
  - TVL is calculated from SLP total supply and its Chainlink USD valuation feed.
  - Added methodology, token representation details, and integration start-date metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->