### PR TITLE
Add Solon protocol adapter (leverage + LP vaults, Robinhood Chain)

### DIFF
--- a/projects/solon/index.js
+++ b/projects/solon/index.js
@@ -1,0 +1,31 @@
+const { sumTokens2 } = require('../helper/unwrapLPs')
+
+const USDG = '0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168'
+const WETH = '0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73'
+const NFPM = '0x73991a25C818Bf1f1128dEAaB1492D45638DE0D3'
+const vaults = [
+  '0x9Db7aDa64D1E8b856E15D916d886797501F28ce0', // UniV3DualVault
+  '0x9e100d524DFEa1Aa76286A7F00682e72F79aC3aE', // UniV3LeverageVault
+  '0xfd7Ab6A724f28cE958Ee29E7A9DfAE7b9efC6B91', // SolonRangeVault
+]
+
+async function tvl(api) {
+  return sumTokens2({
+    api,
+    // Only unborrowed underlying reserves, never eToken supply or debt.
+    tokensAndOwners: [
+      [USDG, '0x59286206faCD48E002a4e0EaC106998567071Ef3'],
+      [WETH, '0x2e3409b1d8068eB330437d89048b3d96D6379dac'],
+    ],
+    tokens: [USDG, WETH],
+    owners: vaults,
+    resolveUniV3: true,
+    uniV3WhitelistedTokens: [USDG, WETH],
+    uniV3ExtraConfig: { nftAddress: NFPM },
+  })
+}
+
+module.exports = {
+  methodology: 'Counts leverage lending-pool underlying reserves, idle USDG/WETH and the underlying principal of Uniswap V3 LP positions held by Solon vaults on Robinhood Chain; the Morpho-curated solUSDG lending vault is tracked separately via the curators registry and is not counted again.',
+  robinhood: { tvl },
+}


### PR DESCRIPTION
Adds a standalone TVL adapter for Solon on Robinhood Chain (chainId 4663). Thanks for reviewing!

**Scope:** this tracks Solon's leverage lending pool and its Uniswap V3 LP / leverage vaults. It intentionally does **not** count Solon's Morpho-curated `solUSDG` lending vault, which is already tracked via the curators registry (entry `solon`, added in #20843) — kept separate to avoid double counting.

**Accounting (assets at rest, no leverage inflation):**
- Underlying USDG/WETH actually held by the leverage lending pool eTokens (unborrowed reserves only — never eToken supply or debt).
- Uniswap V3 LP positions owned by the three Solon vaults, unwrapped to underlying principal via `resolveUniV3`.
- Idle USDG/WETH ERC20 balances in those vaults.

**Verified:** `node test.js projects/solon.js` runs green — current TVL ~$326 (≈200 USDG + 0.05 WETH in reserves; LP positions near-zero right now as this is an early soft-launch on own capital). LP-unwrap path validated against fixtures since no positions are open at the moment.

If the module name `solon` collides with the curator registry entry on the server side, happy to rename this adapter to whatever slug you prefer (e.g. `solon-leverage`) — just let me know.

Links: site https://solonlend.xyz · app https://solonlend.xyz/app/ · docs https://solonlend.xyz/docs/overview

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for tracking Solon Leverage on Robinhood Chain.
  - Portfolio and TVL calculations now include supported USDG and WETH holdings across lending pools and vaults.
  - Uniswap V3 liquidity positions using approved tokens can now be resolved and included in LP accounting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->