### PR TITLE
solon: track curator vaults by owner + follow-up on missing listing

### DIFF
--- a/registries/curators.js
+++ b/registries/curators.js
@@ -1120,11 +1120,14 @@ const configs = {
   },
   "solon": {
     config: {
-      methodology: 'Counts all assets deposited in Morpho vaults curated by Solon.',
+      methodology: 'Counts all assets deposited in Morpho vaults curated by Solon on Robinhood Chain.',
       blockchains: {
         robinhood: {
+          morphoVaultOwners: [
+            '0xD0340F008bee8F6101cD609E0447cd3d44f8cC84', // Solon curator/owner - auto-tracks current & future vaults
+          ],
           morpho: [
-            '0xCBB61788fB5A1969C93A222B1a12E4D1A50c6d99', // Solon USDG Vault
+            '0xCBB61788fB5A1969C93A222B1a12E4D1A50c6d99', // Solon USDG Vault (explicit fallback)
           ],
         },
       }


### PR DESCRIPTION
Small follow-up to #20843. Thanks a lot for maintaining this registry!

**Change:** switch the Solon curator entry to `morphoVaultOwners` (curator/owner `0xD0340F008bee8F6101cD609E0447cd3d44f8cC84`) so our current and any future Solon vaults on Robinhood Chain are picked up automatically, keeping the known vault as an explicit fallback.

Verified on-chain: Solon USDG Vault `0xCBB61788fB5A1969C93A222B1a12E4D1A50c6d99` (Vault V2, Robinhood Chain / 4663) — `owner()` = `0xD034...cC84`, `totalAssets()` ~ 101 USDG, so the adapter resolves a non-zero TVL.

Also, a gentle question (no rush): our earlier entry merged in #20843 but Solon does not seem to show on the site yet. Quite possibly something on our end — if there is anything we should adjust for it to index cleanly, we would be happy to. Thanks for taking a look!

Links: site https://solonlend.xyz · app https://solonlend.xyz/app/ · docs https://solonlend.xyz/docs/overview