### PR TITLE
Add xax adapter

### DIFF
--- a/projects/xax/index.js
+++ b/projects/xax/index.js
@@ -1,0 +1,26 @@
+// DeFiLlama TVL adapter — XAX (XAUSD ERC-4626 vault), Ethereum mainnet.
+
+const VAULT = '0xc452B6D5bf3a7712A9AF9F70BF32f37A531ff220'
+const USDT = '0xdAC17F958D2ee523a2206206994597C13D831ec7'
+
+const OWNERS = [VAULT]
+
+async function tvl(api) {
+  const balances = await api.multiCall({
+    abi: 'erc20:balanceOf',
+    target: USDT,
+    calls: OWNERS,
+  })
+  const total = balances.reduce((sum, bal) => sum + BigInt(bal), 0n)
+  return { [USDT]: total.toString() }
+}
+
+module.exports = {
+  methodology:
+    'Counts USDT backing the XAUSD ERC-4626 vault that is held on-chain — USDT ' +
+    'in the vault contract (idle reserve plus pending-redemption reservations). ' +
+    'USDT held in off-chain MPC custody is excluded, so reported TVL can be ' +
+    "lower than the vault's net asset value.",
+  start: 1780980761,
+  ethereum: { tvl },
+}

--- a/projects/xax/index.js
+++ b/projects/xax/index.js
@@ -1,26 +1,43 @@
-// DeFiLlama TVL adapter — XAX (XAUSD ERC-4626 vault), Ethereum mainnet.
+// DeFiLlama TVL adapter for XAX (XAUSD ERC-4626 vault), Ethereum mainnet.
+//
+// Copy this file to projects/xax/index.js in a fork of
+// DefiLlama/DefiLlama-Adapters and open a PR (see ./README.md).
+//
+// Count actual USDT in the vault,
+// less deferred treasury fees. Queued shares stay backed until assets are paid.
+// Vault totalAssets/reportedNav and MPC totalAssets/currentDebt include reported
+// strategy value, so they cannot measure onchain custody. Do not add them.
+// Strategy balances, including local MPC reserves, are outside this scope.
+//
+// Addresses are sourced from contracts/deployments/mainnet.json in the xax
+// repo. Update them here if the vault is redeployed.
 
-const VAULT = '0xc452B6D5bf3a7712A9AF9F70BF32f37A531ff220'
+const VAULT = '0xd3dCB074C007DeB82b511E263d15966A05E6ef92'
 const USDT = '0xdAC17F958D2ee523a2206206994597C13D831ec7'
 
-const OWNERS = [VAULT]
+function rawAmount(value) {
+  if ((typeof value !== 'string' && typeof value !== 'bigint') || !/^\d+$/.test(value)) {
+    throw new Error('Invalid raw USDT amount')
+  }
+  return BigInt(value)
+}
 
 async function tvl(api) {
-  const balances = await api.multiCall({
-    abi: 'erc20:balanceOf',
-    target: USDT,
-    calls: OWNERS,
-  })
-  const total = balances.reduce((sum, bal) => sum + BigInt(bal), 0n)
-  return { [USDT]: total.toString() }
+  // Pin recent/latest runs too, so a fee payout cannot mix cash and liability states.
+  await api.getBlock()
+  const [balance, pendingTreasuryFee] = await Promise.all([
+    api.call({ abi: 'erc20:balanceOf', target: USDT, params: [VAULT] }),
+    api.call({ abi: 'uint256:pendingTreasuryFee', target: VAULT }),
+  ])
+  const backing = rawAmount(balance) - rawAmount(pendingTreasuryFee)
+  return { [USDT]: (backing > 0n ? backing : 0n).toString() } // raw 6-dec USDT
 }
 
 module.exports = {
   methodology:
-    'Counts USDT backing the XAUSD ERC-4626 vault that is held on-chain — USDT ' +
-    'in the vault contract (idle reserve plus pending-redemption reservations). ' +
-    'USDT held in off-chain MPC custody is excluded, so reported TVL can be ' +
-    "lower than the vault's net asset value.",
-  start: 1780980761,
+    'Counts onchain USDT held by the XAUSD vault contract, ' +
+    'less pending treasury fees. Queued redemptions remain included until paid. ' +
+    'All strategy balances, including MPC adapter reserves and external custody, are excluded.',
+  start: 1787306267, // V2 mainnet deploy block 25802758, 2026-08-21T09:57:47Z
   ethereum: { tvl },
 }


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

---

1. If you would like to add a `volume/fees/revenue` adapter please submit the PR [here](https://github.com/DefiLlama/dimension-adapters).

2. Once your adapter has been merged, it takes time to show on the UI. If more than 24 hours have passed, please let us know in Discord.
3. Sorry, We no longer accept fetch adapter for new projects, we prefer the tvl to computed from blockchain data, if you have trouble with creating a the adapter, please hop onto our discord, we are happy to assist you.
4. **For updating listing info** Please send a mail to metadata@defillama.com
5. Please do not add new npm dependencies, do not edit/push `pnpm-lock.yaml` file as part of your changes

---
## (Needs to be filled only for new listings)

##### Name (to be shown on DefiLlama):

XAX v2

##### Twitter Link:

https://x.com/xaxtrading

##### List of audit links if any:

https://skynet.certik.com/projects/xeffy

##### Website Link:

https://xax.trading

##### Logo (High resolution, will be shown with rounded borders):

https://xax.trading/safe-app-icon.svg

##### Current TVL:

~$79k (onchain vault USDT backing per adapter methodology)

##### Treasury Addresses (if the protocol has treasury)

`0xD49Ec4a0eD6A335650B952B96AEda0A0ef632263` (not counted in TVL)

##### Chain:

Ethereum

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama):

USDT yield vault on Ethereum. Deposit USDT, receive XAUSD ERC-4626 shares.

##### Token address and ticker if any:

`0xd3dCB074C007DeB82b511E263d15966A05E6ef92` (XAUSD, ERC-4626 vault shares)

##### Category (full list at https://defillama.com/categories) *Please choose only one:

Yield

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):

N/A for TVL (reads onchain USDT balance and `pendingTreasuryFee`)

##### Implementation Details: Briefly describe how the oracle is integrated into your project:

N/A

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:

N/A

##### forkedFrom (Does your project originate from another project):

No

##### methodology (what is being counted as tvl, how is tvl being calculated):

Counts onchain USDT held by the XAUSD vault contract (`0xd3dCB074C007DeB82b511E263d15966A05E6ef92`), less `pendingTreasuryFee`. Queued redemptions stay included until paid. Strategy balances, MPC adapter reserves, and external custody are excluded. Does not use `totalAssets` / reported NAV.

##### Github org/user (Optional, if your code is open source, we can track activity):

https://github.com/XAX-Vault

##### Does this project have a referral program?

No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Ethereum TVL tracking for the XAX V2 XAUSD vault.
  * Reports vault assets after accounting for pending treasury fees.
  * Includes methodology details and tracking from the V2 deployment block.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->