### PR TITLE
Add HASHCATS TVL adapter on Robinhood Chain

### DIFF
--- a/registries/sumTokens.js
+++ b/registries/sumTokens.js
@@ -15754,6 +15754,16 @@ const configs = {
       }
     },
   },
+  "hashcats": {
+    "methodology": "Rent accrued to the cats currently alive and not claimed yet, held as ether by the HASHCATS collection at 0xca75df55cc9c476db27a7375d1fc8e794cf80721. A cat is minted only when a miner submits a hash below the collection's target, and the price is split on the spot between the cats already alive and the protocol's hook. The hook's cut leaves in the same transaction that creates it, so what stays behind is owed to NFT holders: the contract has no owner withdrawal, sweep or rescue, and the only two paths that send ether are the hook's cut at mint time and the claim paying a cat's owner. The hook's own buyback queue and Uniswap V4 position are protocol-owned liquidity and are deliberately not counted.",
+    "start": "2026-09-11",
+    "robinhood": {
+      "owner": "0xca75df55cc9c476db27a7375d1fc8e794cf80721",
+      "tokens": [
+        ADDRESSES.null
+      ]
+    }
+  },
   "hedgehog-protocol": {
     "methodology": "TVL is the native S and USDC held in the HedgehogCore contract — including hub pool liquidity and bonding curve spoke reserves.",
     "sonic": {


### PR DESCRIPTION
Adds a TVL adapter for HASHCATS, a proof-of-work NFT collection on Robinhood Chain.

A cat is minted only when a miner submits a hash below the collection's target. The entry price is derived rather than chosen — the number of cats created so far times a fixed step — and is split on the spot: a share per past cat accrues as rent to the cats still alive, the rest goes to the hook, which spends 70% of everything it receives on buying $HASH back and burning it.

**Where the value sits, and why each part counts**

| Item | Counted | Why |
|---|---|---|
| Collection balance | `tvl` | Rent accrued to living cats and not yet claimed. The contract has no path that sends ether anywhere except to cat owners and to the hook. |
| Hook's buyback queue | `tvl` | Read from `queue()`, not from the hook's balance — that balance also carries the developer's accrued share, which is income, not locked value. |
| ETH side of the hook's v4 position | `tvl` | Derived from the position's liquidity as recorded by StateView, its tick range and the pool's current price. |
| Royalties received in WETH | `tvl` | Arrived at the hook and not yet unwrapped into the queue. Small, but it is value held. |
| $HASH side of the position | `ownTokens` | The protocol's own token. |
| Developer's accrued share | not counted | Income, not locked value. |

**Overlap, stated plainly:** the buyback queue and the pool position also fall inside `projects/uniswap-v4/index.js` for this chain, which sums PoolManager balances and the balances of every hook. The collection balance — the larger half — does not. I have not set `doublecounted` because only part of the total overlaps; happy to set it if you prefer that.

Tested with `node test.js projects/hashcats/index.js` at the current block and at historical dates, and cross-checked against an independent read of the same contracts: $259,754 computed independently vs $259,505 from the adapter, the difference being rent accrued between the two runs. A date before the deployment block returns zero rather than reverting.

##### Name (to be shown on DefiLlama):
HASHCATS

##### Twitter Link:
https://x.com/hashcats_rh

##### List of audit links if any:
None

##### Website Link:
https://hashcats.fun

##### Logo (High resolution, will be shown with rounded borders):
https://raw.githubusercontent.com/hashcats-dot-fun/branding/HEAD/logo/hashcats-mark-1000.png

##### Current TVL:
~$260,000

##### Treasury Addresses (if the protocol has treasury)
None

##### Chain:
Robinhood Chain

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama):
A fully on-chain proof-of-work NFT collection on Robinhood Chain. A cat exists only when someone's machine finds a hash below the target — no allowlist, no auction, no team allocation. Every mint pays rent to all the cats already alive, and 70% of what the protocol earns buys back and burns $HASH.

##### Token address and ticker if any:
$HASH — 0xca75082b85bb7bec8325d513f615b16bda260020 (Robinhood Chain)

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Gamified Mining

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
None — the protocol uses no price oracle. Mint prices are derived from the contract's own supply curve, and the buyback reads the pool's own price directly.

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
Not applicable.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
Not applicable. Protocol documentation: https://hashcats.fun/docs

##### forkedFrom (Does your project originate from another project):
No

##### methodology (what is being counted as tvl, how is tvl being calculated):
See the `methodology` string in the adapter and the table above. In short: unclaimed rent held by the collection, the hook's buyback queue read from `queue()`, the ether side of the hook's own Uniswap V4 position derived from its liquidity and tick range, and royalties received as WETH. The $HASH side of the position is reported under `ownTokens`.

##### Github org/user (Optional, if your code is open source, we can track activity):

##### Does this project have a referral program?
No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added registry information for the HASHCATS collection, including its methodology, start date, and owner configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->