### PR TITLE
archade: count the curves under the two newer configs

### DIFF
--- a/projects/archade/index.js
+++ b/projects/archade/index.js
@@ -9,12 +9,14 @@ const { PublicKey } = require('@solana/web3.js')
 // config field) returns the complete set. No protocol API is involved.
 const DBC_PROGRAM = new PublicKey('dbcij3LWUppWqq96dh6gJWwBifmcGfLSB5D4DuSMaqN')
 
-// Both configs are quoted in wSOL (the config's quote_mint). A future config
+// Every config is quoted in wSOL (the config's quote_mint). A future config
 // with a different quote token is a one-line addition here.
 const WSOL = ADDRESSES.solana.SOL
 const ARCHADE_CONFIGS = [
   { config: 'HeaH1eyowUas1U9f9646CJ866jNGNzeCsCzeGJ8ryMbe', quoteMint: WSOL }, // production
   { config: 'ELnnqpYUMoKtkULm4LZ4uyashtxpgaccqucZdCY7Ym6H', quoteMint: WSOL }, // test
+  { config: '7tMsZkJTCR616N9vUMBRWN5y4fKr9JXSopnk3vMEL2nN', quoteMint: WSOL }, // anti-sniper fee schedule
+  { config: 'FWX2KPTGZR9mujdSpbAEKhxHULXJYXRizgAXBYwVMKbU', quoteMint: WSOL }, // smaller curve
 ]
 
 // DBC VirtualPool account layout (424 bytes: 8-byte anchor discriminator + C-repr struct).


### PR DESCRIPTION
Archade launches coins under several of its own Meteora DBC configs. The adapter lists the two that existed when it was written; two more have been in use since 2026-09-09 (one with an anti-sniper fee schedule, one on a smaller curve that graduates at 22 SOL instead of 86) and their curves were not counted.

`node test.js projects/archade` -> total 4.43 (was 3.97). Small today, but new launches go to these configs, so without them the reported TVL drifts away from the real one. No logic change, two entries in the config list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ibmQJkwteu5g8mgZPBcbK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added two additional configuration options for improved flexibility:
    - An anti-sniper fee schedule.
    - A smaller curve configuration.
  - Existing configuration options remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->