### PR TITLE
ref-market: add the live Base escrow to TVL owners

### DIFF
--- a/registries/sumTokens/data3.js
+++ b/registries/sumTokens/data3.js
@@ -932,7 +932,7 @@ module.exports = {
   "ref-market": {
     "methodology": "USDC held by the ref_market ReferralEscrow contracts on Base: rewards, protocol fees and dispute stakes escrowed for open offers and claims in flight, plus settled balances not yet withdrawn.",
     "base": {
-      "tvl": { "owners": ["0xa9f96c74230810205023c3E3AFEe33d3151e5Ee8", "0xA4bFddBc6Bb8F589a92A4d4595c6902e95eb9a38"], "tokens": [ADDRESSES.base.USDC] }
+      "tvl": { "owners": ["0xa9f96c74230810205023c3E3AFEe33d3151e5Ee8", "0xA4bFddBc6Bb8F589a92A4d4595c6902e95eb9a38", "0xe9339BecfB1F6F4d0A031e7132fCf745CEb6611A"], "tokens": [ADDRESSES.base.USDC] }
     }
   }
 }


### PR DESCRIPTION
ref_market redeployed its ReferralEscrow on Base this morning (2026-09-11, block 51164040). Since then the protocol page shows 0 TVL, because the `ref-market` entry in `registries/sumTokens/data3.js` lists only the two earlier escrows, which now hold no USDC.

This adds the live escrow, [`0xe9339BecfB1F6F4d0A031e7132fCf745CEb6611A`](https://basescan.org/address/0xe9339BecfB1F6F4d0A031e7132fCf745CEb6611A), to `owners`. The two earlier addresses stay listed, since claims still settling on them can hold balances.

Checked on chain: `USDC.balanceOf` is 50.2 USDC for the new escrow and 0 for both earlier ones.

The matching fees change is in DefiLlama/dimension-adapters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167erCUMTdcUWCBwDcXswNT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Added a third ReferralEscrow owner address to the Base TVL configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->