### PR TITLE
Add REP369 TVL adapter

### DIFF
--- a/projects/REP369
+++ b/projects/REP369
@@ -1,0 +1,33 @@
+// REP369 on PulseChain
+// Main liquidity pool referenced by the project's public configuration:
+// REP369 / WPLS on PulseX V2
+
+const REP369 = '0x0EE7adC2BAb46BaD56B91D9641A8cDEd09f82369'
+const WPLS = '0xA1077a294dDE1B09bB078844df40758a5D0f9a27'
+const MAIN_PAIR = '0x240e7A47fE5F91806c6D6056Fe4f62622303E1A5'
+
+const balanceOfAbi = 'erc20:balanceOf(address)'
+
+module.exports = {
+  methodology: `Counts the REP369/WPLS PulseX V2 liquidity pool. TVL is computed from the pool's on-chain ERC20 balances for REP369 and WPLS; DefiLlama prices the returned assets. No TVL value is hard-coded.`,
+  pulsechain: {
+    tvl: async (api) => {
+      const rep369Balance = await api.call({
+        abi: balanceOfAbi,
+        target: REP369,
+        params: [MAIN_PAIR],
+      })
+
+      const wplsBalance = await api.call({
+        abi: balanceOfAbi,
+        target: WPLS,
+        params: [MAIN_PAIR],
+      })
+
+      return {
+        [REP369]: rep369Balance,
+        [WPLS]: wplsBalance,
+      }
+    },
+  },
+}


### PR DESCRIPTION
## New listing: REP369

##### Name (to be shown on DefiLlama):
REP369

##### Twitter Link:
https://x.com/GregRadiator

##### List of audit links if any:

##### Website Link:
https://www.reptalianie.com/

##### Logo:
https://www.reptalianie.com/rep369_logo.jpg

##### Current TVL:
$679

##### Treasury Addresses:

##### Chain:
PulseChain

##### Coingecko ID:

##### Coinmarketcap ID:

##### Short Description:
REP369 is a deflationary PulseChain community treasury token that rewards holders in REP from transaction volume and automatically contributes to REP369/PLS liquidity.

##### Token address and ticker:
0x0EE7adC2BAb46BaD56B91D9641A8cDEd09f82369 — REP369

##### Category:
DeFi

##### Oracle Provider(s):

##### Implementation Details:
No external price oracle is used by the REP369 protocol. The TVL adapter reads the tracked REP369/WPLS liquidity pool balances directly from the blockchain, while DefiLlama's pricing system values the returned assets.

##### Documentation/Proof:
https://www.reptalianie.com/

##### forkedFrom:
No

##### methodology:
TVL counts the on-chain REP369 and WPLS balances held by the tracked REP369/WPLS PulseX V2 liquidity pool. The adapter reads the pool's ERC20 balances directly from the blockchain and DefiLlama's SDK prices the returned assets.

##### Github org/user:

##### Does this project have a referral program?
No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added DefiLlama coverage for REP369 on PulseChain.
  - Added TVL tracking for REP369/WPLS liquidity on PulseX V2.
  - TVL is calculated from live token balances in the liquidity pool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->